### PR TITLE
Fix android's build warnings

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -137,11 +137,11 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-gesture-handler')
-    compile project(':react-native-screens')
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-gesture-handler')
+    implementation project(':react-native-screens')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -23,7 +23,7 @@ allprojects {
 }
 
 ext {
-    buildToolsVersion = "26.0.3"
+    buildToolsVersion = "27.0.3"
     minSdkVersion = 16
     compileSdkVersion = 26
     targetSdkVersion = 26


### PR DESCRIPTION
1. Configuration 'compile' is obsolete and has been replaced with 'implementation'

2. `buildToolsVersion  27.0.3` is a minimal version supported by `android.tools.build:gradle:3.1.4` and previous version has been ignored