### PR TITLE
Add bluring inputs on disactivating screen

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -1,5 +1,6 @@
 #import "RNSScreen.h"
 #import "RNSScreenContainer.h"
+#import <RCTText/RCTBaseTextInputView.h>
 
 @interface RNSScreen : UIViewController
 
@@ -23,10 +24,30 @@
   return self;
 }
 
++ (void)walkThroughSubviewsAndBlurTextInputs:(UIView *) view
+// This is a workaroud for an issue of preserving focus on mounting
+// and unmounting TextInput. In screen was set to inactive with focused
+// text input inside, textInput was still focused on reactivation of a screen.
+// It was invconsistent behavior with react-navigation without RNS.
+// What's more, then TextInput's focus couldn't be managed with
+// imperative API neither for bluring nor dismissing keyboard.
+{
+  if ([view isKindOfClass:[RCTBaseTextInputView class]]) {
+    [(RCTBaseTextInputView *)view reactBlur];
+  } else {
+    for (view in view.subviews) {
+      [RNSScreenView walkThroughSubviewsAndBlurTextInputs:view];
+    }
+  }
+}
+
 - (void)setActive:(BOOL)active
 {
   if (active != _active) {
     _active = active;
+    if (!active) {
+      [RNSScreenView walkThroughSubviewsAndBlurTextInputs:self];
+    }
     [_reactSuperview markChildUpdated];
   }
 }


### PR DESCRIPTION
## Motivation
This a solution for https://github.com/kmagiera/react-native-screens/issues/67

Keyboard doesn't dismiss after navigating to another screen and back. Even on `Keyboard.dismiss()` call. It seems like without Screens keyboard is dismissed on every navigation.

Repo: [snack.expo.io/@andrey/keyboard-bug](https://snack.expo.io/@andrey/keyboard-bug)
Focus TextInput -> Next Screen -> Back -> Keyboard is not dismissing

## Changes
Before setting screen to inactive, I added walking through all subviews and checking whether it's TextInput. If yes, it's being blurred then. 