### PR TITLE
Stop disabling interaction of newly added screen

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -102,30 +102,11 @@
   }
 
   // detect if new screen is going to be activated
-  BOOL activeScreenAdded = NO;
+  RNSScreenView* activeScreenAdded = NULL;
   for (RNSScreenView *screen in _reactSubviews) {
     if (screen.active && ![_activeScreens containsObject:screen]) {
-      activeScreenAdded = YES;
-    }
-  }
-
-  // if we are adding new active screen, we perform remounting of all already marked as active
-  // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
-  // triggered before the animation starts
-  if (activeScreenAdded) {
-    for (RNSScreenView *screen in _reactSubviews) {
-      if (screen.active && [_activeScreens containsObject:screen]) {
-        [self detachScreen:screen];
-        // disable interactions for the duration of transition
-        screen.userInteractionEnabled = NO;
-      }
-    }
-
-    // add new screens in order they are placed in subviews array
-    for (RNSScreenView *screen in _reactSubviews) {
-      if (screen.active) {
-        [self attachScreen:screen];
-      }
+      screen.userInteractionEnabled = NO;
+      [self attachScreen:screen];
     }
   }
 

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -105,11 +105,15 @@
   RNSScreenView* activeScreenAdded = NULL;
   for (RNSScreenView *screen in _reactSubviews) {
     if (screen.active && ![_activeScreens containsObject:screen]) {
-      screen.userInteractionEnabled = NO;
-      [self attachScreen:screen];
+      activeScreenAdded = screen;
     }
   }
-
+  
+  if (activeScreenAdded) {
+    activeScreenAdded.userInteractionEnabled = NO;
+    [self attachScreen:activeScreenAdded];
+  }
+  
   // if we are down to one active screen it means the transitioning is over and we want to notify
   // the transition has finished
   if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {


### PR DESCRIPTION
## Motivation

In react navigation we want to keep recognising gesture even if second screen beneath is active (in stack impl). Previously it was working bc there was only one gesture recogniser for whole stack, but we want to get rid of this pattern in order to extend customisation. 

## Test
### How it was? Screen below is rendered is gesture state is active so it's get rendered for a while (or no) and then gesture is cancelled immediately
https://streamable.com/4bkmt

### How it is after this fix
https://streamable.com/dho7v

