### PR TITLE
remove activeScreenRemoved, activeScreenAdded dismissal code

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -138,15 +138,6 @@
     [singleActiveScreen notifyFinishTransitioning];
   }
 
-  if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil) {
-    // if user has reachability enabled (one hand use) and the window is slided down the below
-    // method will force it to slide back up as it is expected to happen with UINavController when
-    // we push or pop views.
-    // We only do that if `presentedViewController` is nil, as otherwise it'd mean that modal has
-    // been presented on top of recently changed controller in which case the below method would
-    // dismiss such a modal (e.g., permission modal or alert)
-    [_controller dismissViewControllerAnimated:NO completion:nil];
-  }
 }
 
 - (void)didUpdateReactSubviews


### PR DESCRIPTION
This piece of code is causing a bug on an implementation I am working on with react-navigation, in which the RNScreens ViewController is dismissed when I'm transitioning from my initial screen to another. During that transition, `activeScreenAdded` is true as is `_controller.presentedViewController == nil`, so this piece of code dismisses the RNScreens ViewController, which means our screens no longer show.

I'm submitting this PR because I don't fully understand the comment `the below method will force it to slide back up as it is expected to happen with UINavController when we push or pop views.` – that doesn't seem like expected behavior to me and after testing with this change, I don't see any regressions. I'm not as familiar with Reachability but think this code may be related to some of the non-expo issues that people are seeing with blank/white screens on iOS (https://github.com/kmagiera/react-native-screens/issues/106) and from my experience, removal of this code results in a better implementation. 