### PR TITLE
Implement largeTitle on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -6,21 +6,21 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.uimanager.PixelUtil;
 import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+
+import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 public class ScreenStackFragment extends ScreenFragment {
 
   private static final float TOOLBAR_ELEVATION = PixelUtil.toPixelFromDIP(4);
 
   private AppBarLayout mAppBarLayout;
-  private Toolbar mToolbar;
   private boolean mShadowHidden;
 
   @SuppressLint("ValidFragment")
@@ -29,20 +29,39 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   public void removeToolbar() {
+    CoordinatorLayout contentView = (CoordinatorLayout) getView();
+    contentView.setFitsSystemWindows(false);
+
     if (mAppBarLayout != null) {
-      ((CoordinatorLayout) getView()).removeView(mAppBarLayout);
+      mAppBarLayout.setFitsSystemWindows(false);
+      contentView.removeView(mAppBarLayout);
+      mAppBarLayout = null;
     }
+
+    contentView.requestApplyInsets();
   }
 
-  public void setToolbar(Toolbar toolbar) {
-    if (mAppBarLayout != null) {
+  public void setToolbar(CollapsingToolbarLayout toolbar) {
+    CoordinatorLayout contentView = (CoordinatorLayout) getView();
+    contentView.setFitsSystemWindows(true);
+
+    if (mAppBarLayout == null) {
+      mAppBarLayout = new AppBarLayout(getContext());
+      // By default AppBarLayout will have a background color set but since we cover the whole layout
+      // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
+      // role. On top of that it breaks screens animations when alfa offscreen compositing is off
+      // (which is the default)
+      mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
+      FrameLayout.LayoutParams appBarLayoutParams = new FrameLayout.LayoutParams(
+          FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+      mAppBarLayout.setLayoutParams(appBarLayoutParams);
+      mAppBarLayout.setFitsSystemWindows(true);
+
       mAppBarLayout.addView(toolbar);
+      contentView.addView(mAppBarLayout);
     }
-    mToolbar = toolbar;
-    AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(
-            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT);
-    params.setScrollFlags(0);
-    mToolbar.setLayoutParams(params);
+
+    contentView.requestApplyInsets();
   }
 
   public void setToolbarShadowHidden(boolean hidden) {
@@ -65,24 +84,10 @@ public class ScreenStackFragment extends ScreenFragment {
                            @Nullable Bundle savedInstanceState) {
     CoordinatorLayout view = new CoordinatorLayout(getContext());
     CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
+        LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
     params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
     mScreenView.setLayoutParams(params);
     view.addView(mScreenView);
-
-    mAppBarLayout = new AppBarLayout(getContext());
-    // By default AppBarLayout will have a background color set but since we cover the whole layout
-    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
-    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
-    // (which is the default)
-    mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
-    mAppBarLayout.setLayoutParams(new AppBarLayout.LayoutParams(
-            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
-    view.addView(mAppBarLayout);
-
-    if (mToolbar != null) {
-      mAppBarLayout.addView(mToolbar);
-    }
 
     return view;
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -33,7 +33,6 @@ public class ScreenStackFragment extends ScreenFragment {
     contentView.setFitsSystemWindows(false);
 
     if (mAppBarLayout != null) {
-      mAppBarLayout.setFitsSystemWindows(false);
       contentView.removeView(mAppBarLayout);
       mAppBarLayout = null;
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -63,8 +63,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     mCollapsingToolbarLayout = new CollapsingToolbarLayout(getContext());
     mCollapsingToolbarLayout.setFitsSystemWindows(true);
-    mCollapsingToolbarLayout.setExpandedTitleMarginStart((int) PixelUtil.toPixelFromDIP(16));
-    mCollapsingToolbarLayout.setExpandedTitleMarginEnd((int) PixelUtil.toPixelFromDIP(16));
     mCollapsingToolbarLayout.addView(mToolbar);
 
     // set primary color as background by default

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -58,6 +58,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     parent.onUpdate();
   }
 
+  @ReactProp(name = "collapsable")
+  public void setCollapsable(ScreenStackHeaderConfig config, boolean collapsable) {
+    config.setCollapsable(collapsable);
+  }
+
   @ReactProp(name = "title")
   public void setTitle(ScreenStackHeaderConfig config, String title) {
     config.setTitle(title);
@@ -69,8 +74,23 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
   }
 
   @ReactProp(name = "titleFontSize")
-  public void setTitleFontSize(ScreenStackHeaderConfig config, double titleFontSizeSP) {
-    config.setTitleFontSize((int) PixelUtil.toPixelFromSP(titleFontSizeSP));
+  public void setTitleFontSize(ScreenStackHeaderConfig config, float titleFontSize) {
+    config.setTitleFontSize(titleFontSize);
+  }
+
+  @ReactProp(name = "largeTitle")
+  public void setLargeTitle(ScreenStackHeaderConfig config, boolean largeTitle) {
+    config.setLargeTitle(largeTitle);
+  }
+
+  @ReactProp(name = "largeTitleFontFamily")
+  public void setLargeTitleFontFamily(ScreenStackHeaderConfig config, String titleFontFamily) {
+    config.setLargeTitleFontFamily(titleFontFamily);
+  }
+
+  @ReactProp(name = "largeTitleFontSize")
+  public void setLargeTitleFontSize(ScreenStackHeaderConfig config, float titleFontSize) {
+    config.setLargeTitleFontSize(titleFontSize);
   }
 
   @ReactProp(name = "titleColor", customType = "Color")


### PR DESCRIPTION
This adds support for large header on Android, similar to what exists on iOS. The main issue is that we need a way to communicate scroll to `CoordinatorLayout`. Normally this is done using `NestedScrollView` or a `RecyclerView` as a direct child of `CoordinatorLayout`. This is however not really possible with the current setup and the way react native works.

I was able to get it working by making `ReactScrollView` inherit `NestedScrollView` to test but we will need to find a better solution as I don't think this is upstreamable. There might also be some subtle behavior differences when the `NestedScrollView` is not a direct child of the `CoordinatorLayout`. This is to be verified with a fully native app.

I need to investigate more how `NestedScrollView` works to forward scroll events to the parent `CoordinatorLayout`. Some options I see:

-  Have a custom ScrollView component that would extend `NestedScrollView`. Probably the easiest to implement but requires app changes to work.
- Traverse subviews to find instances of `ReactScrollView` and find a way to hook into its scroll events. We could then have some proxy `ScrollView` that we insert as a child of `CoordinatorLayout` that sends the scroll events the way it expects it. The issue is we'd have to know and re-traverse whenever the view hierachy changes.

Summary of the changes:

- Use `CollapsingToolbarLayout` to implement large title behaviors
- Adds support for existing `largeTitle` and `largeTitleFontFamily` props
- Add `largeTitleFontSize` but currently unused, `CollapsingToolbarLayout` only allows passing a resource id for styling titles. See if we can hack something by traversing subviews.
- Add new `collapsable` prop to make the header hide during scroll, not sure about the name. It was simple to add support for this with `CollapsingToolbarLayout` so I figured why not.