### PR TITLE
Add missing Headers to modal screens on iOS

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -164,14 +164,20 @@
     }
   }
 
+  if (changeRootController != _controller) {
+    changeRootController = changeRootController.parentViewController;
+  }
+
   void (^finish)(void) = ^{
     UIViewController *previous = changeRootController;
     for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
       UIViewController *next = controllers[i];
-      [previous presentViewController:next
+      UINavigationController *nc = [[UINavigationController alloc] initWithRootViewController:next];
+      nc.delegate = self;
+      [previous presentViewController:nc
                              animated:(i == controllers.count - 1)
                              completion:nil];
-      previous = next;
+      previous = nc;
     }
 
     [self->_presentedModals removeAllObjects];
@@ -263,8 +269,9 @@
 
 - (void)invalidate
 {
+  [_controller dismissViewControllerAnimated:NO completion:nil];
   for (UIViewController *controller in _presentedModals) {
-    [controller dismissViewControllerAnimated:NO completion:nil];
+    [controller.parentViewController dismissViewControllerAnimated:NO completion:nil];
   }
   [_presentedModals removeAllObjects];
 }


### PR DESCRIPTION
Disclaimer: I still don't know much about iOS development, @kmagiera 😛 But what I did notice is that the headers for modally pushed screens work and show up on Android but not on iOS.

I looked into this and noticed that the modal UIViewControllers are never connected to any UINavigationController that could hand them their own headers, so this does just that.

I'm unsure whether this is because A) I'm missing something, B) This isn't desired — which I'd doubt, or C) because of an inconsistency in newer iOS versions (although I did test iOS 12 and 13)