### PR TITLE
Apply custom color to largeTitle

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -20,6 +20,7 @@
 @property (nonatomic) BOOL largeTitle;
 @property (nonatomic, retain) NSString *largeTitleFontFamily;
 @property (nonatomic, retain) NSNumber *largeTitleFontSize;
+@property (nonatomic, retain) UIColor *largeTitleColor;
 @property (nonatomic) BOOL hideBackButton;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -159,10 +159,10 @@
     }
 
     if (@available(iOS 11.0, *)) {
-      if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor)) {
+      if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor)) {
         NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
-        if (config.titleColor) {
-          largeAttrs[NSForegroundColorAttributeName] = config.titleColor;
+        if (config.largeTitleColor) {
+          largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor;
         }
         CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;
         if (config.largeTitleFontFamily) {
@@ -356,11 +356,11 @@
       appearance.titleTextAttributes = attrs;
     }
 
-    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor) {
+    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor) {
       NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
 
-      if (config.titleColor) {
-        largeAttrs[NSForegroundColorAttributeName] = config.titleColor;
+      if (config.largeTitleColor) {
+        largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor;
       }
 
       CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;
@@ -457,6 +457,7 @@ RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
 // `hidden` is an UIView property, we need to use different name internally

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -159,10 +159,10 @@
     }
 
     if (@available(iOS 11.0, *)) {
-      if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor)) {
+      if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor || config.titleColor)) {
         NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
-        if (config.largeTitleColor) {
-          largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor;
+        if (config.largeTitleColor || config.titleColor) {
+          largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor ? config.largeTitleColor : config.titleColor;
         }
         CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;
         if (config.largeTitleFontFamily) {
@@ -356,11 +356,11 @@
       appearance.titleTextAttributes = attrs;
     }
 
-    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor) {
+    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor || config.titleColor) {
       NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
 
-      if (config.largeTitleColor) {
-        largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor;
+      if (config.largeTitleColor || config.titleColor) {
+        largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor ? config.largeTitleColor : config.titleColor;
       }
 
       CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -123,7 +123,7 @@ declare module 'react-native-screens' {
     largeTitleFontSize?: number;
     /**
      * @host (iOS only)
-     * @description Customize the color to be used for the large title.
+     * @description Customize the color to be used for the large title. By default uses the titleColor property.
      */
     largeTitleColor?: string;
     /**

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -122,6 +122,11 @@ declare module 'react-native-screens' {
      */
     largeTitleFontSize?: number;
     /**
+     * @host (iOS only)
+     * @description Customize the color to be used for the large title.
+     */
+    largeTitleColor?: string;
+    /**
      * Pass HeaderLeft, HeaderRight and HeaderTitle
      */
     children?: React.ReactNode;


### PR DESCRIPTION
Currently you cannot set a different color to largeTitle then the one applied to the non large title. This PR adds `largeTitleColor` that allows setting the color for the largeTitle, following the existing `largeTitleFontFamily` and `largeTitleFontSize`.