### PR TITLE
Fix gestureEnabled for modal with no header on iOS

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -109,6 +109,17 @@
   }
 }
 
+- (void)setGestureEnabled:(BOOL)gestureEnabled
+{
+  #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+      _controller.modalInPresentation = !gestureEnabled;
+    }
+  #endif
+
+  _gestureEnabled = gestureEnabled;
+}
+
 - (UIView *)reactSuperview
 {
   return _reactSuperview;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -275,11 +275,7 @@
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:YES];
-#ifdef __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    vc.modalInPresentation = !config.screenView.gestureEnabled;
-  }
-#endif
+
   if (shouldHide) {
     return;
   }


### PR DESCRIPTION
Since the config is only updated in the HeaderConfig view it will not get executed for stacks with no header. This fixes it by setting the prop directly in the Screen when the gestureEnabled prop is set.