### PR TITLE
Fix screen already added issue

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -25,12 +25,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
   protected final ArrayList<T> mScreenFragments = new ArrayList<>();
   private final ArrayList<Runnable> mAfterTransitionRunnables = new ArrayList<>(1);
 
-  protected @Nullable
-  FragmentManager mFragmentManager;
-  private @Nullable
-  FragmentTransaction mCurrentTransaction;
-  private @Nullable
-  FragmentTransaction mProcessingTransaction;
+  protected @Nullable FragmentManager mFragmentManager;
+  private @Nullable FragmentTransaction mCurrentTransaction;
+  private @Nullable FragmentTransaction mProcessingTransaction;
   private boolean mNeedUpdate;
   private boolean mIsAttached;
   private boolean mIsTransitioning;


### PR DESCRIPTION
In order to fix errors with messages like 'Screen already added' taht happend when dismissing modal screens from JS Stack Navigators, I removed `mActiveScreenFragments`.  Instead, I used `mFragmentManager.getFreagments()`. FragmentManager manages them itself, there is no need for duplication.