### PR TITLE
Trigger transition finish event from native stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -11,7 +11,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
@@ -47,13 +46,21 @@ public class Screen extends ViewGroup {
     }
   };
 
-  private @Nullable Fragment mFragment;
+  private @Nullable ScreenFragment mFragment;
   private @Nullable ScreenContainer mContainer;
   private boolean mActive;
   private boolean mTransitioning;
   private StackPresentation mStackPresentation = StackPresentation.PUSH;
   private StackAnimation mStackAnimation = StackAnimation.DEFAULT;
   private boolean mGestureEnabled = true;
+
+  @Override
+  protected void onAnimationEnd() {
+    super.onAnimationEnd();
+    if (mFragment != null) {
+      mFragment.onViewAnimationEnd();
+    }
+  }
 
   public Screen(ReactContext context) {
     super(context);
@@ -168,11 +175,11 @@ public class Screen extends ViewGroup {
     mContainer = container;
   }
 
-  protected void setFragment(Fragment fragment) {
+  protected void setFragment(ScreenFragment fragment) {
     mFragment = fragment;
   }
 
-  protected @Nullable Fragment getFragment() {
+  protected @Nullable ScreenFragment getFragment() {
     return mFragment;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -45,19 +45,15 @@ public class ScreenFragment extends Fragment {
   }
 
   @Override
-  public void onCreate(@Nullable Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ScreenContainer container = mScreenView.getContainer();
-    if (container.isTransitioning()) {
-      container.postAfterTransition(new Runnable() {
-        @Override
-        public void run() {
-          dispatchOnAppear();
-        }
-      });
-    } else {
-      dispatchOnAppear();
-    }
+  public void onResume() {
+    super.onResume();
+  }
+
+  public void onViewAnimationEnd() {
+    // onViewAnimationEnd is triggered from View#onAnimationEnd method of the fragment's root view.
+    // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
+    // in order to achieve this.
+    dispatchOnAppear();
   }
 
   @Override

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -69,6 +69,8 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
             ScreenDismissedEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onDismissed"),
             ScreenAppearEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onAppear"));
+            MapBuilder.of("registrationName", "onAppear"),
+            StackFinishTransitioningEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onFinishTransitioning"));
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/StackFinishTransitioningEvent.java
+++ b/android/src/main/java/com/swmansion/rnscreens/StackFinishTransitioningEvent.java
@@ -1,0 +1,29 @@
+package com.swmansion.rnscreens;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class StackFinishTransitioningEvent extends Event<ScreenAppearEvent> {
+  public static final String EVENT_NAME = "topFinishTransitioning";
+
+  public StackFinishTransitioningEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
+  }
+}

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -191,6 +191,19 @@
   [_touchHandler reset];
 }
 
+- (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController
+{
+  return _gestureEnabled;
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
+  if ([_reactSuperview respondsToSelector:@selector(presentationControllerDidDismiss:)]) {
+    [_reactSuperview performSelector:@selector(presentationControllerDidDismiss:)
+                          withObject:presentationController];
+  }
+}
+
 @end
 
 @implementation RNSScreen {
@@ -248,6 +261,8 @@
     // screen dismissed, send event
     [((RNSScreenView *)self.view) notifyDismissed];
   }
+  _view = self.view;
+  self.view = nil;
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -260,9 +260,9 @@
   if (self.parentViewController == nil && self.presentingViewController == nil) {
     // screen dismissed, send event
     [((RNSScreenView *)self.view) notifyDismissed];
+    _view = self.view;
+    self.view = nil;
   }
-  _view = self.view;
-  self.view = nil;
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -4,6 +4,8 @@
 
 @interface RNSScreenStackView : UIView <RNSScreenContainerDelegate, RCTInvalidating>
 
+@property (nonatomic, copy) RCTDirectEventBlock onFinishTransitioning;
+
 - (void)markChildUpdated;
 - (void)didUpdateChildren;
 


### PR DESCRIPTION
This change adds new event that gets dispatched from native stack when screen transitioning is finished.

The new event is used by react-navigation to update the library internal state that the triggered action has been finished. Previously we were relying solely on onAppear and onDisappear events, however those does not get triggered when new iOS 13 modals are used or when transparent modals are displayed. This is because with transparent modals the view below is still visible. We therefore needed another way of notifying the library that screen transition have finished despite the fact that disappear event couldn't be triggered.

As a part of this change I also refactored invalid ref cycle-break code on iOS which was ought to remove reference cycle between view and view controller. This code have been moved to viewWillDisappear callback.

Also on Android part small refactoring has been done and we removed the necessity to keep mActiveScreens array which was occasionally getting out of sync with the list of active fragments.
