### PR TITLE
Implement largeTitle backgroundColor and hideShadow on iOS

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -15,6 +15,7 @@
 @property (nonatomic, retain) NSString *backTitleFontFamily;
 @property (nonatomic, retain) NSNumber *backTitleFontSize;
 @property (nonatomic, retain) UIColor *backgroundColor;
+@property (nonatomic, retain) UIColor *scrollEdgeBackgroundColor;
 @property (nonatomic, retain) UIColor *color;
 @property (nonatomic) BOOL hide;
 @property (nonatomic) BOOL largeTitle;

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -15,15 +15,15 @@
 @property (nonatomic, retain) NSString *backTitleFontFamily;
 @property (nonatomic, retain) NSNumber *backTitleFontSize;
 @property (nonatomic, retain) UIColor *backgroundColor;
-@property (nonatomic, retain) UIColor *scrollEdgeBackgroundColor;
 @property (nonatomic, retain) UIColor *color;
 @property (nonatomic) BOOL hide;
 @property (nonatomic) BOOL largeTitle;
 @property (nonatomic, retain) NSString *largeTitleFontFamily;
 @property (nonatomic, retain) NSNumber *largeTitleFontSize;
+@property (nonatomic, retain) UIColor *largeTitleBackgroundColor;
+@property (nonatomic) BOOL largeTitleHideShadow;
 @property (nonatomic) BOOL hideBackButton;
 @property (nonatomic) BOOL hideShadow;
-@property (nonatomic) BOOL scrollEdgeHideShadow;
 @property (nonatomic) BOOL translucent;
 
 + (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -23,6 +23,7 @@
 @property (nonatomic, retain) NSNumber *largeTitleFontSize;
 @property (nonatomic) BOOL hideBackButton;
 @property (nonatomic) BOOL hideShadow;
+@property (nonatomic) BOOL scrollEdgeHideShadow;
 @property (nonatomic) BOOL translucent;
 
 + (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -392,8 +392,8 @@
     navitem.compactAppearance = appearance;
 
     UINavigationBarAppearance *scrollEdgeAppearance = [self buildAppearance: vc withConfig:config];
-    scrollEdgeAppearance.backgroundColor = config.scrollEdgeBackgroundColor;
-    if (config.scrollEdgeHideShadow) {
+    scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
+    if (config.largeTitleHideShadow) {
         scrollEdgeAppearance.shadowColor = nil;
     }
     navitem.scrollEdgeAppearance = scrollEdgeAppearance;
@@ -484,14 +484,14 @@ RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
-RCT_EXPORT_VIEW_PROPERTY(scrollEdgeBackgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleBackgroundColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleHideShadow, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(scrollEdgeHideShadow, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -390,8 +390,12 @@
     UINavigationBarAppearance *appearance = [self buildAppearance: vc withConfig:config];
     navitem.standardAppearance = appearance;
     navitem.compactAppearance = appearance;
+
     UINavigationBarAppearance *scrollEdgeAppearance = [self buildAppearance: vc withConfig:config];
     scrollEdgeAppearance.backgroundColor = config.scrollEdgeBackgroundColor;
+    if (config.scrollEdgeHideShadow) {
+        scrollEdgeAppearance.shadowColor = nil;
+    }
     navitem.scrollEdgeAppearance = scrollEdgeAppearance;
   } else
 #endif
@@ -487,6 +491,7 @@ RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(scrollEdgeHideShadow, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.1",
   "description": "First incomplete navigation solution for your react-native app.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "2.0.1",
+  "version": "2.0.0-beta.10",
   "description": "First incomplete navigation solution for your react-native app.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -84,13 +84,17 @@ declare module 'react-native-screens' {
      */
     backgroundColor?: string;
     /**
-     *@description Controlls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation ba.
+     *@description Controlls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
      */
     scrollEdgeBackgroundColor?: string;
     /**
      * @description Boolean that allows for disabling drop shadow under navigation header. The default value is true.
      */
     hideShadow?: boolean;
+    /**
+     * @description Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+     */
+    scrollEdgeHideShadow?: boolean;
     /**
      * @description If set to true the back button will not be rendered as a part of navigation header.
      */

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -84,6 +84,10 @@ declare module 'react-native-screens' {
      */
     backgroundColor?: string;
     /**
+     *@description Controlls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation ba.
+     */
+    scrollEdgeBackgroundColor?: string;
+    /**
      * @description Boolean that allows for disabling drop shadow under navigation header. The default value is true.
      */
     hideShadow?: boolean;

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -84,17 +84,9 @@ declare module 'react-native-screens' {
      */
     backgroundColor?: string;
     /**
-     *@description Controlls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
-     */
-    scrollEdgeBackgroundColor?: string;
-    /**
      * @description Boolean that allows for disabling drop shadow under navigation header. The default value is true.
      */
     hideShadow?: boolean;
-    /**
-     * @description Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
-     */
-    scrollEdgeHideShadow?: boolean;
     /**
      * @description If set to true the back button will not be rendered as a part of navigation header.
      */
@@ -134,6 +126,14 @@ declare module 'react-native-screens' {
      * @description Customize the size of the font to be used for the large title.
      */
     largeTitleFontSize?: number;
+    /**
+     *@description Controlls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+     */
+    largeTitleBackgroundColor?: string;
+    /**
+     * @description Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+     */
+    largeTitleHideShadow?: boolean;
     /**
      * Pass HeaderLeft, HeaderRight and HeaderTitle
      */


### PR DESCRIPTION
New props allowing to:
- define the background color 
- hide the shadow

of the header when the edge of any scrollable content reaches the matching edge of the navigation bar.

See [scrollEdgeAppearance](https://developer.apple.com/documentation/uikit/uinavigationitem/3198041-scrolledgeappearance)