### PR TITLE
Default to absolute fill for stack screen items.

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -204,7 +204,7 @@ class StackView extends React.Component {
     return (
       <Screen
         key={`screen_${route.key}`}
-        style={options.cardStyle}
+        style={[StyleSheet.absoluteFill, options.cardStyle]}
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}
         gestureEnabled={


### PR DESCRIPTION
This change makes navigation screen wrapper to set absolute fill style for screen items wrendered within native stack. We obvserved an issue where screens are rendered with a versy small height when the initial style is not set properly on iOS. This change makes the screen default to full screen and only then be resized down in case navigation bars are set.

This is not an ideal solution and we likely want to come up with some solution that'd resolve issue with an additional layout passes for native screen and that does not depend on us relying on navigation wrapper but for now this fixes the problem for navigation wrapper consumers.