### PR TITLE
Add support for disabling animations when presenting/dismissing modals on iOS

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -210,6 +210,14 @@
     for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
       UIViewController *next = controllers[i];
       BOOL animate = (i == controllers.count - 1);
+
+      if (animate && [next.view isKindOfClass:[RNSScreenView class]]) {
+        RNSScreenView *screen = (RNSScreenView*)next.view;
+        if (screen.stackAnimation == RNSScreenStackAnimationNone) {
+          animate = NO;
+        }
+      }
+
       [previous presentViewController:next
                              animated:animate
                            completion:animate ? dispatchFinishTransitioning : nil];
@@ -221,8 +229,19 @@
   };
 
   if (changeRootController.presentedViewController) {
+    BOOL animate = (changeRootIndex == controllers.count);
+
+    UIViewController *lastTop = _controller.viewControllers.lastObject;
+
+    if (animate && lastTop && [lastTop.view isKindOfClass:[RNSScreenView class]]) {
+      RNSScreenView *screen = (RNSScreenView*)lastTop.view;
+      if (screen.stackAnimation == RNSScreenStackAnimationNone) {
+        animate = NO;
+      }
+    }
+
     [changeRootController
-     dismissViewControllerAnimated:(changeRootIndex == controllers.count)
+     dismissViewControllerAnimated:animate
      completion:finish];
   } else {
     finish();


### PR DESCRIPTION
Currently, there's no way to disable the system animation for presenting modal view controllers.

if you're using the native stack navigator on iOS and you have a modal with a custom animation, it presents the new controller with the system animation, and then your modal with the custom animation will trigger – two animations, when you only meant for one to happen. 

To address this, I made it so that, when presenting the next view controller, it checks if the `RNSScreenView` has `stackAnimation` set to `RNSScreenStackAnimationNone`, and if so,`animated` will be `NO`. It also does the reverse check when dismissing, but relying on the top screen. 

- I tested this manually in my app, though I also noticed a possible memory leak on modals that have been dismissed. I don't think the memory leak is related to this PR though.
- I'm not totally sure about using `stackAnimation` for this, since `stack` and `modal` are not the same thing....but it seems like the easiest way to do this while introducing the fewest number of changes.
- This probably should be considered a breaking change, since it might change behavior for _some_ existing apps using the 2.0.0 beta. If merged, I would suggest bumping the version to 2.1.0 beta.