### PR TITLE
Android fix for invisible stack views after navigating back

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -23,6 +23,10 @@ public class ScreenFragment extends Fragment {
       ((ViewGroup) parent).endViewTransition(view);
       ((ViewGroup) parent).removeView(view);
     }
+    // view detached from fragment manager get their visibility changed to GONE after their state is
+    // dumped. Since we don't restore the state but want to reuse the view we need to change visibility
+    // back to VISIBLE in order for the fragment manager to animate in the view.
+    view.setVisibility(View.VISIBLE);
     return view;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -32,11 +32,6 @@ public class ScreenStackFragment extends ScreenFragment {
     }
 
     @Override
-    public void startAnimation(Animation animation) {
-      super.startAnimation(animation);
-    }
-
-    @Override
     protected void onAnimationEnd() {
       super.onAnimationEnd();
       mFragment.onViewAnimationEnd();


### PR DESCRIPTION
After fragment library upgrade we observed a regression caused by the screens that we navigate back to being invisible. This turned out to be a problem with view restore mechanism that we don't rely on. On native android the detached view state is dumped and then view's visibility is change to GONE after screen animated away. However, since we don't rely on view state restore and instead just reuse the whole view object, when navigating back we'd move to a view with visibility set to GONE. This change workarounds this problem in the method responsible for recycling views where we reset visibility flag back to VISIBLE.