### PR TITLE
check object instance of before calling detachScreen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -252,7 +252,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     if (!orphaned.isEmpty()) {
       Object[] orphanedAry = orphaned.toArray();
       for (int i = 0; i < orphanedAry.length; i++) {
-        detachScreen((ScreenFragment) orphanedAry[i]);
+        if (orphanedAry[i] instanceof ScreenFragment) {
+          detachScreen((ScreenFragment) orphanedAry[i]);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #343 

This change filters out non ScreenFragment instances when iterating through the list of installed fragments. The reason why other fragments can be added to the manager is that some libraries (e.g. glide) use fragment manager to store screen local data and attach to the screen lifecycle.
