### PR TITLE
Enable to control content insets in Android Toolbar from React Native

### DIFF
--- a/Example/nativeStack.js
+++ b/Example/nativeStack.js
@@ -64,7 +64,11 @@ export class Stack extends Component {
         stackAnimation="fade"
         active={1}
         onDismissed={() => this.removeByKey(key)}>
-        <ScreenStackHeaderConfig title={key}>
+        <ScreenStackHeaderConfig
+          title={key}
+          insetLeft={0}
+          insetRight={0}
+          insetBackButton={11}>
           {/* {index === 0 && (
             <ScreenStackHeaderLeftView>
               <TouchableHighlight onPress={() => alert('sdf')}>

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -4811,7 +4811,7 @@ react-native-safe-area-view@^0.14.1:
     debounce "^1.2.0"
 
 "react-native-screens@file:..":
-  version "2.0.0-alpha.22"
+  version "2.0.0-beta.7"
   dependencies:
     debounce "^1.2.0"
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ If set to `true` the back button will not be rendered as a part of navigation he
 
 When set to `false` the back swipe gesture will be disabled when the parent `Screen` is on top of the stack. The default value is `true`.
 
+#### `insetBackButton` (Android only)
+
+Customize the inset between back button and content, it will still has small space between due size of image view containing icon. 
+ 
+#### `insetBackButton` (Android only)
+
+Customize the inset between end action and content.
+
+#### `insetLeft` (Android only)
+
+Customize the inset on left size of content.
+
+#### `insetRight` (Android only)
+
+Customize the inset on left size of content.
+
 #### `translucent` (iOS only)
 
 When set to `true`, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is `false`.

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ A callback that gets called when the current screen is dismissed by hardware bac
 
 #### `stackAnimation`
 
-Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The followin values are currently supported:
+Allows for the customization of how the given screen should appear/disappear when pushed or popped at the top of the stack. The following values are currently supported:
  - `"default"` – uses a platform default animation
  - `"fade"` – fades screen in or out
  - `"flip"` – flips the screen, requires `stackPresentation: "modal"` (iOS only)
- - `"none"` – the screen appears/dissapears without an animation
+ - `"none"` – the screen appears/disappears without an animation
 
  #### `stackPresentation`
 
@@ -155,7 +155,7 @@ Defines how the method that should be used to present the given screen. It is a 
 The config component is expected to be rendered as a direct children of `<Screen>`. It provides an ability to configure native navigation header that gets rendered as a part of native screen stack. The component acts as a "virtual" element that is not directly rendered under `Screen`. You can use its properties to customize platform native header for the parent screen and also render react-native components that you'd like to be displayed inside the header (e.g. in the title are or on the side).
 
 Along with this component properties that can be used to customize header behavior one can also use one or the below component containers to render custom react-native content in different areas of the native header:
- - `ScreenStackHeaderCenterView` – the childern will render in the center of the native navigation bar.
+ - `ScreenStackHeaderCenterView` – the children will render in the center of the native navigation bar.
  - `ScreenStackHeaderRightView` – the children will render on the right hand side of the navigation bar (or on the left hand side in case LTR locales are set on the user's device).
  - `ScreenStackHeaderLeftView` – the children will render on the left hand side of the navigation bar (or on the right hand side in case LTR locales are set on the user's device).
 
@@ -188,7 +188,7 @@ Allows for setting text color of the title.
 
 #### `backgroundColor`
 
-Controlls the color of the navigation header.
+Controls the color of the navigation header.
 
 #### `hideShadow`
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -23,297 +23,334 @@ import java.util.ArrayList;
 
 public class ScreenStackHeaderConfig extends ViewGroup {
 
-  private final ArrayList<ScreenStackHeaderSubview> mConfigSubviews = new ArrayList<>(3);
-  private String mTitle;
-  private int mTitleColor;
-  private String mTitleFontFamily;
-  private float mTitleFontSize;
-  private int mBackgroundColor;
-  private boolean mIsHidden;
-  private boolean mIsBackButtonHidden;
-  private boolean mIsShadowHidden;
-  private boolean mDestroyed;
-  private int mTintColor;
-  private final Toolbar mToolbar;
+    private final ArrayList<ScreenStackHeaderSubview> mConfigSubviews = new ArrayList<>(3);
+    private String mTitle;
+    private int mTitleColor;
+    private String mTitleFontFamily;
+    private float mTitleFontSize;
+    private int mBackgroundColor;
+    private boolean mIsHidden;
+    private boolean mIsBackButtonHidden;
+    private int mInsetBackButton = -1;
+    private int mInsetEndAction = -1;
+    private int mInsetLeft = -1;
+    private int mInsetRight = -1;
+    private boolean mIsShadowHidden;
+    private boolean mDestroyed;
+    private int mTintColor;
+    private final Toolbar mToolbar;
 
-  private boolean mIsAttachedToWindow = false;
+    private boolean mIsAttachedToWindow = false;
 
-  private OnClickListener mBackClickListener = new OnClickListener() {
+    private OnClickListener mBackClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            ScreenStack stack = getScreenStack();
+            ScreenStackFragment fragment = getScreenFragment();
+            if (stack.getRootScreen() == fragment.getScreen()) {
+                Fragment parentFragment = fragment.getParentFragment();
+                if (parentFragment instanceof ScreenStackFragment) {
+                    ((ScreenStackFragment) parentFragment).dismiss();
+                }
+            } else {
+                fragment.dismiss();
+            }
+        }
+    };
+
+    public ScreenStackHeaderConfig(Context context) {
+        super(context);
+        setVisibility(View.GONE);
+
+        mToolbar = new Toolbar(context);
+
+        // set primary color as background by default
+        TypedValue tv = new TypedValue();
+        if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
+            mToolbar.setBackgroundColor(tv.data);
+        }
+    }
+
     @Override
-    public void onClick(View view) {
-      ScreenStack stack = getScreenStack();
-      ScreenStackFragment fragment = getScreenFragment();
-      if (stack.getRootScreen() == fragment.getScreen()) {
-        Fragment parentFragment = fragment.getParentFragment();
-        if (parentFragment instanceof ScreenStackFragment) {
-          ((ScreenStackFragment) parentFragment).dismiss();
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        // no-op
+    }
+
+    public void destroy() {
+        mDestroyed = true;
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        mIsAttachedToWindow = true;
+        onUpdate();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        mIsAttachedToWindow = false;
+    }
+
+    private Screen getScreen() {
+        ViewParent screen = getParent();
+        if (screen instanceof Screen) {
+            return (Screen) screen;
         }
-      } else {
-        fragment.dismiss();
-      }
-    }
-  };
-
-  public ScreenStackHeaderConfig(Context context) {
-    super(context);
-    setVisibility(View.GONE);
-
-    mToolbar = new Toolbar(context);
-    // reset content insets to be 0 to allow react position custom navbar views. Note that this does
-    // not affect platform native back button as toolbar does not apply left inset when navigation
-    // button is specified
-    mToolbar.setContentInsetsAbsolute(0, 0);
-
-    // set primary color as background by default
-    TypedValue tv = new TypedValue();
-    if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
-      mToolbar.setBackgroundColor(tv.data);
-    }
-  }
-
-  @Override
-  protected void onLayout(boolean changed, int l, int t, int r, int b) {
-    // no-op
-  }
-
-  public void destroy() {
-    mDestroyed = true;
-  }
-
-  @Override
-  protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
-    mIsAttachedToWindow = true;
-    onUpdate();
-  }
-
-  @Override
-  protected void onDetachedFromWindow() {
-    super.onDetachedFromWindow();
-    mIsAttachedToWindow = false;
-  }
-
-  private Screen getScreen() {
-    ViewParent screen = getParent();
-    if (screen instanceof Screen) {
-      return (Screen) screen;
-    }
-    return null;
-  }
-
-  private ScreenStack getScreenStack() {
-    Screen screen = getScreen();
-    if (screen  != null) {
-      ScreenContainer container = screen.getContainer();
-      if (container instanceof ScreenStack) {
-        return (ScreenStack) container;
-      }
-    }
-    return null;
-  }
-
-  private ScreenStackFragment getScreenFragment() {
-    ViewParent screen = getParent();
-    if (screen instanceof Screen) {
-      Fragment fragment = ((Screen) screen).getFragment();
-      if (fragment instanceof ScreenStackFragment) {
-        return (ScreenStackFragment) fragment;
-      }
-    }
-    return null;
-  }
-
-  public void onUpdate() {
-    Screen parent = (Screen) getParent();
-    final ScreenStack stack = getScreenStack();
-    boolean isTop = stack == null ? true : stack.getTopScreen() == parent;
-
-    if (!mIsAttachedToWindow || !isTop || mDestroyed) {
-      return;
+        return null;
     }
 
-    AppCompatActivity activity = (AppCompatActivity) getScreenFragment().getActivity();
-    if (activity == null) {
-      return;
-    }
-
-    if (mIsHidden) {
-      if (mToolbar.getParent() != null) {
-        getScreenFragment().removeToolbar();
-      }
-      return;
-    }
-
-    if (mToolbar.getParent() == null) {
-      getScreenFragment().setToolbar(mToolbar);
-    }
-
-    activity.setSupportActionBar(mToolbar);
-    ActionBar actionBar = activity.getSupportActionBar();
-
-    // hide back button
-    actionBar.setDisplayHomeAsUpEnabled(getScreenFragment().canNavigateBack() ? !mIsBackButtonHidden : false);
-
-    // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
-    // navigation click listener. The default behavior set in the wrapper is to call into
-    // menu options handlers, but we prefer the back handling logic to stay here instead.
-    mToolbar.setNavigationOnClickListener(mBackClickListener);
-
-
-    // shadow
-    getScreenFragment().setToolbarShadowHidden(mIsShadowHidden);
-
-    // title
-    actionBar.setTitle(mTitle);
-    TextView titleTextView = getTitleTextView();
-    if (mTitleColor != 0) {
-      mToolbar.setTitleTextColor(mTitleColor);
-    }
-    if (titleTextView != null) {
-      if (mTitleFontFamily != null) {
-        titleTextView.setTypeface(ReactFontManager.getInstance().getTypeface(
-                mTitleFontFamily, 0, getContext().getAssets()));
-      }
-      if (mTitleFontSize > 0) {
-        titleTextView.setTextSize(mTitleFontSize);
-      }
-    }
-
-    // background
-    if (mBackgroundColor != 0) {
-      mToolbar.setBackgroundColor(mBackgroundColor);
-    }
-
-    // color
-    if (mTintColor != 0) {
-      Drawable navigationIcon = mToolbar.getNavigationIcon();
-      if (navigationIcon != null) {
-        navigationIcon.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP);
-      }
-    }
-
-    // subviews
-    for (int i = mToolbar.getChildCount() - 1; i >= 0; i--) {
-      if (mToolbar.getChildAt(i) instanceof ScreenStackHeaderSubview) {
-        mToolbar.removeViewAt(i);
-      }
-    }
-    for (int i = 0, size = mConfigSubviews.size(); i < size; i++) {
-      ScreenStackHeaderSubview view = mConfigSubviews.get(i);
-      ScreenStackHeaderSubview.Type type = view.getType();
-
-      if (type == ScreenStackHeaderSubview.Type.BACK) {
-        // we special case BACK button header config type as we don't add it as a view into toolbar
-        // but instead just copy the drawable from imageview that's added as a first child to it.
-        View firstChild = view.getChildAt(0);
-        if (!(firstChild instanceof ImageView)) {
-          throw new JSApplicationIllegalArgumentException("Back button header config view should have Image as first child");
+    private ScreenStack getScreenStack() {
+        Screen screen = getScreen();
+        if (screen != null) {
+            ScreenContainer container = screen.getContainer();
+            if (container instanceof ScreenStack) {
+                return (ScreenStack) container;
+            }
         }
-        actionBar.setHomeAsUpIndicator(((ImageView) firstChild).getDrawable());
-        continue;
-      }
-
-      Toolbar.LayoutParams params =
-              new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
-
-      switch (type) {
-        case LEFT:
-          // when there is a left item we need to disable navigation icon
-          // we also hide title as there is no other way to display left side items
-          mToolbar.setNavigationIcon(null);
-          mToolbar.setTitle(null);
-          params.gravity = Gravity.LEFT;
-          break;
-        case RIGHT:
-          params.gravity = Gravity.RIGHT;
-          break;
-        case CENTER:
-          params.width = LayoutParams.MATCH_PARENT;
-          params.gravity = Gravity.CENTER_HORIZONTAL;
-          mToolbar.setTitle(null);
-          break;
-      }
-
-      view.setLayoutParams(params);
-      mToolbar.addView(view);
+        return null;
     }
-  }
 
-  private void maybeUpdate() {
-    if (getParent() != null && !mDestroyed) {
-      onUpdate();
-    }
-  }
-
-  public ScreenStackHeaderSubview getConfigSubview(int index) {
-    return mConfigSubviews.get(index);
-  }
-
-  public int getConfigSubviewsCount() {
-    return mConfigSubviews.size();
-  }
-
-  public void removeConfigSubview(int index) {
-    mConfigSubviews.remove(index);
-    maybeUpdate();
-  }
-
-  public void removeAllConfigSubviews() {
-    mConfigSubviews.clear();
-    maybeUpdate();
-  }
-
-  public void addConfigSubview(ScreenStackHeaderSubview child, int index) {
-    mConfigSubviews.add(index, child);
-    maybeUpdate();
-  }
-
-  private TextView getTitleTextView() {
-    for (int i = 0, size = mToolbar.getChildCount(); i < size; i++) {
-      View view = mToolbar.getChildAt(i);
-      if (view instanceof TextView) {
-        TextView tv = (TextView) view;
-        if (tv.getText().equals(mToolbar.getTitle())) {
-          return tv;
+    private ScreenStackFragment getScreenFragment() {
+        ViewParent screen = getParent();
+        if (screen instanceof Screen) {
+            Fragment fragment = ((Screen) screen).getFragment();
+            if (fragment instanceof ScreenStackFragment) {
+                return (ScreenStackFragment) fragment;
+            }
         }
-      }
+        return null;
     }
-    return null;
-  }
 
-  public void setTitle(String title) {
-    mTitle = title;
-  }
+    public void onUpdate() {
+        Screen parent = (Screen) getParent();
+        final ScreenStack stack = getScreenStack();
+        boolean isTop = stack == null ? true : stack.getTopScreen() == parent;
 
-  public void setTitleFontFamily(String titleFontFamily) {
-    mTitleFontFamily = titleFontFamily;
-  }
+        if (!mIsAttachedToWindow || !isTop || mDestroyed) {
+            return;
+        }
 
-  public void setTitleFontSize(float titleFontSize) {
-    mTitleFontSize = titleFontSize;
-  }
+        AppCompatActivity activity = (AppCompatActivity) getScreenFragment().getActivity();
+        if (activity == null) {
+            return;
+        }
 
-  public void setTitleColor(int color) {
-    mTitleColor = color;
-  }
+        if (mIsHidden) {
+            if (mToolbar.getParent() != null) {
+                getScreenFragment().removeToolbar();
+            }
+            return;
+        }
 
-  public void setTintColor(int color) {
-    mTintColor = color;
-  }
+        if (mToolbar.getParent() == null) {
+            getScreenFragment().setToolbar(mToolbar);
+        }
 
-  public void setBackgroundColor(int color) {
-    mBackgroundColor = color;
-  }
+        activity.setSupportActionBar(mToolbar);
+        ActionBar actionBar = activity.getSupportActionBar();
 
-  public void setHideShadow(boolean hideShadow) {
-    mIsShadowHidden = hideShadow;
-  }
+        // hide back button
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(getScreenFragment().canNavigateBack() && !mIsBackButtonHidden);
+        }
 
-  public void setHideBackButton(boolean hideBackButton) {
-    mIsBackButtonHidden = hideBackButton;
-  }
+        // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
+        // navigation click listener. The default behavior set in the wrapper is to call into
+        // menu options handlers, but we prefer the back handling logic to stay here instead.
+        mToolbar.setNavigationOnClickListener(mBackClickListener);
 
-  public void setHidden(boolean hidden) {
-    mIsHidden = hidden;
-  }
+        //content insets
+        setConsentInsets();
+
+        // shadow
+        getScreenFragment().setToolbarShadowHidden(mIsShadowHidden);
+
+        // title
+        actionBar.setTitle(mTitle);
+        TextView titleTextView = getTitleTextView();
+        if (mTitleColor != 0) {
+            mToolbar.setTitleTextColor(mTitleColor);
+        }
+        if (titleTextView != null) {
+            if (mTitleFontFamily != null) {
+                titleTextView.setTypeface(ReactFontManager.getInstance().getTypeface(
+                        mTitleFontFamily, 0, getContext().getAssets()));
+            }
+            if (mTitleFontSize > 0) {
+                titleTextView.setTextSize(mTitleFontSize);
+            }
+        }
+
+        // background
+        if (mBackgroundColor != 0) {
+            mToolbar.setBackgroundColor(mBackgroundColor);
+        }
+
+        // color
+        if (mTintColor != 0) {
+            Drawable navigationIcon = mToolbar.getNavigationIcon();
+            if (navigationIcon != null) {
+                navigationIcon.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP);
+            }
+        }
+
+        // subviews
+        for (int i = mToolbar.getChildCount() - 1; i >= 0; i--) {
+            if (mToolbar.getChildAt(i) instanceof ScreenStackHeaderSubview) {
+                mToolbar.removeViewAt(i);
+            }
+        }
+        for (int i = 0, size = mConfigSubviews.size(); i < size; i++) {
+            ScreenStackHeaderSubview view = mConfigSubviews.get(i);
+            ScreenStackHeaderSubview.Type type = view.getType();
+
+            if (type == ScreenStackHeaderSubview.Type.BACK) {
+                // we special case BACK button header config type as we don't add it as a view into toolbar
+                // but instead just copy the drawable from imageview that's added as a first child to it.
+                View firstChild = view.getChildAt(0);
+                if (!(firstChild instanceof ImageView)) {
+                    throw new JSApplicationIllegalArgumentException("Back button header config view should have Image as first child");
+                }
+                actionBar.setHomeAsUpIndicator(((ImageView) firstChild).getDrawable());
+                continue;
+            }
+
+            Toolbar.LayoutParams params =
+                    new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+
+            switch (type) {
+                case LEFT:
+                    // when there is a left item we need to disable navigation icon
+                    // we also hide title as there is no other way to display left side items
+                    mToolbar.setNavigationIcon(null);
+                    mToolbar.setTitle(null);
+                    params.gravity = Gravity.LEFT;
+                    break;
+                case RIGHT:
+                    params.gravity = Gravity.RIGHT;
+                    break;
+                case CENTER:
+                    params.width = LayoutParams.MATCH_PARENT;
+                    params.gravity = Gravity.CENTER_HORIZONTAL;
+                    mToolbar.setTitle(null);
+                    break;
+            }
+
+            view.setLayoutParams(params);
+            mToolbar.addView(view);
+        }
+    }
+
+    private void maybeUpdate() {
+        if (getParent() != null && !mDestroyed) {
+            onUpdate();
+        }
+    }
+
+    public ScreenStackHeaderSubview getConfigSubview(int index) {
+        return mConfigSubviews.get(index);
+    }
+
+    public int getConfigSubviewsCount() {
+        return mConfigSubviews.size();
+    }
+
+    public void removeConfigSubview(int index) {
+        mConfigSubviews.remove(index);
+        maybeUpdate();
+    }
+
+    public void removeAllConfigSubviews() {
+        mConfigSubviews.clear();
+        maybeUpdate();
+    }
+
+    public void addConfigSubview(ScreenStackHeaderSubview child, int index) {
+        mConfigSubviews.add(index, child);
+        maybeUpdate();
+    }
+
+    /*
+     * Sets insets to toolbar content if specified or use default native defaults
+     * */
+    private void setConsentInsets() {
+        if (mInsetLeft == -1) mInsetLeft = mToolbar.getContentInsetStart();
+        if (mInsetRight == -1) mInsetRight = mToolbar.getContentInsetEnd();
+
+        mToolbar.setContentInsetsAbsolute(mInsetLeft, mInsetRight);
+
+        if (mInsetBackButton != -1)
+            mToolbar.setContentInsetStartWithNavigation(mInsetBackButton);
+
+        if (mInsetEndAction != -1)
+            mToolbar.setContentInsetEndWithActions(mInsetEndAction);
+    }
+
+
+    private TextView getTitleTextView() {
+        for (int i = 0, size = mToolbar.getChildCount(); i < size; i++) {
+            View view = mToolbar.getChildAt(i);
+            if (view instanceof TextView) {
+                TextView tv = (TextView) view;
+                if (tv.getText().equals(mToolbar.getTitle())) {
+                    return tv;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void setTitle(String title) {
+        mTitle = title;
+    }
+
+    public void setTitleFontFamily(String titleFontFamily) {
+        mTitleFontFamily = titleFontFamily;
+    }
+
+    public void setTitleFontSize(float titleFontSize) {
+        mTitleFontSize = titleFontSize;
+    }
+
+    public void setTitleColor(int color) {
+        mTitleColor = color;
+    }
+
+    public void setTintColor(int color) {
+        mTintColor = color;
+    }
+
+    public void setBackgroundColor(int color) {
+        mBackgroundColor = color;
+    }
+
+    public void setHideShadow(boolean hideShadow) {
+        mIsShadowHidden = hideShadow;
+    }
+
+    public void setHideBackButton(boolean hideBackButton) {
+        mIsBackButtonHidden = hideBackButton;
+    }
+
+    public void setInsetBackButton(int insetBackButton) {
+        mInsetBackButton = insetBackButton;
+    }
+
+    public void setInsetEndAction(int insetEndAction) {
+        mInsetEndAction = insetEndAction;
+    }
+
+    public void setInsetLeft(int insetLeft) {
+        mInsetLeft = insetLeft;
+    }
+
+    public void setInsetRight(int insetRight) {
+        mInsetRight = insetRight;
+    }
+
+    public void setHidden(boolean hidden) {
+        mIsHidden = hidden;
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -114,6 +114,25 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHidden(hidden);
   }
 
+  @ReactProp(name = "insetBackButton")
+  public void setInsetBackButton(ScreenStackHeaderConfig config, int insetBackButton) {
+    config.setInsetBackButton(insetBackButton);
+  }
+
+  @ReactProp(name = "insetEndAction")
+  public void setInsetEndAction(ScreenStackHeaderConfig config, int insetEndAction) {
+    config.setInsetEndAction(insetEndAction);
+  }
+  @ReactProp(name = "insetRight")
+  public void setInsetRight(ScreenStackHeaderConfig config, int insetRight) {
+    config.setInsetRight(insetRight);
+  }
+
+  @ReactProp(name = "insetLeft")
+  public void setInsetLeft(ScreenStackHeaderConfig config, int insetLeft) {
+    config.setInsetLeft(insetLeft);
+  }
+
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -72,6 +72,10 @@ class StackView extends React.Component {
       headerLargeTitleStyle,
       translucent,
       hideShadow,
+      insetLeft,
+      insetRight,
+      insetBackButton,
+      insetEndAction,
     } = options;
 
     const scene = {
@@ -98,6 +102,10 @@ class StackView extends React.Component {
       largeTitleFontSize:
         headerLargeTitleStyle && headerLargeTitleStyle.fontSize,
       hideShadow,
+      insetLeft,
+      insetRight,
+      insetBackButton,
+      insetEndAction,
     };
 
     const hasHeader = headerMode !== 'none' && options.header !== null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "First incomplete navigation solution for your react-native app.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -92,6 +92,24 @@ declare module 'react-native-screens' {
      */
     hideBackButton?: boolean;
     /**
+     * @host (Android only)
+     * @description Customize the inset between back button and content, it will still has small space between due size of image view containing icon.
+     */
+    insetBackButton?: number;
+    /**
+     * @host (Android only)
+     * @description Customize the inset between end action and content */
+    insetEndAction?: number;
+    /**
+     * @host (Android only)
+     * @description Customize the inset on left size of content  */
+    insetLeft?: number;
+    /**
+     * @host (Android only)
+     * @description Customize the inset on left size of content
+     */
+    insetRight?: number;
+    /**
      * @host (iOS only)
      * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
      */


### PR DESCRIPTION
From now on you can set inset on the left and right side of toolbar when there are not additional actions and inset between action button and toolbar content, keep in mind that it still has space that is forced by ImageView containing icon. 

Also added fixes for few typos in docs 😄 
resolves #332