### PR TITLE
Fix didMoveToWindow logic.

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -46,6 +46,11 @@
   // subviews
 }
 
+- (UIViewController *)reactViewController
+{
+  return _controller;
+}
+
 - (void)updateBounds
 {
   [_bridge.uiManager setSize:self.bounds.size forView:self];
@@ -268,6 +273,7 @@
 
 - (void)willMoveToParentViewController:(UIViewController *)parent
 {
+  [super willMoveToParentViewController:parent];
   if (parent == nil) {
     id responder = [self findFirstResponder:self.view];
     if (responder != nil) {
@@ -282,9 +288,9 @@
   if (self.parentViewController == nil && self.presentingViewController == nil) {
     // screen dismissed, send event
     [((RNSScreenView *)self.view) notifyDismissed];
-    _view = self.view;
-    self.view = nil;
   }
+  _view = self.view;
+  self.view = nil;
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -158,20 +158,11 @@
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+  [self reactAddControllerToClosestParent:_controller];
   _controller.view.frame = self.bounds;
   for (RNSScreenView *subview in _reactSubviews) {
     subview.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
     [subview setNeedsLayout];
-  }
-}
-
-- (void)didMoveToWindow
-{
-  if (self.window) {
-    [self reactAddControllerToClosestParent:_controller];
-  } else {
-    [_controller removeFromParentViewController];
-    [_controller didMoveToParentViewController:nil];
   }
 }
 


### PR DESCRIPTION
This change fixes logic that we run when stack is moved to a window. Before we'd first attach stack to parent VC and then run updateContainer. This could've led to a buggy behavior in case the stack is mounted within other stack that is running a transition (e.g. dismissing a modal). In such a case setting initial push VCs would fail (because UIKit does not allow push to be modified while transitioning). Because of that stack would initialize with the dummy VC and the initial VC would get added to dismissedScreens (which is another side effect of the logic that keeps track of dismissed screens).

The fix was to add call to updateContainer before VC is added to parent. This makes it possible for push screens to be properly initialized (since VC is not yet added it does not know its parent is transitioning). Then, since updating modals handles gracefully the case when modals cannot be shown (and they wont be shown unless added to parent VC) we can safely run updateContainer yet another time after the VC is added to parent.

Howeer after the above fix was applied we observed another issue that was due to an invalida appear/disappear event management within view controllers. To address that fix we no longer allow navigaton VC's view to be added to the container view unless it starts transition to parent view controller. We also fixed missing calls to super in willMoveToParentViewController callback of RNSScreen controller and also fixed view reference management withing RNScreen to keep views as weak references while the view is not attached. The latter fixes the problem with screen view leaking under certain conditions.