### PR TITLE
Fix no view found crash in fragment manager.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -218,6 +218,10 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
 
   @Override
   protected void onDetachedFromWindow() {
+    // if there are pending transactions and this view is about to get detached we need to perform
+    // them here as otherwise fragment manager will crash because it won't be able to find container
+    // view.
+    mFragmentManager.executePendingTransactions();
     super.onDetachedFromWindow();
     mIsAttached = false;
   }


### PR DESCRIPTION
This change fixes issue reported in #54. The issue was caused by the fragment transaction that run past the moment when container view is detached. This could happen when container is quickly added and removed as fragment transactions sometimes may take long time to execute. Unfortunately enqueued fragment transactions cannot be cancelled, so to make sure that transaction isn't run past container unmount we call executePendingTransactions right before the screen is detached.