### PR TITLE
Verify integrity of fragment manager before executePendingTransactions on detach.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -221,7 +221,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     // if there are pending transactions and this view is about to get detached we need to perform
     // them here as otherwise fragment manager will crash because it won't be able to find container
     // view.
-    mFragmentManager.executePendingTransactions();
+    if (mFragmentManager != null && !mFragmentManager.isDestroyed()) {
+      mFragmentManager.executePendingTransactions();
+    }
     super.onDetachedFromWindow();
     mIsAttached = false;
   }


### PR DESCRIPTION
This PR fixes an issue introduced by executePendingTransactions call added in #376 