### PR TITLE
Fix offset left after popping in JS stack on iOS

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -54,7 +54,7 @@
 {
   subview.reactSuperview = self;
   [_reactSubviews insertObject:subview atIndex:atIndex];
-  subview.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
+  [subview reactSetFrame:CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height)];
 }
 
 - (void)removeReactSubview:(RNSScreenView *)subview
@@ -181,7 +181,7 @@
   [super layoutSubviews];
   _controller.view.frame = self.bounds;
   for (RNSScreenView *subview in _reactSubviews) {
-    subview.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
+    [subview reactSetFrame:CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height)];
     [subview setNeedsLayout];
   }
 }


### PR DESCRIPTION
UIkit calculated center of RCTView with transform offset. In order to avoid that we can use `reactSetFrame` method.