### PR TITLE
Properly update header for non-animated transitions and on old iOS devices

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -63,7 +63,7 @@
       break;
     }
   }
-  [RNSScreenStackHeaderConfig willShowViewController:viewController withConfig:config];
+  [RNSScreenStackHeaderConfig willShowViewController:viewController animated:animated withConfig:config];
 }
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -202,6 +202,11 @@
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
         [controller didMoveToParentViewController:parentView.reactViewController];
+        // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
+        // get triggered when the navigation controller is instantiated. As the only thing we do in
+        // that delegate method is ask nav header to update to the current state it does not hurt to
+        // trigger that logic from here too such that we can be sure the header is properly updated.
+        [self navigationController:_controller willShowViewController:_controller.topViewController animated:NO];
         break;
       }
       parentView = (UIView *)parentView.reactSuperview;

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -24,7 +24,7 @@
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 
-+ (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;
++ (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -97,7 +97,9 @@
   }
 
   if (vc != nil && nextVC == vc) {
-    [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self];
+    [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller
+                                          withConfig:self
+                                            animated:YES];
   }
 }
 
@@ -249,12 +251,12 @@
   return nil;
 }
 
-+ (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
++ (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig *)config
 {
-  [self updateViewController:vc withConfig:config];
+  [self updateViewController:vc withConfig:config animated:animated];
 }
 
-+ (void)updateViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
++ (void)updateViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config animated:(BOOL)animated
 {
   UINavigationItem *navitem = vc.navigationItem;
   UINavigationController *navctr = (UINavigationController *)vc.parentViewController;
@@ -274,7 +276,7 @@
     vc.edgesForExtendedLayout = UIRectEdgeAll;
   }
 
-  [navctr setNavigationBarHidden:shouldHide animated:YES];
+  [navctr setNavigationBarHidden:shouldHide animated:animated];
 
   if (shouldHide) {
     return;
@@ -417,7 +419,8 @@
     }
   }
 
-  if (vc.transitionCoordinator != nil
+  if (animated
+      && vc.transitionCoordinator != nil
       && vc.transitionCoordinator.presentationStyle == UIModalPresentationNone
       && !wasHidden) {
     // when there is an ongoing transition we may need to update navbar setting in animation block


### PR DESCRIPTION
This change fixes an issue when navigation header wasn't properly updated on mount time. The issue was due to us trying to animate transition while adding initial set of push VCs should never be animated. On top of that we observed that willShow delegate method wasn't getting triggered in some cases on old iOS devices. We added additional call to updating the header during mount time to workaround that.