### PR TITLE
Fix NPE crash in back click listener.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -41,15 +41,17 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private OnClickListener mBackClickListener = new OnClickListener() {
     @Override
     public void onClick(View view) {
-      ScreenStack stack = getScreenStack();
       ScreenStackFragment fragment = getScreenFragment();
-      if (stack.getRootScreen() == fragment.getScreen()) {
-        Fragment parentFragment = fragment.getParentFragment();
-        if (parentFragment instanceof ScreenStackFragment) {
-          ((ScreenStackFragment) parentFragment).dismiss();
+      if (fragment != null) {
+        ScreenStack stack = getScreenStack();
+        if (stack != null && stack.getRootScreen() == fragment.getScreen()) {
+          Fragment parentFragment = fragment.getParentFragment();
+          if (parentFragment instanceof ScreenStackFragment) {
+            ((ScreenStackFragment) parentFragment).dismiss();
+          }
+        } else {
+          fragment.dismiss();
         }
-      } else {
-        fragment.dismiss();
       }
     }
   };


### PR DESCRIPTION
Unders some conditions it is possible that back click listener is triggered after the fragment is already unmounted. This is due to the fact that the fragment lifecycle can be controlled from JS. We need to add extra null checks to prevent from crashing in this case. There is no need to handle this case separately as we cannot dismiss screen fragment that is already unmounted.