### PR TITLE
Fix wrong import for react-navigation in v4 stack

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -5,7 +5,7 @@ import {
   SceneView,
   StackActions,
   createNavigator,
-} from '@react-navigation/core';
+} from 'react-navigation';
 import { HeaderBackButton } from 'react-navigation-stack';
 import {
   ScreenStack,


### PR DESCRIPTION
Navigators in v4 need to import from 'react-navigation' package instead of '@react-navigation/xxx'.