### PR TITLE
Reshuffle androidx dependencies not to require them being listed at the project level

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -171,8 +171,6 @@ android {
 dependencies {
     implementation project(':react-native-screens')
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 
     def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
 }
 


### PR DESCRIPTION
Unfortunately we still need to require swipetorefresh as some of the material classes use it without listing swipetorefresh package as dependency. However it appears like we can put all the dependencies in the screen build.gradle and not require additional dependencies to be listed in the app's top level gradle.