### PR TITLE
Fix enter animation on Android native stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -194,10 +194,10 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
 
     if (!mStack.contains(newTop)) {
       // if new top screen wasn't on stack we do "open animation" so long it is not the very first screen on stack
-      if (mTopScreen != null) {
+      if (mTopScreen != null && newTop != null) {
         // there was some other screen attached before
         int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
-        switch (mTopScreen.getScreen().getStackAnimation()) {
+        switch (newTop.getScreen().getStackAnimation()) {
           case NONE:
             transition = FragmentTransaction.TRANSIT_NONE;
             break;


### PR DESCRIPTION
This change fixes a bug that made us determine enter animation based on the previous screen setting rather than the new screen being added.