### PR TITLE
Xcode Semantic Issue: Block implicitly retains 'self'

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -211,10 +211,10 @@ RCT_EXPORT_MODULE()
     // we enqueue updates to be run on the main queue in order to make sure that
     // all this updates (new screens attached etc) are executed in one batch
     RCTExecuteOnMainQueue(^{
-      for (RNSScreenContainerView *container in _markedContainers) {
+      for (RNSScreenContainerView *container in self->_markedContainers) {
         [container updateContainer];
       }
-      [_markedContainers removeAllObjects];
+      [self->_markedContainers removeAllObjects];
     });
   }
 }


### PR DESCRIPTION
Xcode Semantic Issue: Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior