### PR TITLE
Fix push updates during transition

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
+@property (nonatomic, readonly) BOOL dismissed;
 @property (nonatomic) BOOL active;
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -27,6 +27,7 @@
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
     _gestureEnabled = YES;
+    _dismissed = NO;
   }
 
   return self;
@@ -168,6 +169,7 @@
 
 - (void)notifyDismissed
 {
+  _dismissed = YES;
   if (self.onDismissed) {
     dispatch_async(dispatch_get_main_queue(), ^{
       if (self.onDismissed) {

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -24,7 +24,6 @@
 @implementation RNSScreenStackView {
   UINavigationController *_controller;
   NSMutableArray<RNSScreenView *> *_reactSubviews;
-  NSMutableSet<RNSScreenView *> *_dismissedScreens;
   __weak RNSScreenStackManager *_manager;
 }
 
@@ -34,7 +33,6 @@
     _manager = manager;
     _reactSubviews = [NSMutableArray new];
     _presentedModals = [NSMutableArray new];
-    _dismissedScreens = [NSMutableSet new];
     _controller = [[UINavigationController alloc] init];
     _controller.delegate = self;
 
@@ -67,14 +65,6 @@
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-  for (NSUInteger i = _reactSubviews.count; i > 0; i--) {
-    RNSScreenView *screenView = [_reactSubviews objectAtIndex:i - 1];
-    if ([viewController isEqual:screenView.controller]) {
-      break;
-    } else if (screenView.stackPresentation == RNSScreenStackPresentationPush) {
-      [_dismissedScreens addObject:screenView];
-    }
-  }
   if (self.onFinishTransitioning) {
     self.onFinishTransitioning(nil);
   }
@@ -86,7 +76,6 @@
   // forward certain calls to the container (Stack).
   UIView *screenView = presentationController.presentedViewController.view;
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
-    [_dismissedScreens addObject:(RNSScreenView *)screenView];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the
@@ -155,7 +144,6 @@
 {
   subview.reactSuperview = nil;
   [_reactSubviews removeObject:subview];
-  [_dismissedScreens removeObject:subview];
 }
 
 - (NSArray<UIView *> *)reactSubviews
@@ -324,6 +312,21 @@
   if (self.window == nil) {
     return;
   }
+  // when transition is ongoing, any updates made to the controller will not be reflected until the
+  // transition is complete. In particular, when we push/pop view controllers we expect viewControllers
+  // property to be updated immediately. Based on that property we then calculate future updates.
+  // When the transition is ongoing the property won't be updated immediatly. We therefore avoid
+  // making any updated when transition is ongoing and schedule updates for when the transition
+  // is complete.
+  if (_controller.transitionCoordinator != nil) {
+    __weak RNSScreenStackView *weakSelf = self;
+    [_controller.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      // do nothing here, we only want to be notified when transition is complete
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      [weakSelf updateContainer];
+    }];
+    return;
+  }
 
   UIViewController *top = controllers.lastObject;
   UIViewController *lastTop = _controller.viewControllers.lastObject;
@@ -372,7 +375,7 @@
   NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
   NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
   for (RNSScreenView *screen in _reactSubviews) {
-    if (![_dismissedScreens containsObject:screen] && screen.controller != nil) {
+    if (!screen.dismissed && screen.controller != nil) {
       if (pushControllers.count == 0) {
         // first screen on the list needs to be places as "push controller"
         [pushControllers addObject:screen.controller];


### PR DESCRIPTION
This change fixes an issue that was caused by us updating view controllers while there was an ongoing transition.

When changes to viewControllers where made during other transition, the navigation controller wouldn't update view controllers property immediately. As a result we could've get out of sync between stack subviews and ciewController property. And some of the stack logic relied on those two props being in sync. In particular, when we make a push transition we expected viewControllers to contain newly pushed item so that we won't push it again in the future. However, the item wouldn't be added immediately if the controller was running the transition.

To fix that there are two key changes introduced here:
1) when updating push controllers, we check if nav controller is already running a transition. If so, we wait with the updates until the transition is over.
2) we no longer use didShowViewController delegate method to mark screens as dismissed. Apparently, that approach does not work when viewContollers and subviews are out of sync. Because of it, we'd mark newly added screens as dismissed just because there weren't yet added to viewControllers prop. Instead we introduced dismissed property directly in screen class which is set in viewWillDisappear. This way we no longer need to keep a set of dismissed screens.