### PR TITLE
Remove screens from dismissed registry

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -126,7 +126,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   @Override
   protected void removeScreenAt(int index) {
     Screen toBeRemoved = getScreenAt(index);
-    mDismissed.remove(toBeRemoved);
+    mDismissed.remove(toBeRemoved.getFragment());
     super.removeScreenAt(index);
   }
 


### PR DESCRIPTION
This change fixes a bug which resulted in screens being kept in dismissed registry when dismissed using hw back button or the navigation back button. The problem was that we were removing Screen classes while adding ScreenFragments tothe registry. As a result the added entries where never being wiped.