### PR TITLE
Fix focus events after native dismiss

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -30,6 +30,7 @@ class StackView extends React.Component {
   _removeScene = route => {
     this.props.navigation.dispatch({
       type: REMOVE_ACTION,
+      immediate: true,
       key: route.key,
     });
   };


### PR DESCRIPTION
This change fixes navigation state after native dismiss transition. We add 'immediate' flag to remove action as at the point dismiss event is triggered the transition has already completed.