### PR TITLE
Fix nav header not showing after being hidden and unhidden on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -51,8 +51,8 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   public void removeToolbar() {
-    if (mAppBarLayout != null) {
-      ((CoordinatorLayout) getView()).removeView(mAppBarLayout);
+    if (mAppBarLayout != null && mToolbar.getParent() == mAppBarLayout) {
+      mAppBarLayout.removeView(mToolbar);
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -51,9 +51,10 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   public void removeToolbar() {
-    if (mAppBarLayout != null && mToolbar.getParent() == mAppBarLayout) {
+    if (mAppBarLayout != null && mToolbar != null && mToolbar.getParent() == mAppBarLayout) {
       mAppBarLayout.removeView(mToolbar);
     }
+    mToolbar = null;
   }
 
   public void setToolbar(Toolbar toolbar) {


### PR DESCRIPTION
If a screen has dynamic navigation options which changes from 'header: null' to be showing headers, the nav header is not appearing on Android platform. This PR aims to fix this issue.