### PR TITLE
Add large title color prop to native stack navigator's headerLargeTitleStyle

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -102,6 +102,7 @@ class StackView extends React.Component {
         headerLargeTitleStyle && headerLargeTitleStyle.fontFamily,
       largeTitleFontSize:
         headerLargeTitleStyle && headerLargeTitleStyle.fontSize,
+      largeTitleColor: headerLargeTitleStyle && headerLargeTitleStyle.color,
       hideShadow,
     };
 

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -158,6 +158,7 @@ export type NativeStackNavigationOptions = {
   headerLargeTitleStyle?: {
     fontFamily?: string;
     fontSize?: number;
+    color?: string;
   };
   /**
    * Style object for header back title. Supported properties:

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -60,6 +60,7 @@ export default function HeaderConfig(props: Props) {
       largeTitle={headerLargeTitle}
       largeTitleFontFamily={headerLargeTitleStyle.fontFamily}
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
+      largeTitleColor={headerLargeTitleStyle.color}
       backgroundColor={
         headerStyle.backgroundColor !== undefined
           ? headerStyle.backgroundColor


### PR DESCRIPTION
Follow up PR to https://github.com/software-mansion/react-native-screens/pull/307. This PR allows native stack navigators to set the large title color as part of the `headerLargeTitleStyle` prop.