### PR TITLE
Fix 'No view found for' exception on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -23,6 +23,13 @@ public class ScreenFragment extends Fragment {
       ((ViewGroup) parent).endViewTransition(view);
       ((ViewGroup) parent).removeView(view);
     }
+    // the below check is here to help determine if crashes due to IllegalStateException with
+    // "child already has a parent" caused when view is created are there because for some reason
+    // the above code fails detach the view from its parent
+    if (view.getParent() != null) {
+      throw new IllegalStateException("Recycled fragment view is not detached from its parent");
+    }
+
     // view detached from fragment manager get their visibility changed to GONE after their state is
     // dumped. Since we don't restore the state but want to reuse the view we need to change visibility
     // back to VISIBLE in order for the fragment manager to animate in the view.
@@ -58,11 +65,6 @@ public class ScreenFragment extends Fragment {
             .getNativeModule(UIManagerModule.class)
             .getEventDispatcher()
             .dispatchEvent(new ScreenAppearEvent(mScreenView.getId()));
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
   }
 
   public void onViewAnimationEnd() {


### PR DESCRIPTION
This change fixes the problem with the following crash noticed in the wild:
IllegalArgumentException No view found for id 0x1cb (unknown) for fragment ScreenStackFragment

After investigating we discovered the crash could occur under the following circumstances:
1. we have a stack with nested stack on the first screen
2. we push new screen on the top level stack
3. we immediately pop that screen and also remove the nested stack at the same time
4. the "immediate" action needs to be taken as we need to make sure the transition happens before the screen animaton is done

Under the above condition what'd happen is that the child fragment manager used for the nested stack will not move to "destroyed" state but instead will go from "detached" back to "attached" and will attempt to restore previously added fragments. But since in the meantime we removed the nested stack component it will fail to do so as the container for which the fragments were added will no longer be in the tree.

As we cannot force fragment manager to go into destroyed state we now perform additional cleanup when the screen container is detached. We remove all added screen from the FM in that step. This way even so the FM gets restored it has no fragments to add.