### PR TITLE
Add headerLeft function to render left side of header

### DIFF
--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -83,6 +83,10 @@ Title string used by the back button on iOS. Defaults to the previous scene's `h
 
 Whether the back button title should be visible or not. Defaults to `true`. Only supported on iOS.
 
+#### `headerLeft`
+
+Function which returns a React Element to display on the left side of the header.
+
 #### `headerRight`
 
 Function which returns a React Element to display on the right side of the header.

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -110,6 +110,10 @@ export type NativeStackNavigationOptions = {
    */
   headerLargeTitle?: boolean;
   /**
+   * Function which returns a React Element to display on the left side of the header.
+   */
+  headerLeft?: () => React.ReactNode;
+  /**
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: () => React.ReactNode;

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   ScreenStackHeaderConfig,
+  ScreenStackHeaderLeftView,
   ScreenStackHeaderRightView,
 } from 'react-native-screens';
 import { Route, useTheme } from '@react-navigation/native';
@@ -15,6 +16,7 @@ export default function HeaderConfig(props: Props) {
   const {
     route,
     title,
+    headerLeft,
     headerRight,
     headerTitle,
     headerBackTitle,
@@ -66,6 +68,9 @@ export default function HeaderConfig(props: Props) {
           ? headerStyle.backgroundColor
           : colors.card
       }>
+      {headerLeft !== undefined ? (
+        <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
+      ) : null}
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
       ) : null}


### PR DESCRIPTION
I don't really understand why don't you implement the `headerLeft` function but I think it's really necessary when designing UI.

<img width="391" alt="Screen Shot 2020-03-21 at 1 44 32 AM" src="https://user-images.githubusercontent.com/13638569/77185938-8b133b00-6b15-11ea-891a-f43528d0c556.png">
