### PR TITLE
Fix large header background when largeTitleBackgroundColor is not set

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -389,7 +389,9 @@
     navitem.compactAppearance = appearance;
 
     UINavigationBarAppearance *scrollEdgeAppearance = [[UINavigationBarAppearance alloc] initWithBarAppearance:appearance];
-    scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
+    if (config.largeTitleBackgroundColor != nil) {
+      scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
+    }
     if (config.largeTitleHideShadow) {
         scrollEdgeAppearance.shadowColor = nil;
     }


### PR DESCRIPTION
Fix a regression caused by #333

When `largeTitleBackgroundColor` we want to keep the current background color, setting to nil will cause it to become transparent.

Fixes #433 
Fixes #431