### PR TITLE
fix: fullScreenModal presentation behavior

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -317,7 +317,7 @@
 
   // if view controller is not yet attached to window we skip updates now and run them when view
   // is attached
-  if (self.window == nil) {
+  if (self.window == nil && _presentedModals.lastObject.view.window == nil) {
     return;
   }
   // when transition is ongoing, any updates made to the controller will not be reflected until the


### PR DESCRIPTION
Adding this check checks if the current window is not present outside of the container, which happens for `fullScreenModal` presentation type.