### PR TITLE
Don't clip custom header subviews on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -73,6 +73,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
       mToolbar.setBackgroundColor(tv.data);
     }
+    mToolbar.setClipChildren(false);
   }
 
   @Override


### PR DESCRIPTION
This is mostly noticeable when using icons with ripple overflow.

Before

![2](https://user-images.githubusercontent.com/2677334/78511095-099fe780-7768-11ea-9f1e-d37690f9d2d0.png)

After

![1](https://user-images.githubusercontent.com/2677334/78511098-0c024180-7768-11ea-9703-4e72d0cb65c1.png)
