### PR TITLE
feat: support header title color

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -90,7 +90,7 @@ class StackView extends React.Component {
       translucent: translucent === undefined ? false : translucent,
       title,
       titleFontFamily: headerTitleStyle && headerTitleStyle.fontFamily,
-      titleColor: headerTintColor,
+      titleColor: (headerTitleStyle && headerTitleStyle.color) || headerTintColor,
       titleFontSize: headerTitleStyle && headerTitleStyle.fontSize,
       backTitle: headerBackTitleVisible === false ? '' : headerBackTitle,
       backTitleFontFamily:


### PR DESCRIPTION
Currently it was not possible to set a title color different than the tint color. This PR keeps the tintColor as the default header title color but also uses the headerStyle.color if defined.