### PR TITLE
feat: add types for header views and back button visibility prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Since version 2.0.0 react-native-screens requires RN v0.60+. Check 1.0.0-alpha f
 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation) (without Expo)
 
-Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc). We plan on adding it to other navigators in near future.
+Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc). We plan on adding it to other navigators shortly.
 
 To configure react-navigation to use screens instead of plain RN Views for rendering screen views, follow the steps below:
 
-1. Add this library as a dependency to your project:
+1.  Add this library as a dependency to your project:
 
 ```bash
 yarn add react-native-screens
 ```
 
-2.Link native modules this library ships with into your app:
+2.  Link native modules this library ships with into your app:
 
 ```bash
 react-native link react-native-screens
@@ -31,7 +31,7 @@ react-native link react-native-screens
 
 > If you are not familiar with the concept of linking libraries [read on here](https://facebook.github.io/react-native/docs/linking-libraries-ios).
 
-3.Enable screens support before any of your navigation screen renders. Add the following code to your main application file (e.g. App.js):
+3.  Enable screens support before any of your navigation screens renders. Add the following code to your main application file (e.g. App.js):
 
 ```js
 import { enableScreens } from 'react-native-screens';
@@ -39,23 +39,23 @@ import { enableScreens } from 'react-native-screens';
 enableScreens();
 ```
 
-Note that the above code need to execute before first render of a navigation screen. You can check Example's app [App.js](https://github.com/kmagiera/react-native-screens/blob/master/Example/App.js#L16) file as a reference.
+Note that the above code needs to execute before the first render of a navigation screen. You can check the Example's app [App.js](https://github.com/kmagiera/react-native-screens/blob/master/Example/App.js#L16) file as a reference.
 
-4. Make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher
+4.  Make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher
 
-5. You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
+5.  You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
 
 ## Usage in Expo with [react-navigation](https://github.com/react-navigation/react-navigation) v1.0.0
 
-Screens support is built into Expo [SDK 30](https://blog.expo.io/expo-sdk-30-0-0-is-now-available-e64d8b1db2a7) and react-navigation starting from [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0). Make sure your app use these versions before you start.
+Screens support is built into Expo [SDK 30](https://blog.expo.io/expo-sdk-30-0-0-is-now-available-e64d8b1db2a7) and react-navigation starting from [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0). Make sure your app uses these versions before you start.
 
-1. Add screens library as dependency to your project – you can skip this step when using snack as the dependency will be imported when you import it in one of the JS files
+1.  Add screens library as a dependency to your project – you can skip this step when using snack as the dependency will be imported when you import it in one of the JS files
 
 ```bash
 yarn add react-native-screens
 ```
 
-2. Open your App.js file and add the following snippet somewhere near the top of the file (e.g. right after import statements):
+2.  Open your App.js file and add the following snippet somewhere near the top of the file (e.g. right after import statements):
 
 ```js
 import { enableScreens } from 'react-native-screens';
@@ -63,7 +63,7 @@ import { enableScreens } from 'react-native-screens';
 enableScreens();
 ```
 
-3. That's all 🎉 – enjoy faster navigation in your Expo app. Keep in mind screens are in pretty early phase so please report if you discover some issues.
+3.  That's all 🎉 – enjoy faster navigation in your Expo app. Keep in mind screens are in the pretty early phase so please report if you discover some issues.
 
 ## Interop with [react-native-navigation](https://github.com/wix/react-native-navigation)
 
@@ -71,13 +71,13 @@ React-native-navigation library already uses native containers for rendering nav
 
 ## Using native stack navigator
 
-In order to take advantage of the native stack navigator primitive introduced in version 2.0 you need to use navigator creator function exported by react-native-screens package:
+To take advantage of the native stack navigator primitive introduced in version 2.0 you need to use navigator creator function exported by react-native-screens package:
 
 ```js
 import createNativeStackNavigator from 'react-native-screens/createNativeStackNavigator';
 ```
 
-Then replace places when you use `createStackNavigator` with `createNativeStackNavigator`. Note that not all the screen customization options are supported. There are some technical limitations for implementing some of the stack header options. Documenting the supported parameters is on an immediate roadmap and will be available soon.
+Then replace places when you use `createStackNavigator` with `createNativeStackNavigator`. Note that not all the screen customization options are supported. There are some technical limitations to implementing some of the stack header options. Documenting the supported parameters is on an immediate roadmap and will be available soon.
 
 ## Interop with other libraries
 
@@ -85,17 +85,17 @@ This library should work out of the box with all existing react-native libraries
 
 ## Guide for navigation library authors
 
-If you are building navigation library you may want to use react-native-screens to have a control which parts of the react component tree are attached to the native view hierarchy.
+If you are building a navigation library you may want to use react-native-screens to have control over which parts of the React component tree are attached to the native view hierarchy.
 To do that react-native-screens provides you with two components documented below:
 
 ### `<ScreenContainer/>`
 
 This component is a container for one or more `Screen` components.
 It does not accept other component types as direct children.
-The role of the container is to control which of its children screens should be attached to the view hierarchy.
+The role of the container is to control which of its children's screens should be attached to the view hierarchy.
 It does that by monitoring the `active` property of each of its children.
-It is possible to have as many `active` children as you'd like but in order for the component to be the most efficient we should keep the number of active screens to a minimum.
-In a case of a stack navigator or tabs navigator we only want to have one active screen (the top most view on a stack or the selected tab).
+It is possible to have as many `active` children as you'd like but for the component to be the most efficient, we should keep the number of active screens to a minimum.
+In the case of a stack navigator or tabs navigator, we only want to have one active screen (the topmost view on a stack or the selected tab).
 While transitioning between views we may want to activate a second screen for the duration of the transition, and then go back to just one active screen.
 
 ### `<Screen/>`
@@ -104,7 +104,7 @@ This component is a container for views we want to display on a navigation scree
 It is designed to only be rendered as a direct child of `ScreenContainer`.
 In addition to plain React Native [View props](http://facebook.github.io/react-native/docs/view#props) this component only accepts a single additional property called `active`.
 When `active` is set to `0`, the parent container will detach its views from the native view hierarchy.
-Otherwise the views will be attached as long as the parent container is attached too.
+Otherwise, the views will be attached as long as the parent container is attached too.
 
 #### Example
 
@@ -118,9 +118,9 @@ Otherwise the views will be attached as long as the parent container is attached
 
 ### `<ScreenStack>`
 
-Screen stack component expects one or more `Screen` components as direct children and renders them in a platform native stack container (for iOS it is `UINavigationController` and for Android inside `Fragment` container). For `Screen` components placed as children of `ScreenStack` the `active` property is ignored and instead the screen that corresponds to the last child is rendered as active. All type of updates done to the list of children are acceptable, when the top element is exchanged the container will use platform default (unless customized) animation to transition between screens.
+Screen stack component expects one or more `Screen` components as direct children and renders them in a platform-native stack container (for iOS it is `UINavigationController` and for Android inside `Fragment` container). For `Screen` components placed as children of `ScreenStack` the `active` property is ignored and instead the screen that corresponds to the last child is rendered as active. All types of updates done to the list of children are acceptable when the top element is exchanged the container will use platform default (unless customized) animation to transition between screens.
 
-`StackScreen` extends the capabilities of `Screen` component to allow additional customizations and to make it possible to handle events such as using hardware back or back gesture to dismiss the top screen. Below is the list of additional properties that can be used for `Screen` component:
+`StackScreen` extends the capabilities of the `Screen` component to allow additional customizations and to make it possible to handle events such as using hardware back or back gesture to dismiss the top screen. Below is the list of additional properties that can be used for `Screen` component:
 
 #### `onDismissed`
 
@@ -128,30 +128,32 @@ A callback that gets called when the current screen is dismissed by hardware bac
 
 #### `stackAnimation`
 
-Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The followin values are currently supported:
- - `"default"` – uses a platform default animation
- - `"fade"` – fades screen in or out
- - `"flip"` – flips the screen, requires `stackPresentation: "modal"` (iOS only)
- - `"none"` – the screen appears/dissapears without an animation
+Allows for the customization of how the given screen should appear/disappear when pushed or popped at the top of the stack. The following values are currently supported:
 
- #### `stackPresentation`
+- `"default"` – uses a platform default animation
+- `"fade"` – fades screen in or out
+- `"flip"` – flips the screen, requires `stackPresentation: "modal"` (iOS only)
+- `"none"` – the screen appears/disappears without an animation
+
+#### `stackPresentation`
 
 Defines how the method that should be used to present the given screen. It is a separate property from `stackAnimation` as the presentation mode can carry additional semantic. The allowed values are:
- - `"push"` – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
- - `"modal"` – the new screen will be presented modally. In addition this allow for a nested stack to be rendered inside such screens
- - `"transparentModal"` – the new screen will be presented modally but in addition the second to last screen will remain attached to the stack container such that if the top screen is non opaque the content below can still be seen. If `"modal"` is used instead the below screen will get unmounted as soon as the transition ends.
+
+- `"push"` – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
+- `"modal"` – the new screen will be presented modally. Besides, this allows for a nested stack to be rendered inside such screens
+- `"transparentModal"` – the new screen will be presented modally but also, the second to last screen will remain attached to the stack container such that if the top screen is non-opaque, the content below can still be seen. If `"modal"` is used instead the below screen will get unmounted as soon as the transition ends.
 
 ### `<ScreenStackHeaderConfig>`
 
-The config component is expected to be rendered as a direct children of `<Screen>`. It provides an ability to configure native navigation header that gets rendered as a part of native screen stack. The component acts as a "virtual" element that is not directly rendered under `Screen`. You can use its properties to customize platform native header for the parent screen and also render react-native components that you'd like to be displayed inside the header (e.g. in the title are or on the side).
+The config component is expected to be rendered as a direct child of `<Screen>`. It provides an ability to configure native navigation header that gets rendered as a part of the native screen stack. The component acts as a "virtual" element that is not directly rendered under `Screen`. You can use its properties to customize platform native header for the parent screen and also render react-native components that you'd like to be displayed inside the header (e.g. in the title are or on the side).
 
-Along with this component properties that can be used to customize header behavior one can also use one or the below component containers to render custom react-native content in different areas of the native header:
- - `ScreenStackHeaderCenterView` – the childern will render in the center of the native navigation bar.
- - `ScreenStackHeaderRightView` – the children will render on the right hand side of the navigation bar (or on the left hand side in case LTR locales are set on the user's device).
- - `ScreenStackHeaderLeftView` – the children will render on the left hand side of the navigation bar (or on the right hand side in case LTR locales are set on the user's device).
+Along with this component's properties that can be used to customize header behavior, one can also use one of the below component containers to render custom react-native content in different areas of the native header:
+
+- `ScreenStackHeaderCenterView` – the children will render in the center of the native navigation bar.
+- `ScreenStackHeaderRightView` – the children will render on the right-hand side of the navigation bar (or on the left-hand side in case LTR locales are set on the user's device).
+- `ScreenStackHeaderLeftView` – the children will render on the left-hand side of the navigation bar (or on the right-hand side in case LTR locales are set on the user's device).
 
 Below is a list of properties that can be set with `ScreenStackHeaderConfig` component:
-
 
 #### `hidden`
 
@@ -159,15 +161,15 @@ When set to `true` the header will be hidden while the parent `Screen` is on the
 
 #### `color`
 
-Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use `titleColor` property.
+Controls the color of items rendered on the header. This includes a back icon, back text (iOS only) and title text. If you want the title to have a different color use `titleColor` property.
 
 #### `title`
 
-String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
+A string representing screen title that will get rendered in the middle section of the header. On iOS, the title is centered on the header while on Android it is aligned to the left and placed next to the back button (if one is present).
 
 #### `titleFontFamily`
 
-Customize font family to be used for the title.
+Customize the font family to be used for the title.
 
 #### `titleFontSize`
 
@@ -179,7 +181,7 @@ Allows for setting text color of the title.
 
 #### `backgroundColor`
 
-Controlls the color of the navigation header.
+Controls the color of the navigation header.
 
 #### `hideShadow`
 
@@ -187,7 +189,11 @@ Boolean that allows for disabling drop shadow under navigation header. The defau
 
 #### `hideBackButton`
 
-If set to `true` the back button will not be rendered as a part of navigation header.
+If set to `true` the back button will also be rendered while using `headerLeft` function.
+
+#### `backButtonInCustomView`
+
+If set to `true` the back button will not be rendered as a part of the navigation header.
 
 #### `gestureEnabled`
 
@@ -195,19 +201,19 @@ When set to `false` the back swipe gesture will be disabled when the parent `Scr
 
 #### `translucent` (iOS only)
 
-When set to `true`, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is `false`.
+When set to `true`, it makes native navigation bar on iOS semi-transparent with blur effect. It is a common way of presenting a navigation bar introduced in iOS 11. The default value is `false`.
 
 #### `backTitle` (iOS only)
 
-Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.
+Allows for controlling the string to be rendered next to the back button. By default, iOS uses the title of the previous screen.
 
 #### `backTitleFontFamily` (iOS only)
 
-Allows for customizing font family to be used for back button title on iOS.
+Allows for customizing font family to be used for the back button title on iOS.
 
 #### `backTitleFontSize` (iOS only)
 
-Allows for customizing font size to be used for back button title on iOS.
+Allows for customizing font size to be used for the back button title on iOS.
 
 #### `largeTitle` (iOS only)
 
@@ -215,7 +221,7 @@ When set to `true` it makes the title display using the large title effect.
 
 #### `largeTitleFontFamily` (iOS only)
 
-Customize font family to be used for the large title.
+Customize the font family to be used for the large title.
 
 #### `largeTitleFontSize` (iOS only)
 
@@ -225,9 +231,9 @@ Customize the size of the font to be used for the large title.
 
 If you are adding a new native component to be used from the React Native app, you may want it to respond to navigation lifecycle events.
 
-Good example is a map component that shows current user location. When component is on the top-most screen it should register for location updates and display users location on the map. But if we navigate away from a screen that has a map, e.g. by pushing new screen on top of it or if it is in one of a tabs and user just switched to the previous app, we may want to stop listening to location updates.
+A good example is a map component that shows the current user location. When the component is on the top-most screen, it should register for location updates and display the user's location on the map. But if we navigate away from a screen that has a map, e.g. by pushing a new screen on top of it or if it is in one of the tabs, and the user just switched to the previous app, we may want to stop listening to location updates.
 
-In order to achieve that we need to know at the native component level when our native view goes out of sight. With react-native-screens you can do that in the following way:
+To achieve that, we need to know at the native component level when our native view goes out of sight. With react-native-screens you can do that in the following way:
 
 ### Navigation lifecycle on iOS
 
@@ -250,10 +256,10 @@ You can check our example app for a fully functional demo see [RNSSampleLifecycl
 
 ### Navigation lifecycle on Android
 
-On Android you can use [LifecycleObserver](https://developer.android.com/reference/android/arch/lifecycle/LifecycleObserver) interface which is a part of Android compat library to make your view handle lifecycle events.
+On Android, you can use [LifecycleObserver](https://developer.android.com/reference/android/arch/lifecycle/LifecycleObserver) interface which is a part of Android compat library to make your view handle lifecycle events.
 Check [LifecycleAwareView.java](https://github.com/kmagiera/react-native-screens/blob/master/Example/android/app/src/main/java/com/swmansion/rnscreens/example/LifecycleAwareView.java) from our example app for more details on that.
 
-In addition to that you will need to register for receiving these updates. This can be done using [`LifecycleHelper.register`](https://github.com/kmagiera/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L50).
+In addition to that, you will need to register for receiving these updates. This can be done using [`LifecycleHelper.register`](https://github.com/kmagiera/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L50).
 Remember to call [`LifecycleHelper.unregister`](https://github.com/kmagiera/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L59) before the view is dropped.
 Please refer to [SampleLifecycleAwareViewManager.java](https://github.com/kmagiera/react-native-screens/blob/master/Example/android/app/src/main/java/com/swmansion/rnscreens/example/SampleLifecycleAwareViewManager.java) from our example app to see what are the best ways of using the above methods.
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ Boolean that allows for disabling drop shadow under navigation header. The defau
 
 #### `hideBackButton`
 
-If set to `true` the back button will also be rendered while using `headerLeft` function.
+If set to `true` the back button will not be rendered as a part of the navigation header.
 
 #### `backButtonInCustomView`
 
-If set to `true` the back button will not be rendered as a part of the navigation header.
+If set to `true` the back button will also be rendered while using `headerLeft` function.
 
 #### `gestureEnabled`
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -338,5 +338,5 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     mIsHidden = hidden;
   }
 
-  public void setbackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }
+  public void setBackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -34,6 +34,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
   private boolean mDestroyed;
+  private boolean mBackButtonInCustomView;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -236,9 +237,11 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
       switch (type) {
         case LEFT:
-          // when there is a left item we need to disable navigation icon
+          // when there is a left item we need to disable navigation icon by default
           // we also hide title as there is no other way to display left side items
-          mToolbar.setNavigationIcon(null);
+          if (!mBackButtonInCustomView) {
+            mToolbar.setNavigationIcon(null);
+          }
           mToolbar.setTitle(null);
           params.gravity = Gravity.LEFT;
           break;
@@ -334,4 +337,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   public void setHidden(boolean hidden) {
     mIsHidden = hidden;
   }
+
+  public void setbackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -115,8 +115,8 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
   }
 
   @ReactProp(name = "backButtonInCustomView")
-  public void setbackButtonInCustomView(ScreenStackHeaderConfig config, boolean backButtonInCustomView) {
-    config.setbackButtonInCustomView(backButtonInCustomView);
+  public void setBackButtonInCustomView(ScreenStackHeaderConfig config, boolean backButtonInCustomView) {
+    config.setBackButtonInCustomView(backButtonInCustomView);
   }
 
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -114,6 +114,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHidden(hidden);
   }
 
+  @ReactProp(name = "backButtonInCustomView")
+  public void setbackButtonInCustomView(ScreenStackHeaderConfig config, boolean backButtonInCustomView) {
+    config.setbackButtonInCustomView(backButtonInCustomView);
+  }
+
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -24,6 +24,7 @@
 @property (nonatomic) BOOL largeTitleHideShadow;
 @property (nonatomic, retain) UIColor *largeTitleColor;
 @property (nonatomic) BOOL hideBackButton;
+@property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -394,7 +394,7 @@
       scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
     }
     if (config.largeTitleHideShadow) {
-        scrollEdgeAppearance.shadowColor = nil;
+      scrollEdgeAppearance.shadowColor = nil;
     }
     navitem.scrollEdgeAppearance = scrollEdgeAppearance;
   } else
@@ -418,6 +418,7 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
+        navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
         navitem.leftBarButtonItem = buttonItem;
         break;
@@ -494,6 +495,7 @@ RCT_EXPORT_VIEW_PROPERTY(largeTitleBackgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleHideShadow, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(backButtonInCustomView, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -91,6 +91,14 @@ Whether the back button title should be visible or not. Defaults to `true`. Only
 
 Function which returns a React Element to display on the right side of the header.
 
+#### `headerLeft`
+
+Function which returns a React Element to display on the left side of the header. For now, on Android, using it will cause the title to also disappear.
+
+#### `headerCenter`
+
+Function which returns a React Element to display in the center of the header.
+
 #### `headerTranslucent`
 
 Boolean indicating whether the navigation bar is translucent. Only supported on iOS.

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -2,9 +2,9 @@
 
 Provides a way for your app to transition between screens where each new screen is placed on top of a stack.
 
-By default the stack navigator is configured to have the familiar iOS and Android look & feel: new screens slide in from the right on iOS, fade in from the bottom on Android. On iOS the stack navigator can also be configured to a modal style where screens slide in from the bottom.
+By default the stack navigator is configured to have the familiar iOS and Android look & feel: new screens slide in from the right on iOS, fade in from the bottom on Android. On iOS, the stack navigator can also be configured to a modal style where screens slide in from the bottom.
 
-This navigator uses native navigation primitives (`UINavigationController` on iOS and `Fragment` on Android) for navigation under the hood. The main difference from React Navigation's JS based [stack navigator](https://reactnavigation.org/docs/stack-navigator.html) is that the JS based navigator re-implements animations and gestures while the native stack navigator relies on the platform primitives for animations and gestures. You should use this navigator if you want native feeling and performance for navigation and don't need much customization, as the customization options of this navigator are limited.
+This navigator uses native navigation primitives (`UINavigationController` on iOS and `Fragment` on Android) for navigation under the hood. The main difference from React Navigation's JS-based [stack navigator](https://reactnavigation.org/docs/stack-navigator.html) is that the JS-based navigator re-implements animations and gestures while the native stack navigator relies on the platform primitives for animations and gestures. You should use this navigator if you want native feeling and performance for navigation and don't need much customization, as the customization options of this navigator are limited.
 
 ```sh
 npm install react-native-screens @react-navigation/native
@@ -45,7 +45,7 @@ The `Stack.Navigator` component accepts following props:
 
 #### `initialRouteName`
 
-The name of the route to render on first load of the navigator.
+The name of the route to render on the first load of the navigator.
 
 #### `screenOptions`
 
@@ -57,7 +57,7 @@ The `options` prop can be used to configure individual screens inside the naviga
 
 #### `title`
 
-String that can be used as a fallback for `headerTitle`.
+A string that can be used as a fallback for `headerTitle`.
 
 #### `headerShown`
 
@@ -65,7 +65,11 @@ Whether to show or hide the header for the screen. The header is shown by defaul
 
 #### `headerHideBackButton`
 
-Boolean indicating whether to hide the back button in header. Only supported on Android.
+Boolean indicating whether to hide the back button in the header. Only supported on Android.
+
+#### `backButtonInCustomView`
+
+Boolean indicating whether to hide the back button while using `headerLeft` function.
 
 #### `headerHideShadow`
 
@@ -93,15 +97,15 @@ Boolean indicating whether the navigation bar is translucent. Only supported on 
 
 #### `headerLargeTitle`
 
-Boolean to set native property to prefer large title header (like in iOS setting).
+Boolean used to set a native property to prefer a large title header (like in iOS setting).
 
-For large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`. If the scrollable area doesn't fill the screen, the large title won't collapse on scroll.
+For the large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`. If the scrollable area doesn't fill the screen, the large title won't collapse on scroll.
 
 Only supported on iOS.
 
 #### `headerTintColor`
 
-Tint color for the header. Changes the color of back button and title.
+Tint color for the header. Changes the color of the back button and title.
 
 #### `headerStyle`
 
@@ -136,10 +140,10 @@ Gestures are only supported on iOS. They can be disabled only when `stackPresent
 
 #### `stackPresentation`
 
-How should the screen be presented. Possible values:
+How the screen should be presented. Possible values:
 
 - `push` - The new screen will be pushed onto a stack. The default animation on iOS is to slide from the side. The animation on Android may vary depending on the OS version and theme.
-- `modal` - The new screen will be presented modally. In addition this allows for a nested stack to be rendered inside such screens
+- `modal` - The new screen will be presented modally. In addition, this allows for a nested stack to be rendered inside such screens
 - `transparentModal` - The new screen will be presented modally. In addition, the second to last screen will remain attached to the stack container such that if the top screen is translucent, the content below can still be seen. If `"modal"` is used instead, the below screen gets removed as soon as the transition ends.
 
 Defaults to `push`.
@@ -166,13 +170,16 @@ Event which fires when the screen appears.
 Example:
 
 ```js
-React.useEffect(() => {
-  const unsubscribe = navigation.addListener('appear', e => {
-    // Do something
-  });
+React.useEffect(
+  () => {
+    const unsubscribe = navigation.addListener('appear', e => {
+      // Do something
+    });
 
-  return unsubscribe;
-}, [navigation]);
+    return unsubscribe;
+  },
+  [navigation]
+);
 ```
 
 #### `dismiss`
@@ -182,13 +189,16 @@ Event which fires when the current screen is dismissed by hardware back (on Andr
 Example:
 
 ```js
-React.useEffect(() => {
-  const unsubscribe = navigation.addListener('dismiss', e => {
-    // Do something
-  });
+React.useEffect(
+  () => {
+    const unsubscribe = navigation.addListener('dismiss', e => {
+      // Do something
+    });
 
-  return unsubscribe;
-}, [navigation]);
+    return unsubscribe;
+  },
+  [navigation]
+);
 ```
 
 #### `finishTransitioning`
@@ -198,13 +208,16 @@ Event which fires when the current screen finishes its transition.
 Example:
 
 ```js
-React.useEffect(() => {
-  const unsubscribe = navigation.addListener('finishTransitioning', e => {
-    // Do something
-  });
+React.useEffect(
+  () => {
+    const unsubscribe = navigation.addListener('finishTransitioning', e => {
+      // Do something
+    });
 
-  return unsubscribe;
-}, [navigation]);
+    return unsubscribe;
+  },
+  [navigation]
+);
 ```
 
 ### Helpers
@@ -213,7 +226,7 @@ The stack navigator adds the following methods to the navigation prop:
 
 #### `push`
 
-Pushes a new screen to top of the stack and navigate to it. The method accepts following arguments:
+Pushes a new screen to the top of the stack and navigate to it. The method accepts the following arguments:
 
 - `name` - _string_ - Name of the route to push onto the stack.
 - `params` - _object_ - Screen params to merge into the destination route (found in the pushed screen through `route.params`).
@@ -253,8 +266,7 @@ function MyStack() {
         headerShown: false,
         headerTintColor: 'white',
         headerStyle: { backgroundColor: 'tomato' },
-      }}
-    >
+      }}>
       <Stack.Screen
         name="Home"
         component={Home}

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -94,6 +94,10 @@ export type NativeStackNavigationOptions = {
    */
   headerShown?: boolean;
   /**
+   * Whether to show the back button with custom left side of the header.
+   */
+  backButtonInCustomView?: boolean;
+  /**
    * Boolean indicating whether the navigation bar is translucent.
    * Only supported on iOS.
    *
@@ -113,6 +117,14 @@ export type NativeStackNavigationOptions = {
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: () => React.ReactNode;
+  /**
+   * Function which returns a React Element to display on the left side of the header.
+   */
+  headerLeft?: () => React.ReactNode;
+  /**
+   * Function which returns a React Element to display in the center of the header.
+   */
+  headerCenter?: () => React.ReactNode;
   /**
    * Tint color for the header. Changes the color of back button and title.
    */

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {
   ScreenStackHeaderConfig,
   ScreenStackHeaderRightView,
+  ScreenStackHeaderLeftView,
+  ScreenStackHeaderCenterView,
 } from 'react-native-screens';
 import { Route, useTheme } from '@react-navigation/native';
 import { NativeStackNavigationOptions } from '../types';
@@ -16,6 +18,8 @@ export default function HeaderConfig(props: Props) {
     route,
     title,
     headerRight,
+    headerLeft,
+    headerCenter,
     headerTitle,
     headerBackTitle,
     headerBackTitleVisible = true,
@@ -31,11 +35,13 @@ export default function HeaderConfig(props: Props) {
     headerLargeTitleStyle = {},
     headerBackTitleStyle = {},
     headerShown,
+    backButtonInCustomView,
   } = props;
 
   return (
     <ScreenStackHeaderConfig
       hidden={headerShown === false}
+      backButtonInCustomView={backButtonInCustomView}
       translucent={headerTranslucent === true}
       hideShadow={headerHideShadow}
       largeTitleHideShadow={headerLargeTitleHideShadow}
@@ -72,6 +78,14 @@ export default function HeaderConfig(props: Props) {
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
+      ) : null}
+      {headerLeft !== undefined ? (
+        <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
+      ) : null}
+      {headerCenter !== undefined ? (
+        <ScreenStackHeaderCenterView>
+          {headerCenter()}
+        </ScreenStackHeaderCenterView>
       ) : null}
     </ScreenStackHeaderConfig>
   );

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -104,7 +104,8 @@ declare module 'react-native-screens' {
      */
     hideBackButton?: boolean;
     /**
-     * Whether to show the back button with custom left side of the header.
+     * @host (iOS only)
+     * @description Whether to show the back button with a custom left side of the header.
      */
     backButtonInCustomView?: boolean;
     /**

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -104,6 +104,10 @@ declare module 'react-native-screens' {
      */
     hideBackButton?: boolean;
     /**
+     * Whether to show the back button with custom left side of the header.
+     */
+    backButtonInCustomView?: boolean;
+    /**
      * @host (iOS only)
      * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
      */

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -104,7 +104,6 @@ declare module 'react-native-screens' {
      */
     hideBackButton?: boolean;
     /**
-     * @host (iOS only)
      * @description Whether to show the back button with a custom left side of the header.
      */
     backButtonInCustomView?: boolean;


### PR DESCRIPTION
Added type definitions for `headerLeft` and `headerCenter` and an option allowing the custom left view to be rendered to the right of the back button requested in #445.