### PR TITLE
Fix ScreenContainer while performing gesture and adding new screen

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -136,6 +136,9 @@
         } else {
           [_controller addChildViewController:screen.controller];
           if (onlyActiveScreen == nil) {
+			 // the frame is already set at this moment because we adjust it in insertReactSubview. We don't
+			 // want to update it here as react-driven animations may already run and hence changing the frame
+			 // would result in visual glitches
             [_controller.view addSubview:screen.controller.view];
           } else {
             // We need to keep the native views' order sync with js.

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -122,14 +122,14 @@
   // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
   // triggered before the animation starts
   if (activeScreenAdded) {
-    // Following the assumption that there're mostly two active screens
+    // Following the assumption that there are mostly two active screens at once,
     // it's reasonable to assume that it's not allowed to add an additional one
-    // if there're already two on them
+    // if there are already two of them
     RCTAssert(_activeScreens.count < 2, @"It's allowed to have max two active screens");
     RNSScreenView* onlyActiveScreen = [_activeScreens anyObject];
     if (onlyActiveScreen != nil) {
-      // We're not using [self.detachScreen:] couse we don't
-      // want ot actually call [view.removeFromSuperview] in order 
+      // We're not using [self.detachScreen:] cause we don't
+      // want to actually call [view.removeFromSuperview] in order 
       // to keep the gesture recognition continuous
       [onlyActiveScreen.controller removeFromParentViewController];
       [onlyActiveScreen.controller willMoveToParentViewController:nil];
@@ -152,15 +152,15 @@
           if (onlyActiveScreen == nil) {
             [_controller.view addSubview:screen.controller.view];
           } else {
-            // We need to keed the native views' order sync with js.
-            // if there's already another active screen attached we
+            // We need to keep the native views' order sync with js.
+            // If there's already another active screen attached, we
             // need to keep the order of screens on native site the
-            // same as on the react site. Therefore assuming that the order 
+            // same as on the react site. Therefore, assuming that the order 
             // of screens' attaching might be different than the order 
             // in the react hierarchy and assuming that there might
-            // be at most two active screens we're inserting the new screen 
-            // either at index 0 or index 1 according to
-            // the position is the react hierarchy.
+            // be at most two active screens, we're inserting the new screen 
+            // either at index 0 or 1, according to
+            // the position in the react hierarchy.
             BOOL isBeforePreviouslyOnlyOneActiveScreen = [_reactSubviews indexOfObject:screen] < [_reactSubviews indexOfObject:onlyActiveScreen];
             [_controller.view insertSubview:screen.controller.view atIndex: isBeforePreviouslyOnlyOneActiveScreen ? 0 : 1];
           }

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -128,7 +128,7 @@
     RCTAssert(_activeScreens.count < 2, @"It's allowed to have max two active screens");
     RNSScreenView* onlyActiveScreen = [_activeScreens anyObject];
     if (onlyActiveScreen != nil) {
-      // We're not using [self.detachScreen:] screen couse we don't
+      // We're not using [self.detachScreen:] couse we don't
       // want ot actually call [view.removeFromSuperview] in order 
       // to keep the gesture recognition continuous
       [onlyActiveScreen.controller removeFromParentViewController];
@@ -141,7 +141,7 @@
     for (RNSScreenView *screen in _reactSubviews) {
       if (screen.active) {
         if (screen == onlyActiveScreen) {
-          // We're not using [self.attachScreen:] screen couse we don't
+          // We're not using [self.attachScreen:] couse we don't
           // want to call [view.addSubview:] to keep the gesture
           // recognition continuos
           [_controller addChildViewController:screen.controller];

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -130,9 +130,6 @@
     for (RNSScreenView *screen in _reactSubviews) {
       if (screen.active) {
         if (screen == onlyActiveScreen) {
-          // We're not using [self.attachScreen:] cause we don't
-          // want to call [view.addSubview:] to keep the gesture
-          // recognition continuous
           [_controller addChildViewController:screen.controller];
           [screen.controller didMoveToParentViewController:_controller];
           [_activeScreens addObject:screen];

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -123,7 +123,7 @@
   // triggered before the animation starts
   if (activeScreenAdded) {
     // Following the assumption that there're mostly two active screens
-    // it's reasnabe to assume that it's not allowed to add additional one
+    // it's reasonable to assume that it's not allowed to add an additional one
     // if there're already two on them
     RCTAssert(_activeScreens.count < 2, @"It's allowed to have max two active screens");
     RNSScreenView* onlyActiveScreen = [_activeScreens anyObject];
@@ -137,13 +137,13 @@
       onlyActiveScreen.userInteractionEnabled = YES;
     }
 
-    // add new screens in order they are placed in subviews array
+    // add new screens in the order they were placed in subviews array
     for (RNSScreenView *screen in _reactSubviews) {
       if (screen.active) {
         if (screen == onlyActiveScreen) {
-          // We're not using [self.attachScreen:] couse we don't
+          // We're not using [self.attachScreen:] cause we don't
           // want to call [view.addSubview:] to keep the gesture
-          // recognition continuos
+          // recognition continuous
           [_controller addChildViewController:screen.controller];
           [screen.controller didMoveToParentViewController:_controller];
           [_activeScreens addObject:screen];
@@ -155,12 +155,12 @@
             // We need to keed the native views' order sync with js.
             // if there's already another active screen attached we
             // need to keep the order of screens on native site the
-            // same as on react site. Therefore assuming that the order 
+            // same as on the react site. Therefore assuming that the order 
             // of screens' attaching might be different than the order 
             // in the react hierarchy and assuming that there might
-            // be max two active screens we're insering the new screen 
-            // either at index 0 or at index 1 according to
-            // the position is react hierarchy.
+            // be at most two active screens we're inserting the new screen 
+            // either at index 0 or index 1 according to
+            // the position is the react hierarchy.
             BOOL isBeforePreviouslyOnlyOneActiveScreen = [_reactSubviews indexOfObject:screen] < [_reactSubviews indexOfObject:onlyActiveScreen];
             [_controller.view insertSubview:screen.controller.view atIndex: isBeforePreviouslyOnlyOneActiveScreen ? 0 : 1];
           }

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -81,17 +81,6 @@
   [_activeScreens removeObject:screen];
 }
 
-- (void)attachScreen:(RNSScreenView *)screen
-{
-  [_controller addChildViewController:screen.controller];
-  // the frame is already set at this moment because we adjust it in insertReactSubview. We don't
-  // want to update it here as react-driven animations may already run and hence changing the frame
-  // would result in visual glitches
-  [_controller.view addSubview:screen.controller.view];
-  [screen.controller didMoveToParentViewController:_controller];
-  [_activeScreens addObject:screen];
-}
-
 - (void)updateContainer
 {
   _needUpdate = NO;

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -122,14 +122,15 @@
   // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
   // triggered before the animation starts
   if (activeScreenAdded) {
-    // Follow the assumption that there're mostly two active screens
-    // it's reasnabe to assume that it's not allowed to add any other
+    // Following the assumption that there're mostly two active screens
+    // it's reasnabe to assume that it's not allowed to add additional one
+    // if there're already two on them
     RCTAssert(_activeScreens.count < 2, @"It's allowed to have max two active screens");
     RNSScreenView* onlyActiveScreen = [_activeScreens anyObject];
     if (onlyActiveScreen != nil) {
-      // We're not using [self.detachScreen:] screen couse in we don't
-      // want ot actually add removeFromSuperview to keep the gesture
-      // recognition continuos
+      // We're not using [self.detachScreen:] screen couse we don't
+      // want ot actually call [view.removeFromSuperview] in order 
+      // to keep the gesture recognition continuous
       [onlyActiveScreen.controller removeFromParentViewController];
       [onlyActiveScreen.controller willMoveToParentViewController:nil];
       [_activeScreens removeObject:onlyActiveScreen];
@@ -141,25 +142,25 @@
       if (screen.active) {
         if (screen == onlyActiveScreen) {
           // We're not using [self.attachScreen:] screen couse we don't
-          // want to actually removeFromSuperview to keep the gesture
+          // want to call [view.addSubview:] to keep the gesture
           // recognition continuos
           [_controller addChildViewController:screen.controller];
           [screen.controller didMoveToParentViewController:_controller];
           [_activeScreens addObject:screen];
         } else {
           [_controller addChildViewController:screen.controller];
-          // We need to keed the native views' order sync with js
           if (onlyActiveScreen == nil) {
             [_controller.view addSubview:screen.controller.view];
           } else {
+            // We need to keed the native views' order sync with js.
             // if there's already another active screen attached we
-            // need to keep the order or screens on native site
-            // same as in JS. Therefore assuming that the order of attaching
-            // might be different that order in he hierarchy and
-            // assuming that there might be max two active screens
-            // we're insering the new screen either at index 0
-            // or at index 1 according to the position is react
-            // hierarchy.
+            // need to keep the order of screens on native site the
+            // same as on react site. Therefore assuming that the order 
+            // of screens' attaching might be different than the order 
+            // in the react hierarchy and assuming that there might
+            // be max two active screens we're insering the new screen 
+            // either at index 0 or at index 1 according to
+            // the position is react hierarchy.
             BOOL isBeforePreviouslyOnlyOneActiveScreen = [_reactSubviews indexOfObject:screen] < [_reactSubviews indexOfObject:onlyActiveScreen];
             [_controller.view insertSubview:screen.controller.view atIndex: isBeforePreviouslyOnlyOneActiveScreen ? 0 : 1];
           }


### PR DESCRIPTION
## Motivation
I'd love to enable RNScrees on both platforms in React Navigation. We're observing memory issues with navigation stack and having rn-screens support will help us resolve it.

## Repro

While dismissing a screen with a gesture (after modifying react-navigation core https://github.com/react-navigation/react-navigation/pull/8008 to enable screens on iOS) in an example app of react native screen app freezes. 

## Changes
I observed that the issue is related to Gesture Handler and the problem is that making a continuous gesture (panning) breaks the app. It freezes and stops responding to gestures and taps. 

After some debugging, I managed to get rid of it. My observation was that reattaching all screens while adding a new one is a weak point. I decided to make a small fix: assuming that there're at most two active screens in one time, I realized that while adding a new active one, there might only one already active. 
Following this assumption, I decided not to call `removeFromSuperview` and `addSubview` for this one already active screen keeping the same logic as previously (including calling `removeFromParentViewController` `addChildViewController`, `didMoveToParentViewController` etc. to keep all already existing behaviors).

The last aspect is actually inserting the newly active screen. Previously we were able to keep order or `screens` by detaching and attaching each of them every time. Now it becomes a bit more complex because we need to insert the screen at proper index in the native hierarchy. However, because there're at most two of them, we need to insert it either at index `1` or `0`. 
Line ` BOOL isBeforePreviouslyOnlyOneActiveScreen = [_reactSubviews indexOfObject:screen] < [_reactSubviews indexOfObject:onlyActiveScreen];` is responsible for this check and after this line we can safely insert new screen at proper position. 

The rest of the logic is kept without any changes


## Impact
After these changes, I realized that issues related to `rn-screens` on iOS are gone and we'd love to enable it by default. I tested it on our example app and works like a charm.

Also, I made a check with the memory profiler, because I was concerned about memory leaks and observed no leaks.

https://github.com/react-navigation/react-navigation/pull/8008  
After this PR, I'd like to have it merged