### PR TITLE
Simplify the implementation on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "url": "https://github.com/kmagiera/react-native-screens/issues"
   },
   "homepage": "https://github.com/kmagiera/react-native-screens#readme",
-  "dependencies": {
-    "debounce": "^1.2.0"
-  },
   "peerDependencies": {
     "react": "*",
     "react-native": "*"

--- a/src/screens.web.js
+++ b/src/screens.web.js
@@ -1,113 +1,35 @@
-import debounce from 'debounce';
 import React from 'react';
 import { Animated, View } from 'react-native';
 
-let _shouldEnableScreens = true;
+let ENABLE_SCREENS = true;
 
 export function enableScreens(shouldEnableScreens = true) {
-  if (shouldEnableScreens) {
-    console.warn(
-      'react-native-screens is not fully supported on this platform yet.'
-    );
-  }
-  _shouldEnableScreens = shouldEnableScreens;
+  ENABLE_SCREENS = shouldEnableScreens;
 }
 
 export function screensEnabled() {
-  return _shouldEnableScreens;
+  return ENABLE_SCREENS;
 }
 
-function isAnimatedValue(value) {
-  return value && value.__getValue && value.addListener;
-}
-
-function isPropTruthy(prop) {
-  let activeValue = prop;
-  if (isAnimatedValue(prop)) {
-    activeValue = prop.__getValue();
-  }
-
-  return !!activeValue;
-}
-
-export class Screen extends React.Component {
+export class NativeScreen extends React.Component {
   static defaultProps = {
     active: true,
   };
 
-  listenerId = null;
-
-  constructor(props) {
-    super(props);
-
-    this._onAnimatedValueUpdated = debounce(this._onAnimatedValueUpdated, 10);
-    this._addListener(props.active);
-  }
-
-  componentWillUnmount() {
-    this._removeListener(this.props.active);
-  }
-
-  _addListener = possibleListener => {
-    if (this.listenerId)
-      throw new Error(
-        'Screen: Attempting to observe an animated value while another value is already observed.'
-      );
-    if (isAnimatedValue(possibleListener)) {
-      this.listenerId = possibleListener.addListener(
-        this._onAnimatedValueUpdated
-      );
-    }
-  };
-
-  _removeListener = possibleListener => {
-    if (isAnimatedValue(possibleListener)) {
-      possibleListener.removeListener(this.listenerId);
-      this.listenerId = null;
-    }
-  };
-
-  shouldComponentUpdate({ active: nextActive }) {
-    const { active } = this.props;
-    if (nextActive !== active) {
-      this._removeListener(active);
-      this._addListener(nextActive);
-      this._updateDisplay(isPropTruthy(nextActive));
-      return false;
-    }
-    return true;
-  }
-
-  _onAnimatedValueUpdated = ({ value }) => {
-    this._updateDisplay(!!value);
-  };
-
-  _updateDisplay = isActive => {
-    if (isActive === undefined) {
-      isActive = isPropTruthy(this.props.active);
-    }
-    const display = isActive ? 'flex' : 'none';
-    this.setNativeProps({ style: { display } });
-  };
-
-  setNativeProps = nativeProps => {
-    if (this._view) {
-      this._view.setNativeProps(nativeProps);
-    }
-  };
-
-  _setRef = view => {
-    this._view = view;
-    this._updateDisplay();
-  };
-
   render() {
-    return <Animated.View {...this.props} ref={this._setRef} />;
+    const { active, style, ...rest } = this.props;
+
+    return (
+      <View
+        style={[style, ENABLE_SCREENS && !active ? { display: 'none' } : null]}
+        {...rest}
+      />
+    );
   }
 }
 
-export const ScreenContainer = View;
+export const Screen = Animated.createAnimatedComponent(NativeScreen);
 
-export const NativeScreen = View;
+export const ScreenContainer = View;
 
 export const NativeScreenContainer = View;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,11 +2035,6 @@ date-fns@^1.27.2:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Use `Animated.createComponent` on web instead of adding listeners manually. This means:

- No extra listeners
- One less dependency (`debounce`)
- Smaller component hierarchy since `Animated.View` used the HOC anyway

This also fixes some issues on web:

- Fix `NativeScreen` ignoring the `active` prop
- Fix `enableScreens(false)` not respected
- Fix custom `display` value not being respected since it was set to `flex`
- Fix view not re-appearing sometimes when `active` state changes

I couldn't find the reasoning for the previous implementation (https://github.com/software-mansion/react-native-screens/pull/88), so I assumed that it was an oversight. Lemme know if I'm missing something.