### PR TITLE
feat: detach only screens from current container

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -237,7 +237,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     FragmentTransaction transaction = mFragmentManager.beginTransaction();
     boolean hasFragments = false;
     for (Fragment fragment : mFragmentManager.getFragments()) {
-      if (fragment instanceof ScreenFragment) {
+      if (fragment instanceof ScreenFragment && ((ScreenFragment) fragment).mScreenView.getContainer() == this) {
         transaction.remove(fragment);
         hasFragments = true;
       }
@@ -293,7 +293,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
       Object[] orphanedAry = orphaned.toArray();
       for (int i = 0; i < orphanedAry.length; i++) {
         if (orphanedAry[i] instanceof ScreenFragment) {
-          detachScreen((ScreenFragment) orphanedAry[i]);
+          if (((ScreenFragment) orphanedAry[i]).getScreen().getContainer() == null) {
+            detachScreen((ScreenFragment) orphanedAry[i]);
+          }
         }
       }
     }


### PR DESCRIPTION
When two `ScreenContainer`s have the same FragmentManager, which happens e.g. here #238, where Stack Navigator, which doesn't have screens enabled, has two screens, which both are Stack Navigators, so each has his own `ScreenContainer`, then, when performing an update or removing one of the `ScreenContainer`s, the other `ScreenContainer`s Screens will get removed due to current behavior in:
1. `performUpdate` detaches all Screens from FragmentManager that are not active or from the current `ScreenContainer`. In PR, we check if the Screens don't belong to any other `ScreenContainer`, and only then remove them. 
2. `removeMyFragments` removes all fragments from the FragmentManager of the `ScreenContainer` being removed. In PR, we remove only Screens from the current  `ScreenContainer`.