### PR TITLE
Fix screen container to prevent event mutex lock

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -73,21 +73,41 @@
   return _controller;
 }
 
+- (UIViewController*)findChildControllerForScreen:(RNSScreenView*)screen
+{
+  for (UIViewController *vc in _controller.childViewControllers) {
+    if (vc.view == screen) {
+      return vc;
+    }
+  }
+  return nil;
+}
+
+- (void)prepareDetach:(RNSScreenView *)screen
+{
+  [[self findChildControllerForScreen:screen] willMoveToParentViewController:nil];
+}
+
 - (void)detachScreen:(RNSScreenView *)screen
 {
-  [screen.controller willMoveToParentViewController:nil];
-  [screen.controller.view removeFromSuperview];
-  [screen.controller removeFromParentViewController];
+  // We use findChildControllerForScreen method instead of directly accesing
+  // screen.controller because screen.controller may be reset to nil when the
+  // original screen view gets detached from the view hierarchy (we reset controller
+  // reference to avoid reference loops)
+  UIViewController *detachController = [self findChildControllerForScreen:screen];
+  [detachController willMoveToParentViewController:nil];
+  [screen removeFromSuperview];
+  [detachController removeFromParentViewController];
   [_activeScreens removeObject:screen];
 }
 
-- (void)attachScreen:(RNSScreenView *)screen
+- (void)attachScreen:(RNSScreenView *)screen atIndex:(NSInteger)index
 {
   [_controller addChildViewController:screen.controller];
   // the frame is already set at this moment because we adjust it in insertReactSubview. We don't
   // want to update it here as react-driven animations may already run and hence changing the frame
   // would result in visual glitches
-  [_controller.view addSubview:screen.controller.view];
+  [_controller.view insertSubview:screen.controller.view atIndex:index];
   [screen.controller didMoveToParentViewController:_controller];
   [_activeScreens addObject:screen];
 }
@@ -118,22 +138,22 @@
     }
   }
 
-  // if we are adding new active screen, we perform remounting of all already marked as active
-  // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
-  // triggered before the animation starts
-  if (activeScreenAdded) {
-    for (RNSScreenView *screen in _reactSubviews) {
-      if (screen.active && [_activeScreens containsObject:screen]) {
-        [self detachScreen:screen];
-        // disable interactions for the duration of transition
-        screen.userInteractionEnabled = NO;
-      }
-    }
 
+  if (activeScreenAdded) {
     // add new screens in order they are placed in subviews array
+    NSInteger index = 0;
     for (RNSScreenView *screen in _reactSubviews) {
       if (screen.active) {
-        [self attachScreen:screen];
+        if ([_activeScreens containsObject:screen]) {
+          // for screens that were already active we want to mimick the effect UINavigationController
+          // has when willMoveToWindow:nil is triggered before the animation starts
+          [self prepareDetach:screen];
+          // disable interactions for the duration of transition
+          screen.userInteractionEnabled = NO;
+        } else {
+          [self attachScreen:screen atIndex:index];
+        }
+        index += 1;
       }
     }
   }


### PR DESCRIPTION
This change fixes RNSScreenContainer on iOS to prevent from reentering RN's event emitter which resulted in app not responding when used together with react-navigation v5.

The original issue coulv;e been reproduced when using simple react-navigation stack with two views and when attempting to swipe back from the detail view back to home. When that happened the app would go into a deadlock and stop responding.

The underlying issue was due to the fact that we'd trigger detach for screens that are going to be kept active just to make sure that screens are kept in the correct order. As a result, detach would trigger gesture handler to cancel swipe which as a result would attempt to generate an event. Since this whole process would already happen as a result of gesture handler event (during ongoing pan gesture), the RN's gesture emitter would go into deadlock as it uses mutex w/o reentry flag.

As we don't need to go throught the full detach/attach lifecycle for screens that are kept this change updates that logic to only dispatch `willMoveToParent` for screens that are active at the time when new active screen is added. We also had to update `attachScreen` method in order to support index at which the new screen should be placed.

On top of the above I also noticed that ther was a second problem caused by a recent change landed in #378, which would result in the screen we removed from the react hierarchy to not be detached. This was due to the fact we were relying on accessing controller reference via RNSScreenView (view.controller) while the controller ref was being reset to avoid reference cycles. In order to fix this problem we added `findChildControllerForScreen` which looks for the screen's controller reference in childViewControllers array instead of accessing controller property in RNSScreenView.