### PR TITLE
Proper container children cleanup

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -107,12 +107,6 @@ public class Screen extends ViewGroup {
   }
 
   @Override
-  protected void onDetachedFromWindow() {
-    super.onDetachedFromWindow();
-    clearDisappearingChildren();
-  }
-
-  @Override
   protected void onAttachedToWindow() {
     super.onAttachedToWindow();
     // This method implements a workaround for RN's autoFocus functionality. Because of the way

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.FrameLayout;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -53,7 +54,12 @@ public class ScreenFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState) {
-    return recycleView(mScreenView);
+    FrameLayout wrapper = new FrameLayout(getContext());
+    FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+    mScreenView.setLayoutParams(params);
+    wrapper.addView(recycleView(mScreenView));
+    return wrapper;
   }
 
   public Screen getScreen() {
@@ -72,12 +78,6 @@ public class ScreenFragment extends Fragment {
     // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
     // in order to achieve this.
     dispatchOnAppear();
-  }
-
-  @Override
-  public void onDestroyView() {
-    super.onDestroyView();
-    recycleView(getView());
   }
 
   @Override

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -24,12 +24,6 @@ public class ScreenFragment extends Fragment {
       ((ViewGroup) parent).endViewTransition(view);
       ((ViewGroup) parent).removeView(view);
     }
-    // the below check is here to help determine if crashes due to IllegalStateException with
-    // "child already has a parent" caused when view is created are there because for some reason
-    // the above code fails detach the view from its parent
-    if (view.getParent() != null) {
-      throw new IllegalStateException("Recycled fragment view is not detached from its parent");
-    }
 
     // view detached from fragment manager get their visibility changed to GONE after their state is
     // dumped. Since we don't restore the state but want to reuse the view we need to change visibility

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -43,7 +43,6 @@ public class ScreenStackFragment extends ScreenFragment {
   private AppBarLayout mAppBarLayout;
   private Toolbar mToolbar;
   private boolean mShadowHidden;
-  private CoordinatorLayout mScreenRootView;
 
   @SuppressLint("ValidFragment")
   public ScreenStackFragment(Screen screenView) {
@@ -82,31 +81,6 @@ public class ScreenStackFragment extends ScreenFragment {
     }
   }
 
-  private CoordinatorLayout configureView() {
-    CoordinatorLayout view = new NotifyingCoordinatorLayout(getContext(), this);
-    CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
-    params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
-    mScreenView.setLayoutParams(params);
-    view.addView(mScreenView);
-
-    mAppBarLayout = new AppBarLayout(getContext());
-    // By default AppBarLayout will have a background color set but since we cover the whole layout
-    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
-    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
-    // (which is the default)
-    mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
-    mAppBarLayout.setLayoutParams(new AppBarLayout.LayoutParams(
-            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
-    view.addView(mAppBarLayout);
-
-    if (mToolbar != null) {
-      mAppBarLayout.addView(mToolbar);
-    }
-
-    return view;
-  }
-
   @Override
   public void onViewAnimationEnd() {
     super.onViewAnimationEnd();
@@ -135,11 +109,28 @@ public class ScreenStackFragment extends ScreenFragment {
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState) {
-    if (mScreenRootView == null) {
-      mScreenRootView = configureView();
+    CoordinatorLayout view = new NotifyingCoordinatorLayout(getContext(), this);
+    CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
+    params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
+    mScreenView.setLayoutParams(params);
+    view.addView(recycleView(mScreenView));
+
+    mAppBarLayout = new AppBarLayout(getContext());
+    // By default AppBarLayout will have a background color set but since we cover the whole layout
+    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
+    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
+    // (which is the default)
+    mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
+    mAppBarLayout.setLayoutParams(new AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
+    view.addView(mAppBarLayout);
+
+    if (mToolbar != null) {
+      mAppBarLayout.addView(recycleView(mToolbar));
     }
 
-    return recycleView(mScreenRootView);
+    return view;
   }
 
   public boolean isDismissable() {


### PR DESCRIPTION
This change attempts to fix a problem when screen fragment views aren't properly detached from their parents despite `recycleView` being invoked on them.

The final outcome of the issue was that the app would crash with an error that view it tries to attach already has a parent. We observed this issue happening in production but with no clear repro steps the problem appeared to be a bit cryptic. Our investigation shown that `recycleView` does not reset the parent because the view is not listed in `mDisappearingChildren` in `ViewGroup`'s implementation.

We suspect that the above was due to us triggering `clearDisappearingChildren` directly in `Screen` and hence this PR updates that. 

The second change we make here is that we no longer attempt to reuse the main fragment view (crated by `onCreateView`). We used a custom container for stack fragments anyways and in this PR we adapt the same approach for `ScreenFragment` and make it so that the container view is not recycled (only the contents of the container that is managed by React Native is what we recycle).

Next, we update detach handler in containers. As we don't know the exact source of the parent reference cleanup we suspect that what is happening is that some children views remain attached to container past the child fragment lifecycle. This is due to the fact that fragments may perform transitions which may delay the process of child views being detached. As when the container is detached, its children are no longer visible we can safely drop all the children there. We restore fragment hierarchy when the container is attached anyways.
 
Lastly, we make small refactor in `ScreenContainer.java` which aims to extract fragment selection logic out of on attach handler. We may consider moving it elsewhere in the future or consider making it "asynchronous". This leads to some nullability check changes in that file as well as a new methods `setFragmentManager` being added.

