### PR TITLE
Fix user interface style in native stack view controllers

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -285,6 +285,12 @@
       for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
+
+        if (@available(iOS 13.0, *)) {
+          // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
+          next.overrideUserInterfaceStyle = previous.overrideUserInterfaceStyle;
+        }
+
         [previous presentViewController:next
                                animated:lastModal
                              completion:^{

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -286,10 +286,12 @@
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
 
+#ifdef __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
           // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
           next.overrideUserInterfaceStyle = previous.overrideUserInterfaceStyle;
         }
+#endif
 
         [previous presentViewController:next
                                animated:lastModal

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -289,7 +289,7 @@
 #ifdef __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
           // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
-          next.overrideUserInterfaceStyle = previous.overrideUserInterfaceStyle;
+          next.overrideUserInterfaceStyle = _controller.overrideUserInterfaceStyle;
         }
 #endif
 


### PR DESCRIPTION
# Why

In Expo client, which supports both light and dark styles, you can open an experience that has strict setting to light or dark mode. In that case experience's root view controller is set to the style specified by the user, however view controllers presented over it or added as a child have `overrideUserInterfaceStyle` set to `UIUserInterfaceStyleUnspecified` which causes the view controller to use the style that is set in system settings so we get some UIKit's views rendered with incorrect interface style 😞 This only affects view controllers presented modally, thus doing the same for pushed screens is not necessary.
@brentvatne prepared reproducible example: https://github.com/brentvatne/modal-example

# How

Native stack's view controllers will inherit `overrideUserInterfaceStyle` from presenting view controller.

# Test Plan

Example https://github.com/brentvatne/modal-example works as expected in Expo client with style set to Dark in system settings. _*This also requires one small change in the client itself, so it won't work in the current version in the app store._
