### PR TITLE
feat: add replace animation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -30,6 +30,11 @@ public class Screen extends ViewGroup {
     FADE
   }
 
+  public enum ReplaceAnimation {
+    PUSH,
+    POP
+  }
+
   private static OnAttachStateChangeListener sShowSoftKeyboardOnAttach = new OnAttachStateChangeListener() {
 
     @Override
@@ -51,6 +56,7 @@ public class Screen extends ViewGroup {
   private boolean mActive;
   private boolean mTransitioning;
   private StackPresentation mStackPresentation = StackPresentation.PUSH;
+  private ReplaceAnimation mReplaceAnimation = ReplaceAnimation.PUSH;
   private StackAnimation mStackAnimation = StackAnimation.DEFAULT;
   private boolean mGestureEnabled = true;
 
@@ -156,12 +162,20 @@ public class Screen extends ViewGroup {
     mStackAnimation = stackAnimation;
   }
 
+  public void setReplaceAnimation(ReplaceAnimation replaceAnimation) {
+    mReplaceAnimation = replaceAnimation;
+  }
+
   public void setGestureEnabled(boolean gestureEnabled) {
     mGestureEnabled = gestureEnabled;
   }
 
   public StackAnimation getStackAnimation() {
     return mStackAnimation;
+  }
+
+  public ReplaceAnimation getReplaceAnimation() {
+    return mReplaceAnimation;
   }
 
   public StackPresentation getStackPresentation() {

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -56,7 +56,7 @@ public class Screen extends ViewGroup {
   private boolean mActive;
   private boolean mTransitioning;
   private StackPresentation mStackPresentation = StackPresentation.PUSH;
-  private ReplaceAnimation mReplaceAnimation = ReplaceAnimation.PUSH;
+  private ReplaceAnimation mReplaceAnimation = ReplaceAnimation.POP;
   private StackAnimation mStackAnimation = StackAnimation.DEFAULT;
   private boolean mGestureEnabled = true;
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -197,9 +197,9 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       if (mTopScreen != null && newTop != null) {
         // there was some other screen attached before
         int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
-        if (mStack.size() == mScreenFragments.size() && newTop.getScreen().getReplaceAnimation() == Screen.ReplaceAnimation.POP) {
-          // new screen was not on the stack before and the stack has the same amount of screens as before,
-          // so probably the "replace" action was called
+        if (!mScreenFragments.contains(mTopScreen) && newTop.getScreen().getReplaceAnimation() == Screen.ReplaceAnimation.POP) {
+          // if the previous top screen does not exist anymore and the new top was not on the stack before,
+          // probably replace was called, so we check the animation
           transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
         }
         switch (newTop.getScreen().getStackAnimation()) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -197,6 +197,11 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       if (mTopScreen != null && newTop != null) {
         // there was some other screen attached before
         int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
+        if (mStack.size() == mScreenFragments.size() && newTop.getScreen().getReplaceAnimation() == Screen.ReplaceAnimation.POP) {
+          // new screen was not on the stack before and the stack has the same amount of screens as before,
+          // so probably the "replace" action was called
+          transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
+        }
         switch (newTop.getScreen().getStackAnimation()) {
           case NONE:
             transition = FragmentTransaction.TRANSIT_NONE;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -62,6 +62,15 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     view.setGestureEnabled(gestureEnabled);
   }
 
+  @ReactProp(name = "replaceAnimation")
+  public void setReplaceAnimation(Screen view, String animation) {
+    if (animation == null || "pop".equals(animation)) {
+      view.setReplaceAnimation(Screen.ReplaceAnimation.POP);
+    } else if ("push".equals(animation)) {
+      view.setReplaceAnimation(Screen.ReplaceAnimation.PUSH);
+    }
+  }
+
   @Nullable
   @Override
   public Map getExportedCustomDirectEventTypeConstants() {

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -22,6 +22,11 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
   RNSScreenStackAnimationFlip,
 };
 
+typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
+  RNSScreenReplaceAnimationPop,
+  RNSScreenReplaceAnimationPush,
+};
+
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
@@ -53,6 +58,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
+@property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -27,6 +27,7 @@
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
     _gestureEnabled = YES;
+    _replaceAnimation = RNSScreenReplaceAnimationPop;
     _dismissed = NO;
   }
 
@@ -146,6 +147,11 @@
   #endif
 
   _gestureEnabled = gestureEnabled;
+}
+
+- (void)setReplaceAnimation:(RNSScreenReplaceAnimation)replaceAnimation
+{
+  _replaceAnimation = replaceAnimation;
 }
 
 - (UIView *)reactSuperview
@@ -365,6 +371,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(active, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
@@ -398,6 +405,11 @@ RCT_ENUM_CONVERTER(RNSScreenStackAnimation, (@{
                                                   @"fade": @(RNSScreenStackAnimationFade),
                                                   @"flip": @(RNSScreenStackAnimationFlip),
                                                   }), RNSScreenStackAnimationDefault, integerValue)
+
+RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation, (@{
+                                                  @"push": @(RNSScreenReplaceAnimationPush),
+                                                  @"pop": @(RNSScreenReplaceAnimationPop),
+                                                  }), RNSScreenReplaceAnimationPop, integerValue)
 
 
 @end

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -364,13 +364,21 @@
     [_controller setViewControllers:controllers animated:NO];
   } else if (top != lastTop) {
     if (![controllers containsObject:lastTop]) {
-      // last top controller is no longer on stack
-      // in this case we set the controllers stack to the new list with
-      // added the last top element to it and perform (animated) pop
-      NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
-      [newControllers addObject:lastTop];
-      [_controller setViewControllers:newControllers animated:NO];
-      [_controller popViewControllerAnimated:shouldAnimate];
+      // if we have same amount of controllers as before and the screen wasn't on the stack before probably replace was called
+      // so we check if the new screen has "push" replace animation
+      if (_controller.viewControllers.count == controllers.count && ![_controller.viewControllers containsObject:top] && ((RNSScreenView *) top.view).replaceAnimation == RNSScreenReplaceAnimationPush) {
+        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
+        [_controller pushViewController:top animated:shouldAnimate];
+        [_controller setViewControllers:newControllers animated:NO];
+      } else {
+        // last top controller is no longer on stack
+        // in this case we set the controllers stack to the new list with
+        // added the last top element to it and perform (animated) pop
+        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
+        [newControllers addObject:lastTop];
+        [_controller setViewControllers:newControllers animated:NO];
+        [_controller popViewControllerAnimated:shouldAnimate];
+      }
     } else if (![_controller.viewControllers containsObject:top]) {
       // new top controller is not on the stack
       // in such case we update the stack except from the last element with

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -364,9 +364,8 @@
     [_controller setViewControllers:controllers animated:NO];
   } else if (top != lastTop) {
     if (![controllers containsObject:lastTop]) {
-      // if we have same amount of controllers as before and the screen wasn't on the stack before probably replace was called
-      // so we check if the new screen has "push" replace animation
-      if (_controller.viewControllers.count == controllers.count && ![_controller.viewControllers containsObject:top] && ((RNSScreenView *) top.view).replaceAnimation == RNSScreenReplaceAnimationPush) {
+      // if the previous top screen does not exist anymore and the new top was not on the stack before, probably replace was called, so we check the animation
+      if ( ![_controller.viewControllers containsObject:top] && ((RNSScreenView *) top.view).replaceAnimation == RNSScreenReplaceAnimationPush) {
         NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
         [_controller pushViewController:top animated:shouldAnimate];
         [_controller setViewControllers:newControllers animated:NO];

--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -7,13 +7,13 @@ import {
   ScreenStackHeaderCenterView,
   ScreenStackHeaderConfig,
   ScreenStackHeaderLeftView,
-  ScreenStackHeaderRightView
+  ScreenStackHeaderRightView,
 } from 'react-native-screens';
 import {
   createNavigator,
   SceneView,
   StackActions,
-  StackRouter
+  StackRouter,
 } from 'react-navigation';
 import { HeaderBackButton } from 'react-navigation-stack';
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -211,7 +211,7 @@ declare module 'react-native-screens' {
      * Pass HeaderLeft, HeaderRight and HeaderTitle
      */
     children?: React.ReactNode;
-    /*
+    /**
      * @host (iOS only)
      * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
      */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,7 @@ declare module 'react-native-screens' {
     | 'systemMaterialDark'
     | 'systemThickMaterialDark'
     | 'systemChromeMaterialDark';
+  export type ScreenReplaceTypes = 'push' | 'pop';
 
   export interface ScreenProps extends ViewProps {
     active?: 0 | 1 | Animated.AnimatedInterpolation;
@@ -82,13 +83,19 @@ declare module 'react-native-screens' {
      */
     stackPresentation: StackPresentationTypes;
     /**
-     * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The followin values are currently supported:
+     * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The following values are currently supported:
      *  @type "default" – uses a platform default animation
      *  @type "fade" – fades screen in or out
      *  @type "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
      *  @type "none" – the screen appears/dissapears without an animation
      */
     stackAnimation?: StackAnimationTypes;
+    /**
+     * @description Allows for the customization of the type of animation to use when this screen replaces another screen at the top of the stack. The following values are currently supported:
+     *  @type "push" – performs push animation
+     *  @type "pop" – performs pop animation (default)
+     */
+    replaceAnimation?: ScreenReplaceTypes;
     /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */
@@ -108,31 +115,31 @@ declare module 'react-native-screens' {
 
   export interface ScreenStackHeaderConfigProps extends ViewProps {
     /**
-     *@description String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
+     * @description String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
      */
     title?: string;
     /**
-     *@description When set to true the header will be hidden while the parent Screen is on the top of the stack. The default value is false.
+     * @description When set to true the header will be hidden while the parent Screen is on the top of the stack. The default value is false.
      */
     hidden?: boolean;
     /**
-     *@description Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use titleColor property.
+     * @description Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use titleColor property.
      */
     color?: string;
     /**
-     *@description Customize font family to be used for the title.
+     * @description Customize font family to be used for the title.
      */
     titleFontFamily?: string;
     /**
-     *@description Customize the size of the font to be used for the title.
+     * @description Customize the size of the font to be used for the title.
      */
     titleFontSize?: number;
     /**
-     *@description Allows for setting text color of the title.
+     * @description Allows for setting text color of the title.
      */
     titleColor?: string;
     /**
-     *@description Controls the color of the navigation header.
+     * @description Controls the color of the navigation header.
      */
     backgroundColor?: string;
     /**
@@ -204,7 +211,7 @@ declare module 'react-native-screens' {
      * Pass HeaderLeft, HeaderRight and HeaderTitle
      */
     children?: React.ReactNode;
-    /**
+    /*
      * @host (iOS only)
      * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
      */

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -233,6 +233,13 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * How should the screen replacing another screen animate. Defaults to `pop`.
+   * The following values are currently supported:
+   * - "push" – the new screen will perform push animation.
+   * - "pop" – the new screen will perform pop animation.
+   */
+  replaceAnimation?: ScreenProps['replaceAnimation'];
+  /**
    * How should the screen be presented.
    * The following values are currently supported:
    * - "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -1,18 +1,18 @@
 import {
   StackActions,
   StackNavigationState,
-  useTheme
+  useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import {
   Screen as ScreenComponent,
   ScreenProps,
-  ScreenStack
+  ScreenStack,
 } from 'react-native-screens';
 import {
   NativeStackDescriptorMap,
-  NativeStackNavigationHelpers
+  NativeStackNavigationHelpers,
 } from '../types';
 import HeaderConfig from './HeaderConfig';
 
@@ -39,6 +39,7 @@ export default function NativeStackView({
         const { options, render: renderScene } = descriptors[route.key];
         const {
           gestureEnabled,
+          replaceAnimation = 'pop',
           stackPresentation = 'push',
           stackAnimation,
           contentStyle,
@@ -57,6 +58,7 @@ export default function NativeStackView({
             key={route.key}
             style={StyleSheet.absoluteFill}
             gestureEnabled={isAndroid ? false : gestureEnabled}
+            replaceAnimation={replaceAnimation}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
             onWillAppear={() => {


### PR DESCRIPTION
Added animation options for `replace` action. At the update of the container, if the previous top screen is no longer on the stack and the new screen was not there before, it probably means that `replace` action was invoked, so we choose the animation of the new screen. Should close #394.