### PR TITLE
fix: add better shadow handling for newer apis

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -44,7 +44,6 @@ public class ScreenStackFragment extends ScreenFragment {
 
   private AppBarLayout mAppBarLayout;
   private Toolbar mToolbar;
-  private boolean mShadowHidden;
 
   @SuppressLint("ValidFragment")
   public ScreenStackFragment(Screen screenView) {
@@ -74,9 +73,6 @@ public class ScreenStackFragment extends ScreenFragment {
       StateListAnimator stateListAnimator = new StateListAnimator();
       stateListAnimator.addState(new int[0], ObjectAnimator.ofFloat(mAppBarLayout, "elevation",hidden ?  0 : TOOLBAR_ELEVATION));
       mAppBarLayout.setStateListAnimator(stateListAnimator);
-    } else if (mShadowHidden != hidden) {
-      mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
-      mShadowHidden = hidden;
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -1,5 +1,7 @@
 package com.swmansion.rnscreens;
 
+import android.animation.ObjectAnimator;
+import android.animation.StateListAnimator;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
@@ -68,7 +70,11 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   public void setToolbarShadowHidden(boolean hidden) {
-    if (mShadowHidden != hidden) {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP){
+      StateListAnimator stateListAnimator = new StateListAnimator();
+      stateListAnimator.addState(new int[0], ObjectAnimator.ofFloat(mAppBarLayout, "elevation",hidden ?  0 : TOOLBAR_ELEVATION));
+      mAppBarLayout.setStateListAnimator(stateListAnimator);
+    } else if (mShadowHidden != hidden) {
       mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
       mShadowHidden = hidden;
     }


### PR DESCRIPTION
When `headerHideShadow` is set to true on a screen, pushing another screen on top of it and then going back makes the shadow appear again. It looks like a problem with the usage of deprecated method `setTargetElevation`. This change fixes the problem on the newer APIs by using another method of changing the elevation. Should resolve #484.