### PR TITLE
fix: disable gestures in native stack on Android

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import {
   StackRouter,
   SceneView,
@@ -90,7 +90,8 @@ class StackView extends React.Component {
       translucent: translucent === undefined ? false : translucent,
       title,
       titleFontFamily: headerTitleStyle && headerTitleStyle.fontFamily,
-      titleColor: (headerTitleStyle && headerTitleStyle.color) || headerTintColor,
+      titleColor:
+        (headerTitleStyle && headerTitleStyle.color) || headerTintColor,
       titleFontSize: headerTitleStyle && headerTitleStyle.fontSize,
       backTitle: headerBackTitleVisible === false ? '' : headerBackTitle,
       backTitleFontFamily:
@@ -213,13 +214,22 @@ class StackView extends React.Component {
         style={[StyleSheet.absoluteFill, options.cardStyle]}
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}
+        replaceAnimation={
+          options.replaceAnimation === undefined
+            ? 'pop'
+            : options.replaceAnimation
+        }
         pointerEvents={
           index === this.props.navigation.state.routes.length - 1
             ? 'auto'
             : 'none'
         }
         gestureEnabled={
-          options.gestureEnabled === undefined ? true : options.gestureEnabled
+          Platform.OS === 'android'
+            ? false
+            : options.gestureEnabled === undefined
+              ? true
+              : options.gestureEnabled
         }
         onAppear={() => this._onAppear(route, descriptor)}
         onDismissed={() => this._removeScene(route)}>

--- a/native-stack/views/NativeStackView.tsx
+++ b/native-stack/views/NativeStackView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import {
   ScreenStack,
   Screen as ScreenComponent,
@@ -46,7 +46,7 @@ export default function NativeStackView({
           <Screen
             key={route.key}
             style={StyleSheet.absoluteFill}
-            gestureEnabled={gestureEnabled}
+            gestureEnabled={Platform.OS === 'android' ? false : gestureEnabled}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
             onAppear={() => {


### PR DESCRIPTION
If `ScreenStack`s of native-stack navigators have the same `FragmentManager` (because each of them is not under a different `Screen` component), changing a screen in one of the stacks pops one screen in the other stack because of the  https://github.com/software-mansion/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java#L34 being called in both `ScreenStack`s by the `FragmentManager`. The workaround is to set `gestureEnabled` to false in `createNativeStackNavigator` on Android since React-Navigation handles hw back button and setting it will make the https://github.com/software-mansion/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java#L283 not to be called because the screen is not dismissable without `gestureEnabled` set to `true`. Should fix #402. PR also fixes some indentations since the file was not indented properly.