### PR TITLE
Fix type for onFinishTransitioning, remove event from native-stack

### DIFF
--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -20,10 +20,6 @@ export type NativeStackNavigationEventMap = {
    * Event which fires when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down).
    */
   dismiss: { data: undefined };
-  /**
-   * Event which fires when the screen finishes its transition
-   */
-  finishTransitioning: { data: undefined };
 };
 
 export type NativeStackNavigationProp<

--- a/native-stack/views/NativeStackView.tsx
+++ b/native-stack/views/NativeStackView.tsx
@@ -33,7 +33,7 @@ export default function NativeStackView({
 
   return (
     <ScreenStack style={styles.container}>
-      {state.routes.map(route => {
+      {state.routes.map((route) => {
         const { options, render: renderScene } = descriptors[route.key];
         const {
           gestureEnabled,
@@ -65,12 +65,6 @@ export default function NativeStackView({
                 ...StackActions.pop(),
                 source: route.key,
                 target: state.key,
-              });
-            }}
-            onFinishTransitioning={() => {
-              navigation.emit({
-                type: 'finishTransitioning',
-                target: route.key,
               });
             }}>
             <HeaderConfig {...options} route={route} />

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -36,10 +36,6 @@ declare module 'react-native-screens' {
      */
     onDismissed?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
-     *@description A callback that gets called when the current screen finishes its transition.
-     */
-    onFinishTransitioning?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
-    /**
      * @type "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
      * @type "modal" – the new screen will be presented modally. In addition this allow for a nested stack to be rendered inside such screens
      * @type "transparentModal" – the new screen will be presented modally but in addition the second to last screen will remain attached to the stack container such that if the top screen is non opaque the content below can still be seen. If "modal" is used instead the below screen will get unmounted as soon as the transition ends.
@@ -64,6 +60,10 @@ declare module 'react-native-screens' {
   export interface ScreenStackProps extends ViewProps {
     transitioning?: number;
     progress?: number;
+    /**
+     * @description A callback that gets called when the current screen finishes its transition.
+     */
+    onFinishTransitioning?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
   }
 
   export interface ScreenStackHeaderConfigProps extends ViewProps {
@@ -170,7 +170,5 @@ declare module 'react-native-screens' {
   export const ScreenStackHeaderLeftView: ComponentClass<ViewProps>;
   export const ScreenStackHeaderRightView: ComponentClass<ViewProps>;
   export const ScreenStackHeaderCenterView: ComponentClass<ViewProps>;
-  export const ScreenStackHeaderConfig: ComponentClass<
-    ScreenStackHeaderConfigProps
-  >;
+  export const ScreenStackHeaderConfig: ComponentClass<ScreenStackHeaderConfigProps>;
 }


### PR DESCRIPTION
`onFinishTransitioning` is actually implemented on the `ScreenStack` component and not `Screen`. I noticed since the event was never called in native-stack. I removed it since I don't think there is any infra for Stack based events and I doubt it was used anyway since it wasn't working at all.