### PR TITLE
[native-stack] Add transitionStart and transitionEnd events

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -55,6 +55,14 @@ public class Screen extends ViewGroup {
   private boolean mGestureEnabled = true;
 
   @Override
+  protected void onAnimationStart() {
+    super.onAnimationStart();
+    if (mFragment != null) {
+      mFragment.onViewAnimationStart();
+    }
+  }
+
+  @Override
   protected void onAnimationEnd() {
     super.onAnimationEnd();
     if (mFragment != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenDisappearEvent.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenDisappearEvent.java
@@ -1,0 +1,30 @@
+package com.swmansion.rnscreens;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class ScreenDisappearEvent extends Event<ScreenAppearEvent> {
+
+  public static final String EVENT_NAME = "topDisappear";
+
+  public ScreenDisappearEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
+  }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -11,6 +11,9 @@ import android.widget.FrameLayout;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
@@ -33,6 +36,7 @@ public class ScreenFragment extends Fragment {
   }
 
   protected Screen mScreenView;
+  private List<ScreenContainer> mChildScreenContainers = new ArrayList<>();
 
   public ScreenFragment() {
     throw new IllegalStateException("Screen fragments should never be restored");
@@ -65,6 +69,13 @@ public class ScreenFragment extends Fragment {
         .getNativeModule(UIManagerModule.class)
         .getEventDispatcher()
         .dispatchEvent(new ScreenWillAppearEvent(mScreenView.getId()));
+
+    for (ScreenContainer sc : mChildScreenContainers) {
+      if (sc.getScreenCount() > 0) {
+        Screen topScreen = sc.getScreenAt(sc.getScreenCount() - 1);
+        topScreen.getFragment().dispatchOnWillAppear();
+      }
+    }
   }
 
   protected void dispatchOnAppear() {
@@ -72,6 +83,13 @@ public class ScreenFragment extends Fragment {
             .getNativeModule(UIManagerModule.class)
             .getEventDispatcher()
             .dispatchEvent(new ScreenAppearEvent(mScreenView.getId()));
+
+    for (ScreenContainer sc : mChildScreenContainers) {
+      if (sc.getScreenCount() > 0) {
+        Screen topScreen = sc.getScreenAt(sc.getScreenCount() - 1);
+        topScreen.getFragment().dispatchOnAppear();
+      }
+    }
   }
 
   protected void dispatchOnWillDisappear() {
@@ -79,6 +97,13 @@ public class ScreenFragment extends Fragment {
         .getNativeModule(UIManagerModule.class)
         .getEventDispatcher()
         .dispatchEvent(new ScreenWillDisappearEvent(mScreenView.getId()));
+
+    for (ScreenContainer sc : mChildScreenContainers) {
+      if (sc.getScreenCount() > 0) {
+        Screen topScreen = sc.getScreenAt(sc.getScreenCount() - 1);
+        topScreen.getFragment().dispatchOnWillDisappear();
+      }
+    }
   }
 
   protected void dispatchOnDisappear() {
@@ -86,6 +111,21 @@ public class ScreenFragment extends Fragment {
         .getNativeModule(UIManagerModule.class)
         .getEventDispatcher()
         .dispatchEvent(new ScreenDisappearEvent(mScreenView.getId()));
+
+    for (ScreenContainer sc : mChildScreenContainers) {
+      if (sc.getScreenCount() > 0) {
+        Screen topScreen = sc.getScreenAt(sc.getScreenCount() - 1);
+        topScreen.getFragment().dispatchOnDisappear();
+      }
+    }
+  }
+
+  public void registerChildScreenContainer(ScreenContainer screenContainer) {
+    mChildScreenContainers.add(screenContainer);
+  }
+
+  public void unregisterChildScreenContainer(ScreenContainer screenContainer) {
+    mChildScreenContainers.remove(screenContainer);
   }
 
   public void onViewAnimationStart() {
@@ -121,5 +161,6 @@ public class ScreenFragment extends Fragment {
               .getEventDispatcher()
               .dispatchEvent(new ScreenDismissedEvent(mScreenView.getId()));
     }
+    mChildScreenContainers.clear();
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -8,11 +8,11 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.FrameLayout;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 public class ScreenFragment extends Fragment {
 
@@ -60,18 +60,54 @@ public class ScreenFragment extends Fragment {
     return mScreenView;
   }
 
-  private void dispatchOnAppear() {
+  protected void dispatchOnWillAppear() {
+    ((ReactContext) mScreenView.getContext())
+        .getNativeModule(UIManagerModule.class)
+        .getEventDispatcher()
+        .dispatchEvent(new ScreenWillAppearEvent(mScreenView.getId()));
+  }
+
+  protected void dispatchOnAppear() {
     ((ReactContext) mScreenView.getContext())
             .getNativeModule(UIManagerModule.class)
             .getEventDispatcher()
             .dispatchEvent(new ScreenAppearEvent(mScreenView.getId()));
   }
 
+  protected void dispatchOnWillDisappear() {
+    ((ReactContext) mScreenView.getContext())
+        .getNativeModule(UIManagerModule.class)
+        .getEventDispatcher()
+        .dispatchEvent(new ScreenWillDisappearEvent(mScreenView.getId()));
+  }
+
+  protected void dispatchOnDisappear() {
+    ((ReactContext) mScreenView.getContext())
+        .getNativeModule(UIManagerModule.class)
+        .getEventDispatcher()
+        .dispatchEvent(new ScreenDisappearEvent(mScreenView.getId()));
+  }
+
+  public void onViewAnimationStart() {
+    // onViewAnimationStart is triggered from View#onAnimationStart method of the fragment's root view.
+    // We override Screen#onAnimationStart and an appropriate method of the StackFragment's root view
+    // in order to achieve this.
+    if (isResumed()) {
+      dispatchOnWillAppear();
+    } else {
+      dispatchOnWillDisappear();
+    }
+  }
+
   public void onViewAnimationEnd() {
     // onViewAnimationEnd is triggered from View#onAnimationEnd method of the fragment's root view.
     // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
     // in order to achieve this.
-    dispatchOnAppear();
+    if (isResumed()) {
+      dispatchOnAppear();
+    } else {
+      dispatchOnDisappear();
+    }
   }
 
   @Override

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -9,16 +9,17 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.animation.Animation;
+import android.view.animation.AnimationSet;
 import android.widget.LinearLayout;
+
+import com.facebook.react.uimanager.PixelUtil;
+import com.google.android.material.appbar.AppBarLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.fragment.app.Fragment;
-
-import com.facebook.react.uimanager.PixelUtil;
-import com.google.android.material.appbar.AppBarLayout;
 
 public class ScreenStackFragment extends ScreenFragment {
 
@@ -31,10 +32,31 @@ public class ScreenStackFragment extends ScreenFragment {
       mFragment = fragment;
     }
 
+    private Animation.AnimationListener mAnimationListener = new Animation.AnimationListener() {
+      @Override
+      public void onAnimationStart(Animation animation) {
+        mFragment.onViewAnimationStart();
+      }
+
+      @Override
+      public void onAnimationEnd(Animation animation) {
+        mFragment.onViewAnimationEnd();
+      }
+
+      @Override
+      public void onAnimationRepeat(Animation animation) {
+
+      }
+    };
+
     @Override
-    protected void onAnimationEnd() {
-      super.onAnimationEnd();
-      mFragment.onViewAnimationEnd();
+    public void startAnimation(Animation animation) {
+      // For some reason View##onAnimationEnd doesn't get called for
+      // exit transitions so we use this hack.
+      AnimationSet set = new AnimationSet(true);
+      set.addAnimation(animation);
+      set.setAnimationListener(mAnimationListener);
+      super.startAnimation(set);
     }
   }
 
@@ -89,12 +111,24 @@ public class ScreenStackFragment extends ScreenFragment {
 
   @Nullable
   @Override
-  public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
-    if (enter && transit == 0) {
-      // this means that the fragment will appear without transition, in this case onViewAnimationEnd
-      // won't be called and we need to notify stack directly from here.
-      notifyViewAppearTransitionEnd();
+  public Animation onCreateAnimation(int transit, final boolean enter, int nextAnim) {
+    // this means that the fragment will appear without transition, in this case
+    // onViewAnimationStart and onViewAnimationEnd won't be called and we need to notify
+    // stack directly from here.
+    // When using the Toolbar back button this is called an extra time with transit = 0 but in
+    // this case we don't want to notify. The way I found to detect is case is check isHidden.
+    if (transit == 0 && !isHidden()) {
+      if (enter) {
+        dispatchOnWillAppear();
+        dispatchOnAppear();
+      } else {
+        dispatchOnWillDisappear();
+        dispatchOnDisappear();
+        notifyViewAppearTransitionEnd();
+      }
+
     }
+
     return null;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -118,12 +118,20 @@ public class ScreenStackFragment extends ScreenFragment {
     // When using the Toolbar back button this is called an extra time with transit = 0 but in
     // this case we don't want to notify. The way I found to detect is case is check isHidden.
     if (transit == 0 && !isHidden()) {
+      // If the container is nested then appear events will be dispatched by their parent screen so
+      // they must not be triggered here.
+      ScreenContainer container = getScreen().getContainer();
+      boolean isNested = container != null && container.isNested();
       if (enter) {
-        dispatchOnWillAppear();
-        dispatchOnAppear();
+        if (!isNested) {
+          dispatchOnWillAppear();
+          dispatchOnAppear();
+        }
       } else {
-        dispatchOnWillDisappear();
-        dispatchOnDisappear();
+        if (!isNested) {
+          dispatchOnWillDisappear();
+          dispatchOnDisappear();
+        }
         notifyViewAppearTransitionEnd();
       }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -68,8 +68,14 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     return MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onDismissed"),
+            ScreenWillAppearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onWillAppear"),
             ScreenAppearEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onAppear"),
+            ScreenWillDisappearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onWillDisappear"),
+            ScreenDisappearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onDisappear"),
             StackFinishTransitioningEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onFinishTransitioning"));
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWillAppearEvent.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWillAppearEvent.java
@@ -1,0 +1,30 @@
+package com.swmansion.rnscreens;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class ScreenWillAppearEvent extends Event<ScreenAppearEvent> {
+
+  public static final String EVENT_NAME = "topWillAppear";
+
+  public ScreenWillAppearEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
+  }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWillDisappearEvent.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWillDisappearEvent.java
@@ -1,0 +1,30 @@
+package com.swmansion.rnscreens;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class ScreenWillDisappearEvent extends Event<ScreenAppearEvent> {
+
+  public static final String EVENT_NAME = "topWillDisappear";
+
+  public ScreenWillDisappearEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
+  }
+}

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -42,7 +42,10 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @interface RNSScreenView : RCTView
 
 @property (nonatomic, copy) RCTDirectEventBlock onAppear;
+@property (nonatomic, copy) RCTDirectEventBlock onDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onDismissed;
+@property (nonatomic, copy) RCTDirectEventBlock onWillAppear;
+@property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic, readonly) BOOL dismissed;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -179,6 +179,20 @@
   }
 }
 
+- (void)notifyWillAppear
+{
+  if (self.onWillAppear) {
+    self.onWillAppear(nil);
+  }
+}
+
+- (void)notifyWillDisappear
+{
+  if (self.onWillDisappear) {
+    self.onWillDisappear(nil);
+  }
+}
+
 - (void)notifyAppear
 {
   if (self.onAppear) {
@@ -187,6 +201,13 @@
         self.onAppear(nil);
       }
     });
+  }
+}
+
+- (void)notifyDisappear
+{
+  if (self.onDisappear) {
+    self.onDisappear(nil);
   }
 }
 
@@ -299,19 +320,35 @@
   }
 }
 
-- (void)viewDidDisappear:(BOOL)animated
+- (void)viewWillAppear:(BOOL)animated
 {
-  [super viewDidDisappear:animated];
-  if (self.parentViewController == nil && self.presentingViewController == nil) {
-    // screen dismissed, send event
-    [((RNSScreenView *)self.view) notifyDismissed];
-  }
+  [super viewWillAppear:animated];
+
+  [((RNSScreenView *)self.view) notifyWillAppear];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+  [super viewWillDisappear:animated];
+
+  [((RNSScreenView *)self.view) notifyWillDisappear];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
   [((RNSScreenView *)self.view) notifyAppear];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+  [super viewDidDisappear:animated];
+
+  [((RNSScreenView *)self.view) notifyDisappear];
+  if (self.parentViewController == nil && self.presentingViewController == nil) {
+    // screen dismissed, send event
+    [((RNSScreenView *)self.view) notifyDismissed];
+  }
 }
 
 - (void)notifyFinishTransitioning
@@ -330,7 +367,10 @@ RCT_EXPORT_VIEW_PROPERTY(active, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
+RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onDismissed, RCTDirectEventBlock);
 
 - (UIView *)view

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -217,17 +217,52 @@ React.useEffect(
 );
 ```
 
-#### `finishTransitioning`
+#### `transitionStart`
 
-Event which fires when the current screen finishes its transition.
+Event which fires when a transition animation starts.
+
+Event data:
+
+- `closing` - Whether the screen will be dismissed or will appear.
 
 Example:
 
 ```js
 React.useEffect(
   () => {
-    const unsubscribe = navigation.addListener('finishTransitioning', e => {
-      // Do something
+    const unsubscribe = navigation.addListener('transitionStart', e => {
+      if (e.data.closing) {
+        // Will be dismissed
+      } else {
+        // Will appear
+      }
+    });
+
+    return unsubscribe;
+  },
+  [navigation]
+);
+```
+
+#### `transitionEnd`
+
+Event which fires when a transition animation ends.
+
+Event data:
+
+- `closing` - Whether the screen was dismissed or did appear.
+
+Example:
+
+```js
+React.useEffect(
+  () => {
+    const unsubscribe = navigation.addListener('transitionEnd', e => {
+      if (e.data.closing) {
+        // Was dismissed
+      } else {
+        // Did appear
+      }
     });
 
     return unsubscribe;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,7 @@ declare module 'react-native-screens' {
      */
     onWillAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
-     * @description A callback that gets called when the current screen will disappears. This is called as soon as the transition begins.
+     * @description A callback that gets called when the current screen will disappear. This is called as soon as the transition begins.
      */
     onWillDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,7 +52,7 @@ declare module 'react-native-screens' {
     children?: React.ReactNode;
 
     /**
-     * @description A callback that gets called when the current screen will appears. This is called as soon as the transition begins.
+     * @description A callback that gets called when the current screen will appear. This is called as soon as the transition begins.
      */
     onWillAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,12 +50,25 @@ declare module 'react-native-screens' {
     active?: 0 | 1 | Animated.AnimatedInterpolation;
     onComponentRef?: (view: any) => void;
     children?: React.ReactNode;
+
     /**
-     *@description A callback that gets called when the current screen appears.
+     * @description A callback that gets called when the current screen will appears. This is called as soon as the transition begins.
+     */
+    onWillAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    /**
+     * @description A callback that gets called when the current screen will disappears. This is called as soon as the transition begins.
+     */
+    onWillDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    /**
+     * @description A callback that gets called when the current screen appears.
      */
     onAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
-     *@description A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down). The callback takes no arguments.
+     * @description A callback that gets called when the current screen disappears.
+     */
+    onDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    /**
+     * @description A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down). The callback takes no arguments.
      */
     onDismissed?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
@@ -69,7 +82,7 @@ declare module 'react-native-screens' {
      */
     stackPresentation: StackPresentationTypes;
     /**
-     *@description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The followin values are currently supported:
+     * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The followin values are currently supported:
      *  @type "default" – uses a platform default animation
      *  @type "fade" – fades screen in or out
      *  @type "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -23,6 +23,14 @@ export type NativeStackNavigationEventMap = {
    * Event which fires when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down).
    */
   dismiss: { data: undefined };
+  /**
+   * Event which fires when a transition animation starts.
+   */
+  transitionStart: { data: { closing: boolean } };
+  /**
+   * Event which fires when a transition animation ends.
+   */
+  transitionEnd: { data: { closing: boolean } };
 };
 
 export type NativeStackNavigationProp<

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -49,9 +49,35 @@ export default function NativeStackView({
             gestureEnabled={Platform.OS === 'android' ? false : gestureEnabled}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
+            onWillAppear={() => {
+              navigation.emit({
+                type: 'transitionStart',
+                data: { closing: false },
+                target: route.key,
+              });
+            }}
+            onWillDisappear={() => {
+              navigation.emit({
+                type: 'transitionStart',
+                data: { closing: true },
+                target: route.key,
+              });
+            }}
             onAppear={() => {
               navigation.emit({
                 type: 'appear',
+                target: route.key,
+              });
+              navigation.emit({
+                type: 'transitionEnd',
+                data: { closing: false },
+                target: route.key,
+              });
+            }}
+            onDisappear={() => {
+              navigation.emit({
+                type: 'transitionEnd',
+                data: { closing: true },
                 target: route.key,
               });
             }}


### PR DESCRIPTION
Implement [these](https://github.com/react-navigation/react-navigation/blob/bea14aa26fd5cbfebc7973733c5cf1f44fd323aa/packages/stack/src/types.tsx#L25) events in native stack, similar to the events available in js stack.