### PR TITLE
Add props to headerLeft and headerRight

### DIFF
--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -124,7 +124,7 @@ export type NativeStackNavigationOptions = {
   /**
    * Function which returns a React Element to display in the center of the header.
    */
-  headerCenter?: () => React.ReactNode;
+  headerCenter?: (props: {tintColor?: string}) => React.ReactNode;
   /**
    * Tint color for the header. Changes the color of back button and title.
    */

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -116,15 +116,15 @@ export type NativeStackNavigationOptions = {
   /**
    * Function which returns a React Element to display on the right side of the header.
    */
-  headerRight?: (props: {tintColor?: string}) => React.ReactNode;
+  headerRight?: (props: { tintColor?: string }) => React.ReactNode;
   /**
    * Function which returns a React Element to display on the left side of the header.
    */
-  headerLeft?: (props: {tintColor?: string}) => React.ReactNode;
+  headerLeft?: (props: { tintColor?: string }) => React.ReactNode;
   /**
    * Function which returns a React Element to display in the center of the header.
    */
-  headerCenter?: (props: {tintColor?: string}) => React.ReactNode;
+  headerCenter?: (props: { tintColor?: string }) => React.ReactNode;
   /**
    * Tint color for the header. Changes the color of back button and title.
    */

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -116,11 +116,11 @@ export type NativeStackNavigationOptions = {
   /**
    * Function which returns a React Element to display on the right side of the header.
    */
-  headerRight?: () => React.ReactNode;
+  headerRight?: (props: {tintColor?: string}) => React.ReactNode;
   /**
    * Function which returns a React Element to display on the left side of the header.
    */
-  headerLeft?: () => React.ReactNode;
+  headerLeft?: (props: {tintColor?: string}) => React.ReactNode;
   /**
    * Function which returns a React Element to display in the center of the header.
    */

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -50,8 +50,8 @@ export default function HeaderConfig(props: Props) {
         headerTitle !== undefined
           ? headerTitle
           : title !== undefined
-          ? title
-          : route.name
+            ? title
+            : route.name
       }
       titleFontFamily={headerTitleStyle.fontFamily}
       titleFontSize={headerTitleStyle.fontSize}
@@ -59,8 +59,8 @@ export default function HeaderConfig(props: Props) {
         headerTitleStyle.color !== undefined
           ? headerTitleStyle.color
           : headerTintColor !== undefined
-          ? headerTintColor
-          : colors.text
+            ? headerTintColor
+            : colors.text
       }
       backTitle={headerBackTitleVisible ? headerBackTitle : ' '}
       backTitleFontFamily={headerBackTitleStyle.fontFamily}

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -77,10 +77,10 @@ export default function HeaderConfig(props: Props) {
       }
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
       {headerRight !== undefined ? (
-        <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
+        <ScreenStackHeaderRightView>{headerRight({tintColor: colors.primary})}</ScreenStackHeaderRightView>
       ) : null}
       {headerLeft !== undefined ? (
-        <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
+        <ScreenStackHeaderLeftView>{headerLeft({tintColor: colors.primary})}</ScreenStackHeaderLeftView>
       ) : null}
       {headerCenter !== undefined ? (
         <ScreenStackHeaderCenterView>

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -88,7 +88,7 @@ export default function HeaderConfig(props: Props) {
       ) : null}
       {headerCenter !== undefined ? (
         <ScreenStackHeaderCenterView>
-          {headerCenter({ tintColor: headerTintColor ?? colors.text })}
+          {headerCenter({ tintColor: headerTintColor ?? colors.primary })}
         </ScreenStackHeaderCenterView>
       ) : null}
     </ScreenStackHeaderConfig>

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -50,8 +50,8 @@ export default function HeaderConfig(props: Props) {
         headerTitle !== undefined
           ? headerTitle
           : title !== undefined
-            ? title
-            : route.name
+          ? title
+          : route.name
       }
       titleFontFamily={headerTitleStyle.fontFamily}
       titleFontSize={headerTitleStyle.fontSize}
@@ -59,8 +59,8 @@ export default function HeaderConfig(props: Props) {
         headerTitleStyle.color !== undefined
           ? headerTitleStyle.color
           : headerTintColor !== undefined
-            ? headerTintColor
-            : colors.text
+          ? headerTintColor
+          : colors.text
       }
       backTitle={headerBackTitleVisible ? headerBackTitle : ' '}
       backTitleFontFamily={headerBackTitleStyle.fontFamily}
@@ -77,14 +77,18 @@ export default function HeaderConfig(props: Props) {
       }
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
       {headerRight !== undefined ? (
-        <ScreenStackHeaderRightView>{headerRight({tintColor: colors.primary})}</ScreenStackHeaderRightView>
+        <ScreenStackHeaderRightView>
+          {headerRight({ tintColor: headerTintColor ?? colors.primary })}
+        </ScreenStackHeaderRightView>
       ) : null}
       {headerLeft !== undefined ? (
-        <ScreenStackHeaderLeftView>{headerLeft({tintColor: colors.primary})}</ScreenStackHeaderLeftView>
+        <ScreenStackHeaderLeftView>
+          {headerLeft({ tintColor: headerTintColor ?? colors.primary })}
+        </ScreenStackHeaderLeftView>
       ) : null}
       {headerCenter !== undefined ? (
         <ScreenStackHeaderCenterView>
-          {headerCenter()}
+          {headerCenter({ tintColor: headerTintColor ?? colors.text })}
         </ScreenStackHeaderCenterView>
       ) : null}
     </ScreenStackHeaderConfig>


### PR DESCRIPTION
This PR will allow users to custom headerRight and headerLeft components using user's theme color.
For example, if I want a custom settings icon in headerRight to navigate to my settings page, I will be able to retrieve color from my custom theme. It's already available in ReactNavigation.

`colors.primary` is used by the back button so it makes sense to use it for headerRight and headerLeft.

The same logic may be applied to headerCenter (Imagine a custom TextComponent), we may apply colors.text in this case.

Let me know if you find this useful (or not), or if I can make it better to be integrated.