### PR TITLE
feat: remove default active prop on web

### DIFF
--- a/src/screens.web.js
+++ b/src/screens.web.js
@@ -12,10 +12,6 @@ export function screensEnabled() {
 }
 
 export class NativeScreen extends React.Component {
-  static defaultProps = {
-    active: true,
-  };
-
   render() {
     const { active, style, ...rest } = this.props;
 


### PR DESCRIPTION
Remove the `defaultProps` since it is not necessary. Should fix #492.