### PR TITLE
@wolewicki/add header blur effect

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -15,6 +15,7 @@
 @property (nonatomic, retain) NSString *backTitleFontFamily;
 @property (nonatomic, retain) NSNumber *backTitleFontSize;
 @property (nonatomic, retain) UIColor *backgroundColor;
+@property (nonatomic, retain) NSString *blurEffect;
 @property (nonatomic, retain) UIColor *color;
 @property (nonatomic) BOOL hide;
 @property (nonatomic) BOOL largeTitle;

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -15,7 +15,7 @@
 @property (nonatomic, retain) NSString *backTitleFontFamily;
 @property (nonatomic, retain) NSNumber *backTitleFontSize;
 @property (nonatomic, retain) UIColor *backgroundColor;
-@property (nonatomic, retain) NSString *blurEffect;
+@property (nonatomic) UIBlurEffectStyle blurEffect;
 @property (nonatomic, retain) UIColor *color;
 @property (nonatomic) BOOL hide;
 @property (nonatomic) BOOL largeTitle;
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 @interface RCTConvert (RNSScreenStackHeader)
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
++ (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -266,12 +266,7 @@
     // transparent background color
     [appearance configureWithTransparentBackground];
   } else {
-    // non-transparent background or default background
-    if (config.translucent) {
-      [appearance configureWithDefaultBackground];
-    } else {
-      [appearance configureWithOpaqueBackground];
-    }
+    [appearance configureWithOpaqueBackground];
   }
   
   // set background color if specified
@@ -524,21 +519,21 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 #ifdef __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [blurEffects addEntriesFromDictionary:@{
-      @"ultraThinMaterial": @(UIBlurEffectStyleSystemUltraThinMaterial),
-      @"thinMaterial": @(UIBlurEffectStyleSystemThinMaterial),
-      @"material": @(UIBlurEffectStyleSystemMaterial),
-      @"thickMaterial": @(UIBlurEffectStyleSystemThickMaterial),
-      @"chromeMaterial": @(UIBlurEffectStyleSystemChromeMaterial),
-      @"ultraThinMaterialLight": @(UIBlurEffectStyleSystemUltraThinMaterialLight),
-      @"thinMaterialLight": @(UIBlurEffectStyleSystemThinMaterialLight),
-      @"materialLight": @(UIBlurEffectStyleSystemMaterialLight),
-      @"thickMaterialLight": @(UIBlurEffectStyleSystemThickMaterialLight),
-      @"chromeMaterialLight": @(UIBlurEffectStyleSystemChromeMaterialLight),
-      @"ultraThinMaterialDark": @(UIBlurEffectStyleSystemUltraThinMaterialDark),
-      @"thinMaterialDark": @(UIBlurEffectStyleSystemThinMaterialDark),
-      @"materialDark": @(UIBlurEffectStyleSystemMaterialDark),
-      @"thickMaterialDark": @(UIBlurEffectStyleSystemThickMaterialDark),
-      @"chromeMaterialDark": @(UIBlurEffectStyleSystemChromeMaterialDark),
+      @"systemUltraThinMaterial": @(UIBlurEffectStyleSystemUltraThinMaterial),
+      @"systemThinMaterial": @(UIBlurEffectStyleSystemThinMaterial),
+      @"systemMaterial": @(UIBlurEffectStyleSystemMaterial),
+      @"systemThickMaterial": @(UIBlurEffectStyleSystemThickMaterial),
+      @"systemChromeMaterial": @(UIBlurEffectStyleSystemChromeMaterial),
+      @"systemUltraThinMaterialLight": @(UIBlurEffectStyleSystemUltraThinMaterialLight),
+      @"systemThinMaterialLight": @(UIBlurEffectStyleSystemThinMaterialLight),
+      @"systemMaterialLight": @(UIBlurEffectStyleSystemMaterialLight),
+      @"systemThickMaterialLight": @(UIBlurEffectStyleSystemThickMaterialLight),
+      @"systemChromeMaterialLight": @(UIBlurEffectStyleSystemChromeMaterialLight),
+      @"systemUltraThinMaterialDark": @(UIBlurEffectStyleSystemUltraThinMaterialDark),
+      @"systemThinMaterialDark": @(UIBlurEffectStyleSystemThinMaterialDark),
+      @"systemMaterialDark": @(UIBlurEffectStyleSystemMaterialDark),
+      @"systemThickMaterialDark": @(UIBlurEffectStyleSystemThickMaterialDark),
+      @"systemChromeMaterialDark": @(UIBlurEffectStyleSystemChromeMaterialDark),
     }];
   }
 #endif

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -265,6 +265,7 @@
   if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
     // transparent background color
     [appearance configureWithTransparentBackground];
+    appearance.backgroundColor = config.backgroundColor;
   } else {
     // non-transparent background or default background
     if (config.translucent) {
@@ -279,8 +280,8 @@
     }
   }
 
-  if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
-    appearance.backgroundColor = config.backgroundColor;
+  if (config.blurEffect) {
+    appearance.backgroundEffect = [UIBlurEffect effectWithStyle:[self blurEffectStyleFromEffectName:config.blurEffect]];
   }
 
   if (config.hideShadow) {
@@ -467,6 +468,59 @@
   }
 }
 
++ (UIBlurEffectStyle)blurEffectStyleFromEffectName:(NSString *)effectName
+{
+  if (@available(iOS 13.0, *)) {
+    if ([effectName  isEqual: @"extraLight"]) {
+      return UIBlurEffectStyleExtraLight;
+    } else if ([effectName  isEqual: @"light"]) {
+      return UIBlurEffectStyleLight;
+    } else if ([effectName  isEqual: @"dark"]) {
+      return UIBlurEffectStyleDark;
+      
+    } else if ([effectName  isEqual: @"regular"]) {
+      return UIBlurEffectStyleRegular;
+    } else if ([effectName  isEqual: @"prominent"]) {
+      return UIBlurEffectStyleProminent;
+
+    } else if ([effectName  isEqual: @"ultraThinMaterial"]) {
+      return UIBlurEffectStyleSystemUltraThinMaterial;
+    } else if ([effectName  isEqual: @"thinMaterial"]) {
+      return UIBlurEffectStyleSystemThinMaterial;
+    } else if ([effectName  isEqual: @"material"]) {
+      return UIBlurEffectStyleSystemMaterial;
+    } else if ([effectName  isEqual: @"thickMaterial"]) {
+      return UIBlurEffectStyleSystemThickMaterial;
+    } else if ([effectName  isEqual: @"chromeMaterial"]) {
+      return UIBlurEffectStyleSystemChromeMaterial;
+
+
+    } else if ([effectName  isEqual: @"ultraThinMaterialLight"]) {
+      return UIBlurEffectStyleSystemUltraThinMaterialLight;
+    } else if ([effectName  isEqual: @"thinMaterialLight"]) {
+      return UIBlurEffectStyleSystemThinMaterialLight;
+    } else if ([effectName  isEqual: @"materialLight"]) {
+      return UIBlurEffectStyleSystemMaterialLight;
+    } else if ([effectName  isEqual: @"thickMaterialLight"]) {
+      return UIBlurEffectStyleSystemThickMaterialLight;
+    } else if ([effectName  isEqual: @"chromeMaterialLight"]) {
+      return UIBlurEffectStyleSystemChromeMaterialLight;
+    
+    } else if ([effectName  isEqual: @"ultraThinMaterialDark"]) {
+      return UIBlurEffectStyleSystemUltraThinMaterialDark;
+    } else if ([effectName  isEqual: @"thinMaterialDark"]) {
+      return UIBlurEffectStyleSystemThinMaterialDark;
+    } else if ([effectName  isEqual: @"materialDark"]) {
+      return UIBlurEffectStyleSystemMaterialDark;
+    } else if ([effectName  isEqual: @"thickMaterialDark"]) {
+      return UIBlurEffectStyleSystemThickMaterialDark;
+    } else if ([effectName  isEqual: @"chromeMaterialDark"]) {
+      return UIBlurEffectStyleSystemChromeMaterialDark;
+    }
+  }
+  return UIBlurEffectStyleLight;
+}
+
 @end
 
 @implementation RNSScreenStackHeaderConfigManager
@@ -486,6 +540,7 @@ RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(blurEffect, NSString)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -265,7 +265,6 @@
   if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
     // transparent background color
     [appearance configureWithTransparentBackground];
-    appearance.backgroundColor = config.backgroundColor;
   } else {
     // non-transparent background or default background
     if (config.translucent) {
@@ -273,15 +272,15 @@
     } else {
       [appearance configureWithOpaqueBackground];
     }
-
-    // set background color if specified
-    if (config.backgroundColor) {
-      appearance.backgroundColor = config.backgroundColor;
-    }
+  }
+  
+  // set background color if specified
+  if (config.backgroundColor) {
+    appearance.backgroundColor = config.backgroundColor;
   }
 
   if (config.blurEffect) {
-    appearance.backgroundEffect = [UIBlurEffect effectWithStyle:[self blurEffectStyleFromEffectName:config.blurEffect]];
+    appearance.backgroundEffect = [UIBlurEffect effectWithStyle:config.blurEffect];
   }
 
   if (config.hideShadow) {
@@ -468,59 +467,6 @@
   }
 }
 
-+ (UIBlurEffectStyle)blurEffectStyleFromEffectName:(NSString *)effectName
-{
-  if (@available(iOS 13.0, *)) {
-    if ([effectName  isEqual: @"extraLight"]) {
-      return UIBlurEffectStyleExtraLight;
-    } else if ([effectName  isEqual: @"light"]) {
-      return UIBlurEffectStyleLight;
-    } else if ([effectName  isEqual: @"dark"]) {
-      return UIBlurEffectStyleDark;
-      
-    } else if ([effectName  isEqual: @"regular"]) {
-      return UIBlurEffectStyleRegular;
-    } else if ([effectName  isEqual: @"prominent"]) {
-      return UIBlurEffectStyleProminent;
-
-    } else if ([effectName  isEqual: @"ultraThinMaterial"]) {
-      return UIBlurEffectStyleSystemUltraThinMaterial;
-    } else if ([effectName  isEqual: @"thinMaterial"]) {
-      return UIBlurEffectStyleSystemThinMaterial;
-    } else if ([effectName  isEqual: @"material"]) {
-      return UIBlurEffectStyleSystemMaterial;
-    } else if ([effectName  isEqual: @"thickMaterial"]) {
-      return UIBlurEffectStyleSystemThickMaterial;
-    } else if ([effectName  isEqual: @"chromeMaterial"]) {
-      return UIBlurEffectStyleSystemChromeMaterial;
-
-
-    } else if ([effectName  isEqual: @"ultraThinMaterialLight"]) {
-      return UIBlurEffectStyleSystemUltraThinMaterialLight;
-    } else if ([effectName  isEqual: @"thinMaterialLight"]) {
-      return UIBlurEffectStyleSystemThinMaterialLight;
-    } else if ([effectName  isEqual: @"materialLight"]) {
-      return UIBlurEffectStyleSystemMaterialLight;
-    } else if ([effectName  isEqual: @"thickMaterialLight"]) {
-      return UIBlurEffectStyleSystemThickMaterialLight;
-    } else if ([effectName  isEqual: @"chromeMaterialLight"]) {
-      return UIBlurEffectStyleSystemChromeMaterialLight;
-    
-    } else if ([effectName  isEqual: @"ultraThinMaterialDark"]) {
-      return UIBlurEffectStyleSystemUltraThinMaterialDark;
-    } else if ([effectName  isEqual: @"thinMaterialDark"]) {
-      return UIBlurEffectStyleSystemThinMaterialDark;
-    } else if ([effectName  isEqual: @"materialDark"]) {
-      return UIBlurEffectStyleSystemMaterialDark;
-    } else if ([effectName  isEqual: @"thickMaterialDark"]) {
-      return UIBlurEffectStyleSystemThickMaterialDark;
-    } else if ([effectName  isEqual: @"chromeMaterialDark"]) {
-      return UIBlurEffectStyleSystemChromeMaterialDark;
-    }
-  }
-  return UIBlurEffectStyleLight;
-}
-
 @end
 
 @implementation RNSScreenStackHeaderConfigManager
@@ -540,7 +486,7 @@ RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
-RCT_EXPORT_VIEW_PROPERTY(blurEffect, NSString)
+RCT_EXPORT_VIEW_PROPERTY(blurEffect, UIBlurEffectStyle)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
@@ -559,6 +505,46 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 
 @implementation RCTConvert (RNSScreenStackHeader)
 
++ (NSMutableDictionary *)blurEffectsForIOSVersion
+{
+  NSMutableDictionary *blurEffects = [NSMutableDictionary new];
+  [blurEffects addEntriesFromDictionary:@{
+    @"extraLight": @(UIBlurEffectStyleExtraLight),
+    @"light": @(UIBlurEffectStyleLight),
+    @"dark": @(UIBlurEffectStyleDark),
+  }];
+  
+  if (@available(iOS 10.0, *)) {
+    [blurEffects addEntriesFromDictionary:@{
+      @"regular": @(UIBlurEffectStyleRegular),
+      @"prominent": @(UIBlurEffectStyleProminent),
+
+    }];
+  }
+#ifdef __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    [blurEffects addEntriesFromDictionary:@{
+      @"ultraThinMaterial": @(UIBlurEffectStyleSystemUltraThinMaterial),
+      @"thinMaterial": @(UIBlurEffectStyleSystemThinMaterial),
+      @"material": @(UIBlurEffectStyleSystemMaterial),
+      @"thickMaterial": @(UIBlurEffectStyleSystemThickMaterial),
+      @"chromeMaterial": @(UIBlurEffectStyleSystemChromeMaterial),
+      @"ultraThinMaterialLight": @(UIBlurEffectStyleSystemUltraThinMaterialLight),
+      @"thinMaterialLight": @(UIBlurEffectStyleSystemThinMaterialLight),
+      @"materialLight": @(UIBlurEffectStyleSystemMaterialLight),
+      @"thickMaterialLight": @(UIBlurEffectStyleSystemThickMaterialLight),
+      @"chromeMaterialLight": @(UIBlurEffectStyleSystemChromeMaterialLight),
+      @"ultraThinMaterialDark": @(UIBlurEffectStyleSystemUltraThinMaterialDark),
+      @"thinMaterialDark": @(UIBlurEffectStyleSystemThinMaterialDark),
+      @"materialDark": @(UIBlurEffectStyleSystemMaterialDark),
+      @"thickMaterialDark": @(UIBlurEffectStyleSystemThickMaterialDark),
+      @"chromeMaterialDark": @(UIBlurEffectStyleSystemChromeMaterialDark),
+    }];
+  }
+#endif
+  return blurEffects;
+}
+
 RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType, (@{
    @"back": @(RNSScreenStackHeaderSubviewTypeBackButton),
    @"left": @(RNSScreenStackHeaderSubviewTypeLeft),
@@ -567,6 +553,8 @@ RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType, (@{
    @"center": @(RNSScreenStackHeaderSubviewTypeCenter),
    }), RNSScreenStackHeaderSubviewTypeTitle, integerValue)
 
+RCT_ENUM_CONVERTER(UIBlurEffectStyle, ([self blurEffectsForIOSVersion]), UIBlurEffectStyleExtraLight, integerValue)
+  
 @end
 
 @implementation RNSScreenStackHeaderSubviewManager

--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -116,6 +116,7 @@ class StackView extends React.Component {
 
     if (headerStyle !== undefined) {
       headerOptions.backgroundColor = headerStyle.backgroundColor;
+      headerOptions.blurEffect = headerStyle.blurEffect;
     }
 
     const children = [];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -187,7 +187,7 @@ declare module 'react-native-screens' {
     children?: React.ReactNode;
     /**
      * @host (iOS only)
-     * @description Blur effect to be applied to the header
+     * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
      */
     blurEffect?: BlurEffectTypes;
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,27 @@ declare module 'react-native-screens' {
     | 'fullScreenModal'
     | 'formSheet';
   export type StackAnimationTypes = 'default' | 'fade' | 'flip' | 'none';
+  export type BlurEffectTypes =
+    | 'extraLight'
+    | 'light'
+    | 'dark'
+    | 'regular'
+    | 'prominent'
+    | 'systemUltraThinMaterial '
+    | 'systemThinMaterial'
+    | 'systemMaterial'
+    | 'systemThickMaterial'
+    | 'systemChromeMaterial'
+    | 'systemUltraThinMaterialLight'
+    | 'systemThinMaterialLight'
+    | 'systemMaterialLight'
+    | 'systemThickMaterialLight'
+    | 'systemChromeMaterialLight'
+    | 'systemUltraThinMaterialDark'
+    | 'systemThinMaterialDark'
+    | 'systemMaterialDark'
+    | 'systemThickMaterialDark'
+    | 'systemChromeMaterialDark';
 
   export interface ScreenProps extends ViewProps {
     active?: 0 | 1 | Animated.AnimatedInterpolation;
@@ -164,6 +185,11 @@ declare module 'react-native-screens' {
      * Pass HeaderLeft, HeaderRight and HeaderTitle
      */
     children?: React.ReactNode;
+    /**
+     * @host (iOS only)
+     * @description Blur effect to be applied to the header
+     */
+    blurEffect?: BlurEffectTypes;
   }
 
   export const Screen: ComponentClass<ScreenProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,7 @@ declare module 'react-native-screens' {
     | 'dark'
     | 'regular'
     | 'prominent'
-    | 'systemUltraThinMaterial '
+    | 'systemUltraThinMaterial'
     | 'systemThinMaterial'
     | 'systemMaterial'
     | 'systemThickMaterial'

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { StyleProp, ViewStyle, ImageSourcePropType } from 'react-native';
-import { ScreenProps } from 'react-native-screens';
+import {
+  ScreenProps,
+  ScreenStackHeaderConfigProps,
+} from 'react-native-screens';
 import {
   DefaultNavigatorOptions,
   Descriptor,
@@ -25,35 +28,35 @@ export type NativeStackNavigationEventMap = {
 export type NativeStackNavigationProp<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = string
-> = NavigationProp<
-  ParamList,
-  RouteName,
-  StackNavigationState,
-  NativeStackNavigationOptions,
-  NativeStackNavigationEventMap
-> & {
-  /**
-   * Push a new screen onto the stack.
-   *
-   * @param name Name of the route for the tab.
-   * @param [params] Params object for the route.
-   */
-  push<RouteName extends keyof ParamList>(
-    ...args: ParamList[RouteName] extends undefined | any
-      ? [RouteName] | [RouteName, ParamList[RouteName]]
-      : [RouteName, ParamList[RouteName]]
-  ): void;
+  > = NavigationProp<
+    ParamList,
+    RouteName,
+    StackNavigationState,
+    NativeStackNavigationOptions,
+    NativeStackNavigationEventMap
+  > & {
+    /**
+     * Push a new screen onto the stack.
+     *
+     * @param name Name of the route for the tab.
+     * @param [params] Params object for the route.
+     */
+    push<RouteName extends keyof ParamList>(
+      ...args: ParamList[RouteName] extends undefined | any
+        ? [RouteName] | [RouteName, ParamList[RouteName]]
+        : [RouteName, ParamList[RouteName]]
+    ): void;
 
-  /**
-   * Pop a screen from the stack.
-   */
-  pop(count?: number): void;
+    /**
+     * Pop a screen from the stack.
+     */
+    pop(count?: number): void;
 
-  /**
-   * Pop to the first route in the stack, dismissing all other screens.
-   */
-  popToTop(): void;
-};
+    /**
+     * Pop to the first route in the stack, dismissing all other screens.
+     */
+    popToTop(): void;
+  };
 
 export type NativeStackNavigationHelpers = NavigationHelpers<
   ParamListBase,
@@ -148,9 +151,11 @@ export type NativeStackNavigationOptions = {
   /**
    * Style object for header title. Supported properties:
    * - backgroundColor
+   * - blurEffect
    */
   headerStyle?: {
     backgroundColor?: string;
+    blurEffect?: ScreenStackHeaderConfigProps['blurEffect'];
   };
   /**
    * Controls the style of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar. Supported properties:

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -79,6 +79,7 @@ export default function HeaderConfig(props: Props) {
           ? headerStyle.backgroundColor
           : colors.card
       }
+      blurEffect={headerStyle.blurEffect}
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>


### PR DESCRIPTION
Added `appearance.backgroundEffect` options for blurring background in semi-transparent and transparent header.
PR also removes `configureWithDefaultBackground` option of appearance for translucent header since it applies `blurEffect` which causes problems (#520) and is not necessary since the prop for `blurEffect` will now be available.