### PR TITLE
add support for back button image in native stack

### DIFF
--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle, ImageSourcePropType } from 'react-native';
 import { ScreenProps } from 'react-native-screens';
 import {
   DefaultNavigatorOptions,
@@ -75,6 +75,11 @@ export type NativeStackNavigationOptions = {
    * String to display in the header as title. Defaults to scene `title`.
    */
   headerTitle?: string;
+  /**
+   * Image to display in the header as the back button.
+   * Defaults to back icon image for the platform (a chevron on iOS and an arrow on Android).
+   */
+  backButtonImage?: ImageSourcePropType;
   /**
    * Title to display in the back button.
    * Only supported on iOS.

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderConfig,
   ScreenStackHeaderRightView,
   ScreenStackHeaderLeftView,
@@ -23,6 +24,7 @@ export default function HeaderConfig(props: Props) {
     headerTitle,
     headerBackTitle,
     headerBackTitleVisible = true,
+    backButtonImage,
     headerHideBackButton,
     headerHideShadow,
     headerLargeTitleHideShadow,
@@ -78,6 +80,9 @@ export default function HeaderConfig(props: Props) {
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
+      ) : null}
+      {backButtonImage !== undefined ? (
+        <ScreenStackHeaderBackButtonImage key="backImage" source={backButtonImage} />
       ) : null}
       {headerLeft !== undefined ? (
         <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>


### PR DESCRIPTION
backButtonImage prop is supported on the v4 native stack but is not exposed with v5 native stack. This PR brings that in the native-stack as well.

cc @WoLewicki @kmagiera @SRandazzo