### PR TITLE
fix: disable shadow if needed

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -126,6 +126,10 @@ public class ScreenStackFragment extends ScreenFragment {
             AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
     view.addView(mAppBarLayout);
 
+    if (mShadowHidden) {
+      mAppBarLayout.setTargetElevation(0);
+    }
+
     if (mToolbar != null) {
       mAppBarLayout.addView(recycleView(mToolbar));
     }


### PR DESCRIPTION
`mAppBarLayout` is created on every screen change so we need to check if the shadow shouldn't be disabled. This method is needed here since the if clause in `setToolbarShadowHidden` will return false e.g. when going back to the previous screen.