### PR TITLE
feat: add translucent status bar handling

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -3,18 +3,23 @@ package com.swmansion.rnscreens;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.Window;
+import android.view.WindowInsets;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -173,6 +178,11 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     mToolbar.setNavigationOnClickListener(mBackClickListener);
 
 
+    // we apply padding if status bar is translucent
+    if (Build.VERSION.SDK_INT >= 21) {
+      applyWindowInsets(activity.getWindow());
+    }
+
     // shadow
     getScreenFragment().setToolbarShadowHidden(mIsShadowHidden);
 
@@ -300,6 +310,24 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       }
     }
     return null;
+  }
+
+  @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+  protected void applyWindowInsets(Window window)
+  {
+      window.getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+        @Override
+        public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+          WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
+          // this inset is set to 0 by translucent status bar
+          if (defaultInsets.getStableInsetTop() == 0) {
+            mToolbar.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+          } else {
+            mToolbar.setPadding(0, defaultInsets.getSystemWindowInsetTop(), 0, 0);
+          }
+          return insets.consumeSystemWindowInsets();
+        }
+      });
   }
 
   public void setTitle(String title) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -313,21 +313,20 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   }
 
   @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-  protected void applyWindowInsets(Window window)
-  {
-      window.getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
-        @Override
-        public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-          WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
-          // this inset is set to 0 by translucent status bar
-          if (defaultInsets.getStableInsetTop() == 0) {
-            mToolbar.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
-          } else {
-            mToolbar.setPadding(0, defaultInsets.getSystemWindowInsetTop(), 0, 0);
-          }
-          return insets.consumeSystemWindowInsets();
+  protected void applyWindowInsets(Window window) {
+    window.getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+      @Override
+      public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+        WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
+        // this inset is set to 0 by translucent status bar
+        if (defaultInsets.getStableInsetTop() == 0) {
+          mToolbar.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+        } else {
+          mToolbar.setPadding(0, defaultInsets.getSystemWindowInsetTop(), 0, 0);
         }
-      });
+        return insets.consumeSystemWindowInsets();
+      }
+    });
   }
 
   public void setTitle(String title) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -119,6 +119,10 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setBackButtonInCustomView(backButtonInCustomView);
   }
 
+  @ReactProp(name = "translucentStatusBar")
+  public void setTranslucentStatusBar(ScreenStackHeaderConfig config, boolean translucentStatusBar) {
+    config.setTranslucentStatusBar(translucentStatusBar);
+  }
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -77,6 +77,7 @@ class StackView extends React.Component {
       headerLargeTitleStyle,
       translucent,
       hideShadow,
+      translucentStatusBar,
     } = options;
 
     const scene = {
@@ -88,6 +89,8 @@ class StackView extends React.Component {
 
     const headerOptions = {
       translucent: translucent === undefined ? false : translucent,
+      translucentStatusBar:
+        translucentStatusBar === undefined ? false : translucentStatusBar,
       title,
       titleFontFamily: headerTitleStyle && headerTitleStyle.fontFamily,
       titleColor:

--- a/native-stack/types.tsx
+++ b/native-stack/types.tsx
@@ -211,6 +211,13 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Set this prop to true whenever you have translucent status bar in order for it to work correctly. Defaults to `false`.
+   * Only supported on Android.
+   *
+   * @platform android
+   */
+  translucentStatusBar?: boolean;
+  /**
    * How should the screen be presented.
    * The following values are currently supported:
    * - "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.

--- a/native-stack/views/HeaderConfig.tsx
+++ b/native-stack/views/HeaderConfig.tsx
@@ -38,6 +38,7 @@ export default function HeaderConfig(props: Props) {
     headerBackTitleStyle = {},
     headerShown,
     backButtonInCustomView,
+    translucentStatusBar,
   } = props;
 
   return (
@@ -77,14 +78,18 @@ export default function HeaderConfig(props: Props) {
           ? headerStyle.backgroundColor
           : colors.card
       }
-      largeTitleBackgroundColor={headerLargeStyle.backgroundColor}>
+      largeTitleBackgroundColor={headerLargeStyle.backgroundColor}
+      translucentStatusBar={translucentStatusBar}>
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>
           {headerRight({ tintColor: headerTintColor ?? colors.primary })}
         </ScreenStackHeaderRightView>
       ) : null}
       {backButtonImage !== undefined ? (
-        <ScreenStackHeaderBackButtonImage key="backImage" source={backButtonImage} />
+        <ScreenStackHeaderBackButtonImage
+          key="backImage"
+          source={backButtonImage}
+        />
       ) : null}
       {headerLeft !== undefined ? (
         <ScreenStackHeaderLeftView>

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -109,9 +109,14 @@ declare module 'react-native-screens' {
     backButtonInCustomView?: boolean;
     /**
      * @host (iOS only)
-     * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
+     * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false.
      */
     translucent?: boolean;
+    /**
+     * @host (Android only)
+     * @description When set to true, the header will be rendered under the status bar with additional top padding. It should be only used with translucent status bar. The default value is false.
+     */
+    translucentStatusBar?: boolean;
     /**
      * @host (iOS only)
      * @description Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.


### PR DESCRIPTION
Added a listener on the insets of the window which mimics the behavior of RN's StatusBar: (https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java#L145). The addition of padding is controlled by the exported `translucentStatusBar` prop. The prop is needed because of the incorrect behavior which occurred sometimes if the padding was only controlled by the listener, where the toolbar's top padding was added to the window insets top padding, causing the doubled top padding of the toolbar.
The situation handled here is the case where a user has his status bar set to translucent via RN StatusBar component with `translucent={true}` prop. In that case, the header's top padding is not applied properly which causes the content of the header to go under the Status Bar. See #485 for more info.