### PR TITLE
fix: set final frame of fade animation

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -499,6 +499,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFinishTransitioning, RCTDirectEventBlock);
 {
   UIViewController* toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
   UIViewController* fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+  toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 
   if (_operation == UINavigationControllerOperationPush) {
     [[transitionContext containerView] addSubview:toViewController.view];


### PR DESCRIPTION
According to https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/CustomizingtheTransitionAnimations.html, the final frame of the `toViewController`'s view should be set via `finalFrameForViewController:` method. It fixes the problem with the view, which we transition to, not respecting the header's height. Should resolve #326.