### PR TITLE
Add headerTopInsetEnabled prop that defaults to true to account for translucent status bars on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -35,6 +36,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mIsShadowHidden;
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
+  private boolean mIsTopInsetEnabled = true;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -151,6 +153,19 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     if (mToolbar.getParent() == null) {
       getScreenFragment().setToolbar(mToolbar);
+    }
+
+    if (mIsTopInsetEnabled) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        mToolbar.setPadding(0, getRootWindowInsets().getSystemWindowInsetTop(), 0, 0);
+      } else {
+        // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25
+        mToolbar.setPadding(0, (int) (25 * getResources().getDisplayMetrics().density), 0, 0);
+      }
+    } else {
+      if (mToolbar.getPaddingTop() > 0) {
+        mToolbar.setPadding(0, 0, 0, 0);
+      }
     }
 
     activity.setSupportActionBar(mToolbar);
@@ -321,6 +336,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   public void setTintColor(int color) {
     mTintColor = color;
   }
+
+  public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
   public void setBackgroundColor(int color) {
     mBackgroundColor = color;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -104,6 +104,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHideBackButton(hideBackButton);
   }
 
+  @ReactProp(name = "topInsetEnabled")
+  public void setTopInsetEnabled(ScreenStackHeaderConfig config, boolean topInsetEnabled) {
+    config.setTopInsetEnabled(topInsetEnabled);
+  }
+
   @ReactProp(name = "color", customType = "Color")
   public void setColor(ScreenStackHeaderConfig config, int color) {
     config.setTintColor(color);

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -103,6 +103,10 @@ Function which returns a React Element to display in the center of the header.
 
 Boolean indicating whether the navigation bar is translucent. Only supported on iOS.
 
+#### `headerTopInsetEnabled`
+
+A Boolean to that lets you opt out of insetting the header. You may want to * set this to `false` if you use an opaque status bar. Defaults to `true`. Insets are always applied on iOS because the header cannot be opaque. Only supported on Android.
+
 #### `headerLargeTitle`
 
 Boolean used to set a native property to prefer a large title header (like in iOS setting).

--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -77,6 +77,7 @@ class StackView extends React.Component {
       headerLargeTitleStyle,
       translucent,
       hideShadow,
+      headerTopInsetEnabled = true,
     } = options;
 
     const scene = {
@@ -105,6 +106,7 @@ class StackView extends React.Component {
         headerLargeTitleStyle && headerLargeTitleStyle.fontSize,
       largeTitleColor: headerLargeTitleStyle && headerLargeTitleStyle.color,
       hideShadow,
+      headerTopInsetEnabled,
     };
 
     const hasHeader = headerMode !== 'none' && options.header !== null;
@@ -228,8 +230,8 @@ class StackView extends React.Component {
           Platform.OS === 'android'
             ? false
             : options.gestureEnabled === undefined
-            ? true
-            : options.gestureEnabled
+              ? true
+              : options.gestureEnabled
         }
         onAppear={() => this._onAppear(route, descriptor)}
         onDismissed={() => this._removeScene(route)}>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,6 +113,11 @@ declare module 'react-native-screens' {
      */
     translucent?: boolean;
     /**
+     * @description A flag to that lets you opt out of insetting the header. You may want to set this to `false` if you use an opaque status bar. Defaults to `true`.
+     * @host (Android only)
+     */
+    headerTopInsetEnabled?: boolean;
+    /**
      * @host (iOS only)
      * @description Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.
      */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -116,7 +116,7 @@ declare module 'react-native-screens' {
      * @description A flag to that lets you opt out of insetting the header. You may want to set this to `false` if you use an opaque status bar. Defaults to `true`.
      * @host (Android only)
      */
-    headerTopInsetEnabled?: boolean;
+    topInsetEnabled?: boolean;
     /**
      * @host (iOS only)
      * @description Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -200,6 +200,15 @@ export type NativeStackNavigationOptions = {
     fontSize?: number;
   };
   /**
+   * A flag to that lets you opt out of insetting the header. You may want to
+   * set this to `false` if you use an opaque status bar. Defaults to `true`.
+   * Only supported on Android. Insets are always applied on iOS because the
+   * header cannot be opaque.
+   *
+   * @platform android
+   */
+  headerTopInsetEnabled?: boolean;
+  /**
    * Style object for the scene content.
    */
   contentStyle?: StyleProp<ViewStyle>;

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -29,6 +29,7 @@ export default function HeaderConfig(props: Props) {
     headerHideShadow,
     headerLargeTitleHideShadow,
     headerTintColor,
+    headerTopInsetEnabled = true,
     headerLargeTitle,
     headerTranslucent,
     headerStyle = {},
@@ -64,6 +65,7 @@ export default function HeaderConfig(props: Props) {
           ? headerTintColor
           : colors.text
       }
+      topInsetEnabled={headerTopInsetEnabled}
       backTitle={headerBackTitleVisible ? headerBackTitle : ' '}
       backTitleFontFamily={headerBackTitleStyle.fontFamily}
       backTitleFontSize={headerBackTitleStyle.fontSize}


### PR DESCRIPTION
Follow up from https://github.com/software-mansion/react-native-screens/pull/518 using @janicduplessis' suggested solution. The inset is applied by default to encourage developers to use translucent status bars on Android, which is typically a better experience for users and consistent with the iOS behavior.