### PR TITLE
fix: trigger color change on every update

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -119,7 +119,8 @@
 + (void)setAnimatedConfig:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   UINavigationBar *navbar = ((UINavigationController *)vc.parentViewController).navigationBar;
-  [navbar setTintColor:[UIColor whiteColor]]; // really weird, but triggering the change of color resolves issue with custom back image
+  // really weird, but triggering the change of color resolves issue with custom back image, so we change it by a really small value and then back to the right one
+  [navbar setTintColor:[config.color colorWithAlphaComponent:CGColorGetAlpha(config.color.CGColor) - 0.01]];
   [navbar setTintColor:config.color];
 
 #ifdef __IPHONE_13_0

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -119,6 +119,7 @@
 + (void)setAnimatedConfig:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   UINavigationBar *navbar = ((UINavigationController *)vc.parentViewController).navigationBar;
+  [navbar setTintColor:[UIColor whiteColor]]; // really weird, but triggering the change of color resolves issue with custom back image
   [navbar setTintColor:config.color];
 
 #ifdef __IPHONE_13_0

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -119,7 +119,10 @@
 + (void)setAnimatedConfig:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   UINavigationBar *navbar = ((UINavigationController *)vc.parentViewController).navigationBar;
-  // really weird, but triggering the change of color resolves issue with custom back image, so we change it by a really small value and then back to the right one
+  // It is workaround for loading custom back icon when transitioning from a screen without header to the screen which has one.
+  // This action fails when navigating to the screen with header for the second time and loads default back button.
+  // It looks like changing the tint color of navbar triggers an update of the items belonging to it and it seems to load the custom back image
+  // so we change the tint color's alpha by a very small amount and then set it to the one it should have.  
   [navbar setTintColor:[config.color colorWithAlphaComponent:CGColorGetAlpha(config.color.CGColor) - 0.01]];
   [navbar setTintColor:config.color];
 


### PR DESCRIPTION
It is workaround for loading custom back icon when transitioning from a screen without header to the screen which has one. This action fails when navigating to the screen with header for the second time and loads default back button. It looks like changing the tint color of navbar triggers an update of the items belonging to it and it seems to load the custom back image so we change the tint color's alpha by a very small amount and then set it to the one it should have. Should resolve #550.