### PR TITLE
[Android] Add support for translucent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,27 +109,27 @@ Allows for the customization of how the given screen should appear/disappear whe
 
 Defines how the method that should be used to present the given screen. It is a separate property from `stackAnimation` as the presentation mode can carry additional semantic. The allowed values are:
 
- - `push` – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
- - `modal` – Explained below.
- - `transparentModal` – Explained below.
- - `containedModal` – Explained below.
- - `containedTransparentModal` – Explained below.
- - `fullScreenModal` – Explained below.
- - `formSheet` – Explained below.
+- `push` – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
+- `modal` – Explained below.
+- `transparentModal` – Explained below.
+- `containedModal` – Explained below.
+- `containedTransparentModal` – Explained below.
+- `fullScreenModal` – Explained below.
+- `formSheet` – Explained below.
 
- For iOS:
- - `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier.
- - `fullScreenModal` will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc)
- - `formSheet` will use [`UIModalPresentationFormSheet`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationformsheet?language=objc)
- - `transparentModal` will use [`UIModalPresentationOverFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationoverfullscreen?language=objc)
- - `containedModal` will use [`UIModalPresentationCurrentContext`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationcurrentcontext?language=objc)
- - `containedTransparentModal` will use [`UIModalPresentationOverCurrentContext`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationovercurrentcontext?language=objc)
+For iOS:
+- `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier.
+- `fullScreenModal` will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc)
+- `formSheet` will use [`UIModalPresentationFormSheet`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationformsheet?language=objc)
+- `transparentModal` will use [`UIModalPresentationOverFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationoverfullscreen?language=objc)
+- `containedModal` will use [`UIModalPresentationCurrentContext`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationcurrentcontext?language=objc)
+- `containedTransparentModal` will use [`UIModalPresentationOverCurrentContext`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationovercurrentcontext?language=objc)
 
- For Android:
+For Android:
 
- `modal`, `containedModal`, `fullScreenModal`, `formSheet` will use `Screen.StackPresentation.MODAL`.
+`modal`, `containedModal`, `fullScreenModal`, `formSheet` will use `Screen.StackPresentation.MODAL`.
 
- `transparentModal`, `containedTransparentModal` will use `Screen.StackPresentation.TRANSPARENT_MODAL`.
+`transparentModal`, `containedTransparentModal` will use `Screen.StackPresentation.TRANSPARENT_MODAL`.
 
 ### `<ScreenStackHeaderConfig>`
 
@@ -191,9 +191,9 @@ String that applies `rtl` or `ltr` form to the stack.
 
 When set to `false` the back swipe gesture will be disabled when the parent `Screen` is on top of the stack. The default value is `true`.
 
-#### `translucent` (iOS only)
+#### `translucent`
 
-When set to `true`, it makes native navigation bar on iOS semi-transparent with blur effect. It is a common way of presenting a navigation bar introduced in iOS 11. The default value is `false`.
+When set to `true`, it makes native navigation bar on iOS semi-transparent with blur effect, while on Android is fully transparent. It is a common way of presenting a navigation bar introduced in iOS 11. The default value is `false`.
 
 #### `backTitle` (iOS only)
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ When set to `false` the back swipe gesture will be disabled when the parent `Scr
 
 #### `translucent`
 
-When set to `true`, it makes native navigation bar on iOS semi-transparent with blur effect, while on Android is fully transparent. It is a common way of presenting a navigation bar introduced in iOS 11. The default value is `false`.
+When set to `true`, it allows the content to go under the navigation header, not bellow. If you want to create a transparent header, you should also set `backgroundColor` to `transparent`. The default value is `false`.
 
 #### `backTitle` (iOS only)
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -65,6 +65,7 @@ public class ScreenStackFragment extends ScreenFragment {
   private AppBarLayout mAppBarLayout;
   private Toolbar mToolbar;
   private boolean mShadowHidden;
+  private boolean mIsTranslucent;
 
   @SuppressLint("ValidFragment")
   public ScreenStackFragment(Screen screenView) {
@@ -93,6 +94,14 @@ public class ScreenStackFragment extends ScreenFragment {
     if (mShadowHidden != hidden) {
       mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
       mShadowHidden = hidden;
+    }
+  }
+
+  public void setToolbarTranslucent(boolean translucent) {
+    if (mIsTranslucent != translucent) {
+      ViewGroup.LayoutParams params = mScreenView.getLayoutParams();
+      ((CoordinatorLayout.LayoutParams) params).setBehavior(translucent ? null : new AppBarLayout.ScrollingViewBehavior());
+      mIsTranslucent = translucent;
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -163,7 +163,7 @@ public class ScreenStackFragment extends ScreenFragment {
     CoordinatorLayout view = new NotifyingCoordinatorLayout(getContext(), this);
     CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
-    params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
+    params.setBehavior(mIsTranslucent ? null : new AppBarLayout.ScrollingViewBehavior());
     mScreenView.setLayoutParams(params);
     view.addView(recycleView(mScreenView));
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -92,6 +92,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
       mToolbar.setBackgroundColor(tv.data);
     }
+    mToolbar.setClipChildren(false);
   }
 
   @Override
@@ -380,6 +381,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setHidden(boolean hidden) {
     mIsHidden = hidden;
+  }
+
+  public void setTranslucent(boolean translucent) {
+    mIsTranslucent = translucent;
   }
 
   public void setBackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -32,13 +32,14 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private String mTitleFontFamily;
   private String mDirection;
   private float mTitleFontSize;
-  private int mBackgroundColor;
+  private Integer mBackgroundColor;
   private boolean mIsHidden;
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
   private boolean mIsTopInsetEnabled = true;
+  private boolean mIsTranslucent;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -91,7 +92,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
       mToolbar.setBackgroundColor(tv.data);
     }
-    mToolbar.setClipChildren(false);
   }
 
   @Override
@@ -215,6 +215,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     // shadow
     getScreenFragment().setToolbarShadowHidden(mIsShadowHidden);
 
+    // translucent
+    getScreenFragment().setToolbarTranslucent(mIsTranslucent);
+
     // title
     actionBar.setTitle(mTitle);
     if (TextUtils.isEmpty(mTitle)) {
@@ -238,7 +241,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // background
-    if (mBackgroundColor != 0) {
+    if (mBackgroundColor != null) {
       mToolbar.setBackgroundColor(mBackgroundColor);
     }
 
@@ -363,7 +366,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
-  public void setBackgroundColor(int color) {
+  public void setBackgroundColor(Integer color) {
     mBackgroundColor = color;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -32,7 +32,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private String mTitleFontFamily;
   private String mDirection;
   private float mTitleFontSize;
-  private Integer mBackgroundColor;
+  private int mBackgroundColor;
   private boolean mIsHidden;
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
@@ -242,7 +242,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // background
-    if (mBackgroundColor != null) {
+    if (mBackgroundColor != -1) {
       mToolbar.setBackgroundColor(mBackgroundColor);
     }
 
@@ -367,7 +367,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
-  public void setBackgroundColor(Integer color) {
+  public void setBackgroundColor(int color) {
     mBackgroundColor = color;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -90,8 +90,8 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
   }
 
   @ReactProp(name = "backgroundColor", customType = "Color")
-  public void setBackgroundColor(ScreenStackHeaderConfig config, int titleColor) {
-    config.setBackgroundColor(titleColor);
+  public void setBackgroundColor(ScreenStackHeaderConfig config, Integer backgroundColor) {
+    config.setBackgroundColor(backgroundColor);
   }
 
   @ReactProp(name = "hideShadow")
@@ -134,5 +134,4 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSString)
 //  // `hidden` is an UIView property, we need to use different name internally
-//  RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -90,7 +90,7 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
   }
 
   @ReactProp(name = "backgroundColor", customType = "Color")
-  public void setBackgroundColor(ScreenStackHeaderConfig config, Integer backgroundColor) {
+  public void setBackgroundColor(ScreenStackHeaderConfig config, int backgroundColor) {
     config.setBackgroundColor(backgroundColor);
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -119,6 +119,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHidden(hidden);
   }
 
+  @ReactProp(name = "translucent")
+  public void setTranslucent(ScreenStackHeaderConfig config, boolean translucent) {
+    config.setTranslucent(translucent);
+  }
+
   @ReactProp(name = "backButtonInCustomView")
   public void setBackButtonInCustomView(ScreenStackHeaderConfig config, boolean backButtonInCustomView) {
     config.setBackButtonInCustomView(backButtonInCustomView);

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -89,7 +89,7 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setTitleColor(titleColor);
   }
 
-  @ReactProp(name = "backgroundColor", customType = "Color")
+  @ReactProp(name = "backgroundColor", customType = "Color", defaultInt = -1)
   public void setBackgroundColor(ScreenStackHeaderConfig config, int backgroundColor) {
     config.setBackgroundColor(backgroundColor);
   }

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -101,7 +101,7 @@ Function which returns a React Element to display in the center of the header.
 
 #### `headerTranslucent`
 
-Boolean indicating whether the navigation bar is translucent. Only supported on iOS.
+Boolean indicating whether the navigation bar is translucent.
 
 #### `headerTopInsetEnabled`
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -155,7 +155,6 @@ declare module 'react-native-screens' {
      */
     backButtonInCustomView?: boolean;
     /**
-     * @host (iOS only)
      * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
      */
     translucent?: boolean;

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -111,9 +111,6 @@ export type NativeStackNavigationOptions = {
   backButtonInCustomView?: boolean;
   /**
    * Boolean indicating whether the navigation bar is translucent.
-   * Only supported on iOS.
-   *
-   * @platform ios
    */
   headerTranslucent?: boolean;
   /**


### PR DESCRIPTION
Currently, the `headerTranslucent = true` is only supported on iOS. With this PR the setting will also work on Android