### PR TITLE
feat: add RTL support

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -304,7 +304,7 @@ PODS:
     - React
   - RNReanimated (1.10.1):
     - React
-  - RNScreens (2.9.0):
+  - RNScreens (2.10.1):
     - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
-  RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
+  RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,11 @@ If set to `true` the back button will not be rendered as a part of the navigatio
 
 If set to `true` the back button will also be rendered while using `headerLeft` function.
 
-#### `gestureEnabled`
+#### `direction`
+
+String that applies `rtl` or `ltr` form to the stack.
+
+#### `gestureEnabled` (iOS only)
 
 When set to `false` the back swipe gesture will be disabled when the parent `Screen` is on top of the stack. The default value is `true`.
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -162,9 +162,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mDirection != null) {
       if (mDirection.equals("rtl")) {
-        activity.getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
+        mToolbar.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
       } else if (mDirection.equals("ltr")) {
-        activity.getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
+        mToolbar.setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
       }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -282,10 +282,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
             mToolbar.setNavigationIcon(null);
           }
           mToolbar.setTitle(null);
-          params.gravity = Gravity.LEFT;
+          params.gravity = Gravity.START;
           break;
         case RIGHT:
-          params.gravity = Gravity.RIGHT;
+          params.gravity = Gravity.END;
           break;
         case CENTER:
           params.width = LayoutParams.MATCH_PARENT;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -30,6 +30,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private String mTitle;
   private int mTitleColor;
   private String mTitleFontFamily;
+  private String mDirection;
   private float mTitleFontSize;
   private int mBackgroundColor;
   private boolean mIsHidden;
@@ -157,6 +158,14 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     AppCompatActivity activity = (AppCompatActivity) getScreenFragment().getActivity();
     if (activity == null) {
       return;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mDirection != null) {
+      if (mDirection.equals("rtl")) {
+        activity.getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
+      } else if (mDirection.equals("ltr")) {
+        activity.getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
+      }
     }
 
     if (mIsHidden) {
@@ -371,4 +380,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   }
 
   public void setBackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }
+
+  public void setDirection(String direction) {
+    mDirection = direction;
+  }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -124,6 +124,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setBackButtonInCustomView(backButtonInCustomView);
   }
 
+  @ReactProp(name = "direction")
+  public void setDirection(ScreenStackHeaderConfig config, String direction) {
+    config.setDirection(direction);
+  }
+
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -3,6 +3,11 @@
 
 #import "RNSScreen.h"
 
+typedef NS_ENUM(NSInteger, RNSScreenDirection) {
+  RNSScreenDirectionLeftToRight,
+  RNSScreenDirectionRightToLeft,
+};
+
 @interface RNSScreenStackHeaderConfig : UIView
 
 @property (nonatomic, weak) RNSScreenView *screenView;
@@ -28,6 +33,7 @@
 @property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
+@property (nonatomic) RNSScreenDirection direction;
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 
@@ -49,6 +55,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
++ (RNSScreenDirection)RNSScreenDirection:(id)json;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -3,11 +3,6 @@
 
 #import "RNSScreen.h"
 
-typedef NS_ENUM(NSInteger, RNSScreenDirection) {
-  RNSScreenDirectionLeftToRight,
-  RNSScreenDirectionRightToLeft,
-};
-
 @interface RNSScreenStackHeaderConfig : UIView
 
 @property (nonatomic, weak) RNSScreenView *screenView;
@@ -33,7 +28,7 @@ typedef NS_ENUM(NSInteger, RNSScreenDirection) {
 @property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
-@property (nonatomic) RNSScreenDirection direction;
+@property (nonatomic) UISemanticContentAttribute direction;
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 
@@ -55,7 +50,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
-+ (RNSScreenDirection)RNSScreenDirection:(id)json;
++ (UISemanticContentAttribute)RNSScreenDirection:(id)json;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -355,20 +355,20 @@
   if (shouldHide) {
     return;
   }
-
-  if (config.direction) {
-    switch (config.direction) {
-      case RNSScreenDirectionLeftToRight:
-        navctr.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-        navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-        break;
-      case RNSScreenDirectionRightToLeft:
-        navctr.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-        navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-        break;
-      default:
-        break;
-    }
+  
+  // if we don't explicitly change the direction in config, we should get it from the phone settings
+  if (config.direction == UISemanticContentAttributeUnspecified) {
+    if ([NSLocale preferredLanguages].count != 0 &&
+         [NSLocale characterDirectionForLanguage:[[NSLocale preferredLanguages] objectAtIndex:0]] == NSLocaleLanguageDirectionRightToLeft) {
+       navctr.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+       navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+     } else {
+       navctr.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+       navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+     }
+  } else {
+    navctr.view.semanticContentAttribute = config.direction;
+    navctr.navigationBar.semanticContentAttribute = config.direction;
   }
 
   navitem.title = config.title;
@@ -503,7 +503,7 @@ RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(blurEffect, UIBlurEffectStyle)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
-RCT_EXPORT_VIEW_PROPERTY(direction, RNSScreenDirection)
+RCT_EXPORT_VIEW_PROPERTY(direction, UISemanticContentAttribute)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
@@ -569,10 +569,10 @@ RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType, (@{
    @"center": @(RNSScreenStackHeaderSubviewTypeCenter),
    }), RNSScreenStackHeaderSubviewTypeTitle, integerValue)
 
-RCT_ENUM_CONVERTER(RNSScreenDirection, (@{
-   @"ltr": @(RNSScreenDirectionLeftToRight),
-   @"rtl": @(RNSScreenDirectionRightToLeft),
-   }), RNSScreenDirectionLeftToRight, integerValue)
+RCT_ENUM_CONVERTER(UISemanticContentAttribute, (@{
+   @"ltr": @(UISemanticContentAttributeForceLeftToRight),
+   @"rtl": @(UISemanticContentAttributeForceRightToLeft),
+   }), UISemanticContentAttributeUnspecified, integerValue)
 
 RCT_ENUM_CONVERTER(UIBlurEffectStyle, ([self blurEffectsForIOSVersion]), UIBlurEffectStyleExtraLight, integerValue)
   

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -356,6 +356,21 @@
     return;
   }
 
+  if (config.direction) {
+    switch (config.direction) {
+      case RNSScreenDirectionLeftToRight:
+        navctr.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        break;
+      case RNSScreenDirectionRightToLeft:
+        navctr.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+        navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+        break;
+      default:
+        break;
+    }
+  }
+
   navitem.title = config.title;
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize) {
     prevItem.backBarButtonItem = [[UIBarButtonItem alloc]
@@ -488,6 +503,7 @@ RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(blurEffect, UIBlurEffectStyle)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(direction, RNSScreenDirection)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
@@ -552,6 +568,11 @@ RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType, (@{
    @"title": @(RNSScreenStackHeaderSubviewTypeTitle),
    @"center": @(RNSScreenStackHeaderSubviewTypeCenter),
    }), RNSScreenStackHeaderSubviewTypeTitle, integerValue)
+
+RCT_ENUM_CONVERTER(RNSScreenDirection, (@{
+   @"ltr": @(RNSScreenDirectionLeftToRight),
+   @"rtl": @(RNSScreenDirectionRightToLeft),
+   }), RNSScreenDirectionLeftToRight, integerValue)
 
 RCT_ENUM_CONVERTER(UIBlurEffectStyle, ([self blurEffectsForIOSVersion]), UIBlurEffectStyleExtraLight, integerValue)
   

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -356,7 +356,6 @@
     return;
   }
   
-  // if we don't explicitly change the direction in config, we should get it from the phone settings
   if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -357,16 +357,7 @@
   }
   
   // if we don't explicitly change the direction in config, we should get it from the phone settings
-  if (config.direction == UISemanticContentAttributeUnspecified) {
-    if ([NSLocale preferredLanguages].count != 0 &&
-         [NSLocale characterDirectionForLanguage:[[NSLocale preferredLanguages] objectAtIndex:0]] == NSLocaleLanguageDirectionRightToLeft) {
-       navctr.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-       navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-     } else {
-       navctr.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-       navctr.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-     }
-  } else {
+  if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;
   }

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -115,6 +115,10 @@ For the large title to collapse on scroll, the content of the screen should be w
 
 Only supported on iOS.
 
+### `direction`
+
+String that applies `rtl` or `ltr` form to the stack.
+
 #### `headerTintColor`
 
 Tint color for the header. Changes the color of the back button and title.

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -117,7 +117,7 @@ Only supported on iOS.
 
 ### `direction`
 
-String that applies `rtl` or `ltr` form to the stack. On Android, you have to add `android:supportsRtl="true"` in the manifest of your app to enable `rtl`. On Android, if you set the above flag in the manifest, the orientation changes without the need to do it programmatically if the phone has `rtl` direction enabled. On iOS, the direction defaults to ltr, and only way to change the direction is to do it programmatically via this prop.
+String that applies `rtl` or `ltr` form to the stack. On Android, you have to add `android:supportsRtl="true"` in the manifest of your app to enable `rtl`. On Android, if you set the above flag in the manifest, the orientation changes without the need to do it programmatically if the phone has `rtl` direction enabled. On iOS, the direction defaults to `ltr`, and only way to change it is via this prop.
 
 #### `headerTintColor`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -117,7 +117,7 @@ Only supported on iOS.
 
 ### `direction`
 
-String that applies `rtl` or `ltr` form to the stack.
+String that applies `rtl` or `ltr` form to the stack. On Android, you have to add `android:supportsRtl="true"` in the manifest of your app to enable `rtl`. On Android, if you set the above flag in the manifest, the orientation changes without the need to do it programmatically if the phone has `rtl` direction enabled. On iOS, the direction defaults to ltr, and only way to change the direction is to do it programmatically via this prop.
 
 #### `headerTintColor`
 

--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -79,6 +79,7 @@ class StackView extends React.Component {
       translucent,
       hideShadow,
       headerTopInsetEnabled = true,
+      direction,
     } = options;
 
     const scene = {
@@ -108,6 +109,7 @@ class StackView extends React.Component {
       largeTitleColor: headerLargeTitleStyle && headerLargeTitleStyle.color,
       hideShadow,
       headerTopInsetEnabled,
+      direction,
     };
 
     const hasHeader = headerMode !== 'none' && options.header !== null;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -185,6 +185,10 @@ declare module 'react-native-screens' {
      */
     largeTitle?: boolean;
     /**
+     *@description Controls whether the stack should be in rtl or ltr form.
+     */
+    direction?: 'rtl' | 'ltr';
+    /**
      * @host (iOS only)
      * @description Customize font family to be used for the large title.
      */

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -126,6 +126,10 @@ export type NativeStackNavigationOptions = {
    */
   headerLargeTitle?: boolean;
   /**
+   * Whether the stack should be in rtl or ltr form.
+   */
+  direction?: 'rtl' | 'ltr';
+  /**
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: (props: { tintColor?: string }) => React.ReactNode;

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -37,6 +37,7 @@ export default function HeaderConfig({
   headerBackTitleStyle = {},
   headerShown,
   backButtonInCustomView,
+  direction,
 }: Props): JSX.Element {
   const { colors } = useTheme();
   const tintColor = headerTintColor ?? colors.primary;
@@ -52,6 +53,7 @@ export default function HeaderConfig({
       backTitleFontSize={headerBackTitleStyle.fontSize}
       blurEffect={headerStyle.blurEffect}
       color={tintColor}
+      direction={direction}
       hidden={headerShown === false}
       hideBackButton={headerHideBackButton}
       hideShadow={headerHideShadow}


### PR DESCRIPTION
Added RTL support for both platforms. In order to use `rtl` on Android, you have to add `android:supportsRtl="true"` in the manifest of your app.
On Android, if you set the above flag in the manifest, the orientation changes without the need to do it programmatically. On iOS, the direction defaults to `ltr`, and only way to change the direction is to do it programmatically. Should resolve #403.