### PR TITLE
Fix keyboard not hiding on RN 62+

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -1,11 +1,13 @@
 package com.swmansion.rnscreens;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
 import androidx.annotation.Nullable;
@@ -54,6 +56,24 @@ public class ScreenFragment extends Fragment {
     mScreenView.setLayoutParams(params);
     wrapper.addView(recycleView(mScreenView));
     return wrapper;
+  }
+
+  @Override
+  public void onDetach() {
+    super.onDetach();
+    // The below line is a workaround for an issue with keyboard handling within fragments. Despite
+    // Android handles input focus on the fragments that leave the screen, the keyboard stays open
+    // in a number of cases. The issue can be best reproduced on Android 5 devices, before some changes
+    // in Android's InputMethodManager have been introduced (specifically around dismissing the
+    // keyboard in onDetachedFromWindow). However, we also noticed the keyboard issue happen
+    // intermittently on recent versions of Android as well. The issue hasn't been previously noticed
+    // as in React Native <= 0.61 there was a logic that'd trigger keyboard dismiss upon a blur event
+    // (the blur even gets dispatched properly, the keyboard just stays open despite that) – note
+    // the change in RN core here: https://github.com/facebook/react-native/commit/e9b4928311513d3cbbd9d875827694eab6cfa932
+    // The workaround is to force-hide keyboard passing the fragment's view token when the given fragment
+    // is detached. It is safe to call this method regardless of whether the keyboard was open or not.
+    ((InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE))
+            .hideSoftInputFromWindow(mScreenView.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
   }
 
   public Screen getScreen() {


### PR DESCRIPTION
This PR fixes the problem with Android's soft keyboard staying open when going away from a screen with the focused text input.

The fix is to force keyboard to hide when the screen is detached.

### Testing

The issue could've been reproduced on RN 62 on NativeStack example in the repo, but was only apparent on Android 5, while we haven't figured out a consistent way to reproduce on modern version of Android (we know the new versions were also intermittently affected). Repro steps:
1) Go to NativeStack example app on Android
2) Touch text field and see soft keyboard opens
3) Click "PUSH" button to navigate to the next screen – the keyboard would stay open despite the text field from the previous screen is gone

With this change in, the keybord is closed upon navigating away from the screen with the focused field.
