### PR TITLE
Fix ordering of appear / disappear events on Android to match iOS

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -11,6 +11,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 
 import java.util.ArrayList;
@@ -153,7 +154,17 @@ public class ScreenFragment extends Fragment {
     // We override Screen#onAnimationStart and an appropriate method of the StackFragment's root view
     // in order to achieve this.
     if (isResumed()) {
-      dispatchOnWillAppear();
+      // Android dispatches the animation start event for the fragment that is being added first
+      // however we want the one being dismissed first to match iOS. It also makes more sense from
+      // a navigation point of view to have the disappear event first.
+      // Since there are no explicit relationships between the fragment being added / removed the
+      // practical way to fix this is delaying dispatching the appear events at the end of the frame.
+      UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          dispatchOnWillAppear();
+        }
+      });
     } else {
       dispatchOnWillDisappear();
     }
@@ -164,7 +175,13 @@ public class ScreenFragment extends Fragment {
     // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
     // in order to achieve this.
     if (isResumed()) {
-      dispatchOnAppear();
+      // See the comment in onViewAnimationStart for why this event is delayed.
+      UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          dispatchOnAppear();
+        }
+      });
     } else {
       dispatchOnDisappear();
     }


### PR DESCRIPTION
Some potential issues with the different event ordering were pointed out and I think are worth fixing. We're kind of limited by the ordering of animation events on android so I don't really see another way to fix the ordering without adding a lot of complexity.

Android seems to dispatch both animation events right one after the other so I haven't seen any cases of race conditions with simply re-dispatching on the main thread for the appear events.