### PR TITLE
fix: scrollview behavior on transitioning between screens

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -355,6 +355,17 @@
     // screen dismissed, send event
     [((RNSScreenView *)self.view) notifyDismissed];
   }
+  [self traverseForScrollView:self.view];
+}
+
+- (void)traverseForScrollView:(UIView*)view
+{
+  if([view isKindOfClass:[UIScrollView class]] && ([[(UIScrollView*)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) ) {
+    [[(UIScrollView*)view delegate] scrollViewDidEndDecelerating:(id)view];
+  }
+  [view.subviews enumerateObjectsUsingBlock:^(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [self traverseForScrollView:obj];
+  }];
 }
 
 - (void)notifyFinishTransitioning


### PR DESCRIPTION
Based on https://github.com/wix/react-native-navigation/pull/1630 (since it fixes the same problem), we traverse the view in order to find ScrollViews and invoke `scrollViewDidEndDecelerating` on them. It is needed due to the situation where we start scrolling, and before the `ScrollView` stops decelerating, we move to another screen and as a result, the `scrollViewDidEndDecelerating` is not called on that `ScrollView`. Due to JS implementation of `ScrollView` (see https://github.com/software-mansion/react-native-screens/issues/102#issuecomment-638101039), it causes the elements of the `ScrollView` not to respond to touches after going back to that screen. 
More information can be seen in #102. It should also close #102.