### PR TITLE
feat: enable dev menu on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -56,10 +56,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     @Override
     public boolean showOverflowMenu() {
-      Activity activity =  ((ThemedReactContext) getContext()).getCurrentActivity();
-      if (activity != null) {
-        ((ReactApplication) activity.getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
-      }
+      ((ReactApplication) getContext().getApplicationContext()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
       return true;
     }
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -20,6 +21,7 @@ import androidx.fragment.app.Fragment;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.text.ReactFontManager;
 
 import java.util.ArrayList;
@@ -46,7 +48,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private int mDefaultStartInset;
   private int mDefaultStartInsetWithNavigation;
 
-  private class DebugMenuToolbar extends Toolbar {
+  private static class DebugMenuToolbar extends Toolbar {
 
     public DebugMenuToolbar(Context context) {
       super(context);
@@ -54,7 +56,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     @Override
     public boolean showOverflowMenu() {
-      ((ReactApplication) getScreenFragment().getActivity().getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
+      Activity activity =  ((ThemedReactContext) getContext()).getCurrentActivity();
+      if (activity != null) {
+        ((ReactApplication) activity.getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
+      }
       return true;
     }
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -197,8 +197,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     // hide back button
     actionBar.setDisplayHomeAsUpEnabled(getScreenFragment().canNavigateBack() ? !mIsBackButtonHidden : false);
 
-//    ((ReactApplication) activity.getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
-
     // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
     // navigation click listener. The default behavior set in the wrapper is to call into
     // menu options handlers, but we prefer the back handling logic to stay here instead.

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -1,6 +1,5 @@
 package com.swmansion.rnscreens;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -21,7 +20,6 @@ import androidx.fragment.app.Fragment;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.text.ReactFontManager;
 
 import java.util.ArrayList;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -18,6 +18,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
+import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.views.text.ReactFontManager;
 
@@ -45,6 +46,19 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private int mDefaultStartInset;
   private int mDefaultStartInsetWithNavigation;
 
+  private class MyToolbar extends Toolbar {
+
+    public MyToolbar(Context context) {
+      super(context);
+    }
+
+    @Override
+    public boolean showOverflowMenu() {
+      ((ReactApplication) getScreenFragment().getActivity().getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
+      return true;
+    }
+  }
+
   private OnClickListener mBackClickListener = new OnClickListener() {
     @Override
     public void onClick(View view) {
@@ -67,7 +81,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     super(context);
     setVisibility(View.GONE);
 
-    mToolbar = new Toolbar(context);
+    mToolbar = new MyToolbar(context);
     mDefaultStartInset = mToolbar.getContentInsetStart();
     mDefaultStartInsetWithNavigation = mToolbar.getContentInsetStartWithNavigation();
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -46,9 +46,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private int mDefaultStartInset;
   private int mDefaultStartInsetWithNavigation;
 
-  private class MyToolbar extends Toolbar {
+  private class DebugMenuToolbar extends Toolbar {
 
-    public MyToolbar(Context context) {
+    public DebugMenuToolbar(Context context) {
       super(context);
     }
 
@@ -81,7 +81,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     super(context);
     setVisibility(View.GONE);
 
-    mToolbar = new MyToolbar(context);
+    mToolbar = BuildConfig.DEBUG ? new DebugMenuToolbar(context) : new Toolbar(context);
     mDefaultStartInset = mToolbar.getContentInsetStart();
     mDefaultStartInsetWithNavigation = mToolbar.getContentInsetStartWithNavigation();
 
@@ -196,6 +196,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     // hide back button
     actionBar.setDisplayHomeAsUpEnabled(getScreenFragment().canNavigateBack() ? !mIsBackButtonHidden : false);
+
+//    ((ReactApplication) activity.getApplication()).getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
 
     // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
     // navigation click listener. The default behavior set in the wrapper is to call into


### PR DESCRIPTION
Overridded method that is called on the key event on which the developer menu on Android should be opened. Change added only for debug mode. Should resolve #276.
Clicking `cmd+m` on macOS in debug mode should open the developer menu on Android, but Action Bar wants to handle that key event in order to trigger `showOverflowMenu` on the Toolbar. We then override this method and call React's `showDevOptionsDialog` in it.