### PR TITLE
Fix problem with keyboard staying open on Android after screen change

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -62,24 +62,6 @@ public class ScreenFragment extends Fragment {
     return wrapper;
   }
 
-  @Override
-  public void onDetach() {
-    super.onDetach();
-    // The below line is a workaround for an issue with keyboard handling within fragments. Despite
-    // Android handles input focus on the fragments that leave the screen, the keyboard stays open
-    // in a number of cases. The issue can be best reproduced on Android 5 devices, before some changes
-    // in Android's InputMethodManager have been introduced (specifically around dismissing the
-    // keyboard in onDetachedFromWindow). However, we also noticed the keyboard issue happen
-    // intermittently on recent versions of Android as well. The issue hasn't been previously noticed
-    // as in React Native <= 0.61 there was a logic that'd trigger keyboard dismiss upon a blur event
-    // (the blur even gets dispatched properly, the keyboard just stays open despite that) – note
-    // the change in RN core here: https://github.com/facebook/react-native/commit/e9b4928311513d3cbbd9d875827694eab6cfa932
-    // The workaround is to force-hide keyboard passing the fragment's view token when the given fragment
-    // is detached. It is safe to call this method regardless of whether the keyboard was open or not.
-    ((InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE))
-            .hideSoftInputFromWindow(mScreenView.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-  }
-
   public Screen getScreen() {
     return mScreenView;
   }


### PR DESCRIPTION
This is a follow up fix after #592 where we attempted to fix the issue while introducing a regression in the way autoFocus is handled. That is, in case there was a text field with an auto focus in the next screen, the logic we added for screen dismissal would cause it to immediately lose focus.

This fix moves the logic responsible for keyboard force-dismiss to execute earlier – at the moment when we attempt to detach the previous screen. This way we can still rely on the focused child property to point to a correct children. Note that before, detaching a view would result in the child losing focus but the keyboard would stay open. We now use this fact and can verify that the focused children is the one being removed, and only in that case we ask system to hide the keyboard.
