### PR TITLE
fix: webview in stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -153,6 +153,9 @@ public class Screen extends ViewGroup {
     }
     mTransitioning = transitioning;
     boolean isWebViewInScreen = hasWebView(this);
+    if (isWebViewInScreen && getLayerType() != View.LAYER_TYPE_HARDWARE) {
+      return;
+    }
     super.setLayerType(transitioning && !isWebViewInScreen ? View.LAYER_TYPE_HARDWARE : View.LAYER_TYPE_NONE, null);
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -152,17 +152,17 @@ public class Screen extends ViewGroup {
       return;
     }
     mTransitioning = transitioning;
-    boolean isWebViewInScreen = findWebView(this);
+    boolean isWebViewInScreen = hasWebView(this);
     super.setLayerType(transitioning && !isWebViewInScreen ? View.LAYER_TYPE_HARDWARE : View.LAYER_TYPE_NONE, null);
   }
 
-  private boolean findWebView(ViewGroup viewGroup) {
+  private boolean hasWebView(ViewGroup viewGroup) {
     for(int i = 0; i < viewGroup.getChildCount(); i++) {
       View child = viewGroup.getChildAt(i);
       if (child instanceof WebView) {
         return true;
       } else if (child instanceof ViewGroup) {
-         if (findWebView((ViewGroup) child)) {
+         if (hasWebView((ViewGroup) child)) {
            return true;
          }
       }

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.WebView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
@@ -151,7 +152,22 @@ public class Screen extends ViewGroup {
       return;
     }
     mTransitioning = transitioning;
-    super.setLayerType(transitioning ? View.LAYER_TYPE_HARDWARE : View.LAYER_TYPE_NONE, null);
+    boolean isWebViewInScreen = findWebView(this);
+    super.setLayerType(transitioning && !isWebViewInScreen ? View.LAYER_TYPE_HARDWARE : View.LAYER_TYPE_NONE, null);
+  }
+
+  private boolean findWebView(ViewGroup viewGroup) {
+    for(int i = 0; i < viewGroup.getChildCount(); i++) {
+      View child = viewGroup.getChildAt(i);
+      if (child instanceof WebView) {
+        return true;
+      } else if (child instanceof ViewGroup) {
+         if (findWebView((ViewGroup) child)) {
+           return true;
+         }
+      }
+    }
+    return false;
   }
 
   public void setStackPresentation(StackPresentation stackPresentation) {


### PR DESCRIPTION
Added check for if there is WebView on the screen we are transitioning to. If there is, we don't change the layer type in stack navigator to avoid crash seen in #105.