### PR TITLE
fix: add appContainer to modal screens

### DIFF
--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -4,7 +4,8 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View, ViewProps } from 'react-native';
+// @ts-ignore Getting private component
 import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
 import {
   Screen as ScreenComponent,
@@ -23,9 +24,9 @@ const isAndroid = Platform.OS === 'android';
 let Container = View;
 
 if (__DEV__) {
-  const DebugContainer = (props) => {
-    const { stackAnimation, index, ...rest } = props;
-    if (Platform.OS === 'ios' && stackAnimation !== 'push' && index !== 0) {
+  const DebugContainer = (props: ViewProps & { stackAnimation: string }) => {
+    const { stackAnimation, ...rest } = props;
+    if (Platform.OS === 'ios' && stackAnimation !== 'push') {
       return (
         <AppContainer>
           <View {...rest} />
@@ -34,6 +35,7 @@ if (__DEV__) {
     }
     return <View {...rest} />;
   };
+  // @ts-ignore Wrong props
   Container = DebugContainer;
 }
 
@@ -126,6 +128,7 @@ export default function NativeStackView({
             <HeaderConfig {...options} route={route} />
             <Container
               style={viewStyles}
+              // @ts-ignore Wrong props passed to View
               stackPresentation={stackPresentation}
               index={index}>
               {renderScene()}

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -55,7 +55,7 @@ export default function NativeStackView({
 
   return (
     <ScreenStack style={styles.container}>
-      {routes.map((route, index) => {
+      {routes.map((route) => {
         const { options, render: renderScene } = descriptors[route.key];
         const {
           gestureEnabled,
@@ -129,8 +129,7 @@ export default function NativeStackView({
             <Container
               style={viewStyles}
               // @ts-ignore Wrong props passed to View
-              stackPresentation={stackPresentation}
-              index={index}>
+              stackPresentation={stackPresentation}>
               {renderScene()}
             </Container>
           </Screen>

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -5,6 +5,7 @@ import {
 } from '@react-navigation/native';
 import * as React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
+import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
 import {
   Screen as ScreenComponent,
   ScreenProps,
@@ -35,7 +36,7 @@ export default function NativeStackView({
 
   return (
     <ScreenStack style={styles.container}>
-      {routes.map((route) => {
+      {routes.map((route, index) => {
         const { options, render: renderScene } = descriptors[route.key];
         const {
           gestureEnabled,
@@ -106,7 +107,16 @@ export default function NativeStackView({
               });
             }}>
             <HeaderConfig {...options} route={route} />
-            <View style={viewStyles}>{renderScene()}</View>
+            {__DEV__ &&
+            Platform.OS === 'ios' &&
+            stackPresentation !== 'push' &&
+            index !== 0 ? (
+              <AppContainer>
+                <View style={viewStyles}>{renderScene()}</View>
+              </AppContainer>
+            ) : (
+              <View style={viewStyles}>{renderScene()}</View>
+            )}
           </Screen>
         );
       })}

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -20,6 +20,23 @@ import HeaderConfig from './HeaderConfig';
 const Screen = (ScreenComponent as unknown) as React.ComponentType<ScreenProps>;
 const isAndroid = Platform.OS === 'android';
 
+let Container = View;
+
+if (__DEV__) {
+  const DebugContainer = (props) => {
+    const { stackAnimation, index, ...rest } = props;
+    if (Platform.OS === 'ios' && stackAnimation !== 'push' && index !== 0) {
+      return (
+        <AppContainer>
+          <View {...rest} />
+        </AppContainer>
+      );
+    }
+    return <View {...rest} />;
+  };
+  Container = DebugContainer;
+}
+
 type Props = {
   state: StackNavigationState;
   navigation: NativeStackNavigationHelpers;
@@ -107,16 +124,12 @@ export default function NativeStackView({
               });
             }}>
             <HeaderConfig {...options} route={route} />
-            {__DEV__ &&
-            Platform.OS === 'ios' &&
-            stackPresentation !== 'push' &&
-            index !== 0 ? (
-              <AppContainer>
-                <View style={viewStyles}>{renderScene()}</View>
-              </AppContainer>
-            ) : (
-              <View style={viewStyles}>{renderScene()}</View>
-            )}
+            <Container
+              style={viewStyles}
+              stackPresentation={stackPresentation}
+              index={index}>
+              {renderScene()}
+            </Container>
           </Screen>
         );
       })}


### PR DESCRIPTION
Following the implementation of `Modal` in `react-native`: https://github.com/facebook/react-native/blob/master/Libraries/Modal/Modal.js#L206, we attach each screen that is presented modally with an `AppContainer` that has a listener for `LogBox` and `ElementInspector`. This allows for these elements to pop up over the modal screen. There will be 2 `ElementInspectors` on the first screen due to 2 `AppContainer` components rendered in it. If we added check for if the `index === 0`, changing that index would unmount and remount screen content while calling e.g. `navigation.reset()`. Should resolve #268. 