### PR TITLE
fix: check if in modal

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -167,7 +167,7 @@
     [singleActiveScreen notifyFinishTransitioning];
   }
 
-  if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil) {
+  if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil && _controller.presentingViewController == nil) {
     // if user has reachability enabled (one hand use) and the window is slided down the below
     // method will force it to slide back up as it is expected to happen with UINavController when
     // we push or pop views.


### PR DESCRIPTION
We check if the screen is in modal since the method in the `if` clause will dismiss the modal screen when e.g. changing the screens in a bottom-tabs navigator nested in the modal.