### PR TITLE
Replace deprecated useSafeArea with useSafeAreaInsets in example

### DIFF
--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -312,11 +312,11 @@ navigation.popToTop();
 
 Using translucent header on iOS can result in the need of measuring your header's height. In order to do it, you can use `react-native-safe-area-context`. It can be measured like this:
 ```js
-import {useSafeArea} from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 ...
 
-const statusBarInset = useSafeArea().top; // inset of the status bar
+const statusBarInset = useSafeAreaInsets().top; // inset of the status bar
 const smallHeaderInset = statusBarInset + 44; // inset to use for a small header since it's frame is equal to 44 + the frame of status bar
 const largeHeaderInset = statusBarInset + 96; // inset to use for a large header since it's frame is equal to 96 + the frame of status bar
 ```


### PR DESCRIPTION
`useSafeArea` hook is deprecated (replaced by [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets)).