### PR TITLE
feat: orientation managment on iOS

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -304,7 +304,7 @@ PODS:
     - React
   - RNReanimated (1.10.1):
     - React
-  - RNScreens (2.10.1):
+  - RNScreens (2.11.0):
     - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
-  RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2
+  RNScreens: 0e91da98ab26d5d04c7b59a9b6bd694124caf88c
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -305,7 +305,7 @@ PODS:
   - RNReanimated (1.10.1):
     - React
   - RNScreens (2.11.0):
-    - React
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
-  RNScreens: 0e91da98ab26d5d04c7b59a9b6bd694124caf88c
+  RNScreens: b389898260092cf4d19c01ee15dfca52a46208ed
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/Example/ios/ScreensExample/AppDelegate.m
+++ b/Example/ios/ScreensExample/AppDelegate.m
@@ -2,6 +2,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <RNScreens/UIViewController+RNScreens.h>
 
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
@@ -22,25 +23,6 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
-@interface RNScreensRootViewController: UIViewController
-@end
-
-@implementation RNScreensRootViewController
-
-- (UIViewController *)childViewControllerForStatusBarStyle
-{
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
-}
-
-- (UIViewController *)childViewControllerForStatusBarHidden
-{
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
-}
-
-@end
-
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -56,7 +38,7 @@ static void InitializeFlipper(UIApplication *application) {
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [RNScreensRootViewController new];
+  UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/Example/ios/ScreensExample/AppDelegate.m
+++ b/Example/ios/ScreensExample/AppDelegate.m
@@ -22,6 +22,19 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
+@interface RNScreensViewController: UIViewController
+@end
+
+@implementation RNScreensViewController
+
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
+}
+
+@end
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -37,7 +50,7 @@ static void InitializeFlipper(UIApplication *application) {
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [UIViewController new];
+  UIViewController *rootViewController = [RNScreensViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/Example/ios/ScreensExample/AppDelegate.m
+++ b/Example/ios/ScreensExample/AppDelegate.m
@@ -22,15 +22,21 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
-@interface RNScreensViewController: UIViewController
+@interface RNScreensRootViewController: UIViewController
 @end
 
-@implementation RNScreensViewController
+@implementation RNScreensRootViewController
 
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden
+{
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
 }
 
 @end
@@ -50,7 +56,7 @@ static void InitializeFlipper(UIApplication *application) {
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [RNScreensViewController new];
+  UIViewController *rootViewController = [RNScreensRootViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/Example/ios/ScreensExample/Info.plist
+++ b/Example/ios/ScreensExample/Info.plist
@@ -37,7 +37,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSAppTransportSecurity</key>

--- a/Example/nativeNavigation.js
+++ b/Example/nativeNavigation.js
@@ -51,14 +51,15 @@ class PushScreen extends React.Component {
 const AppStack = createNativeStackNavigator();
 
 const App = () => (
-  <AppStack.Navigator>
+  <AppStack.Navigator screenProps={{ statusBarAnimation: 'fade' }}>
     <AppStack.Screen
       name="Some"
       component={SomeScreen}
       options={{
         title: 'Start',
         headerTintColor: 'black',
-        statusBarStyle: 'light-content',
+        statusBarStyle: 'dark-content',
+        statusBarHidden: false,
       }}
     />
     <AppStack.Screen
@@ -68,13 +69,13 @@ const App = () => (
         title: 'Pushed',
         headerStyle: { backgroundColor: '#3da4ab' },
         headerTintColor: 'black',
-        statusBarStyle: 'dark-content',
+        statusBarHidden: true,
       }}
     />
     <AppStack.Screen
       name="Modal"
       component={PushScreen}
-      options={{ stackPresentation: 'modal', statusBarStyle: 'default' }}
+      options={{ stackPresentation: 'modal' }}
     />
   </AppStack.Navigator>
 );

--- a/Example/nativeNavigation.js
+++ b/Example/nativeNavigation.js
@@ -28,6 +28,7 @@ class PushScreen extends React.Component {
       visible: false,
     },
   };
+
   render() {
     return (
       <View style={styles.screen}>
@@ -54,7 +55,11 @@ const App = () => (
     <AppStack.Screen
       name="Some"
       component={SomeScreen}
-      options={{ title: 'Start', headerTintColor: 'black' }}
+      options={{
+        title: 'Start',
+        headerTintColor: 'black',
+        statusBarStyle: 'light-content',
+      }}
     />
     <AppStack.Screen
       name="Push"
@@ -63,12 +68,13 @@ const App = () => (
         title: 'Pushed',
         headerStyle: { backgroundColor: '#3da4ab' },
         headerTintColor: 'black',
+        statusBarStyle: 'dark-content',
       }}
     />
     <AppStack.Screen
       name="Modal"
       component={PushScreen}
-      options={{ stackPresentation: 'modal' }}
+      options={{ stackPresentation: 'modal', statusBarStyle: 'default' }}
     />
   </AppStack.Navigator>
 );

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
 @property (nonatomic) UIStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
+@property (nonatomic) BOOL statusBarHidden;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -27,7 +27,6 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
   RNSScreenReplaceAnimationPush,
 };
 
-
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -27,10 +27,18 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
   RNSScreenReplaceAnimationPush,
 };
 
+typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
+  RNSStatusBarStyleAuto,
+  RNSStatusBarStyleInverted,
+  RNSStatusBarStyleLight,
+  RNSStatusBarStyleDark,
+};
+
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
++ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
 
 @end
 
@@ -59,7 +67,7 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
-@property (nonatomic) UIStatusBarStyle statusBarStyle;
+@property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -1,6 +1,7 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTView.h>
 #import <React/RCTComponent.h>
+
 #import "RNSScreenContainer.h"
 
 @class RNSScreenContainerView;
@@ -34,11 +35,10 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 
 @end
 
-@interface RNSScreen : UIViewController
+@interface RNSScreen : UIViewController <RNScreensViewControllerDelegate>
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
-- (void)updateStatusBarAppearance;
 
 @end
 
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 @property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 @property (nonatomic, copy) RCTDirectEventBlock onWillAppear;
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
-@property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
+@property (weak, nonatomic) UIView <RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic, readonly) BOOL dismissed;
 @property (nonatomic) BOOL active;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -27,20 +27,11 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
   RNSScreenReplaceAnimationPush,
 };
 
-typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
-  RNSStatusBarStyleAuto,
-  RNSStatusBarStyleInverted,
-  RNSStatusBarStyleLight,
-  RNSStatusBarStyleDark,
-};
-
 
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
-+ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
-+ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
 
 @end
 
@@ -52,6 +43,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 + (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
 + (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask;
+- (void)updateStatusBarAppearance;
 
 @end
 
@@ -73,10 +65,6 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
-@property (nonatomic) RNSStatusBarStyle statusBarStyle;
-@property (nonatomic) UIStatusBarAnimation statusBarAnimation;
-@property (nonatomic) BOOL statusBarHidden;
-@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -34,17 +34,6 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
   RNSStatusBarStyleDark,
 };
 
-typedef NS_ENUM(NSInteger, RNSScreenOrientationMask) {
-  RNSScreenOrientationMaskDefault,
-  RNSScreenOrientationMaskAll,
-  RNSScreenOrientationMaskPortrait,
-  RNSScreenOrientationMaskPortraitUp,
-  RNSScreenOrientationMaskPortraitDown,
-  RNSScreenOrientationMaskLandscape,
-  RNSScreenOrientationMaskLandscapeLeft,
-  RNSScreenOrientationMaskLandscapeRight,
-};
-
 
 
 @interface RCTConvert (RNSScreen)
@@ -52,15 +41,13 @@ typedef NS_ENUM(NSInteger, RNSScreenOrientationMask) {
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
 + (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
-+ (RNSScreenOrientationMask)RNSScreenOrientationMask:(id)json;
-
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
 @end
 
 @interface RNSScreen : UIViewController
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
-+ (UIInterfaceOrientationMask)interfaceOrientationMaskForStackOrientationMask:(RNSScreenOrientationMask)stackOrientationMask;
 + (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
 + (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
@@ -89,7 +76,7 @@ typedef NS_ENUM(NSInteger, RNSScreenOrientationMask) {
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
-@property (nonatomic) RNSScreenOrientationMask stackOrientationMask;
+@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -39,10 +39,6 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
-+ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
-+ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
-+ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
-+ (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask;
 - (void)updateStatusBarAppearance;
 
 @end

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -35,13 +35,13 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 };
 
 
-
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
 + (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
+
 @end
 
 @interface RNSScreen : UIViewController

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -34,11 +34,25 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
   RNSStatusBarStyleDark,
 };
 
+typedef NS_ENUM(NSInteger, RNSScreenOrientationMask) {
+  RNSScreenOrientationMaskDefault,
+  RNSScreenOrientationMaskAll,
+  RNSScreenOrientationMaskPortrait,
+  RNSScreenOrientationMaskPortraitUp,
+  RNSScreenOrientationMaskPortraitDown,
+  RNSScreenOrientationMaskLandscape,
+  RNSScreenOrientationMaskLandscapeLeft,
+  RNSScreenOrientationMaskLandscapeRight,
+};
+
+
+
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
 + (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
++ (RNSScreenOrientationMask)RNSScreenOrientationMask:(id)json;
 
 @end
 
@@ -46,6 +60,11 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
++ (UIInterfaceOrientationMask)interfaceOrientationMaskForStackOrientationMask:(RNSScreenOrientationMask)stackOrientationMask;
++ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
++ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
++ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
++ (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask;
 
 @end
 
@@ -70,6 +89,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
+@property (nonatomic) RNSScreenOrientationMask stackOrientationMask;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 @end
 
 @interface RNSScreenManager : RCTViewManager
+
 @end
 
 @interface RNSScreenView : RCTView

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -59,6 +59,8 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
+@property (nonatomic) UIStatusBarStyle statusBarStyle;
+@property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -379,9 +379,16 @@
   // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
   UIViewController *parent = [self parentViewController];
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
-    parent = [parent parentViewController];
+    if ([parent parentViewController] == nil && [parent isKindOfClass:[RNSScreen class]]) {
+      // we are at the top of hierarchy and the controller is RNSScreen so we are in modal screen
+      break;
+    } else {
+      parent = [parent parentViewController];
+    }
   }
-  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]) : ((RNSScreenView *)self.view);
+  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
+    ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
+    : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
   return [screenView statusBarStyleForRNSStatusBarStyle];
 }
 
@@ -394,9 +401,17 @@
   // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
   UIViewController *parent = [self parentViewController];
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
-    parent = [parent parentViewController];
+    if ([parent parentViewController] == nil && [parent isKindOfClass:[RNSScreen class]]) {
+      // we are at the top of hierarchy and the controller is RNSScreen so we are in modal screen
+      break;
+    } else {
+      parent = [parent parentViewController];
+    }
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarAnimation : ((RNSScreenView *)self.view).statusBarAnimation;
+  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
+    ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
+    : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
+  return screenView.statusBarAnimation;
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -410,9 +425,17 @@
   // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
   UIViewController *parent = [self parentViewController];
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
-    parent = [parent parentViewController];
+    if ([parent parentViewController] == nil && [parent isKindOfClass:[RNSScreen class]]) {
+      // we are at the top of hierarchy and the controller is RNSScreen so we are in modal screen
+      break;
+    } else {
+      parent = [parent parentViewController];
+    }
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarHidden : ((RNSScreenView *)self.view).statusBarHidden;
+  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
+    ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
+    : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
+  return screenView.statusBarHidden;
 }
 
 - (void)viewDidLayoutSubviews

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -31,7 +31,7 @@
     _statusBarStyle = RNSStatusBarStyleAuto;
     _statusBarAnimation = UIStatusBarAnimationFade;
     _statusBarHidden = NO;
-    _stackOrientationMask = RNSScreenOrientationMaskDefault;
+    _screenOrientation = UIInterfaceOrientationMaskAllButUpsideDown;
 #endif
     _gestureEnabled = YES;
     _replaceAnimation = RNSScreenReplaceAnimationPop;
@@ -197,10 +197,10 @@
   }
 }
 
-- (void)setStackOrientationMask:(RNSScreenOrientationMask)stackOrientationMask
+- (void)setScreenOrientation:(UIInterfaceOrientationMask)screenOrientation
 {
-  _stackOrientationMask = stackOrientationMask;
-  [RNSScreen enforceDesiredDeviceOrientationWithOrientationMask:[RNSScreen interfaceOrientationMaskForStackOrientationMask:_stackOrientationMask]];
+  _screenOrientation = screenOrientation;
+  [RNSScreen enforceDesiredDeviceOrientationWithOrientationMask:_screenOrientation];
 }
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
@@ -422,7 +422,7 @@
   }
   RNSScreenView *screenView = [self findScreenViewForScreenProps];
   
-  UIInterfaceOrientationMask orientationMask = [RNSScreen interfaceOrientationMaskForStackOrientationMask:screenView.stackOrientationMask];
+  UIInterfaceOrientationMask orientationMask = screenView.screenOrientation;
   return orientationMask;
 }
 
@@ -529,30 +529,6 @@
   _previousFirstResponder = nil;
 }
 
-+ (UIInterfaceOrientationMask)interfaceOrientationMaskForStackOrientationMask:(RNSScreenOrientationMask)stackOrientationMask
-{
-  switch (stackOrientationMask) {
-    case RNSScreenOrientationMaskDefault:
-      return UIInterfaceOrientationMaskAllButUpsideDown;
-    case RNSScreenOrientationMaskAll:
-      return UIInterfaceOrientationMaskAll;
-    case RNSScreenOrientationMaskPortrait:
-      return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
-    case RNSScreenOrientationMaskPortraitUp:
-      return UIInterfaceOrientationMaskPortrait;
-    case RNSScreenOrientationMaskPortraitDown:
-      return UIInterfaceOrientationMaskPortraitUpsideDown;
-    case RNSScreenOrientationMaskLandscape:
-      return UIInterfaceOrientationMaskLandscape;
-    case RNSScreenOrientationMaskLandscapeLeft:
-      return UIInterfaceOrientationMaskLandscapeLeft;
-    case RNSScreenOrientationMaskLandscapeRight:
-      return UIInterfaceOrientationMaskLandscapeRight;
-    default:
-      return UIInterfaceOrientationMaskAllButUpsideDown;
-  }
-}
-
 + (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask
 {
   if (UIInterfaceOrientationMaskPortrait & orientationMask) {
@@ -618,7 +594,7 @@ RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(stackOrientationMask, RNSScreenOrientationMask)
+RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
@@ -656,22 +632,34 @@ RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation, (@{
                                                   @"pop": @(RNSScreenReplaceAnimationPop),
                                                   }), RNSScreenReplaceAnimationPop, integerValue)
 
-RCT_ENUM_CONVERTER(RNSScreenOrientationMask, (@{
-                                                  @"default": @(RNSScreenOrientationMaskDefault),
-                                                  @"all": @(RNSScreenOrientationMaskAll),
-                                                  @"portrait": @(RNSScreenOrientationMaskPortrait),
-                                                  @"portrait_up": @(RNSScreenOrientationMaskPortraitUp),
-                                                  @"portrait_down": @(RNSScreenOrientationMaskPortraitDown),
-                                                  @"landscape": @(RNSScreenOrientationMaskLandscape),
-                                                  @"landscape_left": @(RNSScreenOrientationMaskLandscapeLeft),
-                                                  @"landscape_right": @(RNSScreenOrientationMaskLandscapeRight),
-                                                  }), RNSScreenOrientationMaskAll, integerValue)
-
 RCT_ENUM_CONVERTER(RNSStatusBarStyle, (@{
                                                   @"auto": @(RNSStatusBarStyleAuto),
                                                   @"inverted": @(RNSStatusBarStyleInverted),
                                                   @"light": @(RNSStatusBarStyleLight),
                                                   @"dark": @(RNSStatusBarStyleDark),
                                                   }), RNSStatusBarStyleAuto, integerValue)
+
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json
+{
+  json = [self NSString:json];
+  if ([json isEqualToString:@"default"]) {
+    return UIInterfaceOrientationMaskAllButUpsideDown;
+  } else if ([json isEqualToString:@"all"]) {
+    return UIInterfaceOrientationMaskAll;
+  } else if ([json isEqualToString:@"portrait"]) {
+    return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+  } else if ([json isEqualToString:@"portrait_up"]) {
+    return UIInterfaceOrientationMaskPortrait;
+  } else if ([json isEqualToString:@"portrait_down"]) {
+    return UIInterfaceOrientationMaskPortraitUpsideDown;
+  } else if ([json isEqualToString:@"landscape"]) {
+    return UIInterfaceOrientationMaskLandscape;
+  } else if ([json isEqualToString:@"landscape_left"]) {
+    return UIInterfaceOrientationMaskLandscapeLeft;
+  } else if ([json isEqualToString:@"landscape_right"]) {
+    return UIInterfaceOrientationMaskLandscapeRight;
+  }
+  return UIInterfaceOrientationMaskAllButUpsideDown;
+}
 
 @end

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -156,6 +156,7 @@
       UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
     } else {
       _statusBarStyle = statusBarStyle;
+      _controller.modalPresentationCapturesStatusBarAppearance = YES;
       [UIView animateWithDuration:0.5 animations:^{
         [self->_controller setNeedsStatusBarAppearanceUpdate];
       }];
@@ -171,6 +172,7 @@
       UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
     } else {
       _statusBarAnimation = statusBarAnimation;
+      _controller.modalPresentationCapturesStatusBarAppearance = YES;
       [UIView animateWithDuration:0.5 animations:^{
         [self->_controller setNeedsStatusBarAppearanceUpdate];
       }];
@@ -186,6 +188,7 @@
       UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
     } else {
       _statusBarHidden = statusBarHidden;
+      _controller.modalPresentationCapturesStatusBarAppearance = YES;
       [UIView animateWithDuration:0.5 animations:^{
         [self->_controller setNeedsStatusBarAppearanceUpdate];
       }];
@@ -357,7 +360,7 @@
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
     parent = [parent parentViewController];
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarStyle : UIStatusBarStyleDefault;
+  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarStyle : ((RNSScreenView *)self.view).statusBarStyle;
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
@@ -371,7 +374,7 @@
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
     parent = [parent parentViewController];
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarAnimation : UIStatusBarAnimationFade;
+  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarAnimation : ((RNSScreenView *)self.view).statusBarAnimation;
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -387,7 +390,7 @@
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
     parent = [parent parentViewController];
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarHidden : NO;
+  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarHidden : ((RNSScreenView *)self.view).statusBarHidden;
 }
 
 - (void)viewDidLayoutSubviews

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -28,7 +28,7 @@
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
 #if (TARGET_OS_IOS)
-    _statusBarStyle = UIStatusBarStyleDefault;
+    _statusBarStyle = RNSStatusBarStyleAuto;
     _statusBarAnimation = UIStatusBarAnimationFade;
     _statusBarHidden = NO;
 #endif
@@ -148,7 +148,7 @@
   }
 }
 
-- (void)setStatusBarStyle:(UIStatusBarStyle)statusBarStyle
+- (void)setStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
   if (statusBarStyle != _statusBarStyle) {
     if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue]) {
@@ -334,6 +334,27 @@
   _controller = nil;
 }
 
+- (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle
+{
+#ifdef __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    switch (_statusBarStyle) {
+      case RNSStatusBarStyleAuto:
+          return [[self traitCollection] userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleLightContent : UIStatusBarStyleDarkContent;
+      case RNSStatusBarStyleInverted:
+          return [[self traitCollection] userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleDarkContent : UIStatusBarStyleLightContent;
+      case RNSStatusBarStyleLight:
+          return UIStatusBarStyleLightContent;
+      case RNSStatusBarStyleDark:
+          return UIStatusBarStyleDarkContent;
+      default:
+        return UIStatusBarStyleLightContent;
+    }
+  }
+#endif
+  return UIStatusBarStyleLightContent;
+}
+
 @end
 
 @implementation RNSScreen {
@@ -360,7 +381,8 @@
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
     parent = [parent parentViewController];
   }
-  return [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]).statusBarStyle : ((RNSScreenView *)self.view).statusBarStyle;
+  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]] ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view]) : ((RNSScreenView *)self.view);
+  return [screenView statusBarStyleForRNSStatusBarStyle];
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
@@ -489,7 +511,7 @@ RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
-RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, UIStatusBarStyle)
+RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
@@ -529,5 +551,11 @@ RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation, (@{
                                                   @"pop": @(RNSScreenReplaceAnimationPop),
                                                   }), RNSScreenReplaceAnimationPop, integerValue)
 
+RCT_ENUM_CONVERTER(RNSStatusBarStyle, (@{
+                                                  @"auto": @(RNSStatusBarStyleAuto),
+                                                  @"inverted": @(RNSStatusBarStyleInverted),
+                                                  @"light": @(RNSStatusBarStyleLight),
+                                                  @"dark": @(RNSStatusBarStyleDark),
+                                                  }), RNSStatusBarStyleAuto, integerValue)
 
 @end

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -156,7 +156,9 @@
       UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
     } else {
       _statusBarStyle = statusBarStyle;
-      [_controller setNeedsStatusBarAppearanceUpdate];
+      [UIView animateWithDuration:0.5 animations:^{
+        [self->_controller setNeedsStatusBarAppearanceUpdate];
+      }];
     }
   }
 }
@@ -169,7 +171,9 @@
       UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
     } else {
       _statusBarAnimation = statusBarAnimation;
-      [_controller setNeedsStatusBarAppearanceUpdate];
+      [UIView animateWithDuration:0.5 animations:^{
+        [self->_controller setNeedsStatusBarAppearanceUpdate];
+      }];
     }
   }
 }
@@ -346,9 +350,7 @@
 {
   UIViewController *child = [[self childViewControllers] lastObject];
   if ([child isKindOfClass:[RNScreensNavigationController class]] || [child isKindOfClass:[RNScreensViewController class]]) {
-    if ([child childViewControllerForStatusBarStyle]) {
-      return [child childViewControllerForStatusBarStyle].preferredStatusBarStyle;
-    }
+    return child.preferredStatusBarStyle;
   }
   // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
   UIViewController *parent = [self parentViewController];
@@ -426,7 +428,9 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-
+  [UIView animateWithDuration:0.5 animations:^{
+    [self setNeedsStatusBarAppearanceUpdate];
+  }];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -26,6 +26,10 @@
     _controller = [[RNSScreen alloc] initWithView:self];
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
+#if (TARGET_OS_IOS)
+    _statusBarStyle = UIStatusBarStyleDefault;
+    _statusBarAnimation = UIStatusBarAnimationNone;
+#endif
     _gestureEnabled = YES;
     _replaceAnimation = RNSScreenReplaceAnimationPop;
     _dismissed = NO;
@@ -140,6 +144,24 @@
       // Default
       break;
   }
+}
+
+- (void)setStatusBarStyle:(UIStatusBarStyle)statusBarStyle
+{
+  if (statusBarStyle != _statusBarStyle) {
+    if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue]) {
+      RCTLogError(@"If you want to change the style of status bar, you have to change \
+      UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
+    } else {
+      _statusBarStyle = statusBarStyle;
+      [_controller setNeedsStatusBarAppearanceUpdate];
+    }
+  }
+}
+
+- (void)setStatusBarAnimation:(UIStatusBarAnimation)statusBarAnimation
+{
+  _statusBarAnimation = statusBarAnimation;
 }
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
@@ -295,6 +317,16 @@
   return self;
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  return ((RNSScreenView *)self.view).statusBarStyle;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+  return ((RNSScreenView *)self.view).statusBarAnimation;
+}
+
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
@@ -389,6 +421,8 @@ RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
+RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, UIStatusBarStyle)
+RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
@@ -428,4 +462,3 @@ RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation, (@{
 
 
 @end
-

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -143,7 +143,6 @@
   }
 }
 
-
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
   #ifdef __IPHONE_13_0
@@ -408,7 +407,7 @@
 {
   [super viewWillAppear:animated];
   [self updateStatusBarAppearance];
-  [RNSScreen enforceDesiredDeviceOrientationWithOrientationMask:self.supportedInterfaceOrientations];
+  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientationWithOrientationMask:self.supportedInterfaceOrientations];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }
 
@@ -451,91 +450,6 @@
 {
   [_previousFirstResponder becomeFirstResponder];
   _previousFirstResponder = nil;
-}
-
-+ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask
-{
-  if (UIInterfaceOrientationMaskPortrait & orientationMask) {
-    return UIInterfaceOrientationPortrait;
-  } else if (UIInterfaceOrientationMaskLandscapeLeft & orientationMask) {
-    return UIInterfaceOrientationLandscapeLeft;
-  } else if (UIInterfaceOrientationMaskLandscapeRight & orientationMask) {
-    return UIInterfaceOrientationLandscapeRight;
-  } else if (UIInterfaceOrientationMaskPortraitUpsideDown & orientationMask) {
-    return UIInterfaceOrientationPortraitUpsideDown;
-  }
-  return UIInterfaceOrientationUnknown;
-}
-
-+ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation
-{
-   switch (deviceOrientation) {
-     case UIDeviceOrientationPortrait:
-       return UIInterfaceOrientationPortrait;
-     case UIDeviceOrientationPortraitUpsideDown:
-       return UIInterfaceOrientationPortraitUpsideDown;
-     // UIDevice and UIInterface landscape orientations are switched
-     case UIDeviceOrientationLandscapeLeft:
-       return UIInterfaceOrientationLandscapeRight;
-     case UIDeviceOrientationLandscapeRight:
-       return UIInterfaceOrientationLandscapeLeft;
-     default:
-       return UIInterfaceOrientationUnknown;
-   }
-}
-  
-+ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation
-{
-  return 1 << orientation;
-}
-
-+ (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask
-{
-  dispatch_async(dispatch_get_main_queue(), ^{
-    UIInterfaceOrientation currentDeviceOrientation = [RNSScreen interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
-    UIInterfaceOrientation currentInterfaceOrientation = [RNSScreen interfaceOrientation];
-    UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
-    if ([RNSScreen maskFromOrientation:currentDeviceOrientation] & orientationMask) {
-      if (!([RNSScreen maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
-        // if the device orientation is in the mask, but interface orientation is not, we rotate to device's orientation
-        newOrientation = currentDeviceOrientation;
-      } else {
-        if (currentDeviceOrientation != currentInterfaceOrientation) {
-          // if both device orientation and interface orientation are in the mask, but in different orientations, we rotate to device's orientation
-          newOrientation = currentDeviceOrientation;
-        }
-      }
-    } else {
-      if (!([RNSScreen maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
-        // if both device orientation and interface orientation are not in the mask, we rotate to closest available rotation from mask
-        newOrientation = [RNSScreen defaultOrientationForOrientationMask:orientationMask];
-      } else {
-        // if the device orientation is not in the mask, but interface orientation is in the mask, do nothing
-      }
-    }
-    if (newOrientation != UIInterfaceOrientationUnknown) {
-      [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
-      [UIViewController attemptRotationToDeviceOrientation];
-    }
-  });
-}
-
-// based on https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
-+ (UIInterfaceOrientation)interfaceOrientation
-{
-    if (@available(iOS 13.0, *)) {
-        UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
-        if (firstWindow == nil) {
-          return UIInterfaceOrientationUnknown;
-        }
-        UIWindowScene *windowScene = firstWindow.windowScene;
-        if (windowScene == nil) {
-          return UIInterfaceOrientationUnknown;
-        }
-        return windowScene.interfaceOrientation;
-    } else {
-        return UIApplication.sharedApplication.statusBarOrientation;
-    }
 }
 
 // duration based on "Programming iOS 13" p. 311 implementation

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -376,19 +376,7 @@
   if ([child isKindOfClass:[RNScreensNavigationController class]] || [child isKindOfClass:[RNScreensViewController class]]) {
     return child.preferredStatusBarStyle;
   }
-  // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
-  UIViewController *parent = [self parentViewController];
-  while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
-    if ([parent parentViewController] == nil && [parent isKindOfClass:[RNSScreen class]]) {
-      // we are at the top of hierarchy and the controller is RNSScreen so we are in modal screen
-      break;
-    } else {
-      parent = [parent parentViewController];
-    }
-  }
-  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
-    ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
-    : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
+  RNSScreenView *screenView = [self findScreenViewForScreenProps];
   return [screenView statusBarStyleForRNSStatusBarStyle];
 }
 
@@ -398,19 +386,7 @@
   if ([child isKindOfClass:[RNScreensNavigationController class]] || [child isKindOfClass:[RNScreensViewController class]]) {
     return child.preferredStatusBarUpdateAnimation;
   }
-  // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
-  UIViewController *parent = [self parentViewController];
-  while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
-    if ([parent parentViewController] == nil && [parent isKindOfClass:[RNSScreen class]]) {
-      // we are at the top of hierarchy and the controller is RNSScreen so we are in modal screen
-      break;
-    } else {
-      parent = [parent parentViewController];
-    }
-  }
-  RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
-    ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
-    : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
+  RNSScreenView *screenView = [self findScreenViewForScreenProps];
   return screenView.statusBarAnimation;
 }
 
@@ -422,6 +398,12 @@
       return [child childViewControllerForStatusBarHidden].prefersStatusBarHidden;
     }
   }
+  RNSScreenView *screenView = [self findScreenViewForScreenProps];
+  return screenView.statusBarHidden;
+}
+
+- (RNSScreenView *)findScreenViewForScreenProps
+{
   // if there is no child navigator and the parent is `RNSScreenContainer`, we should fallback to the parent's (that is not `RNSScreenContainer`) option
   UIViewController *parent = [self parentViewController];
   while ([parent isKindOfClass:[RNScreensViewController class]] || [parent isKindOfClass:[RNSScreen class]]) {
@@ -435,7 +417,7 @@
   RNSScreenView *screenView = [parent isKindOfClass:[RNScreensNavigationController class]]
     ? ((RNSScreenView *)[[[parent childViewControllers] lastObject] view])
     : [parent isKindOfClass:[RNSScreen class]] ? ((RNSScreenView *)parent.view) : ((RNSScreenView *)self.view);
-  return screenView.statusBarHidden;
+  return screenView;
 }
 
 - (void)viewDidLayoutSubviews

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -28,7 +28,8 @@
     _stackAnimation = RNSScreenStackAnimationDefault;
 #if (TARGET_OS_IOS)
     _statusBarStyle = UIStatusBarStyleDefault;
-    _statusBarAnimation = UIStatusBarAnimationNone;
+    _statusBarAnimation = UIStatusBarAnimationFade;
+    _statusBarHidden = NO;
 #endif
     _gestureEnabled = YES;
     _replaceAnimation = RNSScreenReplaceAnimationPop;
@@ -161,7 +162,30 @@
 
 - (void)setStatusBarAnimation:(UIStatusBarAnimation)statusBarAnimation
 {
-  _statusBarAnimation = statusBarAnimation;
+  if (statusBarAnimation != _statusBarAnimation) {
+    if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue]) {
+      RCTLogError(@"If you want to change the style of status bar, you have to change \
+      UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
+    } else {
+      _statusBarAnimation = statusBarAnimation;
+      [_controller setNeedsStatusBarAppearanceUpdate];
+    }
+  }
+}
+
+- (void)setStatusBarHidden:(BOOL)statusBarHidden
+{
+  if (statusBarHidden != _statusBarHidden) {
+    if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue]) {
+      RCTLogError(@"If you want to change the style of status bar, you have to change \
+      UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
+    } else {
+      _statusBarHidden = statusBarHidden;
+      [UIView animateWithDuration:0.5 animations:^{
+        [self->_controller setNeedsStatusBarAppearanceUpdate];
+      }];
+    }
+  }
 }
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
@@ -319,12 +343,29 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
+  UIViewController *child = [[self childViewControllers] lastObject];
+  if (child != nil) {
+    return child.preferredStatusBarStyle;
+  }
   return ((RNSScreenView *)self.view).statusBarStyle;
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
+  UIViewController *child = [[self childViewControllers] lastObject];
+  if (child != nil) {
+    return child.preferredStatusBarUpdateAnimation;
+  }
   return ((RNSScreenView *)self.view).statusBarAnimation;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+  UIViewController *child = [[self childViewControllers] lastObject];
+  if (child != nil) {
+    return child.prefersStatusBarHidden;
+  }
+  return ((RNSScreenView *)self.view).statusBarHidden;
 }
 
 - (void)viewDidLayoutSubviews
@@ -423,6 +464,7 @@ RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, UIStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
+RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -6,7 +6,11 @@
 
 @end
 
-@interface RNScreensViewController: UIViewController
+@protocol RNScreensViewControllerDelegate
+
+@end
+
+@interface RNScreensViewController: UIViewController <RNScreensViewControllerDelegate>
 
 @end
 

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -7,7 +7,9 @@
 @end
 
 @interface RNScreensViewController: UIViewController
+
 @end
 
 @interface RNSScreenContainerView : UIView <RNSScreenContainerDelegate>
+
 @end

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -6,5 +6,8 @@
 
 @end
 
+@interface RNScreensViewController: UIViewController
+@end
+
 @interface RNSScreenContainerView : UIView <RNSScreenContainerDelegate>
 @end

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -21,6 +21,31 @@
 
 @end
 
+@interface RNScreensController: UIViewController
+@end
+
+@implementation RNScreensController
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.prefersStatusBarHidden : false;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+}
+
+@end
+
 @implementation RNSScreenContainerView {
   BOOL _needUpdate;
   __weak RNSScreenContainerManager *_manager;
@@ -31,7 +56,7 @@
   if (self = [super init]) {
     _activeScreens = [NSMutableSet new];
     _reactSubviews = [NSMutableArray new];
-    _controller = [[UIViewController alloc] init];
+    _controller = [[RNScreensController alloc] init];
     _needUpdate = NO;
     _manager = manager;
     [self addSubview:_controller.view];

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -165,12 +165,23 @@
           // for screens that were already active we want to mimick the effect UINavigationController
           // has when willMoveToWindow:nil is triggered before the animation starts
           [self prepareDetach:screen];
+          // disable interactions for the duration of transition	
+          screen.userInteractionEnabled = NO;
         } else {
           [self attachScreen:screen atIndex:index];
         }
         index += 1;
       }
     }
+  }
+
+  // if we are down to one active screen it means the transitioning is over and we want to notify	
+  // the transition has finished	
+  if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {	
+    RNSScreenView *singleActiveScreen = [_activeScreens anyObject];	
+    // restore interactions	
+    singleActiveScreen.userInteractionEnabled = YES;	
+    [singleActiveScreen notifyFinishTransitioning];	
   }
 
   if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil && _controller.presentingViewController == nil) {

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -165,7 +165,7 @@
           // for screens that were already active we want to mimick the effect UINavigationController
           // has when willMoveToWindow:nil is triggered before the animation starts
           [self prepareDetach:screen];
-          // disable interactions for the duration of transition	
+          // disable interactions for the duration of transition
           screen.userInteractionEnabled = NO;
         } else {
           [self attachScreen:screen atIndex:index];
@@ -177,11 +177,11 @@
 
   // if we are down to one active screen it means the transitioning is over and we want to notify	
   // the transition has finished	
-  if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {	
-    RNSScreenView *singleActiveScreen = [_activeScreens anyObject];	
-    // restore interactions	
-    singleActiveScreen.userInteractionEnabled = YES;	
-    [singleActiveScreen notifyFinishTransitioning];	
+  if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {
+    RNSScreenView *singleActiveScreen = [_activeScreens anyObject];
+    // restore interactions
+    singleActiveScreen.userInteractionEnabled = YES;
+    [singleActiveScreen notifyFinishTransitioning];
   }
 
   if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil && _controller.presentingViewController == nil) {

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -175,8 +175,8 @@
     }
   }
 
-  // if we are down to one active screen it means the transitioning is over and we want to notify	
-  // the transition has finished	
+  // if we are down to one active screen it means the transitioning is over and we want to notify
+  // the transition has finished
   if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {
     RNSScreenView *singleActiveScreen = [_activeScreens anyObject];
     // restore interactions

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -23,6 +23,19 @@
 @end
 
 @implementation RNScreensViewController
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+}
+
 @end
 
 @implementation RNSScreenContainerView {

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -1,5 +1,6 @@
 #import "RNSScreenContainer.h"
 #import "RNSScreen.h"
+#import "UIViewController+RNScreens.h"
 
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
@@ -21,29 +22,7 @@
 
 @end
 
-@interface RNScreensViewController: UIViewController
-@end
-
 @implementation RNScreensViewController
-
-- (UIStatusBarStyle)preferredStatusBarStyle
-{
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
-}
-
-- (BOOL)prefersStatusBarHidden
-{
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.prefersStatusBarHidden : false;
-}
-
-- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
-{
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
-}
-
 @end
 
 @implementation RNSScreenContainerView {
@@ -173,23 +152,12 @@
           // for screens that were already active we want to mimick the effect UINavigationController
           // has when willMoveToWindow:nil is triggered before the animation starts
           [self prepareDetach:screen];
-          // disable interactions for the duration of transition
-          screen.userInteractionEnabled = NO;
         } else {
           [self attachScreen:screen atIndex:index];
         }
         index += 1;
       }
     }
-  }
-
-  // if we are down to one active screen it means the transitioning is over and we want to notify
-  // the transition has finished
-  if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {
-    RNSScreenView *singleActiveScreen = [_activeScreens anyObject];
-    // restore interactions
-    singleActiveScreen.userInteractionEnabled = YES;
-    [singleActiveScreen notifyFinishTransitioning];
   }
 
   if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil && _controller.presentingViewController == nil) {

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -1,6 +1,5 @@
 #import "RNSScreenContainer.h"
 #import "RNSScreen.h"
-#import "UIViewController+RNScreens.h"
 
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
@@ -24,16 +23,35 @@
 
 @implementation RNScreensViewController
 
-- (UIStatusBarStyle)preferredStatusBarStyle
+- (UIViewController *)childViewControllerForStatusBarStyle
 {
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+  return [self findActiveChildVC];
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+  return [self findActiveChildVC].preferredStatusBarUpdateAnimation;
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden
+{
+  return [self findActiveChildVC];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return [self findActiveChildVC].supportedInterfaceOrientations;
+}
+
+- (UIViewController *)findActiveChildVC
+{
+  for (UIViewController *childVC in self.childViewControllers) {
+    // condition should be changed when activityState is introduced to check for activityState == 2
+    if ([childVC isKindOfClass:[RNSScreen class]] && ((RNSScreenView *)((RNSScreen *)childVC.view)).active) {
+      return childVC;
+    }
+  }
+  return [[self childViewControllers] lastObject];
 }
 
 @end

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -21,10 +21,10 @@
 
 @end
 
-@interface RNScreensController: UIViewController
+@interface RNScreensViewController: UIViewController
 @end
 
-@implementation RNScreensController
+@implementation RNScreensViewController
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
@@ -56,7 +56,7 @@
   if (self = [super init]) {
     _activeScreens = [NSMutableSet new];
     _reactSubviews = [NSMutableArray new];
-    _controller = [[RNScreensController alloc] init];
+    _controller = [[RNScreensViewController alloc] init];
     _needUpdate = NO;
     _manager = manager;
     [self addSubview:_controller.view];

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -1,6 +1,11 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
+
 #import "RNSScreenContainer.h"
+
+@interface RNScreensNavigationController: UINavigationController <RNScreensViewControllerDelegate>
+
+@end
 
 @interface RNSScreenStackView : UIView <RNSScreenContainerDelegate, RCTInvalidating>
 
@@ -8,10 +13,6 @@
 
 - (void)markChildUpdated;
 - (void)didUpdateChildren;
-
-@end
-
-@interface RNScreensNavigationController: UINavigationController
 
 @end
 

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -11,6 +11,10 @@
 
 @end
 
+@interface RNScreensNavigationController: UINavigationController
+
+@end
+
 @interface RNSScreenStackManager : RCTViewManager <RCTInvalidating>
 
 @end

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -1,6 +1,7 @@
 #import "RNSScreenStack.h"
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
+#import "UIViewController+RNScreens.h"
 
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
@@ -19,20 +20,22 @@
 
 @implementation RNScreensNavigationController
 
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return [childVC isKindOfClass:[RNSScreen class]] ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+}
+
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
   return [[self childViewControllers] lastObject].preferredStatusBarUpdateAnimation;
 }
 
+
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
-  // this method is not called in extension, probably due to being subclass of UINavigationController which uses his own implementation
-  return [[self childViewControllers] lastObject];
-}
-
-- (UIViewController *)childViewControllerForStatusBarHidden
-{
-  return [[self childViewControllers] lastObject];
+  // this method is not called in category, probably due to being subclass of UINavigationController and not UIViewController and having own implementation
+  return nil;
 }
 
 @end

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -1,7 +1,6 @@
 #import "RNSScreenStack.h"
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
-#import "UIViewController+RNScreens.h"
 
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
@@ -20,26 +19,24 @@
 
 @implementation RNScreensNavigationController
 
-- (UIStatusBarStyle)preferredStatusBarStyle
+- (UIViewController *)childViewControllerForStatusBarStyle
 {
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return [childVC isKindOfClass:[RNSScreen class]] ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+  return [self topViewController];
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
-  return [[self childViewControllers] lastObject].preferredStatusBarUpdateAnimation;
+  return [self topViewController].preferredStatusBarUpdateAnimation;
 }
 
-- (UIViewController *)childViewControllerForStatusBarStyle
+- (UIViewController *)childViewControllerForStatusBarHidden
 {
-  // this method is not called in category, probably due to being subclass of UINavigationController and not UIViewController and having own implementation
-  return nil;
+  return [self topViewController];
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  return [[self childViewControllers] lastObject].supportedInterfaceOrientations;
+  return [self topViewController].supportedInterfaceOrientations;
 }
 
 @end
@@ -107,10 +104,8 @@
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
     // that can handle it when dismissing a modal, the same for orientation
-    [UIView animateWithDuration:0.4 animations:^{
-      [presentationController.presentingViewController setNeedsStatusBarAppearanceUpdate];
-    }];
-    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientationWithOrientationMask:presentationController.presentingViewController.supportedInterfaceOrientations];
+    [RNSScreenStackHeaderConfig updateStatusBarAppearance];
+    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -28,6 +28,19 @@
   return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.prefersStatusBarHidden : false;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+}
+
+
 @end
 
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -198,9 +198,7 @@
 
 - (void)maybeAddToParentAndUpdateContainer
 {
-  BOOL wasScreenMounted = _controller.parentViewController != nil;
-  BOOL isScreenReadyForShowing = self.window && _hasLayout;
-  if (!isScreenReadyForShowing && !wasScreenMounted) {
+  if (!self.window || !_hasLayout) {
     // We wait with adding to parent controller until the stack is mounted and has its initial
     // layout done.
     // If we add it before layout, some of the items (specifically items from the navigation bar),
@@ -212,7 +210,7 @@
     return;
   }
   [self updateContainer];
-  if (!wasScreenMounted) {
+  if (_controller.parentViewController == nil) {
     // when stack hasn't been added to parent VC yet we do two things:
     // 1) we run updateContainer (the one above) – we do this because we want push view controllers to
     // be installed before the VC is mounted. If we do that after it is added to parent the push
@@ -235,7 +233,9 @@
       if (parentView.reactViewController) {
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
+#if (TARGET_OS_IOS)
         _controller.interactivePopGestureRecognizer.delegate = self;
+#endif
         [controller didMoveToParentViewController:parentView.reactViewController];
         // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
         // get triggered when the navigation controller is instantiated. As the only thing we do in

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -17,6 +17,19 @@
 
 @end
 
+@interface RNScreensNavigationController: UINavigationController
+@end
+
+@implementation RNScreensNavigationController
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarStyle : UIStatusBarStyleDefault;
+}
+
+@end
+
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
 - (instancetype)initWithOperation:(UINavigationControllerOperation)operation;
 @end
@@ -35,7 +48,7 @@
     _manager = manager;
     _reactSubviews = [NSMutableArray new];
     _presentedModals = [NSMutableArray new];
-    _controller = [[UINavigationController alloc] init];
+    _controller = [[RNScreensNavigationController alloc] init];
     _controller.delegate = self;
 
     // we have to initialize viewControllers with a non empty array for
@@ -209,9 +222,7 @@
       if (parentView.reactViewController) {
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
-#if (TARGET_OS_IOS)
         _controller.interactivePopGestureRecognizer.delegate = self;
-#endif
         [controller didMoveToParentViewController:parentView.reactViewController];
         // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
         // get triggered when the navigation controller is instantiated. As the only thing we do in

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -38,6 +38,11 @@
   return nil;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return [[self childViewControllers] lastObject].supportedInterfaceOrientations;
+}
+
 @end
 
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -237,7 +237,9 @@
       if (parentView.reactViewController) {
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
+#if (TARGET_OS_IOS)
         _controller.interactivePopGestureRecognizer.delegate = self;
+#endif
         [controller didMoveToParentViewController:parentView.reactViewController];
         // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
         // get triggered when the navigation controller is instantiated. As the only thing we do in

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -108,10 +108,10 @@
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
     // that can handle it when dismissing a modal, the same for orientation
-    [UIView animateWithDuration:0.5 animations:^{
+    [UIView animateWithDuration:0.4 animations:^{
       [presentationController.presentingViewController setNeedsStatusBarAppearanceUpdate];
     }];
-    [RNSScreen enforceDesiredDeviceOrientationWithOrientationMask:presentationController.presentingViewController.supportedInterfaceOrientations];
+    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientationWithOrientationMask:presentationController.presentingViewController.supportedInterfaceOrientations];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -101,6 +101,11 @@
   // forward certain calls to the container (Stack).
   UIView *screenView = presentationController.presentedViewController.view;
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
+    // we trigger the update of status bar's appearance here because there is no other lifecycle method
+    // that can handle it when dismissing a modal
+    [UIView animateWithDuration:0.5 animations:^{
+      [presentationController.presentingViewController setNeedsStatusBarAppearanceUpdate];
+    }];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -31,7 +31,6 @@
   return [[self childViewControllers] lastObject].preferredStatusBarUpdateAnimation;
 }
 
-
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   // this method is not called in category, probably due to being subclass of UINavigationController and not UIViewController and having own implementation

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -107,10 +107,11 @@
   UIView *screenView = presentationController.presentedViewController.view;
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
-    // that can handle it when dismissing a modal
+    // that can handle it when dismissing a modal, the same for orientation
     [UIView animateWithDuration:0.5 animations:^{
       [presentationController.presentingViewController setNeedsStatusBarAppearanceUpdate];
     }];
+    [RNSScreen enforceDesiredDeviceOrientationWithOrientationMask:presentationController.presentingViewController.supportedInterfaceOrientations];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -42,6 +42,10 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
++ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
++ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
++ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
++ (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -3,6 +3,13 @@
 
 #import "RNSScreen.h"
 
+typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
+  RNSStatusBarStyleAuto,
+  RNSStatusBarStyleInverted,
+  RNSStatusBarStyleLight,
+  RNSStatusBarStyleDark,
+};
+
 @interface RNSScreenStackHeaderConfig : UIView
 
 @property (nonatomic, weak) RNSScreenView *screenView;
@@ -29,6 +36,10 @@
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) UISemanticContentAttribute direction;
+@property (nonatomic) RNSStatusBarStyle statusBarStyle;
+@property (nonatomic) UIStatusBarAnimation statusBarAnimation;
+@property (nonatomic) BOOL statusBarHidden;
+@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 
@@ -50,7 +61,9 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
-+ (UISemanticContentAttribute)RNSScreenDirection:(id)json;
++ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
++ (UISemanticContentAttribute)UISemanticContentAttribute:(id)json;
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -35,6 +35,8 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
+@property (nonatomic) BOOL hasSearch;
+@property (nonatomic, retain) NSString *searchPlaceholder;
 @property (nonatomic) UISemanticContentAttribute direction;
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
@@ -42,10 +44,12 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
++ (void)updateStatusBarAppearance;
++ (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
 + (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
 + (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
-+ (void)enforceDesiredDeviceOrientationWithOrientationMask:(UIInterfaceOrientationMask)orientationMask;
++ (void)enforceDesiredDeviceOrientation;
 
 @end
 
@@ -65,8 +69,8 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
-+ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
 + (UISemanticContentAttribute)UISemanticContentAttribute:(id)json;
++ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
 
 @end

--- a/ios/UIViewController+RNScreens.h
+++ b/ios/UIViewController+RNScreens.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIViewController (RNScreens)
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/UIViewController+RNScreens.h
+++ b/ios/UIViewController+RNScreens.h
@@ -3,6 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface UIViewController (RNScreens)
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -34,6 +34,15 @@
   return [self RNSPreferredStatusBarUpdateAnimation];
 }
 
+- (UIInterfaceOrientationMask)RNSSupportedInterfaceOrientations
+{
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
+    return lastViewController.supportedInterfaceOrientations;
+  }
+  return [self RNSSupportedInterfaceOrientations];
+}
+
 + (void)load
 {
   Class uiVCClass = [UIViewController class];
@@ -46,6 +55,8 @@
   
   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
                                  class_getInstanceMethod(uiVCClass, @selector(RNSPreferredStatusBarUpdateAnimation)));
+  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
+                                 class_getInstanceMethod(uiVCClass, @selector(RNSSupportedInterfaceOrientations)));
 }
 
 @end

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -1,7 +1,5 @@
 #import "UIViewController+RNScreens.h"
 #import "RNSScreenContainer.h"
-#import "RNSScreenStack.h"
-#import "RNSScreen.h"
 
 #import <objc/runtime.h>
 
@@ -9,54 +7,55 @@
 
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarStyle
 {
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return lastViewController;
-  }
-  return [self reactNativeScreensChildViewControllerForStatusBarStyle];
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ?: [self reactNativeScreensChildViewControllerForStatusBarStyle];
 }
 
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarHidden
 {
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return lastViewController;
-  }
-  return [self reactNativeScreensChildViewControllerForStatusBarHidden];
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ?: [self reactNativeScreensChildViewControllerForStatusBarHidden];
 }
 
 - (UIStatusBarAnimation)reactNativeScreensPreferredStatusBarUpdateAnimation
 {
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return lastViewController.preferredStatusBarUpdateAnimation;
-  }
-  return [self reactNativeScreensPreferredStatusBarUpdateAnimation];
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ? childVC.preferredStatusBarUpdateAnimation : [self reactNativeScreensPreferredStatusBarUpdateAnimation];
 }
 
 - (UIInterfaceOrientationMask)reactNativeScreensSupportedInterfaceOrientations
 {
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return lastViewController.supportedInterfaceOrientations;
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ? childVC.supportedInterfaceOrientations : [self reactNativeScreensSupportedInterfaceOrientations];
+}
+
+- (UIViewController *)findChildRNScreensViewController
+{
+  UIViewController *lastViewController = [[self childViewControllers] lastObject];
+  if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+    return lastViewController;
   }
-  return [self reactNativeScreensSupportedInterfaceOrientations];
+  return nil;
 }
 
 + (void)load
 {
-  Class uiVCClass = [UIViewController class];
+  static dispatch_once_t once_token;
+  dispatch_once(&once_token,  ^{
+   Class uiVCClass = [UIViewController class];
+   
+   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
+                                  class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));
 
-  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
-                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));
+   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
+                                  class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarHidden)));
+   
+   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
+                                  class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
 
-  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
-                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarHidden)));
-  
-  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
-                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
-  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
-                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
+   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
+                                  class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
+  });
 }
 
 @end

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -1,0 +1,54 @@
+#import "UIViewController+RNScreens.h"
+#import "RNSScreenContainer.h"
+#import "RNSScreenStack.h"
+#import "RNSScreen.h"
+
+#import <objc/runtime.h>
+
+@implementation UIViewController (RNScreens)
+
+- (UIViewController *)RNSChildViewControllerForStatusBarStyle
+{
+  if ([self isKindOfClass:[RNSScreen class]]) {
+    return nil;
+  }
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
+    return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
+  }
+  return [self RNSChildViewControllerForStatusBarStyle];
+}
+
+- (UIViewController *)RNSChildViewControllerForStatusBarHidden
+{
+  if ([self isKindOfClass:[RNSScreen class]]) {
+    return nil;
+  }
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
+    return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
+  }
+  return [self RNSChildViewControllerForStatusBarHidden];
+}
+
+- (UIStatusBarAnimation)RNSPreferredStatusBarUpdateAnimation
+{
+  UIViewController *childVC =  [[self childViewControllers] lastObject];
+  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+}
+
++ (void)load
+{
+  Class uiVCClass = [UIViewController class];
+
+  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
+                                 class_getInstanceMethod(uiVCClass, @selector(RNSChildViewControllerForStatusBarStyle)));
+
+  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
+                                 class_getInstanceMethod(uiVCClass, @selector(RNSChildViewControllerForStatusBarHidden)));
+  
+  method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
+                                 class_getInstanceMethod(uiVCClass, @selector(RNSPreferredStatusBarUpdateAnimation)));
+}
+
+@end

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -9,32 +9,29 @@
 
 - (UIViewController *)RNSChildViewControllerForStatusBarStyle
 {
-  if ([self isKindOfClass:[RNSScreen class]]) {
-    return nil;
-  }
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
+    return lastViewController;
   }
   return [self RNSChildViewControllerForStatusBarStyle];
 }
 
 - (UIViewController *)RNSChildViewControllerForStatusBarHidden
 {
-  if ([self isKindOfClass:[RNSScreen class]]) {
-    return nil;
-  }
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
-    return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
+    return lastViewController;
   }
   return [self RNSChildViewControllerForStatusBarHidden];
 }
 
 - (UIStatusBarAnimation)RNSPreferredStatusBarUpdateAnimation
 {
-  UIViewController *childVC =  [[self childViewControllers] lastObject];
-  return childVC ? childVC.preferredStatusBarUpdateAnimation : UIStatusBarAnimationFade;
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
+    return lastViewController.preferredStatusBarUpdateAnimation;
+  }
+  return [self RNSPreferredStatusBarUpdateAnimation];
 }
 
 + (void)load

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -7,40 +7,40 @@
 
 @implementation UIViewController (RNScreens)
 
-- (UIViewController *)RNSChildViewControllerForStatusBarStyle
+- (UIViewController *)reactNativeScreensChildViewControllerForStatusBarStyle
 {
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
     return lastViewController;
   }
-  return [self RNSChildViewControllerForStatusBarStyle];
+  return [self reactNativeScreensChildViewControllerForStatusBarStyle];
 }
 
-- (UIViewController *)RNSChildViewControllerForStatusBarHidden
+- (UIViewController *)reactNativeScreensChildViewControllerForStatusBarHidden
 {
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
     return lastViewController;
   }
-  return [self RNSChildViewControllerForStatusBarHidden];
+  return [self reactNativeScreensChildViewControllerForStatusBarHidden];
 }
 
-- (UIStatusBarAnimation)RNSPreferredStatusBarUpdateAnimation
+- (UIStatusBarAnimation)reactNativeScreensPreferredStatusBarUpdateAnimation
 {
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
     return lastViewController.preferredStatusBarUpdateAnimation;
   }
-  return [self RNSPreferredStatusBarUpdateAnimation];
+  return [self reactNativeScreensPreferredStatusBarUpdateAnimation];
 }
 
-- (UIInterfaceOrientationMask)RNSSupportedInterfaceOrientations
+- (UIInterfaceOrientationMask)reactNativeScreensSupportedInterfaceOrientations
 {
   UIViewController* lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController isKindOfClass:[RNScreensNavigationController class]] || [lastViewController isKindOfClass:[RNScreensViewController class]] || [lastViewController isKindOfClass:[RNSScreen class]]) {
     return lastViewController.supportedInterfaceOrientations;
   }
-  return [self RNSSupportedInterfaceOrientations];
+  return [self reactNativeScreensSupportedInterfaceOrientations];
 }
 
 + (void)load
@@ -48,15 +48,15 @@
   Class uiVCClass = [UIViewController class];
 
   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
-                                 class_getInstanceMethod(uiVCClass, @selector(RNSChildViewControllerForStatusBarStyle)));
+                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));
 
   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
-                                 class_getInstanceMethod(uiVCClass, @selector(RNSChildViewControllerForStatusBarHidden)));
+                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarHidden)));
   
   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
-                                 class_getInstanceMethod(uiVCClass, @selector(RNSPreferredStatusBarUpdateAnimation)));
+                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
-                                 class_getInstanceMethod(uiVCClass, @selector(RNSSupportedInterfaceOrientations)));
+                                 class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
 }
 
 @end

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -179,6 +179,59 @@ How the given screen should appear/disappear when pushed or popped at the top of
 
 Defaults to `default`.
 
+### Status bar managment
+
+With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use RN's <StatusBar /> component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
+
+1. Add the interface and implementation of `RNScreensRootViewController`:
+
+```objc
+@interface RNScreensRootViewController: UIViewController
+@end
+
+@implementation RNScreensRootViewController
+
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden
+{
+  UIViewController* lastViewController = [[self childViewControllers] lastObject];
+  return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
+}
+
+@end
+```
+
+2. Add the `RNScreensRootViewController` as your `rootViewController`:
+
+```objc
+  UIViewController *rootViewController = [RNScreensRootViewController new];
+```
+
+You can see those changes applied in the `AppDelegate.m` of `Example` project.
+
+#### `statusBarStyle`
+
+Sets the status bar color (similar to the <StatusBar /> component). Possible values: `default`, `light-content`, `dark-content`.
+
+Defaults to `default`.
+
+#### `statusBarAnimation`
+
+Sets the status bar animation (similar to the <StatusBar /> component). Possible values: `fade`, `none`, `slide`.
+
+Defaults to `fade`.
+
+#### `statusBarHidden`
+
+Boolean saying if the status bar for this screen is hidden.
+
+Defaults to `false`.
+
 ### Events
 
 The navigator can [emit events](https://reactnavigation.org/docs/navigation-events) on certain actions. Supported events are:

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -181,10 +181,10 @@ Defaults to `default`.
 
 ### Status bar and orientation managment
 
-With `native-stack`, the status bar and current screen orientation mask can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. It requires:
 
 1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
-2. For both status abr and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
+2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -204,9 +204,9 @@ Boolean saying if the status bar for this screen is hidden.
 
 Defaults to `false`.
 
-#### `stackOrientationMask`
+#### `screenOrientation`
 
-Sets the current screen's orientation mask and forces rotation if current orientation is not included in the mask. Possible values:
+Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
 
 - `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
 - `all`

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -188,9 +188,9 @@ With `native-stack`, the status bar can be managed by `UIViewController` on iOS.
 
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Possible values: `default`, `light-content`, `dark-content`.
+Sets the status bar color (similar to the `StatusBar` component). Possible values: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`.
 
-Defaults to `default`.
+Defaults to `auto`.
 
 #### `statusBarAnimation`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -181,38 +181,7 @@ Defaults to `default`.
 
 ### Status bar managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use React Native's `StatusBar` component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
-
-1. Add the interface and implementation of `RNScreensRootViewController`:
-
-```objc
-@interface RNScreensRootViewController: UIViewController
-@end
-
-@implementation RNScreensRootViewController
-
-- (UIViewController *)childViewControllerForStatusBarStyle
-{
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  return [lastViewController childViewControllerForStatusBarStyle] ?: lastViewController;
-}
-
-- (UIViewController *)childViewControllerForStatusBarHidden
-{
-  UIViewController* lastViewController = [[self childViewControllers] lastObject];
-  return [lastViewController childViewControllerForStatusBarHidden] ?: lastViewController;
-}
-
-@end
-```
-
-2. Add the `RNScreensRootViewController` as your `rootViewController`:
-
-```objc
-  UIViewController *rootViewController = [RNScreensRootViewController new];
-```
-
-You can see those changes applied in the `AppDelegate.m` of `Example` project.
+With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use React Native's `StatusBar` component. For each of those 3 props to work, you also need to **add `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m`** (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -181,7 +181,7 @@ Defaults to `default`.
 
 ### Status bar managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use react-native `StatusBar` component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
+With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use React Native's `StatusBar` component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
 
 1. Add the interface and implementation of `RNScreensRootViewController`:
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -181,7 +181,7 @@ Defaults to `default`.
 
 ### Status bar managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use RN's <StatusBar /> component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
+With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use react-native `StatusBar` component. For each of those 3 props to work, you also need to apply those changes to the `rootViewController` in your project's `AppDelegate.m`:
 
 1. Add the interface and implementation of `RNScreensRootViewController`:
 
@@ -216,13 +216,13 @@ You can see those changes applied in the `AppDelegate.m` of `Example` project.
 
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the <StatusBar /> component). Possible values: `default`, `light-content`, `dark-content`.
+Sets the status bar color (similar to the `StatusBar` component). Possible values: `default`, `light-content`, `dark-content`.
 
 Defaults to `default`.
 
 #### `statusBarAnimation`
 
-Sets the status bar animation (similar to the <StatusBar /> component). Possible values: `fade`, `none`, `slide`.
+Sets the status bar animation (similar to the `StatusBar` component). Possible values: `fade`, `none`, `slide`.
 
 Defaults to `fade`.
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -181,7 +181,10 @@ Defaults to `default`.
 
 ### Status bar managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file and so disables the option to use React Native's `StatusBar` component. For each of those 3 props to work, you also need to **add `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m`** (you can see this change applied in the `AppDelegate.m` of `Example` project).
+With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires:
+
+1. Enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (and so disables the option to use React Native's `StatusBar` component). 
+2. Adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -179,12 +179,12 @@ How the given screen should appear/disappear when pushed or popped at the top of
 
 Defaults to `default`.
 
-### Status bar managment
+### Status bar and orientation managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and current screen orientation mask can be managed by `UIViewController` on iOS. It requires:
 
-1. Enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (and so disables the option to use React Native's `StatusBar` component). 
-2. Adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
+1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
+2. For both status abr and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 
@@ -203,6 +203,21 @@ Defaults to `fade`.
 Boolean saying if the status bar for this screen is hidden.
 
 Defaults to `false`.
+
+#### `stackOrientationMask`
+
+Sets the current screen's orientation mask and forces rotation if current orientation is not included in the mask. Possible values:
+
+- `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
+- `all`
+- `portrait`
+- `portrait_up`
+- `portrait_down`
+- `landscape`
+- `landscape_left`
+- `landscape_right`
+
+Defaults to `default`.
 
 ### Events
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,6 +101,16 @@ declare module 'react-native-screens' {
      */
     replaceAnimation?: ScreenReplaceTypes;
     /**
+     * @host (iOS only)
+     * @description Sets the status bar color (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `default`.
+     */
+    statusBarStyle?: 'default' | 'light-content' | 'dark-content';
+    /**
+     * @host (iOS only)
+     * @description Sets the status bar animation (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
+     */
+    statusBarAnimation?: 'none' | 'fade' | 'slide';
+    /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */
     gestureEnabled?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,25 +46,31 @@ declare module 'react-native-screens' {
     | 'systemThickMaterialDark'
     | 'systemChromeMaterialDark';
   export type ScreenReplaceTypes = 'push' | 'pop';
-  export type ScreenOrientationTypes =
-    | 'default'
-    | 'all'
-    | 'portrait'
-    | 'portrait_up'
-    | 'portrait_down'
-    | 'landscape'
-    | 'landscape_left'
-    | 'landscape_right';
 
   export interface ScreenProps extends ViewProps {
     active?: 0 | 1 | Animated.AnimatedInterpolation;
-    onComponentRef?: (view: any) => void;
     children?: React.ReactNode;
-
     /**
      * @description All children screens should have the same value of their "enabled" prop as their container.
      */
     enabled?: boolean;
+    /**
+     * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
+     */
+    gestureEnabled?: boolean;
+    /**
+     * @description A callback that gets called when the current screen appears.
+     */
+    onAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    onComponentRef?: (view: any) => void;
+    /**
+     * @description A callback that gets called when the current screen disappears.
+     */
+    onDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    /**
+     * @description A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down). The callback takes no arguments.
+     */
+    onDismissed?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
      * @description A callback that gets called when the current screen will appear. This is called as soon as the transition begins.
      */
@@ -74,17 +80,19 @@ declare module 'react-native-screens' {
      */
     onWillDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
     /**
-     * @description A callback that gets called when the current screen appears.
+     * @description Allows for the customization of the type of animation to use when this screen replaces another screen at the top of the stack. The following values are currently supported:
+     *  @type "push" – performs push animation
+     *  @type "pop" – performs pop animation (default)
      */
-    onAppear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    replaceAnimation?: ScreenReplaceTypes;
     /**
-     * @description A callback that gets called when the current screen disappears.
+     * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The following values are currently supported:
+     *  @type "default" – uses a platform default animation
+     *  @type "fade" – fades screen in or out
+     *  @type "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
+     *  @type "none" – the screen appears/dissapears without an animation
      */
-    onDisappear?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
-    /**
-     * @description A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down). The callback takes no arguments.
-     */
-    onDismissed?: (e: NativeSyntheticEvent<NativeTouchEvent>) => void;
+    stackAnimation?: StackAnimationTypes;
     /**
      * @type "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
      * @type "modal" – the new screen will be presented modally. In addition this allow for a nested stack to be rendered inside such screens.
@@ -95,24 +103,6 @@ declare module 'react-native-screens' {
      * @type "formSheet" – will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
      */
     stackPresentation?: StackPresentationTypes;
-    /**
-     * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The following values are currently supported:
-     *  @type "default" – uses a platform default animation
-     *  @type "fade" – fades screen in or out
-     *  @type "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
-     *  @type "none" – the screen appears/dissapears without an animation
-     */
-    stackAnimation?: StackAnimationTypes;
-    /**
-     * @description Allows for the customization of the type of animation to use when this screen replaces another screen at the top of the stack. The following values are currently supported:
-     *  @type "push" – performs push animation
-     *  @type "pop" – performs pop animation (default)
-     */
-    replaceAnimation?: ScreenReplaceTypes;
-    /**
-     * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
-     */
-    gestureEnabled?: boolean;
   }
 
   export interface ScreenContainerProps extends ViewProps {
@@ -123,8 +113,6 @@ declare module 'react-native-screens' {
   }
 
   export interface ScreenStackProps extends ViewProps {
-    transitioning?: number;
-    progress?: number;
     /**
      * @description A callback that gets called when the current screen finishes its transition.
      */
@@ -133,55 +121,13 @@ declare module 'react-native-screens' {
 
   export interface ScreenStackHeaderConfigProps extends ViewProps {
     /**
-     * @description String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
-     */
-    title?: string;
-    /**
-     * @description When set to true the header will be hidden while the parent Screen is on the top of the stack. The default value is false.
-     */
-    hidden?: boolean;
-    /**
-     * @description Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use titleColor property.
-     */
-    color?: string;
-    /**
-     * @description Customize font family to be used for the title.
-     */
-    titleFontFamily?: string;
-    /**
-     * @description Customize the size of the font to be used for the title.
-     */
-    titleFontSize?: number;
-    /**
-     * @description Allows for setting text color of the title.
-     */
-    titleColor?: string;
-    /**
-     * @description Controls the color of the navigation header.
-     */
-    backgroundColor?: string;
-    /**
-     * @description Boolean that allows for disabling drop shadow under navigation header. The default value is true.
-     */
-    hideShadow?: boolean;
-    /**
-     * @description If set to true the back button will not be rendered as a part of navigation header.
-     */
-    hideBackButton?: boolean;
-    /**
      * @description Whether to show the back button with a custom left side of the header.
      */
     backButtonInCustomView?: boolean;
     /**
-     * @host (iOS only)
-     * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
+     * @description Controls the color of the navigation header.
      */
-    translucent?: boolean;
-    /**
-     * @description A flag to that lets you opt out of insetting the header. You may want to set this to `false` if you use an opaque status bar. Defaults to `true`.
-     * @host (Android only)
-     */
-    topInsetEnabled?: boolean;
+    backgroundColor?: string;
     /**
      * @host (iOS only)
      * @description Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.
@@ -199,13 +145,47 @@ declare module 'react-native-screens' {
     backTitleFontSize?: number;
     /**
      * @host (iOS only)
-     * @description When set to true it makes the title display using the large title effect.
+     * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
      */
-    largeTitle?: boolean;
+    blurEffect?: BlurEffectTypes;
+    /**
+     * Pass HeaderLeft, HeaderRight and HeaderTitle
+     */
+    children?: React.ReactNode;
     /**
      *@description Controls whether the stack should be in rtl or ltr form.
      */
     direction?: 'rtl' | 'ltr';
+    /**
+     * @description When set to true the header will be hidden while the parent Screen is on the top of the stack. The default value is false.
+     */
+    hidden?: boolean;
+    /**
+     * @description Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use titleColor property.
+     */
+    color?: string;
+    /**
+     * @description If set to true the back button will not be rendered as a part of navigation header.
+     */
+    hideBackButton?: boolean;
+    /**
+     * @description Boolean that allows for disabling drop shadow under navigation header. The default value is true.
+     */
+    hideShadow?: boolean;
+    /**
+     * @host (iOS only)
+     * @description When set to true it makes the title display using the large title effect.
+     */
+    largeTitle?: boolean;
+    /**
+     *@description Controls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+     */
+    largeTitleBackgroundColor?: string;
+    /**
+     * @host (iOS only)
+     * @description Customize the color to be used for the large title. By default uses the titleColor property.
+     */
+    largeTitleColor?: string;
     /**
      * @host (iOS only)
      * @description Customize font family to be used for the large title.
@@ -217,32 +197,21 @@ declare module 'react-native-screens' {
      */
     largeTitleFontSize?: number;
     /**
-     *@description Controls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
-     */
-    largeTitleBackgroundColor?: string;
-    /**
      * @description Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
      */
     largeTitleHideShadow?: boolean;
     /**
-     * @host (iOS only)
-     * @description Customize the color to be used for the large title. By default uses the titleColor property.
+     * @description Controls in which orientation should the screen appear.
+     * @type "default" - resolves to "all" without "portrait_down"
+     * @type "all" – all orientations are permitted
+     * @type "portrait" – portrait orientations are permitted
+     * @type "portrait_up" – right-side portrait orientation is permitted
+     * @type "portrait_down" – upside-down portrait orientation is permitted
+     * @type "landscape" – landscape orientations are permitted
+     * @type "landscape_left" – landscape-left orientation is permitted
+     * @type "landscape_right" – landscape-right orientation is permitted
      */
-    largeTitleColor?: string;
-    /**
-     * Pass HeaderLeft, HeaderRight and HeaderTitle
-     */
-    children?: React.ReactNode;
-    /**
-     * @host (iOS only)
-     * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
-     */
-    blurEffect?: BlurEffectTypes;
-    /**
-     * @host (iOS only)
-     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
-     */
-    statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
+    screenOrientation?: ScreenOrientationTypes;
     /**
      * @host (iOS only)
      * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
@@ -254,17 +223,35 @@ declare module 'react-native-screens' {
      */
     statusBarHidden?: boolean;
     /**
-     * @description Controls in which orientation should the screen appear.
-     * @type "default" - resolves to "all" without "portrait_down" on iOS.
-     * @type "all" – all orientations are permitted
-     * @type "portrait" – portrait orientations are permitted
-     * @type "portrait_up" – right-side portrait orientation is permitted
-     * @type "portrait_down" – upside-down portrait orientation is permitted
-     * @type "landscape" – landscape orientations are permitted
-     * @type "landscape_left" – landscape-left orientation is permitted
-     * @type "landscape_right" – landscape-right orientation is permitted
+     * @host (iOS only)
+     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
      */
-    screenOrientation?: ScreenOrientationTypes;
+    statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
+    /**
+     * @description String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
+     */
+    title?: string;
+    /**
+     * @description Allows for setting text color of the title.
+     */
+    titleColor?: string;
+    /**
+     * @description Customize font family to be used for the title.
+     */
+    titleFontFamily?: string;
+    /**
+     * @description Customize the size of the font to be used for the title.
+     */
+    titleFontSize?: number;
+    /**
+     * @host (Android only)
+     * @description A flag to that lets you opt out of insetting the header. You may want to set this to `false` if you use an opaque status bar. Defaults to `true`.
+     */
+    topInsetEnabled?: boolean;
+    /**
+     * @description When set to true, it makes native navigation bar on iOS semi transparent with blur effect. It is a common way of presenting navigation bar introduced in iOS 11. The default value is false
+     */
+    translucent?: boolean;
   }
 
   export const Screen: ComponentClass<ScreenProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -111,7 +111,7 @@ declare module 'react-native-screens' {
      */
     statusBarAnimation?: 'none' | 'fade' | 'slide';
     /**
-     * @description When set to true, the status bar for this screen is hidden.
+     * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
      */
     statusBarHidden?: boolean;
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,7 +46,7 @@ declare module 'react-native-screens' {
     | 'systemThickMaterialDark'
     | 'systemChromeMaterialDark';
   export type ScreenReplaceTypes = 'push' | 'pop';
-  export type StackOrientationMaskTypes =
+  export type ScreenOrientationTypes =
     | 'default'
     | 'all'
     | 'portrait'
@@ -134,7 +134,7 @@ declare module 'react-native-screens' {
      * @type "landscape_left" – landscape-left orientation is permitted
      * @type "landscape_right" – landscape-right orientation is permitted
      */
-    stackOrientationMask?: StackOrientationMaskTypes;
+    screenOrientation?: ScreenOrientationTypes;
     /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -124,7 +124,7 @@ declare module 'react-native-screens' {
      */
     statusBarHidden?: boolean;
     /**
-     * @description Controls in which orientation should the screen appear.
+     * @description Controls in which orientation should the screen appear. Defaults to `default`.
      * @type "default" - resolves to "all" without "portrait_down"
      * @type "all" – all orientations are permitted
      * @type "portrait" – portrait orientations are permitted

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,6 +46,15 @@ declare module 'react-native-screens' {
     | 'systemThickMaterialDark'
     | 'systemChromeMaterialDark';
   export type ScreenReplaceTypes = 'push' | 'pop';
+  export type StackOrientationMaskTypes =
+    | 'default'
+    | 'all'
+    | 'portrait'
+    | 'portrait_up'
+    | 'portrait_down'
+    | 'landscape'
+    | 'landscape_left'
+    | 'landscape_right';
 
   export interface ScreenProps extends ViewProps {
     active?: 0 | 1 | Animated.AnimatedInterpolation;
@@ -114,6 +123,18 @@ declare module 'react-native-screens' {
      * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
      */
     statusBarHidden?: boolean;
+    /**
+     * @description Controls in which orientation should the screen appear.
+     * @type "default" - resolves to "all" without "portrait_down"
+     * @type "all" – all orientations are permitted
+     * @type "portrait" – portrait orientations are permitted
+     * @type "portrait_up" – right-side portrait orientation is permitted
+     * @type "portrait_down" – upside-down portrait orientation is permitted
+     * @type "landscape" – landscape orientations are permitted
+     * @type "landscape_left" – landscape-left orientation is permitted
+     * @type "landscape_right" – landscape-right orientation is permitted
+     */
+    stackOrientationMask?: StackOrientationMaskTypes;
     /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,12 +102,12 @@ declare module 'react-native-screens' {
     replaceAnimation?: ScreenReplaceTypes;
     /**
      * @host (iOS only)
-     * @description Sets the status bar color (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `default`.
+     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `default`.
      */
     statusBarStyle?: 'default' | 'light-content' | 'dark-content';
     /**
      * @host (iOS only)
-     * @description Sets the status bar animation (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
+     * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
      */
     statusBarAnimation?: 'none' | 'fade' | 'slide';
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,9 +102,9 @@ declare module 'react-native-screens' {
     replaceAnimation?: ScreenReplaceTypes;
     /**
      * @host (iOS only)
-     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `default`.
+     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
      */
-    statusBarStyle?: 'default' | 'light-content' | 'dark-content';
+    statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
     /**
      * @host (iOS only)
      * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -110,32 +110,6 @@ declare module 'react-native-screens' {
      */
     replaceAnimation?: ScreenReplaceTypes;
     /**
-     * @host (iOS only)
-     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
-     */
-    statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
-    /**
-     * @host (iOS only)
-     * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
-     */
-    statusBarAnimation?: 'none' | 'fade' | 'slide';
-    /**
-     * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
-     */
-    statusBarHidden?: boolean;
-    /**
-     * @description Controls in which orientation should the screen appear. Defaults to `default`.
-     * @type "default" - resolves to "all" without "portrait_down"
-     * @type "all" – all orientations are permitted
-     * @type "portrait" – portrait orientations are permitted
-     * @type "portrait_up" – right-side portrait orientation is permitted
-     * @type "portrait_down" – upside-down portrait orientation is permitted
-     * @type "landscape" – landscape orientations are permitted
-     * @type "landscape_left" – landscape-left orientation is permitted
-     * @type "landscape_right" – landscape-right orientation is permitted
-     */
-    screenOrientation?: ScreenOrientationTypes;
-    /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */
     gestureEnabled?: boolean;
@@ -264,6 +238,33 @@ declare module 'react-native-screens' {
      * @description Blur effect to be applied to the header. Works with backgroundColor's alpha < 1.
      */
     blurEffect?: BlurEffectTypes;
+    /**
+     * @host (iOS only)
+     * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
+     */
+    statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
+    /**
+     * @host (iOS only)
+     * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
+     */
+    statusBarAnimation?: 'none' | 'fade' | 'slide';
+    /**
+     * @host (iOS only)
+     * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
+     */
+    statusBarHidden?: boolean;
+    /**
+     * @description Controls in which orientation should the screen appear.
+     * @type "default" - resolves to "all" without "portrait_down" on iOS.
+     * @type "all" – all orientations are permitted
+     * @type "portrait" – portrait orientations are permitted
+     * @type "portrait_up" – right-side portrait orientation is permitted
+     * @type "portrait_down" – upside-down portrait orientation is permitted
+     * @type "landscape" – landscape orientations are permitted
+     * @type "landscape_left" – landscape-left orientation is permitted
+     * @type "landscape_right" – landscape-right orientation is permitted
+     */
+    screenOrientation?: ScreenOrientationTypes;
   }
 
   export const Screen: ComponentClass<ScreenProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -111,6 +111,10 @@ declare module 'react-native-screens' {
      */
     statusBarAnimation?: 'none' | 'fade' | 'slide';
     /**
+     * @description When set to true, the status bar for this screen is hidden.
+     */
+    statusBarHidden?: boolean;
+    /**
      * @description When set to false the back swipe gesture will be disabled when the parent Screen is on top of the stack. The default value is true.
      */
     gestureEnabled?: boolean;

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -276,7 +276,7 @@ export type NativeStackNavigationOptions = {
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**
    * @host (iOS only)
-   * @description Whether the status bar should be hidden on this screen
+   * @description Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    */
   statusBarHidden?: boolean;
 };

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -269,13 +269,13 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  statusBarStyle?: ScreenProps['statusBarStyle'];
+  statusBarStyle?: ScreenStackHeaderConfigProps['statusBarStyle'];
   /**
    * Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    *
    * @platform ios
    */
-  statusBarAnimation?: ScreenProps['statusBarAnimation'];
+  statusBarAnimation?: ScreenStackHeaderConfigProps['statusBarAnimation'];
   /**
    * Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    *
@@ -294,7 +294,7 @@ export type NativeStackNavigationOptions = {
    * - "landscape_left" – landscape-left orientation is permitted
    * - "landscape_right" – landscape-right orientation is permitted
    */
-  screenOrientation?: ScreenProps['screenOrientation'];
+  screenOrientation?: ScreenStackHeaderConfigProps['screenOrientation'];
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -265,18 +265,21 @@ export type NativeStackNavigationOptions = {
    */
   stackAnimation?: ScreenProps['stackAnimation'];
   /**
-   * @host (iOS only)
-   * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
    */
   statusBarStyle?: ScreenProps['statusBarStyle'];
   /**
-   * @host (iOS only)
-   * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   * Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
    */
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**
-   * @host (iOS only)
-   * @description Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   * Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
    */
   statusBarHidden?: boolean;
 };

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -75,18 +75,29 @@ export type NativeStackNavigationConfig = Record<string, unknown>;
 
 export type NativeStackNavigationOptions = {
   /**
-   * String that can be displayed in the header as a fallback for `headerTitle`.
-   */
-  title?: string;
-  /**
-   * String to display in the header as title. Defaults to scene `title`.
-   */
-  headerTitle?: string;
-  /**
    * Image to display in the header as the back button.
    * Defaults to back icon image for the platform (a chevron on iOS and an arrow on Android).
    */
   backButtonImage?: ImageSourcePropType;
+  /**
+   * Whether to show the back button with custom left side of the header.
+   */
+  backButtonInCustomView?: boolean;
+  /**
+   * Style object for the scene content.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
+  /**
+   * Whether the stack should be in rtl or ltr form.
+   */
+  direction?: 'rtl' | 'ltr';
+  /**
+   * Whether you can use gestures to dismiss this screen. Defaults to `true`.
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  gestureEnabled?: boolean;
   /**
    * Title to display in the back button.
    * Only supported on iOS.
@@ -95,6 +106,19 @@ export type NativeStackNavigationOptions = {
    */
   headerBackTitle?: string;
   /**
+   * Style object for header back title. Supported properties:
+   * - fontFamily
+   * - fontSize
+   *
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  headerBackTitleStyle?: {
+    fontFamily?: string;
+    fontSize?: number;
+  };
+  /**
    * Whether the back button title should be visible or not. Defaults to `true`.
    * Only supported on iOS.
    *
@@ -102,49 +126,9 @@ export type NativeStackNavigationOptions = {
    */
   headerBackTitleVisible?: boolean;
   /**
-   * Whether to show the header.
-   */
-  headerShown?: boolean;
-  /**
-   * Whether to show the back button with custom left side of the header.
-   */
-  backButtonInCustomView?: boolean;
-  /**
-   * Boolean indicating whether the navigation bar is translucent.
-   * Only supported on iOS.
-   *
-   * @platform ios
-   */
-  headerTranslucent?: boolean;
-  /**
-   * Boolean to set native property to prefer large title header (like in iOS setting).
-   * For large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`.
-   * If the scrollable area doesn't fill the screen, the large title won't collapse on scroll.
-   * Only supported on iOS.
-   *
-   * @platform ios
-   */
-  headerLargeTitle?: boolean;
-  /**
-   * Whether the stack should be in rtl or ltr form.
-   */
-  direction?: 'rtl' | 'ltr';
-  /**
-   * Function which returns a React Element to display on the right side of the header.
-   */
-  headerRight?: (props: { tintColor?: string }) => React.ReactNode;
-  /**
-   * Function which returns a React Element to display on the left side of the header.
-   */
-  headerLeft?: (props: { tintColor?: string }) => React.ReactNode;
-  /**
    * Function which returns a React Element to display in the center of the header.
    */
   headerCenter?: (props: { tintColor?: string }) => React.ReactNode;
-  /**
-   * Tint color for the header. Changes the color of back button and title.
-   */
-  headerTintColor?: string;
   /**
    * Boolean indicating whether to hide the back button in header.
    * Only supported on Android.
@@ -157,19 +141,6 @@ export type NativeStackNavigationOptions = {
    */
   headerHideShadow?: boolean;
   /**
-   * Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
-   */
-  headerLargeTitleHideShadow?: boolean;
-  /**
-   * Style object for header title. Supported properties:
-   * - backgroundColor
-   * - blurEffect
-   */
-  headerStyle?: {
-    backgroundColor?: string;
-    blurEffect?: ScreenStackHeaderConfigProps['blurEffect'];
-  };
-  /**
    * Controls the style of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar. Supported properties:
    * - backgroundColor
    *
@@ -179,16 +150,18 @@ export type NativeStackNavigationOptions = {
     backgroundColor?: string;
   };
   /**
-   * Style object for header title. Supported properties:
-   * - fontFamily
-   * - fontSize
-   * - color
+   * Boolean to set native property to prefer large title header (like in iOS setting).
+   * For large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`.
+   * If the scrollable area doesn't fill the screen, the large title won't collapse on scroll.
+   * Only supported on iOS.
+   *
+   * @platform ios
    */
-  headerTitleStyle?: {
-    fontFamily?: string;
-    fontSize?: number;
-    color?: string;
-  };
+  headerLargeTitle?: boolean;
+  /**
+   * Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+   */
+  headerLargeTitleHideShadow?: boolean;
   /**
    * Style object for header large title. Supported properties:
    * - fontFamily
@@ -204,17 +177,44 @@ export type NativeStackNavigationOptions = {
     color?: string;
   };
   /**
-   * Style object for header back title. Supported properties:
+   * Function which returns a React Element to display on the left side of the header.
+   */
+  headerLeft?: (props: { tintColor?: string }) => React.ReactNode;
+  /**
+   * Function which returns a React Element to display on the right side of the header.
+   */
+  headerRight?: (props: { tintColor?: string }) => React.ReactNode;
+  /**
+   * Whether to show the header.
+   */
+  headerShown?: boolean;
+  /**
+   * Style object for header title. Supported properties:
+   * - backgroundColor
+   * - blurEffect
+   */
+  headerStyle?: {
+    backgroundColor?: string;
+    blurEffect?: ScreenStackHeaderConfigProps['blurEffect'];
+  };
+  /**
+   * Tint color for the header. Changes the color of back button and title.
+   */
+  headerTintColor?: string;
+  /**
+   * String to display in the header as title. Defaults to scene `title`.
+   */
+  headerTitle?: string;
+  /**
+   * Style object for header title. Supported properties:
    * - fontFamily
    * - fontSize
-   *
-   * Only supported on iOS.
-   *
-   * @platform ios
+   * - color
    */
-  headerBackTitleStyle?: {
+  headerTitleStyle?: {
     fontFamily?: string;
     fontSize?: number;
+    color?: string;
   };
   /**
    * A flag to that lets you opt out of insetting the header. You may want to
@@ -226,16 +226,9 @@ export type NativeStackNavigationOptions = {
    */
   headerTopInsetEnabled?: boolean;
   /**
-   * Style object for the scene content.
+   * Boolean indicating whether the navigation bar is translucent.
    */
-  contentStyle?: StyleProp<ViewStyle>;
-  /**
-   * Whether you can use gestures to dismiss this screen. Defaults to `true`.
-   * Only supported on iOS.
-   *
-   * @platform ios
-   */
-  gestureEnabled?: boolean;
+  headerTranslucent?: boolean;
   /**
    * How should the screen replacing another screen animate. Defaults to `pop`.
    * The following values are currently supported:
@@ -243,45 +236,6 @@ export type NativeStackNavigationOptions = {
    * - "pop" – the new screen will perform pop animation.
    */
   replaceAnimation?: ScreenProps['replaceAnimation'];
-  /**
-   * How should the screen be presented.
-   * The following values are currently supported:
-   * - "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
-   * - "modal" – the new screen will be presented modally. In addition this allow for a nested stack to be rendered inside such screens.
-   * - "transparentModal" – the new screen will be presented modally but in addition the second to last screen will remain attached to the stack container such that if the top screen is non opaque the content below can still be seen. If "modal" is used instead the below screen will get unmounted as soon as the transition ends.
-   * - "containedModal" – will use "UIModalPresentationCurrentContext" modal style on iOS and will fallback to "modal" on Android.
-   * - "containedTransparentModal" – will use "UIModalPresentationOverCurrentContext" modal style on iOS and will fallback to "transparentModal" on Android.
-   * - "fullScreenModal" – will use "UIModalPresentationFullScreen" modal style on iOS and will fallback to "modal" on Android.
-   * - "formSheet" – will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
-   */
-  stackPresentation?: ScreenProps['stackPresentation'];
-  /**
-   * How the screen should appear/disappear when pushed or popped at the top of the stack.
-   * The following values are currently supported:
-   * - "default" – uses a platform default animation
-   * - "fade" – fades screen in or out
-   * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
-   * - "none" – the screen appears/dissapears without an animation
-   */
-  stackAnimation?: ScreenProps['stackAnimation'];
-  /**
-   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
-   *
-   * @platform ios
-   */
-  statusBarStyle?: ScreenStackHeaderConfigProps['statusBarStyle'];
-  /**
-   * Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
-   *
-   * @platform ios
-   */
-  statusBarAnimation?: ScreenStackHeaderConfigProps['statusBarAnimation'];
-  /**
-   * Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
-   *
-   * @platform ios
-   */
-  statusBarHidden?: boolean;
   /**
    * In which orientation should the screen appear.
    * The following values are currently supported:
@@ -295,6 +249,48 @@ export type NativeStackNavigationOptions = {
    * - "landscape_right" – landscape-right orientation is permitted
    */
   screenOrientation?: ScreenStackHeaderConfigProps['screenOrientation'];
+  /**
+   * How the screen should appear/disappear when pushed or popped at the top of the stack.
+   * The following values are currently supported:
+   * - "default" – uses a platform default animation
+   * - "fade" – fades screen in or out
+   * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
+   * - "none" – the screen appears/dissapears without an animation
+   */
+  stackAnimation?: ScreenProps['stackAnimation'];
+  /**
+   * How should the screen be presented.
+   * The following values are currently supported:
+   * - "push" – the new screen will be pushed onto a stack which on iOS means that the default animation will be slide from the side, the animation on Android may vary depending on the OS version and theme.
+   * - "modal" – the new screen will be presented modally. In addition this allow for a nested stack to be rendered inside such screens.
+   * - "transparentModal" – the new screen will be presented modally but in addition the second to last screen will remain attached to the stack container such that if the top screen is non opaque the content below can still be seen. If "modal" is used instead the below screen will get unmounted as soon as the transition ends.
+   * - "containedModal" – will use "UIModalPresentationCurrentContext" modal style on iOS and will fallback to "modal" on Android.
+   * - "containedTransparentModal" – will use "UIModalPresentationOverCurrentContext" modal style on iOS and will fallback to "transparentModal" on Android.
+   * - "fullScreenModal" – will use "UIModalPresentationFullScreen" modal style on iOS and will fallback to "modal" on Android.
+   * - "formSheet" – will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
+   */
+  stackPresentation?: ScreenProps['stackPresentation'];
+  /**
+   * Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
+   */
+  statusBarAnimation?: ScreenStackHeaderConfigProps['statusBarAnimation'];
+  /**
+   * Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
+   */
+  statusBarHidden?: boolean;
+  /** Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   *
+   * @platform ios
+   */
+  statusBarStyle?: ScreenStackHeaderConfigProps['statusBarStyle'];
+  /**
+   * String that can be displayed in the header as a fallback for `headerTitle`.
+   */
+  title?: string;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -266,12 +266,12 @@ export type NativeStackNavigationOptions = {
   stackAnimation?: ScreenProps['stackAnimation'];
   /**
    * @host (iOS only)
-   * @description Sets the status bar color (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    */
   statusBarStyle?: ScreenProps['statusBarStyle'];
   /**
    * @host (iOS only)
-   * @description Sets the status bar animation (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    */
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -264,6 +264,16 @@ export type NativeStackNavigationOptions = {
    * - "none" – the screen appears/dissapears without an animation
    */
   stackAnimation?: ScreenProps['stackAnimation'];
+  /**
+   * @host (iOS only)
+   * @description Sets the status bar color (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   */
+  statusBarStyle?: ScreenProps['statusBarStyle'];
+  /**
+   * @host (iOS only)
+   * @description Sets the status bar animation (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
+   */
+  statusBarAnimation?: ScreenProps['statusBarAnimation'];
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -294,7 +294,7 @@ export type NativeStackNavigationOptions = {
    * - "landscape_left" – landscape-left orientation is permitted
    * - "landscape_right" – landscape-right orientation is permitted
    */
-  stackOrientationMask?: ScreenProps['stackOrientationMask'];
+  screenOrientation?: ScreenProps['screenOrientation'];
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -282,6 +282,19 @@ export type NativeStackNavigationOptions = {
    * @platform ios
    */
   statusBarHidden?: boolean;
+  /**
+   * In which orientation should the screen appear.
+   * The following values are currently supported:
+   * - "default" - resolves to "all" without "portrait_down".
+   * - "all" – all orientations are permitted
+   * - "portrait" – portrait orientations are permitted
+   * - "portrait_up" – right-side portrait orientation is permitted
+   * - "portrait_down" – upside-down portrait orientation is permitted
+   * - "landscape" – landscape orientations are permitted
+   * - "landscape_left" – landscape-left orientation is permitted
+   * - "landscape_right" – landscape-right orientation is permitted
+   */
+  stackOrientationMask?: ScreenProps['stackOrientationMask'];
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -274,6 +274,11 @@ export type NativeStackNavigationOptions = {
    * @description Sets the status bar animation (similar to the <StatusBar /> component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    */
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
+  /**
+   * @host (iOS only)
+   * @description Whether the status bar should be hidden on this screen
+   */
+  statusBarHidden?: boolean;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -8,43 +8,54 @@ import {
   ScreenStackHeaderRightView,
 } from 'react-native-screens';
 import { NativeStackNavigationOptions } from '../types';
+import { processFonts } from './FontProcessor';
 
 type Props = NativeStackNavigationOptions & {
   route: Route<string>;
 };
 
 export default function HeaderConfig({
-  route,
-  title,
-  headerRight,
-  headerLeft,
-  headerCenter,
-  headerTitle,
-  headerBackTitle,
-  headerBackTitleVisible = true,
   backButtonImage,
-  headerHideBackButton,
-  headerHideShadow,
-  headerLargeTitleHideShadow,
-  headerTintColor,
-  headerTopInsetEnabled = true,
-  headerLargeTitle,
-  headerTranslucent,
-  headerStyle = {},
-  headerLargeStyle = {},
-  headerTitleStyle = {},
-  headerLargeTitleStyle = {},
-  headerBackTitleStyle = {},
-  headerShown,
   backButtonInCustomView,
   direction,
+  headerBackTitle,
+  headerBackTitleStyle = {},
+  headerBackTitleVisible = true,
+  headerCenter,
+  headerHideBackButton,
+  headerHideShadow,
+  headerLargeStyle = {},
+  headerLargeTitle,
+  headerLargeTitleHideShadow,
+  headerLargeTitleStyle = {},
+  headerLeft,
+  headerRight,
+  headerShown,
+  headerStyle = {},
+  headerTintColor,
+  headerTitle,
+  headerTitleStyle = {},
+  headerTopInsetEnabled = true,
+  headerTranslucent,
+  route,
   screenOrientation,
   statusBarAnimation,
   statusBarHidden,
   statusBarStyle,
+  title,
 }: Props): JSX.Element {
   const { colors } = useTheme();
   const tintColor = headerTintColor ?? colors.primary;
+
+  const [
+    backTitleFontFamily,
+    largeTitleFontFamily,
+    titleFontFamily,
+  ] = processFonts([
+    headerBackTitleStyle.fontFamily,
+    headerLargeTitleStyle.fontFamily,
+    headerTitleStyle.fontFamily,
+  ]);
 
   return (
     <ScreenStackHeaderConfig
@@ -53,7 +64,7 @@ export default function HeaderConfig({
         headerStyle.backgroundColor ? headerStyle.backgroundColor : colors.card
       }
       backTitle={headerBackTitleVisible ? headerBackTitle : ' '}
-      backTitleFontFamily={headerBackTitleStyle.fontFamily}
+      backTitleFontFamily={backTitleFontFamily}
       backTitleFontSize={headerBackTitleStyle.fontSize}
       blurEffect={headerStyle.blurEffect}
       color={tintColor}
@@ -64,13 +75,13 @@ export default function HeaderConfig({
       largeTitle={headerLargeTitle}
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}
       largeTitleColor={headerLargeTitleStyle.color}
-      largeTitleFontFamily={headerLargeTitleStyle.fontFamily}
+      largeTitleFontFamily={largeTitleFontFamily}
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       largeTitleHideShadow={headerLargeTitleHideShadow}
+      screenOrientation={screenOrientation}
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
-      screenOrientation={screenOrientation}
       title={
         headerTitle !== undefined
           ? headerTitle
@@ -85,7 +96,7 @@ export default function HeaderConfig({
           ? headerTintColor
           : colors.text
       }
-      titleFontFamily={headerTitleStyle.fontFamily}
+      titleFontFamily={titleFontFamily}
       titleFontSize={headerTitleStyle.fontSize}
       topInsetEnabled={headerTopInsetEnabled}
       translucent={headerTranslucent === true}>

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -38,6 +38,10 @@ export default function HeaderConfig({
   headerShown,
   backButtonInCustomView,
   direction,
+  screenOrientation,
+  statusBarAnimation,
+  statusBarHidden,
+  statusBarStyle,
 }: Props): JSX.Element {
   const { colors } = useTheme();
   const tintColor = headerTintColor ?? colors.primary;
@@ -63,6 +67,10 @@ export default function HeaderConfig({
       largeTitleFontFamily={headerLargeTitleStyle.fontFamily}
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       largeTitleHideShadow={headerLargeTitleHideShadow}
+      statusBarAnimation={statusBarAnimation}
+      statusBarHidden={statusBarHidden}
+      statusBarStyle={statusBarStyle}
+      screenOrientation={screenOrientation}
       title={
         headerTitle !== undefined
           ? headerTitle

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -62,6 +62,8 @@ export default function NativeStackView({
           replaceAnimation = 'pop',
           stackPresentation = 'push',
           stackAnimation,
+          statusBarStyle,
+          statusBarAnimation,
           contentStyle,
         } = options;
 
@@ -81,6 +83,8 @@ export default function NativeStackView({
             replaceAnimation={replaceAnimation}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
+            statusBarStyle={statusBarStyle}
+            statusBarAnimation={statusBarAnimation}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -65,6 +65,7 @@ export default function NativeStackView({
           statusBarStyle,
           statusBarAnimation,
           statusBarHidden,
+          stackOrientationMask,
           contentStyle,
         } = options;
 
@@ -87,6 +88,7 @@ export default function NativeStackView({
             statusBarAnimation={statusBarAnimation}
             statusBarHidden={statusBarHidden}
             statusBarStyle={statusBarStyle}
+            stackOrientationMask={stackOrientationMask}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -62,10 +62,6 @@ export default function NativeStackView({
           replaceAnimation = 'pop',
           stackPresentation = 'push',
           stackAnimation,
-          statusBarStyle,
-          statusBarAnimation,
-          statusBarHidden,
-          screenOrientation,
           contentStyle,
         } = options;
 
@@ -85,10 +81,6 @@ export default function NativeStackView({
             replaceAnimation={replaceAnimation}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
-            statusBarAnimation={statusBarAnimation}
-            statusBarHidden={statusBarHidden}
-            statusBarStyle={statusBarStyle}
-            screenOrientation={screenOrientation}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -64,6 +64,7 @@ export default function NativeStackView({
           stackAnimation,
           statusBarStyle,
           statusBarAnimation,
+          statusBarHidden,
           contentStyle,
         } = options;
 
@@ -83,8 +84,9 @@ export default function NativeStackView({
             replaceAnimation={replaceAnimation}
             stackPresentation={stackPresentation}
             stackAnimation={stackAnimation}
-            statusBarStyle={statusBarStyle}
             statusBarAnimation={statusBarAnimation}
+            statusBarHidden={statusBarHidden}
+            statusBarStyle={statusBarStyle}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -65,7 +65,7 @@ export default function NativeStackView({
           statusBarStyle,
           statusBarAnimation,
           statusBarHidden,
-          stackOrientationMask,
+          screenOrientation,
           contentStyle,
         } = options;
 
@@ -88,7 +88,7 @@ export default function NativeStackView({
             statusBarAnimation={statusBarAnimation}
             statusBarHidden={statusBarHidden}
             statusBarStyle={statusBarStyle}
-            stackOrientationMask={stackOrientationMask}
+            screenOrientation={screenOrientation}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',


### PR DESCRIPTION
Added orientation management on top of #642. Helper methods taken from [expo-screen-orientation](https://docs.expo.io/versions/latest/sdk/screen-orientation/).