### PR TITLE
fix: remove check for background color

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -242,9 +242,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // background
-    if (mBackgroundColor != -1) {
-      mToolbar.setBackgroundColor(mBackgroundColor);
-    }
+    mToolbar.setBackgroundColor(mBackgroundColor);
 
     // color
     if (mTintColor != 0) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -32,7 +32,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private String mTitleFontFamily;
   private String mDirection;
   private float mTitleFontSize;
-  private int mBackgroundColor;
+  private Integer mBackgroundColor;
   private boolean mIsHidden;
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
@@ -242,7 +242,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // background
-    mToolbar.setBackgroundColor(mBackgroundColor);
+    if (mBackgroundColor != null) {
+      mToolbar.setBackgroundColor(mBackgroundColor);
+    }
 
     // color
     if (mTintColor != 0) {
@@ -365,7 +367,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
-  public void setBackgroundColor(int color) {
+  public void setBackgroundColor(Integer color) {
     mBackgroundColor = color;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -89,8 +89,8 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setTitleColor(titleColor);
   }
 
-  @ReactProp(name = "backgroundColor", customType = "Color", defaultInt = -1)
-  public void setBackgroundColor(ScreenStackHeaderConfig config, int backgroundColor) {
+  @ReactProp(name = "backgroundColor", customType = "Color")
+  public void setBackgroundColor(ScreenStackHeaderConfig config, Integer backgroundColor) {
     config.setBackgroundColor(backgroundColor);
   }
 


### PR DESCRIPTION
"#fff", "#ffffff" and `white` colors all have a value of "-1" on the native side, and `transparent` color has a value of "0", so using Integer and checking if it is `null` is the best option now.