### PR TITLE
Fix: iOS modal page sheet frame should not be that of UINavigationController

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -37,7 +37,7 @@
 - (void)reactSetFrame:(CGRect)frame
 {
   if (![self.reactViewController.parentViewController
-        isKindOfClass:[UINavigationController class]]) {
+        isKindOfClass:[UINavigationController class]] && self.stackPresentation != RNSScreenStackPresentationModal) {
     [super reactSetFrame:frame];
   }
   // when screen is mounted under UINavigationController it's size is controller


### PR DESCRIPTION
I was having [this issue](https://github.com/software-mansion/react-native-screens/issues/577#issuecomment-665689734) when pulling up an iOS 13 page sheet modal on phone devices. 

Cause of issue: The RNScreen frame was being set to equal the parent UINavigationController. This height is larger than the iOS modal since page sheet modals are not full screen. It corrects itself when `updateBounds` is called. However if you pull up the modal reactSetFrame is called multiple time to match the UINavigationControllers frame and a loop happens where frame is set, then bounds are updated causing a violent jitter to anything pinned to the bottom of the screen.

This fixed it by only calling `[super reactSetFrame:frame]` if the parent is not a NavigationController && the stack presentation is not RNSScreenStackPresentationModal. 

There may be a better way of casing this as it will affect FullScreenModals for < iOS 13 devices. I have not noticed any adverse affects with this.