### PR TITLE
Add support for "stackAnimation: 'slide'" on iOS & Add a "slide-up" animation for modal screens on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Allows for the customization of how the given screen should appear/disappear whe
 - `"flip"` – flips the screen, requires `stackPresentation: "modal"` (iOS only)
 - `"slide_from_right"` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `"slide_from_left"` - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
+- `"slide_from_bottom"` - slide in the new screen from bottom to top (Android only, resolves to default transition on iOS)
 - `"none"` – the screen appears/disappears without an animation
 
 #### `stackPresentation`

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -30,7 +30,8 @@ public class Screen extends ViewGroup {
     NONE,
     FADE,
     SLIDE_FROM_RIGHT,
-    SLIDE_FROM_LEFT
+    SLIDE_FROM_LEFT,
+    SLIDE_FROM_BOTTOM
   }
 
   public enum ReplaceAnimation {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -192,6 +192,10 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
             customAnimation = true;
             getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
             break;
+          case SLIDE_FROM_BOTTOM:
+            customAnimation = true;
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_bottom, R.anim.rns_slide_out_to_bottom);
+            break;
         }
 
         if (!customAnimation) {
@@ -216,6 +220,10 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
         case SLIDE_FROM_LEFT:
           customAnimation = true;
           getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
+          break;
+        case SLIDE_FROM_BOTTOM:
+          customAnimation = true;
+          getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_bottom, R.anim.rns_slide_out_to_bottom);
           break;
       }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -71,6 +71,8 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
       view.setStackAnimation(Screen.StackAnimation.SLIDE_FROM_RIGHT);
     } else if ("slide_from_left".equals(animation)) {
       view.setStackAnimation(Screen.StackAnimation.SLIDE_FROM_LEFT);
+    } else if ("slide_from_bottom".equals(animation)) {
+      view.setStackAnimation(Screen.StackAnimation.SLIDE_FROM_BOTTOM);
     }
   }
 

--- a/android/src/main/res/anim/rns_slide_in_from_bottom.xml
+++ b/android/src/main/res/anim/rns_slide_in_from_bottom.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+           android:duration="@android:integer/config_mediumAnimTime"
+           android:fromYDelta="100%"
+           android:toYDelta="0%" />

--- a/android/src/main/res/anim/rns_slide_out_to_bottom.xml
+++ b/android/src/main/res/anim/rns_slide_out_to_bottom.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+           android:duration="@android:integer/config_mediumAnimTime"
+           android:fromYDelta="0%"
+           android:toYDelta="100%" />

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -127,6 +127,7 @@ How the given screen should appear/disappear when pushed or popped at the top of
 - `flip` – Flips the screen, requires stackPresentation: `modal` (iOS only).
 - `slide_from_right` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `slide_from_left` - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
+- `slide_from_bottom` - slide in the new screen from bottom to top (Android only, resolves to default transition on iOS)
 - `none` - The screen appears/disappears without an animation.
 
 Defaults to `default`.

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -519,6 +519,7 @@ RCT_ENUM_CONVERTER(RNSScreenStackAnimation, (@{
                                                   @"flip": @(RNSScreenStackAnimationFlip),
                                                   @"slide_from_right": @(RNSScreenStackAnimationDefault),
                                                   @"slide_from_left": @(RNSScreenStackAnimationDefault),
+                                                  @"slide_from_bottom": @(RNSScreenStackAnimationDefault),
                                                   }), RNSScreenStackAnimationDefault, integerValue)
 
 RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation, (@{

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -160,6 +160,7 @@ How the given screen should appear/disappear when pushed or popped at the top of
 - `flip` – Flips the screen, requires stackPresentation: `modal` (iOS only).
 - `slide_from_right` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `slide_from_left` - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
+- `slide_from_bottom` - slide in the new screen from bottom to top (Android only, resolves to default transition on iOS)
 - `none` - The screen appears/disappears without an animation.
 
 Defaults to `default`.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,8 @@ declare module 'react-native-screens' {
     | 'flip'
     | 'none'
     | 'slide_from_right'
-    | 'slide_from_left';
+    | 'slide_from_left'
+    | 'slide_from_bottom';
   export type BlurEffectTypes =
     | 'extraLight'
     | 'light'
@@ -98,6 +99,7 @@ declare module 'react-native-screens' {
      *  @type "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
      *  @type "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
      *  @type "slide_from_left" - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
+     *  @type "slide_from_bottom" - slide in the new screen from bottom to top (Android only, resolves to default transition on iOS)
      *  @type "none" – the screen appears/dissapears without an animation
      */
     stackAnimation?: StackAnimationTypes;

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -224,6 +224,7 @@ export type NativeStackNavigationOptions = {
    * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
    * - "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
    * - "slide_from_left" - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
+   * - "slide_from_bottom" - slide in the new screen from bottom to top (Android only, resolves to default transition on iOS)
    * - "none" – the screen appears/dissapears without an animation
    */
   stackAnimation?: ScreenProps['stackAnimation'];


### PR DESCRIPTION
This PR is a follow-up to #648 

It does

1º) Add support for `stackAnimation: 'slide'` on iOS (same behaviour as `default`)
2º) Update the animation of stackAnimation: ‘slide’ when the screen is a modal.

`stackAnimation: 'slide'` & `stackPresentation: ' push' `.

![slider-right-to-left](https://user-images.githubusercontent.com/18426262/95730231-418b6880-0c7e-11eb-8894-3b6715eb08bb.gif)

`stackAnimation: 'slide'`& `stackPresentation: 'transparentModal'`.

![slide-bottom-top](https://user-images.githubusercontent.com/18426262/95730348-6e3f8000-0c7e-11eb-9625-54fbbc026673.gif)



PD: With this custom animation, we stopped experiencing white flashes/flicks when pushing & going back from screens (in our case, it was directly related to the "default" scale-in/scale-out animation).