### PR TITLE
feat: add missing prop

### DIFF
--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -107,6 +107,8 @@ class StackView extends React.Component {
       largeTitleFontSize:
         headerLargeTitleStyle && headerLargeTitleStyle.fontSize,
       largeTitleColor: headerLargeTitleStyle && headerLargeTitleStyle.color,
+      largeTitleBackgroundColor:
+        headerLargeTitleStyle && headerLargeTitleStyle.backgroundColor,
       hideShadow,
       headerTopInsetEnabled,
       direction,


### PR DESCRIPTION
Added missing prop to the old version of `native-stack`. Based on #454 by @agarant.