### PR TITLE
fix: check if view is not null

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -154,7 +154,7 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   private void notifyViewAppearTransitionEnd() {
-    ViewParent screenStack = getView().getParent();
+    ViewParent screenStack = getView() != null ? getView().getParent() : null;
     if (screenStack instanceof ScreenStack) {
       ((ScreenStack) screenStack).onViewAppearTransitionEnd();
     }


### PR DESCRIPTION
Added a check for if `View` is a null. Should resolve #646.