### PR TITLE
feat: add screen orientation on iOS

### DIFF
--- a/Example/nativeNavigation.js
+++ b/Example/nativeNavigation.js
@@ -5,38 +5,26 @@ import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 const SomeScreen = ({ navigation }) => {
   return (
     <ScrollView style={styles.screen}>
-      <Button
-        onPress={() => navigation.push('Push')}
-        title="Push"
-      />
-      <Button
-        onPress={() => navigation.navigate('Modal')}
-        title="Modal"
-      />
+      <Button onPress={() => navigation.push('Push')} title="Push" />
+      <Button onPress={() => navigation.navigate('Modal')} title="Modal" />
       <Button onPress={() => navigation.pop()} title="Back" />
       <View style={styles.leftTop} />
       <View style={styles.bottomRight} />
     </ScrollView>
   );
-}
+};
 
 const PushScreen = ({ navigation }) => {
   return (
     <View style={styles.screen}>
       <TextInput placeholder="Hello" style={styles.textInput} />
-      <Button
-        onPress={() => navigation.goBack()}
-        title="Go back"
-      />
-      <Button
-        onPress={() => navigation.push('Push')}
-        title="Push more"
-      />
+      <Button onPress={() => navigation.goBack()} title="Go back" />
+      <Button onPress={() => navigation.push('Push')} title="Push more" />
       <View style={styles.leftTop} />
       <View style={styles.bottomRight} />
     </View>
   );
-}
+};
 
 const AppStack = createNativeStackNavigator();
 
@@ -49,6 +37,7 @@ const App = () => (
         title: 'Start',
         headerTintColor: 'black',
         statusBarStyle: 'auto',
+        screenOrientation: 'portrait',
       }}
     />
     <AppStack.Screen
@@ -64,7 +53,11 @@ const App = () => (
     <AppStack.Screen
       name="Modal"
       component={PushScreen}
-      options={{ stackPresentation: 'modal', statusBarStyle: 'light' }}
+      options={{
+        stackPresentation: 'modal',
+        statusBarStyle: 'light',
+        screenOrientation: 'portrait_up',
+      }}
     />
   </AppStack.Navigator>
 );

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -27,5 +27,5 @@ import Test713 from './src/Test713';
 enableScreens();
 
 export default function App() {
-  return <Test642 />;
+  return <Test42 />;
 }

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -27,5 +27,5 @@ import Test713 from './src/Test713';
 enableScreens();
 
 export default function App() {
-  return <Test42 />;
+  return <Test642 />;
 }

--- a/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
+++ b/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
@@ -194,7 +194,6 @@
 				2C8EF49C5A488D5575B90176 /* Pods-TestsExample-tvOSTests.debug.xcconfig */,
 				6CC8BF9F7F61E5E37D4E0288 /* Pods-TestsExample-tvOSTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};

--- a/TestsExample/ios/TestsExample/Info.plist
+++ b/TestsExample/ios/TestsExample/Info.plist
@@ -47,6 +47,7 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>

--- a/TestsExample/src/Test42.js
+++ b/TestsExample/src/Test42.js
@@ -69,7 +69,13 @@ function Home({navigation}) {
         }}
       />
       <Button
-        title="status bar style"
+        title="Pop to top"
+        onPress={() => {
+          navigation.popToTop();
+        }}
+      />
+      <Button
+        title="Randomly change screen orientation"
         onPress={() => {
           navigation.setOptions({
             screenOrientation: Math.random() > 0.5 ? 'portrait' : 'landscape',

--- a/TestsExample/src/Test42.js
+++ b/TestsExample/src/Test42.js
@@ -1,7 +1,7 @@
 // connected PRs: #679, #675
 import {NavigationContainer} from '@react-navigation/native';
 import React from 'react';
-import {ScrollView, StyleSheet, View, Button} from 'react-native';
+import {ScrollView, StyleSheet, View, Button, Text} from 'react-native';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 
@@ -83,6 +83,7 @@ function Home({navigation}) {
           setYes(!yes);
         }}
       />
+      <Text>Go to `TabNavigator` and then go to second tab there. Spot the difference between dismissing modal with a swipe and with a `Pop to top` button. </Text> 
     </ScrollView>
   );
 }

--- a/TestsExample/src/Test42.js
+++ b/TestsExample/src/Test42.js
@@ -1,7 +1,7 @@
 // connected PRs: #679, #675
 import {NavigationContainer} from '@react-navigation/native';
 import React from 'react';
-import {ScrollView, StyleSheet, Text, View, Button} from 'react-native';
+import {ScrollView, StyleSheet, View, Button} from 'react-native';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 
@@ -22,7 +22,7 @@ export default function NativeNavigation() {
           }}
         />
         <Stack.Screen
-          name="Profile"
+          name="TabNavigator"
           component={TabNavigator}
           options={{
             screenOrientation: 'landscape',
@@ -41,14 +41,6 @@ const TabNavigator = (props) => (
     <Tab.Screen name="Tab2" component={Inner} />
     <Tab.Screen name="Tab3" component={Home} />
   </Tab.Navigator>
-);
-
-const NestedTab = createBottomTabNavigator();
-
-const NestedTabNavigator = (props) => (
-  <NestedTab.Navigator screensEnabled={true}>
-    <NestedTab.Screen name="Tab1" component={Home} />
-  </NestedTab.Navigator>
 );
 
 const InnerStack = createNativeStackNavigator();
@@ -71,9 +63,9 @@ function Home({navigation}) {
       >
       <View style={styles.leftTop} />
       <Button
-        title="Profile"
+        title="TabNavigator"
         onPress={() => {
-          navigation.push('Profile');
+          navigation.push('TabNavigator');
         }}
       />
       <Button
@@ -81,36 +73,6 @@ function Home({navigation}) {
         onPress={() => {
           navigation.setOptions({
             screenOrientation: Math.random() > 0.5 ? 'portrait' : 'landscape',
-          });
-          setYes(!yes);
-        }}
-      />
-    </ScrollView>
-  );
-}
-
-function Profile({navigation}) {
-  const [yes, setYes] = React.useState(true);
-  return (
-    <ScrollView style={{backgroundColor: 'red'}}>
-      <Text>Profile</Text>
-      <Button
-        title="Home"
-        onPress={() => {
-          navigation.navigate('Home');
-        }}
-      />
-      <Button
-        title="One more Profile"
-        onPress={() => {
-          navigation.push('Profile');
-        }}
-      />
-      <Button
-        title="status bar style"
-        onPress={() => {
-          navigation.setOptions({
-            statusBarHidden: yes,
           });
           setYes(!yes);
         }}

--- a/TestsExample/src/Test42.js
+++ b/TestsExample/src/Test42.js
@@ -69,9 +69,9 @@ function Home({navigation}) {
         }}
       />
       <Button
-        title="Pop to top"
+        title="Pop one modal"
         onPress={() => {
-          navigation.popToTop();
+          navigation.pop();
         }}
       />
       <Button

--- a/TestsExample/src/Test642.js
+++ b/TestsExample/src/Test642.js
@@ -18,7 +18,7 @@ export default function NativeNavigation() {
           name="Home"
           component={Home}
           options={{
-            statusBarStyle: 'auto',
+            statusBarStyle: 'light',
           }}
         />
         <Stack.Screen
@@ -78,9 +78,9 @@ function Home({navigation}) {
         }}
       />
       <Button
-        title="Go back"
+        title="Pop one modal"
         onPress={() => {
-          navigation.goBack();
+          navigation.pop();
         }}
       />
     </ScrollView>

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -154,12 +154,12 @@ A string that can be used as a fallback for `headerTitle`.
 
 Boolean indicating whether the navigation bar is translucent.
 
-### Status bar managment
+### Status bar and orientation managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. It requires:
 
-1. Enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
-2. Adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
+1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
+2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 
@@ -178,6 +178,21 @@ Defaults to `fade`.
 Boolean saying if the status bar for this screen is hidden.
 
 Defaults to `false`.
+
+#### `screenOrientation`
+
+Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
+
+- `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
+- `all`
+- `portrait`
+- `portrait_up`
+- `portrait_down`
+- `landscape`
+- `landscape_left`
+- `landscape_right`
+
+Defaults to `default`.
 
 ### Helpers
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -81,7 +81,8 @@
 {
   switch (stackPresentation) {
     case RNSScreenStackPresentationModal:
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       if (@available(iOS 13.0, *)) {
         _controller.modalPresentationStyle = UIModalPresentationAutomatic;
       } else {
@@ -94,7 +95,7 @@
     case RNSScreenStackPresentationFullScreenModal:
       _controller.modalPresentationStyle = UIModalPresentationFullScreen;
       break;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     case RNSScreenStackPresentationFormSheet:
       _controller.modalPresentationStyle = UIModalPresentationFormSheet;
       break;
@@ -135,7 +136,7 @@
     case RNSScreenStackAnimationFade:
       _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
       break;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     case RNSScreenStackAnimationFlip:
       _controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal;
       break;
@@ -149,11 +150,12 @@
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
-  #ifdef __IPHONE_13_0
-    if (@available(iOS 13.0, *)) {
-      _controller.modalInPresentation = !gestureEnabled;
-    }
-  #endif
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    _controller.modalInPresentation = !gestureEnabled;
+  }
+#endif
 
   _gestureEnabled = gestureEnabled;
 }

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -444,8 +444,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
+  [RNSScreenStackHeaderConfig updateWindowTraits];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }
 
@@ -489,8 +488,7 @@
   [_previousFirstResponder becomeFirstResponder];
   _previousFirstResponder = nil;
   // the correct Screen for appearance is set after the transition, same for orientation.
-  [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
+  [RNSScreenStackHeaderConfig updateWindowTraits];
 }
 
 @end

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -300,6 +300,7 @@
   return self;
 }
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   UIViewController *vc = [self findChildVCForConfig];
@@ -327,12 +328,23 @@
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
   UIViewController *vc = [self findChildVCForConfig];
-  if (vc != self && vc != nil) {
-    return vc.preferredStatusBarUpdateAnimation;
+  
+  if ([vc isKindOfClass:[RNSScreen class]]) {
+    RNSScreenStackHeaderConfig *config = [(RNSScreen *)vc findScreenConfig];
+    return config && config.statusBarAnimation ? config.statusBarAnimation : UIStatusBarAnimationFade;
   }
+  return UIStatusBarAnimationFade;
+}
 
-  RNSScreenStackHeaderConfig *config = [self findScreenConfig];
-  return config && config.statusBarAnimation ? config.statusBarAnimation : UIStatusBarAnimationFade;
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  UIViewController *vc = [self findChildVCForConfig];
+
+  if ([vc isKindOfClass:[RNSScreen class]]) {
+    RNSScreenStackHeaderConfig *config = [(RNSScreen *)vc findScreenConfig];
+    return config && config.screenOrientation ? config.screenOrientation : UIInterfaceOrientationMaskAllButUpsideDown;
+  }
+  return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 
 // if the returned vc is a child, it means that it can provide config;
@@ -343,12 +355,13 @@
 - (UIViewController *)findChildVCForConfig
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
-  if (self.presentedViewController != nil) {
+  if ([self.presentedViewController isKindOfClass:[RNSScreen class]]) {
     lastViewController = self.presentedViewController;
     // setting this makes the modal vc being asked for appearance,
     // so it doesn't matter what we return here since the modal's root screen will be asked
     lastViewController.modalPresentationCapturesStatusBarAppearance = YES;
-    return nil;
+    // for screen orientation, we need to start the search again from that modal
+    return [(RNSScreen *)lastViewController findChildVCForConfig] ?: lastViewController;
   }
 
   UIViewController *selfOrNil = [self findScreenConfig] != nil ? self : nil;
@@ -372,6 +385,7 @@
     }
   }
 }
+#endif
 
 - (RNSScreenStackHeaderConfig *)findScreenConfig
 {
@@ -429,6 +443,7 @@
 {
   [super viewWillAppear:animated];
   [RNSScreenStackHeaderConfig updateStatusBarAppearance];
+  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }
 
@@ -471,8 +486,9 @@
 {
   [_previousFirstResponder becomeFirstResponder];
   _previousFirstResponder = nil;
-  // the correct Screen for appearance is set after the transition
+  // the correct Screen for appearance is set after the transition, same for orientation.
   [RNSScreenStackHeaderConfig updateStatusBarAppearance];
+  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
 }
 
 @end

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -23,6 +23,7 @@
 
 @implementation RNScreensViewController
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   return [self findActiveChildVC];
@@ -36,7 +37,11 @@
 - (UIViewController *)childViewControllerForStatusBarHidden
 {
   return [self findActiveChildVC];
+}
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return [self findActiveChildVC].supportedInterfaceOrientations;
 }
 
 - (UIViewController *)findActiveChildVC
@@ -48,6 +53,7 @@
   }
   return [[self childViewControllers] lastObject];
 }
+#endif
 
 @end
 

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -324,6 +324,7 @@
       weakSelf.scheduleModalsUpdate = NO;
       [weakSelf updateContainer];
     }
+    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
   };
 
   void (^finish)(void) = ^{

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -324,6 +324,9 @@
       weakSelf.scheduleModalsUpdate = NO;
       [weakSelf updateContainer];
     }
+    // we trigger the update of orientation here because, when dismissing the modal from JS,
+    // neither `viewWillAppear` nor `presentationControllerDidDismiss` are called, same for status bar.
+    [RNSScreenStackHeaderConfig updateStatusBarAppearance];
     [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
   };
 

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -108,8 +108,7 @@
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
     // that can handle it when dismissing a modal, the same for orientation
-    [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
+    [RNSScreenStackHeaderConfig updateWindowTraits];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the
@@ -326,8 +325,7 @@
     }
     // we trigger the update of orientation here because, when dismissing the modal from JS,
     // neither `viewWillAppear` nor `presentationControllerDidDismiss` are called, same for status bar.
-    [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
+    [RNSScreenStackHeaderConfig updateWindowTraits];
   };
 
   void (^finish)(void) = ^{

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -19,6 +19,7 @@
 
 @implementation RNScreensNavigationController
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   return [self topViewController];
@@ -33,6 +34,12 @@
 {
   return [self topViewController];
 }
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return [self topViewController].supportedInterfaceOrientations;
+}
+#endif
 
 @end
 
@@ -100,8 +107,9 @@
   UIView *screenView = presentationController.presentedViewController.view;
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
-    // that can handle it when dismissing a modal
+    // that can handle it when dismissing a modal, the same for orientation
     [RNSScreenStackHeaderConfig updateStatusBarAppearance];
+    [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -246,7 +246,7 @@
       if (parentView.reactViewController) {
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
         _controller.interactivePopGestureRecognizer.delegate = self;
 #endif
         [controller didMoveToParentViewController:parentView.reactViewController];
@@ -346,10 +346,11 @@
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
 
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
           // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
-          next.overrideUserInterfaceStyle = _controller.overrideUserInterfaceStyle;
+          next.overrideUserInterfaceStyle = self->_controller.overrideUserInterfaceStyle;
         }
 #endif
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -48,6 +48,8 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 + (void)updateStatusBarAppearance;
++ (void)enforceDesiredDeviceOrientation;
++ (void)updateWindowTraits;
 
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
@@ -55,7 +57,6 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 + (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
 #endif
-+ (void)enforceDesiredDeviceOrientation;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -47,8 +47,6 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 #endif
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
-+ (void)updateStatusBarAppearance;
-+ (void)enforceDesiredDeviceOrientation;
 + (void)updateWindowTraits;
 
 #if !TARGET_OS_TV

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -38,13 +38,22 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) UISemanticContentAttribute direction;
+#if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
+@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
+#endif
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 + (void)updateStatusBarAppearance;
+#if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
++ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
++ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
++ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
+#endif
++ (void)enforceDesiredDeviceOrientation;
 
 @end
 
@@ -65,7 +74,10 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
 + (UISemanticContentAttribute)UISemanticContentAttribute:(id)json;
+#if !TARGET_OS_TV
 + (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
+#endif
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) UISemanticContentAttribute direction;
+
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
@@ -47,6 +48,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 + (void)updateStatusBarAppearance;
+
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
 + (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
@@ -74,6 +76,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
 + (UISemanticContentAttribute)UISemanticContentAttribute:(id)json;
+
 #if !TARGET_OS_TV
 + (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -531,12 +531,16 @@ API_AVAILABLE(ios(13.0)){
 {
 #if !TARGET_OS_TV
   [UIView animateWithDuration:0.4 animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     if (@available(iOS 13, *)) {
       UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
       if (firstWindow != nil) {
         [[firstWindow rootViewController] setNeedsStatusBarAppearanceUpdate];
       }
-    } else {
+    } else
+#endif
+    {
       [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
     }
   }];
@@ -610,12 +614,16 @@ API_AVAILABLE(ios(13.0)){
 #if !TARGET_OS_TV
   dispatch_async(dispatch_get_main_queue(), ^{
     UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAllButUpsideDown;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     if (@available(iOS 13, *)) {
       UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
       if (firstWindow != nil) {
         orientationMask = [firstWindow rootViewController].supportedInterfaceOrientations;
       }
-    } else {
+    } else
+#endif
+    {
       orientationMask = UIApplication.sharedApplication.keyWindow.rootViewController.supportedInterfaceOrientations;
     }
     UIInterfaceOrientation currentDeviceOrientation = [RNSScreenStackHeaderConfig interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
@@ -734,7 +742,7 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
       @"prominent": @(UIBlurEffectStyleProminent),
     }];
   }
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+#if !TARGET_OS_TV && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [blurEffects addEntriesFromDictionary:@{

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -655,6 +655,12 @@ API_AVAILABLE(ios(13.0)){
 #endif
 }
 
++ (void)updateWindowTraits
+{
+  [RNSScreenStackHeaderConfig updateStatusBarAppearance];
+  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
+}
+
 #if !TARGET_OS_TV
 // based on https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
 + (UIInterfaceOrientation)interfaceOrientation

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -126,7 +126,8 @@
   [navbar setTintColor:[config.color colorWithAlphaComponent:CGColorGetAlpha(config.color.CGColor) - 0.01]];
   [navbar setTintColor:config.color];
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     // font customized on the navigation item level, so nothing to do here
   } else
@@ -163,7 +164,7 @@
       [navbar setTitleTextAttributes:attrs];
     }
 
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     if (@available(iOS 11.0, *)) {
       if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleFontWeight || config.largeTitleColor || config.titleColor)) {
         NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
@@ -172,7 +173,7 @@
         }
         NSString *largeFamily = config.largeTitleFontFamily ?: nil;
         NSNumber *largeSize = config.largeTitleFontSize ?: @34;
-        NSNumber *largeWeight = config.largeTitleFontWeight ?: nil;
+        NSString *largeWeight = config.largeTitleFontWeight ?: nil;
         if (largeFamily || largeWeight) {
           largeAttrs[NSFontAttributeName] = [RCTFont updateFont:nil withFamily:largeFamily size:largeSize weight:largeWeight style:nil variant:nil scaleMultiplier:1.0];
         } else {
@@ -191,9 +192,7 @@
   [button setTitleTextAttributes:attrs forState:UIControlStateHighlighted];
   [button setTitleTextAttributes:attrs forState:UIControlStateDisabled];
   [button setTitleTextAttributes:attrs forState:UIControlStateSelected];
-  if (@available(iOS 9.0, *)) {
-    [button setTitleTextAttributes:attrs forState:UIControlStateFocused];
-  }
+  [button setTitleTextAttributes:attrs forState:UIControlStateFocused];
 }
 
 + (UIImage*)loadBackButtonImageInViewController:(UIViewController *)vc
@@ -250,7 +249,7 @@
             // in order for new back button image to be loaded we need to trigger another change
             // in back button props that'd make UIKit redraw the button. Otherwise the changes are
             // not reflected. Here we change back button visibility which is then immediately restored
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
             vc.navigationItem.hidesBackButton = YES;
 #endif
             [config updateViewControllerIfNeeded];
@@ -270,9 +269,10 @@
   [self updateViewController:vc withConfig:config animated:animated];
 }
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 + (UINavigationBarAppearance*)buildAppearance:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
-{
+API_AVAILABLE(ios(13.0)){
   UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
 
   if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
@@ -389,7 +389,7 @@
   }
 
   navitem.title = config.title;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize) {
     prevItem.backBarButtonItem = [[UIBarButtonItem alloc]
                                   initWithTitle:config.backTitle ?: prevItem.title
@@ -418,7 +418,8 @@
   }
 #endif
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
     navitem.standardAppearance = appearance;
@@ -435,7 +436,7 @@
   } else
 #endif
   {
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     // updating backIndicatotImage does not work when called during transition. On iOS pre 13 we need
     // to update it before the navigation starts.
     UIImage *backButtonImage = [self loadBackButtonImageInViewController:vc withConfig:config];
@@ -448,7 +449,7 @@
     }
 #endif
   }
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
   navitem.hidesBackButton = config.hideBackButton;
 #endif
   navitem.leftBarButtonItem = nil;
@@ -457,7 +458,7 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
         navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
 #endif
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
@@ -472,6 +473,9 @@
       case RNSScreenStackHeaderSubviewTypeCenter:
       case RNSScreenStackHeaderSubviewTypeTitle: {
         navitem.titleView = subview;
+        break;
+      }
+      case RNSScreenStackHeaderSubviewTypeBackButton: {
         break;
       }
     }
@@ -542,7 +546,8 @@
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     switch (statusBarStyle) {
       case RNSStatusBarStyleAuto:
@@ -576,9 +581,7 @@
   }
   return UIInterfaceOrientationUnknown;
 }
-#endif
 
-#if !TARGET_OS_TV
 + (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation
 {
    switch (deviceOrientation) {
@@ -595,9 +598,7 @@
        return UIInterfaceOrientationUnknown;
    }
 }
-#endif
 
-#if !TARGET_OS_TV
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation
 {
   return 1 << orientation;
@@ -650,6 +651,8 @@
 // based on https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
 + (UIInterfaceOrientation)interfaceOrientation
 {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
     if (firstWindow == nil) {
@@ -660,7 +663,9 @@
       return UIInterfaceOrientationUnknown;
     }
     return windowScene.interfaceOrientation;
-  } else {
+  } else
+#endif
+  {
     return UIApplication.sharedApplication.statusBarOrientation;
   }
 }
@@ -702,6 +707,7 @@ RCT_EXPORT_VIEW_PROPERTY(backButtonInCustomView, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
@@ -728,7 +734,8 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
       @"prominent": @(UIBlurEffectStyleProminent),
     }];
   }
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [blurEffects addEntriesFromDictionary:@{
       @"systemUltraThinMaterial": @(UIBlurEffectStyleSystemUltraThinMaterial),

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -5,6 +5,7 @@
 
 @implementation UIViewController (RNScreens)
 
+#if !TARGET_OS_TV
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarStyle
 {
   UIViewController *childVC = [self findChildRNScreensViewController];
@@ -21,6 +22,12 @@
 {
   UIViewController *childVC = [self findChildRNScreensViewController];
   return childVC ? childVC.preferredStatusBarUpdateAnimation : [self reactNativeScreensPreferredStatusBarUpdateAnimation];
+}
+
+- (UIInterfaceOrientationMask)reactNativeScreensSupportedInterfaceOrientations
+{
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ? childVC.supportedInterfaceOrientations : [self reactNativeScreensSupportedInterfaceOrientations];
 }
 
 - (UIViewController *)findChildRNScreensViewController
@@ -46,7 +53,11 @@
    
    method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
+
+   method_exchangeImplementations(class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
+                                  class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
   });
 }
+#endif
 
 @end

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -183,12 +183,12 @@ Defaults to `push`.
 
 A string that can be used as a fallback for `headerTitle`.
 
-### Status bar managment
+	### Status bar and orientation managment
 
-With `native-stack`, the status bar can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. It requires:
 
-1. Enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
-2. Adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
+1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
+2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
 #### `statusBarStyle`
 
@@ -207,6 +207,21 @@ Defaults to `fade`.
 Boolean saying if the status bar for this screen is hidden.
 
 Defaults to `false`.
+
+#### `screenOrientation`
+
+Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
+
+- `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
+- `all`
+- `portrait`
+- `portrait_up`
+- `portrait_down`
+- `landscape`
+- `landscape_left`
+- `landscape_right`
+
+Defaults to `default`.
 
 ### Events
 

--- a/src/createNativeStackNavigator.js
+++ b/src/createNativeStackNavigator.js
@@ -80,6 +80,7 @@ class StackView extends React.Component {
       headerTopInsetEnabled = true,
       hideShadow,
       largeTitle,
+      screenOrientation,
       statusBarAnimation,
       statusBarHidden,
       statusBarStyle,
@@ -115,6 +116,7 @@ class StackView extends React.Component {
         headerLargeTitleStyle && headerLargeTitleStyle.fontSize,
       largeTitleFontWeight:
         headerLargeTitleStyle && headerLargeTitleStyle.fontWeight,
+      screenOrientation,
       statusBarAnimation,
       statusBarHidden,
       statusBarStyle,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -214,6 +214,18 @@ declare module 'react-native-screens' {
      */
     largeTitleHideShadow?: boolean;
     /**
+     * @description Controls in which orientation should the screen appear.
+     * @type "default" - resolves to "all" without "portrait_down"
+     * @type "all" – all orientations are permitted
+     * @type "portrait" – portrait orientations are permitted
+     * @type "portrait_up" – right-side portrait orientation is permitted
+     * @type "portrait_down" – upside-down portrait orientation is permitted
+     * @type "landscape" – landscape orientations are permitted
+     * @type "landscape_left" – landscape-left orientation is permitted
+     * @type "landscape_right" – landscape-right orientation is permitted
+     */
+    screenOrientation?: ScreenOrientationTypes;
+    /**
      * @host (iOS only)
      * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
      */

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -220,6 +220,19 @@ export type NativeStackNavigationOptions = {
    */
   replaceAnimation?: ScreenProps['replaceAnimation'];
   /**
+   * In which orientation should the screen appear.
+   * The following values are currently supported:
+   * - "default" - resolves to "all" without "portrait_down".
+   * - "all" – all orientations are permitted
+   * - "portrait" – portrait orientations are permitted
+   * - "portrait_up" – right-side portrait orientation is permitted
+   * - "portrait_down" – upside-down portrait orientation is permitted
+   * - "landscape" – landscape orientations are permitted
+   * - "landscape_left" – landscape-left orientation is permitted
+   * - "landscape_right" – landscape-right orientation is permitted
+   */
+  screenOrientation?: ScreenStackHeaderConfigProps['screenOrientation'];
+  /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:
    * - "default" – uses a platform default animation

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -38,6 +38,7 @@ export default function HeaderConfig({
   headerTopInsetEnabled = true,
   headerTranslucent,
   route,
+  screenOrientation,
   statusBarAnimation,
   statusBarHidden,
   statusBarStyle,
@@ -78,6 +79,7 @@ export default function HeaderConfig({
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       largeTitleFontWeight={headerLargeTitleStyle.fontWeight}
       largeTitleHideShadow={headerLargeTitleHideShadow}
+      screenOrientation={screenOrientation}
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}


### PR DESCRIPTION
## Description

Added orientation management on iOS.

## Changes

Changed implementation details of `findChildVCForConfig` to always return the exact VC that should be used.
Added checks for `OS_TV`, where these APIs are unavailable.

## Test code and steps to reproduce

`Test42.js` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/index.d.ts
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes