### PR TITLE
feat: android orientation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,21 @@ Customize the weight of the font to be used for the large title.
 
 Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
 
+#### `screenOrientation`
+
+Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
+
+- `default` - on iOS, it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc). On Android, this lets the system decide the best orientation.
+- `all`
+- `portrait`
+- `portrait_up`
+- `portrait_down`
+- `landscape`
+- `landscape_left`
+- `landscape_right`
+
+Defaults to `default`.
+
 #### `statusBarAnimation` (iOS only)
 
 Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.

--- a/TestsExample/src/Test42.js
+++ b/TestsExample/src/Test42.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {ScrollView, StyleSheet, View, Button, Text} from 'react-native';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {createStackNavigator} from '@react-navigation/stack';
 
 const Stack = createNativeStackNavigator();
 
@@ -22,8 +23,8 @@ export default function NativeNavigation() {
           }}
         />
         <Stack.Screen
-          name="TabNavigator"
-          component={TabNavigator}
+          name="NestedNavigator"
+          component={NestedNavigator}
           options={{
             screenOrientation: 'landscape',
           }}
@@ -33,13 +34,14 @@ export default function NativeNavigation() {
   );
 }
 
+// change to createStackNavigator to test with stack in the middle
 const Tab = createBottomTabNavigator();
 
-const TabNavigator = (props) => (
+const NestedNavigator = (props) => (
   <Tab.Navigator screensEnabled={true}>
-    <Tab.Screen name="Tab1" component={Home} />
-    <Tab.Screen name="Tab2" component={Inner} />
-    <Tab.Screen name="Tab3" component={Home} />
+    <Tab.Screen name="Screen1" component={Home} />
+    <Tab.Screen name="Screen2" component={Inner} />
+    <Tab.Screen name="Screen3" component={Home} />
   </Tab.Navigator>
 );
 
@@ -63,9 +65,15 @@ function Home({navigation}) {
       >
       <View style={styles.leftTop} />
       <Button
-        title="TabNavigator"
+        title="NestedNavigator"
         onPress={() => {
-          navigation.push('TabNavigator');
+          navigation.push('NestedNavigator');
+        }}
+      />
+      <Button
+        title="Screen2"
+        onPress={() => {
+          navigation.navigate('Screen2');
         }}
       />
       <Button

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -150,6 +150,14 @@ public class Screen extends ViewGroup {
     }
   }
 
+  protected ScreenStackHeaderConfig getHeaderConfig() {
+    View child = getChildAt(0);
+    if (child instanceof ScreenStackHeaderConfig) {
+      return (ScreenStackHeaderConfig) child;
+    }
+    return null;
+  }
+
   /**
    * While transitioning this property allows to optimize rendering behavior on Android and provide
    * a correct blending options for the animated screen. It is turned on automatically by the container

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -151,8 +151,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     return mScreenFragments.get(index).getScreen();
   }
 
-  @Nullable
-  public Screen getTopScreen() {
+  public @Nullable Screen getTopScreen() {
     for (ScreenFragment screenFragment: mScreenFragments) {
       if (getActivityState(screenFragment) == Screen.ActivityState.ON_TOP) {
         return screenFragment.getScreen();

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -153,7 +153,6 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
 
   private void setFragmentManager(FragmentManager fm) {
     mFragmentManager = fm;
-    updateIfNeeded();
   }
 
   private void setupFragmentManager() {
@@ -169,6 +168,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
       setFragmentManager(screenFragment.getChildFragmentManager());
       mParentScreenFragment = screenFragment;
       mParentScreenFragment.registerChildScreenContainer(this);
+      updateIfNeeded();
       return;
     }
 
@@ -191,6 +191,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
               "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
     }
     setFragmentManager(((FragmentActivity) context).getSupportFragmentManager());
+    updateIfNeeded();
   }
 
   protected FragmentTransaction getOrCreateTransaction() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -328,6 +328,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     mFragmentManager.executePendingTransactions();
 
     performUpdate();
+    updateChildFragments();
   }
 
   protected void performUpdate() {
@@ -376,5 +377,12 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     }
 
     tryCommitTransaction();
+  }
+
+  protected void updateChildFragments() {
+    for (int i = 0, size = mScreenFragments.size(); i < size; i++) {
+      ScreenFragment screenFragment = mScreenFragments.get(i);
+      screenFragment.onContainerUpdate();
+    }
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -366,6 +366,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
 
     Screen topScreen = getTopScreen();
     if (topScreen != null) {
+      // if there is an "onTop" screen it means the transition has ended
       transitioning = false;
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -153,6 +153,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
 
   private void setFragmentManager(FragmentManager fm) {
     mFragmentManager = fm;
+    updateIfNeeded();
   }
 
   private void setupFragmentManager() {
@@ -168,7 +169,6 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
       setFragmentManager(screenFragment.getChildFragmentManager());
       mParentScreenFragment = screenFragment;
       mParentScreenFragment.registerChildScreenContainer(this);
-      updateIfNeeded();
       return;
     }
 
@@ -191,7 +191,6 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
               "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
     }
     setFragmentManager(((FragmentActivity) context).getSupportFragmentManager());
-    updateIfNeeded();
   }
 
   protected FragmentTransaction getOrCreateTransaction() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -382,7 +382,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
   protected void updateChildFragments() {
     for (int i = 0, size = mScreenFragments.size(); i < size; i++) {
       ScreenFragment screenFragment = mScreenFragments.get(i);
-      screenFragment.onContainerUpdate();
+      if (getActivityState(screenFragment) == Screen.ActivityState.ON_TOP) {
+        screenFragment.onContainerUpdate();
+      }
     }
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -36,7 +36,6 @@ public class ScreenFragment extends Fragment {
   }
 
   protected Screen mScreenView;
-  protected boolean mHasChildWithConfig = false;
   private List<ScreenContainer> mChildScreenContainers = new ArrayList<>();
 
   public ScreenFragment() {
@@ -66,9 +65,7 @@ public class ScreenFragment extends Fragment {
   }
 
   public void onContainerUpdate() {
-    mHasChildWithConfig = hasChildScreenWithConfig(getScreen());
-    markParentFragments(mHasChildWithConfig);
-    if (!mHasChildWithConfig) {
+    if (!hasChildScreenWithConfig(getScreen())) {
       // if there is no child with config, we look for a parent with config to set the orientation
       ScreenStackHeaderConfig config = findHeaderConfig();
       if (config != null && config.getScreenFragment().getActivity() != null) {
@@ -85,10 +82,8 @@ public class ScreenFragment extends Fragment {
         if (headerConfig != null) {
           return headerConfig;
         }
-        parent = ((Screen) parent).getContainer();
-      } else {
-        parent = parent.getParent();
       }
+      parent = parent.getParent();
     }
     return null;
   }
@@ -104,23 +99,11 @@ public class ScreenFragment extends Fragment {
       if (headerConfig != null) {
         return true;
       }
-      if (topScreen.getFragment().mHasChildWithConfig) {
+      if (hasChildScreenWithConfig(topScreen)) {
         return true;
       }
     }
     return false;
-  }
-
-  protected void markParentFragments(boolean hasChildWithConfig) {
-    ViewParent parent = getScreen().getContainer();
-    while (parent != null) {
-      if (parent instanceof Screen) {
-        ((Screen) parent).getFragment().mHasChildWithConfig = hasChildWithConfig;
-        parent = ((Screen) parent).getContainer();
-      } else {
-        parent = parent.getParent();
-      }
-    }
   }
 
   public List<ScreenContainer> getChildScreenContainers() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -65,14 +65,16 @@ public class ScreenFragment extends Fragment {
   }
 
   public void onContainerUpdate() {
-    ScreenStackHeaderConfig config = findHeaderConfig();
-    boolean configInChild = hasChildScreenWithConfig(getScreen());
-    if (!configInChild && config != null && config.getScreenFragment().getActivity() != null) {
+    if (!hasChildScreenWithConfig(getScreen())) {
       // if there is no child with config, we look for a parent with config to set the orientation
-      config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
+      ScreenStackHeaderConfig config = findHeaderConfig();
+      if (config != null && config.getScreenFragment().getActivity() != null) {
+        config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
+      }
     }
   }
 
+  @Nullable
   private ScreenStackHeaderConfig findHeaderConfig() {
     ViewParent parent = getScreen().getContainer();
     while (parent != null) {
@@ -92,26 +94,13 @@ public class ScreenFragment extends Fragment {
       return false;
     }
     for (ScreenContainer sc : screen.getFragment().getChildScreenContainers()) {
-      if (sc instanceof ScreenStack) {
-        // we check only the top screen of stack for header config
-        Screen topScreen = ((ScreenStack) sc).getTopScreen();
-        ScreenStackHeaderConfig headerConfig = topScreen != null ? topScreen.getHeaderConfig(): null;
-        if (headerConfig != null) {
-          return true;
-        }
-        if (hasChildScreenWithConfig(topScreen)) {
-          return true;
-        }
-      } else {
-        // in ScreenContainer we check only the screen that is on top
-        for (int i = 0; i < sc.getScreenCount(); i++) {
-          Screen childScreen = sc.getScreenAt(i);
-          if (childScreen.getActivityState() == Screen.ActivityState.ON_TOP) {
-            if (hasChildScreenWithConfig(childScreen)) {
-              return true;
-            }
-          }
-        }
+      Screen topScreen = sc.getTopScreen();
+      ScreenStackHeaderConfig headerConfig = topScreen != null ? topScreen.getHeaderConfig(): null;
+      if (headerConfig != null) {
+        return true;
+      }
+      if (hasChildScreenWithConfig(topScreen)) {
+        return true;
       }
     }
     return false;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -66,6 +66,32 @@ public class ScreenFragment extends Fragment {
     return mScreenView;
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+
+    ScreenStackHeaderConfig config = findHeaderConfig();
+    if (config != null && config.getScreenFragment().getActivity() != null) {
+      config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
+    }
+  }
+
+  private ScreenStackHeaderConfig findHeaderConfig() {
+    ViewParent parent = getScreen();
+    while (parent != null) {
+      if (parent instanceof Screen) {
+        for (int i = 0; i < ((Screen) parent).getChildCount(); i++) {
+          View child = ((Screen) parent).getChildAt(i);
+          if (child instanceof ScreenStackHeaderConfig) {
+            return (ScreenStackHeaderConfig) child;
+          }
+        }
+      }
+      parent = parent.getParent();
+    }
+    return null;
+  }
+
   protected void dispatchOnWillAppear() {
     ((ReactContext) mScreenView.getContext())
         .getNativeModule(UIManagerModule.class)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -74,8 +74,7 @@ public class ScreenFragment extends Fragment {
     }
   }
 
-  @Nullable
-  private ScreenStackHeaderConfig findHeaderConfig() {
+  private @Nullable ScreenStackHeaderConfig findHeaderConfig() {
     ViewParent parent = getScreen().getContainer();
     while (parent != null) {
       if (parent instanceof Screen) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -66,10 +66,7 @@ public class ScreenFragment extends Fragment {
     return mScreenView;
   }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-
+  public void onContainerUpdate() {
     ScreenStackHeaderConfig config = findHeaderConfig();
     if (config != null && config.getScreenFragment().getActivity() != null) {
       config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -94,6 +94,7 @@ public class ScreenFragment extends Fragment {
       return false;
     }
     for (ScreenContainer sc : screen.getFragment().getChildScreenContainers()) {
+      // we check only the top screen for header config
       Screen topScreen = sc.getTopScreen();
       ScreenStackHeaderConfig headerConfig = topScreen != null ? topScreen.getHeaderConfig(): null;
       if (headerConfig != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -68,7 +68,7 @@ public class ScreenFragment extends Fragment {
 
   public void onContainerUpdate() {
     ScreenStackHeaderConfig config = findHeaderConfig();
-    boolean configInChild = checkIfChildWithConfig(getScreen());
+    boolean configInChild = isChildScreenWithConfig(getScreen());
     if (!configInChild && config != null && config.getScreenFragment().getActivity() != null) {
       // if there is no child with config, we look for a parent with config to set the orientation
       config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
@@ -91,16 +91,18 @@ public class ScreenFragment extends Fragment {
     return null;
   }
 
-  protected static boolean checkIfChildWithConfig(View view) {
-    if (view instanceof ViewGroup) {
-      for (int i = 0; i < ((ViewGroup) view).getChildCount(); i++) {
-        View child = ((ViewGroup) view).getChildAt(i);
-        if (child instanceof ScreenStackHeaderConfig) {
-          return true;
-        } else {
-          if (checkIfChildWithConfig(child)) {
+  protected boolean isChildScreenWithConfig(Screen screen) {
+    for (ScreenContainer sc : mChildScreenContainers) {
+      if (sc.getScreenCount() > 0) {
+        Screen topScreen = sc.getScreenAt(sc.getScreenCount() - 1);
+        for (int i = 0; i < topScreen.getChildCount(); i++) {
+          View child = screen.getChildAt(i);
+          if (child instanceof ScreenStackHeaderConfig) {
             return true;
           }
+        }
+        if (isChildScreenWithConfig(topScreen)) {
+          return true;
         }
       }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -68,13 +68,15 @@ public class ScreenFragment extends Fragment {
 
   public void onContainerUpdate() {
     ScreenStackHeaderConfig config = findHeaderConfig();
-    if (config != null && config.getScreenFragment().getActivity() != null) {
+    boolean configInChild = checkIfChildWithConfig(getScreen());
+    if (!configInChild && config != null && config.getScreenFragment().getActivity() != null) {
+      // if there is no child with config, we look for a parent with config to set the orientation
       config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
     }
   }
 
   private ScreenStackHeaderConfig findHeaderConfig() {
-    ViewParent parent = getScreen();
+    ViewParent parent = getScreen().getContainer();
     while (parent != null) {
       if (parent instanceof Screen) {
         for (int i = 0; i < ((Screen) parent).getChildCount(); i++) {
@@ -87,6 +89,22 @@ public class ScreenFragment extends Fragment {
       parent = parent.getParent();
     }
     return null;
+  }
+
+  protected static boolean checkIfChildWithConfig(View view) {
+    if (view instanceof ViewGroup) {
+      for (int i = 0; i < ((ViewGroup) view).getChildCount(); i++) {
+        View child = ((ViewGroup) view).getChildAt(i);
+        if (child instanceof ScreenStackHeaderConfig) {
+          return true;
+        } else {
+          if (checkIfChildWithConfig(child)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   protected void dispatchOnWillAppear() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -95,7 +95,7 @@ public class ScreenFragment extends Fragment {
       if (sc instanceof ScreenStack) {
         // we check only the top screen of stack for header config
         Screen topScreen = ((ScreenStack) sc).getTopScreen();
-        ScreenStackHeaderConfig headerConfig = topScreen.getHeaderConfig();
+        ScreenStackHeaderConfig headerConfig = topScreen != null ? topScreen.getHeaderConfig(): null;
         if (headerConfig != null) {
           return true;
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -36,6 +36,7 @@ public class ScreenFragment extends Fragment {
   }
 
   protected Screen mScreenView;
+  protected boolean mHasChildWithConfig = false;
   private List<ScreenContainer> mChildScreenContainers = new ArrayList<>();
 
   public ScreenFragment() {
@@ -65,7 +66,9 @@ public class ScreenFragment extends Fragment {
   }
 
   public void onContainerUpdate() {
-    if (!hasChildScreenWithConfig(getScreen())) {
+    mHasChildWithConfig = hasChildScreenWithConfig(getScreen());
+    markParentFragments(mHasChildWithConfig);
+    if (!mHasChildWithConfig) {
       // if there is no child with config, we look for a parent with config to set the orientation
       ScreenStackHeaderConfig config = findHeaderConfig();
       if (config != null && config.getScreenFragment().getActivity() != null) {
@@ -82,8 +85,10 @@ public class ScreenFragment extends Fragment {
         if (headerConfig != null) {
           return headerConfig;
         }
+        parent = ((Screen) parent).getContainer();
+      } else {
+        parent = parent.getParent();
       }
-      parent = parent.getParent();
     }
     return null;
   }
@@ -99,11 +104,23 @@ public class ScreenFragment extends Fragment {
       if (headerConfig != null) {
         return true;
       }
-      if (hasChildScreenWithConfig(topScreen)) {
+      if (topScreen.getFragment().mHasChildWithConfig) {
         return true;
       }
     }
     return false;
+  }
+
+  protected void markParentFragments(boolean hasChildWithConfig) {
+    ViewParent parent = getScreen().getContainer();
+    while (parent != null) {
+      if (parent instanceof Screen) {
+        ((Screen) parent).getFragment().mHasChildWithConfig = hasChildWithConfig;
+        parent = ((Screen) parent).getContainer();
+      } else {
+        parent = parent.getParent();
+      }
+    }
   }
 
   public List<ScreenContainer> getChildScreenContainers() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -261,9 +261,12 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     if (mTopScreen != null) {
       setupBackHandlerIfNeeded(mTopScreen);
     }
+  }
 
+  @Override
+  protected void updateChildFragments() {
     for (ScreenStackFragment screen : mStack) {
-      screen.onStackUpdate();
+      screen.onContainerUpdate();
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -54,6 +55,8 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     markUpdated();
   }
 
+  @Nullable
+  @Override
   public Screen getTopScreen() {
     return mTopScreen != null ? mTopScreen.getScreen() : null;
   }
@@ -264,7 +267,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   }
 
   @Override
-  protected void updateChildFragments() {
+  protected void notifyContainerUpdate() {
     for (ScreenStackFragment screen : mStack) {
       screen.onContainerUpdate();
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -55,9 +55,8 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     markUpdated();
   }
 
-  @Nullable
   @Override
-  public Screen getTopScreen() {
+  public @Nullable Screen getTopScreen() {
     return mTopScreen != null ? mTopScreen.getScreen() : null;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -111,9 +111,9 @@ public class ScreenStackFragment extends ScreenFragment {
 
   @Override
   public void onContainerUpdate() {
-    View child = mScreenView.getChildAt(0);
-    if (child instanceof ScreenStackHeaderConfig) {
-      ((ScreenStackHeaderConfig) child).onUpdate();
+    ScreenStackHeaderConfig headerConfig = getHeaderConfig(getScreen());
+    if (headerConfig != null) {
+      headerConfig.onUpdate();
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -109,7 +109,8 @@ public class ScreenStackFragment extends ScreenFragment {
     }
   }
 
-  public void onStackUpdate() {
+  @Override
+  public void onContainerUpdate() {
     View child = mScreenView.getChildAt(0);
     if (child instanceof ScreenStackHeaderConfig) {
       ((ScreenStackHeaderConfig) child).onUpdate();

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -111,7 +111,7 @@ public class ScreenStackFragment extends ScreenFragment {
 
   @Override
   public void onContainerUpdate() {
-    ScreenStackHeaderConfig headerConfig = getHeaderConfig(getScreen());
+    ScreenStackHeaderConfig headerConfig = getScreen().getHeaderConfig();
     if (headerConfig != null) {
       headerConfig.onUpdate();
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -172,8 +172,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // orientation
-    if (getScreen() == null || !getScreenFragment().isChildScreenWithConfig(getScreen())) {
-      // we check if there is no child that provides config, since then we shouldn't change orientation here
+    if (getScreen() == null || getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen().getChildAt(1))) {
+      // we check if there is no child that provides config, since then we shouldn't change orientation here (child with index 0 is this header config)
       activity.setRequestedOrientation(mScreenOrientation);
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -172,8 +172,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // orientation
-    if (!ScreenFragment.checkIfChildWithConfig(getScreen() != null ? getScreen().getChildAt(1) : null)) {
-      // we check if there is no child that provides config, since then we shouldn't change orientation here (child with index 0 is this header config)
+    if (getScreen() == null || !getScreenFragment().isChildScreenWithConfig(getScreen())) {
+      // we check if there is no child that provides config, since then we shouldn't change orientation here
       activity.setRequestedOrientation(mScreenOrientation);
     }
 
@@ -353,7 +353,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
-  public int getScreenOrientation(){
+  public int getScreenOrientation() {
     return mScreenOrientation;
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -40,6 +40,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
   private boolean mIsTopInsetEnabled = true;
+  private boolean mIsTranslucent;	
   private int mTintColor;
   private final Toolbar mToolbar;
   private int mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens;
 
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -39,9 +40,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
   private boolean mIsTopInsetEnabled = true;
-  private boolean mIsTranslucent;
   private int mTintColor;
   private final Toolbar mToolbar;
+  private int mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
 
   private boolean mIsAttachedToWindow = false;
 
@@ -136,7 +137,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
-  private ScreenStackFragment getScreenFragment() {
+  protected ScreenStackFragment getScreenFragment() {
     ViewParent screen = getParent();
     if (screen instanceof Screen) {
       Fragment fragment = ((Screen) screen).getFragment();
@@ -168,6 +169,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
         mToolbar.setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
       }
     }
+
+    // orientation
+    activity.setRequestedOrientation(mScreenOrientation);
 
     if (mIsHidden) {
       if (mToolbar.getParent() != null) {
@@ -345,6 +349,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
+  public int getScreenOrientation(){
+    return mScreenOrientation;
+  }
+
   public void setTitle(String title) {
     mTitle = title;
   }
@@ -391,5 +399,39 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setDirection(String direction) {
     mDirection = direction;
+  }
+
+  public void setScreenOrientation(String screenOrientation) {
+    if (screenOrientation == null) {
+      mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+      return;
+    }
+
+    switch (screenOrientation) {
+      case "all":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+        break;
+      case "portrait":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
+        break;
+      case "portrait_up":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+        break;
+      case "portrait_down":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+        break;
+      case "landscape":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+        break;
+      case "landscape_left":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+        break;
+      case "landscape_right":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+        break;
+      default:
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+        break;
+    }
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -173,7 +173,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     // orientation
     if (getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen())) {
-      // we check if there is no child that provides config, since then we shouldn't change orientation here (child with index 0 is this header config)
+      // we check if there is no child that provides config, since then we shouldn't change orientation here
       activity.setRequestedOrientation(mScreenOrientation);
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -172,7 +172,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // orientation
-    if (getScreen() == null || getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen().getChildAt(1))) {
+    if (getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen())) {
       // we check if there is no child that provides config, since then we shouldn't change orientation here (child with index 0 is this header config)
       activity.setRequestedOrientation(mScreenOrientation);
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -14,6 +14,7 @@ import android.view.ViewParent;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -138,7 +139,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
-  protected ScreenStackFragment getScreenFragment() {
+  protected @Nullable ScreenStackFragment getScreenFragment() {
     ViewParent screen = getParent();
     if (screen instanceof Screen) {
       Fragment fragment = ((Screen) screen).getFragment();
@@ -175,6 +176,9 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen())) {
       // we check if there is no child that provides config, since then we shouldn't change orientation here
       activity.setRequestedOrientation(mScreenOrientation);
+      if (getScreenFragment() != null) {
+        getScreenFragment().markParentFragments(true);
+      }
     }
 
     if (mIsHidden) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -172,7 +172,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // orientation
-    activity.setRequestedOrientation(mScreenOrientation);
+    if (!ScreenFragment.checkIfChildWithConfig(getScreen() != null ? getScreen().getChildAt(1) : null)) {
+      // we check if there is no child that provides config, since then we shouldn't change orientation here (child with index 0 is this header config)
+      activity.setRequestedOrientation(mScreenOrientation);
+    }
 
     if (mIsHidden) {
       if (mToolbar.getParent() != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -176,9 +176,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen())) {
       // we check if there is no child that provides config, since then we shouldn't change orientation here
       activity.setRequestedOrientation(mScreenOrientation);
-      if (getScreenFragment() != null) {
-        getScreenFragment().markParentFragments(true);
-      }
     }
 
     if (mIsHidden) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -40,7 +40,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
   private boolean mIsTopInsetEnabled = true;
-  private boolean mIsTranslucent;	
+  private boolean mIsTranslucent;
   private int mTintColor;
   private final Toolbar mToolbar;
   private int mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -134,6 +134,10 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setDirection(direction);
   }
 
+  @ReactProp(name = "screenOrientation")
+  public void setScreenOrientation(ScreenStackHeaderConfig config, String screenOrientation) {
+    config.setScreenOrientation(screenOrientation);
+  }
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -180,21 +180,23 @@ With `native-stack`, the status bar and screen orientation can be managed by `UI
 1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
 2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
+On Android, no additional setup is required.
+
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Possible values: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`.
+Sets the status bar color (similar to the `StatusBar` component). Possible values: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`. Only supported on iOS.
 
 Defaults to `auto`.
 
 #### `statusBarAnimation`
 
-Sets the status bar animation (similar to the `StatusBar` component). Possible values: `fade`, `none`, `slide`.
+Sets the status bar animation (similar to the `StatusBar` component). Possible values: `fade`, `none`, `slide`. Only supported on iOS.
 
 Defaults to `fade`.
 
 #### `statusBarHidden`
 
-Boolean saying if the status bar for this screen is hidden.
+Boolean saying if the status bar for this screen is hidden. Only supported on iOS.
 
 Defaults to `false`.
 
@@ -202,7 +204,7 @@ Defaults to `false`.
 
 Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
 
-- `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
+- `default` - on iOS, it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc). On Android, this lets the system decide the best orientation.
 - `all`
 - `portrait`
 - `portrait_up`

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -175,7 +175,7 @@ Boolean indicating whether the navigation bar is translucent.
 
 ### Status bar and orientation managment
 
-With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. On Android, the screen orientation can be managed by `FragmentActivity`. On iOS, it requires:
 
 1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
 2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -212,7 +212,7 @@ A string that can be used as a fallback for `headerTitle`.
 
 ### Status bar and orientation managment
 
-With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. It requires:
+With `native-stack`, the status bar and screen orientation can be managed by `UIViewController` on iOS. On Android, the screen orientation can be managed by `FragmentActivity`. On iOS, it requires:
 
 1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
 2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -217,21 +217,23 @@ With `native-stack`, the status bar and screen orientation can be managed by `UI
 1. For status bar managment: enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file (it disables the option to use React Native's `StatusBar` component). 
 2. For both status bar and orientation managment: adding `#import <RNScreens/UIViewController+RNScreens.h>` in your project's `AppDelegate.m` (you can see this change applied in the `AppDelegate.m` of `Example` project).
 
+On Android, no additional setup is required.
+
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Possible values: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`.
+Sets the status bar color (similar to the `StatusBar` component). Possible values: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`. Only supported on iOS.
 
 Defaults to `auto`.
 
 #### `statusBarAnimation`
 
-Sets the status bar animation (similar to the `StatusBar` component). Possible values: `fade`, `none`, `slide`.
+Sets the status bar animation (similar to the `StatusBar` component). Possible values: `fade`, `none`, `slide`. Only supported on iOS.
 
 Defaults to `fade`.
 
 #### `statusBarHidden`
 
-Boolean saying if the status bar for this screen is hidden.
+Boolean saying if the status bar for this screen is hidden. Only supported on iOS.
 
 Defaults to `false`.
 
@@ -239,7 +241,7 @@ Defaults to `false`.
 
 Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
 
-- `default` - it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc)
+- `default` - on iOS, it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc). On Android, this lets the system decide the best orientation.
 - `all`
 - `portrait`
 - `portrait_up`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -216,7 +216,7 @@ declare module 'react-native-screens' {
     largeTitleHideShadow?: boolean;
     /**
      * @description Controls in which orientation should the screen appear.
-     * @type "default" - resolves to "all" without "portrait_down"
+     * @type "default" - on iOS, it resolves to "all" without "portrait_down" and on Android it lets the system decide the best orientation
      * @type "all" – all orientations are permitted
      * @type "portrait" – portrait orientations are permitted
      * @type "portrait_up" – right-side portrait orientation is permitted

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -223,7 +223,7 @@ export type NativeStackNavigationOptions = {
   /**
    * In which orientation should the screen appear.
    * The following values are currently supported:
-   * - "default" - resolves to "all" without "portrait_down".
+   * - "default" - resolves to "all" without "portrait_down" on iOS. On Android, this lets the system decide the best orientation.
    * - "all" – all orientations are permitted
    * - "portrait" – portrait orientations are permitted
    * - "portrait_up" – right-side portrait orientation is permitted


### PR DESCRIPTION
## Description

`SC` will stand for `ScreenContainer`. Added orientation management on Android. On every update of `native-stack` or navigators with using `SC` we check if there is orientation change needed. We do it by checking the top `Screen` and, if there is no child `HeaderConfig` (which has the priority) and there is a `HeaderConfig` above the `Screen`, changing the orientation according to it. If there are no child `SC`s in the `Screen` in `onContainerUpdate` even though the `Screen` has a child `SC`, it means that the child has not fired `onAttachedToWindow`, where the registration of child `SC` happens. It is not a problem, because then the correct update of orientation will be fired in `onAttachedToWindow` of the child `Screen` `HeaderConfig`, if it exists.

## Changes

- Added `getHeaderConfig` for unified checking for if `Screen` has a header
- Abstracted `updateChildFragments` method for updating `SC`/`ScreenStack` children on update
- Added `hasChildScreenWithConfig` that parses child `SCs` and checks if any of their `Screens` have `HeaderConfig`

## Test code and steps to reproduce

`Test42.js` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/index.d.ts
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes