### PR TITLE
fix: silence warning

### DIFF
--- a/src/native-stack/views/FontProcessor.expo.tsx
+++ b/src/native-stack/views/FontProcessor.expo.tsx
@@ -1,4 +1,5 @@
-// this file extension is parsed only in managed workflow, so `expo-font` should be always available there
+// @ts-ignore this file extension is parsed only in managed workflow, so `expo-font` should be always available there
+// eslint-disable-next-line import/no-unresolved
 import { processFontFamily } from 'expo-font';
 
 export function processFonts(


### PR DESCRIPTION
Added `@ts-ignore` and `eslint-disable-next-line import/no-unresolved` since `.expo.tsx` extension should be parsed only in Expo managed workflow, so `expo-font` should be always available there.