### PR TITLE
feat: remove useScreens and outdated code

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -304,7 +304,7 @@ PODS:
     - React
   - RNReanimated (1.10.1):
     - React
-  - RNScreens (2.13.0):
+  - RNScreens (2.14.0):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
-  RNScreens: 13f23e5498fb4aa749d19a5eda7f8792fbb9d01f
+  RNScreens: 2e278a90eb15092ed261d4f2271e3fc9b60d08d4
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,6 @@ declare module 'react-native-screens' {
     ViewProps,
   } from 'react-native';
 
-  export function useScreens(shouldUseScreens?: boolean): void;
   export function enableScreens(shouldEnableScreens?: boolean): void;
   export function screensEnabled(): boolean;
 

--- a/src/index.native.js
+++ b/src/index.native.js
@@ -7,20 +7,12 @@ import {
   UIManager,
   View,
 } from 'react-native';
-import { version } from 'react-native/Libraries/Core/ReactNativeVersion';
 
 let ENABLE_SCREENS = false;
 
-// UIManager[`${moduleName}`] is deprecated in RN 0.58 and `getViewManagerConfig` is added.
-// We can remove this when we drop support for RN < 0.58.
-const getViewManagerConfigCompat = (name) =>
-  typeof UIManager.getViewManagerConfig !== 'undefined'
-    ? UIManager.getViewManagerConfig(name)
-    : UIManager[name];
-
 function enableScreens(shouldEnableScreens = true) {
   ENABLE_SCREENS = shouldEnableScreens;
-  if (ENABLE_SCREENS && !getViewManagerConfigCompat('RNSScreen')) {
+  if (ENABLE_SCREENS && !UIManager.getViewManagerConfig('RNSScreen')) {
     console.error(
       `Screen native module hasn't been linked. Please check the react-native-screens README for more details`
     );
@@ -29,12 +21,6 @@ function enableScreens(shouldEnableScreens = true) {
 
 // const that tells if the library should use new implementation, will be undefined for older versions
 const shouldUseActivityState = true;
-
-// we should remove this at some point
-function useScreens(shouldUseScreens = true) {
-  console.warn('Method `useScreens` is deprecated, please use `enableScreens`');
-  enableScreens(shouldUseScreens);
-}
 
 function screensEnabled() {
   return ENABLE_SCREENS;
@@ -111,37 +97,20 @@ class Screen extends React.Component {
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
 
-      // When using RN from master version is 0.0.0
-      if (version.minor >= 57 || version.minor === 0) {
-        let { enabled, active, activityState, ...rest } = this.props;
-        if (active !== undefined && activityState === undefined) {
-          console.warn(
-            'It appears that you are using old version of react-navigation library. Please update @react-navigation/bottom-tabs, @react-navigation/stack and @react-navigation/drawer to version 5.10.0 or above to take full advantage of new functionality added to react-native-screens'
-          );
-          activityState = active !== 0 ? 2 : 0; // in the new version, we need one of the screens to have value of 2 after the transition
-        }
-        return (
-          <AnimatedNativeScreen
-            {...rest}
-            activityState={activityState}
-            ref={this.setRef}
-          />
+      let { enabled, active, activityState, ...rest } = this.props;
+      if (active !== undefined && activityState === undefined) {
+        console.warn(
+          'It appears that you are using old version of react-navigation library. Please update @react-navigation/bottom-tabs, @react-navigation/stack and @react-navigation/drawer to version 5.10.0 or above to take full advantage of new functionality added to react-native-screens'
         );
-      } else {
-        // On RN version below 0.57 we need to wrap screen's children with an
-        // additional View because of a bug fixed in react-native/pull/20658 which
-        // was preventing a view from having both styles and some other props being
-        // "animated" (using Animated native driver)
-        const { style, children, enabled, ...rest } = this.props;
-        return (
-          <AnimatedNativeScreen
-            {...rest}
-            ref={this.setRef}
-            style={StyleSheet.absoluteFill}>
-            <Animated.View style={style}>{children}</Animated.View>
-          </AnimatedNativeScreen>
-        );
+        activityState = active !== 0 ? 2 : 0; // in the new version, we need one of the screens to have value of 2 after the transition
       }
+      return (
+        <AnimatedNativeScreen
+          {...rest}
+          activityState={activityState}
+          ref={this.setRef}
+        />
+      );
     }
   }
 }
@@ -227,7 +196,6 @@ module.exports = {
   ScreenStackHeaderCenterView,
 
   enableScreens,
-  useScreens,
   screensEnabled,
   shouldUseActivityState,
 };


### PR DESCRIPTION
## Description

Updated the code by removing the deprecated method and code checking for unsupported RN versions (we support RN >= 0.60). It is a breaking change due to the removal of `useScreens`.

## Changes

Removed `useScreens`, code checking for `UIManager[name]` and `Screen` implementation for RN < 0.57.

## Checklist

- [x] Updated TS types
- [x] Ensured that CI passes
