### PR TITLE
Fix relayout loop on header show/hide change

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -36,15 +36,15 @@
 
 - (void)reactSetFrame:(CGRect)frame
 {
-  if (![self.reactViewController.parentViewController
-        isKindOfClass:[UINavigationController class]]) {
+  UIViewController *parentVC = self.reactViewController.parentViewController;
+  if (parentVC != nil && ![parentVC isKindOfClass:[UINavigationController class]]) {
     [super reactSetFrame:frame];
   }
   // when screen is mounted under UINavigationController it's size is controller
   // by the navigation controller itself. That is, it is set to fill space of
   // the controller. In that case we ignore react layout system from managing
-  // the screen dimentions and we wait for the screen VC to update and then we
-  // pass the dimentions to ui view manager to take into account when laying out
+  // the screen dimensions and we wait for the screen VC to update and then we
+  // pass the dimensions to ui view manager to take into account when laying out
   // subviews
 }
 
@@ -325,7 +325,7 @@
   if (vc != self && vc != nil) {
     return vc.preferredStatusBarUpdateAnimation;
   }
-  
+
   RNSScreenStackHeaderConfig *config = [self findScreenConfig];
   return config && config.statusBarAnimation ? config.statusBarAnimation : UIStatusBarAnimationFade;
 }
@@ -345,7 +345,7 @@
     lastViewController.modalPresentationCapturesStatusBarAppearance = YES;
     return nil;
   }
-  
+
   UIViewController *selfOrNil = [self findScreenConfig] != nil ? self : nil;
   if (lastViewController == nil) {
     return selfOrNil;
@@ -382,7 +382,14 @@
 {
   [super viewDidLayoutSubviews];
 
-  if (!CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
+  // The below code makes the screen view adapt dimensions provided by the system. We take these
+  // into account only when the view is mounted under UINavigationController in which case system
+  // provides additional padding to account for possible header, and in the case when screen is
+  // shown as a native modal, as the final dimensions of the modal on iOS 12+ are shorter than the
+  // screen size
+  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[UINavigationController class]];
+  BOOL isPresentedAsNativeModal = self.parentViewController == nil && self.presentingViewController != nil;
+  if ((isDisplayedWithinUINavController || isPresentedAsNativeModal) && !CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
     _lastViewFrame = self.view.frame;
     [((RNSScreenView *)self.viewIfLoaded) updateBounds];
   }


### PR DESCRIPTION
## Description

This PR fixes a rarely occuring problem with a re-layout loop on header visibility change. The problem would surface in situation when we have a bottom tabs container inside of a stack, then we'd update header visibility such that it is hidden on some tabs and not on the other. As a result in some cases the screens code would end up re-layouting the screen with header disabled. The loop was caused by the code in RNSScreen where we call `updateBounds` as a result of native layout but also notify uimanager about view bounds change with `setSize` method. 

This PR breaks the loop by preventing screen container (not in stack) from calling `updateBounds`. We only need to notify uimanager about container size when the screen is rendered under navigation controller or as a native modal.

## Changes

We update the logic in RNScreen to prevent `uiManager setSize` call via `updateBounds` to be executed unless the screen is rendered directly by navigation controller or as a native modal. Otherwise the size should be controller by react-native layout and we should never modify the size in uimanager.

## Test code and steps to reproduce

Apparently I have not been able to find an easy reproducable case for this issue. But can confirm it has fixed an issue for one of the apps I'm working on.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
