### PR TITLE
fix: check if activityState is nil

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -27,7 +27,14 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
   }
 
   @ReactProp(name = "activityState")
-  public void setActivityState(Screen view, int activityState) {
+  public void setActivityState(Screen view, Integer activityState) {
+    if (activityState == null) {
+      // Null will be provided when activityState is set as an animated value and we change
+      // it from JS to be a plain value (non animated).
+      // In this scenario we first trigger the code which resets it to the default, which is null.
+      // In that case we want to ignore such update because soon after we get the actual, valid state passed from JS.
+      return;
+    }
     if (activityState == 0) {
       view.setActivityState(Screen.ActivityState.INACTIVE);
     } else if (activityState == 1) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -31,8 +31,8 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     if (activityState == null) {
       // Null will be provided when activityState is set as an animated value and we change
       // it from JS to be a plain value (non animated).
-      // In this scenario we first trigger the code which resets it to the default, which is null.
-      // In that case we want to ignore such update because soon after we get the actual, valid state passed from JS.
+      // In case when null is received, we want to ignore such value and not make
+      // any updates as the actual non-null value will follow immediately.
       return;
     }
     if (activityState == 0) {

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -58,9 +58,10 @@
   [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
-- (void)setActivityState:(int)activityState
+- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
-  if (activityState != _activityState) {
+  int activityState = [activityStateOrNil intValue];
+  if (activityStateOrNil != nil && activityState != _activityState) {
     _activityState = activityState;
     [_reactSuperview markChildUpdated];
   }
@@ -476,7 +477,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_VIEW_PROPERTY(activityState, int)
+RCT_REMAP_VIEW_PROPERTY(activityState, activityStateOrNil, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -58,6 +58,12 @@
   [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
+// Nil will be provided when activityState is set as an animated value and we change
+// it from JS to be a plain value (non animated).
+// In this scenario we first trigger the code which resets it to the default,
+// which is nil, and which maps to 0 meaning Inactive.
+// In that case we want to ignore such update
+// because soon after we get the actual, valid state passed from JS.
 - (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
   int activityState = [activityStateOrNil intValue];
@@ -477,6 +483,7 @@
 
 RCT_EXPORT_MODULE()
 
+// we want to handle the case when activityState is nil
 RCT_REMAP_VIEW_PROPERTY(activityState, activityStateOrNil, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -60,10 +60,8 @@
 
 // Nil will be provided when activityState is set as an animated value and we change
 // it from JS to be a plain value (non animated).
-// In this scenario we first trigger the code which resets it to the default,
-// which is nil, and which maps to 0 meaning Inactive.
-// In that case we want to ignore such update
-// because soon after we get the actual, valid state passed from JS.
+// In case when nil is received, we want to ignore such value and not make
+// any updates as the actual non-nil value will follow immediately.
 - (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
   int activityState = [activityStateOrNil intValue];

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -190,13 +190,13 @@
   if (screenRemoved || screenAdded) {
     // we disable interaction for the duration of the transition until one of the screens changes its state to "onTop"
     self.userInteractionEnabled = NO;
-    
-    for (RNSScreenView *screen in _reactSubviews) {
-      if (screen.activityState == RNSActivityStateOnTop) {
-        // if there is an "onTop" screen it means the transition has ended so we restore interactions
-        self.userInteractionEnabled = YES;
-        [screen notifyFinishTransitioning];
-      }
+  }
+
+  for (RNSScreenView *screen in _reactSubviews) {
+    if (screen.activityState == RNSActivityStateOnTop) {
+      // if there is an "onTop" screen it means the transition has ended so we restore interactions
+      self.userInteractionEnabled = YES;
+      [screen notifyFinishTransitioning];
     }
   }
 


### PR DESCRIPTION
## Description

Changed the logic of resolving `activityState` to take into account the initial `nil` value of it by passing the `NSNumber` instead of `int` (which was resolved to `0`) on iOS. The logic for restoring user interaction in `ScreenContainer` had to be changed too since it did not take into account going from value `1` to `2` for one of `Screen`s. It worked before because, at the end of the transition, the `activityState` of all `Screen`s was changed to `0` due to the initial `nil` pass, and then switched back to the proper value in the next evaluation, which resulted in `screenAdded` being set to `YES`. A similar situation, but without the need for change in `ScreenContainer` applies to Android. Fixes #702.

## Changes

Added check for `nil` value of `activityState`. Added new prop `activityStateOrNil`. Changed logic in `ScreenContainer`'s `updateContainer`.

## Test code and steps to reproduce

`Test702.js` file with reproduction in `TestsExample`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
