### PR TITLE
Multiple log box showing

### DIFF
--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -12,6 +12,7 @@ import {
   Screen as ScreenComponent,
   ScreenProps,
   ScreenStack,
+  StackPresentationTypes,
 } from 'react-native-screens';
 import {
   NativeStackDescriptorMap,
@@ -25,7 +26,7 @@ const isAndroid = Platform.OS === 'android';
 let Container = View;
 
 if (__DEV__) {
-  const DebugContainer = (props: ViewProps & { stackPresentation: string }) => {
+  const DebugContainer = (props: ViewProps & { stackPresentation: StackPresentationTypes }) => {
     const { stackPresentation, ...rest } = props;
     if (Platform.OS === 'ios' && stackPresentation !== 'push') {
       return (

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -25,9 +25,9 @@ const isAndroid = Platform.OS === 'android';
 let Container = View;
 
 if (__DEV__) {
-  const DebugContainer = (props: ViewProps & { stackAnimation: string }) => {
-    const { stackAnimation, ...rest } = props;
-    if (Platform.OS === 'ios' && stackAnimation !== 'push') {
+  const DebugContainer = (props: ViewProps & { stackPresentation: string }) => {
+    const { stackPresentation, ...rest } = props;
+    if (Platform.OS === 'ios' && stackPresentation !== 'push') {
       return (
         <AppContainer>
           <View {...rest} />

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -26,7 +26,9 @@ const isAndroid = Platform.OS === 'android';
 let Container = View;
 
 if (__DEV__) {
-  const DebugContainer = (props: ViewProps & { stackPresentation: StackPresentationTypes }) => {
+  const DebugContainer = (
+    props: ViewProps & { stackPresentation: StackPresentationTypes }
+  ) => {
     const { stackPresentation, ...rest } = props;
     if (Platform.OS === 'ios' && stackPresentation !== 'push') {
       return (


### PR DESCRIPTION
## Description

This fixes an incorrectly used prop to the `DebugContainer`. This was causing an appContainer to be rendered on every stackPresentation type causing a logbox to be rendered on every screen within a stack. So 1 on that main stack from RN and one additional one on every screen.

## Changes

Change stackAnimation to stackPresentation on NativeStackView.ts props.

No evidence given as it is clearly visible via the code that this was being passed incorrectly. Logbox shown on modals.

## Checklist

- [x] Ensured that CI passes
