### PR TITLE
Add issue validator

### DIFF
--- a/.github/workflows/issue-validator.yml
+++ b/.github/workflows/issue-validator.yml
@@ -1,0 +1,17 @@
+name: Validate issues
+on:
+  issues:
+    types: [edited, labeled, unlabeled]
+
+jobs:
+  check_issue:
+    runs-on: ubuntu-latest
+    name: Validate issue
+    steps:
+    - name: Validate issue
+      id: validate-issue
+      uses: karol-bisztyga/issue-validator@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        required-sections: bug,Description,Steps To Reproduce,Expected behavior,Actual behavior,Package versions;enhancement,Description;Question,Description
+


### PR DESCRIPTION
## Description

Adds new GitHub action which validates every issue when they are `labeled`/`unlabeled`/`edited`(no need to launch it when an issue is created since it's being triggered by `labeled` event anyway).

For every specific label there are some sections required
- `bug` label requires sections:
	- Description
	- Steps To Reproduce
	- Expected behavior
	- Actual behavior
	- Package versions
- `enhancement ` label requires section:
	- Description
- `Question` label requires section:
	- Description

A section is defined by any type of header(which is made using any number of `#` signs at the beginning of the line)

When there are any requirements that aren't fulfilled, the bot adds a comment and it keeps updating it/adding new ones until they are. It adds a new comment if there are no comments or the last one isn't made by the bot. If the last comment is made by them, it updates it. If there were any errors in the past but the issue is correct now, it gives a proper message.

The validator's code is available [here](https://github.com/karol-bisztyga/issue-validator)
