### PR TITLE
fix: make back button visible

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -425,9 +425,28 @@
   }
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+  [self relayoutHeader];
+}
+
+- (void)relayoutHeader
+{
+  double delayInSeconds = 0.1;
+  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+  dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+    [self.view.reactSubviews enumerateObjectsUsingBlock:^(UIView * _Nonnull view, NSUInteger idx, BOOL * _Nonnull stop) {
+      if ([view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+        [RNSScreenStackHeaderConfig willShowViewController:self animated:NO withConfig:(RNSScreenStackHeaderConfig *)view];
+      }
+    }];
+  });
+}
+
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+  [self relayoutHeader];
   [RNSScreenStackHeaderConfig updateStatusBarAppearance];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -374,7 +374,7 @@
 
   if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
     navctr.view.semanticContentAttribute = config.direction;
-    navctr.navigationBar.semanticContentAttribute = config.direction;
+    [RNSScreenStackHeaderConfig updateSubviews:navctr.navigationBar withDirection:config.direction];
   }
 
   navitem.title = config.title;
@@ -543,6 +543,14 @@
   }
 #endif
   return UIStatusBarStyleLightContent;
+}
+
++ (void)updateSubviews:(UIView*)view withDirection:(UISemanticContentAttribute)direction
+{
+  view.semanticContentAttribute = direction;
+  [view.subviews enumerateObjectsUsingBlock:^(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [RNSScreenStackHeaderConfig updateSubviews:obj withDirection:direction];
+  }];
 }
 
 @end

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -368,13 +368,14 @@
   }
 #endif
 
-  if (shouldHide) {
-    return;
-  }
-
   if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
+    // we do it before check for `shouldHide` since we may want the `rtl` screen transition (line below) without header present.
     navctr.view.semanticContentAttribute = config.direction;
     [RNSScreenStackHeaderConfig updateSubviews:navctr.navigationBar withDirection:config.direction];
+  }
+
+  if (shouldHide) {
+    return;
   }
 
   navitem.title = config.title;


### PR DESCRIPTION
## Description

Added traversing through the subviews of `navigationBar` and changing their direction. Also, added the second call for updating the header. Those changes combined resolve in the back button being visible in `rtl` direction. Fixes #654.

## Changes

- Updated `Screen.m` to update the header at the beginning of the transition
- Added method for traversing through subviews of `navigationBar` and applying the direction to them. It is needed to change the `direction` of some private views that seem to be not updated along with `navigationBar` update

## Test code and steps to reproduce

`Test654.js` in the `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
