### PR TITLE
fix: add checks for tvOS and unify macros

### DIFF
--- a/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
+++ b/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
@@ -194,7 +194,6 @@
 				2C8EF49C5A488D5575B90176 /* Pods-TestsExample-tvOSTests.debug.xcconfig */,
 				6CC8BF9F7F61E5E37D4E0288 /* Pods-TestsExample-tvOSTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -294,6 +293,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = Q558NGQ89W;
 						LastSwiftMigration = 1120;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -720,6 +720,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q558NGQ89W;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TestsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -743,6 +744,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q558NGQ89W;
 				INFOPLIST_FILE = TestsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (

--- a/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
+++ b/TestsExample/ios/TestsExample.xcodeproj/project.pbxproj
@@ -293,7 +293,6 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = Q558NGQ89W;
 						LastSwiftMigration = 1120;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -720,7 +719,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q558NGQ89W;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TestsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -744,7 +742,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Q558NGQ89W;
 				INFOPLIST_FILE = TestsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -81,7 +81,8 @@
 {
   switch (stackPresentation) {
     case RNSScreenStackPresentationModal:
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       if (@available(iOS 13.0, *)) {
         _controller.modalPresentationStyle = UIModalPresentationAutomatic;
       } else {
@@ -94,7 +95,7 @@
     case RNSScreenStackPresentationFullScreenModal:
       _controller.modalPresentationStyle = UIModalPresentationFullScreen;
       break;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     case RNSScreenStackPresentationFormSheet:
       _controller.modalPresentationStyle = UIModalPresentationFormSheet;
       break;
@@ -135,7 +136,7 @@
     case RNSScreenStackAnimationFade:
       _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
       break;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     case RNSScreenStackAnimationFlip:
       _controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal;
       break;
@@ -149,11 +150,12 @@
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
-  #ifdef __IPHONE_13_0
-    if (@available(iOS 13.0, *)) {
-      _controller.modalInPresentation = !gestureEnabled;
-    }
-  #endif
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    _controller.modalInPresentation = !gestureEnabled;
+  }
+#endif
 
   _gestureEnabled = gestureEnabled;
 }
@@ -300,6 +302,7 @@
   return self;
 }
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   UIViewController *vc = [self findChildVCForConfig];
@@ -372,6 +375,7 @@
     }
   }
 }
+#endif
 
 - (RNSScreenStackHeaderConfig *)findScreenConfig
 {

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -23,6 +23,7 @@
 
 @implementation RNScreensViewController
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   return [self findActiveChildVC];
@@ -36,8 +37,8 @@
 - (UIViewController *)childViewControllerForStatusBarHidden
 {
   return [self findActiveChildVC];
-
 }
+#endif
 
 - (UIViewController *)findActiveChildVC
 {

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -19,6 +19,7 @@
 
 @implementation RNScreensNavigationController
 
+#if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
   return [self topViewController];
@@ -33,6 +34,7 @@
 {
   return [self topViewController];
 }
+#endif
 
 @end
 
@@ -238,7 +240,7 @@
       if (parentView.reactViewController) {
         [parentView.reactViewController addChildViewController:controller];
         [self addSubview:controller.view];
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
         _controller.interactivePopGestureRecognizer.delegate = self;
 #endif
         [controller didMoveToParentViewController:parentView.reactViewController];
@@ -338,10 +340,11 @@
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
 
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
           // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
-          next.overrideUserInterfaceStyle = _controller.overrideUserInterfaceStyle;
+          next.overrideUserInterfaceStyle = self->_controller.overrideUserInterfaceStyle;
         }
 #endif
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -36,13 +36,19 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) UISemanticContentAttribute direction;
+
+#if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
+#endif
 
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
 + (void)updateStatusBarAppearance;
+
+#if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
+#endif
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -126,7 +126,8 @@
   [navbar setTintColor:[config.color colorWithAlphaComponent:CGColorGetAlpha(config.color.CGColor) - 0.01]];
   [navbar setTintColor:config.color];
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     // font customized on the navigation item level, so nothing to do here
   } else
@@ -161,7 +162,7 @@
       [navbar setTitleTextAttributes:attrs];
     }
 
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     if (@available(iOS 11.0, *)) {
       if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleColor || config.titleColor)) {
         NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
@@ -246,7 +247,7 @@
             // in order for new back button image to be loaded we need to trigger another change
             // in back button props that'd make UIKit redraw the button. Otherwise the changes are
             // not reflected. Here we change back button visibility which is then immediately restored
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
             vc.navigationItem.hidesBackButton = YES;
 #endif
             [config updateViewControllerIfNeeded];
@@ -266,9 +267,10 @@
   [self updateViewController:vc withConfig:config animated:animated];
 }
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 + (UINavigationBarAppearance*)buildAppearance:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
-{
+API_AVAILABLE(ios(13.0)){
   UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
 
   if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
@@ -356,7 +358,7 @@
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
 
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
   // we put it before check with return because we want to apply changes to status bar even if the header is hidden
   if (config != nil) {
     if (config.statusBarStyle || config.statusBarAnimation || config.statusBarHidden) {
@@ -378,7 +380,7 @@
   }
 
   navitem.title = config.title;
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize) {
     prevItem.backBarButtonItem = [[UIBarButtonItem alloc]
                                   initWithTitle:config.backTitle ?: prevItem.title
@@ -407,7 +409,8 @@
   }
 #endif
 
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
     navitem.standardAppearance = appearance;
@@ -424,7 +427,7 @@
   } else
 #endif
   {
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
     // updating backIndicatotImage does not work when called during transition. On iOS pre 13 we need
     // to update it before the navigation starts.
     UIImage *backButtonImage = [self loadBackButtonImageInViewController:vc withConfig:config];
@@ -437,7 +440,7 @@
     }
 #endif
   }
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
   navitem.hidesBackButton = config.hideBackButton;
 #endif
   navitem.leftBarButtonItem = nil;
@@ -446,7 +449,7 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
-#if (TARGET_OS_IOS)
+#if !TARGET_OS_TV
         navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
 #endif
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
@@ -463,6 +466,8 @@
         navitem.titleView = subview;
         break;
       }
+      case RNSScreenStackHeaderSubviewTypeBackButton:
+        break;
     }
   }
 
@@ -497,6 +502,7 @@
   }
 }
 
+#if !TARGET_OS_TV
 + (void)assertViewControllerBasedStatusBarAppearenceSet
 {
   static dispatch_once_t once;
@@ -509,9 +515,11 @@
     UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
   }
 }
+#endif
 
 + (void)updateStatusBarAppearance
 {
+#if !TARGET_OS_TV
   [UIView animateWithDuration:0.4 animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
     if (@available(iOS 13, *)) {
       UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
@@ -522,11 +530,14 @@
       [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
     }
   }];
+#endif
 }
 
+#if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
-#ifdef __IPHONE_13_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     switch (statusBarStyle) {
       case RNSStatusBarStyleAuto:
@@ -544,6 +555,7 @@
 #endif
   return UIStatusBarStyleLightContent;
 }
+#endif
 
 @end
 
@@ -579,9 +591,12 @@ RCT_EXPORT_VIEW_PROPERTY(backButtonInCustomView, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+
+#if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
+#endif
 
 @end
 
@@ -602,7 +617,8 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
       @"prominent": @(UIBlurEffectStyleProminent),
     }];
   }
-#if defined(__IPHONE_13_0) && TARGET_OS_IOS
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [blurEffects addEntriesFromDictionary:@{
       @"systemUltraThinMaterial": @(UIBlurEffectStyleSystemUltraThinMaterial),

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -5,6 +5,7 @@
 
 @implementation UIViewController (RNScreens)
 
+#if !TARGET_OS_TV
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarStyle
 {
   UIViewController *childVC = [self findChildRNScreensViewController];
@@ -48,5 +49,6 @@
                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
   });
 }
+#endif
 
 @end


### PR DESCRIPTION
## Description

Added checks for `tvOS` to make it compile. Changed all `#if (TARGET_OS_IOS)` to `#if !TARGET_OS_TV` since it is the option used in other repositories. Changed all `#ifdef __IPHONE_13_0` to `#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0` for the same reason. Silenced some warnings by adding the missing case to switch, `self->` and `API_AVAILABLE(ios(13.0))`.


## Test code and steps to reproduce

Compile the project on `tvOS`.

## Checklist

- [x] Ensured that CI passes
