### PR TITLE
fix: add native-stack to ts and eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   settings: {
-    'import/core-modules': ['react-native-screens'],
+    'import/core-modules': ['react-native-screens', 'react-native-screens/native-stack'],
     'import/ignore': ['node_modules/react-native/index\\.js$'],
     'import/resolver': {
       node: {

--- a/TestsExample/babel.config.js
+++ b/TestsExample/babel.config.js
@@ -7,7 +7,6 @@ module.exports = {
       {
         alias: {
           'react-native-screens': '../src',
-          'react-native-screens/native-stack': '../src/native-stack',
           'react': './node_modules/react',
           'react-native': './node_modules/react-native',
           '@babel': './node_modules/@babel',

--- a/TestsExample/babel.config.js
+++ b/TestsExample/babel.config.js
@@ -7,6 +7,7 @@ module.exports = {
       {
         alias: {
           'react-native-screens': '../src',
+          'react-native-screens/native-stack': '../src/native-stack',
           'react': './node_modules/react',
           'react-native': './node_modules/react-native',
           '@babel': './node_modules/@babel',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "react-native-screens": ["./src/screens.d.ts"]
+      "react-native-screens": ["./src/screens.d.ts"],
+      "react-native-screens/native-stack": ["./src/native-stack/index.tsx"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
## Description

Added `native-stack` path to `tsconfig` and `.eslintrc.js` to properly resolve it in `TestsExample` project.

## Changes

Updated `tsconfig.json` and `.eslintrc.js`.

## Test code and steps to reproduce

Spot no eslint error in files of `TestsExample` project.

## Checklist

- [x] Ensured that CI passes
