### PR TITLE
fix: add symbols to color types to allow PlatformColor values

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -135,7 +135,7 @@ declare module 'react-native-screens' {
     /**
      * @description Controls the color of the navigation header.
      */
-    backgroundColor?: string;
+    backgroundColor?: string | symbol;
     /**
      * @host (iOS only)
      * @description Allows for controlling the string to be rendered next to back button. By default iOS uses the title of the previous screen.
@@ -171,7 +171,7 @@ declare module 'react-native-screens' {
     /**
      * @description Controls the color of items rendered on the header. This includes back icon, back text (iOS only) and title text. If you want the title to have different color use titleColor property.
      */
-    color?: string;
+    color?: string | symbol;
     /**
      * @description If set to true the back button will not be rendered as a part of navigation header.
      */
@@ -188,12 +188,12 @@ declare module 'react-native-screens' {
     /**
      *@description Controls the color of the navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
      */
-    largeTitleBackgroundColor?: string;
+    largeTitleBackgroundColor?: string | symbol;
     /**
      * @host (iOS only)
      * @description Customize the color to be used for the large title. By default uses the titleColor property.
      */
-    largeTitleColor?: string;
+    largeTitleColor?: string | symbol;
     /**
      * @host (iOS only)
      * @description Customize font family to be used for the large title.
@@ -235,7 +235,7 @@ declare module 'react-native-screens' {
     /**
      * @description Allows for setting text color of the title.
      */
-    titleColor?: string;
+    titleColor?: string | symbol;
     /**
      * @description Customize font family to be used for the title.
      */

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -108,7 +108,7 @@ export type NativeStackNavigationOptions = {
   /**
    * Function which returns a React Element to display in the center of the header.
    */
-  headerCenter?: (props: { tintColor?: string }) => React.ReactNode;
+  headerCenter?: (props: { tintColor?: string | symbol }) => React.ReactNode;
   /**
    * Boolean indicating whether to hide the back button in header.
    * Only supported on Android.
@@ -127,7 +127,7 @@ export type NativeStackNavigationOptions = {
    * @platform ios
    */
   headerLargeStyle?: {
-    backgroundColor?: string;
+    backgroundColor?: string | symbol;
   };
   /**
    * Boolean to set native property to prefer large title header (like in iOS setting).
@@ -155,16 +155,16 @@ export type NativeStackNavigationOptions = {
     fontFamily?: string;
     fontSize?: number;
     fontWeight?: string;
-    color?: string;
+    color?: string | symbol;
   };
   /**
    * Function which returns a React Element to display on the left side of the header.
    */
-  headerLeft?: (props: { tintColor?: string }) => React.ReactNode;
+  headerLeft?: (props: { tintColor?: string | symbol }) => React.ReactNode;
   /**
    * Function which returns a React Element to display on the right side of the header.
    */
-  headerRight?: (props: { tintColor?: string }) => React.ReactNode;
+  headerRight?: (props: { tintColor?: string | symbol }) => React.ReactNode;
   /**
    * Whether to show the header.
    */
@@ -175,13 +175,13 @@ export type NativeStackNavigationOptions = {
    * - blurEffect
    */
   headerStyle?: {
-    backgroundColor?: string;
+    backgroundColor?: string | symbol;
     blurEffect?: ScreenStackHeaderConfigProps['blurEffect'];
   };
   /**
    * Tint color for the header. Changes the color of back button and title.
    */
-  headerTintColor?: string;
+  headerTintColor?: string | symbol;
   /**
    * String to display in the header as title. Defaults to scene `title`.
    */
@@ -197,7 +197,7 @@ export type NativeStackNavigationOptions = {
     fontFamily?: string;
     fontSize?: number;
     fontWeight?: string;
-    color?: string;
+    color?: string | symbol;
   };
   /**
    * A flag to that lets you opt out of insetting the header. You may want to


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Fixes TypeScript errors when using the PlatformColor API to set colors.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

Added symbol as a permitted value for all instances where colors can be set.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/index.d.ts
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
