### PR TITLE
feat: add default status bar style

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -567,7 +567,11 @@ API_AVAILABLE(ios(13.0)){
     }
   }
 #endif
-  return UIStatusBarStyleLightContent;
+  // it is the only non-default style available for iOS < 13
+  if (statusBarStyle == RNSStatusBarStyleLight) {
+    return UIStatusBarStyleLightContent;
+  }
+  return UIStatusBarStyleDefault;
 }
 #endif
 


### PR DESCRIPTION
## Description

Added better handling of iOS < 13 for `statusBarStyle`. It now resolves to `UIStatusBarStyleLightContent` when `RNSStatusBarStyleLight` passed, and `UIStatusBarStyleDefault` otherwise, since these are the options available in iOS < 13. Fixes #755.

## Changes

Updated `RNSScreenStackHeaderConfig.m`.

## Test code and steps to reproduce

`Test642.js`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
