### PR TITLE
feat: blurred modal background

### DIFF
--- a/Example/nativeNavigation.js
+++ b/Example/nativeNavigation.js
@@ -6,7 +6,7 @@ const SomeScreen = ({ navigation }) => {
   return (
     <ScrollView style={styles.screen}>
       <Button onPress={() => navigation.push('Push')} title="Push" />
-      <Button onPress={() => navigation.navigate('Modal')} title="Modal" />
+      <Button onPress={() => navigation.navigate('Modal')} title="Transparent Modal" />
       <Button onPress={() => navigation.pop()} title="Back" />
       <View style={styles.leftTop} />
       <View style={styles.bottomRight} />
@@ -16,7 +16,7 @@ const SomeScreen = ({ navigation }) => {
 
 const PushScreen = ({ navigation }) => {
   return (
-    <View style={styles.screen}>
+    <View style={[styles.screen, {width: 400, borderWidth: 8, alignSelf: 'center', left: undefined, right: undefined, top: 100, height: 500}]}>
       <TextInput placeholder="Hello" style={styles.textInput} />
       <Button onPress={() => navigation.goBack()} title="Go back" />
       <Button onPress={() => navigation.push('Push')} title="Push more" />
@@ -37,7 +37,7 @@ const App = () => (
         title: 'Start',
         headerTintColor: 'black',
         statusBarStyle: 'auto',
-        screenOrientation: 'portrait',
+        // screenOrientation: 'portrait',
       }}
     />
     <AppStack.Screen
@@ -46,15 +46,17 @@ const App = () => (
       options={{
         title: 'Pushed',
         headerStyle: { backgroundColor: '#3da4ab' },
+        blurEffect: 'dark',
         headerTintColor: 'black',
         statusBarHidden: true,
+        gestureEnabled: true,
       }}
     />
     <AppStack.Screen
       name="Modal"
       component={PushScreen}
       options={{
-        stackPresentation: 'modal',
+        stackPresentation: 'transparentModal',
         statusBarStyle: 'light',
         screenOrientation: 'portrait_up',
       }}

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -444,6 +444,35 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+    
+    
+    
+
+    if(self.modalPresentationStyle == UIModalPresentationOverFullScreen){
+        
+        self.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+
+          //only apply the blur if the user hasn't disabled transparency effects
+          if (!UIAccessibilityIsReduceTransparencyEnabled()) {
+            self.view.backgroundColor = [UIColor clearColor];
+            UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
+            UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+            blurEffectView.frame = self.parentViewController.view.bounds;
+            blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+              
+              [self.view insertSubview:blurEffectView atIndex:0];
+
+              [blurEffectView setAlpha:0.0];
+                [UIView animateWithDuration:0.5
+                                 animations:^{
+                                    blurEffectView.alpha = 1;
+                                 }
+                                 completion:^(BOOL finished){ }];
+          } else {
+              self.view.backgroundColor = [UIColor blackColor];
+          }
+    }
+
   [RNSScreenStackHeaderConfig updateWindowTraits];
   [((RNSScreenView *)self.view) notifyWillAppear];
 }
@@ -458,6 +487,8 @@
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
+
+    
   [((RNSScreenView *)self.view) notifyAppear];
 }
 


### PR DESCRIPTION
## Description

Introduces an option to blur screens behind a transparent modal. 

So far only a POC on iOS, if you would like this feature I am happy to finalize the implementation by fixing the "disappearing shadow glitch" (seen in the video below), expose a new prop, and add android support. 

<!--
## Changes
- [x] iOS PoC
- [ ] iOS implementation
- [ ] Android implementation
- [ ] Expose new prop

Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->



### After
https://user-images.githubusercontent.com/1652607/103346239-bb6c0a80-4a93-11eb-931d-3913f775a43f.mov

<!--
## Test code and steps to reproduce


Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: 
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/index.d.ts
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
-->

