### PR TITLE
refactor: replace deprecated API

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -232,7 +232,14 @@
         // in DEV MODE we try to load from cache (we use private API for that as it is not exposed
         // publically in headers).
         RCTImageSource *source = imageView.imageSources[0];
-        image = [subview.bridge.imageLoader.imageCache
+        RCTImageLoader *imageloader = nil;
+        if ([subview.bridge respondsToSelector:@selector(moduleForClass:)]) {
+            imageloader = [subview.bridge moduleForClass:[RCTImageLoader class]];
+        }
+        else {
+            imageloader = subview.bridge.imageLoader;
+        }
+        image = [imageloader.imageCache
                  imageForUrl:source.request.URL.absoluteString
                  size:source.size
                  scale:source.scale

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -232,13 +232,7 @@
         // in DEV MODE we try to load from cache (we use private API for that as it is not exposed
         // publically in headers).
         RCTImageSource *source = imageView.imageSources[0];
-        RCTImageLoader *imageloader = nil;
-        if ([subview.bridge respondsToSelector:@selector(moduleForClass:)]) {
-            imageloader = [subview.bridge moduleForClass:[RCTImageLoader class]];
-        }
-        else {
-            imageloader = subview.bridge.imageLoader;
-        }
+        RCTImageLoader *imageloader = [subview.bridge moduleForClass:[RCTImageLoader class]];
         image = [imageloader.imageCache
                  imageForUrl:source.request.URL.absoluteString
                  size:source.size


### PR DESCRIPTION
## Description

replace deprecate bridge.imageloader API, use `moduleForClass:`

## Changes

change ios file RNSScreenStackHeaderConfig.m

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/index.d.ts
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes
