### PR TITLE
feat: add setting frame in notifyWillAppear

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -23,6 +23,7 @@ import Test691 from './src/Test691';
 import Test702 from './src/Test702';
 import Test706 from './src/Test706';
 import Test713 from './src/Test713';
+import Test750 from './src/Test750';
 
 enableScreens();
 

--- a/TestsExample/src/Test750.js
+++ b/TestsExample/src/Test750.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Button } from 'react-native';
+import { enableScreens } from 'react-native-screens';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+
+enableScreens();
+
+const Tab = createBottomTabNavigator();
+export default function TabNav() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator lazy={false}>
+        <Tab.Screen name="Tab1" component={Tab1} />
+        <Tab.Screen name="Tab2" component={StackNav} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+function StackNav() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Screen1" component={Screen1} options={{ headerShown: true }} />
+      <Stack.Screen name="Screen2" component={Screen2} />
+    </Stack.Navigator>
+  );
+}
+
+const Tab1 = () => <View style={{ flex: 1, backgroundColor: 'red' }} />;
+const Screen1 = ({ navigation }) => (
+  <View style={{ flex: 1, backgroundColor: 'green', justifyContent: 'center' }}>
+    <Button title="navigate" onPress={() => navigation.navigate('Screen2')} />
+  </View>
+);
+const Screen2 = () => <View style={{ flex: 1 }} />;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -204,7 +204,7 @@
     self.onWillAppear(nil);
   }
   // we do it here too because at this moment the `parentViewController` is already not nil,
-  // so if it is not UINavCtr, the frame will be updated to the correct one.
+  // so if the parent is not UINavCtr, the frame will be updated to the correct one.
   [self reactSetFrame:_reactFrame];
 }
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -15,6 +15,7 @@
   __weak RCTBridge *_bridge;
   RNSScreen *_controller;
   RCTTouchHandler *_touchHandler;
+  CGRect _reactFrame;
 }
 
 @synthesize controller = _controller;
@@ -36,6 +37,7 @@
 
 - (void)reactSetFrame:(CGRect)frame
 {
+  _reactFrame = frame;
   UIViewController *parentVC = self.reactViewController.parentViewController;
   if (parentVC != nil && ![parentVC isKindOfClass:[UINavigationController class]]) {
     [super reactSetFrame:frame];
@@ -201,6 +203,9 @@
   if (self.onWillAppear) {
     self.onWillAppear(nil);
   }
+  // we do it here too because at this moment the `parentViewController` is already not nil,
+  // so if it is not UINavCtr, the frame will be updated to the correct one.
+  [self reactSetFrame:_reactFrame];
 }
 
 - (void)notifyWillDisappear


### PR DESCRIPTION
## Description

Suggested by @kmagiera change adding setting frame in the `viewWillAppear`. It ensures that the `parentViewController` is set when trying to set the frame, and if the parent is not `UINavigationController`, then the frame is properly set. It fixes the issue that appeared after #712 was merged, where there is a check for `parentViewController` not being `nil` introduced. The issue can be spotted and should fix #750.

## Changes

Added setting frame in `notifyWillAppear`.

## Screenshots / GIFs

### Before

![image](https://user-images.githubusercontent.com/32481228/104304504-bb283200-54cb-11eb-8ac8-580ac2621e80.png)


### After

![image](https://user-images.githubusercontent.com/32481228/104304440-a9df2580-54cb-11eb-9c0b-a1c6b160e36e.png)

-->

## Test code and steps to reproduce

`Test750.js` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
