### PR TITLE
feat: add async container update on ios

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -24,6 +24,7 @@ import Test691 from './src/Test691';
 import Test702 from './src/Test702';
 import Test706 from './src/Test706';
 import Test713 from './src/Test713';
+import Test726 from './src/Test726';
 import Test748 from './src/Test748';
 import Test750 from './src/Test750';
 

--- a/TestsExample/src/Test726.js
+++ b/TestsExample/src/Test726.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Text, TextInput, View, StyleSheet, Button } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+
+function TestScreen({ navigation }) {
+  return (
+    <View style={styles.content}>
+      <Button
+        title="PUSH ME"
+        onPress={() => navigation.push('Test')}
+        style={styles.button} />
+    </View>
+  );
+}
+
+function TestScreen2() {
+  return (
+    <View style={styles.content}>
+      <Text>Try to swipe back, it will freeze</Text>
+      <TextInput autoFocus />
+    </View>
+  );
+}
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator keyboardHandlingEnabled={false}>
+        <Stack.Screen
+          name="Home"
+          component={TestScreen}
+        />
+        <Stack.Screen
+          name="Test"
+          component={TestScreen2}
+        />
+    </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: { margin: 8 },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -268,12 +268,11 @@ RCT_EXPORT_MODULE()
 
 - (void)markUpdated:(RNSScreenContainerView *)screen
 {
-  RCTAssertMainQueue();
   [_markedContainers addObject:screen];
   if ([_markedContainers count] == 1) {
     // we enqueue updates to be run on the main queue in order to make sure that
     // all this updates (new screens attached etc) are executed in one batch
-    RCTExecuteOnMainQueue(^{
+    dispatch_async(dispatch_get_main_queue(), ^{
       for (RNSScreenContainerView *container in self->_markedContainers) {
         [container updateContainer];
       }

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -271,7 +271,12 @@ RCT_EXPORT_MODULE()
   [_markedContainers addObject:screen];
   if ([_markedContainers count] == 1) {
     // we enqueue updates to be run on the main queue in order to make sure that
-    // all this updates (new screens attached etc) are executed in one batch
+    // all these updates (new screens attached etc) are executed in one batch.
+    // We call it asynchronously because the events being fired when swiping the screen
+    // resolve in calling this method, and inside it, the same type of event
+    // can be fired when calling e.g. `notifyFinishTransitioning` leading to a deadlock.
+    // See https://github.com/software-mansion/react-native-screens/issues/726#issuecomment-757879605
+    // for more information.
     dispatch_async(dispatch_get_main_queue(), ^{
       for (RNSScreenContainerView *container in self->_markedContainers) {
         [container updateContainer];


### PR DESCRIPTION
## Description

This change attempts to resolve the issue from #726 (see https://github.com/software-mansion/react-native-screens/issues/726#issuecomment-757879605). The issue itself is similar to what we fixed in #473, which is preventing deadlock on `sendEvent` mutex. We try to prevent it here by making the `updateContainer` method run asynchronously on the main queue.

## Changes

Changed `ScreenContainer.m` to use `dispatch_async(dispatch_get_main_queue(), ...)` instead of `RCTExecuteOnMainQueue`.

## Test code and steps to reproduce

`Test726.js` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
