### PR TITLE
fix: change babel and metro resolvers logic

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   settings: {
-    'import/core-modules': ['react-native-screens', 'react-native-screens/native-stack'],
+    'import/core-modules': ['react-native-screens', 'react-native-screens/native-stack', 'react-native-screens/createNativeStackNavigator'],
     'import/ignore': ['node_modules/react-native/index\\.js$'],
     'import/resolver': {
       node: {

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -27,6 +27,7 @@ import Test713 from './src/Test713';
 import Test726 from './src/Test726';
 import Test748 from './src/Test748';
 import Test750 from './src/Test750';
+import Test765 from './src/Test765';
 
 enableScreens();
 

--- a/TestsExample/babel.config.js
+++ b/TestsExample/babel.config.js
@@ -1,16 +1,11 @@
 module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
-    '@babel/plugin-transform-modules-commonjs',
     [
       'module-resolver',
       {
         alias: {
-          'react-native-screens': '../src',
-          'react': './node_modules/react',
-          'react-native': './node_modules/react-native',
-          '@babel': './node_modules/@babel',
-          '@react-navigation/native': './node_modules/@react-navigation/native/src',
+          'react-native-screens': '../src'
         },
       },
     ],

--- a/TestsExample/metro.config.js
+++ b/TestsExample/metro.config.js
@@ -1,30 +1,44 @@
-const blacklist = require('metro-config/src/defaults/blacklist');
+/* eslint-disable import/no-commonjs */
+
 const path = require('path');
+const blacklist = require('metro-config/src/defaults/blacklist');
+const escape = require('escape-string-regexp');
+const pack = require('../package.json');
 
-const glob = require('glob-to-regexp');
+const root = path.resolve(__dirname, '..');
 
-function getBlacklist() {
-  const nodeModuleDirs = [
-    glob(`${path.resolve(__dirname, '..')}/node_modules/*`),
-    glob(
-      `${path.resolve(
-        __dirname
-      )}/node_modules/react-native/node_modules/@babel/*`
-    ),
-  ];
-  return blacklist(nodeModuleDirs);
-}
+const modules = [
+  '@react-navigation/native',
+  'react-navigation',
+  'react-navigation-stack',
+  ...Object.keys(pack.peerDependencies),
+];
 
 module.exports = {
+  projectRoot: __dirname,
+  watchFolders: [root],
+
+  // We need to make sure that only one version is loaded for peerDependencies
+  // So we blacklist them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    blacklistRE: getBlacklist(),
+    blacklistRE: blacklist(
+      modules.map(
+        (m) =>
+          new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
+      )
+    ),
+
+    extraNodeModules: modules.reduce((acc, name) => {
+      acc[name] = path.join(__dirname, 'node_modules', name);
+      return acc;
+    }, {}),
   },
-  watchFolders: [path.resolve(__dirname, '..')],
+
   transformer: {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },

--- a/TestsExample/src/Test765.js
+++ b/TestsExample/src/Test765.js
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import {
+  View,
+} from 'react-native';
+import {
+  createAppContainer,
+} from 'react-navigation';
+
+import createNativeStackNavigator from 'react-native-screens/createNativeStackNavigator';	
+
+const DEFAULT_STACK_OPTIONS
+ = {
+	headerBackTitleVisible: false,
+	headerTintColor: 'black',
+	headerTitleStyle: {
+    fontFamily: 'arial',
+  },
+	headerStyle: {
+		backgroundColor: 'white',
+	},
+	cardStyle: {
+		backgroundColor: 'white',
+	},
+	hideShadow: true,
+	backButtonImage: undefined,
+	headerTopInsetEnabled: false,
+};
+
+function makeStacks() {
+	const PushStack = createNativeStackNavigator(
+		{
+			Home1: Home,
+		},
+		{
+			defaultNavigationOptions: DEFAULT_STACK_OPTIONS,
+		},
+	);
+	const ModalPushStack = createNativeStackNavigator(
+		{
+			Home2: Home,
+		},
+		{
+			defaultNavigationOptions: DEFAULT_STACK_OPTIONS,
+		},
+	);
+	const ModalStack = createNativeStackNavigator(
+		{
+			PushStack,
+			Home3: ModalPushStack,
+			Home4: {
+				screen: Home,
+				navigationOptions: {
+					cardTransparent: true,
+					gestureEnabled: false,
+					stackAnimation: 'fade',
+					cardStyle: {
+						backgroundColor: 'blue',
+          },
+				},
+			},
+		},
+		{
+			headerMode: 'none',
+			mode: 'containedModal',
+		},
+	);
+	const MainStack = createNativeStackNavigator(
+		{
+			ModalStack,
+			Home5: {
+				screen: Home,
+				navigationOptions: {
+					gestureEnabled: false,
+					stackAnimation: 'fade',
+				},
+			},
+		},
+		{
+			headerMode: 'none',
+			mode: 'containedModal',
+		},
+	);
+	return MainStack;
+}
+
+export default createAppContainer(makeStacks());
+
+function Home() {
+  return (
+    <View style={{ flex: 1, backgroundColor: 'red' }} />
+  );
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,15 +1,5 @@
 module.exports = {
   presets: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          node: 'current',
-        },
-      },
-    ],
-    '@babel/preset-typescript',
     'module:metro-react-native-babel-preset',
   ],
-  plugins: ['@babel/plugin-proposal-class-properties'],
 };


### PR DESCRIPTION
## Description

Based on help from @satya164 we change the resolving logic for babel and metro, leading to ability of using both react-navigation v4 and v5 in `TestsExample` project.

## Changes

Added changes to `.eslintrc.js`, `babel.config.js` and `metro.config.js`.

## Test code and steps to reproduce

`Test765.js` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
