### PR TITLE
feat: remove buildscript from main build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,3 @@
-
-buildscript {
-    // The Android Gradle plugin is only required when opening the android folder stand-alone.
-    // This avoids unnecessary downloads and potential conflicts when the library is included as a
-    // module dependency in an application project.
-    if (project == rootProject) {
-        repositories {
-            google()
-            jcenter()
-        }
-
-        dependencies {
-            classpath("com.android.tools.build:gradle:3.6.2")
-        }
-    }
-}
-
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {


### PR DESCRIPTION
## Description

After consultation with @kmagiera we came to a conclusion that keeping `buildscript` is not necessary since it would only be used when the project is a `rootProject` and `react-native-screens` are not meant to be used as a standalone project.

## Changes

Removed `buildScript` from `android/build.gradle`

## Checklist

- [x] Ensured that CI passes
