### PR TITLE
feat: add check for isDestroyed

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -80,7 +80,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     if (mFragmentManager != null) {
       mFragmentManager.removeOnBackStackChangedListener(mBackStackListener);
       mFragmentManager.unregisterFragmentLifecycleCallbacks(mLifecycleCallbacks);
-      if (!mFragmentManager.isStateSaved()) {
+      if (!mFragmentManager.isStateSaved() && !mFragmentManager.isDestroyed()) {
         // state save means that the container where fragment manager was installed has been unmounted.
         // This could happen as a result of dismissing nested stack. In such a case we don't need to
         // reset back stack as it'd result in a crash caused by the fact the fragment manager is no


### PR DESCRIPTION
## Description

Added a check for `!mFragmentManager.isDestroyed()` in `ScreenStack.java` since the code inside of `if` clause requires it. Not adding this sometimes resolves in crash seen in #751. Unfortunately it is not reproduced yet.

Should fix #751.

## Changes 

`!mFragmentManager.isDestroyed()` in `ScreenStack.java`.

Added 

## Checklist

- [x] Ensured that CI passes
