### PR TITLE
fix: restore the proper type for NavigationConfig

### DIFF
--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -51,7 +51,9 @@ export type NativeStackNavigationHelpers = NavigationHelpers<
   NativeStackNavigationEventMap
 >;
 
-export type NativeStackNavigationConfig = Record<string, unknown>;
+// We want it to be an empty object beacuse navigator does not have any additional config
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NativeStackNavigationConfig = {};
 
 export type NativeStackNavigationOptions = {
   /**


### PR DESCRIPTION
## Description

Suggested by @satya164 revert of `NativeStackNavigationConfig` to an empty object. It makes the `native-stack` `Navigator` accept only `screenOptions`, just how it is supposed to do. Should fix #809.

## Changes

Changed `native-stack` `types.tsx` to properly show props for navigator.

## Test code and steps to reproduce

Pass props other than `screenOptions` to `native-stack`'s `Navigator` component.

## Checklist

- [x] Updated TS types
- [x] Ensured that CI passes
