### PR TITLE
fix: rtl transition without header on iOS

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -29,6 +29,7 @@ import Test748 from './src/Test748';
 import Test750 from './src/Test750';
 import Test765 from './src/Test765';
 import Test780 from './src/Test780';
+import Test831 from './src/Test831';
 
 enableScreens();
 

--- a/TestsExample/src/Test831.tsx
+++ b/TestsExample/src/Test831.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {Button, View} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
+
+const Stack = createNativeStackNavigator();
+
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{direction: 'rtl', headerShown: false}}>
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen
+          name="Second"
+          component={Second}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function First({navigation}: Props) {
+  return (
+    <View style={{flex: 1, justifyContent: 'center'}} >
+      <Button title="Tap me for second screen" onPress={() => navigation.navigate('Second')} />
+    </View>
+  );
+}
+
+function Second({navigation}: Props) {
+  return (
+    <View style={{flex: 1, justifyContent: 'center'}} >
+      <Button title="Tap me for first screen" onPress={() => navigation.navigate('First')} />
+    </View>
+  );
+}
+

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -388,15 +388,15 @@ API_AVAILABLE(ios(13.0)){
   }
 #endif
 
-  if (shouldHide) {
-    return;
-  }
-
   if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;
   }
 
+  if (shouldHide) {
+    return;
+  }
+  
   navitem.title = config.title;
 #if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize) {


### PR DESCRIPTION
## Description

Moved check for `rtl` to before the `return` option with header not shown to be able to apply `rtl` transition between screens.

## Test code and steps to reproduce

`Test831.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
