### PR TITLE
docs: add warning about mixing modal types

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Defines how the method that should be used to present the given screen. It is a 
 - `fullScreenModal` – Explained below.
 - `formSheet` – Explained below.
 
+Using `containedModal` and `containedTransparentModal` with other types of modals in one native stack navigator is not recommended and can result in a freeze or a crash of the application.
+
 For iOS:
 - `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier.
 - `fullScreenModal` will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc)

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -165,6 +165,8 @@ How the screen should be presented. Possible values:
 
 Defaults to `push`.
 
+Using `containedModal` and `containedTransparentModal` with other types of modals in one native stack navigator is not recommended and can result in a freeze or a crash of the application.
+
 #### `title`
 
 A string that can be used as a fallback for `headerTitle`.

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -206,6 +206,8 @@ How the screen should be presented. Possible values:
 
 Defaults to `push`.
 
+Using `containedModal` and `containedTransparentModal` with other types of modals in one native stack navigator is not recommended and can result in a freeze or a crash of the application.
+
 #### `title`
 
 A string that can be used as a fallback for `headerTitle`.


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->
Added information in READMEs that mixing `containedModal` and `containedTransparentModal` with different types of modals in one flow can lead to crashes.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->
- Updated `README.md` docs
- Updated `native-stack/README.md` docs
- Updated `createNativeStackNavigator/README.md` docs

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


## Checklist

- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
