### PR TITLE
fix: don't update header without navctr

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -37,5 +37,5 @@ import Test844 from './src/Test844';
 enableScreens();
 
 export default function App() {
-  return <Test844 />;
+  return <Test42 />;
 }

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -32,9 +32,10 @@ import Test765 from './src/Test765';
 import Test780 from './src/Test780';
 import Test817 from './src/Test817';
 import Test831 from './src/Test831';
+import Test844 from './src/Test844';
 
 enableScreens();
 
 export default function App() {
-  return <Test42 />;
+  return <Test844 />;
 }

--- a/TestsExample/src/Test844.tsx
+++ b/TestsExample/src/Test844.tsx
@@ -1,0 +1,105 @@
+import React, {useEffect, useRef} from 'react';
+import {Text, View, Button, StyleSheet} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+
+const defaultOptions = {
+  headerHideShadow: true,
+  headerTintColor: 'red',
+  headerStyle: {
+    backgroundColor: '#f0f0f0',
+  },
+  contentStyle: {
+    backgroundColor: '#f0f0f0',
+  },
+};
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+};
+
+function Main({navigation}: Props) {
+  const times = useRef(8);
+  const id = useRef<any>(0);
+
+  useEffect(() => {
+    id.current = setInterval(() => {
+      if (times.current) {
+        navigation.navigate('modal-stack');
+        setTimeout(() => navigation.goBack(), 500);
+        times.current--;
+      } else {
+        clearInterval(id.current);
+      }
+    }, 1500);
+    return () => clearInterval(id.current);
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title="modal"
+        onPress={() => navigation.navigate('modal-stack')}
+      />
+    </View>
+  );
+}
+
+const Modal = ({navigation}: Props) => (
+  <View style={styles.container}>
+    <Button title="back" onPress={() => navigation.goBack()} />
+  </View>
+);
+
+const ModalStack = createNativeStackNavigator();
+
+const ModalNavigator = () => (
+  <ModalStack.Navigator
+    screenOptions={{...defaultOptions, headerTitle: 'modal'}}>
+    <ModalStack.Screen
+      name="modal"
+      component={Modal}
+      options={{
+        // eslint-disable-next-line react/display-name
+        headerLeft: () => <Text>cancel</Text>,
+      }}
+    />
+  </ModalStack.Navigator>
+);
+
+const Stack = createNativeStackNavigator();
+
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={defaultOptions}>
+        <Stack.Screen
+          name="main"
+          component={Main}
+          options={{
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="modal-stack"
+          component={ModalNavigator}
+          options={{
+            headerShown: false,
+            stackPresentation: 'containedModal',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -97,8 +97,9 @@
     nextVC = nav.topViewController;
   }
 
-  // if nav is nil, it means we are in a fullScreen modal, so there is no nextVC, but we still want to update
-  if (vc != nil && (nav == nil || nextVC == vc)) {
+  BOOL isInFullScreenModal = nav == nil && _screenView.stackPresentation == RNSScreenStackPresentationFullScreenModal;
+  // if nav is nil, it means we can be in a fullScreen modal, so there is no nextVC, but we still want to update
+  if (vc != nil && (nextVC == vc || isInFullScreenModal)) {
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller
                                           withConfig:self
                                             animated:YES];


### PR DESCRIPTION
## Description

Reverted the change of updating the header introduced in #798 and added proper check. Should fix #844.

## Changes

Changed the condition in `RNSScreenStackHeaderConfig` to only allow change without the `navctr` if we are in a `fullScreenModal`.

## Test code and steps to reproduce

`Test844.tsx` in `TestsExample` project.

## Checklist

- [x] Ensured that CI passes
