### PR TITLE
feat: move status bar and orientation management to Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ Allows for the customization of the type of animation to use when this screen re
 - `push` – performs push animation
 - `pop` – performs pop animation (default)
 
+#### `screenOrientation`
+
+Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
+
+- `default` - on iOS, it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc). On Android, this lets the system decide the best orientation.
+- `all`
+- `portrait`
+- `portrait_up`
+- `portrait_down`
+- `landscape`
+- `landscape_left`
+- `landscape_right`
+
+Defaults to `default`.
+
 #### `stackAnimation`
 
 Allows for the customization of how the given screen should appear/disappear when pushed or popped at the top of the stack. The following values are currently supported:
@@ -184,6 +199,18 @@ For Android:
 `modal`, `containedModal`, `fullScreenModal`, `formSheet` will use `Screen.StackPresentation.MODAL`.
 
 `transparentModal`, `containedTransparentModal` will use `Screen.StackPresentation.TRANSPARENT_MODAL`.
+
+#### `statusBarAnimation` (iOS only)
+
+Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
+
+#### `statusBarHidden` (iOS only)
+
+When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
+
+#### `statusBarStyle` (iOS only)
+
+Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
 
 ### `<ScreenStackHeaderConfig>`
 
@@ -273,33 +300,6 @@ Customize the weight of the font to be used for the large title.
 #### `largeTitleHideShadow` (iOS only)
 
 Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
-
-#### `screenOrientation`
-
-Sets the current screen's available orientations and forces rotation if current orientation is not included. Possible values:
-
-- `default` - on iOS, it resolves to [UIInterfaceOrientationMaskAllButUpsideDown](https://developer.apple.com/documentation/uikit/uiinterfaceorientationmask/uiinterfaceorientationmaskallbutupsidedown?language=objc). On Android, this lets the system decide the best orientation.
-- `all`
-- `portrait`
-- `portrait_up`
-- `portrait_down`
-- `landscape`
-- `landscape_left`
-- `landscape_right`
-
-Defaults to `default`.
-
-#### `statusBarAnimation` (iOS only)
-
-Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
-
-#### `statusBarHidden` (iOS only)
-
-When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
-
-#### `statusBarStyle` (iOS only)
-
-Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
 
 #### `title`
 

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -37,5 +37,5 @@ import Test844 from './src/Test844';
 enableScreens();
 
 export default function App() {
-  return <Test42 />;
+  return <Test642 />;
 }

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -37,5 +37,5 @@ import Test844 from './src/Test844';
 enableScreens();
 
 export default function App() {
-  return <Test642 />;
+  return <Test42 />;
 }

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -308,7 +308,7 @@ PODS:
     - React
   - RNReanimated (1.13.1):
     - React
-  - RNScreens (2.18.0):
+  - RNScreens (2.18.1):
     - React-Core
   - RNSearchBar (3.5.1):
     - React
@@ -506,7 +506,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNReanimated: dd8c286ab5dd4ba36d3a7fef8bff7e08711b5476
-  RNScreens: f0d7a2a440a8ba9f4574ca1ddb3368f473891be4
+  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSearchBar: 9860431356b7d12a8449d2fddb2b5f3c78d1e99f
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a

--- a/TestsExample/src/Test42.tsx
+++ b/TestsExample/src/Test42.tsx
@@ -1,10 +1,10 @@
 // connected PRs: #679, #675
-import {NavigationContainer} from '@react-navigation/native';
 import React from 'react';
-import {ScrollView, StyleSheet, View, Button, Text} from 'react-native';
-import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {ScrollView, Button, Text} from 'react-native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
-import {createStackNavigator} from '@react-navigation/stack';
+// import {createStackNavigator} from '@react-navigation/stack';
 
 const Stack = createNativeStackNavigator();
 
@@ -19,7 +19,7 @@ export default function NativeNavigation() {
           name="Home"
           component={Home}
           options={{
-            screenOrientation: 'portrait_up',
+            screenOrientation: 'default',
           }}
         />
         <Stack.Screen
@@ -37,8 +37,8 @@ export default function NativeNavigation() {
 // change to createStackNavigator to test with stack in the middle
 const Tab = createBottomTabNavigator();
 
-const NestedNavigator = (props) => (
-  <Tab.Navigator screensEnabled={true}>
+const NestedNavigator = () => (
+  <Tab.Navigator>
     <Tab.Screen name="Screen1" component={Home} />
     <Tab.Screen name="Screen2" component={Inner} />
     <Tab.Screen name="Screen3" component={Home} />
@@ -47,7 +47,7 @@ const NestedNavigator = (props) => (
 
 const InnerStack = createNativeStackNavigator();
 
-const Inner = (props) => (
+const Inner = () => (
   <InnerStack.Navigator
     screenOptions={{
       screenOrientation: 'portrait_down',
@@ -56,14 +56,13 @@ const Inner = (props) => (
   </InnerStack.Navigator>
 );
 
-function Home({navigation}) {
+function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase>}) {
   const [yes, setYes] = React.useState(true);
   return (
     <ScrollView
       style={{backgroundColor: 'yellow'}}
       contentInsetAdjustmentBehavior="automatic"
       >
-      <View style={styles.leftTop} />
       <Button
         title="NestedNavigator"
         onPress={() => {
@@ -95,11 +94,3 @@ function Home({navigation}) {
     </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/TestsExample/src/Test642.tsx
+++ b/TestsExample/src/Test642.tsx
@@ -68,6 +68,8 @@ const Inner = () => (
 
 function Home({navigation}: Props) {
   const [yes, setYes] = React.useState(true);
+  const [hidden, setHidden] = React.useState(true);
+  const [animation, setAnimation] = React.useState(true);
   return (
     <ScrollView
       style={{backgroundColor: 'rgba(255,255,0,0.5)'}}
@@ -93,6 +95,24 @@ function Home({navigation}: Props) {
             statusBarStyle: yes ? 'light' : 'dark',
           });
           setYes(!yes);
+        }}
+      />
+      <Button
+        title="status bar animation"
+        onPress={() => {
+          navigation.setOptions({
+            statusBarAnimation: animation ? 'fade' : 'none',
+          });
+          setAnimation(!animation);
+        }}
+      />
+      <Button
+        title="status bar hidden"
+        onPress={() => {
+          navigation.setOptions({
+            statusBarHidden: hidden,
+          });
+          setHidden(!hidden);
         }}
       />
       <Button

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens;
 
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.graphics.Paint;
 import android.os.Parcelable;
 import android.util.SparseArray;
@@ -12,6 +13,7 @@ import android.webkit.WebView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
@@ -68,6 +70,8 @@ public class Screen extends ViewGroup {
   private ReplaceAnimation mReplaceAnimation = ReplaceAnimation.POP;
   private StackAnimation mStackAnimation = StackAnimation.DEFAULT;
   private boolean mGestureEnabled = true;
+  private int mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+  private boolean mHasOrientationSet = false;
 
   @Override
   protected void onAnimationStart() {
@@ -254,5 +258,50 @@ public class Screen extends ViewGroup {
 
   public boolean isGestureEnabled() {
     return mGestureEnabled;
+  }
+
+  public void setScreenOrientation(String screenOrientation) {
+    if (screenOrientation == null) {
+      mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+      mHasOrientationSet = false;
+      return;
+    }
+
+    mHasOrientationSet = true;
+
+    switch (screenOrientation) {
+      case "all":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+        break;
+      case "portrait":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
+        break;
+      case "portrait_up":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+        break;
+      case "portrait_down":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+        break;
+      case "landscape":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+        break;
+      case "landscape_left":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+        break;
+      case "landscape_right":
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+        break;
+      default:
+        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+        break;
+    }
+  }
+
+  public boolean hasOrientationSet() {
+    return mHasOrientationSet;
+  }
+
+  public int getScreenOrientation() {
+    return mScreenOrientation;
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -65,22 +65,25 @@ public class ScreenFragment extends Fragment {
   }
 
   public void onContainerUpdate() {
-    if (!hasChildScreenWithConfig(getScreen())) {
-      // if there is no child with config, we look for a parent with config to set the orientation
-      ScreenStackHeaderConfig config = findHeaderConfig();
-      if (config != null && config.getScreenFragment().getActivity() != null) {
-        config.getScreenFragment().getActivity().setRequestedOrientation(config.getScreenOrientation());
+    if (!hasChildScreenWithOrientationSet(getScreen())) {
+      if (getScreen().hasOrientationSet() && getActivity() != null) {
+        getActivity().setRequestedOrientation(getScreen().getScreenOrientation());
+      }
+
+      // if this screen has no orientation set and there is no child with orientation set, we look for a parent that has the orientation set
+      Screen parent = findParentWithOrientationSet();
+      if (parent != null && parent.getFragment() != null && parent.getFragment().getActivity() != null) {
+        parent.getFragment().getActivity().setRequestedOrientation(parent.getScreenOrientation());
       }
     }
   }
 
-  private @Nullable ScreenStackHeaderConfig findHeaderConfig() {
+  private @Nullable Screen findParentWithOrientationSet() {
     ViewParent parent = getScreen().getContainer();
     while (parent != null) {
       if (parent instanceof Screen) {
-        ScreenStackHeaderConfig headerConfig = ((Screen) parent).getHeaderConfig();
-        if (headerConfig != null) {
-          return headerConfig;
+        if (((Screen) parent).hasOrientationSet()) {
+          return (Screen) parent;
         }
       }
       parent = parent.getParent();
@@ -88,18 +91,17 @@ public class ScreenFragment extends Fragment {
     return null;
   }
 
-  protected boolean hasChildScreenWithConfig(Screen screen) {
+  protected boolean hasChildScreenWithOrientationSet(Screen screen) {
     if (screen == null) {
       return false;
     }
     for (ScreenContainer sc : screen.getFragment().getChildScreenContainers()) {
       // we check only the top screen for header config
       Screen topScreen = sc.getTopScreen();
-      ScreenStackHeaderConfig headerConfig = topScreen != null ? topScreen.getHeaderConfig(): null;
-      if (headerConfig != null) {
+      if (topScreen != null && topScreen.hasOrientationSet()) {
         return true;
       }
-      if (hasChildScreenWithConfig(topScreen)) {
+      if (hasChildScreenWithOrientationSet(topScreen)) {
         return true;
       }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -66,14 +66,21 @@ public class ScreenFragment extends Fragment {
 
   public void onContainerUpdate() {
     if (!hasChildScreenWithOrientationSet(getScreen())) {
-      if (getScreen().hasOrientationSet() && getActivity() != null) {
-        getActivity().setRequestedOrientation(getScreen().getScreenOrientation());
-      }
-
-      // if this screen has no orientation set and there is no child with orientation set, we look for a parent that has the orientation set
-      Screen parent = findParentWithOrientationSet();
-      if (parent != null && parent.getFragment() != null && parent.getFragment().getActivity() != null) {
-        parent.getFragment().getActivity().setRequestedOrientation(parent.getScreenOrientation());
+      if (getScreen().hasOrientationSet()) {
+        if (getActivity() == null) {
+          // the activity of fragment is not set yet, so we take the base activity
+          if(mScreenView.getContext() != null && ((ReactContext) mScreenView.getContext()).getCurrentActivity() != null) {
+            ((ReactContext) mScreenView.getContext()).getCurrentActivity().setRequestedOrientation(getScreen().getScreenOrientation());
+          }
+        } else {
+          getActivity().setRequestedOrientation(getScreen().getScreenOrientation());
+        }
+      } else {
+        // if this screen has no orientation set and there is no child with orientation set, we look for a parent that has the orientation set
+        Screen parent = findParentWithOrientationSet();
+        if (parent != null && parent.getFragment() != null && parent.getFragment().getActivity() != null) {
+          parent.getFragment().getActivity().setRequestedOrientation(parent.getScreenOrientation());
+        }
       }
     }
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -1,7 +1,6 @@
 package com.swmansion.rnscreens;
 
 import android.content.Context;
-import android.content.pm.ActivityInfo;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -44,7 +43,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mIsTranslucent;
   private int mTintColor;
   private final Toolbar mToolbar;
-  private int mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
 
   private boolean mIsAttachedToWindow = false;
 
@@ -173,9 +171,11 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
 
     // orientation
-    if (getScreenFragment() == null || !getScreenFragment().hasChildScreenWithConfig(getScreen())) {
+    if (getScreen().hasOrientationSet() && !getScreenFragment().hasChildScreenWithOrientationSet(getScreen())) {
       // we check if there is no child that provides config, since then we shouldn't change orientation here
-      activity.setRequestedOrientation(mScreenOrientation);
+      // we set the orientation here, not when the prop for Screen is passed
+      // because we don't have the Fragment and Activity available then yet
+      activity.setRequestedOrientation(getScreen().getScreenOrientation());
     }
 
     if (mIsHidden) {
@@ -358,10 +358,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
-  public int getScreenOrientation() {
-    return mScreenOrientation;
-  }
-
   public void setTitle(String title) {
     mTitle = title;
   }
@@ -408,39 +404,5 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setDirection(String direction) {
     mDirection = direction;
-  }
-
-  public void setScreenOrientation(String screenOrientation) {
-    if (screenOrientation == null) {
-      mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
-      return;
-    }
-
-    switch (screenOrientation) {
-      case "all":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
-        break;
-      case "portrait":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
-        break;
-      case "portrait_up":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
-        break;
-      case "portrait_down":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
-        break;
-      case "landscape":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
-        break;
-      case "landscape_left":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
-        break;
-      case "landscape_right":
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
-        break;
-      default:
-        mScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
-        break;
-    }
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -134,11 +134,6 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setDirection(direction);
   }
 
-  @ReactProp(name = "screenOrientation")
-  public void setScreenOrientation(ScreenStackHeaderConfig config, String screenOrientation) {
-    config.setScreenOrientation(screenOrientation);
-  }
-
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSString)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -88,6 +88,11 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     }
   }
 
+  @ReactProp(name = "screenOrientation")
+  public void setScreenOrientation(Screen view, String screenOrientation) {
+    view.setScreenOrientation(screenOrientation);
+  }
+
   @Nullable
   @Override
   public Map getExportedCustomDirectEventTypeConstants() {

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -34,10 +34,22 @@ typedef NS_ENUM(NSInteger, RNSActivityState) {
   RNSActivityStateOnTop = 2
 };
 
+typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
+  RNSStatusBarStyleAuto,
+  RNSStatusBarStyleInverted,
+  RNSStatusBarStyleLight,
+  RNSStatusBarStyleDark,
+};
+
 @interface RCTConvert (RNSScreen)
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
 + (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
+
+#if !TARGET_OS_TV
++ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
+#endif
 
 @end
 
@@ -67,6 +79,13 @@ typedef NS_ENUM(NSInteger, RNSActivityState) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
+
+#if !TARGET_OS_TV
+@property (nonatomic) RNSStatusBarStyle statusBarStyle;
+@property (nonatomic) UIStatusBarAnimation statusBarAnimation;
+@property (nonatomic) BOOL statusBarHidden;
+@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
+#endif
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -79,6 +79,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
+@property (nonatomic) BOOL hasWindowTraitsSet;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -31,6 +31,7 @@
     _gestureEnabled = YES;
     _replaceAnimation = RNSScreenReplaceAnimationPop;
     _dismissed = NO;
+    _hasWindowTraitsSet = NO;
   }
 
   return self;
@@ -172,19 +173,21 @@
 - (void)setStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
   _statusBarStyle = statusBarStyle;
+  _hasWindowTraitsSet = YES;
   [RNSScreenWindowTraits assertViewControllerBasedStatusBarAppearenceSet];
   [RNSScreenWindowTraits updateStatusBarAppearance];
 }
 
 - (void)setStatusBarAnimation:(UIStatusBarAnimation)statusBarAnimation
 {
+  _hasWindowTraitsSet = YES;
   _statusBarAnimation = statusBarAnimation;
   [RNSScreenWindowTraits assertViewControllerBasedStatusBarAppearenceSet];
-  [RNSScreenWindowTraits updateStatusBarAppearance];
 }
 
 - (void)setStatusBarHidden:(BOOL)statusBarHidden
 {
+  _hasWindowTraitsSet = YES;
   _statusBarHidden = statusBarHidden;
   [RNSScreenWindowTraits assertViewControllerBasedStatusBarAppearenceSet];
   [RNSScreenWindowTraits updateStatusBarAppearance];
@@ -192,6 +195,7 @@
 
 - (void)setScreenOrientation:(UIInterfaceOrientationMask)screenOrientation
 {
+  _hasWindowTraitsSet = YES;
   _screenOrientation = screenOrientation;
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
 }
@@ -411,7 +415,7 @@
     return !includingModals ? nil : [(RNSScreen *)lastViewController findChildVCForConfigIncludingModals:includingModals] ?: lastViewController;
   }
 
-  UIViewController *selfOrNil = [self findScreenConfig] != nil ? self : nil;
+  UIViewController *selfOrNil = ((RNSScreenView *)self.view).hasWindowTraitsSet ? self : nil;
   if (lastViewController == nil) {
     return selfOrNil;
   } else {
@@ -433,16 +437,6 @@
   }
 }
 #endif
-
-- (RNSScreenStackHeaderConfig *)findScreenConfig
-{
-  for (UIView *subview in self.view.reactSubviews) {
-    if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
-      return (RNSScreenStackHeaderConfig *)subview;
-    }
-  }
-  return nil;
-}
 
 - (void)viewDidLayoutSubviews
 {

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -1,6 +1,7 @@
 #import "RNSScreenStack.h"
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
+#import "RNSScreenWindowTraits.h"
 
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
@@ -108,7 +109,7 @@
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
     // we trigger the update of status bar's appearance here because there is no other lifecycle method
     // that can handle it when dismissing a modal, the same for orientation
-    [RNSScreenStackHeaderConfig updateWindowTraits];
+    [RNSScreenWindowTraits updateWindowTraits];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the
@@ -328,7 +329,7 @@
     }
     // we trigger the update of orientation here because, when dismissing the modal from JS,
     // neither `viewWillAppear` nor `presentationControllerDidDismiss` are called, same for status bar.
-    [RNSScreenStackHeaderConfig updateWindowTraits];
+    [RNSScreenWindowTraits updateWindowTraits];
   };
 
   void (^finish)(void) = ^{

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -3,13 +3,6 @@
 
 #import "RNSScreen.h"
 
-typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
-  RNSStatusBarStyleAuto,
-  RNSStatusBarStyleInverted,
-  RNSStatusBarStyleLight,
-  RNSStatusBarStyleDark,
-};
-
 @interface RNSScreenStackHeaderConfig : UIView
 
 @property (nonatomic, weak) RNSScreenView *screenView;
@@ -39,22 +32,7 @@ typedef NS_ENUM(NSInteger, RNSStatusBarStyle) {
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) UISemanticContentAttribute direction;
 
-#if !TARGET_OS_TV
-@property (nonatomic) RNSStatusBarStyle statusBarStyle;
-@property (nonatomic) UIStatusBarAnimation statusBarAnimation;
-@property (nonatomic) BOOL statusBarHidden;
-@property (nonatomic) UIInterfaceOrientationMask screenOrientation;
-#endif
-
 + (void)willShowViewController:(UIViewController *)vc animated:(BOOL)animated withConfig:(RNSScreenStackHeaderConfig*)config;
-+ (void)updateWindowTraits;
-
-#if !TARGET_OS_TV
-+ (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
-+ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
-+ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
-+ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
-#endif
 
 @end
 
@@ -75,11 +53,6 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
 + (UIBlurEffectStyle)UIBlurEffectStyle:(id)json;
 + (UISemanticContentAttribute)UISemanticContentAttribute:(id)json;
-
-#if !TARGET_OS_TV
-+ (RNSStatusBarStyle)RNSStatusBarStyle:(id)json;
-+ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json;
-#endif
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -374,21 +374,6 @@ API_AVAILABLE(ios(13.0)){
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
 
-#if !TARGET_OS_TV
-  // we put it before check with return because we want to apply changes to status bar even if the header is hidden
-  if (config != nil) {
-    if (config.statusBarStyle || config.statusBarAnimation || config.statusBarHidden) {
-      [RNSScreenStackHeaderConfig assertViewControllerBasedStatusBarAppearenceSet];
-      if ([vc isKindOfClass:[RNSScreen class]]) {
-        [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-      }
-    }
-    if (config.screenOrientation) {
-      [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
-    }
-  }
-#endif
-
   if (config.direction == UISemanticContentAttributeForceLeftToRight || config.direction == UISemanticContentAttributeForceRightToLeft) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;
@@ -522,183 +507,6 @@ API_AVAILABLE(ios(13.0)){
   }
 }
 
-#if !TARGET_OS_TV
-+ (void)assertViewControllerBasedStatusBarAppearenceSet
-{
-  static dispatch_once_t once;
-  static bool viewControllerBasedAppearence;
-  dispatch_once(&once, ^{
-    viewControllerBasedAppearence = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue];
-  });
-  if (!viewControllerBasedAppearence) {
-    RCTLogError(@"If you want to change the appearance of status bar, you have to change \
-    UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
-  }
-}
-#endif
-
-+ (void)updateStatusBarAppearance
-{
-#if !TARGET_OS_TV
-  [UIView animateWithDuration:0.4 animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13, *)) {
-      UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
-      if (firstWindow != nil) {
-        [[firstWindow rootViewController] setNeedsStatusBarAppearanceUpdate];
-      }
-    } else
-#endif
-    {
-      [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
-    }
-  }];
-#endif
-}
-
-#if !TARGET_OS_TV
-+ (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
-{
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    switch (statusBarStyle) {
-      case RNSStatusBarStyleAuto:
-          return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleLightContent : UIStatusBarStyleDarkContent;
-      case RNSStatusBarStyleInverted:
-          return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleDarkContent : UIStatusBarStyleLightContent;
-      case RNSStatusBarStyleLight:
-          return UIStatusBarStyleLightContent;
-      case RNSStatusBarStyleDark:
-          return UIStatusBarStyleDarkContent;
-      default:
-        return UIStatusBarStyleLightContent;
-    }
-  }
-#endif
-  // it is the only non-default style available for iOS < 13
-  if (statusBarStyle == RNSStatusBarStyleLight) {
-    return UIStatusBarStyleLightContent;
-  }
-  return UIStatusBarStyleDefault;
-}
-#endif
-
-#if !TARGET_OS_TV
-+ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask
-{
-  if (UIInterfaceOrientationMaskPortrait & orientationMask) {
-    return UIInterfaceOrientationPortrait;
-  } else if (UIInterfaceOrientationMaskLandscapeLeft & orientationMask) {
-    return UIInterfaceOrientationLandscapeLeft;
-  } else if (UIInterfaceOrientationMaskLandscapeRight & orientationMask) {
-    return UIInterfaceOrientationLandscapeRight;
-  } else if (UIInterfaceOrientationMaskPortraitUpsideDown & orientationMask) {
-    return UIInterfaceOrientationPortraitUpsideDown;
-  }
-  return UIInterfaceOrientationUnknown;
-}
-
-+ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation
-{
-   switch (deviceOrientation) {
-     case UIDeviceOrientationPortrait:
-       return UIInterfaceOrientationPortrait;
-     case UIDeviceOrientationPortraitUpsideDown:
-       return UIInterfaceOrientationPortraitUpsideDown;
-     // UIDevice and UIInterface landscape orientations are switched
-     case UIDeviceOrientationLandscapeLeft:
-       return UIInterfaceOrientationLandscapeRight;
-     case UIDeviceOrientationLandscapeRight:
-       return UIInterfaceOrientationLandscapeLeft;
-     default:
-       return UIInterfaceOrientationUnknown;
-   }
-}
-
-+ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation
-{
-  return 1 << orientation;
-}
-#endif
-
-+ (void)enforceDesiredDeviceOrientation
-{
-#if !TARGET_OS_TV
-  dispatch_async(dispatch_get_main_queue(), ^{
-    UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAllButUpsideDown;
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13, *)) {
-      UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
-      if (firstWindow != nil) {
-        orientationMask = [firstWindow rootViewController].supportedInterfaceOrientations;
-      }
-    } else
-#endif
-    {
-      orientationMask = UIApplication.sharedApplication.keyWindow.rootViewController.supportedInterfaceOrientations;
-    }
-    UIInterfaceOrientation currentDeviceOrientation = [RNSScreenStackHeaderConfig interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
-    UIInterfaceOrientation currentInterfaceOrientation = [RNSScreenStackHeaderConfig interfaceOrientation];
-    UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
-    if ([RNSScreenStackHeaderConfig maskFromOrientation:currentDeviceOrientation] & orientationMask) {
-      if (!([RNSScreenStackHeaderConfig maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
-        // if the device orientation is in the mask, but interface orientation is not, we rotate to device's orientation
-        newOrientation = currentDeviceOrientation;
-      } else {
-        if (currentDeviceOrientation != currentInterfaceOrientation) {
-          // if both device orientation and interface orientation are in the mask, but in different orientations, we rotate to device's orientation
-          newOrientation = currentDeviceOrientation;
-        }
-      }
-    } else {
-      if (!([RNSScreenStackHeaderConfig maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
-        // if both device orientation and interface orientation are not in the mask, we rotate to closest available rotation from mask
-        newOrientation = [RNSScreenStackHeaderConfig defaultOrientationForOrientationMask:orientationMask];
-      } else {
-        // if the device orientation is not in the mask, but interface orientation is in the mask, do nothing
-      }
-    }
-    if (newOrientation != UIInterfaceOrientationUnknown) {
-      [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
-      [UIViewController attemptRotationToDeviceOrientation];
-    }
-  });
-#endif
-}
-
-+ (void)updateWindowTraits
-{
-  [RNSScreenStackHeaderConfig updateStatusBarAppearance];
-  [RNSScreenStackHeaderConfig enforceDesiredDeviceOrientation];
-}
-
-#if !TARGET_OS_TV
-// based on https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
-+ (UIInterfaceOrientation)interfaceOrientation
-{
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
-    if (firstWindow == nil) {
-      return UIInterfaceOrientationUnknown;
-    }
-    UIWindowScene *windowScene = firstWindow.windowScene;
-    if (windowScene == nil) {
-      return UIInterfaceOrientationUnknown;
-    }
-    return windowScene.interfaceOrientation;
-  } else
-#endif
-  {
-    return UIApplication.sharedApplication.statusBarOrientation;
-  }
-}
-#endif
-
 @end
 
 @implementation RNSScreenStackHeaderConfigManager
@@ -735,13 +543,6 @@ RCT_EXPORT_VIEW_PROPERTY(backButtonInCustomView, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
-
-#if !TARGET_OS_TV
-RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)
-RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
-RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
-RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
-#endif
 
 @end
 
@@ -801,38 +602,6 @@ RCT_ENUM_CONVERTER(UISemanticContentAttribute, (@{
   }), UISemanticContentAttributeUnspecified, integerValue)
 
 RCT_ENUM_CONVERTER(UIBlurEffectStyle, ([self blurEffectsForIOSVersion]), UIBlurEffectStyleExtraLight, integerValue)
-
-#if !TARGET_OS_TV
-RCT_ENUM_CONVERTER(RNSStatusBarStyle, (@{
-  @"auto": @(RNSStatusBarStyleAuto),
-  @"inverted": @(RNSStatusBarStyleInverted),
-  @"light": @(RNSStatusBarStyleLight),
-  @"dark": @(RNSStatusBarStyleDark),
-  }), RNSStatusBarStyleAuto, integerValue)
-
-+ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json
-{
-  json = [self NSString:json];
-  if ([json isEqualToString:@"default"]) {
-    return UIInterfaceOrientationMaskAllButUpsideDown;
-  } else if ([json isEqualToString:@"all"]) {
-    return UIInterfaceOrientationMaskAll;
-  } else if ([json isEqualToString:@"portrait"]) {
-    return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
-  } else if ([json isEqualToString:@"portrait_up"]) {
-    return UIInterfaceOrientationMaskPortrait;
-  } else if ([json isEqualToString:@"portrait_down"]) {
-    return UIInterfaceOrientationMaskPortraitUpsideDown;
-  } else if ([json isEqualToString:@"landscape"]) {
-    return UIInterfaceOrientationMaskLandscape;
-  } else if ([json isEqualToString:@"landscape_left"]) {
-    return UIInterfaceOrientationMaskLandscapeLeft;
-  } else if ([json isEqualToString:@"landscape_right"]) {
-    return UIInterfaceOrientationMaskLandscapeRight;
-  }
-  return UIInterfaceOrientationMaskAllButUpsideDown;
-}
-#endif
 
 @end
 

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -1,0 +1,18 @@
+#import "RNSScreen.h"
+
+@interface RNSScreenWindowTraits : NSObject
+
++ (void)updateWindowTraits;
+
++ (void)assertViewControllerBasedStatusBarAppearenceSet;
++ (void)updateStatusBarAppearance;
++ (void)enforceDesiredDeviceOrientation;
+
+#if !TARGET_OS_TV
++ (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;
++ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask;
++ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
++ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
+#endif
+
+@end

--- a/ios/RNSScreenWindowTraits.m
+++ b/ios/RNSScreenWindowTraits.m
@@ -1,0 +1,183 @@
+#import "RNSScreenWindowTraits.h"
+#import "RNSScreen.h"
+
+@implementation RNSScreenWindowTraits
+
+#if !TARGET_OS_TV
++ (void)assertViewControllerBasedStatusBarAppearenceSet
+{
+  static dispatch_once_t once;
+  static bool viewControllerBasedAppearence;
+  dispatch_once(&once, ^{
+    viewControllerBasedAppearence = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue];
+  });
+  if (!viewControllerBasedAppearence) {
+    RCTLogError(@"If you want to change the appearance of status bar, you have to change \
+    UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
+  }
+}
+#endif
+
++ (void)updateStatusBarAppearance
+{
+#if !TARGET_OS_TV
+  [UIView animateWithDuration:0.4 animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    if (@available(iOS 13, *)) {
+      UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+      if (firstWindow != nil) {
+        [[firstWindow rootViewController] setNeedsStatusBarAppearanceUpdate];
+      }
+    } else
+#endif
+    {
+      [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
+    }
+  }];
+#endif
+}
+
+#if !TARGET_OS_TV
++ (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    switch (statusBarStyle) {
+      case RNSStatusBarStyleAuto:
+          return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleLightContent : UIStatusBarStyleDarkContent;
+      case RNSStatusBarStyleInverted:
+          return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark ? UIStatusBarStyleDarkContent : UIStatusBarStyleLightContent;
+      case RNSStatusBarStyleLight:
+          return UIStatusBarStyleLightContent;
+      case RNSStatusBarStyleDark:
+          return UIStatusBarStyleDarkContent;
+      default:
+        return UIStatusBarStyleLightContent;
+    }
+  }
+#endif
+  // it is the only non-default style available for iOS < 13
+  if (statusBarStyle == RNSStatusBarStyleLight) {
+    return UIStatusBarStyleLightContent;
+  }
+  return UIStatusBarStyleDefault;
+}
+#endif
+
+#if !TARGET_OS_TV
++ (UIInterfaceOrientation)defaultOrientationForOrientationMask:(UIInterfaceOrientationMask)orientationMask
+{
+  if (UIInterfaceOrientationMaskPortrait & orientationMask) {
+    return UIInterfaceOrientationPortrait;
+  } else if (UIInterfaceOrientationMaskLandscapeLeft & orientationMask) {
+    return UIInterfaceOrientationLandscapeLeft;
+  } else if (UIInterfaceOrientationMaskLandscapeRight & orientationMask) {
+    return UIInterfaceOrientationLandscapeRight;
+  } else if (UIInterfaceOrientationMaskPortraitUpsideDown & orientationMask) {
+    return UIInterfaceOrientationPortraitUpsideDown;
+  }
+  return UIInterfaceOrientationUnknown;
+}
+
++ (UIInterfaceOrientation)interfaceOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation
+{
+   switch (deviceOrientation) {
+     case UIDeviceOrientationPortrait:
+       return UIInterfaceOrientationPortrait;
+     case UIDeviceOrientationPortraitUpsideDown:
+       return UIInterfaceOrientationPortraitUpsideDown;
+     // UIDevice and UIInterface landscape orientations are switched
+     case UIDeviceOrientationLandscapeLeft:
+       return UIInterfaceOrientationLandscapeRight;
+     case UIDeviceOrientationLandscapeRight:
+       return UIInterfaceOrientationLandscapeLeft;
+     default:
+       return UIInterfaceOrientationUnknown;
+   }
+}
+
++ (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation
+{
+  return 1 << orientation;
+}
+#endif
+
++ (void)enforceDesiredDeviceOrientation
+{
+#if !TARGET_OS_TV
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAllButUpsideDown;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    if (@available(iOS 13, *)) {
+      UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+      if (firstWindow != nil) {
+        orientationMask = [firstWindow rootViewController].supportedInterfaceOrientations;
+      }
+    } else
+#endif
+    {
+      orientationMask = UIApplication.sharedApplication.keyWindow.rootViewController.supportedInterfaceOrientations;
+    }
+    UIInterfaceOrientation currentDeviceOrientation = [RNSScreenWindowTraits interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
+    UIInterfaceOrientation currentInterfaceOrientation = [RNSScreenWindowTraits interfaceOrientation];
+    UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
+    if ([RNSScreenWindowTraits maskFromOrientation:currentDeviceOrientation] & orientationMask) {
+      if (!([RNSScreenWindowTraits maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
+        // if the device orientation is in the mask, but interface orientation is not, we rotate to device's orientation
+        newOrientation = currentDeviceOrientation;
+      } else {
+        if (currentDeviceOrientation != currentInterfaceOrientation) {
+          // if both device orientation and interface orientation are in the mask, but in different orientations, we rotate to device's orientation
+          newOrientation = currentDeviceOrientation;
+        }
+      }
+    } else {
+      if (!([RNSScreenWindowTraits maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
+        // if both device orientation and interface orientation are not in the mask, we rotate to closest available rotation from mask
+        newOrientation = [RNSScreenWindowTraits defaultOrientationForOrientationMask:orientationMask];
+      } else {
+        // if the device orientation is not in the mask, but interface orientation is in the mask, do nothing
+      }
+    }
+    if (newOrientation != UIInterfaceOrientationUnknown) {
+      [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
+      [UIViewController attemptRotationToDeviceOrientation];
+    }
+  });
+#endif
+}
+
++ (void)updateWindowTraits
+{
+  [RNSScreenWindowTraits updateStatusBarAppearance];
+  [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
+}
+
+#if !TARGET_OS_TV
+// based on https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
++ (UIInterfaceOrientation)interfaceOrientation
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+    if (firstWindow == nil) {
+      return UIInterfaceOrientationUnknown;
+    }
+    UIWindowScene *windowScene = firstWindow.windowScene;
+    if (windowScene == nil) {
+      return UIInterfaceOrientationUnknown;
+    }
+    return windowScene.interfaceOrientation;
+  } else
+#endif
+  {
+    return UIApplication.sharedApplication.statusBarOrientation;
+  }
+}
+#endif
+
+@end

--- a/src/createNativeStackNavigator.tsx
+++ b/src/createNativeStackNavigator.tsx
@@ -196,10 +196,6 @@ class StackView extends React.Component<Props> {
       hideShadow,
       largeTitle,
       largeTitleHideShadow,
-      screenOrientation,
-      statusBarAnimation,
-      statusBarHidden,
-      statusBarStyle,
       title,
       translucent,
     } = options;
@@ -231,10 +227,6 @@ class StackView extends React.Component<Props> {
       largeTitleFontSize: headerLargeTitleStyle?.fontSize,
       largeTitleFontWeight: headerLargeTitleStyle?.fontWeight,
       largeTitleHideShadow: largeTitleHideShadow || headerLargeTitleHideShadow,
-      screenOrientation,
-      statusBarAnimation,
-      statusBarHidden,
-      statusBarStyle,
       title,
       titleColor: headerTitleStyle?.color || headerTintColor,
       titleFontFamily: headerTitleStyle?.fontFamily,
@@ -384,6 +376,10 @@ class StackView extends React.Component<Props> {
             ? true
             : options.gestureEnabled
         }
+        screenOrientation={options.screenOrientation}
+        statusBarAnimation={options.statusBarAnimation}
+        statusBarHidden={options.statusBarHidden}
+        statusBarStyle={options.statusBarStyle}
         onAppear={() => this.onAppear(route, descriptor)}
         onWillAppear={() => options?.onWillAppear?.()}
         onWillDisappear={() => options?.onWillDisappear?.()}

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -234,7 +234,7 @@ export type NativeStackNavigationOptions = {
    * - "landscape_left" – landscape-left orientation is permitted
    * - "landscape_right" – landscape-right orientation is permitted
    */
-  screenOrientation?: ScreenStackHeaderConfigProps['screenOrientation'];
+  screenOrientation?: ScreenProps['screenOrientation'];
   /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:
@@ -263,7 +263,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  statusBarAnimation?: ScreenStackHeaderConfigProps['statusBarAnimation'];
+  statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**
    * Whether the status bar should be hidden on this screen. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
    *
@@ -274,7 +274,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  statusBarStyle?: ScreenStackHeaderConfigProps['statusBarStyle'];
+  statusBarStyle?: ScreenProps['statusBarStyle'];
   /**
    * String that can be displayed in the header as a fallback for `headerTitle`.
    */

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -38,10 +38,6 @@ export default function HeaderConfig({
   headerTopInsetEnabled = true,
   headerTranslucent,
   route,
-  screenOrientation,
-  statusBarAnimation,
-  statusBarHidden,
-  statusBarStyle,
   title,
 }: Props): JSX.Element {
   const { colors } = useTheme();
@@ -79,10 +75,6 @@ export default function HeaderConfig({
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       largeTitleFontWeight={headerLargeTitleStyle.fontWeight}
       largeTitleHideShadow={headerLargeTitleHideShadow}
-      screenOrientation={screenOrientation}
-      statusBarAnimation={statusBarAnimation}
-      statusBarHidden={statusBarHidden}
-      statusBarStyle={statusBarStyle}
       title={
         headerTitle !== undefined
           ? headerTitle

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -62,11 +62,15 @@ export default function NativeStackView({
       {routes.map((route) => {
         const { options, render: renderScene } = descriptors[route.key];
         const {
+          contentStyle,
           gestureEnabled,
           replaceAnimation = 'pop',
+          screenOrientation,
           stackPresentation = 'push',
           stackAnimation,
-          contentStyle,
+          statusBarAnimation,
+          statusBarHidden,
+          statusBarStyle,
         } = options;
 
         const viewStyles = [
@@ -83,8 +87,12 @@ export default function NativeStackView({
             style={StyleSheet.absoluteFill}
             gestureEnabled={isAndroid ? false : gestureEnabled}
             replaceAnimation={replaceAnimation}
-            stackPresentation={stackPresentation}
+            screenOrientation={screenOrientation}
             stackAnimation={stackAnimation}
+            stackPresentation={stackPresentation}
+            statusBarAnimation={statusBarAnimation}
+            statusBarHidden={statusBarHidden}
+            statusBarStyle={statusBarStyle}
             onWillAppear={() => {
               navigation.emit({
                 type: 'transitionStart',

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -96,6 +96,18 @@ export interface ScreenProps extends ViewProps {
    */
   replaceAnimation?: ScreenReplaceTypes;
   /**
+   * @description Controls in which orientation should the screen appear.
+   * @type "default" - on iOS, it resolves to "all" without "portrait_down" and on Android it lets the system decide the best orientation
+   * @type "all" – all orientations are permitted
+   * @type "portrait" – portrait orientations are permitted
+   * @type "portrait_up" – right-side portrait orientation is permitted
+   * @type "portrait_down" – upside-down portrait orientation is permitted
+   * @type "landscape" – landscape orientations are permitted
+   * @type "landscape_left" – landscape-left orientation is permitted
+   * @type "landscape_right" – landscape-right orientation is permitted
+   */
+  screenOrientation?: ScreenOrientationTypes;
+  /**
    * @description Allows for the customization of how the given screen should appear/dissapear when pushed or popped at the top of the stack. The following values are currently supported:
    *  @type "default" – uses a platform default animation
    *  @type "fade" – fades screen in or out
@@ -115,6 +127,21 @@ export interface ScreenProps extends ViewProps {
    * @type "formSheet" – will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
    */
   stackPresentation?: StackPresentationTypes;
+  /**
+   * @host (iOS only)
+   * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
+   */
+  statusBarAnimation?: 'none' | 'fade' | 'slide';
+  /**
+   * @host (iOS only)
+   * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
+   */
+  statusBarHidden?: boolean;
+  /**
+   * @host (iOS only)
+   * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
+   */
+  statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
 }
 
 export interface ScreenContainerProps extends ViewProps {
@@ -219,33 +246,6 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
    * @description Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
    */
   largeTitleHideShadow?: boolean;
-  /**
-   * @description Controls in which orientation should the screen appear.
-   * @type "default" - on iOS, it resolves to "all" without "portrait_down" and on Android it lets the system decide the best orientation
-   * @type "all" – all orientations are permitted
-   * @type "portrait" – portrait orientations are permitted
-   * @type "portrait_up" – right-side portrait orientation is permitted
-   * @type "portrait_down" – upside-down portrait orientation is permitted
-   * @type "landscape" – landscape orientations are permitted
-   * @type "landscape_left" – landscape-left orientation is permitted
-   * @type "landscape_right" – landscape-right orientation is permitted
-   */
-  screenOrientation?: ScreenOrientationTypes;
-  /**
-   * @host (iOS only)
-   * @description Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `fade`.
-   */
-  statusBarAnimation?: 'none' | 'fade' | 'slide';
-  /**
-   * @host (iOS only)
-   * @description When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `false`.
-   */
-  statusBarHidden?: boolean;
-  /**
-   * @host (iOS only)
-   * @description Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Defaults to `auto`.
-   */
-  statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
   /**
    * @description String that representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).
    */


### PR DESCRIPTION
## Description

Moved the props used for status bar and orientation management from the `HeaderConfig` to `Screen` component in order to make it available for them to be used by all navigators, not only `native-stack`. It should also fix #836 due to check if the orientation has been set on Android.

## Changes

Moved the logic from `HeaderConfig` into `Screen` both on iOS and Android.
On iOS, there has been added new class with static methods used when managing those props.
On Android, for `native-stack` (where the `HeaderConfig` lives), the logic of setting the proper `screenOrientation` was left in `HeaderConfig` because it is required to have the `Fragment` and `Activity` ready to set it, and it is not available when setting the prop.

## Test code and steps to reproduce

`Test42.tsx` for orientation and `Test642.tsx` for status bar management in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes
