### PR TITLE
feat: make enabled take precendce over ENABLE_SCREENS

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -100,9 +100,9 @@ class Screen extends React.Component<ScreenProps> {
   };
 
   render() {
-    const { enabled } = this.props;
+    const { enabled = ENABLE_SCREENS } = this.props;
 
-    if (enabled || (enabled === undefined && ENABLE_SCREENS)) {
+    if (enabled) {
       AnimatedNativeScreen =
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
@@ -139,9 +139,9 @@ class Screen extends React.Component<ScreenProps> {
 
 class ScreenContainer extends React.Component<ScreenContainerProps> {
   render() {
-    const { enabled, ...rest } = this.props;
+    const { enabled = ENABLE_SCREENS, ...rest } = this.props;
 
-    if (enabled || (enabled === undefined && ENABLE_SCREENS)) {
+    if (enabled) {
       return <ScreensNativeModules.NativeScreenContainer {...rest} />;
     }
 

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -100,19 +100,9 @@ class Screen extends React.Component<ScreenProps> {
   };
 
   render() {
-    const { enabled = true } = this.props;
+    const { enabled } = this.props;
 
-    if (!ENABLE_SCREENS || !enabled) {
-      // Filter out active prop in this case because it is unused and
-      // can cause problems depending on react-native version:
-      // https://github.com/react-navigation/react-navigation/issues/4886
-      // same for enabled prop
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { active, enabled, onComponentRef, ...rest } = this.props;
-
-      return <Animated.View {...rest} ref={this.setRef} />;
-    } else {
+    if (enabled || (enabled === undefined && ENABLE_SCREENS)) {
       AnimatedNativeScreen =
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
@@ -133,19 +123,29 @@ class Screen extends React.Component<ScreenProps> {
           ref={this.setRef}
         />
       );
+    } else {
+      // Filter out active prop in this case because it is unused and
+      // can cause problems depending on react-native version:
+      // https://github.com/react-navigation/react-navigation/issues/4886
+      // same for enabled prop
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { active, enabled, onComponentRef, ...rest } = this.props;
+
+      return <Animated.View {...rest} ref={this.setRef} />;
     }
   }
 }
 
 class ScreenContainer extends React.Component<ScreenContainerProps> {
   render() {
-    const { enabled = true, ...rest } = this.props;
+    const { enabled, ...rest } = this.props;
 
-    if (!ENABLE_SCREENS || !enabled) {
-      return <View {...rest} />;
-    } else {
-      return <ScreensNativeModules.NativeScreenContainer {...this.props} />;
+    if (enabled || (enabled === undefined && ENABLE_SCREENS)) {
+      return <ScreensNativeModules.NativeScreenContainer {...rest} />;
     }
+
+    return <View {...rest} />;
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,13 @@ export function screensEnabled(): boolean {
 
 export class NativeScreen extends React.Component<ScreenProps> {
   render(): JSX.Element {
-    let { active, activityState, style, enabled = true, ...rest } = this.props;
+    let {
+      active,
+      activityState,
+      style,
+      enabled = ENABLE_SCREENS,
+      ...rest
+    } = this.props;
     if (active !== undefined && activityState === undefined) {
       activityState = active !== 0 ? 2 : 0; // change taken from index.native.tsx
     }
@@ -30,9 +36,7 @@ export class NativeScreen extends React.Component<ScreenProps> {
       <View
         style={[
           style,
-          ENABLE_SCREENS && enabled && activityState !== 2
-            ? { display: 'none' }
-            : null,
+          enabled && activityState !== 2 ? { display: 'none' } : null,
         ]}
         {...rest}
       />


### PR DESCRIPTION
## Description

Changed the logic to make the `enabled` prop set to `true` result in using native code even if `ENABLE_SCREENS` is set to `false`.

## Changes

Changed `index.native.tsx`.

## Test code and steps to reproduce

Don't call `enableScreens()` in your app and don't pass `false` to `detachInactiveScreens` in your navigator and it will resolve in native `react-native-screens` components being used.

## Checklist

- [x] Ensured that CI passes
