### PR TITLE
feat: enable screens by default

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -23,7 +23,7 @@ import {
   ScreenStackHeaderConfigProps,
 } from './types';
 
-let ENABLE_SCREENS = false;
+let ENABLE_SCREENS = true;
 
 function enableScreens(shouldEnableScreens = true): void {
   ENABLE_SCREENS = shouldEnableScreens;


### PR DESCRIPTION
## Description

Enabled native components of `react-native-screens` by default. It results in no need of calling `enableScreens()` at the top of your app to use them 🎉 

## Changes

Changed `index.native.tsx`.

## Test code and steps to reproduce

Do not call `enableScreens()` at the top of your app and spot that native components are used.

## Checklist

- [x] Ensured that CI passes
