### PR TITLE
fix: rework open/back animation logic on Android

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -34,6 +34,7 @@ import Test817 from './src/Test817';
 import Test831 from './src/Test831';
 import Test844 from './src/Test844';
 import Test861 from './src/Test861';
+import Test865 from './src/Test865';
 
 enableScreens();
 

--- a/TestsExample/src/Test865.tsx
+++ b/TestsExample/src/Test865.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { View, Text, Button } from 'react-native';
+import {View, Text, Button} from 'react-native';
 
-import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
 
 const Stack = createNativeStackNavigator();
 
-const First = ({ navigation }: any) => (
-  <View style={{ flex: 1, justifyContent: 'center' }}>
-    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 1</Text>
+const First = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) => (
+  <View style={{flex: 1, justifyContent: 'center'}}>
+    <Text style={{paddingBottom: 24, textAlign: 'center'}}>Screen 1</Text>
     <Button
       title="PUSH TO SCREEN 2"
       onPress={() => navigation.push('Screen2')}
@@ -16,9 +23,13 @@ const First = ({ navigation }: any) => (
   </View>
 );
 
-const Second = ({ navigation }: any) => (
-  <View style={{ flex: 1, justifyContent: 'center' }}>
-    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 2</Text>
+const Second = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) => (
+  <View style={{flex: 1, justifyContent: 'center'}}>
+    <Text style={{paddingBottom: 24, textAlign: 'center'}}>Screen 2</Text>
     <Button
       title="PUSH TO SCREEN 3"
       onPress={() => navigation.push('Screen3')}
@@ -26,14 +37,18 @@ const Second = ({ navigation }: any) => (
   </View>
 );
 
-const Third = ({ navigation }: any) => (
-  <View style={{ flex: 1, justifyContent: 'center' }}>
-    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 3</Text>
+const Third = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) => (
+  <View style={{flex: 1, justifyContent: 'center'}}>
+    <Text style={{paddingBottom: 24, textAlign: 'center'}}>Screen 3</Text>
     <Button
       title="RESET TO SCREEN 1 WITH INDEX OF 0"
       onPress={() =>
         navigation.reset({
-          routes: [{ name: 'Screen1' }],
+          routes: [{name: 'Screen1'}],
           index: 0,
         })
       }

--- a/TestsExample/src/Test865.tsx
+++ b/TestsExample/src/Test865.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+const First = ({ navigation }: any) => (
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 1</Text>
+    <Button
+      title="PUSH TO SCREEN 2"
+      onPress={() => navigation.push('Screen2')}
+    />
+  </View>
+);
+
+const Second = ({ navigation }: any) => (
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 2</Text>
+    <Button
+      title="PUSH TO SCREEN 3"
+      onPress={() => navigation.push('Screen3')}
+    />
+  </View>
+);
+
+const Third = ({ navigation }: any) => (
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Text style={{ paddingBottom: 24, textAlign: 'center' }}>Screen 3</Text>
+    <Button
+      title="RESET TO SCREEN 1 WITH INDEX OF 0"
+      onPress={() =>
+        navigation.reset({
+          routes: [{ name: 'Screen1' }],
+          index: 0,
+        })
+      }
+    />
+  </View>
+);
+
+const App = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          stackAnimation: 'slide_from_right',
+        }}>
+        <Stack.Screen name="Screen1" component={First} />
+        <Stack.Screen name="Screen2" component={Second} />
+        <Stack.Screen name="Screen3" component={Third} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+export default App;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -215,13 +215,11 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       }
     }
 
-    switch (stackAnimation) {
-      case NONE:
-        transition = FragmentTransaction.TRANSIT_NONE;
-        break;
-      case FADE:
-        transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
-        break;
+    if (stackAnimation == Screen.StackAnimation.NONE) {
+      transition = FragmentTransaction.TRANSIT_NONE;
+    }
+    if (stackAnimation == Screen.StackAnimation.FADE) {
+      transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
     }
 
     // check if it is a custom animation

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -169,7 +169,6 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       }
     }
 
-    // variables used for "open/close animation" logic
     boolean shouldUseOpenAnimation = true;
     int transition;
     Screen.StackAnimation stackAnimation = Screen.StackAnimation.DEFAULT;
@@ -222,7 +221,6 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
     }
 
-    // check if it is a custom animation
     if (!isCustomAnimation(stackAnimation)) {
       getOrCreateTransaction().setTransition(transition);
     }


### PR DESCRIPTION
## Description
Intricate logic for animation opening and closing screens in Android introduced incontinency in `navigation.reset`. 
The issue is described in detail in #865.
Fixes https://github.com/software-mansion/react-native-screens/issues/865.

## Changes
- (Hopefully) simplified transition logic in Android.

## Screenshots / GIFs

### Before

https://user-images.githubusercontent.com/39658211/113130079-ef360800-921b-11eb-9aa8-ce6fd8c43cb3.mov

### After

https://user-images.githubusercontent.com/39658211/113129416-2657e980-921b-11eb-9e99-2497e5ce0d73.mov

## Test code and steps to reproduce

Provided `Test865.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
