### PR TITLE
docs: remove from READMEs info about enabledScreens being required

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Read usage guide depending on if you are [using Expo](#usage-in-expo-with-react-
 
 Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc). We plan on adding it to other navigators shortly.
 
-To configure react-navigation to use screens instead of plain RN Views for rendering screen views, follow the steps below:
-
-1.  Add this library as a dependency to your project:
+To configure react-navigation to use screens instead of plain RN Views for rendering screen views, simply add this library as a dependency to your project:
 
 ```bash
 # bare React Native project
@@ -55,19 +53,9 @@ yarn add react-native-screens
 expo install react-native-screens
 ```
 
-2.  Enable screens support before any of your navigation screens renders. Add the following code to your main application file (e.g. App.js):
+Just make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher.
 
-```js
-import { enableScreens } from 'react-native-screens';
-
-enableScreens();
-```
-
-Note that the above code needs to execute before the first render of a navigation screen. You can check the Example's app [App.js](https://github.com/kmagiera/react-native-screens/blob/master/Example/App.js#L16) file as a reference.
-
-3.  Make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher
-
-4.  You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
+You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
 
 ### Using createNativeStackNavigator with React Navigation
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Just make sure that the version of [react-navigation](https://github.com/react-n
 
 You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
 
+### Disabling `react-native-screens`
+
+If, for whatever reason, you'd like to disable native screens support and use plain React Native Views add the following code in your entry file (e.g. `App.js`):
+
+```js
+import { enableScreens } from 'react-native-screens';
+
+enableScreens(false);
+```
+
 ### Using createNativeStackNavigator with React Navigation
 
 To take advantage of the native stack navigator primitive for React Navigation that leverages `UINavigationController` on iOS and `Fragment` on Android, please refer to the [README in react-native-screens/native-stack](https://github.com/software-mansion/react-native-screens/tree/master/native-stack) for React Navigation v5 and [README in react-native-screens/createNativeStackNavigator](https://github.com/software-mansion/react-native-screens/tree/master/createNativeStackNavigator) for older versions. 

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -10,14 +10,6 @@ This navigator uses native navigation primitives (`UINavigationController` on iO
 npm install react-native-screens @react-navigation/native
 ```
 
-Make sure to enable `react-native-screens`. This needs to be done before our app renders. To do it, add the following code in your entry file (e.g. `App.js`):
-
-```js
-import { enableScreens } from 'react-native-screens';
-
-enableScreens();
-```
-
 ## API Definition
 
 To use this navigator, import it from `react-native-screens/createNativeStackNavigator`:
@@ -310,3 +302,13 @@ const largeHeaderInset = statusBarInset + 96; // inset to use for a large header
 ```
 
 You can also see an example of using these values with a `ScrollView` here: https://snack.expo.io/@wolewicki/ios-header-height.
+
+### Disabling `react-native-screens`
+
+If, for whatever reason, you'd like to disable native screens support and use plain React Native Views just use:
+
+```js
+import { enableScreens } from 'react-native-screens';
+
+enableScreens(false);
+```

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -10,6 +10,16 @@ This navigator uses native navigation primitives (`UINavigationController` on iO
 npm install react-native-screens @react-navigation/native
 ```
 
+## Disabling `react-native-screens`
+
+If, for whatever reason, you'd like to disable native screens support and use plain React Native Views add the following code in your entry file (e.g. `App.js`):
+
+```js
+import { enableScreens } from 'react-native-screens';
+
+enableScreens(false);
+```
+
 ## API Definition
 
 To use this navigator, import it from `react-native-screens/createNativeStackNavigator`:
@@ -302,13 +312,3 @@ const largeHeaderInset = statusBarInset + 96; // inset to use for a large header
 ```
 
 You can also see an example of using these values with a `ScrollView` here: https://snack.expo.io/@wolewicki/ios-header-height.
-
-### Disabling `react-native-screens`
-
-If, for whatever reason, you'd like to disable native screens support and use plain React Native Views just use:
-
-```js
-import { enableScreens } from 'react-native-screens';
-
-enableScreens(false);
-```

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -400,6 +400,7 @@ const largeHeaderInset = statusBarInset + 96; // inset to use for a large header
 
 You can also see an example of using these values with a `ScrollView` here: https://snack.expo.io/@wolewicki/ios-header-height.
 
+
 ## Example
 
 ```js

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -10,6 +10,16 @@ This navigator uses native navigation primitives (`UINavigationController` on iO
 npm install react-native-screens @react-navigation/native
 ```
 
+## Disabling `react-native-screens`
+
+If, for whatever reason, you'd like to disable native screens support and use plain React Native Views add the following code in your entry file (e.g. `App.js`):
+
+```js
+import { enableScreens } from 'react-native-screens';
+
+enableScreens(false);
+```
+
 ## API Definition
 
 To use this navigator, import it from `react-native-screens/native-stack`:
@@ -389,16 +399,6 @@ const largeHeaderInset = statusBarInset + 96; // inset to use for a large header
 ```
 
 You can also see an example of using these values with a `ScrollView` here: https://snack.expo.io/@wolewicki/ios-header-height.
-
-### Disabling `react-native-screens`
-
-If, for whatever reason, you'd like to disable native screens support and use plain React Native Views just use:
-
-```js
-import { enableScreens } from 'react-native-screens';
-
-enableScreens(false);
-```
 
 ## Example
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -10,14 +10,6 @@ This navigator uses native navigation primitives (`UINavigationController` on iO
 npm install react-native-screens @react-navigation/native
 ```
 
-Make sure to enable `react-native-screens`. This needs to be done before our app renders. To do it, add the following code in your entry file (e.g. `App.js`):
-
-```js
-import { enableScreens } from 'react-native-screens';
-
-enableScreens();
-```
-
 ## API Definition
 
 To use this navigator, import it from `react-native-screens/native-stack`:
@@ -398,6 +390,15 @@ const largeHeaderInset = statusBarInset + 96; // inset to use for a large header
 
 You can also see an example of using these values with a `ScrollView` here: https://snack.expo.io/@wolewicki/ios-header-height.
 
+### Disabling `react-native-screens`
+
+If, for whatever reason, you'd like to disable native screens support and use plain React Native Views just use:
+
+```js
+import { enableScreens } from 'react-native-screens';
+
+enableScreens(false);
+```
 
 ## Example
 


### PR DESCRIPTION
## Description

Calling `enableScreens()` at the top of your application is no longer required since `v3.0.0` and this should be reflected in the documentation.

## Changes

- Updated README.md
- Updated native-stack/README.md
- Updated createNativeStackNavigator/README.md

## Checklist

- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
