### PR TITLE
add native stack screen props rype

### DIFF
--- a/src/native-stack/index.tsx
+++ b/src/native-stack/index.tsx
@@ -14,4 +14,5 @@ export { default as NativeStackView } from './views/NativeStackView';
 export type {
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
+  NativeStackScreenProps,
 } from './types';

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -7,6 +7,7 @@ import {
   StackNavigationState,
   StackRouterOptions,
   StackActionHelpers,
+  RouteProp,
 } from '@react-navigation/native';
 import * as React from 'react';
 import { ImageSourcePropType, StyleProp, ViewStyle } from 'react-native';
@@ -45,6 +46,14 @@ export type NativeStackNavigationProp<
   NativeStackNavigationEventMap
 > &
   StackActionHelpers<ParamList>;
+
+export type NativeStackScreenProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = string
+> = {
+navigation: NativeStackNavigationProp<ParamList, RouteName>;
+route: RouteProp<ParamList, RouteName>;
+};
 
 export type NativeStackNavigationHelpers = NavigationHelpers<
   ParamListBase,

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -51,8 +51,8 @@ export type NativeStackScreenProps<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = string
 > = {
-navigation: NativeStackNavigationProp<ParamList, RouteName>;
-route: RouteProp<ParamList, RouteName>;
+  navigation: NativeStackNavigationProp<ParamList, RouteName>;
+  route: RouteProp<ParamList, RouteName>;
 };
 
 export type NativeStackNavigationHelpers = NavigationHelpers<


### PR DESCRIPTION
## Description

When working on my pet project I found out that Native Stack has no type similar to `StackScreenProps` shorthand that I often use with JS Stack.

## Changes

I added one type to typings of native stack, I copied it from JS Stack and updated it to use Navigation Prop type from native stack instead of the JS one.

## Screenshots / GIFs

n/a

### Before

```typescript
import { NativeStackNavigationProp } from 'react-native-screens/native-stack';

type ProfileScreenNavigationProp = NativeStackNavigationProp<
  RootStackParamList,
  'Profile'
>;

interface Props = {
  navigation: ProfileScreenNavigationProp;
};

export const ProgileScreen: React.FC<Props> = () => {
// ...
```

### After

```typescript
import { NativeStackScreenProps } from 'react-native-screens/native-stack';

type Props = NativeStackScreenProps<RootStackParamList, 'Profile'>;

export const ProgileScreen: React.FC<Props> = () => {
// ...
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
