### PR TITLE
fix: add missing import in TestsExample

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -33,6 +33,7 @@ import Test791 from './src/Test791';
 import Test817 from './src/Test817';
 import Test831 from './src/Test831';
 import Test844 from './src/Test844';
+import Test852 from './src/Test852';
 import Test861 from './src/Test861';
 import Test865 from './src/Test865';
 


### PR DESCRIPTION
## Description
Added missing import statement in `App.js` for Test852 in TestsExample project.
