### PR TITLE
fix: properly handle first screen on stack

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -36,6 +36,7 @@ import Test844 from './src/Test844';
 import Test852 from './src/Test852';
 import Test861 from './src/Test861';
 import Test865 from './src/Test865';
+import Test881 from './src/Test881';
 
 export default function App() {
   return <Test42 />;

--- a/TestsExample/src/Test881.tsx
+++ b/TestsExample/src/Test881.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {View} from 'react-native';
+import {NavigationContainer} from '@react-navigation/native';
+
+const View1 = () => <View style={{flex: 1, backgroundColor: 'red'}} />;
+const View2 = () => <View style={{flex: 1, backgroundColor: 'blue'}} />;
+const View3 = () => <View style={{flex: 1, backgroundColor: 'yellow'}} />;
+
+const Stack1 = createNativeStackNavigator();
+const Stack2 = createNativeStackNavigator();
+const Stack3 = createNativeStackNavigator();
+
+const Tab = createBottomTabNavigator();
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="StackNav1" component={StackNav1} />
+        <Tab.Screen name="StackNav2" component={StackNav2} />
+        <Tab.Screen name="StackNav3" component={StackNav3} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function StackNav1() {
+  return (
+    <Stack1.Navigator>
+      <Stack1.Screen name="View1" component={View1} />
+    </Stack1.Navigator>
+  );
+}
+
+function StackNav2() {
+  return (
+    <Stack2.Navigator>
+      <Stack2.Screen name="View2" component={View2} />
+    </Stack2.Navigator>
+  );
+}
+
+function StackNav3() {
+  return (
+    <Stack3.Navigator>
+      <Stack3.Screen name="View3" component={View3} />
+    </Stack3.Navigator>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -170,8 +170,8 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     }
 
     boolean shouldUseOpenAnimation = true;
-    int transition;
-    Screen.StackAnimation stackAnimation = Screen.StackAnimation.DEFAULT;
+    int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
+    Screen.StackAnimation stackAnimation = null;
 
     if (!mStack.contains(newTop)) {
       // if new top screen wasn't on stack we do "open animation" so long it is not the very first screen on stack
@@ -190,27 +190,29 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     }
 
     // animation logic start
-    if (shouldUseOpenAnimation) {
-      transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
+    if (stackAnimation != null) {
+      if (shouldUseOpenAnimation) {
+        transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
 
-      switch (stackAnimation) {
-        case SLIDE_FROM_RIGHT:
-          getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
-          break;
-        case SLIDE_FROM_LEFT:
-          getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
-          break;
-      }
-    } else {
-      transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
+        switch (stackAnimation) {
+          case SLIDE_FROM_RIGHT:
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
+            break;
+          case SLIDE_FROM_LEFT:
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
+            break;
+        }
+      } else {
+        transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
 
-      switch (stackAnimation) {
-        case SLIDE_FROM_RIGHT:
-          getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
-          break;
-        case SLIDE_FROM_LEFT:
-          getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
-          break;
+        switch (stackAnimation) {
+          case SLIDE_FROM_RIGHT:
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
+            break;
+          case SLIDE_FROM_LEFT:
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
+            break;
+        }
       }
     }
 
@@ -221,7 +223,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
     }
 
-    if (!isCustomAnimation(stackAnimation)) {
+    if (stackAnimation != null && !isCustomAnimation(stackAnimation)) {
       getOrCreateTransaction().setTransition(transition);
     }
     // animation logic end


### PR DESCRIPTION
## Description
When a screen is added to an empty stack it shouldn't have any animation. 
The issue is described in detail in #881.
Fixes #881.

## Changes
Changed the default value of `stackAnimation` to `null` in `ScreenStack.java` and handle it accordingly.

## Test code and steps to reproduce
`Test881.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
