### PR TITLE
fix: whitelist supported platforms

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -25,13 +25,14 @@ import {
 } from './types';
 
 let ENABLE_SCREENS = true;
-const isWindows = Platform.OS === 'windows';
+// web implementation is taken from `index.tsx`
+const isPlatformSupported = Platform.OS === 'ios' || Platform.OS === 'android';
 
 function enableScreens(shouldEnableScreens = true): void {
   ENABLE_SCREENS = shouldEnableScreens;
   if (
     ENABLE_SCREENS &&
-    !isWindows &&
+    isPlatformSupported &&
     !UIManager.getViewManagerConfig('RNSScreen')
   ) {
     console.error(
@@ -108,7 +109,7 @@ class Screen extends React.Component<ScreenProps> {
   render() {
     const { enabled = ENABLE_SCREENS } = this.props;
 
-    if (enabled && !isWindows) {
+    if (enabled && isPlatformSupported) {
       AnimatedNativeScreen =
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
@@ -147,7 +148,7 @@ class ScreenContainer extends React.Component<ScreenContainerProps> {
   render() {
     const { enabled = ENABLE_SCREENS, ...rest } = this.props;
 
-    if (enabled && !isWindows) {
+    if (enabled && isPlatformSupported) {
       return <ScreensNativeModules.NativeScreenContainer {...rest} />;
     }
 

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -24,9 +24,10 @@ import {
   ScreenStackHeaderConfigProps,
 } from './types';
 
-let ENABLE_SCREENS = true;
 // web implementation is taken from `index.tsx`
 const isPlatformSupported = Platform.OS === 'ios' || Platform.OS === 'android';
+
+let ENABLE_SCREENS = isPlatformSupported;
 
 function enableScreens(shouldEnableScreens = true): void {
   ENABLE_SCREENS = shouldEnableScreens;
@@ -114,7 +115,10 @@ class Screen extends React.Component<ScreenProps> {
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
 
-      // same reason as above
+      // Filter out active prop in this case because it is unused and
+      // can cause problems depending on react-native version:
+      // https://github.com/react-navigation/react-navigation/issues/4886
+      // same for enabled prop
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let { enabled, active, activityState, ...rest } = this.props;
       if (active !== undefined && activityState === undefined) {
@@ -131,15 +135,27 @@ class Screen extends React.Component<ScreenProps> {
         />
       );
     } else {
-      // Filter out active prop in this case because it is unused and
-      // can cause problems depending on react-native version:
-      // https://github.com/react-navigation/react-navigation/issues/4886
-      // same for enabled prop
+      // same reason as above
+      let {
+        active,
+        activityState,
+        style,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        enabled,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        onComponentRef,
+        ...rest
+      } = this.props;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { active, enabled, onComponentRef, ...rest } = this.props;
-
-      return <Animated.View {...rest} ref={this.setRef} />;
+      if (active !== undefined && activityState === undefined) {
+        activityState = active !== 0 ? 2 : 0;
+      }
+      return (
+        <View
+          style={[style, { display: activityState !== 0 ? 'flex' : 'none' }]}
+          {...rest}
+        />
+      );
     }
   }
 }

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -151,8 +151,9 @@ class Screen extends React.Component<ScreenProps> {
         activityState = active !== 0 ? 2 : 0;
       }
       return (
-        <View
+        <Animated.View
           style={[style, { display: activityState !== 0 ? 'flex' : 'none' }]}
+          ref={this.setRef}
           {...rest}
         />
       );

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   Image,
   ImageProps,
+  Platform,
   requireNativeComponent,
   StyleSheet,
   UIManager,
@@ -24,10 +25,15 @@ import {
 } from './types';
 
 let ENABLE_SCREENS = true;
+const isWindows = Platform.OS === 'windows';
 
 function enableScreens(shouldEnableScreens = true): void {
   ENABLE_SCREENS = shouldEnableScreens;
-  if (ENABLE_SCREENS && !UIManager.getViewManagerConfig('RNSScreen')) {
+  if (
+    ENABLE_SCREENS &&
+    !isWindows &&
+    !UIManager.getViewManagerConfig('RNSScreen')
+  ) {
     console.error(
       `Screen native module hasn't been linked. Please check the react-native-screens README for more details`
     );
@@ -102,7 +108,7 @@ class Screen extends React.Component<ScreenProps> {
   render() {
     const { enabled = ENABLE_SCREENS } = this.props;
 
-    if (enabled) {
+    if (enabled && !isWindows) {
       AnimatedNativeScreen =
         AnimatedNativeScreen ||
         Animated.createAnimatedComponent(ScreensNativeModules.NativeScreen);
@@ -141,7 +147,7 @@ class ScreenContainer extends React.Component<ScreenContainerProps> {
   render() {
     const { enabled = ENABLE_SCREENS, ...rest } = this.props;
 
-    if (enabled) {
+    if (enabled && !isWindows) {
       return <ScreensNativeModules.NativeScreenContainer {...rest} />;
     }
 

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -30,12 +30,8 @@ const isPlatformSupported = Platform.OS === 'ios' || Platform.OS === 'android';
 let ENABLE_SCREENS = isPlatformSupported;
 
 function enableScreens(shouldEnableScreens = true): void {
-  ENABLE_SCREENS = shouldEnableScreens;
-  if (
-    ENABLE_SCREENS &&
-    isPlatformSupported &&
-    !UIManager.getViewManagerConfig('RNSScreen')
-  ) {
+  ENABLE_SCREENS = isPlatformSupported && shouldEnableScreens;
+  if (ENABLE_SCREENS && !UIManager.getViewManagerConfig('RNSScreen')) {
     console.error(
       `Screen native module hasn't been linked. Please check the react-native-screens README for more details`
     );


### PR DESCRIPTION
## Description

Enable `react-native-screens` only on `Android`, `iOS` and `web`.

## Changes

Added checks for `Android` and `iOS` in `index.native.tsx`.

## Checklist

- [x] Ensured that CI passes
