### PR TITLE
Fix broken layout for header subviews in iOS

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -433,6 +433,13 @@
     _lastViewFrame = self.view.frame;
     [((RNSScreenView *)self.viewIfLoaded) updateBounds];
   }
+
+  // Clear any coordinates that have been (inadvertently) set on RNSScreenStackHeaderConfig subviews.
+  // This allows the native UINavigationBar to control the position of header content.
+  RNSScreenStackHeaderConfig * configView = [self findScreenConfig];
+  for (UIView* subview in configView.reactSubviews) {
+    subview.frame = CGRectMake(0, 0, subview.frame.size.width, subview.frame.size.height);
+  }
 }
 
 - (id)findFirstResponder:(UIView*)parent

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -433,13 +433,6 @@
     _lastViewFrame = self.view.frame;
     [((RNSScreenView *)self.viewIfLoaded) updateBounds];
   }
-
-  // Clear any coordinates that have been (inadvertently) set on RNSScreenStackHeaderConfig subviews.
-  // This allows the native UINavigationBar to control the position of header content.
-  RNSScreenStackHeaderConfig * configView = [self findScreenConfig];
-  for (UIView* subview in configView.reactSubviews) {
-    subview.frame = CGRectMake(0, 0, subview.frame.size.width, subview.frame.size.height);
-  }
 }
 
 - (id)findFirstResponder:(UIView*)parent

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -43,8 +43,8 @@
 
 - (void) reactSetFrame:(CGRect)frame
 {
-  // Block any attempt to set coordinates a RNSScreenStackHeaderSubview. This
-  // allows the native UINavigationBar to control the position of header content.
+  // Block any attempt to set coordinates on RNSScreenStackHeaderSubview. This
+  // makes UINavigationBar the only one to control the position of header content.
   [super reactSetFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
 }
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -41,6 +41,13 @@
   return self;
 }
 
+- (void) reactSetFrame:(CGRect)frame
+{
+  // Block any attempt to set coordinates a RNSScreenStackHeaderSubview. This
+  // allows the native UINavigationBar to control the position of header content.
+  [super reactSetFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
+}
+
 @end
 
 @implementation RNSScreenStackHeaderConfig {


### PR DESCRIPTION
## Description

This addresses bugs such as #528 where header content is incorrectly positioned on initial load or after rotation. I was experiencing these issues in my current app, and when I looked at the XCode view debugger I could see that `RNSScreenStackHeaderConfig` subviews had their `.frame.origin.x` property set to a non-zero value that moved them out of place.

I'm fairly new to React Native and very new to this codebase, so I haven't totally got to the bottom of what's happening here. My guess/theory is that RN layout code is setting the position of these views as if they're part of of the regular view hierarchy, even though they're meant to be managed by a `UINavigationBar`. Rather than trying to fix this at a deeper level and risk introducing side effects, I've added a small workaround.

Fixes #528.

## Changes

This PR adds a few lines of code inside `RNSScreen.viewDidLayoutSubviews` which manually set the `.frame.origin.x` and `.y` of each  `RNSScreenStackHeaderConfig` to zero. I believe it's accomplishing the same thing as PR #668 (which was my starting point for this work) but in a simpler and more direct way.
