### PR TITLE
feat: add bottom_fade animation on Android

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -33,6 +33,7 @@ import Test791 from './src/Test791';
 import Test817 from './src/Test817';
 import Test831 from './src/Test831';
 import Test844 from './src/Test844';
+import Test851 from './src/Test851';
 import Test852 from './src/Test852';
 import Test861 from './src/Test861';
 import Test865 from './src/Test865';

--- a/TestsExample/src/Test851.tsx
+++ b/TestsExample/src/Test851.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Button, View } from 'react-native';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+};
+
+const Stack = createNativeStackNavigator();
+
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          stackAnimation: 'bottom_fade',
+        }}>
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen name="Second" component={Second} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const First = ({ navigation }: Props) => (
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Button
+      title="Tap me for second screen"
+      onPress={() => navigation.navigate('Second')}
+    />
+  </View>
+);
+
+const Second = ({ navigation }: Props) => (
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Button title="Go back" onPress={() => navigation.goBack()} />
+  </View>
+);

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -29,6 +29,7 @@ public class Screen extends ViewGroup {
     DEFAULT,
     NONE,
     FADE,
+    BOTTOM_FADE,
     SLIDE_FROM_RIGHT,
     SLIDE_FROM_LEFT
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -195,6 +195,9 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
         transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
 
         switch (stackAnimation) {
+          case BOTTOM_FADE:
+            getOrCreateTransaction().setCustomAnimations(R.anim.rns_bottom_fade_in, R.anim.rns_no_animation);
+            break;
           case SLIDE_FROM_RIGHT:
             getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left);
             break;
@@ -206,6 +209,9 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
         transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
 
         switch (stackAnimation) {
+          case BOTTOM_FADE:
+            getOrCreateTransaction().setCustomAnimations(0, R.anim.rns_bottom_fade_out);
+            break;
           case SLIDE_FROM_RIGHT:
             getOrCreateTransaction().setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right);
             break;
@@ -341,10 +347,12 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   }
 
   private static boolean isCustomAnimation(Screen.StackAnimation stackAnimation) {
-    return stackAnimation == Screen.StackAnimation.SLIDE_FROM_RIGHT || stackAnimation == Screen.StackAnimation.SLIDE_FROM_LEFT;
+    return stackAnimation == Screen.StackAnimation.BOTTOM_FADE
+        || stackAnimation == Screen.StackAnimation.SLIDE_FROM_RIGHT
+        || stackAnimation == Screen.StackAnimation.SLIDE_FROM_LEFT;
   }
 
-  private static boolean isTransparent(ScreenStackFragment fragment){
+  private static boolean isTransparent(ScreenStackFragment fragment) {
     return fragment.getScreen().getStackPresentation() == Screen.StackPresentation.TRANSPARENT_MODAL;
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -67,6 +67,8 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
       view.setStackAnimation(Screen.StackAnimation.NONE);
     } else if ("fade".equals(animation)) {
       view.setStackAnimation(Screen.StackAnimation.FADE);
+    } else if ("bottom_fade".equals(animation)) {
+      view.setStackAnimation(Screen.StackAnimation.BOTTOM_FADE);
     } else if ("slide_from_right".equals(animation)) {
       view.setStackAnimation(Screen.StackAnimation.SLIDE_FROM_RIGHT);
     } else if ("slide_from_left".equals(animation)) {

--- a/android/src/main/res/anim/rns_bottom_fade_in.xml
+++ b/android/src/main/res/anim/rns_bottom_fade_in.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:fromYDelta="100%"
+        android:toYDelta="0%" />
+    <alpha
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+</set>

--- a/android/src/main/res/anim/rns_bottom_fade_out.xml
+++ b/android/src/main/res/anim/rns_bottom_fade_out.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:fromYDelta="0%"
+        android:toYDelta="100%" />
+    <alpha
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0" />
+</set>

--- a/android/src/main/res/anim/rns_no_animation.xml
+++ b/android/src/main/res/anim/rns_no_animation.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+</set>

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -197,6 +197,7 @@ How the given screen should appear/disappear when pushed or popped at the top of
 - `default` - Uses a platform default animation.
 - `fade` - Fades screen in or out.
 - `flip` – Flips the screen, requires stackPresentation: `modal` (iOS only).
+- `bottom_fade` - slide in from bottom with quick fade, mimics default animation on many Android devices (Android only, resolves to default transition on iOS)   
 - `slide_from_right` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `slide_from_left` - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
 - `none` - The screen appears/disappears without an animation.

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -552,6 +552,7 @@ RCT_ENUM_CONVERTER(RNSScreenStackAnimation, (@{
                                                   @"none": @(RNSScreenStackAnimationNone),
                                                   @"fade": @(RNSScreenStackAnimationFade),
                                                   @"flip": @(RNSScreenStackAnimationFlip),
+                                                  @"bottom_fade": @(RNSScreenStackAnimationDefault),
                                                   @"slide_from_right": @(RNSScreenStackAnimationDefault),
                                                   @"slide_from_left": @(RNSScreenStackAnimationDefault),
                                                   }), RNSScreenStackAnimationDefault, integerValue)

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -188,6 +188,7 @@ How the given screen should appear/disappear when pushed or popped at the top of
 - `default` - Uses a platform default animation.
 - `fade` - Fades screen in or out.
 - `flip` – Flips the screen, requires stackPresentation: `modal` (iOS only).
+- `bottom_fade` - slide in from bottom with quick fade, mimics default animation on many Android devices (Android only, resolves to default transition on iOS)
 - `slide_from_right` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `slide_from_left` - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
 - `none` - The screen appears/disappears without an animation.

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -247,6 +247,7 @@ export type NativeStackNavigationOptions = {
    * - "default" – uses a platform default animation
    * - "fade" – fades screen in or out
    * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
+   * - "bottom_fade" - slide in from bottom with quick fade, mimics default animation on many Android devices (Android only, resolves to default transition on iOS)  *
    * - "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
    * - "slide_from_left" - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
    * - "none" – the screen appears/dissapears without an animation

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -19,6 +19,7 @@ export type StackAnimationTypes =
   | 'fade'
   | 'flip'
   | 'none'
+  | 'bottom_fade'
   | 'slide_from_right'
   | 'slide_from_left';
 export type BlurEffectTypes =
@@ -104,6 +105,7 @@ export interface ScreenProps extends ViewProps {
    * - "default" – uses a platform default animation
    * - "fade" – fades screen in or out
    * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
+   * - "bottom_fade" - slide in from bottom with quick fade, mimics default animation on many Android devices (Android only, resolves to default transition on iOS)
    * - "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
    * - "slide_from_left" - slide in the new screen from left to right (Android only, resolves to default transition on iOS)
    * - "none" – the screen appears/dissapears without an animation


### PR DESCRIPTION
## Description
### 🚧 Work in progress 🚧
Fragment Manager's default animation that we are using differs from the current default navigation animation used throughout Android.

Fixes #851 

## Changes

Added `bottom_fade` animation that tries to mimic animation used in many Android apps as default.

## Screenshots / GIFs

Native animation:

https://user-images.githubusercontent.com/39658211/116993849-4a09c600-acd8-11eb-9450-a86e3a97660c.mov



## Test code and steps to reproduce

`Test851.tsx` in TestsExample/ project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes
