### PR TITLE
feat: remove check for screens enabled in native stack

### DIFF
--- a/src/createNativeStackNavigator.tsx
+++ b/src/createNativeStackNavigator.tsx
@@ -439,7 +439,7 @@ class StackView extends React.Component<Props> {
     return (
       <Screen
         key={`screen_${route.key}`}
-        enabled={true}
+        enabled
         style={[StyleSheet.absoluteFill, options.cardStyle]}
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}

--- a/src/createNativeStackNavigator.tsx
+++ b/src/createNativeStackNavigator.tsx
@@ -439,6 +439,7 @@ class StackView extends React.Component<Props> {
     return (
       <Screen
         key={`screen_${route.key}`}
+        enabled={true}
         style={[StyleSheet.absoluteFill, options.cardStyle]}
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}

--- a/src/native-stack/navigators/createNativeStackNavigator.tsx
+++ b/src/native-stack/navigators/createNativeStackNavigator.tsx
@@ -10,7 +10,6 @@ import {
   useNavigationBuilder,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { screensEnabled } from 'react-native-screens';
 import {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
@@ -24,12 +23,6 @@ function NativeStackNavigator({
   screenOptions,
   ...rest
 }: NativeStackNavigatorProps) {
-  if (!screensEnabled()) {
-    throw new Error(
-      'Native stack is only available if React Native Screens is enabled.'
-    );
-  }
-
   const { state, descriptors, navigation } = useNavigationBuilder<
     StackNavigationState<ParamListBase>,
     StackRouterOptions,

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -65,7 +65,7 @@ const maybeRenderNestedStack = (
   if (isHeaderInModal) {
     return (
       <ScreenStack style={styles.container}>
-        <Screen enabled={true} style={StyleSheet.absoluteFill}>
+        <Screen enabled style={StyleSheet.absoluteFill}>
           <HeaderConfig {...options} route={route} />
           <Container
             style={viewStyles}
@@ -151,7 +151,7 @@ export default function NativeStackView({
         return (
           <Screen
             key={route.key}
-            enabled={true}
+            enabled
             style={StyleSheet.absoluteFill}
             gestureEnabled={isAndroid ? false : gestureEnabled}
             replaceAnimation={replaceAnimation}

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -65,7 +65,7 @@ const maybeRenderNestedStack = (
   if (isHeaderInModal) {
     return (
       <ScreenStack style={styles.container}>
-        <Screen style={StyleSheet.absoluteFill}>
+        <Screen enabled={true} style={StyleSheet.absoluteFill}>
           <HeaderConfig {...options} route={route} />
           <Container
             style={viewStyles}
@@ -151,6 +151,7 @@ export default function NativeStackView({
         return (
           <Screen
             key={route.key}
+            enabled={true}
             style={StyleSheet.absoluteFill}
             gestureEnabled={isAndroid ? false : gestureEnabled}
             replaceAnimation={replaceAnimation}


### PR DESCRIPTION
## Description

Removed the check for enabling RNScreens for `native-stack` v4 and v5. It is not necessary since there is no point in using `native-stack` and not enabling the `react-native-screens` for its' components.

## Checklist

- [x] Ensured that CI passes
