### PR TITLE
fix: add headerShown check in modals in Example

### DIFF
--- a/Example/src/screens/Modals.tsx
+++ b/Example/src/screens/Modals.tsx
@@ -73,7 +73,7 @@ const App = (): JSX.Element => (
       component={Alert}
       options={{
         stackPresentation: 'transparentModal',
-        headerShown: false,
+        headerShown: Platform.OS === 'android' ? false : undefined,
         stackAnimation:
           Platform.OS === 'android' ? 'slide_from_left' : 'default',
       }}

--- a/Example/src/screens/SearchBar.tsx
+++ b/Example/src/screens/SearchBar.tsx
@@ -207,7 +207,7 @@ const App = (): JSX.Element => (
       component={Snack}
       options={{
         stackPresentation: 'transparentModal',
-        headerShown: false,
+        headerShown: Platform.OS === 'android' ? false : undefined,
         stackAnimation:
           Platform.OS === 'android' ? 'slide_from_left' : 'default',
       }}

--- a/Example/src/screens/StackPresentation.tsx
+++ b/Example/src/screens/StackPresentation.tsx
@@ -125,7 +125,7 @@ const App = (): JSX.Element => (
       component={Alert}
       options={{
         stackPresentation: 'transparentModal',
-        headerShown: false,
+        headerShown: Platform.OS === 'android' ? false : undefined,
         stackAnimation:
           Platform.OS === 'android' ? 'slide_from_left' : 'default',
       }}
@@ -140,7 +140,7 @@ const App = (): JSX.Element => (
       component={Dialog}
       options={{
         stackPresentation: 'containedTransparentModal',
-        headerShown: false,
+        headerShown: Platform.OS === 'android' ? false : undefined,
         stackAnimation: 'fade',
       }}
     />


### PR DESCRIPTION
## Description

Added platform-dependent checks for hiding headers in modal screens in the Example project.

## Test code and steps to reproduce

Modals, SearchBar and StackPresentation playgrounds in the Example project.

## Checklist

- [x] Ensured that CI passes
