### PR TITLE
Add missing dependency on React-RCTImage pod.

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
+  s.dependency "React-RCTImage"
 end
 


### PR DESCRIPTION
## Description

When building for iOS with `use_frameworks!` in the project Podfile Xcode became fussy about explicitly specifying the framework dependencies rather than just the "React" target. In general RN modules have changed to depend on "React-Core" and all is fine. However, modules that use classes that aren't in the "React-Core" pod need to name all their dependencies explicitly. I've checked and every class that is currently imported by the native iOS code comes from "React-Core" except for RCTImageView and RCTImageLoader. These are both in the "React-RCTImage" framework/pod. Added this to the dependencies to fix linker errors for some projects that use this module.

Fixes #842 .

## Changes

Update RNScreens.podspec to add the missing dependency.

## Test code and steps to reproduce

This should change nothing for most projects, but those with significant extra native code that also have `use_frameworks!` may hit this error seemingly at random - usually when upgrading a pod or adding a new one. It's because without the dependency declared there's nothing to force Xcode to compile the source in the correct order. As such it's very hard to create a reproducible test. However, the code depends on classes in this framework, so the dependency should be declared.

## Checklist

- [ ] Included code example that can be used to test this change - not possible
- [ ] Updated TS types - not applicable
- [ ] Updated documentation: <!-- For adding new props to native-stack --> - not applicable
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md - not applicable
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md - not applicable
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md - not applicable
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx - not applicable
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx - not applicable
- [ ] Ensured that CI passes - will find out when the pull request triggers it I hope!
