### PR TITLE
docs: add CONTRIBUTING guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ This library should work out of the box with all existing react-native libraries
 If you are building a navigation library you may want to use `react-native-screens` to have control over which parts of the React component tree are attached to the native view hierarchy.
 To do that, `react-native-screens` provides you with the components documented [here](https://github.com/kmagiera/react-native-screens/tree/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md).
 
+## Contributing
+
+There are many ways to contribute to this project. See [CONTRIBUTING](https://github.com/kmagiera/react-native-screens/tree/master/guides/CONTRIBUTING.md) guide for more information. Thank you for your interest in contributing!
+
 ## License
 
 React native screens library is licensed under [The MIT License](LICENSE).

--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to `react-native-screens`
+
+### Welcome
+
+Thank you for considering contributing to `react-native-screens`. It's people like you that make open source projects thrive! We love to receive contributions from our community and there are many ways for *you* to be a part of this. 
+
+_tl;dr **Please** do not ignore templates for issues and pull requests and everything will be fine_
+
+### Found a bug?
+
+If you’ve encountered a bug, don't hesitate to submit [an issue](https://github.com/software-mansion/react-native-screens/issues). Just check if someone didn't report it lately.
+
+When filing an issue, make sure to provide:
+- a short description of the problem
+- an operating system that you are currently working on
+- what happened
+- what you expected to happen
+- **snippet of code or Snack that reproduces the bug**. Check out [this guide](https://stackoverflow.com/help/minimal-reproducible-example)
+- version of `react-native` and `react-native-screens` 
+
+We've provided a template on GitHub that simplifies the process of filing an issue.
+
+Following these few steps will show great respect for the time of the developers managing and developing this open-source project.
+
+We inform you that unrespectful issues will be closed.
+
+### Got a question or an idea for a feature?
+
+We use GitHub issues exclusively for tracking bugs. For questions and feature requests check out [Discussions](https://github.com/software-mansion/react-native-screens/discussions).
+
+### Pull requests
+
+Pull requests are more than welcome 🚀
+
+We've created a template to help you with the process of submitting a pull request to this project. Remember to change or add documentation as needed and provide a code snippet (preferably added to `TestsExample/` project) that the developers could test your change on. In the PR template we've added a checklist for all the places where the documentation should be updated.
+
+If it's your first pull request (this guide)[https://github.com/MarcDiethelm/contributing/blob/master/README.md] might be helpful for you.
+
+### Naming convensions
+
+For commits and pull request names we follow a [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+For branch names we use `@username/description-separated-by-dashes` convention.

--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -34,10 +34,10 @@ Pull requests are more than welcome 🚀
 
 We've created a template to help you with the process of submitting a pull request to this project. Remember to change or add documentation as needed and provide a code snippet (preferably added to `TestsExample/` project) that the developers could test your change on. In the PR template we've added a checklist for all the places where the documentation should be updated.
 
-If it's your first pull request (this guide)[https://github.com/MarcDiethelm/contributing/blob/master/README.md] might be helpful for you.
+If it's your first pull request [this guide](https://github.com/MarcDiethelm/contributing/blob/master/README.md) might be helpful for you.
 
 ### Naming convensions
 
-For commits and pull request names we follow a [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+For commits and pull request names we follow a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
 For branch names we use `@username/description-separated-by-dashes` convention.


### PR DESCRIPTION
## Description

To save some time asking for not deliberately ignoring the issue template I've decided to add a short contributing guide to which we could refer people to.

## Changes
- Added CONTRIBUTING.md to `guides/`
- Added a link to contributing to the main README



