### PR TITLE
fix: make events dispatch in correct order

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -11,6 +11,7 @@ import Test550 from './src/Test550';
 import Test556 from './src/Test556';
 import Test564 from './src/Test564';
 import Test577 from './src/Test577';
+import Test593 from './src/Test593';
 import Test619 from './src/Test619';
 import Test624 from './src/Test624';
 import Test640 from './src/Test640';

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -355,7 +355,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.1.1):
+  - RNScreens (3.2.0):
     - React-Core
   - RNVectorIcons (7.1.0):
     - React
@@ -556,7 +556,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: b8c8004b43446e3c2709fe64b2b41072f87428ad
-  RNScreens: bd1523c3bde7069b8e958e5a16e1fc7722ad0bdd
+  RNScreens: c277bfc4b5bb7c2fe977d19635df6f974f95dfd6
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/TestsExample/src/Test593.tsx
+++ b/TestsExample/src/Test593.tsx
@@ -1,0 +1,163 @@
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import React from 'react';
+import { ScrollView, View, Button, Platform } from 'react-native';
+import { createNativeStackNavigator, NativeStackNavigationProp } from 'react-native-screens/native-stack';
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
+
+const Stack = createNativeStackNavigator();
+const NestedStack = createNativeStackNavigator();
+
+function Deeper({ navigation }: Props) {
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener(
+      'transitionStart',
+      ({ data }) => {
+        console.warn(
+          Platform.OS +
+            ' Deeper transitionStart ' +
+            (data.closing ? 'closing' : 'opening')
+        );
+      }
+    );
+
+    return unsubscribe;
+  }, [navigation]);
+
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({ data }) => {
+      console.warn(
+        Platform.OS +
+          ' Deeper transitionEnd ' +
+          (data.closing ? 'closing' : 'opening')
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <NestedStack.Navigator screenOptions={{ headerShown: true, stackAnimation: 'slide_from_left' }}>
+      <NestedStack.Screen name="Privacy" component={Privacy} />
+      <NestedStack.Screen name="Another" component={Another} />
+    </NestedStack.Navigator>
+  );
+}
+
+export default function NativeNavigation() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{stackAnimation: 'slide_from_left'}}>
+        <Stack.Screen name="Status" component={Status} />
+        <Stack.Screen name="Deeper" component={Deeper} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function Status({ navigation }: Props) {
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener(
+      'transitionStart',
+      ({ data }) => {
+        console.warn(
+          Platform.OS +
+            ' Status transitionStart ' +
+            (data.closing ? 'closing' : 'opening')
+        );
+      }
+    );
+
+    return unsubscribe;
+  }, [navigation]);
+
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({ data }) => {
+      console.warn(
+        Platform.OS +
+          ' Status transitionEnd ' +
+          (data.closing ? 'closing' : 'opening')
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <ScrollView>
+      <Button title="Click" onPress={() => navigation.navigate('Deeper')} />
+    </ScrollView>
+  );
+}
+
+function Privacy({ navigation }: Props) {
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener(
+      'transitionStart',
+      ({ data }) => {
+        console.warn(
+          Platform.OS +
+            ' Privacy transitionStart ' +
+            (data.closing ? 'closing' : 'opening')
+        );
+      }
+    );
+
+    return unsubscribe;
+  }, [navigation]);
+
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({ data }) => {
+      console.warn(
+        Platform.OS +
+          ' Privacy transitionEnd ' +
+          (data.closing ? 'closing' : 'opening')
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'rgba(255,0,0,0.2)' }}>
+      <Button title="Click" onPress={() => navigation.navigate('Another')} />
+    </View>
+  );
+}
+
+function Another({ navigation }: Props) {
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener(
+      'transitionStart',
+      ({ data }) => {
+        console.warn(
+          Platform.OS +
+            ' Another transitionStart ' +
+            (data.closing ? 'closing' : 'opening')
+        );
+      }
+    );
+
+    return unsubscribe;
+  }, [navigation]);
+
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({ data }) => {
+      console.warn(
+        Platform.OS +
+          ' Another transitionEnd ' +
+          (data.closing ? 'closing' : 'opening')
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'rgba(255,0,0,0.2)' }}>
+      <Button title="Click" onPress={() => navigation.navigate('Another')} />
+    </View>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -175,9 +175,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     // Otherwise we expect to connect directly with root view and get root fragment manager
     if (parent instanceof Screen) {
       ScreenFragment screenFragment = ((Screen) parent).getFragment();
-      setFragmentManager(screenFragment.getChildFragmentManager());
       mParentScreenFragment = screenFragment;
       mParentScreenFragment.registerChildScreenContainer(this);
+      setFragmentManager(screenFragment.getChildFragmentManager());
       return;
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -182,6 +182,18 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
         // otherwise it's open animation
         shouldUseOpenAnimation = mScreenFragments.contains(mTopScreen) || newTop.getScreen().getReplaceAnimation() != Screen.ReplaceAnimation.POP;
         stackAnimation = newTop.getScreen().getStackAnimation();
+      } else if (mTopScreen == null && newTop != null) {
+        // mTopScreen was not present before so newTop is the first screen added to a stack
+        // and we don't want the animation when it is entering, but we want to send the
+        // willAppear and Appear events to the user, which won't be sent by default if Screen's
+        // stack animation is not NONE (see check for stackAnimation in onCreateAnimation in ScreenStackFragment)
+        // We don't do it if the stack is nested since the parent will trigger these events in child
+        stackAnimation = Screen.StackAnimation.NONE;
+        if (newTop.getScreen().getStackAnimation() != Screen.StackAnimation.NONE
+                && !isNested()) {
+          newTop.dispatchOnWillAppear();
+          newTop.dispatchOnAppear();
+        }
       }
     } else if (mTopScreen != null && !mTopScreen.equals(newTop)) {
       // otherwise if we are performing top screen change we do "close animation"


### PR DESCRIPTION
## Description

PR made on top of #593 fixing the correct order (always willAppear/willDisappear before appear/disappear) on Android to match iOS where it is already correct.

## Changes

- Added dispatching `onAppear` and `onDisappear` on the ui thread suggested in #593 both for normal and `none` transitions.
- Added code in `ScreenStack` making sure that the `willAppear` and `appear` are always dispatched when the new stack appears.
- Changed adding parent fragment order to be present when we setup fragment manager since we sometimes want to know if it is nested in `onUpdate` method.

## Test code and steps to reproduce

`Test593.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
