### PR TITLE
feat: add events example

### DIFF
--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -26,6 +26,7 @@ import StackReactNavigation4 from './src/screens/StackReactNavigation4';
 import Modals from './src/screens/Modals';
 import Orientation from './src/screens/Orientation';
 import SearchBar from './src/screens/SearchBar';
+import Events from './src/screens/Events';
 
 enableScreens();
 
@@ -65,6 +66,11 @@ const SCREENS: Record<
     title: 'Stack react-navigation v4',
     // @ts-ignore react-navigation v4 AppNavigator type
     component: StackReactNavigation4,
+    type: 'example',
+  },
+  Events: {
+    title: 'Events',
+    component: Events,
     type: 'example',
   },
   HeaderOptions: {

--- a/Example/package.json
+++ b/Example/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/drawer": "^5.12.3",
     "@react-navigation/native": "^5.9.2",
     "@react-navigation/stack": "^5.14.2",
+    "nanoid": "^3.1.23",
     "react": "17.0.1",
     "react-native": "0.64.1",
     "react-native-appearance": "^0.3.4",

--- a/Example/src/screens/Events.tsx
+++ b/Example/src/screens/Events.tsx
@@ -1,0 +1,208 @@
+import React, {useEffect} from 'react';
+import {View, StyleSheet, I18nManager, Text} from 'react-native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+import {createStackNavigator} from '@react-navigation/stack';
+import {Button, ToastProvider, useToast} from '../shared';
+
+type StackParamList = {
+  Main: undefined;
+  Next: undefined;
+  NavigationEvents: undefined;
+  NativeEvents: undefined;
+};
+
+interface MainScreenProps {
+  navigation: NativeStackNavigationProp<StackParamList, 'Main'>;
+}
+
+const MainScreen = ({navigation}: MainScreenProps): JSX.Element => (
+  <View style={{...styles.container, backgroundColor: 'aliceblue'}}>
+    <Button
+      title="React Navigation events"
+      onPress={() => navigation.navigate('NavigationEvents')}
+    />
+    <Button
+      title="React Native Screens events"
+      onPress={() => navigation.navigate('NativeEvents')}
+    />
+    <Button onPress={() => navigation.pop()} title="🔙 Back to Examples" />
+  </View>
+);
+
+interface ScreensEventsScreenProps {
+  navigation: NativeStackNavigationProp<StackParamList, 'NativeEvents'>;
+}
+
+const ScreensEventsScreen = ({
+  navigation,
+}: ScreensEventsScreenProps): JSX.Element => {
+  const toast = useToast();
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionStart', ({data}) => {
+      toast.push({
+        message: `transitionStart: ${data.closing ? 'closing' : 'opening'}`,
+        backgroundColor: 'orange',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({data}) => {
+      toast.push({
+        message: `transitionEnd: ${data.closing ? 'closing' : 'opening'}`,
+        backgroundColor: 'dodgerblue',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('appear', () => {
+      toast.push({
+        message: 'appear',
+        backgroundColor: 'darkviolet',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <View style={{...styles.container, backgroundColor: 'lavenderblush'}}>
+      <Button
+        title="Navigate to next screen"
+        onPress={() => navigation.navigate('Next')}
+      />
+      <Button title="Go back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+};
+
+interface NavigationEventsScreenProps {
+  navigation: NativeStackNavigationProp<StackParamList, 'NavigationEvents'>;
+}
+
+const NavigationEventsScreen = ({
+  navigation,
+}: NavigationEventsScreenProps): JSX.Element => {
+  const toast = useToast();
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionStart', ({data}) => {
+      toast.push({
+        message: `transitionStart: ${data.closing ? 'closing' : 'opening'}`,
+        backgroundColor: 'orange',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', ({data}) => {
+      toast.push({
+        message: `transitionEnd: ${data.closing ? 'closing' : 'opening'}`,
+        backgroundColor: 'dodgerblue',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', () => {
+      toast.push({
+        message: 'focus',
+        backgroundColor: 'darkviolet',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('blur', () => {
+      toast.push({
+        message: 'blur',
+        backgroundColor: 'indianred',
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <View style={{...styles.container, backgroundColor: 'lavenderblush'}}>
+      <Button
+        title="Navigate to next screen"
+        onPress={() => navigation.navigate('Next')}
+      />
+      <Button title="Go back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+};
+
+const NextScreen = (): JSX.Element => (
+  <View style={styles.container}>
+    <Text style={styles.text}>Go back using native ways</Text>
+  </View>
+);
+
+const NativeStack = createNativeStackNavigator<StackParamList>();
+const NavigationStack = createStackNavigator<StackParamList>();
+
+const NativeNavigator = () => (
+  <NativeStack.Navigator>
+    <NativeStack.Screen name="NativeEvents" component={ScreensEventsScreen} />
+    <NativeStack.Screen name="Next" component={NextScreen} />
+  </NativeStack.Navigator>
+);
+
+const NavigationNavigator = () => (
+  <NavigationStack.Navigator>
+    <NativeStack.Screen
+      name="NavigationEvents"
+      component={NavigationEventsScreen}
+    />
+    <NavigationStack.Screen name="Next" component={NextScreen} />
+  </NavigationStack.Navigator>
+);
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+const App = (): JSX.Element => (
+  <ToastProvider>
+    <Stack.Navigator
+      screenOptions={{
+        direction: I18nManager.isRTL ? 'rtl' : 'ltr',
+        headerShown: false,
+      }}>
+      <NavigationStack.Screen
+        name="Main"
+        component={MainScreen}
+        options={{title: 'Simple Native Stack'}}
+      />
+      <Stack.Screen name="NativeEvents" component={NativeNavigator} />
+      <Stack.Screen name="NavigationEvents" component={NavigationNavigator} />
+    </Stack.Navigator>
+  </ToastProvider>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 100,
+  },
+  text: {
+    textAlign: 'center',
+  },
+});
+
+export default App;

--- a/Example/src/shared/Toast.tsx
+++ b/Example/src/shared/Toast.tsx
@@ -1,0 +1,116 @@
+import React, {createContext, useState, useContext, useEffect} from 'react';
+import {
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Dimensions,
+  View,
+  ViewStyle,
+} from 'react-native';
+import {nanoid} from 'nanoid/non-secure';
+
+const DISAPPEAR_AFTER = 2000; // ms
+
+interface ToastProps {
+  id: string;
+  backgroundColor: string;
+  message: string;
+  style?: ViewStyle;
+  remove: (_: string) => void;
+}
+
+const Toast = ({
+  id,
+  backgroundColor,
+  message,
+  style = {},
+  remove,
+}: ToastProps): JSX.Element => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      remove(id);
+    }, DISAPPEAR_AFTER);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <TouchableOpacity
+      style={{...styles.container, ...style}}
+      onPress={() => remove(id)}>
+      <View style={{...styles.alert, backgroundColor}}>
+        <Text style={styles.text}>{message}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+interface IToast {
+  id: string;
+  backgroundColor: string;
+  message: string;
+}
+
+const initialState: IToast[] = [];
+
+const ToastContext = createContext({
+  push: (_: Omit<IToast, 'id'>) => {
+    // noop
+  },
+});
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export const ToastProvider = ({children}: ToastProviderProps) => {
+  const [toasts, setToasts] = useState(initialState);
+
+  const remove = (id: string) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  };
+
+  const push = ({backgroundColor, message}: Omit<IToast, 'id'>): void => {
+    const id = nanoid();
+    setToasts((prevToasts) => [...prevToasts, {id, backgroundColor, message}]);
+  };
+
+  return (
+    <ToastContext.Provider value={{push}}>
+      <>
+        {children}
+        {toasts.map((toast, i) => (
+          <Toast
+            key={toast.id}
+            style={{marginBottom: i * 80}}
+            {...toast}
+            remove={remove}
+          />
+        ))}
+      </>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: 'absolute',
+    alignSelf: 'center',
+    bottom: 20,
+  },
+  alert: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 60,
+    position: 'relative',
+    width: Dimensions.get('screen').width - 40,
+    borderRadius: 10,
+  },
+  text: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    color: 'white',
+  },
+});

--- a/Example/src/shared/index.ts
+++ b/Example/src/shared/index.ts
@@ -10,3 +10,4 @@ export * from './Form';
 export * from './Choose';
 export * from './Dialog';
 export * from './Snack';
+export * from './Toast';

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -5596,6 +5596,11 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz"


### PR DESCRIPTION
## Description
PR adding an example with the use of events in `react-native-screens` and `@react-navigation/stack`.

## Changes

- Added an example with snackbars/toasts appearing accordingly to dispatched events.

## Screenshots / GIFs

https://user-images.githubusercontent.com/39658211/118989155-18545880-b982-11eb-8d0e-94821d42a87d.mp4



## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
