### PR TITLE
feat: deprecate appear event

### DIFF
--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -369,7 +369,10 @@ Defaults to an empty string.
 
 The navigator can [emit events](https://reactnavigation.org/docs/navigation-events) on certain actions. Supported events are:
 
-#### `appear`
+#### `appear` - deprecated
+
+Deprecated since `v3.3.0`.
+Use `transitionEnd` with `data.closing: false` instead.
 
 Event which fires when the screen appears.
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -371,8 +371,7 @@ The navigator can [emit events](https://reactnavigation.org/docs/navigation-even
 
 #### `appear` - deprecated
 
-Deprecated since `v3.3.0`.
-Use `transitionEnd` with `data.closing: false` instead.
+Use `transitionEnd` event with `data.closing: false` instead.
 
 Event which fires when the screen appears.
 

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -20,6 +20,8 @@ import {
 export type NativeStackNavigationEventMap = {
   /**
    * Event which fires when the screen appears.
+   *
+   * @deprecated since v3.3.0. Use `transitionEnd` with `data.closing: false` instead.
    */
   appear: { data: undefined };
   /**

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -21,7 +21,7 @@ export type NativeStackNavigationEventMap = {
   /**
    * Event which fires when the screen appears.
    *
-   * @deprecated since v3.3.0. Use `transitionEnd` with `data.closing: false` instead.
+   * @deprecated Use `transitionEnd` event with `data.closing: false` instead.
    */
   appear: { data: undefined };
   /**


### PR DESCRIPTION
## Description

This PR deprecates the `appear` event because of its redundancy to more powerful `transitionStart`/`transitionEnd` events.

## Checklist

- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes
