### PR TITLE
fix: no events when swipe cancelled

### DIFF
--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -355,7 +355,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.2.0):
+  - RNScreens (3.3.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (7.1.0):
@@ -557,7 +557,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: b8c8004b43446e3c2709fe64b2b41072f87428ad
-  RNScreens: 02cc349f80040ea8ea3b6c35642a90094f7b43ce
+  RNScreens: bf59f17fbf001f1025243eeed5f19419d3c11ef2
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a


### PR DESCRIPTION
## Description

When the swipe to go back is cancelled, all lifecycle events are called on both transitioning screens and we don't want them to be sent to JS. In the future, we can send e.g. `swipeCancelled` event in such case if it is requested by users.

## Changes

Added logic catching the case of cancelled swipe and not calling notification methods then.

## Test code and steps to reproduce

`Test593.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
