### PR TITLE
fix: dont warn about header if prop not changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/software-mansion/react-native-screens/issues"
   },
   "homepage": "https://github.com/software-mansion/react-native-screens#readme",
+  "dependencies": {
+    "warn-once": "^0.1.0"
+  },
   "peerDependencies": {
     "react": "*",
     "react-native": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9999,6 +9999,11 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+warn-once@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.0.tgz#4f58d89b84f968d0389176aa99e0cf0f14ffd4c8"
+  integrity sha512-recZTSvuaH/On5ZU5ywq66y99lImWqzP93+AiUo9LUwG8gXHW+LJjhOd6REJHm7qb0niYqrEQJvbHSQfuJtTqA==
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
## Description

Added changes from https://github.com/react-navigation/react-navigation/blob/main/packages/native-stack/src/views/NativeStackView.tsx#L28 to display warning about header in modal only after the prop has been changed, so it will not display the warning if the user specified `headerShown: true` in the options for the screen.

## Test code and steps to reproduce

`Test800.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
