### PR TITLE
fix: keyboard dismissing on swipe

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -45,6 +45,7 @@ import Test861 from './src/Test861';
 import Test865 from './src/Test865';
 import Test881 from './src/Test881';
 import Test898 from './src/Test898';
+import Test958 from './src/Test958';
 
 export default function App() {
   return <Test42 />;

--- a/TestsExample/src/Test958.tsx
+++ b/TestsExample/src/Test958.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+// import { createStackNavigator } from '@react-navigation/stack'
+import { View, Text, Button, KeyboardAvoidingView, Platform, TouchableWithoutFeedback, Keyboard, Image, TextInput } from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+const { Navigator, Screen } = createNativeStackNavigator();
+
+function First({navigation}: {navigation: NativeStackNavigationProp<ParamListBase>}) {
+  return (
+    <View style={{
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center'
+    }}>
+      <Text>First screen</Text>
+      <Button
+        title={'Navigate'}
+        onPress={() => navigation.navigate('Second')}
+      />
+    </View>
+  );
+}
+
+function Second() {
+  return (
+    <KeyboardAvoidingView
+    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    style={{ flex: 1 }}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}>
+          <Image
+            source={require('../assets/backButton.png')}
+            style={{
+              width: 150,
+              height: 150,
+              marginBottom: 30
+            }}
+          />
+          <TextInput
+            placeholder={'Input'}
+            style={{
+              width: 200,
+              height: 40,
+              paddingLeft: 15,
+              paddingRight: 15,
+              borderWidth: 1,
+              borderRadius: 5,
+              borderColor: '#cccccc'
+            }}
+          />
+        </View>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
+  );
+}
+
+// Create app __________________________________________________________________
+const App = () => {
+
+  // Return body
+  return (
+  <NavigationContainer>
+    <Navigator>
+      <Screen
+        name={'First'}
+        component={First}
+      />
+      <Screen
+        name={'Second'}
+        component={Second}
+      />
+    </Navigator>
+  </NavigationContainer>
+  );
+}
+
+// Export app __________________________________________________________________
+export default App

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -250,6 +250,8 @@
 
 - (void)notifyWillDisappear
 {
+  [self endEditing:YES];
+  
   if (self.onWillDisappear) {
     self.onWillDisappear(nil);
   }


### PR DESCRIPTION
## Description

Added code resolving in dismissing keyboard on swipe to go back. Other methods don't seem to work, even calling `Keyboard.dismiss()` in the start of swipe, which resolves in calling `[self resignFirstResponder];` on the `UITextView` (see https://github.com/facebook/react-native/blob/0afd71a18d19edef3d6603cabd2672ffde5ba30e/React/Views/UIView%2BReact.m#L276), but it seems not enough, like if there was some other responder still not resigning. The same thing works in normal `stack` navigator.

## Changes

Added `[self endEditing:YES];` in `notifyWillDisappear` method of `RNSScreenView`.

## Test code and steps to reproduce

`Test958.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
