### PR TITLE
feat: remove enableScreens from example app

### DIFF
--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -27,8 +27,6 @@ import Modals from './src/screens/Modals';
 import Orientation from './src/screens/Orientation';
 import SearchBar from './src/screens/SearchBar';
 
-enableScreens();
-
 if (Platform.OS === 'android') {
   StatusBar.setTranslucent(true);
 }

--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -8,7 +8,6 @@ import {
   Platform,
   StatusBar,
 } from 'react-native';
-import {enableScreens} from 'react-native-screens';
 import {NavigationContainer} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';


### PR DESCRIPTION
## Description

Example app uses the newest version of `react-native-screens` thus it no longer requires to call `enableScreens()`.

Fixes #973

## Checklist

- [x] Ensured that CI passes
