### PR TITLE
fix: make sure we only call onDetachedFromWindow once

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -45,6 +45,7 @@ import Test861 from './src/Test861';
 import Test865 from './src/Test865';
 import Test881 from './src/Test881';
 import Test898 from './src/Test898';
+import Test913 from './src/Test913';
 
 export default function App() {
   return <Test42 />;

--- a/TestsExample/src/Test913.tsx
+++ b/TestsExample/src/Test913.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native'
+import { createStackNavigator } from '@react-navigation/stack'
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import { View, Text } from 'react-native';
+
+const BottomTab = createBottomTabNavigator()
+const Tab1Stack = createStackNavigator()
+
+const CastScreen = () => (
+  <View style={{flex:1,justifyContent:"center",alignItems:"center"}}>
+    <Text style={{marginBottom:20, textAlign:"center"}}>Add logging in `onDetachedFromWindow` in child Screen to see that method triggered twice without the changes</Text>
+    <Text style={{position:"absolute", bottom:0, alignSelf:"flex-end"}}>↓touch Tab2↓</Text>
+  </View>
+)
+
+const Tab2Screen = () => (
+  <View />
+)
+
+const Tab1StackNavigator = () => (
+  <Tab1Stack.Navigator initialRouteName="CastScreen">
+    <Tab1Stack.Screen name="CastScreen" component={CastScreen} />
+  </Tab1Stack.Navigator>
+)
+
+const App = () => (
+  <NavigationContainer>
+    <BottomTab.Navigator initialRouteName="Tab1">
+      <BottomTab.Screen name="Tab1" component={Tab1StackNavigator} />
+      <BottomTab.Screen name="Tab2" component={Tab2Screen} />
+    </BottomTab.Navigator>
+  </NavigationContainer>
+);
+
+ export default App;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -303,10 +303,15 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     // may choose not to remove the view despite the parent container being completely detached
     // from the view hierarchy until the transition is over. In such a case when the container gets
     // re-attached while tre transition is ongoing, the child view would still be there and we'd
-    // attept to re-attach it to with a misconfigured fragment. This would result in a crash. To
+    // attempt to re-attach it to with a misconfigured fragment. This would result in a crash. To
     // avoid it we clear all the children here as we attach all the child fragments when the container
-    // is reattached anyways.
-    removeAllViews();
+    // is reattached anyways. We don't use `removeAllViews` since it does not check if the children are
+    // not already detached, which may lead to calling `onDetachedFromWindow` on them twice. We also
+    // get the size earlier, because we will be removing child views in `for` loop.
+    int size = getChildCount();
+    for (int i = size - 1; i >= 0; i--) {
+      removeViewAt(i);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

Suggested by @kmagiera change to `ScreenContainer.java`, altering https://github.com/software-mansion/react-native-screens/pull/477/, switching `removeAllViews();` to `removeViewAt(i);` in order to fix the case of calling `onDetachedFromWindow` multiple times in the child `Screen`s, which can be seen in `Test913.tsx`. This behaviors occurs due to the logic of `removeAllViews` method, which does not check if the child views are not already detached when the method is called, whereas the check is present in `removeViewAt` method (see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/ViewGroup.java#5559 which is not present in https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/ViewGroup.java#5771).

## Test code and steps to reproduce

`Test913.tsx` in `TestsExample` project.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
