### PR TITLE
revert: async container update

### DIFF
--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -515,9 +515,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: ac93a6e3a2aa5d3536b8c880d42776b2f7e1b68b
+  FBReactNativeSpec: 6eab2fe98018e8f28118d8bb9b34fdf1dd0be10c
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -525,7 +525,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -257,6 +257,9 @@ RCT_EXPORT_MODULE()
 
 - (void)markUpdated:(RNSScreenContainerView *)container
 {
+  // we want the attaching/detaching of children to be always made on main queue, which
+  // is currently true for `react-navigation` since the changes of `Animated` value in stack's
+  // transition and mounting/unmounting views in tabs and drawer are dispatched on main queue.
   RCTAssertMainQueue();
   [container updateContainer];
 }

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -246,38 +246,19 @@
 @end
 
 
-@implementation RNSScreenContainerManager {
-  NSMutableArray<RNSScreenContainerView *> *_markedContainers;
-}
+@implementation RNSScreenContainerManager
 
 RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-  if (!_markedContainers) {
-    _markedContainers = [NSMutableArray new];
-  }
   return [[RNSScreenContainerView alloc] initWithManager:self];
 }
 
-- (void)markUpdated:(RNSScreenContainerView *)screen
+- (void)markUpdated:(RNSScreenContainerView *)container
 {
-  [_markedContainers addObject:screen];
-  if ([_markedContainers count] == 1) {
-    // we enqueue updates to be run on the main queue in order to make sure that
-    // all these updates (new screens attached etc) are executed in one batch.
-    // We call it asynchronously because the events being fired when swiping the screen
-    // resolve in calling this method, and inside it, the same type of event
-    // can be fired when calling e.g. `notifyFinishTransitioning` leading to a deadlock.
-    // See https://github.com/software-mansion/react-native-screens/issues/726#issuecomment-757879605
-    // for more information.
-    dispatch_async(dispatch_get_main_queue(), ^{
-      for (RNSScreenContainerView *container in self->_markedContainers) {
-        [container updateContainer];
-      }
-      [self->_markedContainers removeAllObjects];
-    });
-  }
+  RCTAssertMainQueue();
+  [container updateContainer];
 }
 
 @end


### PR DESCRIPTION
## Description

PR reverting async container update on iOS (#777) since it caused multiple problems: 
- https://github.com/software-mansion/react-native-screens/issues/905#issuecomment-860647715
- https://github.com/software-mansion/react-native-screens/issues/972#issuecomment-861463305
- https://github.com/software-mansion/react-native-screens/issues/943#issuecomment-845479999

The revert should not reintroduce the freeze from #726 since it was connected to disabling user interaction in `updateContainer` method, which we no longer do.

## Changes

Removed `async` dispatching of `updateContainer`.

## Test code and steps to reproduce

`Test726.js` in `TestsExample` project to see the previous freeze not occur. 

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
