### PR TITLE
fix: no animation in nested stacks

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -98,32 +98,24 @@ public class ScreenStackFragment extends ScreenFragment {
     if (transit == 0
         && !isHidden()
         && getScreen().getStackAnimation() == Screen.StackAnimation.NONE) {
-      // If the container is nested then appear events will be dispatched by their parent screen so
-      // they must not be triggered here.
-      ScreenContainer container = getScreen().getContainer();
-      boolean isNested = container != null && container.isNested();
       if (enter) {
-        if (!isNested) {
-          // Android dispatches the animation start event for the fragment that is being added first
-          // however we want the one being dismissed first to match iOS. It also makes more sense
-          // from  a navigation point of view to have the disappear event first.
-          // Since there are no explicit relationships between the fragment being added / removed
-          // the practical way to fix this is delaying dispatching the appear events at the end of
-          // the frame.
-          UiThreadUtil.runOnUiThread(
-              new Runnable() {
-                @Override
-                public void run() {
-                  dispatchOnWillAppear();
-                  dispatchOnAppear();
-                }
-              });
-        }
+        // Android dispatches the animation start event for the fragment that is being added first
+        // however we want the one being dismissed first to match iOS. It also makes more sense
+        // from  a navigation point of view to have the disappear event first.
+        // Since there are no explicit relationships between the fragment being added / removed
+        // the practical way to fix this is delaying dispatching the appear events at the end of
+        // the frame.
+        UiThreadUtil.runOnUiThread(
+            new Runnable() {
+              @Override
+              public void run() {
+                dispatchOnWillAppear();
+                dispatchOnAppear();
+              }
+            });
       } else {
-        if (!isNested) {
-          dispatchOnWillDisappear();
-          dispatchOnDisappear();
-        }
+        dispatchOnWillDisappear();
+        dispatchOnDisappear();
         notifyViewAppearTransitionEnd();
       }
     }


### PR DESCRIPTION
## Description

PR fixing navigating in nested stack without animation, which did not trigger navigation events due to check for being nested, resolving in never dispatching those events there. PR switches it to a check inside parent fragment and makes it decide whether it should dispatch navigation events in a child.
We don't do it if the child has `none` animation and we are going forward since events will be dispatched in child via `onCreateAnimation` of `ScreenStackFragment` then.

## Test code and steps to reproduce

`Test593.tsx` with `stackAnimation == 'none'`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
