### PR TITLE
Access to PixelUtil.toPixelFromDIP when it is necessary

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -22,7 +22,6 @@ import com.google.android.material.appbar.AppBarLayout;
 
 public class ScreenStackFragment extends ScreenFragment {
 
-  private static final float TOOLBAR_ELEVATION = PixelUtil.toPixelFromDIP(4);
   private AppBarLayout mAppBarLayout;
   private Toolbar mToolbar;
   private boolean mShadowHidden;
@@ -59,7 +58,7 @@ public class ScreenStackFragment extends ScreenFragment {
 
   public void setToolbarShadowHidden(boolean hidden) {
     if (mShadowHidden != hidden) {
-      mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
+      mAppBarLayout.setTargetElevation(hidden ? 0 : PixelUtil.toPixelFromDIP(4));
       mShadowHidden = hidden;
     }
   }


### PR DESCRIPTION
## Description

This MR fixes #1008 

## Changes

Instead of assigning PixelUtil.toPixelFromDIP to static variable, use it when it is necessary

## Checklist

- [ ] Ensured that CI passes
