### PR TITLE
fix: layout issues in nested stack header

### DIFF
--- a/TestsExample/src/Test619.js
+++ b/TestsExample/src/Test619.js
@@ -1,110 +1,62 @@
-import React, {useEffect, useState} from 'react';
-import {View, Text, FlatList, ActivityIndicator} from 'react-native';
-import {createStackNavigator} from '@react-navigation/stack';
-import {createNativeStackNavigator} from 'react-native-screens/native-stack';
-import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
-import {NavigationContainer} from '@react-navigation/native';
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native'
+import { createNativeStackNavigator } from "react-native-screens/native-stack"
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import { createStackNavigator } from '@react-navigation/stack'
+import { View, Text, Button } from 'react-native';
+import { useNavigation } from "@react-navigation/native";
 
-const Stack1 = createNativeStackNavigator();
+const ParentStack = createNativeStackNavigator()
+const BottomTab = createBottomTabNavigator()
+const ChildStack = createNativeStackNavigator()
+const Tab1Stack = createNativeStackNavigator()
 
-const Tabs = createBottomTabNavigator();
+const DummyContent = () => {
+  const navigation = useNavigation();
 
-const Stack2 = createNativeStackNavigator();
+  return <View style={{flex:1,justifyContent:"center",alignItems:"center", backgroundColor: 'red'}}>
+    <Text style={{marginBottom:20, textAlign:"center"}}>Child Stack</Text>
+    <Button title="Go Back" onPress={() => navigation.goBack()}/>
+  </View>
+}
 
-const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
+const ChildStackScreen = () => (
+  <ChildStack.Navigator screenOptions={{headerShown: false, headerLargeTitle: false}}>
+    <Tab1Stack.Screen name="ChildStack" component={BottomStackScreen} />
+  </ChildStack.Navigator>
+)
 
-const Screen1 = () => {
-  return (
-    <FlatList
-      contentInsetAdjustmentBehavior={'always'}
-      data={data}
-      onRefresh={() => {}}
-      refreshing={false}
-      keyExtractor={(item) => `${item}`}
-      renderItem={({item}) => {
-        return (
-          <View
-            style={{
-              backgroundColor: item % 2 === 0 ? 'red' : 'green',
-              height: 120,
-            }}
-          />
-        );
-      }}
-      style={{flex: 1}}
-    />
-  );
-};
+const Another = () => (
+  <ChildStack.Navigator screenOptions={{headerShown: true, headerLargeTitle: false}}>
+    <Tab1Stack.Screen name="ChildStack1" component={InitialScreen} />
+  </ChildStack.Navigator>
+)
 
-const Tab1 = () => {
-  return (
-    <Stack2.Navigator>
-      <Stack2.Screen
-        name={'Screen 1'}
-        component={Screen1}
-        options={{
-          headerLeft: () => <Text>Left</Text>,
-          headerRight: () => <Text>Right</Text>,
-          headerLargeTitle: true,
-          headerLargeTitleHideShadow: true,
-        }}
-      />
-    </Stack2.Navigator>
-  );
-};
+const AnotherBottomTabs = () => (
+  <BottomTab.Navigator screenOptions={{headerShown: false}} detachInactiveScreens={true}>
+  <BottomTab.Screen name="Tab2" component={ChildStackScreen} />
+</BottomTab.Navigator>
+)
 
-const Tab2 = () => {
-  return (
-    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-      <Text>Tab 2</Text>
-    </View>
-  );
-};
+const BottomStackScreen = () => (
+  <BottomTab.Navigator screenOptions={{headerShown: false}} detachInactiveScreens={true}>
+    <BottomTab.Screen name="Tab1" component={Another} />
+  </BottomTab.Navigator>
+)
 
-const TabsScreen = () => {
-  return (
-    <Tabs.Navigator>
-      <Tabs.Screen name={'Tab 1'} component={Tab1} />
-      <Tabs.Screen name={'Tab 2'} component={Tab2} />
-    </Tabs.Navigator>
-  );
-};
+const InitialScreen = () => {
+  const navigation = useNavigation();
 
-const Init = () => {
-  return (
-    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-      <ActivityIndicator size={'large'} />
-    </View>
-  );
-};
+  return <View style={{flex:1,justifyContent:"center",alignItems:"center", backgroundColor: 'red'}}><Button title="Click" onPress={() => navigation.navigate('Bottom')}/></View>
+}
 
-const App = () => {
-  const [loaded, setLoaded] = useState(false);
-  useEffect(() => {
-    setTimeout(() => {
-      setLoaded(true);
-    }, 500);
-  }, []);
-  return (
-    <NavigationContainer>
-      <Stack1.Navigator>
-        {loaded && (
-          <Stack1.Screen
-            name={'Tabs'}
-            component={TabsScreen}
-            options={{headerShown: false}}
-          />
-        )}
-        {!loaded && (
-          <Stack1.Screen
-            name={'Loading'}
-            component={Init}
-            options={{headerShown: false}}
-          />
-        )}
-      </Stack1.Navigator>
-    </NavigationContainer>
-  );
-};
+const App = () => (
+  <NavigationContainer>
+    <ParentStack.Navigator>
+    <ParentStack.Screen name="Initial" component={BottomStackScreen} options={{ headerShown: false, stackAnimation: 'default' /** set none to fix */ }} />
+    <ParentStack.Screen name="Bottom" component={ChildStackScreen} options={{ headerShown: false }}></ParentStack.Screen>
+    </ParentStack.Navigator>
+  </NavigationContainer>
+);
 
-export default App;
+ export default App;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -496,6 +496,60 @@
   }
 }
 
+- (void)viewSafeAreaInsetsDidChange
+{
+  [super viewSafeAreaInsetsDidChange];
+  if (self.transitionCoordinator == nil) {
+    // if we are not transitioning, insets should not be set
+    return;
+  }
+  if (@available(iOS 11.0, *)) {
+    RNScreensNavigationController *childNavCtr = [self findChildNavigationControllerWithNavigationBarVisible];
+    if (childNavCtr != nil && !childNavCtr.additionalInsetSet) {
+      childNavCtr.additionalInsetSet = YES;
+      childNavCtr.additionalTopInset = self.view.safeAreaInsets.top;
+      childNavCtr.additionalSafeAreaInsets = UIEdgeInsetsMake(
+          childNavCtr.additionalSafeAreaInsets.top + self.view.safeAreaInsets.top,
+          childNavCtr.additionalSafeAreaInsets.left,
+          childNavCtr.additionalSafeAreaInsets.bottom,
+          childNavCtr.additionalSafeAreaInsets.right);
+    }
+  }
+}
+
+- (RNScreensNavigationController *)findChildNavigationControllerWithNavigationBarVisible
+{
+  // if we are a child of ScreenStack with navigationBar hidden, and there is no parent ScreenStack with navigationBar
+  // visible, this method will be triggered and the inset should be passed to child ScreenStacks. But if the child is a
+  // ScreenContainer, it will not propagate the inset to its children. If that ScreenContainer has a nested ScreenStack
+  // with navigationBar visible as a child, the nested ScreenStack's navigationBar will not have the proper inset during
+  // the transition because of it. We then set the additional inset for during the transition and remove it when the
+  // proper inset comes, which happens after the transition. This search won't work if we have ScreenStack nested in
+  // child ScreenContainer, and we want to search for children in this ScreenStack. It happens because at this moment,
+  // children of this ScreenStack will not be set yet, so even if there is a child ScreenStack with navigation bar
+  // visible, it won't get proper inset. Hopefully it is rare enough case, that it does not matter.
+  if ([self.parentViewController isKindOfClass:[RNScreensNavigationController class]] &&
+      !((RNScreensNavigationController *)self.parentViewController).additionalInsetSet &&
+      self.childViewControllers.count > 0 &&
+      [self.childViewControllers[0] isKindOfClass:[RNScreensViewController class]]) {
+    UIViewController *containerChild = [((RNScreensViewController *)self.childViewControllers[0]) findActiveChildVC];
+    while (containerChild.childViewControllers.count > 0) {
+      containerChild = containerChild.childViewControllers[0];
+      if ([containerChild isKindOfClass:[RNScreensNavigationController class]]) {
+        RNScreensNavigationController *navctr = (RNScreensNavigationController *)containerChild;
+        if (!navctr.navigationBar.isHidden) {
+          return navctr;
+        } else {
+          containerChild = navctr.topViewController;
+        }
+      } else if ([containerChild isKindOfClass:[RNScreensViewController class]]) {
+        containerChild = [((RNScreensViewController *)containerChild) findActiveChildVC];
+      }
+    }
+  }
+  return nil;
+}
+
 - (id)findFirstResponder:(UIView *)parent
 {
   if (parent.isFirstResponder) {

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -12,6 +12,8 @@
 
 @interface RNScreensViewController : UIViewController <RNScreensViewControllerDelegate>
 
+- (UIViewController *)findActiveChildVC;
+
 @end
 
 @interface RNSScreenContainerView : UIView <RNSScreenContainerDelegate>

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -43,6 +43,7 @@
 {
   return [self findActiveChildVC].supportedInterfaceOrientations;
 }
+#endif
 
 - (UIViewController *)findActiveChildVC
 {
@@ -54,7 +55,6 @@
   }
   return [[self childViewControllers] lastObject];
 }
-#endif
 
 @end
 

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -5,6 +5,9 @@
 
 @interface RNScreensNavigationController : UINavigationController <RNScreensViewControllerDelegate>
 
+@property (nonatomic) BOOL additionalInsetSet;
+@property (nonatomic) CGFloat additionalTopInset;
+
 @end
 
 @interface RNSScreenStackView : UIView <RNSScreenContainerDelegate, RCTInvalidating>

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -47,6 +47,24 @@
 }
 #endif
 
+- (void)viewSafeAreaInsetsDidChange
+{
+  [super viewSafeAreaInsetsDidChange];
+  // After we set additionSafeAreaInsets in viewSafeAreaInsetsDidChange of RNSScreen, this method is instantly
+  // triggered. Second time it is triggered is after the transition, when the navctr gets correct inset, we then want to
+  // remove the additional safe area.
+  if (_additionalInsetSet) {
+    _additionalInsetSet = NO;
+  } else if (_additionalTopInset > 0) {
+    self.additionalSafeAreaInsets = UIEdgeInsetsMake(
+        self.additionalSafeAreaInsets.top - _additionalTopInset,
+        self.additionalSafeAreaInsets.left,
+        self.additionalSafeAreaInsets.bottom,
+        self.additionalSafeAreaInsets.right);
+    _additionalTopInset = 0;
+  }
+}
+
 @end
 
 #if !TARGET_OS_TV


### PR DESCRIPTION
## Description


PR fixing header layout issues with transition of native-stack nested in `ScreenContainer`. Fixes #619.


## Changes

Added logic to check if there is a nested native-stack with visible navigation bar when transitioning from a screen of native-stack with navigation bar hidden.

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

https://user-images.githubusercontent.com/32481228/126653151-5a2eb382-4e09-422b-a18f-a3443d7e0715.mp4

### After

https://user-images.githubusercontent.com/32481228/126652920-d270bccc-144c-4ff0-97df-48af56702614.mp4

## Test code and steps to reproduce

Different nesting options in `Test619.js`. This PR won't work for `ScreenStack` (no header) -> one or more `ScreenContainer` -> one or more `ScreenStack` (no header) -> `ScreenStack` (header) due to problem described in comment in `RNSScreen.m`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes




