### PR TITLE
feat: add full width back gesture on ios

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -45,6 +45,30 @@
 {
   return [self topViewController].supportedInterfaceOrientations;
 }
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  [self setupFullWidthBackGesture];
+}
+
+- (void)setupFullWidthBackGesture
+{
+  NSArray *targets = [self.interactivePopGestureRecognizer valueForKey:@"_targets"];
+  if ([targets isKindOfClass:[NSArray class]]) {
+    @try {
+      id interactivePanTarget = [[targets firstObject] valueForKey:@"target"];
+      UIPanGestureRecognizer *panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:interactivePanTarget action:NSSelectorFromString(@"handleNavigationTransition:")];
+      [self.view addGestureRecognizer:panRecognizer];
+      
+      self.interactivePopGestureRecognizer.enabled = NO;
+    }
+    @catch (NSException *exception) {
+      NSLog(@"%@", exception);
+    }
+  }
+}
+
 #endif
 
 @end


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-screens/issues/251

This is a hacky solution. I think in order for this to be part of the library there would need to be an option to turn it on/off.

## Changes

Changed the gestureRecognizer to a UIPanGestureRecognizer.

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before
You have to swipe from the left edge

### After
You can swipe from anywhere:

![ezgif-6-ab8f70027cea](https://user-images.githubusercontent.com/865983/127506897-d74fbd96-7ccb-4d05-bfdb-5b3e3582d6d6.gif)


-->

## Test code and steps to reproduce


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
