### PR TITLE
fix: Search bar returns to an incorrect position after losing focus (fix for iOS 13+)

### DIFF
--- a/TestsExample/src/Test1036.tsx
+++ b/TestsExample/src/Test1036.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {NavigationContainer} from '@react-navigation/native';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+const Screen = () => {
+  return null;
+};
+
+const App = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        initialRouteName="Screen"
+        screenOptions={{
+          headerTitle: 'Title',
+          searchBar: {
+            onCancelButtonPress: ()=>{
+              console.log('cancel button press')
+            }
+          },
+        }}>
+        <Stack.Screen name="Screen" component={Screen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+export default App;

--- a/ios/RNSSearchBar.m
+++ b/ios/RNSSearchBar.m
@@ -76,11 +76,11 @@
 - (void)hideCancelButton
 {
 #if !TARGET_OS_TV
-  if (!@available(iOS 13, *)) {
-    [_controller.searchBar setShowsCancelButton:NO animated:YES];
-  } else {
+  if (@available(iOS 13, *)) {
     // On iOS 13+ UISearchController automatically shows/hides cancel button
     // https://developer.apple.com/documentation/uikit/uisearchcontroller/3152926-automaticallyshowscancelbutton?language=objc
+  } else {
+    [_controller.searchBar setShowsCancelButton:NO animated:YES];
   }
 #endif
 }
@@ -88,11 +88,11 @@
 - (void)showCancelButton
 {
 #if !TARGET_OS_TV
-  if (!@available(iOS 13, *)) {
-    [_controller.searchBar setShowsCancelButton:YES animated:YES];
-  } else {
+  if (@available(iOS 13, *)) {
     // On iOS 13+ UISearchController automatically shows/hides cancel button
     // https://developer.apple.com/documentation/uikit/uisearchcontroller/3152926-automaticallyshowscancelbutton?language=objc
+  } else {
+    [_controller.searchBar setShowsCancelButton:YES animated:YES];
   }
 #endif
 }

--- a/ios/RNSSearchBar.m
+++ b/ios/RNSSearchBar.m
@@ -73,6 +73,30 @@
 #endif
 }
 
+- (void)hideCancelButton
+{
+#if !TARGET_OS_TV
+  if (!@available(iOS 13, *)) {
+    [_controller.searchBar setShowsCancelButton:NO animated:YES];
+  } else {
+    // On iOS 13+ UISearchController automatically shows/hides cancel button
+    // https://developer.apple.com/documentation/uikit/uisearchcontroller/3152926-automaticallyshowscancelbutton?language=objc
+  }
+#endif
+}
+
+- (void)showCancelButton
+{
+#if !TARGET_OS_TV
+  if (!@available(iOS 13, *)) {
+    [_controller.searchBar setShowsCancelButton:YES animated:YES];
+  } else {
+    // On iOS 13+ UISearchController automatically shows/hides cancel button
+    // https://developer.apple.com/documentation/uikit/uisearchcontroller/3152926-automaticallyshowscancelbutton?language=objc
+  }
+#endif
+}
+
 #pragma mark delegate methods
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
@@ -88,9 +112,7 @@
   }
 #endif
 
-#if !TARGET_OS_TV
-  [_controller.searchBar setShowsCancelButton:YES animated:YES];
-#endif
+  [self showCancelButton];
   [self becomeFirstResponder];
 
   if (self.onFocus) {
@@ -103,6 +125,7 @@
   if (self.onBlur) {
     self.onBlur(@{});
   }
+  [self hideCancelButton];
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
@@ -128,7 +151,7 @@
 {
   _controller.searchBar.text = @"";
   [self resignFirstResponder];
-  [_controller.searchBar setShowsCancelButton:NO animated:YES];
+  [self hideCancelButton];
 
   if (self.onCancelButtonPress) {
     self.onCancelButtonPress(@{});


### PR DESCRIPTION
## Description

Fixes #1027 on iOS 13 and higher

## Changes

Removes manual cancel button hiding/showing and uses built in function.

## Test code and steps to reproduce

Test1036.tsx

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
