### PR TITLE
fix: Fixes typo in method name for TV-OS

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -550,7 +550,7 @@
     return NO;
   }
 #if TARGET_OS_TV
-  [self cancelTouchHandlerIfExists];
+  [self cancelTouchesInParent];
   return YES;
 #else
   if ([gestureRecognizer isKindOfClass:[RNSGestureRecognizer class]]) {


### PR DESCRIPTION
## Description

We found a typo in method call.

## Changes

Fixes typo

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
