### PR TITLE
fix: animation when replacing ios modal

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -49,6 +49,7 @@ import Test898 from './src/Test898';
 import Test913 from './src/Test913';
 import Test999 from './src/Test999';
 import Test1032 from './src/Test1032';
+import Test1041 from './src/Test1041';
 
 export default function App() {
   return <Test42 />;

--- a/TestsExample/src/Test1041.tsx
+++ b/TestsExample/src/Test1041.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {Button} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+ 
+const Stack = createNativeStackNavigator();
+ 
+type Props = {
+ navigation: NativeStackNavigationProp<ParamListBase>;
+}
+ 
+function First({navigation}: Props) {
+ return (
+   <Button title="Tap me for second screen" onPress={() => navigation.navigate('Second')} />
+ );
+}
+ 
+function Second({navigation}: Props) {
+ return (
+  <Button title="Tap me to replace second screen" onPress={() => navigation.replace('First')} />
+ );
+}
+
+export default function App() {
+ return (
+   <NavigationContainer>
+     <Stack.Navigator>
+       <Stack.Screen name="First" component={First} />
+       <Stack.Screen
+         name="Second"
+         component={Second}
+         options={{stackPresentation: 'modal'}}
+       />
+     </Stack.Navigator>
+   </NavigationContainer>
+ );
+}

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -478,8 +478,8 @@
     }
   }
 
-  [self setPushViewControllers:pushControllers];
   [self setModalViewControllers:modalControllers];
+  [self setPushViewControllers:pushControllers];
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
## Description

PR changing the order of updating the VCs of `native-stack` in order to first dismiss the modal and then push/pop normal screens.

## Screenshots / GIFs

### Before

https://user-images.githubusercontent.com/32481228/128707566-317ccc1a-b324-4bd0-9d1b-09b5c09e0fed.mp4

### After

https://user-images.githubusercontent.com/32481228/128707575-dd6f1e67-89bb-4077-965c-00d654d8a3d0.mp4

## Test code and steps to reproduce

`Test1041.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes




