### PR TITLE
feat: warn when using native-stack from rns in v6

### DIFF
--- a/src/native-stack/navigators/createNativeStackNavigator.tsx
+++ b/src/native-stack/navigators/createNativeStackNavigator.tsx
@@ -35,14 +35,13 @@ function NativeStackNavigator({
     screenOptions,
   });
 
-  // Starting from React Navigation v6 @react-navigation/native-stack should be used.
-  // react-native-screens/native-stack works kinda okay for v6 (still) but types
-  // are different and it isn't supported for v6 so we have to warn users about this.
+  // Starting from React Navigation v6, `native-stack` should be imported from
+  // `@react-navigation/native-stack` rather than `react-native-screens/native-stack`
   React.useEffect(() => {
-    // navigation.dangerouslyGetParent was removed in v6
-    if (navigation.dangerouslyGetParent === undefined) {
+    // @ts-ignore navigation.dangerouslyGetParent was removed in v6
+    if (navigation?.dangerouslyGetParent === undefined) {
       console.warn(
-        'It appears that you are importing native-stack from react-native-screens. Since version 6 of react-navigation, native-stack should be used as separate package @react-navigation/native-stack to take full advantage of new functionalities added to react-navigation'
+        'Looks like you are importing `native-stack` from `react-native-screens/native-stack`. Since version 6 of `react-navigation`, it should be imported from `@react-navigation/native-stack`.'
       );
     }
   }, [navigation]);

--- a/src/native-stack/navigators/createNativeStackNavigator.tsx
+++ b/src/native-stack/navigators/createNativeStackNavigator.tsx
@@ -35,6 +35,18 @@ function NativeStackNavigator({
     screenOptions,
   });
 
+  // Starting from React Navigation v6 @react-navigation/native-stack should be used.
+  // react-native-screens/native-stack works kinda okay for v6 (still) but types
+  // are different and it isn't supported for v6 so we have to warn users about this.
+  React.useEffect(() => {
+    // navigation.dangerouslyGetParent was removed in v6
+    if (navigation.dangerouslyGetParent === undefined) {
+      console.warn(
+        'It appears that you are importing native-stack from react-native-screens. Since version 6 of react-navigation, native-stack should be used as separate package @react-navigation/native-stack to take full advantage of new functionalities added to react-navigation'
+      );
+    }
+  }, [navigation]);
+
   React.useEffect(
     () =>
       navigation?.addListener?.('tabPress', (e) => {


### PR DESCRIPTION
## Description

Since react-navigation v6 `@react-navigation/native-stack` is the preferred way of using native-stack. Nevertheless, nothing stops developers from using `react-native-screens/native-stack` with RNv6. This PR adds a check if react-native-screens' native-stack is used with RNv6 and warns about this.

## Screenshots / GIFs
![Simulator Screen Shot - iPhone 11 - 2021-08-18 at 17 12 17](https://user-images.githubusercontent.com/39658211/129925294-baa511a1-9aad-40dd-a3d4-321b6eb8dfc3.png)

## Test code and steps to reproduce
Bump @react-navigation/native in TestsExample to use v6.

## Checklist

- [x] Ensured that CI passes
