### PR TITLE
fix: iOS screen orientation crash

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -405,7 +405,8 @@
   UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitOrientation includingModals:YES];
 
   if ([vc isKindOfClass:[RNSScreen class]]) {
-    return ((RNSScreenView *)vc.view).screenOrientation;
+    UIInterfaceOrientationMask orientation = ((RNSScreenView *)vc.view).screenOrientation;
+    return orientation ? orientation : UIInterfaceOrientationMaskAllButUpsideDown;
   }
   return UIInterfaceOrientationMaskAllButUpsideDown;
 }


### PR DESCRIPTION
## Description

[This change](https://github.com/software-mansion/react-native-screens/pull/863/files#diff-e988f8ab84e7063d6cc9ad4e634806389882ce6727b5c95f3cfbc9f9d3921a67L365-R399) in PR https://github.com/software-mansion/react-native-screens/pull/863 introduces a crash in some situtations. 

In our case, we are not providing an orientation to the "react-native-screen"-screen and instead we are changing the orientation manually. There are probably several situations where you want to be able to do that.

## Changes

Restored the functionality by returning `UIInterfaceOrientationMaskAllButUpsideDown` in cases where orientation is not provided to the screen.

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [x] Ensured that CI passes
