### PR TITLE
fix: no exception while using flip animation on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -54,7 +54,7 @@ class ScreenViewManager : ViewGroupManager<Screen>() {
     @ReactProp(name = "stackAnimation")
     fun setStackAnimation(view: Screen, animation: String?) {
         view.stackAnimation = when (animation) {
-            null, "default", "simple_push" -> Screen.StackAnimation.DEFAULT
+            null, "default", "flip", "simple_push" -> Screen.StackAnimation.DEFAULT
             "none" -> Screen.StackAnimation.NONE
             "fade" -> Screen.StackAnimation.FADE
             "slide_from_right" -> Screen.StackAnimation.SLIDE_FROM_RIGHT


### PR DESCRIPTION
## Description
Currently setting `stackAnimation: flip` results in exception on Android. It should resolve to default android animation instead.

## Changes

- Resolve `flip` stackAnimation to default Android animation.

## Checklist

- [x] Ensured that CI passes
