### PR TITLE
fix: send progress when container is null

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -190,8 +190,7 @@ open class ScreenFragment : Fragment {
              */
                 val coalescingKey = (if (mProgress == 0.0f) 1 else if (mProgress == 1.0f) 2 else 3).toShort()
                 val container: ScreenContainer<*>? = screen.container
-                check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
-                val goingForward = container.goingForward
+                val goingForward = if (container is ScreenStack) container.goingForward else false
                 (screen.context as ReactContext)
                     .getNativeModule(UIManagerModule::class.java)
                     ?.eventDispatcher


### PR DESCRIPTION
## Description

Fix a bug introduced in #890 where when container is already null, the app crashes.

## Checklist

- [x] Ensured that CI passes
