### PR TITLE
feat: add option for custom swipe animation

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -94,6 +94,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 @property (nonatomic) BOOL hasStatusBarStyleSet;
 @property (nonatomic) BOOL hasStatusBarAnimationSet;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;
+@property (nonatomic) BOOL customAnimatonOnSwipe;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -722,6 +722,7 @@ RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onDismissed, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(customAnimatonOnSwipe, BOOL);
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -553,22 +553,28 @@
   [self cancelTouchesInParent];
   return YES;
 #else
-  if ([gestureRecognizer isKindOfClass:[RNSGestureRecognizer class]]) {
-    // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
-    // of `UISemanticContentAttributeForceLeftToRight`, so we just check if it is RTL or not
-    BOOL isCorrectEdge = (_controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft &&
-                          ((RNSGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeRight) ||
-        (_controller.view.semanticContentAttribute != UISemanticContentAttributeForceRightToLeft &&
-         ((RNSGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeLeft);
-    if (isCorrectEdge && topScreen.stackAnimation == RNSScreenStackAnimationSimplePush) {
-      [self cancelTouchesInParent];
-      return YES;
+  // custom animation should be always served by custom recognizers
+  if (topScreen.customAnimatonOnSwipe && [RNSScreenStackAnimator isCustomAnimation:topScreen.stackAnimation]) {
+    if ([gestureRecognizer isKindOfClass:[RNSGestureRecognizer class]]) {
+      // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
+      // of `UISemanticContentAttributeForceLeftToRight`, so we just check if it is RTL or not
+      BOOL isCorrectEdge = (_controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft &&
+                            ((RNSGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeRight) ||
+          (_controller.view.semanticContentAttribute != UISemanticContentAttributeForceRightToLeft &&
+           ((RNSGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeLeft);
+      if (isCorrectEdge) {
+        [self cancelTouchesInParent];
+        return YES;
+      }
     }
-  } else if (topScreen.stackAnimation != RNSScreenStackAnimationSimplePush) {
+    return NO;
+  } else {
+    if ([gestureRecognizer isKindOfClass:[RNSGestureRecognizer class]]) {
+      return NO;
+    }
     [self cancelTouchesInParent];
     return YES;
   }
-  return NO;
 #endif
 }
 

--- a/ios/RNSScreenStackAnimator.h
+++ b/ios/RNSScreenStackAnimator.h
@@ -1,3 +1,8 @@
+#import "RNSScreen.h"
+
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
 - (instancetype)initWithOperation:(UINavigationControllerOperation)operation;
++ (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation;
+
 @end

--- a/ios/RNSScreenStackAnimator.m
+++ b/ios/RNSScreenStackAnimator.m
@@ -249,4 +249,9 @@
   }
 }
 
++ (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation
+{
+  return (animation != RNSScreenStackAnimationFlip && animation != RNSScreenStackAnimationDefault);
+}
+
 @end

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -82,6 +82,12 @@ export type NativeStackNavigationOptions = {
    */
   contentStyle?: StyleProp<ViewStyle>;
   /**
+   * Boolean indicating that swipe dismissal should trigger animation provided by `stackAnimation`. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  customAnimatonOnSwipe?: boolean;
+  /**
    * Whether the stack should be in rtl or ltr form.
    */
   direction?: 'rtl' | 'ltr';

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -149,6 +149,7 @@ const RouteView = ({
 }) => {
   const { options, render: renderScene } = descriptors[route.key];
   const {
+    customAnimatonOnSwipe,
     gestureEnabled,
     headerShown,
     replaceAnimation = 'pop',
@@ -189,6 +190,7 @@ const RouteView = ({
       enabled
       style={StyleSheet.absoluteFill}
       isNativeStack
+      customAnimatonOnSwipe={customAnimatonOnSwipe}
       gestureEnabled={isAndroid ? false : gestureEnabled}
       replaceAnimation={replaceAnimation}
       screenOrientation={screenOrientation}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -74,6 +74,12 @@ export interface ScreenProps extends ViewProps {
   activityState?: 0 | 1 | 2 | Animated.AnimatedInterpolation;
   children?: React.ReactNode;
   /**
+   * Boolean indicating that swipe dismissal should trigger animation provided by `stackAnimation`. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  customAnimatonOnSwipe?: boolean;
+  /**
    * All children screens should have the same value of their "enabled" prop as their container.
    */
   enabled?: boolean;
@@ -83,7 +89,6 @@ export interface ScreenProps extends ViewProps {
   isNativeStack?: boolean;
   /**
    * Whether you can use gestures to dismiss this screen. Defaults to `true`.
-   * Only supported on iOS.
    *
    * @platform ios
    */


### PR DESCRIPTION
## Description

PR adding `customAnimatonOnSwipe` used for providing animation from `stackAnimation` when swiping the screen on `iOS`. 

***This PR changes the behavior of `simple_push` since now it needs `customAnimatonOnSwipe` to be set to `true` in order to use its back animation***


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
