### PR TITLE
feat: add possibility to run CI builds manually

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   install-and-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
## Description

Adding `workflow_dispatch` event is required to trigger CI manually.
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/