### PR TITLE
fix: add jcenter() to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -40,6 +41,7 @@ repositories {
     mavenCentral()
     mavenLocal()
     google()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
## Description

`jcenter()` repository was removed in #1042. Lack thereof results in failing `./gradlew assembleRelease` in `android/` directory.

Fixes #1092

## Changes

- Brought `jcenter()` repo back to `build.gradle` file

## Test code and steps to reproduce

Remove `jcenter()` from `android/build.gradle` and run `./gradlew assembleRelease` or `./gradlew assembleDebug`.

## Checklist

- [ ] Ensured that CI passes
