### PR TITLE
fix: make search bar appear on iOS 12

### DIFF
--- a/ios/RNSSearchBar.m
+++ b/ios/RNSSearchBar.m
@@ -18,7 +18,7 @@
 {
   if (self = [super init]) {
     _bridge = bridge;
-    _controller = [UISearchController new];
+    _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
     _controller.searchBar.delegate = self;
     _hideWhenScrolling = YES;
   }


### PR DESCRIPTION
## Description

For some reason when `searchBar`'s controller is instantiated with `new`, the `searchBar` itself does not appear on `iOS` 12. Changing it to `[[UISearchController alloc] initWithSearchResultsController:nil]` resolves the issue.


## Test code and steps to reproduce

`Test758.tsx` with `iOS 12`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
