### PR TITLE
fix: delay ScreenContainer updates in same manner as ScreenStack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.kt
@@ -1,7 +1,9 @@
 package com.swmansion.rnscreens
 
 import android.view.View
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 
@@ -34,6 +36,10 @@ class ScreenContainerViewManager : ViewGroupManager<ScreenContainer<*>>() {
 
     override fun getChildAt(parent: ScreenContainer<*>, index: Int): View {
         return parent.getScreenAt(index)
+    }
+
+    override fun createShadowNodeInstance(context: ReactApplicationContext): LayoutShadowNode {
+        return ScreensShadowNode(context)
     }
 
     override fun needsCustomLayoutForChildren(): Boolean {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -20,7 +20,6 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     private val drawingOpPool: MutableList<DrawingOp> = ArrayList()
     private val drawingOps: MutableList<DrawingOp> = ArrayList()
     private var mTopScreen: ScreenStackFragment? = null
-    private var mNeedUpdate = false
     private val mBackStackListener = FragmentManager.OnBackStackChangedListener {
         if (mFragmentManager?.backStackEntryCount == 0) {
             // when back stack entry count hits 0 it means the user's navigated back using hw back
@@ -129,35 +128,7 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
         return super.hasScreen(screenFragment) && !mDismissed.contains(screenFragment)
     }
 
-    public override fun onScreenChanged() {
-        // we perform update in `onBeforeLayout` of `ScreensShadowNode` by adding an UIBlock
-        // which is called after updating children of the ScreenStack.
-        // We do it there because `onUpdate` logic requires all changes of children to be already
-        // made in order to provide proper animation for fragment transition.
-        // The exception to this rule is `updateImmediately` which is triggered by actions
-        // not connected to React view hierarchy changes, but rather internal events
-        mNeedUpdate = true
-    }
-
-    public override fun setFragmentManager(fm: FragmentManager) {
-        mFragmentManager = fm
-        performUpdatesNow()
-    }
-
-    private fun performUpdatesNow() {
-        // we want to update the immediately when the fragment manager is set or native back button
-        // dismiss is dispatched since it is not connected to React view hierarchy changes and will
-        // not trigger `onBeforeLayout` method of `ScreensShadowNode`
-        mNeedUpdate = true
-        performUpdates()
-    }
-
-    fun performUpdates() {
-        if (!mNeedUpdate || !mIsAttached || mFragmentManager == null) {
-            return
-        }
-        mNeedUpdate = false
-
+    override fun onUpdate() {
         // When going back from a nested stack with a single screen on it, we may hit an edge case
         // when all screens are dismissed and no screen is to be displayed on top. We need to gracefully
         // handle the case of newTop being NULL, which happens in several places below
@@ -309,7 +280,6 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
             it.commitNowAllowingStateLoss()
             mTopScreen?.let { screen -> setupBackHandlerIfNeeded(screen) }
         }
-        notifyContainerUpdate()
     }
 
     override fun notifyContainerUpdate() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreensShadowNode.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensShadowNode.kt
@@ -11,7 +11,7 @@ internal class ScreensShadowNode(private var mContext: ReactContext) : LayoutSha
         super.onBeforeLayout(nativeViewHierarchyOptimizer)
         (mContext.getNativeModule(UIManagerModule::class.java))?.addUIBlock { nativeViewHierarchyManager: NativeViewHierarchyManager ->
             val view = nativeViewHierarchyManager.resolveView(reactTag)
-            if (view is ScreenStack) {
+            if (view is ScreenContainer<*>) {
                 view.performUpdates()
             }
         }


### PR DESCRIPTION
## Description

Added delayed update logic to `ScreenContainer` in order to resolve issues with too early detached nested navigators when going back from a screen in `native-stack` with nested different navigators. This change was part of synchronous fragment updates introduced in #1066. Going back like that triggers `removeAllScreens` code of the nested navigator and it resolved in detaching all of the child screens before the update of `native-stack` was dispatched, leading to blank screen from the start of navigation.

## Test code and steps to reproduce

`Test860.tsx` to see that without this change the nested navigators are detached at the start of transition.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
