### PR TITLE
remove com.diffplug.spotless version from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.spotless" version "5.14.1"
+    id "com.diffplug.spotless"
 }
 
 apply plugin: 'com.android.library'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,7 @@
+pluginManagement {
+  plugins {
+    id "com.diffplug.spotless" version "5.14.1"
+  }
+}
+
 include 'lib'


### PR DESCRIPTION
## Description

Fixes android builds failing with 

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/charliecruzan/source/expo/node_modules/react-native-screens/android/build.gradle' line: 14

* What went wrong:
Error resolving plugin [id: 'com.diffplug.spotless', version: '5.14.1']
> Plugin request for plugin already on the classpath must not include a version
```

If projects installing react-native-screens also use `com.diffplug.spotless`

## Changes

removed the version specification from build.gradle, and placed it in settings.gradle inside of `pluginManagement` block, as suggested [here](https://docs.gradle.org/current/userguide/plugins.html#:~:text=Plugin%20Version%20Management,-A%20plugins%20%7B%7D&text=One%20benefit%20of%20setting%20plugin,to%20be%20taken%20from%20gradle)


## Test code and steps to reproduce

init a RN project, add 

```
plugins {
  id "com.diffplug.spotless" version "5.14.1"
}
``` 
to build.gradle

`yarn add react-native-screens`, and try to build.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
