### PR TITLE
fix: apply spotless conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,11 +7,13 @@ buildscript {
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
 }
 
-plugins {
-    id "com.diffplug.spotless" version "5.14.1"
+// spotless is only accessible within react-native-screens repo
+if (project == rootProject) {
+    apply from: 'spotless.gradle'
 }
 
 apply plugin: 'com.android.library'
@@ -57,16 +59,4 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.20"
-}
-
-plugins.apply("com.diffplug.spotless")
-
-spotless {
-    kotlin {
-        target 'src/**/*.kt'
-        ktlint("0.40.0")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
 }

--- a/android/spotless.gradle
+++ b/android/spotless.gradle
@@ -1,0 +1,12 @@
+// formatter & linter configuration for kotlin
+apply plugin: 'com.diffplug.spotless'
+
+spotless {
+  kotlin {
+    target 'src/**/*.kt'
+    ktlint("0.40.0")
+    trimTrailingWhitespace()
+    indentWithSpaces()
+    endWithNewline()
+  }
+}


### PR DESCRIPTION
## Description

Fixes issue mentioned in https://github.com/software-mansion/react-native-screens/pull/1118 with clashing Spotless configuration when developer's app also uses Spotless. 

This PR makes spotless only load within `react-native-screens` project.


## Changes

Moved spotless configuration to separate file and load it conditionally using `apply from` syntax.

## Test code and steps to reproduce

init a RN project, add 

```
plugins {
  id "com.diffplug.spotless" version "5.14.1"
}
``` 
to build.gradle

`yarn add react-native-screens`, and try to build.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
