### PR TITLE
fix: context is never null

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -369,7 +369,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         mDirection = direction
     }
 
-    private class DebugMenuToolbar(context: Context?) : Toolbar(context) {
+    private class DebugMenuToolbar(context: Context) : Toolbar(context) {
         override fun showOverflowMenu(): Boolean {
             (context.applicationContext as ReactApplication)
                 .reactNativeHost


### PR DESCRIPTION
## Description

fixes an error when building for android on different kotlin versions / lint setups

I have changed the project's gradle setup to match the `Example/` in this repo, but still getting the error... but even though this could be kotlin version issue, it seems to me that `context` can't be null here anyways, so figured I'd open a PR for review 🤷 

## Changes

`context` is never null according to the constructor, so I just changed one instance of `Context?` to `Context`

<!--

### Before

> ScreenStackHeaderConfig.kt: (372, 65): Type mismatch: inferred type is Context? but Context was expected

### After

project builds successfully

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
