### PR TITLE
chore: Change concurrency group name

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       WORKING_DIRECTORY: Example
     concurrency:
-      group: ios-${{ github.ref }}
+      group: ios-e2e-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
## Description

Fixes github actions concurrency group for ios e2e

## Checklist

- [ ] Ensured that CI passes
