### PR TITLE
chore: Change concurrency group name for tv os

### DIFF
--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       WORKING_DIRECTORY: TVOSExample
     concurrency:
-      group: ios-${{ github.ref }}
+      group: ios-tv-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
## Description

Fixes concurrency group name for tvOS

## Checklist

- [x] Ensured that CI passes
