### PR TITLE
fix: downgrade kotlin & take kotlinVersion from ext

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         ndkVersion = "20.1.5948944"
-        kotlinVersion = "1.5.20"
+        kotlinVersion = "1.4.10"
     }
     repositories {
         google()

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -1,13 +1,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "20.1.5948944"
+        kotlinVersion = "1.5.20"
+    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.1')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
@@ -26,12 +34,4 @@ allprojects {
         mavenCentral()
         maven { url 'https://www.jitpack.io' }
     }
-}
-
-ext {
-    buildToolsVersion = "30.0.2"
-    minSdkVersion = 21
-    compileSdkVersion = 30
-    targetSdkVersion = 30
-    ndkVersion = "20.1.5948944"
 }

--- a/TestsExample/android/build.gradle
+++ b/TestsExample/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         ndkVersion = "20.1.5948944"
-        kotlinVersion = "1.5.20"
+        kotlinVersion = "1.4.10"
     }
     repositories {
         google()

--- a/TestsExample/android/build.gradle
+++ b/TestsExample/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         ndkVersion = "20.1.5948944"
+        kotlinVersion = "1.5.20"
     }
     repositories {
         google()
@@ -14,7 +15,7 @@ buildscript {
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.1')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
     repositories {
         google()
         jcenter()
@@ -6,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.5.20')}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
 }
@@ -18,10 +21,6 @@ if (project == rootProject) {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -58,14 +57,6 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.20"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.5.20')}"
 }
 
-// Resolve dependencies to use the same kotlin versions
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.jetbrains.kotlin' && details.requested.name == 'kotlin-stdlib-jdk8') {
-            details.useVersion "1.5.20"
-        }
-    }
-}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,4 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation "androidx.core:core-ktx:1.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.10')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.5.20')}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.4.10')}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
 }
@@ -57,6 +57,5 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.core:core-ktx:1.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.5.20')}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.10')}"
 }
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,3 +60,12 @@ dependencies {
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.20"
 }
+
+// Resolve dependencies to use the same kotlin versions
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.jetbrains.kotlin' && details.requested.name == 'kotlin-stdlib-jdk8') {
+            details.useVersion "1.5.20"
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR downgrades kotlin version to match react-native's one - https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/third-party/kotlin/BUCK#L54

Adds a way for the developer to override kotlin version via `kotlinVersion` prop in `build.gradle` `ext` property.

Also, removes the dependency on the standard library ([explaination](https://stackoverflow.com/a/64988522)) thus lets Gradle infer correct versions for a particular Kotlin version.

Fixes #1109.

## Test code and steps to reproduce

Run ./gradlew compileDebugKotlin in react-native-screens/TestsExample/android.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
