### PR TITLE
fix: commit remove and add separately in moveToFront

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -181,7 +181,8 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
     }
 
     private fun moveToFront(screenFragment: ScreenFragment) {
-        createTransaction().remove(screenFragment).add(id, screenFragment).commitNowAllowingStateLoss()
+        createTransaction().remove(screenFragment).commitNowAllowingStateLoss()
+        createTransaction().add(id, screenFragment).commitNowAllowingStateLoss()
     }
 
     private fun detachScreen(screenFragment: ScreenFragment) {


### PR DESCRIPTION
## Description

PR fixing `stack` navigator's `detachPreviousScreen` behavior with new versions of `appCompat`. Seems like one of the new implementations of `Fragment` added some kind of optimization of redundant operations. Therefore, `moveToFront` method does not work correctly there, since we remove and then reattach the same fragment in order to make it appear in front. Committing the `remove` and `add` action separately brings back the correct behavior, probably due to no option of optimization because of synchronous behavior of these actions.

## Changes

Separated `remove` and `add` actions in `moveToFront` method in `ScreenContainer.kt`.

## Test code and steps to reproduce

`Test624.tsx` modal presentation screens with `appCompat` version `1.3.1`.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
