### PR TITLE
fix: enable desugaring of java 8 bytecode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {


### PR DESCRIPTION
## Description

This PR fixes build errors in detox by enabling desugaring in Android.
Thanks to @dantenol for suggesting this fix.

Fixes https://github.com/software-mansion/react-native-screens/issues/1078

## Changes

- Enabled desugaring in android/build.gradle wtih ⬇️
```
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
```

## Checklist

- [x] Ensured that CI passes
