### PR TITLE
chore: Adds screenshot artifact to iOS e2e

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -45,5 +45,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: android-fail-screen-shoots
+          name: ios-fail-screen-shoots
           path: ${{ env.WORKING_DIRECTORY }}/artifacts

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -2,7 +2,7 @@ name: Test iOS e2e
 on:
   pull_request:
     paths:
-        - 'Example/**'
+      - 'Example/**'
   push:
     branches:
       - master
@@ -42,3 +42,8 @@ jobs:
       - name: Test app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn test-e2e-ios
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: android-fail-screen-shoots
+          path: ${{ env.WORKING_DIRECTORY }}/artifacts

--- a/Example/package.json
+++ b/Example/package.json
@@ -11,7 +11,7 @@
     "check-types": "tsc --noEmit",
     "build-e2e-ios": "detox build --configuration ios.release",
     "build-e2e-android": "detox build --configuration android.release",
-    "test-e2e-ios": "detox test --configuration ios.release",
+    "test-e2e-ios": "detox test --configuration ios.release --take-screenshots failing",
     "test-e2e-android": "detox test --configuration android.release"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

When iOS e2e test fail save screenshots as artifacts

## Checklist
- [ ] Ensured that CI passes
