### PR TITLE
fix: canceled swipe gesture on iOS 12 when direction hasn't changed

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -57,6 +57,7 @@ import Test1032 from './src/Test1032';
 import Test1036 from './src/Test1036';
 import Test1072 from './src/Test1072';
 import Test1084 from './src/Test1084';
+import Test1091 from './src/Test1091';
 import Test1096 from './src/Test1096';
 
 export default function App() {

--- a/TestsExample/src/Test1091.tsx
+++ b/TestsExample/src/Test1091.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import {Button, View, Text} from 'react-native';
-// yarn add @react-navigation/native@^6 @react-navigation/native-stack@^6
 import {NavigationContainer} from '@react-navigation/native';
 
 // swipe gesture works when using react-native-screens/native-stack
-// import {
-//   createNativeStackNavigator,
-//   NativeStackScreenProps,
-// } from 'react-native-screens/native-stack';
-
-// but it doesn't work with @react-navigation/native-stack
 import {
   createNativeStackNavigator,
   NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+} from 'react-native-screens/native-stack';
+
+// but it doesn't work with @react-navigation/native-stack
+// use `@react-navigation/native@^6` & `@react-navigation/native-stack@^6` to test this
+// import {
+//   createNativeStackNavigator,
+//   NativeStackScreenProps,
+// } from '@react-navigation/native-stack';
 
 type StackParams = {
   Screen: undefined;

--- a/TestsExample/src/Test1091.tsx
+++ b/TestsExample/src/Test1091.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {Button, View, Text} from 'react-native';
+// yarn add @react-navigation/native@^6 @react-navigation/native-stack@^6
+import {NavigationContainer} from '@react-navigation/native';
+
+// swipe gesture works when using react-native-screens/native-stack
+// import {
+//   createNativeStackNavigator,
+//   NativeStackScreenProps,
+// } from 'react-native-screens/native-stack';
+
+// but it doesn't work with @react-navigation/native-stack
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+
+type StackParams = {
+  Screen: undefined;
+  Screen2: undefined;
+};
+
+const Stack = createNativeStackNavigator<StackParams>();
+
+const Screen2 = () => (
+  <View style={{paddingTop: 200}}>
+    <Text>
+      Swipe gesture doesn't work on iOS 12 in @react-navigation/native-stack
+    </Text>
+  </View>
+);
+
+const Screen = ({navigation}: NativeStackScreenProps<StackParams>) => (
+  <View style={{paddingTop: 200}}>
+    <Button
+      title="Go to Screen2"
+      onPress={() => navigation.navigate('Screen2')}
+    />
+  </View>
+);
+
+const App = () => (
+  <NavigationContainer>
+    <Stack.Navigator
+      initialRouteName="Screen"
+      screenOptions={
+        {
+          // headerShown: false,
+          // gestureEnabled: false,
+          // direction: 'rtl',
+          // animation: 'simple_push',
+        }
+      }>
+      <Stack.Screen name="Screen" component={Screen} />
+      <Stack.Screen name="Screen2" component={Screen2} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+export default App;

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -444,8 +444,10 @@
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
 
-  if (config.direction == UISemanticContentAttributeForceLeftToRight ||
-      config.direction == UISemanticContentAttributeForceRightToLeft) {
+  if ((config.direction == UISemanticContentAttributeForceLeftToRight ||
+       config.direction == UISemanticContentAttributeForceRightToLeft) &&
+      // iOS 12 cancels swipe gesture when direction is changed. See #1091
+      navctr.view.semanticContentAttribute != config.direction) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;
   }


### PR DESCRIPTION
## Description

Setting up the default value for `direction` in [native stack v6](https://github.com/react-navigation/react-navigation/blob/main/packages/native-stack/src/views/HeaderConfig.tsx#L114) revealed an issue with a swipe gesture on iOS 12.

Setting `direction` with the same value twice cancels the transition between screens in iOS 12.

This issue doesn't occur on iOS 13+ because Apple reimplemented how the gesture system works.

Fixes #1091

## Changes

- Added check and set `direction` in `RNScreenStackHeaderConfig` only when it changed

## Screenshots / GIFs

### Before


https://user-images.githubusercontent.com/39658211/134510295-f79104e8-9b0d-4547-981d-7247ffc0a2cd.MP4

### After


https://user-images.githubusercontent.com/39658211/134510751-f2dcd869-1b9c-4182-b5a8-ae80dfe757ea.MP4



## Test code and steps to reproduce

`Test1091.tsx` in `TestsExample` project

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
