### PR TITLE
fix: add hasTwoStates iOS check

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -85,7 +85,9 @@ const ScreensNativeModules = {
   get NativeScreenNavigationContainer() {
     NativeScreenNavigationContainerValue =
       NativeScreenNavigationContainerValue ||
-      requireNativeComponent('RNSScreenNavigationContainer');
+      (Platform.OS === 'ios'
+        ? requireNativeComponent('RNSScreenNavigationContainer')
+        : this.NativeScreenContainer);
     return NativeScreenNavigationContainerValue;
   },
 
@@ -331,10 +333,7 @@ module.exports = {
   },
 
   get NativeScreenNavigationContainer() {
-    if (Platform.OS === 'ios') {
-      return ScreensNativeModules.NativeScreenNavigationContainer;
-    }
-    return ScreensNativeModules.NativeScreenContainer;
+    return ScreensNativeModules.NativeScreenNavigationContainer;
   },
 
   get ScreenStack() {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->
PR adds iOS check for NativeScreenNavigationContainer.  Android trying to call RNSScreenNavigationContainer which is only had on iOS.
![image](https://user-images.githubusercontent.com/7578884/134668879-cccd10c2-7d37-4640-9548-0b617d641a4f.png)

## Changes
Added iOS check before the NativeScreenNavigationContainerValue init. Actually line 235 calls NativeScreenNavigationContainer if navigation hasTwoStates but I combined both check in one place.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


## Test code and steps to reproduce
1- Add navigation patch https://github.com/react-navigation/react-navigation/pull/9772
2- Run Test619 on Android
<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
