### PR TITLE
fix: make method for checking if trait is set

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
+- (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
 
 @end
 

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -13,6 +13,8 @@
 
 @interface RNScreensViewController : UIViewController <RNScreensViewControllerDelegate>
 
+- (UIViewController *)findActiveChildVC;
+
 @end
 
 @interface RNSScreenContainerManager : RCTViewManager

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -17,4 +17,8 @@
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
 #endif
 
++ (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
+                 includingModals:(BOOL)includingModals
+                inViewController:(UIViewController *)vc;
+
 @end

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -20,5 +20,6 @@
 + (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
                  includingModals:(BOOL)includingModals
                 inViewController:(UIViewController *)vc;
++ (BOOL)shouldAskScreensForScreenOrientationInViewController:(UIViewController *)vc;
 
 @end

--- a/ios/RNSScreenWindowTraits.m
+++ b/ios/RNSScreenWindowTraits.m
@@ -211,4 +211,12 @@
   return NO;
 }
 
+// same method as above, but directly for orientation
++ (BOOL)shouldAskScreensForScreenOrientationInViewController:(UIViewController *)vc
+{
+  return [RNSScreenWindowTraits shouldAskScreensForTrait:RNSWindowTraitOrientation
+                                         includingModals:YES
+                                        inViewController:vc];
+}
+
 @end

--- a/ios/RNSScreenWindowTraits.m
+++ b/ios/RNSScreenWindowTraits.m
@@ -1,5 +1,7 @@
 #import "RNSScreenWindowTraits.h"
 #import "RNSScreen.h"
+#import "RNSScreenContainer.h"
+#import "RNSScreenStack.h"
 
 @implementation RNSScreenWindowTraits
 
@@ -189,5 +191,24 @@
   }
 }
 #endif
+
+// method to be used in Expo for checking if RNScreens have trait set
++ (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
+                 includingModals:(BOOL)includingModals
+                inViewController:(UIViewController *)vc
+{
+  UIViewController *lastViewController = [[vc childViewControllers] lastObject];
+  if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+    UIViewController *vc = nil;
+    if ([lastViewController isKindOfClass:[RNScreensViewController class]]) {
+      vc = [(RNScreensViewController *)lastViewController findActiveChildVC];
+    } else if ([lastViewController isKindOfClass:[RNScreensNavigationController class]]) {
+      vc = [(RNScreensNavigationController *)lastViewController topViewController];
+    }
+    return [vc isKindOfClass:[RNSScreen class]] &&
+        [(RNSScreen *)vc findChildVCForConfigAndTrait:trait includingModals:includingModals] != nil;
+  }
+  return NO;
+}
 
 @end


### PR DESCRIPTION
## Description

PR exposing a way to check if there was a window trait (status bar or orientation) set by user in any of the navigators. In such case, it should take precedence over other methods, like `expo-screen-orientation`. Calling 
```
+ (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
                 includingModals:(BOOL)includingModals
                inViewController:(UIViewController *)vc;
```

should return `NO` if there was no screen in view hierarchy that requests a specific trait and `YES` otherwise.

PR to be used e.g. in `Expo`.

***These methods are used by providing their exact signature as a string and therefore their name should not be changed.***

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
