### PR TITLE
fix: ensure mTopScreen's null safety in ScreenStack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -120,10 +120,8 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
                 // if the previous top screen does not exist anymore and the new top was not on the stack
                 // before, probably replace or reset was called, so we play the "close animation".
                 // Otherwise it's open animation
-                shouldUseOpenAnimation = (
-                    mScreenFragments.contains(mTopScreen) ||
-                        newTop.screen.replaceAnimation !== Screen.ReplaceAnimation.POP
-                    )
+                val containsTopScreen = mTopScreen?.let { mScreenFragments.contains(it) } == true
+                shouldUseOpenAnimation = containsTopScreen || newTop.screen.replaceAnimation !== Screen.ReplaceAnimation.POP
                 stackAnimation = newTop.screen.stackAnimation
             } else if (mTopScreen == null && newTop != null) {
                 // mTopScreen was not present before so newTop is the first screen added to a stack


### PR DESCRIPTION
## Description

It seems like Kotlin null safety is slightly differently resolved between versions. This caused a compile error with Kotlin v1.3.X.

Fixes https://github.com/software-mansion/react-native-screens/issues/1163

## Changes

- Ensured mTopScreens null safety in `ScreenStack.kt`

## Test code and steps to reproduce

Change https://github.com/software-mansion/react-native-screens/blob/master/TestsExample/android/build.gradle#L10 to use `kotlinVersion = "1.3.72"`


## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
