### PR TITLE
feat: add scheduling update for Layout Animations

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -277,16 +277,13 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // The exception to this rule is `updateImmediately` which is triggered by actions
         // not connected to React view hierarchy changes, but rather internal events
         mNeedUpdate = true
-        val reactContext = context
-        if (reactContext is ReactContext) {
-            reactContext.runOnUiQueueThread {
-                // We schedule the update here because LayoutAnimations of `react-native-reanimated`
-                // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
-                // already run, and we want to update the container then too. In the other cases,
-                // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
-                // will already be false.
-                performUpdates()
-            }
+        (context as? ReactContext)?.runOnUiQueueThread {
+            // We schedule the update here because LayoutAnimations of `react-native-reanimated`
+            // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
+            // already run, and we want to update the container then too. In the other cases,
+            // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
+            // will already be false.
+            performUpdates()
         }
     }
 


### PR DESCRIPTION
## Description

PR adding scheduled update of container in case of triggering changes in the number of `Screen` components inside the `ScreenContainer`, which can be commited after the `UIBlock` of `ScreensShadowNode` has run. Needed in `LayoutAnimations` and should be tested with proper PR from their side.

## Checklist

- [x] Ensured that CI passes
