### PR TITLE
feat: make android header insets switchable

### DIFF
--- a/TestsExample/src/Test1157.tsx
+++ b/TestsExample/src/Test1157.tsx
@@ -9,7 +9,7 @@ function First({
   navigation: NativeStackNavigationProp<ParamListBase>;
 }) {
   return (
-    <View style={{flex: 1, backgroundColor: 'red'}}>
+    <View style={{flex: 1, backgroundColor: 'green'}}>
       <Button
         title="Tap me for second screen"
         onPress={() => navigation.navigate('Second')}
@@ -44,9 +44,10 @@ export default function App() {
       <Stack.Navigator screenOptions={{stackPresentation: 'modal'}}>
         <Stack.Screen name="First" component={First} 
           options={{headerShown: true,
-            // headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -15}}/>,
-            headerLeft: () => <ButtonWithBiggerChild />,
-            headerRight: () => <TouchableOpacity onPress={() => console.log("there")} style={{width: 30, height: 30, backgroundColor: 'red', marginRight: -15}}/>,
+            resetHeaderInsets: true,
+            headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -0}}/>,
+            // headerLeft: () => <ButtonWithBiggerChild />,
+            headerRight: () => <TouchableOpacity onPress={() => console.log("there")} style={{width: 30, height: 30, backgroundColor: 'red', marginRight: -0}}/>,
             }}
         />
         <Stack.Screen

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -38,6 +38,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private var mIsTranslucent = false
     private var mTintColor = 0
     private var mIsAttachedToWindow = false
+    private var mResetHeaderInsets = false
     private val mDefaultStartInset: Int
     private val mDefaultStartInsetWithNavigation: Int
     private val mBackClickListener = OnClickListener {
@@ -171,7 +172,8 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         // title. If title isn't set we clear that value few lines below to give more space to custom
         // center-mounted views.
         toolbar.contentInsetStartWithNavigation = mDefaultStartInsetWithNavigation
-        toolbar.setContentInsetsRelative(mDefaultStartInset, mDefaultStartInset)
+        val contentInsets = if (mResetHeaderInsets) 0 else mDefaultStartInset
+        toolbar.setContentInsetsRelative(contentInsets, contentInsets)
 
         // hide back button
         actionBar.setDisplayHomeAsUpEnabled(
@@ -367,6 +369,10 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
     fun setDirection(direction: String?) {
         mDirection = direction
+    }
+
+    fun setResetHeaderInsets(resetHeaderInsets: Boolean) {
+        mResetHeaderInsets = resetHeaderInsets
     }
 
     private class DebugMenuToolbar(context: Context) : Toolbar(context) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -130,7 +130,7 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
     }
 
     @ReactProp(name = "resetHeaderInsets")
-    fun setDirection(config: ScreenStackHeaderConfig, resetHeaderInsets: Boolean) {
+    fun setResetHeaderInsets(config: ScreenStackHeaderConfig, resetHeaderInsets: Boolean) {
         config.setResetHeaderInsets(resetHeaderInsets)
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -129,6 +129,11 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
         config.setDirection(direction)
     }
 
+    @ReactProp(name = "resetHeaderInsets")
+    fun setDirection(config: ScreenStackHeaderConfig, resetHeaderInsets: Boolean) {
+        config.setResetHeaderInsets(resetHeaderInsets)
+    }
+
     companion object {
         const val REACT_CLASS = "RNSScreenStackHeaderConfig"
     }

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -205,6 +205,11 @@ The following values are currently supported:
 
 Defaults to `pop`.
 
+#### `resetHeaderInsets` (Android only)
+
+Boolean that resets the insets of header subviews on Android in order to be able to place responsive content there.
+Defaults to `false`.
+
 #### `stackAnimation`
 
 How the given screen should appear/disappear when pushed or popped at the top of the stack. Possible values:

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -349,6 +349,11 @@ Customize the weight of the font to be used for the large title.
 
 Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
 
+### `resetHeaderInsets` (Android only)
+
+Boolean that resets the insets of header subviews on Android in order to be able to place responsive content there.
+Defaults to `false`.
+
 ### `title`
 
 String representing screen title that will get rendered in the middle section of the header. On iOS the title is centered on the header while on Android it is aligned to the left and placed next to back button (if one is present).

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -198,6 +198,11 @@ The following values are currently supported:
 
 Defaults to `pop`.
 
+#### `resetHeaderInsets` (Android only)
+
+Boolean that resets the insets of header subviews on Android in order to be able to place responsive content there.
+Defaults to `false`.
+
 #### `stackAnimation`
 
 How the given screen should appear/disappear when pushed or popped at the top of the stack. Possible values:

--- a/src/createNativeStackNavigator.tsx
+++ b/src/createNativeStackNavigator.tsx
@@ -200,6 +200,7 @@ function renderHeaderConfig(
     hideShadow,
     largeTitle,
     largeTitleHideShadow,
+    resetHeaderInsets,
     title,
     translucent,
   } = options;
@@ -232,6 +233,7 @@ function renderHeaderConfig(
     largeTitleFontSize: headerLargeTitleStyle?.fontSize,
     largeTitleFontWeight: headerLargeTitleStyle?.fontWeight,
     largeTitleHideShadow: largeTitleHideShadow || headerLargeTitleHideShadow,
+    resetHeaderInsets,
     title,
     titleColor: headerTitleStyle?.color || headerTintColor,
     titleFontFamily: headerTitleStyle?.fontFamily,

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -259,6 +259,11 @@ export type NativeStackNavigationOptions = {
    */
   replaceAnimation?: ScreenProps['replaceAnimation'];
   /**
+   * Boolean that resets the insets of header subviews on Android in order to be able to place responsive content there.
+   * @platform android
+   */
+  resetHeaderInsets?: boolean;
+  /**
    * In which orientation should the screen appear.
    * The following values are currently supported:
    * - "default" - resolves to "all" without "portrait_down" on iOS. On Android, this lets the system decide the best orientation.

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -41,6 +41,7 @@ export default function HeaderConfig({
   headerTitleStyle = {},
   headerTopInsetEnabled = true,
   headerTranslucent,
+  resetHeaderInsets,
   route,
   searchBar,
   title,
@@ -81,6 +82,7 @@ export default function HeaderConfig({
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       largeTitleFontWeight={headerLargeTitleStyle.fontWeight}
       largeTitleHideShadow={headerLargeTitleHideShadow}
+      resetHeaderInsets={resetHeaderInsets}
       title={
         headerTitle !== undefined
           ? headerTitle

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -332,6 +332,11 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
    */
   largeTitleHideShadow?: boolean;
   /**
+   * Boolean that resets the insets of header subviews on Android in order to be able to place responsive content there.
+   * @platform android
+   */
+  resetHeaderInsets?: boolean;
+  /**
    * String that can be displayed in the header as a fallback for `headerTitle`.
    */
   title?: string;


### PR DESCRIPTION
## Description

PR adding prop for disabling header insets on Android, which make the header subviews not responsive. They are present by default to mimic the behavior of iOS having insets around the header corners.

## Screenshots / GIFs

With prop set:
![image](https://user-images.githubusercontent.com/32481228/136361882-58666e83-a5e5-4187-a308-c1ac80682a0c.png)
Without prop set (default):
![image](https://user-images.githubusercontent.com/32481228/136361981-9dc60053-4016-4ce5-a374-470f0b46c08c.png)


## Test code and steps to reproduce

`Test1157.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
- [ ] Ensured that CI passes
