### PR TITLE
fix: remove LifecycleHelper from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "windows/",
     "RNScreens.podspec",
     "README.md",
-    "!**/__tests__"
+    "!**/__tests__",
+    "!android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.kt"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

`LifecycleHelper.kt` is a file that isn't used anywhere in the code and serves only as an example. Its presence in the npm package probably caused #1173.

Fixes #1173

## Changes

- Excluded `LifecycleHelper.kt` from files sent to npm

## Test code and steps to reproduce

Run `npm pack` and see that with this change `LifecycleHelper.kt` is not present in the package.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
