### PR TITLE
docs: add kotlin guide to change version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ protected void onCreate(Bundle savedInstanceState) {
 
 For people that must handle cases like this, there is [a more detailed discussion of the difficulties in a series of related comments](https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704633).
 
+<details>
+<summary>Need to use a custom Kotlin version?</summary>
+<br>
+Since `v3.6.0` `react-native-screens` has been rewritten with Kotlin. Kotlin version used in this library defaults to `1.4.10`.
+
+If you need to use a different Kotlin version set `kotlinVersion` ext propery in `android/build.gradle` and the library will use this version accordingly:
+
+```
+buildscript {
+    ext {
+        ...
+        kotlinVersion = "1.4.10"
+    }
+}
+
+```
+`react-native-screens' requires Kotlin v1.3.50 or higher.
+</details>
+
 ### Windows
 
 Installation on Windows should be completely handled with auto-linking when using React Native Windows 0.63+. For earlier versions, you must [manually link](https://microsoft.github.io/react-native-windows/docs/native-modules-using) the native module.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ For people that must handle cases like this, there is [a more detailed discussio
 <details>
 <summary>Need to use a custom Kotlin version?</summary>
 <br>
+
 Since `v3.6.0` `react-native-screens` has been rewritten with Kotlin. Kotlin version used in this library defaults to `1.4.10`.
 
-If you need to use a different Kotlin version set `kotlinVersion` ext propery in `android/build.gradle` and the library will use this version accordingly:
+If you need to use a different Kotlin version, set `kotlinVersion` ext property in your project's `android/build.gradle` and the library will use this version accordingly:
 
 ```
 buildscript {
@@ -52,7 +53,7 @@ buildscript {
 }
 ```
 
-`react-native-screens` requires Kotlin v1.3.50 or higher.
+**Disclaimer**: `react-native-screens` requires Kotlin `1.3.50` or higher.
 </details>
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ buildscript {
         kotlinVersion = "1.4.10"
     }
 }
-
 ```
+
 `react-native-screens' requires Kotlin v1.3.50 or higher.
 </details>
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ buildscript {
 }
 ```
 
-`react-native-screens' requires Kotlin v1.3.50 or higher.
+`react-native-screens` requires Kotlin v1.3.50 or higher.
 </details>
 
 ### Windows


### PR DESCRIPTION
## Description

This PR adds information on how to override the Kotlin version used by screens and the minimum Kotlin required version.

This change becomes relevant since version 3.9.0
