### PR TITLE
fix: overlay in fullscreen modal

### DIFF
--- a/TestsExample/src/Test1096.tsx
+++ b/TestsExample/src/Test1096.tsx
@@ -22,6 +22,10 @@ function Home({
         title="Go to RNScreens modal"
         onPress={() => navigation.navigate('Modal')}
       />
+      <Button
+        title="Go to RNScreens fullScreenModal"
+        onPress={() => navigation.navigate('FullScreenModal')}
+      />
       <Modal
         animationType="slide"
         visible={isShowModal}
@@ -65,6 +69,11 @@ export default function App() {
           name="Modal"
           component={ModalScreen}
           options={{ stackPresentation: 'modal' }}
+        />
+        <NativeStack.Screen
+          name="FullScreenModal"
+          component={ModalScreen}
+          options={{ stackPresentation: 'fullScreenModal' }}
         />
       </NativeStack.Navigator>
     </NavigationContainer>

--- a/ios/RNSFullWindowOverlay.m
+++ b/ios/RNSFullWindowOverlay.m
@@ -63,31 +63,17 @@
   [window addSubview:_container];
 }
 
-- (void)hide
-{
-  if (!_container) {
-    return;
-  }
-
-  [_container removeFromSuperview];
-}
-
 - (void)didMoveToWindow
 {
-  if (self.window == nil) {
-    [self hide];
-    [_touchHandler detachFromView:_container];
-  } else {
-    if (_touchHandler == nil) {
-      _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
-    }
+  if (self.window != nil && _touchHandler == nil) {
+    _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
     [_touchHandler attachToView:_container];
   }
 }
 
 - (void)invalidate
 {
-  [self hide];
+  [_container removeFromSuperview];
   _container = nil;
 }
 


### PR DESCRIPTION
## Description

When the `fullScreenModal` is presented, the `FullWindowOverlay` is removed from native view hierarchy since the view receives `didMoveToWindow` with `nil` value. This behavior can be removed, but then the only way to remove it will be to invalidate it, which means removing the component on the react side. Such change would result e.g. in view not disappearing when moving between screens of navigators since these screens are not removed from the React view hierarchy.

## Test code and steps to reproduce

`Test1096.tsx` in `TestsExample` app.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
