### PR TITLE
fix: fix iOS e2e test

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -351,7 +351,7 @@ PODS:
     - React-Core
   - RNReanimated (1.13.2):
     - React-Core
-  - RNScreens (3.7.0):
+  - RNScreens (3.8.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (8.0.0):
@@ -571,7 +571,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
-  RNScreens: 2a71d74b4e530f051f5684c8111d7591176722cf
+  RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   RNVectorIcons: f67a1abce2ec73e62fe4606e8110e95a832bc859
   Yoga: c11abbf5809216c91fcd62f5571078b83d9b6720
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/Example/package.json
+++ b/Example/package.json
@@ -46,7 +46,7 @@
     "babel-jest": "^26.6.3",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-preset-expo": "^8.3.0",
-    "detox": "^18.20.2",
+    "detox": "^18.23.1",
     "eslint": "^7.20.0",
     "glob-to-regexp": "^0.4.1",
     "jest": "^27.1.0",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -3331,10 +3331,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@^18.20.2:
-  version "18.20.2"
-  resolved "https://registry.npmjs.org/detox/-/detox-18.20.2.tgz#5c1d36131c93f5b5cd7d015c3b9e1b81fc1ae5ad"
-  integrity sha512-b1j42sTnrXQsuFZbmLntmiLvcr8W6L2Spr23ryX8fFAHETA2nU0qfY4zh0A95/A0qOCeqVH3960GNk93Y6Yafg==
+detox@^18.23.1:
+  version "18.23.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-18.23.1.tgz#f09f5e50291cdab3d62dc40ff2e8bb5cfb3cb776"
+  integrity sha512-MnOXfTcBBcXTrlLk3EeHq1nEfob79nChZbfOtlEummyec/X+PQzEvmKk2cvsUzu1f7GiNbCiBKN66w47Z7b/CQ==
   dependencies:
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"


### PR DESCRIPTION
## Description

The currently used detox version in react-native-screens doesn't support iOS 15 - https://github.com/wix/Detox/issues/2895

Bumping `detox` to the newest version fixes failing CI.

## Changes

- Bumped `detox` to v18.23.1

## Test code and steps to reproduce

```bash
brew tap wix/brew && brew install applesimutils

cd Example/
yarn
cd ios && pod install && cd ..
yarn build-e2e-ios
yarn test-e2e-ios
```

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
