### PR TITLE
docs: update required react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Screens are already integrated with the React Native's most popular navigation l
 
 | version | react-native version |
 | ------- | -------------------- |
+| 3.9.0+  | 0.64.0+              |
 | 3.0.0+  | 0.62.0+              |
 | 2.0.0+  | 0.60.0+              |
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ You are all set 🎉 – when screens are enabled in your application code react
 
 ### Experimental support for `react-freeze`
 
-> You have to use React Native 0.64 or higher, react-navigation 5.x or 6.x and react-native-screens 3.9.0 or higher
+> You have to use React Native 0.64 or higher, react-navigation 5.x or 6.x and react-native-screens >= v3.9.0
 
-Since `v3.9.0` `react-native-screens` comes with experimental support for `react-freeze`. It uses the React Suspense mechanism to prevent parts of the react component tree from rendering while keeping its state untouched.
+Since `v3.9.0`, `react-native-screens` comes with experimental support for [`react-freeze`](https://github.com/software-mansion-labs/react-freeze). It uses the React `Suspense` mechanism to prevent parts of the React component tree from rendering, while keeping its state untouched.
 
-To benefit from this feature enable it in your entry file (e.g. `App.js`) with this snippet:
+To benefit from this feature, enable it in your entry file (e.g. `App.js`) with this snippet:
 
 ```js
 import { enableFreeze } from 'react-native-screens';

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Screens are already integrated with the React Native's most popular navigation l
 
 | version | react-native version |
 | ------- | -------------------- |
-| 3.9.0+  | 0.64.0+              |
 | 3.0.0+  | 0.62.0+              |
 | 2.0.0+  | 0.60.0+              |
 
@@ -68,6 +67,24 @@ expo install react-native-screens
 Just make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher.
 
 You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
+
+### Experimental support for `react-freeze`
+
+> You have to use React Native 0.64 or higher, react-navigation 5.x or 6.x and react-native-screens 3.9.0 or higher
+
+Since `v3.9.0` `react-native-screens` comes with experimental support for `react-freeze`. It uses the React Suspense mechanism to prevent parts of the react component tree from rendering while keeping its state untouched.
+
+To benefit from this feature enable it in your entry file (e.g. `App.js`) with this snippet:
+
+```js
+import { enableFreeze } from 'react-native-screens';
+
+enableFreeze(true);
+```
+
+Want to know more? Check out [react-freeze README](https://github.com/software-mansion-labs/react-freeze#readme)
+
+Found a bug? File an issue [here](https://github.com/software-mansion/react-native-screens/issues) or directly in [react-freeze repository](https://github.com/software-mansion-labs/react-freeze/issues).
 
 ### Disabling `react-native-screens`
 

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -49,17 +49,13 @@ function enableScreens(shouldEnableScreens = true): void {
   }
 }
 
-// react-freeze requires react-native 0.64 or higher
-const minReactFreezeReactNativeVersion = 64;
 let ENABLE_FREEZE = false;
 
 function enableFreeze(shouldEnableReactFreeze = true): void {
-  const currentReactNativeVersion = parseInt(version.split('.')[1]); // eg. takes 66 from '0.66.0'
+  const minor = parseInt(version.split('.')[1]); // eg. takes 66 from '0.66.0'
 
-  if (
-    currentReactNativeVersion < minReactFreezeReactNativeVersion &&
-    shouldEnableReactFreeze
-  ) {
+  // react-freeze requires react-native >=0.64, react-native from main is 0.0.0
+  if (!(minor === 0 || minor >= 64) && shouldEnableReactFreeze) {
     console.warn(
       'react-freeze library requires at least react-native 0.64. Please upgrade your react-native version in order to use this feature.'
     );

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -14,6 +14,7 @@ import { Freeze } from 'react-freeze';
 // @ts-ignore Getting private component
 // eslint-disable-next-line import/default
 import processColor from 'react-native/Libraries/StyleSheet/processColor';
+import { version } from 'react-native/package.json';
 
 import TransitionProgressContext from './TransitionProgressContext';
 import useTransitionProgress from './useTransitionProgress';
@@ -48,9 +49,22 @@ function enableScreens(shouldEnableScreens = true): void {
   }
 }
 
+// react-freeze requires react-native 0.64 or higher
+const minReactFreezeReactNativeVersion = 64;
 let ENABLE_FREEZE = false;
 
 function enableFreeze(shouldEnableReactFreeze = true): void {
+  const currentReactNativeVersion = parseInt(version.split('.')[1]); // eg. takes 66 from '0.66.0'
+
+  if (
+    currentReactNativeVersion < minReactFreezeReactNativeVersion &&
+    shouldEnableReactFreeze
+  ) {
+    console.warn(
+      'react-freeze library requires at least react-native 0.64. Please upgrade your react-native version in order to use this feature.'
+    );
+  }
+
   ENABLE_FREEZE = shouldEnableReactFreeze;
 }
 


### PR DESCRIPTION
## Description

Since v3.9.0 `react-native-screens` use `react-freeze` library which requires at least react-native `v0.64`