### PR TITLE
fix: turn off accessibility for screen and header beneath transparent modal on Android

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -64,11 +64,12 @@ import Test1157 from './src/Test1157';
 import Test1162 from './src/Test1162';
 import Test1188 from './src/Test1188';
 import TestFreeze from './src/TestFreeze';
+import Test1204 from './src/Test1204';
 
 export default function App() {
   return (
     <ReanimatedScreenProvider>
-      <Test42 />
+      <Test1204 />
     </ReanimatedScreenProvider>
   );
 }

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -69,7 +69,7 @@ import Test1204 from './src/Test1204';
 export default function App() {
   return (
     <ReanimatedScreenProvider>
-      <Test1204 />
+      <Test42 />
     </ReanimatedScreenProvider>
   );
 }

--- a/TestsExample/src/Test1204.tsx
+++ b/TestsExample/src/Test1204.tsx
@@ -41,6 +41,7 @@ function Main({
 }) {
   return (
     <View style={{flex: 1, justifyContent: 'center'}}>
+      <Text>Example text that could be read out by TalkBack</Text>
       <Button
         title="Open transparent modal"
         onPress={() => navigation.navigate('TransparentModal')}
@@ -63,6 +64,7 @@ function Details({
       style={{
         flex: 1,
         justifyContent: 'center',
+        backgroundColor: '#0005',
       }}>
       <View
         style={{

--- a/TestsExample/src/Test1204.tsx
+++ b/TestsExample/src/Test1204.tsx
@@ -13,6 +13,7 @@ export default function App() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Main" component={Main} />
+        <Stack.Screen name="Second" component={NoA11yOnAndroid} />
         <Stack.Screen
           name="TransparentModal"
           component={Details}
@@ -79,6 +80,29 @@ function Details({
           Buttons beneath the modal shouldn&apos;t be picked up by Android
           TalkBack
         </Text>
+        <Button
+          title="Go to second"
+          onPress={() => navigation.navigate('Second')}
+        />
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+}
+
+function NoA11yOnAndroid({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+      }}>
+      <View importantForAccessibility="no-hide-descendants">
+        <Text>This text shouldn&apos;t be accessible</Text>
         <Button title="Go back" onPress={() => navigation.goBack()} />
       </View>
     </View>

--- a/TestsExample/src/Test1204.tsx
+++ b/TestsExample/src/Test1204.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import {Button, Text, View} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Main" component={Main} />
+        <Stack.Screen
+          name="TransparentModal"
+          component={Details}
+          options={{
+            stackPresentation: 'transparentModal',
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="ContainedTransparentModal"
+          component={Details}
+          options={{
+            stackPresentation: 'containedTransparentModal',
+            headerShown: false,
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function Main({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View style={{flex: 1, justifyContent: 'center'}}>
+      <Button
+        title="Open transparent modal"
+        onPress={() => navigation.navigate('TransparentModal')}
+      />
+      <Button
+        title="Open contained transparent modal"
+        onPress={() => navigation.navigate('ContainedTransparentModal')}
+      />
+    </View>
+  );
+}
+
+function Details({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+      }}>
+      <View
+        style={{
+          padding: 20,
+          margin: 20,
+          borderWidth: 1,
+          borderColor: 'grey',
+          justifyContent: 'space-around',
+          backgroundColor: 'white',
+        }}>
+        <Text style={{padding: 15}}>
+          Buttons beneath the modal shouldn&apos;t be picked up by Android
+          TalkBack
+        </Text>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -183,6 +183,13 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
         fragment?.let { ScreenWindowTraits.setOrientation(this, it.tryGetActivity()) }
     }
 
+    // Accepts one of 4 accessibility flags
+    // developer.android.com/reference/android/view/View#attr_android:importantForAccessibility
+    fun changeAccessibilityMode(mode: Int) {
+        this.importantForAccessibility = mode
+        this.headerConfig?.toolbar?.importantForAccessibility = mode
+    }
+
     var statusBarStyle: String?
         get() = mStatusBarStyle
         set(statusBarStyle) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -237,19 +237,26 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
             mStack.clear()
             mStack.addAll(mScreenFragments)
 
-            turnOffA11yUnderTransparentScreen()
+            turnOffA11yUnderTransparentScreen(visibleBottom)
 
             it.commitNowAllowingStateLoss()
         }
     }
 
-    private fun turnOffA11yUnderTransparentScreen() {
-        if (mScreenFragments.size > 1) {
+    // only top visible screen should be accessible
+    private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenStackFragment?) {
+        if (mScreenFragments.size > 1 && visibleBottom != null) {
             mTopScreen?.let {
                 if (isTransparent(it)) {
                     val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1)
-                    for (screenFragment in screenFragmentsBeneathTop) {
-                        screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                    // go from the top of the stack excluding the top screen
+                    for (i in screenFragmentsBeneathTop.indices.reversed()) {
+                        mScreenFragments[i].screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+
+                        // don't change a11y below non-transparent screens
+                        if (mScreenFragments[i] == visibleBottom) {
+                            break
+                        }
                     }
                 }
             }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -237,22 +237,25 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
             mStack.clear()
             mStack.addAll(mScreenFragments)
 
-            // turn of a11y for every screen beneath transparent one
-            if (mScreenFragments.size > 1) {
-                for (i in mScreenFragments.indices.reversed()) {
-                    val screen = mScreenFragments[i]
-                    val beneath = mScreenFragments[i - 1]
-
-                    if (isTransparent(screen)) {
-                        beneath.screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-                        break
-                    }
-                }
-            } else {
-                mScreenFragments[0].screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
-            }
+            turnOffA11yUnderTransparentScreen()
 
             it.commitNowAllowingStateLoss()
+        }
+    }
+
+    private fun turnOffA11yUnderTransparentScreen() {
+        if (mScreenFragments.size > 1) {
+            for (i in mScreenFragments.indices.reversed()) {
+                val screen = mScreenFragments[i]
+                val screenBeneath = mScreenFragments[i - 1]
+
+                if (isTransparent(screen)) {
+                    screenBeneath.screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    break
+                }
+            }
+        } else {
+            topScreen?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -245,10 +245,9 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
 
     private fun turnOffA11yUnderTransparentScreen() {
         if (mScreenFragments.size > 1) {
-            val belowTop = mScreenFragments[mScreenFragments.lastIndex - 1].screen
-
             mTopScreen?.let {
                 if (isTransparent(it)) {
+                    val belowTop = mScreenFragments[mScreenFragments.lastIndex - 1].screen
                     belowTop.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
                 }
             }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -248,13 +248,13 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
         if (mScreenFragments.size > 1 && visibleBottom != null) {
             mTopScreen?.let {
                 if (isTransparent(it)) {
-                    val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1)
+                    val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1).asReversed()
                     // go from the top of the stack excluding the top screen
-                    for (i in screenFragmentsBeneathTop.indices.reversed()) {
-                        mScreenFragments[i].screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                    for (screenFragment in screenFragmentsBeneathTop) {
+                        screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
 
                         // don't change a11y below non-transparent screens
-                        if (mScreenFragments[i] == visibleBottom) {
+                        if (screenFragment == visibleBottom) {
                             break
                         }
                     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -247,8 +247,10 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
         if (mScreenFragments.size > 1) {
             mTopScreen?.let {
                 if (isTransparent(it)) {
-                    val belowTop = mScreenFragments[mScreenFragments.lastIndex - 1].screen
-                    belowTop.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                    val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1)
+                    for (screenFragment in screenFragmentsBeneathTop) {
+                        screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                    }
                 }
             }
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -249,14 +249,12 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
 
             mTopScreen?.let {
                 if (isTransparent(it)) {
-                    belowTop.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-                    belowTop.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    belowTop.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
                 }
             }
-        } else {
-            topScreen?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
-            topScreen?.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
         }
+
+        topScreen?.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_AUTO)
     }
 
     override fun notifyContainerUpdate() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -245,14 +245,12 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
 
     private fun turnOffA11yUnderTransparentScreen() {
         if (mScreenFragments.size > 1) {
-            for (i in mScreenFragments.indices.reversed()) {
-                val screen = mScreenFragments[i]
-                val screenBeneath = mScreenFragments[i - 1]
+            val belowTop = mScreenFragments[mScreenFragments.lastIndex - 1].screen
 
-                if (isTransparent(screen)) {
-                    screenBeneath.screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-                    screenBeneath.screen.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-                    break
+            mTopScreen?.let {
+                if (isTransparent(it)) {
+                    belowTop.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    belowTop.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
                 }
             }
         } else {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -236,6 +236,22 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
             mTopScreen = newTop
             mStack.clear()
             mStack.addAll(mScreenFragments)
+
+            // turn of a11y for every screen beneath transparent one
+            if (mScreenFragments.size > 1) {
+                for (i in mScreenFragments.indices.reversed()) {
+                    val screen = mScreenFragments[i]
+                    val beneath = mScreenFragments[i - 1]
+
+                    if (isTransparent(screen)) {
+                        beneath.screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                        break
+                    }
+                }
+            } else {
+                mScreenFragments[0].screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+            }
+
             it.commitNowAllowingStateLoss()
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -251,11 +251,13 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
 
                 if (isTransparent(screen)) {
                     screenBeneath.screen.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    screenBeneath.screen.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
                     break
                 }
             }
         } else {
             topScreen?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+            topScreen?.headerConfig?.toolbar?.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
         }
     }
 


### PR DESCRIPTION
## Description

This PR turns off accessibility for screen and header beneath transparent modal on Android.

Fixes #1204

## Changes

Added a `turnOffA11yUnderTransparentScreen` method invoked in ScreenStack's `onUpdate` method. It iterates through the stack to search for the first transparent screen from the top and turns off a11y for the screen and header beneath.

## Screenshots / GIFs

### Before

https://user-images.githubusercontent.com/39658211/140723838-90dec12d-5d3b-4235-80d5-b456a28d7551.mp4

### After

https://user-images.githubusercontent.com/39658211/140723856-53a1057e-77cf-43b5-ac7c-4b34632df53c.mp4


## Test code and steps to reproduce

`Test1204.tsx` in `TestsExample/` project

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
