### PR TITLE
feat: don't set display: 'none' on frozen screens

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 
+import {enableFreeze} from 'react-native-screens';
 import {ReanimatedScreenProvider} from 'react-native-screens/reanimated';
 
 import Test42 from './src/Test42';
@@ -64,6 +65,8 @@ import Test1157 from './src/Test1157';
 import Test1162 from './src/Test1162';
 import Test1188 from './src/Test1188';
 import TestFreeze from './src/TestFreeze';
+
+enableFreeze(true);
 
 export default function App() {
   return (

--- a/TestsExample/src/TestFreeze.tsx
+++ b/TestsExample/src/TestFreeze.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useEffect} from 'react';
 import {View, Text, Button, ScrollView} from 'react-native';
-import {enableFreeze} from 'react-native-screens';
 import {NavigationContainer, ParamListBase} from '@react-navigation/native';
 // import {createStackNavigator} from '@react-navigation/stack';
 // import {createNativeStackNavigator} from '@react-navigation/native-stack';
@@ -8,8 +7,6 @@ import {
   createNativeStackNavigator,
   NativeStackNavigationProp,
 } from 'react-native-screens/native-stack';
-
-enableFreeze(true);
 
 const store = new Set<Dispatch>();
 
@@ -52,7 +49,7 @@ function DetailsScreen({
   navigation: NativeStackNavigationProp<ParamListBase>;
 }) {
   const value = useValue();
-  // should only 2 renders appear at the time
+  // only 1 'render' should appear at the time
   console.log('render', value);
   return (
     <ScrollView>


### PR DESCRIPTION
## Description

The `Suspense` mechanism in `react-freeze` sets `display: none` on a frozen screen. This sometimes results in an 'empty' screen when quickly navigating between screens (e.g. by using iOS back button menu).

This PR prevents showing frozen screen by making the `display` property on `viewConfig.validAttributes.style` not valid. 

A detailed explanation can be found [here](https://github.com/software-mansion/react-native-screens/issues/1207#issue-1048499771)

Thank you @grahammendick for this brilliant idea! 🙌 

Fixes #1207

## Test code and steps to reproduce

`Test658`, `Test791`, `TestFreeze` in `TestsExample/` project

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
