### PR TITLE
Main thread check for traversing scroll view. Fixes #1044

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -683,14 +683,12 @@
   _isSwiping = NO;
   _shouldNotify = YES;
 
-  if ([NSThread isMainThread]) {
-    [self traverseForScrollView:self.view];
-  }
+  [self traverseForScrollView:self.view];
 }
 
 - (void)traverseForScrollView:(UIView *)view
 {
-  if ([view isKindOfClass:[UIScrollView class]] &&
+  if ([NSThread isMainThread] && [view isKindOfClass:[UIScrollView class]] &&
       ([[(UIScrollView *)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)])) {
     [[(UIScrollView *)view delegate] scrollViewDidEndDecelerating:(id)view];
   }

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -683,7 +683,9 @@
   _isSwiping = NO;
   _shouldNotify = YES;
 
-  [self traverseForScrollView:self.view];
+  if ([NSThread isMainThread]) {
+    [self traverseForScrollView:self.view];
+  }
 }
 
 - (void)traverseForScrollView:(UIView *)view


### PR DESCRIPTION
## Description

Fixes #1044: The app crashes when DevSettings.reload() is called

Root cause is that adjustments to the UI layer on iOS 14+ will throw NSInternalInconsistencyException. iOS 14 became extremely strict with this issue.

## Changes

Add a simple main thread guard

## Test code and steps to reproduce

Reproduction available in #1044 

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
