### PR TITLE
fix: check if jsThread is not null

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -688,6 +688,10 @@
 
 - (void)traverseForScrollView:(UIView *)view
 {
+  if (![[self.view valueForKey:@"_bridge"] valueForKey:@"_jsThread"]) {
+    // we don't want to send `scrollViewDidEndDecelerating` event to JS before the JS thread is ready
+    return;
+  }
   if ([view isKindOfClass:[UIScrollView class]] &&
       ([[(UIScrollView *)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)])) {
     [[(UIScrollView *)view delegate] scrollViewDidEndDecelerating:(id)view];


### PR DESCRIPTION
## Description

Added a check for private `_jsThread` field in `_bridge` in order not to try and send events to JS before the thread is ready. Should resolve #1211. Should close #1212. Suggested by @piaskowyk 

## Test code and steps to reproduce

To be provided.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
