### PR TITLE
fix: check if topScreen is RNSScreenView

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -572,7 +572,8 @@
 {
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
 
-  if (!topScreen.gestureEnabled || _controller.viewControllers.count < 2) {
+  if (![topScreen isKindOfClass:[RNSScreenView class]] || !topScreen.gestureEnabled ||
+      _controller.viewControllers.count < 2) {
     return NO;
   }
 


### PR DESCRIPTION
## Description

Added a check for if `topScreen` in `gestureRecognizerShouldBegin` method is `RNSScreenView`, since it is not in some cases. Reproduction of such behavior would be much needed. Should fix #1194.

## Test code and steps to reproduce

Not yet available

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
