### PR TITLE
chore: update search bar playground in Example app

### DIFF
--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -89,7 +89,7 @@ const SCREENS: Record<
     type: 'playground',
   },
   SearchBar: {
-    title: 'Search bar (iOS)',
+    title: 'Search bar',
     component: SearchBar,
     type: 'playground',
   },

--- a/Example/e2e/firstTest.e2e.ts
+++ b/Example/e2e/firstTest.e2e.ts
@@ -44,7 +44,7 @@ const SCREENS: Record<
     type: 'playground',
   },
   SearchBar: {
-    title: 'Search bar (iOS)',
+    title: 'Search bar',
     type: 'playground',
   },
 };

--- a/Example/package.json
+++ b/Example/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/drawer": "^5.12.3",
     "@react-navigation/native": "^5.9.2",
     "@react-navigation/stack": "^5.14.2",
+    "nanoid": "^3.1.30",
     "react": "17.0.2",
     "react-native": "^0.66.0",
     "react-native-appearance": "^0.3.4",

--- a/Example/src/shared/Toast.tsx
+++ b/Example/src/shared/Toast.tsx
@@ -1,0 +1,125 @@
+import React, { createContext, useState, useContext, useEffect } from 'react';
+import {
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Dimensions,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { nanoid } from 'nanoid/non-secure';
+
+interface ToastProps {
+  index: number;
+  id: string;
+  backgroundColor: string;
+  message: string;
+  style?: ViewStyle;
+  remove: (_: string) => void;
+}
+
+const DISAPPEAR_AFTER = 10 * 1000; // 10 x 1000 ms -> 10 s
+
+const Toast = ({
+  index,
+  id,
+  backgroundColor,
+  message,
+  style = {},
+  remove,
+}: ToastProps): JSX.Element => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      remove(id);
+    }, DISAPPEAR_AFTER);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <TouchableOpacity
+      style={{ ...styles.container, ...style }}
+      onPress={() => remove(id)}>
+      <View style={{ ...styles.alert, backgroundColor }}>
+        <Text style={styles.text}>
+          {`${index + 1}. `}
+          {message}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+interface IToast {
+  id: string;
+  backgroundColor: string;
+  message: string;
+}
+
+const initialState: IToast[] = [];
+
+const ToastContext = createContext({
+  push: (_: Omit<IToast, 'id'>) => {
+    // noop
+  },
+});
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toasts, setToasts] = useState(initialState);
+
+  const remove = (id: string) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  };
+
+  const push = ({ backgroundColor, message }: Omit<IToast, 'id'>): void => {
+    const id = nanoid();
+    setToasts((prevToasts) => [
+      ...prevToasts,
+      { id, backgroundColor, message },
+    ]);
+  };
+
+  return (
+    <ToastContext.Provider value={{ push }}>
+      <>
+        {children}
+        {toasts.map((toast, i) => (
+          <Toast
+            index={i}
+            key={toast.id}
+            style={{ marginBottom: i * 45 }}
+            {...toast}
+            remove={remove}
+          />
+        ))}
+      </>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: 'absolute',
+    alignSelf: 'center',
+    bottom: 20,
+  },
+  alert: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 40,
+    position: 'relative',
+    width: Dimensions.get('screen').width - 40,
+    borderRadius: 10,
+  },
+  text: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    color: 'white',
+  },
+});

--- a/Example/src/shared/index.ts
+++ b/Example/src/shared/index.ts
@@ -10,3 +10,4 @@ export * from './Form';
 export * from './Choose';
 export * from './Dialog';
 export * from './Snack';
+export * from './Toast';

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -6035,6 +6035,11 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
+nanoid@^3.1.30:
+  version "3.1.30"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
+  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz"

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -360,9 +360,11 @@ Defaults to `auto`.
 
 Sets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.
 
-### Search bar
+### Search bar (iOS only)
 
 The search bar is just a `searchBar` property that can be specified in the navigator's `defaultNavigationOptions` prop or an individual screen's `navigationOptions`. Search bars are rarely static so normally it is controlled by passing an object to `searchBar` navigation option in the component's body.
+
+Search bar is only supported on iOS.
 
 Example: 
 
@@ -388,11 +390,7 @@ Possible values:
 - `sentences`
 - `characters`
 
-Defaults to `sentences` on iOS and `'none'` on Android.
-
-#### `autoFocus` (Android only)
-
-When set to `true` focuses search bar automatically when screen is appearing. Default value is `false`.
+Defaults to `sentences`.
 
 #### `barTintColor`
 
@@ -400,37 +398,23 @@ The search field background color.
 
 By default bar tint color is translucent.
 
-#### `cancelButtonText` (iOS only)
+#### `cancelButtonText`
 
 The text to be used instead of default `Cancel` button text.
 
-#### `disableBackButtonOverride` (Android only)
-
-Default behavior is to prevent screen from going back when search bar is open (`disableBackButtonOverride: false`). If you don't want this to happen set `disableBackButtonOverride` to `true` 
-
-#### `hideNavigationBar` (iOS only)
+#### `hideNavigationBar`
 
 Boolean indicating whether to hide the navigation bar during searching.
 
 Defaults to `true`.
 
-#### `hideWhenScrolling` (iOS only)
+#### `hideWhenScrolling`
 
 Boolean indicating whether to hide the search bar when scrolling.
 
 Defaults to `true`.
 
-#### `inputType` (Android only)
-
-This prop is used to change type of the input and keyboard. Default value is `'text'`.
-
-All values:
-- `'text'` - normal text input
-- `'number'` - number input
-- `'email'` - email input
-- `'phone'` - phone input
-
-####  `obscureBackground` (iOS only)
+####  `obscureBackground`
 
 Boolean indicating whether to obscure the underlying content with semi-transparent overlay.
 
@@ -440,7 +424,7 @@ Defaults to `true`.
 
 A callback that gets called when search bar has lost focus.
 
-#### `onCancelButtonPress` (iOS only)
+#### `onCancelButtonPress`
 
 A callback that gets called when the cancel button is pressed.
 
@@ -462,17 +446,9 @@ static navigationOptions = ({navigation}) => {
 };
 ```
 
-#### `onClose` (Android only)
-
-A callback that gets called when search bar is closing
-
 #### `onFocus`
 
 A callback that gets called when search bar has received focus.
-
-#### `onOpen` (Android only)
-
-A callback that gets called when search bar is expanding
 
 #### `onSearchButtonPress`
 


### PR DESCRIPTION
## Description

Update Example app to reflect current master status.

The search bar is now available also on Android devices and thus 'Search bar' section needed to be updated.

Not every available search bar setting was reflected in the Example. 

## Changes

- Updated Search bar example
- Reverted search bar documentation for react-navigation v4 

## Screenshots


![Screenshot_1638453841](https://user-images.githubusercontent.com/39658211/144437143-c5d1f519-12ee-40a2-bb2e-fa68fa595602.png)


![Screenshot_1638453853](https://user-images.githubusercontent.com/39658211/144437158-18435775-e80b-4c36-bd5d-f27284eecd09.png)

## Test code and steps to reproduce

Search Bar playground in `Example/` project

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
