### PR TITLE
fix: use shouldUseOpenAnimation to determine animation

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -71,6 +71,7 @@ import Test1198 from './src/Test1198';
 import Test1204 from './src/Test1204';
 import Test1209 from './src/Test1209';
 import Test1214 from './src/Test1214';
+import Test1227 from './src/Test1227';
 
 enableFreeze(true);
 

--- a/TestsExample/src/Test1227.tsx
+++ b/TestsExample/src/Test1227.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {Button, View} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen
+          name="Second"
+          component={Second}
+          options={{stackAnimation: 'slide_from_bottom'}}
+        />
+        <Stack.Screen
+          name="Third"
+          component={Third}
+          options={{stackAnimation: 'fade_from_bottom'}}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function First({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View style={{flex: 1, backgroundColor: 'red'}}>
+      <Button
+        title="Tap me for second screen"
+        onPress={() => navigation.navigate('Second')}
+      />
+    </View>
+  );
+}
+
+function Second({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View style={{flex: 1, backgroundColor: 'yellow'}}>
+      <Button
+        title="Tap me for third screen"
+        onPress={() => navigation.navigate('Third')}
+      />
+    </View>
+  );
+}
+
+function Third({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View style={{flex: 1, backgroundColor: 'blue'}}>
+      <Button
+        title="Tap me for first screen"
+        onPress={() => navigation.navigate('First')}
+      />
+    </View>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -124,7 +124,7 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
                 val isPushReplace = newTop.screen.replaceAnimation === Screen.ReplaceAnimation.PUSH
                 shouldUseOpenAnimation = containsTopScreen || isPushReplace
                 // if the replace animation is `push`, the new top screen provides the animation, otherwise the previous one
-                stackAnimation = if (isPushReplace) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
+                stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
             } else if (mTopScreen == null && newTop != null) {
                 // mTopScreen was not present before so newTop is the first screen added to a stack
                 // and we don't want the animation when it is entering, but we want to send the


### PR DESCRIPTION
## Description

#1190 introduced a bug where stack animation was incorrectly resolved on Android during simple `navigate`.

Thanks to @WoLewicki for creating the fix

## Test code and steps to reproduce

Test1227.tsx


## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
