### PR TITLE
fix: add missing inputType in navigation.setOptions in Example

### DIFF
--- a/Example/src/screens/SearchBar.tsx
+++ b/Example/src/screens/SearchBar.tsx
@@ -52,6 +52,7 @@ const MainScreen = ({ navigation }: MainScreenProps): JSX.Element => {
         hideNavigationBar,
         autoCapitalize,
         placeholder,
+        inputType,
         onChangeText: (event) => setSearch(event.nativeEvent.text),
         onCancelButtonPress: () =>
           toast.push({


### PR DESCRIPTION
## Description

This PR adds missing `inputType` variable in `navigation.setOptions`. Without this, you can't change the keyboard's type on Android in the Example's Searchbar playground.

## Checklist

- [x] Ensured that CI passes
