### PR TITLE
fix: rename master occurences to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,9 +45,9 @@ This snippet should be as minimal as possible and ready to be pasted into editor
 - [ ] Included code example that can be used to test this change
 - [ ] Updated TS types
 - [ ] Updated documentation: <!-- For adding new props to native-stack -->
-  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
-  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/native-stack/README.md
-  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/createNativeStackNavigator/README.md
-  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/types.tsx
-  - [ ] https://github.com/software-mansion/react-native-screens/blob/master/src/native-stack/types.tsx
+  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
+  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/createNativeStackNavigator/README.md
+  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
+  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
 - [ ] Ensured that CI passes

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -2,12 +2,12 @@ name: Test Android build
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'android/**'
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -2,10 +2,10 @@ name: Test Android e2e
 on:
   pull_request:
     paths:
-        - 'Example/**'
+      - 'Example/**'
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   test:
@@ -38,7 +38,7 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: 29
           avd-name: e2e_emulator
-          script: yarn test-e2e-android 
+          script: yarn test-e2e-android
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -1,13 +1,13 @@
 name: Test iOS build
 on:
   pull_request:
-    branches: 
-      - master
+    branches:
+      - main
     paths:
       - 'ios/**'
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -5,7 +5,7 @@ on:
       - 'Example/**'
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,15 +2,15 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   install-and-lint:
     runs-on: ubuntu-latest
-    concurrency: 
+    concurrency:
       group: install-and-lint-${{ github.ref }}
       cancel-in-progress: true
     steps:
@@ -32,4 +32,3 @@ jobs:
       - name: Check types
         run: |
           yarn check-types
-

--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -2,12 +2,12 @@ name: Test tvOS build
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'ios/**'
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ You can also disable the usage of native screens per navigator with [`detachInac
 To take advantage of the native stack navigator primitive for React Navigation that leverages `UINavigationController` on iOS and `Fragment` on Android, please refer:
 
 - for React Navigation >= v6 to the [Native Stack Navigator part of React Navigation documentation](https://reactnavigation.org/docs/native-stack-navigator)
-- for React Navigation v5 to the [README in react-native-screens/native-stack](https://github.com/software-mansion/react-native-screens/tree/master/native-stack)
-- for older versions to the [README in react-native-screens/createNativeStackNavigator](https://github.com/software-mansion/react-native-screens/tree/master/createNativeStackNavigator)
+- for React Navigation v5 to the [README in react-native-screens/native-stack](https://github.com/software-mansion/react-native-screens/tree/main/native-stack)
+- for older versions to the [README in react-native-screens/createNativeStackNavigator](https://github.com/software-mansion/react-native-screens/tree/main/createNativeStackNavigator)
 
 ## Interop with [react-native-navigation](https://github.com/wix/react-native-navigation)
 
@@ -137,7 +137,7 @@ This library should work out of the box with all existing react-native libraries
 ## Guide for navigation library authors
 
 If you are building a navigation library you may want to use `react-native-screens` to have control over which parts of the React component tree are attached to the native view hierarchy.
-To do that, `react-native-screens` provides you with the components documented [here](https://github.com/kmagiera/react-native-screens/tree/master/guides/GUIDE_FOR_LIBRARY_AUTHORS.md).
+To do that, `react-native-screens` provides you with the components documented [here](https://github.com/kmagiera/react-native-screens/tree/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md).
 
 ## Common problems
 
@@ -161,7 +161,7 @@ Use `ScrollView` with prop `contentInsetAdjustmentBehavior=“automatic”` as a
 
 ## Contributing
 
-There are many ways to contribute to this project. See [CONTRIBUTING](https://github.com/kmagiera/react-native-screens/tree/master/guides/CONTRIBUTING.md) guide for more information. Thank you for your interest in contributing!
+There are many ways to contribute to this project. See [CONTRIBUTING](https://github.com/kmagiera/react-native-screens/tree/main/guides/CONTRIBUTING.md) guide for more information. Thank you for your interest in contributing!
 
 ## License
 

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -407,16 +407,16 @@ In order for your native view on iOS to be notified when its parent navigation c
 }
 ```
 
-You can check our example app for a fully functional demo see [RNSSampleLifecycleAwareView.m](https://github.com/kmagiera/react-native-screens/blob/master/Example/ios/ScreensExample/RNSSampleLifecycleAwareView.m) for more details.
+You can check our example app for a fully functional demo see [RNSSampleLifecycleAwareView.m](https://github.com/swmansion/react-native-screens/blob/main/Example/ios/ScreensExample/RNSSampleLifecycleAwareView.m) for more details.
 
 ## Navigation lifecycle on Android
 
 On Android, you can use [LifecycleObserver](https://developer.android.com/reference/android/arch/lifecycle/LifecycleObserver) interface which is a part of Android compat library to make your view handle lifecycle events.
-Check [LifecycleAwareView.java](https://github.com/kmagiera/react-native-screens/blob/master/Example/android/app/src/main/java/com/swmansion/rnscreens/example/LifecycleAwareView.java) from our example app for more details on that.
+Check [LifecycleAwareView.java](https://github.com/swmansion/react-native-screens/blob/main/Example/android/app/src/main/java/com/swmansion/rnscreens/example/LifecycleAwareView.java) from our example app for more details on that.
 
-In addition to that, you will need to register for receiving these updates. This can be done using [`LifecycleHelper.register`](https://github.com/kmagiera/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L50).
-Remember to call [`LifecycleHelper.unregister`](https://github.com/kmagiera/react-native-screens/blob/master/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L59) before the view is dropped.
-Please refer to [SampleLifecycleAwareViewManager.java](https://github.com/kmagiera/react-native-screens/blob/master/Example/android/app/src/main/java/com/swmansion/rnscreens/example/SampleLifecycleAwareViewManager.java) from our example app to see what are the best ways of using the above methods.
+In addition to that, you will need to register for receiving these updates. This can be done using [`LifecycleHelper.register`](https://github.com/swmansion/react-native-screens/blob/main/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L50).
+Remember to call [`LifecycleHelper.unregister`](https://github.com/swmansion/react-native-screens/blob/main/android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.java#L59) before the view is dropped.
+Please refer to [SampleLifecycleAwareViewManager.java](https://github.com/swmansion/react-native-screens/blob/main/Example/android/app/src/main/java/com/swmansion/rnscreens/example/SampleLifecycleAwareViewManager.java) from our example app to see what are the best ways of using the above methods.
 
 ## Android hardware back button
 


### PR DESCRIPTION
## Description

This PR renames `master` occurrences to `main` in the CI and documentation.

## Checklist

- [ ] Ensured that CI passes
