### PR TITLE
fix: dont run needs-repro on comment

### DIFF
--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -2,8 +2,6 @@ name: Check for reproduction
 on:
   issues:
     types: [opened, edited]
-  issue_comment:
-    types: [created, edited]
 
 jobs:
   main:


### PR DESCRIPTION
## Description

It seems like the GitHub Actions bot added in https://github.com/software-mansion/react-native-screens/pull/1253 behaves incorrectly when a new comment is added/edited. This PR disallows needs-repro action to run on adding/editing comments.

## Checklist

- [ ] Ensured that CI passes
