### PR TITLE
feat: bring back needs-repro trigger on comment

### DIFF
--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -2,6 +2,8 @@ name: Check for reproduction
 on:
   issues:
     types: [opened, edited]
+  issue_comment:
+    types: [created, edited, deleted]
 
 jobs:
   main:
@@ -39,3 +41,4 @@ jobs:
           needs-repro-label: 🧰needs-repro
           needs-repro-response: "Hey! 👋 \n\n Thank you for submitting an issue. The issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).\n\nCould you provide a snippet of code, a [snack](https://snack.expo.dev/) or a link to a GitHub repository that reproduces the problem? This would incredibly help us with resolving the issue."
           repro-provided-label: repro-provided
+          check-issues-only-created-after: 2022-01-01


### PR DESCRIPTION
## Description

This PR restores `needs-repro` action to work on comment add/edit/delete.

Also, added prop for `needs-repro` action to trigger only if the issue was created after 01-01-2022.

GitHub Action was fixed here: https://github.com/software-mansion-labs/swmansion-bot

## Checklist

- [ ] Ensured that CI passes
