### PR TITLE
feat: make bot responses shorter

### DIFF
--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -38,6 +38,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           needs-more-info-label: needs-more-info
           required-sections: 'Description;Steps To Reproduce;Reproduction;Platform'
-          needs-more-info-response: "Hey! 👋 \n\n Thank you for submitting an issue. It looks like you've omitted a few important sections from the issue template. Could you provide more information about the problem? We need all the information we can get in order to help you."
-          # This action also appends something like: "It seems like sections X, Y and Z are missing." to the response.
+          needs-more-info-response: "Hey! 👋 \n\nIt looks like you've omitted a few important sections from the issue template."
+          # This action also appends something like: "Please complete X, Y and Z sections." to the response.
           # Code responsible for this can be found here: https://github.com/software-mansion-labs/swmansion-bot/blob/main/needs-more-info/MissingSectionsFormatter.js

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           needs-repro-label: 🧰needs-repro
-          needs-repro-response: "Hey! 👋 \n\n Thank you for submitting an issue. The issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).\n\nCould you provide a snippet of code, a [snack](https://snack.expo.dev/) or a link to a GitHub repository that reproduces the problem? This would incredibly help us with resolving the issue."
+          needs-repro-response: "Hey! 👋 \n\nThe issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).\n\nCould you provide a snippet of code, a [snack](https://snack.expo.dev/) or a link to a GitHub repository that reproduces the problem?"
           repro-provided-label: repro-provided
           check-issues-only-created-after: 2022-01-01


### PR DESCRIPTION
## Description

This PR makes GitHub Actions bot responses more concise. This change was made because of feedback that people tend to ignore and don't want to read messages that are too long.

## Bot response on empty template ⬇️ 

### Before

![image](https://user-images.githubusercontent.com/39658211/148194013-a35fbe83-a23e-49dc-8e36-5dfc865b455b.png)

### After

![image](https://user-images.githubusercontent.com/39658211/148193953-293dae1e-5004-4da8-84a0-cfb2b26d3ad8.png)


## Checklist

- [x] Ensured that CI passes
