### PR TITLE
feat: add android navigation bar manipulation

### DIFF
--- a/TestsExample/src/Test860.tsx
+++ b/TestsExample/src/Test860.tsx
@@ -19,13 +19,13 @@ export default function NativeNavigation() {
           name="Home"
           component={Home}
           options={{
-            statusBarColor: 'blue',
+            statusBarColor: 'rgba(0,0,255,0.25)',
             statusBarAnimation: 'slide',
             statusBarStyle: 'dark',
             statusBarTranslucent: true,
             statusBarHidden: false,
             navigationBarColor: 'green',
-            navigationBarHidden: true,
+            navigationBarHidden: false,
           }}
         />
         <Stack.Screen
@@ -35,10 +35,11 @@ export default function NativeNavigation() {
             statusBarColor: 'red',
             statusBarAnimation: 'slide',
             statusBarStyle: 'dark',
+            statusBarHidden: true,
             statusBarTranslucent: true,
-            statusBarHidden: false,
+            headerTopInsetEnabled: false,
             navigationBarColor: 'blue',
-            navigationBarHidden: false,
+            navigationBarHidden: true,
           }}
         />
       </Stack.Navigator>
@@ -89,6 +90,7 @@ function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase
   const [statusBarAnimation, setStatusBarAnimation] = React.useState<NativeStackNavigationOptions['statusBarAnimation']>('slide');
   const [navigationBarColor, setNavigationBarColor] = React.useState('green');
   const [navigationBarHidden, setNavigationBarHidden] = React.useState(false);
+  const [headerTopInsetEnabled, setHeaderTopInsetEnabled] = React.useState(false);
 
   return (
     <ScrollView
@@ -119,7 +121,7 @@ function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase
           navigation.setOptions({
             statusBarColor,
           });
-          setStatusBarColor(statusBarColor === 'mediumseagreen' ? 'orange' : 'mediumseagreen');
+          setStatusBarColor(statusBarColor === 'mediumseagreen' ? 'rgba(255,128,128,0.5)' : 'mediumseagreen');
         }}
       />
       <Button
@@ -147,6 +149,15 @@ function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase
             statusBarHidden,
           });
           setStatusBarHidden(!statusBarHidden);
+        }}
+      />
+      <Button
+        title="Change status bar top inset"
+        onPress={() => {
+          navigation.setOptions({
+            headerTopInsetEnabled,
+          });
+          setHeaderTopInsetEnabled(!headerTopInsetEnabled);
         }}
       />
             <Button

--- a/TestsExample/src/Test860.tsx
+++ b/TestsExample/src/Test860.tsx
@@ -24,6 +24,8 @@ export default function NativeNavigation() {
             statusBarStyle: 'dark',
             statusBarTranslucent: true,
             statusBarHidden: false,
+            navigationBarColor: 'green',
+            navigationBarHidden: true,
           }}
         />
         <Stack.Screen
@@ -35,6 +37,8 @@ export default function NativeNavigation() {
             statusBarStyle: 'dark',
             statusBarTranslucent: true,
             statusBarHidden: false,
+            navigationBarColor: 'blue',
+            navigationBarHidden: false,
           }}
         />
       </Stack.Navigator>
@@ -70,6 +74,7 @@ const Inner = () => (
       statusBarAnimation: 'none',
       statusBarStyle: 'auto',
       headerTopInsetEnabled: false,
+      navigationBarColor: 'pink',
       // headerShown: false,
     }}>
     <InnerStack.Screen name="DeeperHome" component={Home} />
@@ -82,6 +87,8 @@ function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase
   const [statusBarHidden, setStatusBarHidden] = React.useState(false);
   const [statusBarTranslucent, setStatusBarTranslucent] = React.useState(true);
   const [statusBarAnimation, setStatusBarAnimation] = React.useState<NativeStackNavigationOptions['statusBarAnimation']>('slide');
+  const [navigationBarColor, setNavigationBarColor] = React.useState('green');
+  const [navigationBarHidden, setNavigationBarHidden] = React.useState(false);
 
   return (
     <ScrollView
@@ -158,6 +165,24 @@ function Home({navigation}: {navigation: NativeStackNavigationProp<ParamListBase
             statusBarAnimation,
           });
           setStatusBarAnimation(statusBarAnimation === 'none' ? 'slide' : 'none');
+        }}
+      />
+      <Button
+        title="Change navigation bar color"
+        onPress={() => {
+          navigation.setOptions({
+            navigationBarColor,
+          });
+          setNavigationBarColor(navigationBarColor === 'green' ? 'powderblue' : 'green');
+        }}
+      />
+      <Button
+        title="Change navigation bar hidden"
+        onPress={() => {
+          navigation.setOptions({
+            navigationBarHidden,
+          });
+          setNavigationBarHidden(!navigationBarHidden);
         }}
       />
       <Text>Go to `TabNavigator` and then go to second tab there. Spot the difference between dismissing modal with a swipe and with a `Pop to top` button. </Text> 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
+    implementation "androidx.core:core-ktx:1.5.0"
 }

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -29,6 +29,8 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
     private var mStatusBarHidden: Boolean? = null
     private var mStatusBarTranslucent: Boolean? = null
     private var mStatusBarColor: Int? = null
+    private var mNavigationBarColor: Int? = null
+    private var mNavigationBarHidden: Boolean? = null
     var isStatusBarAnimated: Boolean? = null
     private var mNativeBackButtonDismissalEnabled = true
 
@@ -209,6 +211,31 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
             fragment?.let { ScreenWindowTraits.setColor(this, it.tryGetActivity(), it.tryGetContext()) }
         }
 
+    var navigationBarColor: Int?
+        get() = mNavigationBarColor
+        set(navigationBarColor) {
+            if (navigationBarColor != null) {
+                ScreenWindowTraits.applyDidSetNavigationBarAppearance()
+            }
+            mNavigationBarColor = navigationBarColor
+            fragment?.let { ScreenWindowTraits.setNavigationBarColor(this, it.tryGetActivity()) }
+        }
+
+    var isNavigationBarHidden: Boolean?
+        get() = mNavigationBarHidden
+        set(navigationBarHidden) {
+            if (navigationBarHidden != null) {
+                ScreenWindowTraits.applyDidSetNavigationBarAppearance()
+            }
+            mNavigationBarHidden = navigationBarHidden
+            fragment?.let {
+                ScreenWindowTraits.setNavigationBarHidden(
+                    this,
+                    it.tryGetActivity(),
+                )
+            }
+        }
+
     var nativeBackButtonDismissalEnabled: Boolean
         get() = mNativeBackButtonDismissalEnabled
         set(enableNativeBackButtonDismissal) {
@@ -232,6 +259,6 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
     }
 
     enum class WindowTraits {
-        ORIENTATION, COLOR, STYLE, TRANSLUCENT, HIDDEN, ANIMATED
+        ORIENTATION, COLOR, STYLE, TRANSLUCENT, HIDDEN, ANIMATED, NAVIGATION_BAR_COLOR, NAVIGATION_BAR_HIDDEN
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -112,6 +112,16 @@ class ScreenViewManager : ViewGroupManager<Screen>() {
         view.isStatusBarHidden = statusBarHidden
     }
 
+    @ReactProp(name = "navigationBarColor", customType = "Color")
+    fun setNavigationBarColor(view: Screen, navigationBarColor: Int) {
+        view.navigationBarColor = navigationBarColor
+    }
+
+    @ReactProp(name = "navigationBarHidden")
+    fun setNavigationBarHidden(view: Screen, navigationBarHidden: Boolean?) {
+        view.isNavigationBarHidden = navigationBarHidden
+    }
+
     @ReactProp(name = "nativeBackButtonDismissalEnabled")
     fun setNativeBackButtonDismissalEnabled(
         view: Screen,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -6,11 +6,15 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import android.graphics.Color
 import android.os.Build
 import android.view.View
 import android.view.ViewParent
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
@@ -21,6 +25,7 @@ object ScreenWindowTraits {
     // https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
     private var mDidSetOrientation = false
     private var mDidSetStatusBarAppearance = false
+    private var mDidSetNavigationBarAppearance = false
     private var mDefaultStatusBarColor: Int? = null
     internal fun applyDidSetOrientation() {
         mDidSetOrientation = true
@@ -28,6 +33,10 @@ object ScreenWindowTraits {
 
     internal fun applyDidSetStatusBarAppearance() {
         mDidSetStatusBarAppearance = true
+    }
+
+    internal fun applyDidSetNavigationBarAppearance() {
+        mDidSetNavigationBarAppearance = true
     }
 
     internal fun setOrientation(screen: Screen, activity: Activity?) {
@@ -144,6 +153,44 @@ object ScreenWindowTraits {
         }
     }
 
+    // Methods concerning navigationBar management were taken from `react-native-navigation`'s repo:
+    // https://github.com/wix/react-native-navigation/blob/9bb70d81700692141a2c505c081c2d86c7f9c66e/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+    internal fun setNavigationBarColor(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
+        }
+
+        val window = activity.window
+
+        val screenForNavBarColor = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_COLOR)
+        val color = screenForNavBarColor?.navigationBarColor ?: window.navigationBarColor
+
+        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+            isColorLight(color)
+        window.navigationBarColor = color
+    }
+
+    internal fun setNavigationBarHidden(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
+        }
+
+        val window = activity.window
+
+        val screenForNavBarHidden = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_HIDDEN)
+        val hidden = screenForNavBarHidden?.isNavigationBarHidden ?: false
+
+        WindowCompat.setDecorFitsSystemWindows(window, hidden)
+        if (hidden) {
+            WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+                controller.hide(WindowInsetsCompat.Type.navigationBars())
+                controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else {
+            WindowInsetsControllerCompat(window, window.decorView).show(WindowInsetsCompat.Type.navigationBars())
+        }
+    }
+
     internal fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?) {
         if (mDidSetOrientation) {
             setOrientation(screen, activity)
@@ -153,6 +200,10 @@ object ScreenWindowTraits {
             setStyle(screen, activity, context)
             setTranslucent(screen, activity, context)
             setHidden(screen, activity)
+        }
+        if (mDidSetNavigationBarAppearance) {
+            setNavigationBarColor(screen, activity)
+            setNavigationBarHidden(screen, activity)
         }
     }
 
@@ -211,6 +262,14 @@ object ScreenWindowTraits {
             WindowTraits.TRANSLUCENT -> screen.isStatusBarTranslucent != null
             WindowTraits.HIDDEN -> screen.isStatusBarHidden != null
             WindowTraits.ANIMATED -> screen.isStatusBarAnimated != null
+            WindowTraits.NAVIGATION_BAR_COLOR -> screen.navigationBarColor != null
+            WindowTraits.NAVIGATION_BAR_HIDDEN -> screen.isNavigationBarHidden != null
         }
+    }
+
+    private fun isColorLight(color: Int): Boolean {
+        val darkness: Double =
+            1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255
+        return darkness < 0.5
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -81,23 +81,21 @@ object ScreenWindowTraits {
     }
 
     internal fun setStyle(screen: Screen, activity: Activity?, context: ReactContext?) {
-        if (activity == null || context == null) {
+        if (activity == null || context == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return
         }
         val screenForStyle = findScreenForTrait(screen, WindowTraits.STYLE)
         val style = screenForStyle?.statusBarStyle ?: "light"
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            UiThreadUtil.runOnUiThread {
-                val decorView = activity.window.decorView
-                var systemUiVisibilityFlags = decorView.systemUiVisibility
-                systemUiVisibilityFlags = if ("dark" == style) {
-                    systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                } else {
-                    systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-                }
-                decorView.systemUiVisibility = systemUiVisibilityFlags
+        UiThreadUtil.runOnUiThread {
+            val decorView = activity.window.decorView
+            var systemUiVisibilityFlags = decorView.systemUiVisibility
+            systemUiVisibilityFlags = if ("dark" == style) {
+                systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            } else {
+                systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
             }
+            decorView.systemUiVisibility = systemUiVisibilityFlags
         }
     }
 
@@ -184,10 +182,14 @@ object ScreenWindowTraits {
         if (hidden) {
             WindowInsetsControllerCompat(window, window.decorView).let { controller ->
                 controller.hide(WindowInsetsCompat.Type.navigationBars())
-                controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             }
         } else {
-            WindowInsetsControllerCompat(window, window.decorView).show(WindowInsetsCompat.Type.navigationBars())
+            WindowInsetsControllerCompat(
+                window,
+                window.decorView
+            ).show(WindowInsetsCompat.Type.navigationBars())
         }
     }
 

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -55,6 +55,14 @@ Unfortunately the same behavior is not available on iOS since the behavior of na
 
 Defaults to `false`.
 
+### `navigationBarColor` (Android only)
+
+Sets the navigation bar color. Defaults to initial status bar color.
+
+### `navigationBarHidden` (Android only)
+
+Sets the visibility of the navigation bar. Defaults to `false`.
+
 ### `onAppear`
 
 A callback that gets called when the current screen appears.
@@ -85,7 +93,7 @@ Allows for the customization of the type of animation to use when this screen re
 - `push` – performs push animation
 - `pop` – performs pop animation (default)
 
-#### `screenOrientation`
+### `screenOrientation`
 
 Sets the current screen's available orientations and forces rotation if current orientation is not included. On iOS, if you have supported orientations set in `info.plist`, they will take precedence over this prop. Possible values:
 
@@ -142,33 +150,33 @@ For Android:
 
 `transparentModal`, `containedTransparentModal` will use `Screen.StackPresentation.TRANSPARENT_MODAL`.
 
-#### `statusBarAnimation`
+### `statusBarAnimation`
 
 Sets the status bar animation (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. Possible values: `fade`, `none`, `slide`. On Android, this prop considers the transition of changing status bar color (see https://reactnative.dev/docs/statusbar#animated). There will be no animation if `none` provided.
 
 Defaults to `fade` on iOS and `none` on Android.
 
-#### `statusBarColor` (Android only)
+### `statusBarColor` (Android only)
 
 Sets the status bar color (similar to the `StatusBar` component). Defaults to initial status bar color.
 
-#### `statusBarHidden`
+### `statusBarHidden`
 
 When set to true, the status bar for this screen is hidden. Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file.
 
 Defaults to `false`.
 
-#### `statusBarStyle`
+### `statusBarStyle`
 
 Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. On iOS, the possible values are: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`. On Android, the status bar will be dark if set to `dark` and `light` otherwise.
 
 Defaults to `auto`.
 
-#### `statusBarTranslucent` (Android only)
+### `statusBarTranslucent` (Android only)
 
 Sets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.
 
-#### `useTransitionProgress`
+### `useTransitionProgress`
 
 Hook providing context value of transition progress of the current screen to be used with `react-native` `Animated`. It consists of 2 values:
 - `progress` - `Animated.Value` between `0.0` and `1.0` with the progress of the current transition.
@@ -194,7 +202,7 @@ function Home() {
 }
 ```
 
-#### `useReanimatedTransitionProgress`
+### `useReanimatedTransitionProgress`
 
 A callback called every frame during the transition of screens to be used with `react-native-reanimated` version `2.x`. It consists of 2 shared values:
 - `progress` - between `0.0` and `1.0` with the progress of the current transition.
@@ -308,7 +316,7 @@ Pass `ScreenStackHeaderBackButtonImage`, `ScreenStackHeaderRightView`, `ScreenSt
 
 Controls whether the stack should be in `rtl` or `ltr` form.
 
-#### `disableBackButtonMenu` (iOS only)
+### `disableBackButtonMenu` (iOS only)
 
 Boolean indicating whether to show the menu on longPress of iOS >= 14 back button.
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -189,6 +189,14 @@ Unfortunately the same behavior is not available on iOS since the behavior of na
 
 Defaults to `false`.
 
+#### `navigationBarColor` (Android only)
+
+Sets the navigation bar color. Defaults to initial status bar color.
+
+#### `navigationBarHidden` (Android only)
+
+Sets the visibility of the navigation bar. Defaults to `false`.
+
 #### `replaceAnimation`
 
 How should the screen replacing another screen animate.

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -252,6 +252,18 @@ export type NativeStackNavigationOptions = {
    */
   nativeBackButtonDismissalEnabled?: boolean;
   /**
+   * Sets the navigation bar color. Defaults to initial status bar color.
+   *
+   * @platform android
+   */
+  navigationBarColor?: string;
+  /**
+   * Sets the visibility of the navigation bar. Defaults to `false`.
+   *
+   * @platform android
+   */
+  navigationBarHidden?: boolean;
+  /**
    * How should the screen replacing another screen animate. Defaults to `pop`.
    * The following values are currently supported:
    * - "push" – the new screen will perform push animation.

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -154,6 +154,8 @@ const RouteView = ({
     gestureEnabled,
     headerShown,
     nativeBackButtonDismissalEnabled = false,
+    navigationBarColor,
+    navigationBarHidden,
     replaceAnimation = 'pop',
     screenOrientation,
     stackAnimation,
@@ -196,6 +198,8 @@ const RouteView = ({
       fullScreenSwipeEnabled={fullScreenSwipeEnabled}
       gestureEnabled={isAndroid ? false : gestureEnabled}
       nativeBackButtonDismissalEnabled={nativeBackButtonDismissalEnabled}
+      navigationBarColor={navigationBarColor}
+      navigationBarHidden={navigationBarHidden}
       replaceAnimation={replaceAnimation}
       screenOrientation={screenOrientation}
       stackAnimation={stackAnimation}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -110,6 +110,18 @@ export interface ScreenProps extends ViewProps {
    */
   nativeBackButtonDismissalEnabled?: boolean;
   /**
+   * Sets the navigation bar color. Defaults to initial status bar color.
+   *
+   * @platform android
+   */
+  navigationBarColor?: string;
+  /**
+   * Sets the visibility of the navigation bar. Defaults to `false`.
+   *
+   * @platform android
+   */
+  navigationBarHidden?: boolean;
+  /**
    * A callback that gets called when the current screen appears.
    */
   onAppear?: (e: NativeSyntheticEvent<TargetedEvent>) => void;


### PR DESCRIPTION
## Description

Added props for manipulating navigation bar on `Android`. Requested in https://github.com/software-mansion/react-native-screens/discussions/1244.

## Changes

This PR adds `androidx.core:core-ktx:1.5.0` dependency and it for sure would be good to check if it works in older `Android` APIs. These options use the newer API which affects all system bars, so same changes to both `statusBar` and `navigationBar` are strongly suggested.

## Test code and steps to reproduce

`Test860.tsx`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
