### PR TITLE
feat: add home indicator hiding

### DIFF
--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.10.0):
+  - RNScreens (3.10.1):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (7.1.0):
@@ -592,7 +592,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: b04ef2a4f0cb61b062bbcf033f84a9e470f4f60b
-  RNScreens: 03ba504f8c98607ad1f07808e71040e0afa335ec
+  RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   Yoga: c11abbf5809216c91fcd62f5571078b83d9b6720
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/TestsExample/src/Test642.tsx
+++ b/TestsExample/src/Test642.tsx
@@ -23,6 +23,7 @@ export default function App(): JSX.Element {
           component={Home}
           options={{
             statusBarStyle: 'dark',
+            homeIndicatorHidden: true,
           }}
         />
         <Stack.Screen
@@ -38,6 +39,7 @@ export default function App(): JSX.Element {
           options={{
             statusBarStyle: 'light',
             stackPresentation: "fullScreenModal",
+            homeIndicatorHidden: true,
           }}
         />
       </Stack.Navigator>
@@ -61,6 +63,7 @@ const Inner = () => (
   <InnerStack.Navigator
     screenOptions={{
       statusBarStyle: 'dark',
+      homeIndicatorHidden: true,
     }}>
     <InnerStack.Screen name="DeeperHome" component={Home} />
   </InnerStack.Navigator>

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -48,6 +48,10 @@ Boolean indicating whether the swipe gesture should work on whole screen. Swipin
 
 When set to `false` the back swipe gesture will be disabled. The default value is `true`.
 
+### `homeIndicatorHidden` (iOS only)
+
+Whether the home indicator should be hidden on this screen. Defaults to `false`.
+
 ### `nativeBackButtonDismissalEnabled` (Android only)
 
 Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -47,6 +47,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
   RNSWindowTraitAnimation,
   RNSWindowTraitHidden,
   RNSWindowTraitOrientation,
+  RNSWindowTraitHomeIndicatorHidden,
 };
 
 @interface RCTConvert (RNSScreen)
@@ -96,6 +97,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 @property (nonatomic) BOOL hasStatusBarStyleSet;
 @property (nonatomic) BOOL hasStatusBarAnimationSet;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;
+@property (nonatomic) BOOL hasHomeIndicatorHiddenSet;
 @property (nonatomic) BOOL customAnimationOnSwipe;
 @property (nonatomic) BOOL fullScreenSwipeEnabled;
 
@@ -104,6 +106,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
+@property (nonatomic) BOOL homeIndicatorHidden;
 #endif
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -34,6 +34,7 @@
     _hasStatusBarAnimationSet = NO;
     _hasStatusBarHiddenSet = NO;
     _hasOrientationSet = NO;
+    _hasHomeIndicatorHiddenSet = NO;
   }
 
   return self;
@@ -205,6 +206,13 @@
   _hasOrientationSet = YES;
   _screenOrientation = screenOrientation;
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
+}
+
+- (void)setHomeIndicatorHidden:(BOOL)homeIndicatorHidden
+{
+  _hasHomeIndicatorHiddenSet = YES;
+  _homeIndicatorHidden = homeIndicatorHidden;
+  [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
 }
 #endif
 
@@ -436,6 +444,17 @@
   return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitHomeIndicatorHidden includingModals:YES];
+  return vc == self ? nil : vc;
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden
+{
+  return ((RNSScreenView *)self.view).homeIndicatorHidden;
+}
+
 // if the returned vc is a child, it means that it can provide config;
 // if the returned vc is self, it means that there is no child for config and self has config to provide,
 // so we return self which results in asking self for preferredStatusBarStyle/Animation etc.;
@@ -494,6 +513,9 @@
     }
     case RNSWindowTraitOrientation: {
       return ((RNSScreenView *)self.view).hasOrientationSet;
+    }
+    case RNSWindowTraitHomeIndicatorHidden: {
+      return ((RNSScreenView *)self.view).hasHomeIndicatorHiddenSet;
     }
     default: {
       RCTLogError(@"Unknown trait passed: %d", (int)trait);
@@ -785,6 +807,7 @@ RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
+RCT_EXPORT_VIEW_PROPERTY(homeIndicatorHidden, BOOL)
 #endif
 
 - (UIView *)view

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -23,6 +23,11 @@
 {
   return [self findActiveChildVC].supportedInterfaceOrientations;
 }
+
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  return [self findActiveChildVC];
+}
 #endif
 
 - (UIViewController *)findActiveChildVC

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -45,6 +45,11 @@
 {
   return [self topViewController].supportedInterfaceOrientations;
 }
+
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  return [self topViewController];
+}
 #endif
 
 @end

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -9,6 +9,7 @@
 #endif
 + (void)updateStatusBarAppearance;
 + (void)enforceDesiredDeviceOrientation;
++ (void)updateHomeIndicatorAutoHidden;
 
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;

--- a/ios/RNSScreenWindowTraits.m
+++ b/ios/RNSScreenWindowTraits.m
@@ -42,6 +42,25 @@
 #endif
 }
 
++ (void)updateHomeIndicatorAutoHidden
+{
+#if !TARGET_OS_TV
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13, *)) {
+    UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+    if (firstWindow != nil) {
+      [[firstWindow rootViewController] setNeedsUpdateOfHomeIndicatorAutoHidden];
+    }
+  } else
+#endif
+  {
+    [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+  }
+#endif
+}
+
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
@@ -165,6 +184,7 @@
 {
   [RNSScreenWindowTraits updateStatusBarAppearance];
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
+  [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
 }
 
 #if !TARGET_OS_TV

--- a/ios/UIViewController+RNScreens.m
+++ b/ios/UIViewController+RNScreens.m
@@ -31,6 +31,12 @@
   return childVC ? childVC.supportedInterfaceOrientations : [self reactNativeScreensSupportedInterfaceOrientations];
 }
 
+- (UIViewController *)reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden
+{
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ?: [self reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden];
+}
+
 - (UIViewController *)findChildRNScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
@@ -61,6 +67,10 @@
     method_exchangeImplementations(
         class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
         class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
+
+    method_exchangeImplementations(
+        class_getInstanceMethod(uiVCClass, @selector(childViewControllerForHomeIndicatorAutoHidden)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden)));
   });
 }
 #endif

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -182,6 +182,10 @@ A Boolean to that lets you opt out of insetting the header. You may want to * se
 
 Boolean indicating whether the navigation bar is translucent.
 
+#### `homeIndicatorHidden` (iOS only)
+
+Whether the home indicator should be hidden on this screen. Defaults to `false`.
+
 #### `nativeBackButtonDismissalEnabled` (Android only)
 
 Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -244,6 +244,12 @@ export type NativeStackNavigationOptions = {
    */
   headerTranslucent?: boolean;
   /**
+   * Whether the home indicator should be hidden on this screen. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  homeIndicatorHidden?: boolean;
+  /**
    * Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.
    * Unfortunately the same behavior is not available on iOS since the behavior of native back button cannot be changed there.
    * Defaults to `false`.

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -153,6 +153,7 @@ const RouteView = ({
     fullScreenSwipeEnabled,
     gestureEnabled,
     headerShown,
+    homeIndicatorHidden,
     nativeBackButtonDismissalEnabled = false,
     replaceAnimation = 'pop',
     screenOrientation,
@@ -194,6 +195,7 @@ const RouteView = ({
       style={StyleSheet.absoluteFill}
       customAnimationOnSwipe={customAnimationOnSwipe}
       fullScreenSwipeEnabled={fullScreenSwipeEnabled}
+      homeIndicatorHidden={homeIndicatorHidden}
       gestureEnabled={isAndroid ? false : gestureEnabled}
       nativeBackButtonDismissalEnabled={nativeBackButtonDismissalEnabled}
       replaceAnimation={replaceAnimation}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -102,6 +102,12 @@ export interface ScreenProps extends ViewProps {
    */
   gestureEnabled?: boolean;
   /**
+   * Whether the home indicator should be hidden on this screen. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  homeIndicatorHidden?: boolean;
+  /**
    * Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.
    * Unfortunately the same behavior is not available on iOS since the behavior of native back button cannot be changed there.
    * Defaults to `false`.


### PR DESCRIPTION
## Description

Added prop `homeIndicatorHidden` for hiding home indicator on `iOS`. 

## Test code and steps to reproduce

`Test642.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
