### PR TITLE
fix: remove jcenter as repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -50,7 +49,6 @@ repositories {
     mavenCentral()
     mavenLocal()
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
## Description

jcenter is shutting and is not stabled at the moment. It's better to move to mavenCentral.

## Changes

This PR removes jcenter

