### PR TITLE
chore: bump nanoid to 3.2.0 in /TestsExample

### DIFF
--- a/TestsExample/package.json
+++ b/TestsExample/package.json
@@ -18,7 +18,7 @@
     "@react-navigation/material-top-tabs": "^5.3.9",
     "@react-navigation/native": "^5.9.4",
     "@react-navigation/stack": "^5.14.5",
-    "nanoid": "^3.1.30",
+    "nanoid": "^3.2.0",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0",
     "react": "17.0.2",

--- a/TestsExample/yarn.lock
+++ b/TestsExample/yarn.lock
@@ -6174,7 +6174,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.1.15:
+nanoid@^3.1.15, nanoid@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==


### PR DESCRIPTION
## Description

Changes in #1213 overridden nanoid version bump in #1283. 

This PR bumps nanoid to the most recent nanoid version in /TestsExample
