### PR TITLE
fix: add directory so /reanimated works outside of repo

### DIFF
--- a/reanimated/package.json
+++ b/reanimated/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../lib/commonjs/reanimated/index",
+  "module": "../lib/module/reanimated/index",
+  "react-native": "../src/reanimated/index",
+  "types": "../lib/typescript/reanimated/index"
+}


### PR DESCRIPTION
## Description

Added `reanimated` folder with `package.json` so using files from `react-native-screens/reanimated` works outside of our repo.

## Test code and steps to reproduce

Use files from `/reanimated` outside of this repo.

## Checklist

- [ ] Ensured that CI passes
