### PR TITLE
fix: change Activity to extend to ReactActivity

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -166,7 +166,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         while (context !is FragmentActivity && context is ContextWrapper) {
             context = context.baseContext
         }
-        check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity" }
+        check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactActivity" }
         setFragmentManager(context.supportFragmentManager)
     }
 


### PR DESCRIPTION
## Description

Changed `Activity` to extend to `ReactActivity` since it is the one being extended at least from `react-native` 0.62.