### PR TITLE
fix: set default swipe direction to horizontal

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -30,8 +30,8 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
 };
 
 typedef NS_ENUM(NSInteger, RNSScreenSwipeDirection) {
-  RNSScreenSwipeDirectionVertical,
   RNSScreenSwipeDirectionHorizontal,
+  RNSScreenSwipeDirectionVertical,
 };
 
 typedef NS_ENUM(NSInteger, RNSActivityState) {


### PR DESCRIPTION
## Description

This PR sets `RNSScreenSwipeDirectionHorizontal` as the first property on `RNSScreenSwipeDirection` enum. Effectively that sets `swipeDirection` to `horizontal` in the Obj-C part of the library.

Fixes #1312

## Checklist

- [ ] Ensured that CI passes
