### PR TITLE
fix: Fixes android props on paper

### DIFF
--- a/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -11,6 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -20,6 +21,51 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
   }
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
-    super.setProperty(view, propName, value);
+    switch (propName) {
+      case "stackPresentation":
+        mViewManager.setStackPresentation(view, (String) value);
+        break;
+      case "stackAnimation":
+        mViewManager.setStackAnimation(view, (String) value);
+        break;
+      case "gestureEnabled":
+        mViewManager.setGestureEnabled(view, value == null ? true : (boolean) value);
+        break;
+      case "replaceAnimation":
+        mViewManager.setReplaceAnimation(view, (String) value);
+        break;
+      case "screenOrientation":
+        mViewManager.setScreenOrientation(view, value == null ? null : (String) value);
+        break;
+      case "statusBarAnimation":
+        mViewManager.setStatusBarAnimation(view, value == null ? null : (String) value);
+        break;
+      case "statusBarColor":
+        mViewManager.setStatusBarColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "statusBarStyle":
+        mViewManager.setStatusBarStyle(view, value == null ? null : (String) value);
+        break;
+      case "statusBarTranslucent":
+        mViewManager.setStatusBarTranslucent(view, value == null ? false : (boolean) value);
+        break;
+      case "statusBarHidden":
+        mViewManager.setStatusBarHidden(view, value == null ? false : (boolean) value);
+        break;
+      case "navigationBarColor":
+        mViewManager.setNavigationBarColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "navigationBarHidden":
+        mViewManager.setNavigationBarHidden(view, value == null ? false : (boolean) value);
+        break;
+      case "nativeBackButtonDismissalEnabled":
+        mViewManager.setNativeBackButtonDismissalEnabled(view, value == null ? false : (boolean) value);
+        break;
+      case "activityState":
+        mViewManager.setActivityState(view, value == null ? -1 : ((Double) value).intValue());
+        break;
+      default:
+        super.setProperty(view, propName, value);
+    }
   }
 }

--- a/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -10,7 +10,21 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import androidx.annotation.Nullable;
 
 public interface RNSScreenManagerInterface<T extends View> {
-  // No props
+  void setStackPresentation(T view, @Nullable String value);
+  void setStackAnimation(T view, @Nullable String value);
+  void setGestureEnabled(T view, boolean value);
+  void setReplaceAnimation(T view, @Nullable String value);
+  void setScreenOrientation(T view, @Nullable String value);
+  void setStatusBarAnimation(T view, @Nullable String value);
+  void setStatusBarColor(T view, @Nullable Integer value);
+  void setStatusBarStyle(T view, @Nullable String value);
+  void setStatusBarTranslucent(T view, boolean value);
+  void setStatusBarHidden(T view, boolean value);
+  void setNavigationBarColor(T view, @Nullable Integer value);
+  void setNavigationBarHidden(T view, boolean value);
+  void setNativeBackButtonDismissalEnabled(T view, boolean value);
+  void setActivityState(T view, int value);
 }

--- a/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
+++ b/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
@@ -91,6 +91,12 @@ public class RNSScreenStackHeaderConfigManagerDelegate<T extends View, U extends
       case "hideBackButton":
         mViewManager.setHideBackButton(view, value == null ? false : (boolean) value);
         break;
+      case "topInsetEnabled":
+        mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
+        break;
+      case "backButtonInCustomView":
+        mViewManager.setBackButtonInCustomView(view, value == null ? false : (boolean) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/build/generated/source/codegen/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -36,4 +36,6 @@ public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> {
   void setTitleColor(T view, @Nullable Integer value);
   void setDisableBackButtonMenu(T view, boolean value);
   void setHideBackButton(T view, boolean value);
+  void setTopInsetEnabled(T view, boolean value);
+  void setBackButtonInCustomView(T view, boolean value);
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -110,7 +110,7 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
     }
 
     @ReactProp(name = "topInsetEnabled")
-    fun setTopInsetEnabled(config: ScreenStackHeaderConfig, topInsetEnabled: Boolean) {
+    override fun setTopInsetEnabled(config: ScreenStackHeaderConfig, topInsetEnabled: Boolean) {
         config.setTopInsetEnabled(topInsetEnabled)
     }
 
@@ -130,7 +130,7 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
     }
 
     @ReactProp(name = "backButtonInCustomView")
-    fun setBackButtonInCustomView(
+    override fun setBackButtonInCustomView(
         config: ScreenStackHeaderConfig,
         backButtonInCustomView: Boolean
     ) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -39,8 +39,8 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     }
 
     @ReactProp(name = "activityState")
-    fun setActivityState(view: Screen, activityState: Int?) {
-        if (activityState == null) {
+    override fun setActivityState(view: Screen, activityState: Int) {
+        if (activityState == -1) {
             // Null will be provided when activityState is set as an animated value and we change
             // it from JS to be a plain value (non animated).
             // In case when null is received, we want to ignore such value and not make
@@ -55,7 +55,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     }
 
     @ReactProp(name = "stackPresentation")
-    fun setStackPresentation(view: Screen, presentation: String) {
+    override fun setStackPresentation(view: Screen, presentation: String?) {
         view.stackPresentation = when (presentation) {
             "push" -> Screen.StackPresentation.PUSH
             "modal", "containedModal", "fullScreenModal", "formSheet" ->
@@ -67,7 +67,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     }
 
     @ReactProp(name = "stackAnimation")
-    fun setStackAnimation(view: Screen, animation: String?) {
+    override fun setStackAnimation(view: Screen, animation: String?) {
         view.stackAnimation = when (animation) {
             null, "default", "flip", "simple_push" -> Screen.StackAnimation.DEFAULT
             "none" -> Screen.StackAnimation.NONE
@@ -81,12 +81,12 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     }
 
     @ReactProp(name = "gestureEnabled", defaultBoolean = true)
-    fun setGestureEnabled(view: Screen, gestureEnabled: Boolean) {
+    override fun setGestureEnabled(view: Screen, gestureEnabled: Boolean) {
         view.isGestureEnabled = gestureEnabled
     }
 
     @ReactProp(name = "replaceAnimation")
-    fun setReplaceAnimation(view: Screen, animation: String?) {
+    override fun setReplaceAnimation(view: Screen, animation: String?) {
         view.replaceAnimation = when (animation) {
             null, "pop" -> Screen.ReplaceAnimation.POP
             "push" -> Screen.ReplaceAnimation.PUSH
@@ -95,48 +95,48 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     }
 
     @ReactProp(name = "screenOrientation")
-    fun setScreenOrientation(view: Screen, screenOrientation: String?) {
+    override fun setScreenOrientation(view: Screen, screenOrientation: String?) {
         view.setScreenOrientation(screenOrientation)
     }
 
     @ReactProp(name = "statusBarAnimation")
-    fun setStatusBarAnimation(view: Screen, statusBarAnimation: String?) {
+    override fun setStatusBarAnimation(view: Screen, statusBarAnimation: String?) {
         val animated = statusBarAnimation != null && "none" != statusBarAnimation
         view.isStatusBarAnimated = animated
     }
 
     @ReactProp(name = "statusBarColor")
-    fun setStatusBarColor(view: Screen, statusBarColor: Int?) {
+    override fun setStatusBarColor(view: Screen, statusBarColor: Int?) {
         view.statusBarColor = statusBarColor
     }
 
     @ReactProp(name = "statusBarStyle")
-    fun setStatusBarStyle(view: Screen, statusBarStyle: String?) {
+    override fun setStatusBarStyle(view: Screen, statusBarStyle: String?) {
         view.statusBarStyle = statusBarStyle
     }
 
     @ReactProp(name = "statusBarTranslucent")
-    fun setStatusBarTranslucent(view: Screen, statusBarTranslucent: Boolean?) {
+    override fun setStatusBarTranslucent(view: Screen, statusBarTranslucent: Boolean) {
         view.isStatusBarTranslucent = statusBarTranslucent
     }
 
     @ReactProp(name = "statusBarHidden")
-    fun setStatusBarHidden(view: Screen, statusBarHidden: Boolean?) {
+    override fun setStatusBarHidden(view: Screen, statusBarHidden: Boolean) {
         view.isStatusBarHidden = statusBarHidden
     }
 
     @ReactProp(name = "navigationBarColor", customType = "Color")
-    fun setNavigationBarColor(view: Screen, navigationBarColor: Int) {
+    override fun setNavigationBarColor(view: Screen, navigationBarColor: Int?) {
         view.navigationBarColor = navigationBarColor
     }
 
     @ReactProp(name = "navigationBarHidden")
-    fun setNavigationBarHidden(view: Screen, navigationBarHidden: Boolean?) {
+    override fun setNavigationBarHidden(view: Screen, navigationBarHidden: Boolean) {
         view.isNavigationBarHidden = navigationBarHidden
     }
 
     @ReactProp(name = "nativeBackButtonDismissalEnabled")
-    fun setNativeBackButtonDismissalEnabled(
+    override fun setNativeBackButtonDismissalEnabled(
         view: Screen,
         nativeBackButtonDismissalEnabled: Boolean
     ) {

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -6,8 +6,10 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type { ColorValue } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
+  WithDefault,
   Int32,
 } from 'react-native/Libraries/Types/CodegenTypes';
 
@@ -17,6 +19,20 @@ type ScreenDismissedEvent = $ReadOnly<{|
   dismissCount: Int32,
 |}>;
 
+type StackPresentation = 'push' | 'modal' | 'transparentModal';
+type StackAnimation =
+  | 'default'
+  | 'flip'
+  | 'simple_push'
+  | 'none'
+  | 'fade'
+  | 'slide_from_right'
+  | 'slide_from_left'
+  | 'slide_from_bottom'
+  | 'fade_from_bottom';
+
+type ReplaceAnimation = 'pop' | 'push';
+
 export type NativeProps = $ReadOnly<{|
   ...ViewProps,
   onAppear?: ?BubblingEventHandler<ScreenEvent>,
@@ -24,6 +40,21 @@ export type NativeProps = $ReadOnly<{|
   onDismissed?: ?BubblingEventHandler<ScreenDismissedEvent>,
   onWillAppear?: ?BubblingEventHandler<ScreenEvent>,
   onWillDisappear?: ?BubblingEventHandler<ScreenEvent>,
+  // TODO: implement this props on iOS
+  stackPresentation?: WithDefault<StackPresentation, 'push'>,
+  stackAnimation?: WithDefault<StackAnimation, 'default'>,
+  gestureEnabled?: WithDefault<boolean, true>,
+  replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>,
+  screenOrientation?: string,
+  statusBarAnimation?: string,
+  statusBarColor?: ColorValue,
+  statusBarStyle?: string,
+  statusBarTranslucent?: boolean,
+  statusBarHidden?: boolean,
+  navigationBarColor?: ColorValue,
+  navigationBarHidden?: boolean,
+  nativeBackButtonDismissalEnabled?: boolean,
+  activityState?: WithDefault<Int32, -1>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.js
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.js
@@ -41,6 +41,9 @@ export type NativeProps = $ReadOnly<{|
   titleColor?: ColorValue,
   disableBackButtonMenu?: boolean,
   hideBackButton?: boolean,
+  // TODO: implement this props on iOS
+  topInsetEnabled?: boolean,
+  backButtonInCustomView?: boolean,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
## Description

Props were not working on Android on Paper architecture, because they were not present in delegate. This PR fixes them.

## Test code and steps to reproduce

1. Run Example application
2. Test if all `Screen` and `ScreenStackHeaderConfig` props are working
## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
