### PR TITLE
docs: fix README-Fabric.md link, reword sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project aims to expose native navigation container components to React Nati
 
 ## Fabric
 
-To learn about how to use `react-native-screens` with Fabric architecture head over to [Fabric README](README-Fabric.md). Instructions on how to run Fabric Example within this repo can be found in the [FabricExample README](FabricExample/README.md).
+To learn about how to use `react-native-screens` with Fabric architecture, head over to [Fabric README](README-Fabric.md). Instructions on how to run Fabric Example within this repo can be found in the [FabricExample README](FabricExample/README.md).
 
 ## Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project aims to expose native navigation container components to React Nati
 
 ## Fabric
 
-To read about how to use this library with fabric go to [FABRIC README](README-Farbic.md). If you want to run Fabric Example app go to [FabricExample README](FabricExample/README.md).
+To learn about how to use `react-native-screens` with Fabric architecture head over to [Fabric README](README-Fabric.md). Instructions on how to run Fabric Example within this repo can be found in the [FabricExample README](FabricExample/README.md).
 
 ## Supported platforms
 


### PR DESCRIPTION
## Description

This PR fixes the '404 Not found' error caused by the typo in the `README-Fabric.md` url and rewords the sentences in the Fabric section. 
