### PR TITLE
fix: Ensure screen is RNSScreenView instance

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -132,6 +132,9 @@
   } else if (operation == UINavigationControllerOperationPop) {
     screen = (RNSScreenView *) fromVC.view;
   }
+  if (![screen isKindOfClass:[RNSScreenView class]]) {
+    return nil;
+  }
   if (screen != nil && (screen.stackAnimation == RNSScreenStackAnimationFade || screen.stackAnimation == RNSScreenStackAnimationNone)) {
     return  [[RNSScreenStackAnimator alloc] initWithOperation:operation];
   }
@@ -153,6 +156,10 @@
   }
   
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
+
+  if (![topScreen isKindOfClass:[RNSScreenView class]]) {
+    return NO;
+  }
 
   return _controller.viewControllers.count > 1 && topScreen.gestureEnabled;
 }

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -99,7 +99,11 @@
 
   BOOL isInFullScreenModal = nav == nil && _screenView.stackPresentation == RNSScreenStackPresentationFullScreenModal;
   // if nav is nil, it means we can be in a fullScreen modal, so there is no nextVC, but we still want to update
-  if (vc != nil && (nextVC == vc || isInFullScreenModal)) {
+  
+  BOOL isOverlaid = nextVC != nil && nextVC.modalPresentationStyle == UIModalPresentationOverCurrentContext;
+  // if nextVC doesn't equal vc because of there is overlaid view controller
+    
+  if (vc != nil && (nextVC == vc || isInFullScreenModal || isOverlaid)) {
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller
                                           withConfig:self
                                             animated:YES];


### PR DESCRIPTION
As per title. To prevent unrecognized selector instance on non RNSScreenView screen