### PR TITLE
fix: app reload on fabric on iOS

### DIFF
--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -34,7 +34,6 @@ using namespace facebook::react;
     _controller = [[UINavigationController alloc] init];
     _controller.delegate = self;
     [_controller setViewControllers:@[ [UIViewController new] ]];
-    _invalidated = NO;
   }
 
   return self;
@@ -100,14 +99,6 @@ using namespace facebook::react;
 - (NSArray<UIView *> *)reactSubviews
 {
   return _reactSubviews;
-}
-
-- (void)didMoveToWindow
-{
-  [super didMoveToWindow];
-  if (!_invalidated) {
-    [self maybeAddToParentAndUpdateContainer];
-  }
 }
 
 - (void)navigationController:(UINavigationController *)navigationController
@@ -253,18 +244,10 @@ using namespace facebook::react;
   _controller.view.frame = self.bounds;
 }
 
-- (void)invalidate
-{
-  _invalidated = YES;
-  [_controller willMoveToParentViewController:nil];
-  [_controller removeFromParentViewController];
-}
-
 - (void)dismissOnReload
 {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [self invalidate];
-  });
+  auto screenController = (RNSScreenController *)_controller.viewControllers.lastObject;
+  [screenController resetViewToScreen];
 }
 
 #pragma mark methods connected to transitioning
@@ -280,6 +263,7 @@ using namespace facebook::react;
 {
   [super prepareForRecycle];
   _reactSubviews = [NSMutableArray new];
+  [self dismissOnReload];
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider


### PR DESCRIPTION
## Description

This PR fixes a bug on Fabric architecture where an inactive screen stayed at the top of the stack after app reload.

Fixed by calling `resetViewToScreen` method in `ScreenStack's` `prepareForRecycle` method on iOS.

## Changes

- Removed `_invalidated` logic on Fabric as it is not being used
- Updated and called `dismissOnReload` to call `resetViewToScreen` method in ScreenStack on iOS

## Screenshots / GIFs


### Before


https://user-images.githubusercontent.com/39658211/155159886-ff4ff128-e1c0-4e71-8a98-5b7cc92942d0.mov



### After



https://user-images.githubusercontent.com/39658211/155159913-95e90a31-626e-464c-8e7e-55d74d593d68.mov



## Test code and steps to reproduce

FabricExample/

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
