### PR TITLE
fix: add stack nesting on Fabric

### DIFF
--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -106,6 +106,10 @@ using namespace facebook::react;
 {
   [super didMoveToWindow];
   if (!_invalidated) {
+    // We check whether the view has been invalidated before running side-effects in didMoveToWindow
+    // This is needed because when LayoutAnimations are used it is possible for view to be re-attached
+    // to a window despite the fact it has been removed from the React Native view hierarchy.
+    // See https://github.com/software-mansion/react-native-screens/pull/700
     [self maybeAddToParentAndUpdateContainer];
   }
 }

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -34,6 +34,7 @@ using namespace facebook::react;
     _controller = [[UINavigationController alloc] init];
     _controller.delegate = self;
     [_controller setViewControllers:@[ [UIViewController new] ]];
+    _invalidated = NO;
   }
 
   return self;
@@ -99,6 +100,14 @@ using namespace facebook::react;
 - (NSArray<UIView *> *)reactSubviews
 {
   return _reactSubviews;
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  if (!_invalidated) {
+    [self maybeAddToParentAndUpdateContainer];
+  }
 }
 
 - (void)navigationController:(UINavigationController *)navigationController
@@ -264,6 +273,9 @@ using namespace facebook::react;
   [super prepareForRecycle];
   _reactSubviews = [NSMutableArray new];
   [self dismissOnReload];
+  _invalidated = YES;
+  [_controller willMoveToParentViewController:nil];
+  [_controller removeFromParentViewController];
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-screens/pull/1339 removed code which on Paper architecture was responsible for handling nested stacks. As @Ubax suggested this PR adds this to `prepareForRecycle` method and reverts removal of `didMoveToWindow`.

## Test code and steps to reproduce

Run this code snippet in the `FabricExample/` project

<details>
<summary>Code snippet</summary>
<br>

```jsx
import * as React from 'react';
import {View, StyleSheet, Text} from 'react-native';
import {NavigationContainer} from '@react-navigation/native';
import {createNativeStackNavigator} from '@react-navigation/native-stack';

function First() {
  const NestedStack = createNativeStackNavigator();

  return (
    <NestedStack.Navigator>
      <NestedStack.Screen name="NestedFirst" component={NestedFirst} />
    </NestedStack.Navigator>
  );
}

function NestedFirst() {
  return (
    <View style={styles.verticalContainer}>
      <Text>Hello</Text>
    </View>
  );
}

const Stack = createNativeStackNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator>
        <Stack.Screen name="First" component={First} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

const styles = StyleSheet.create({
  wrapper: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});

```

</details>

## Screenshots / GIFs

### Before

<img src="https://user-images.githubusercontent.com/39658211/155512874-7455f81e-103e-4ca4-bdde-86264df8a931.png" width="300px"/>

### After

<img src="https://user-images.githubusercontent.com/39658211/155512851-a7a7b040-f8ed-487d-b94a-2a3a2d9d3623.png" width="300px" />


## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
