### PR TITLE
fix: apply initial navigation bar content color

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -163,8 +163,10 @@ object ScreenWindowTraits {
         val screenForNavBarColor = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_COLOR)
         val color = screenForNavBarColor?.navigationBarColor ?: window.navigationBarColor
 
-        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
-            isColorLight(color)
+        UiThreadUtil.runOnUiThread {
+            WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+                isColorLight(color)
+        }
         window.navigationBarColor = color
     }
 


### PR DESCRIPTION
## Description
Initial navigation bar content color is not applied. Actually don't know the technical reason behind it.
It works If you edit the 'navigationBarColor' value and save it to a different value while the app is open.
<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce
`Test860.tsx`.

Change `navigationBar` color to `yellow` and you will see the navigation bar content color is not applied on the first app opening.

It should set the light background to dark content, but it is setting the light background to light content.
<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
