### PR TITLE
fix: remove react-native-gradle-plugin from dependencies

### DIFF
--- a/TestsExample/.flowconfig
+++ b/TestsExample/.flowconfig
@@ -11,6 +11,8 @@ node_modules/react-native/Libraries/polyfills/.*
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/LoadingView.js
 
+.*/node_modules/resolve/test/resolver/malformed_package_json/package\.json$
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 

--- a/TestsExample/android/app/build.gradle
+++ b/TestsExample/android/app/build.gradle
@@ -238,14 +238,8 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    // If new architecture is enabled, we let you build RN from source
-    // Otherwise we fallback to a prebuilt .aar bundled in the NPM package.
-    if (isNewArchitectureEnabled()) {
-        implementation project(":ReactAndroid")
-    } else {
-        //noinspection GradleDynamicVersion
-        implementation "com.facebook.react:react-native:+"  // From node_modules
-    }
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
@@ -268,6 +262,18 @@ dependencies {
         releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
+    }
+}
+
+if (isNewArchitectureEnabled()) {
+    // If new architecture is enabled, we let you build RN from source
+    // Otherwise we fallback to a prebuilt .aar bundled in the NPM package.
+    // This will be applied to all the imported transtitive dependency.
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("com.facebook.react:react-native"))
+                    .using(project(":ReactAndroid")).because("On New Architecture we're building React Native from source")
+        }
     }
 }
 

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.0-rc.1)
-  - FBReactNativeSpec (0.68.0-rc.1):
+  - FBLazyVector (0.68.0-rc.2)
+  - FBReactNativeSpec (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.0-rc.1)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Core (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
+    - RCTRequired (= 0.68.0-rc.2)
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Core (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -86,201 +86,201 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.0-rc.1)
-  - RCTTypeSafety (0.68.0-rc.1):
-    - FBLazyVector (= 0.68.0-rc.1)
+  - RCTRequired (0.68.0-rc.2)
+  - RCTTypeSafety (0.68.0-rc.2):
+    - FBLazyVector (= 0.68.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.0-rc.1)
-    - React-Core (= 0.68.0-rc.1)
-  - React (0.68.0-rc.1):
-    - React-Core (= 0.68.0-rc.1)
-    - React-Core/DevSupport (= 0.68.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.68.0-rc.1)
-    - React-RCTActionSheet (= 0.68.0-rc.1)
-    - React-RCTAnimation (= 0.68.0-rc.1)
-    - React-RCTBlob (= 0.68.0-rc.1)
-    - React-RCTImage (= 0.68.0-rc.1)
-    - React-RCTLinking (= 0.68.0-rc.1)
-    - React-RCTNetwork (= 0.68.0-rc.1)
-    - React-RCTSettings (= 0.68.0-rc.1)
-    - React-RCTText (= 0.68.0-rc.1)
-    - React-RCTVibration (= 0.68.0-rc.1)
-  - React-callinvoker (0.68.0-rc.1)
-  - React-Codegen (0.68.0-rc.1):
-    - FBReactNativeSpec (= 0.68.0-rc.1)
+    - RCTRequired (= 0.68.0-rc.2)
+    - React-Core (= 0.68.0-rc.2)
+  - React (0.68.0-rc.2):
+    - React-Core (= 0.68.0-rc.2)
+    - React-Core/DevSupport (= 0.68.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.68.0-rc.2)
+    - React-RCTActionSheet (= 0.68.0-rc.2)
+    - React-RCTAnimation (= 0.68.0-rc.2)
+    - React-RCTBlob (= 0.68.0-rc.2)
+    - React-RCTImage (= 0.68.0-rc.2)
+    - React-RCTLinking (= 0.68.0-rc.2)
+    - React-RCTNetwork (= 0.68.0-rc.2)
+    - React-RCTSettings (= 0.68.0-rc.2)
+    - React-RCTText (= 0.68.0-rc.2)
+    - React-RCTVibration (= 0.68.0-rc.2)
+  - React-callinvoker (0.68.0-rc.2)
+  - React-Codegen (0.68.0-rc.2):
+    - FBReactNativeSpec (= 0.68.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.0-rc.1)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Core (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-Core (0.68.0-rc.1):
+    - RCTRequired (= 0.68.0-rc.2)
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Core (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-Core (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.0-rc.1)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-Core/Default (= 0.68.0-rc.2)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.0-rc.1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
-    - Yoga
-  - React-Core/Default (0.68.0-rc.1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
-    - Yoga
-  - React-Core/DevSupport (0.68.0-rc.1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.68.0-rc.1)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-jsinspector (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.0-rc.1):
+  - React-Core/CoreModulesHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.0-rc.1):
+  - React-Core/Default (0.68.0-rc.2):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
+    - Yoga
+  - React-Core/DevSupport (0.68.0-rc.2):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.68.0-rc.2)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-jsinspector (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.0-rc.1):
+  - React-Core/RCTAnimationHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.0-rc.1):
+  - React-Core/RCTBlobHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.0-rc.1):
+  - React-Core/RCTImageHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.0-rc.1):
+  - React-Core/RCTLinkingHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.0-rc.1):
+  - React-Core/RCTNetworkHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.0-rc.1):
+  - React-Core/RCTSettingsHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.0-rc.1):
+  - React-Core/RCTTextHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.0-rc.1):
+  - React-Core/RCTVibrationHeaders (0.68.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.0-rc.1)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsiexecutor (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
     - Yoga
-  - React-CoreModules (0.68.0-rc.1):
+  - React-Core/RCTWebSocket (0.68.0-rc.2):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/CoreModulesHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-RCTImage (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-cxxreact (0.68.0-rc.1):
+    - React-Core/Default (= 0.68.0-rc.2)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsiexecutor (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
+    - Yoga
+  - React-CoreModules (0.68.0-rc.2):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-RCTImage (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-cxxreact (0.68.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-jsinspector (= 0.68.0-rc.1)
-    - React-logger (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
-    - React-runtimeexecutor (= 0.68.0-rc.1)
-  - React-jsi (0.68.0-rc.1):
+    - React-callinvoker (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-jsinspector (= 0.68.0-rc.2)
+    - React-logger (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
+    - React-runtimeexecutor (= 0.68.0-rc.2)
+  - React-jsi (0.68.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.0-rc.1)
-  - React-jsi/Default (0.68.0-rc.1):
+    - React-jsi/Default (= 0.68.0-rc.2)
+  - React-jsi/Default (0.68.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.0-rc.1):
+  - React-jsiexecutor (0.68.0-rc.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
-  - React-jsinspector (0.68.0-rc.1)
-  - React-logger (0.68.0-rc.1):
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
+  - React-jsinspector (0.68.0-rc.2)
+  - React-logger (0.68.0-rc.2):
     - glog
   - react-native-safe-area-context (4.0.1-rc.5):
     - RCT-Folly
@@ -288,71 +288,71 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.68.0-rc.1)
-  - React-RCTActionSheet (0.68.0-rc.1):
-    - React-Core/RCTActionSheetHeaders (= 0.68.0-rc.1)
-  - React-RCTAnimation (0.68.0-rc.1):
+  - React-perflogger (0.68.0-rc.2)
+  - React-RCTActionSheet (0.68.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.68.0-rc.2)
+  - React-RCTAnimation (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTAnimationHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTBlob (0.68.0-rc.1):
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTAnimationHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTBlob (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTBlobHeaders (= 0.68.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-RCTNetwork (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTImage (0.68.0-rc.1):
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTBlobHeaders (= 0.68.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-RCTNetwork (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTImage (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTImageHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-RCTNetwork (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTLinking (0.68.0-rc.1):
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTLinkingHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTNetwork (0.68.0-rc.1):
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTImageHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-RCTNetwork (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTLinking (0.68.0-rc.2):
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTLinkingHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTNetwork (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTNetworkHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTSettings (0.68.0-rc.1):
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTNetworkHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTSettings (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.0-rc.1)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTSettingsHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-RCTText (0.68.0-rc.1):
-    - React-Core/RCTTextHeaders (= 0.68.0-rc.1)
-  - React-RCTVibration (0.68.0-rc.1):
+    - RCTTypeSafety (= 0.68.0-rc.2)
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTSettingsHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-RCTText (0.68.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.68.0-rc.2)
+  - React-RCTVibration (0.68.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.0-rc.1)
-    - React-Core/RCTVibrationHeaders (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.68.0-rc.1)
-  - React-runtimeexecutor (0.68.0-rc.1):
-    - React-jsi (= 0.68.0-rc.1)
-  - ReactCommon/turbomodule/core (0.68.0-rc.1):
+    - React-Codegen (= 0.68.0-rc.2)
+    - React-Core/RCTVibrationHeaders (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.2)
+  - React-runtimeexecutor (0.68.0-rc.2):
+    - React-jsi (= 0.68.0-rc.2)
+  - ReactCommon/turbomodule/core (0.68.0-rc.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.0-rc.1)
-    - React-Core (= 0.68.0-rc.1)
-    - React-cxxreact (= 0.68.0-rc.1)
-    - React-jsi (= 0.68.0-rc.1)
-    - React-logger (= 0.68.0-rc.1)
-    - React-perflogger (= 0.68.0-rc.1)
+    - React-callinvoker (= 0.68.0-rc.2)
+    - React-Core (= 0.68.0-rc.2)
+    - React-cxxreact (= 0.68.0-rc.2)
+    - React-jsi (= 0.68.0-rc.2)
+    - React-logger (= 0.68.0-rc.2)
+    - React-perflogger (= 0.68.0-rc.2)
   - RNGestureHandler (2.2.0):
     - React-Core
   - RNReanimated (2.4.1):
@@ -546,8 +546,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: bcdeff523be9f87a135b7c6fde8736db94904716
-  FBReactNativeSpec: 3956395215fb59fb220d296cf4fb1a691cb72479
+  FBLazyVector: 07eb8bb0d56ecb0c16f771d81f0f25008bc403b5
+  FBReactNativeSpec: c62f65a739e96e76f4a0fd2f1fbf412e1faf84d5
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -562,36 +562,36 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
-  RCTRequired: 1e4605513e7b6a2871bdb8ae5b162b239ad18602
-  RCTTypeSafety: 0ed8525a159a736981e1aa308e729d83f2fb6926
-  React: 18162465d3219d93792c31f00bfdc0e27a1f8139
-  React-callinvoker: b1d4cc424aa081534368c71c406b186221fe44bb
-  React-Codegen: 11d7a6c69225d46505e3dccaf13a8bf75b43f624
-  React-Core: 71bd283ea2f85047fda4baedf6934fd2f3571cee
-  React-CoreModules: cfbf73b878d68f53604365b395957dd2e36ed0ab
-  React-cxxreact: 9f09977545dfb3723528973a1dda5e5f2f915aec
-  React-jsi: 7eb40a56fc0b6752532366ef88f13b5f86f90178
-  React-jsiexecutor: b95fc3494e76e7a5832c4386978c3ada3d1e2bed
-  React-jsinspector: dc394b84375f124b823720b59e322113d85f23b4
-  React-logger: c208f7a035008b696c43c94dde8b4c53b30534af
+  RCTRequired: 180eaa134050e3315986c2ae145f3674be78ae3e
+  RCTTypeSafety: 91d830366397fae0974496104cedce043279045d
+  React: f6ee8a53d6212d8939ce92a537cb4b179dc01109
+  React-callinvoker: 62fc4e32f979e20a321d60e37c792b70c210244b
+  React-Codegen: d1c1b8d5ae78b10e01b93be321bf3760e0bbe925
+  React-Core: d894f74339f2c56bf2d4e87c20f135b34803d676
+  React-CoreModules: 89cdf26ecff5d019f5e73c2cb750abc9f2657c87
+  React-cxxreact: f7bad9461a1570a1871b9f2b3276ccd989253562
+  React-jsi: ef80f544ee1c0b9d7d29b33963520fafd9992fa9
+  React-jsiexecutor: 352a2d26dd981cf2586e144196ae0972fd7ee0d0
+  React-jsinspector: f5ae77343a320a7d644b424ab4808c7827f3a1b3
+  React-logger: 2fa2f7404a8f41ed2c787e1bb84d13343f2997cf
   react-native-safe-area-context: 44537ac9078b2e1e23fef0079cd70fbbf46f1f4c
-  React-perflogger: 93144f240a4f95e1698dc054a1ef8b18ca80a64f
-  React-RCTActionSheet: e63525d962fdc663ddca3a2b83012a905055e777
-  React-RCTAnimation: 3b827fbfad9a873f66ca80542e036ca42f92f578
-  React-RCTBlob: 797720d926a7c40900e6639edeb5b53bce8e98bb
-  React-RCTImage: 08148cbb7e09cabef720f828979d9ab244867c3e
-  React-RCTLinking: 7c1df1a1cf524f271202e72be019a5b4c79478a0
-  React-RCTNetwork: c9c78bea7914a937889568b16d202f84fe04570b
-  React-RCTSettings: 3c912118a14deb628595263246c33718581c4f4f
-  React-RCTText: c76aaedce74fdebc24bd3d8f9df2e05987a97a35
-  React-RCTVibration: 5cab6419b68d5750482b0fc34dbb27af550469cc
-  React-runtimeexecutor: 10cda3a396b14a764a5f86088e7e3810b9c66cec
-  ReactCommon: 73a01eb83f22c84a6b09dfb60f3463888ebd4975
+  React-perflogger: 3bf9ae62c5bff7308a3886ab4e51f4420bfa16c0
+  React-RCTActionSheet: d056d06abe9e0a7c59a6dbd6103a323417bdc901
+  React-RCTAnimation: 34339473f0ebaf7b183a2344a1fe6a18da6162a8
+  React-RCTBlob: 08c8d788b269ff3ea1df236a33b91d1cfaed0f0d
+  React-RCTImage: a4d41a79b2a1cbfdbf779907f803f57ebbb85af1
+  React-RCTLinking: a98387924d98d68e686ebaa539bf0523ebb3d61c
+  React-RCTNetwork: dc08d04b3f49c42fcc6d56c869fd98542945d48a
+  React-RCTSettings: 45a6f0a9a45eb0f1f0272c359af8ce6957b6eb10
+  React-RCTText: b88155b89ba6fb2d4e21d17dce575d0fc206a7b1
+  React-RCTVibration: 25ef5d6f6141ea389d41d93d5a2ca1b4771920b4
+  React-runtimeexecutor: 37e5fa0b81067a8e487391e2816bae8813b226a5
+  ReactCommon: 4c7431a20d472996669b2230f34df0115bf5dc8d
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
   RNReanimated: 3d1432ce7b6b7fc31f375dcabe5b4585e0634a43
   RNScreens: 2559f98b0835103cbef3b26ba77fa61d4bb37ae7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: d29dba374c1a582b40cfb736647b5e1b5ed35dba
+  Yoga: d7b12009fb66b91a161cddf00c349d42a0015de2
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 54439993ba279e900534ada11d49259eaead9508

--- a/TestsExample/package.json
+++ b/TestsExample/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/stack": "^5.14.9",
     "nanoid": "^3.2.0",
     "react": "17.0.2",
-    "react-native": "0.68.0-rc.1",
+    "react-native": "0.68.0-rc.2",
     "react-native-gesture-handler": "^2.2.0",
     "react-native-reanimated": "^2.4.1",
     "react-native-safe-area-context": "^4.0.1-rc.5",
@@ -37,14 +37,10 @@
     "eslint": "^7.32.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.67.0",
-    "react-native-gradle-plugin": "^0.0.4",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.5.5"
   },
   "jest": {
     "preset": "react-native"
-  },
-  "codegenConfig": {
-    "libraries": []
   }
 }

--- a/TestsExample/yarn.lock
+++ b/TestsExample/yarn.lock
@@ -1043,55 +1043,39 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@react-native-community/cli-config@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-7.0.1.tgz#81bf88a5c0eb21c9b0fc1f825372699c375a45a0"
-  integrity sha512-HGBnytnZzcT+24qAshksGpmPAXFPsKL6g9FNU7TIM9s23Hl4SXqNVEf6wj6XHXKgg8pfjXK3Lwf9IBEnZzqA/g==
-  dependencies:
-    "@react-native-community/cli-tools" "^7.0.1"
-    cosmiconfig "^5.1.0"
-    deepmerge "^3.2.0"
-    glob "^7.1.3"
-    joi "^17.2.1"
-
-"@react-native-community/cli-debugger-ui@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-7.0.1.tgz#2834617ee57802559c20a0a75ad7eeeef73ff422"
-  integrity sha512-N4ASQY5VbRiiyhfAWhvURavANtFd7JPJFpXd59hsZxvaFEDB2L2HhVkwbw6BSbVUrYDuAWFQGx3S10L+MCHAjQ==
+"@react-native-community/cli-debugger-ui@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-7.0.3.tgz#3eeeacc5a43513cbcae56e5e965d77726361bcb4"
+  integrity sha512-G4SA6jFI0j22o+j+kYP8/7sxzbCDqSp2QiHA/X5E0lsGEd2o9qN2zbIjiFr8b8k+VVAYSUONhoC0+uKuINvmkA==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-7.0.1.tgz#36ba3da91a358b0c38fd199782db2d857fee16d0"
-  integrity sha512-y5RBAuBiOwiiFfj9N/iuj6PZ3c5j68LE8XTQdhZJE+qTuSxWXQrdpFwL9Nc9KIk3bBxC72uBfRFGxa/mLZGYMw==
+"@react-native-community/cli-hermes@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-6.3.0.tgz#92b2f07d08626a60f6893c3e3d57c1538c8fb5a7"
+  integrity sha512-Uhbm9bubyZLZ12vFCIfWbE/Qi3SBTbYIN/TC08EudTLhv/KbPomCQnmFsnJ7AXQFuOZJs73mBxoEAYSbRbwyVA==
   dependencies:
-    "@react-native-community/cli-config" "^7.0.1"
-    "@react-native-community/cli-tools" "^7.0.1"
-    chalk "^3.0.0"
-    command-exists "^1.2.8"
-    envinfo "^7.7.2"
-    execa "^1.0.0"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
-    node-stream-zip "^1.9.1"
-    ora "^5.4.1"
-    prompts "^2.4.0"
-    semver "^6.3.0"
-    strip-ansi "^5.2.0"
-    sudo-prompt "^9.0.0"
-    wcwidth "^1.0.1"
-
-"@react-native-community/cli-hermes@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-7.0.1.tgz#d6229bfc6da9ee2fd71a5e4ef86e92a4690bde79"
-  integrity sha512-NzKxW8LzNr3ttD5E479HCpSLfcpdv0SwpsIBsDCWhuDmGW5NXo8Qdu5/plVWZJ1CVBWkVFeVHIlKs0pov7GlOw==
-  dependencies:
-    "@react-native-community/cli-platform-android" "^7.0.1"
-    "@react-native-community/cli-tools" "^7.0.1"
+    "@react-native-community/cli-platform-android" "^6.3.0"
+    "@react-native-community/cli-tools" "^6.2.0"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
+
+"@react-native-community/cli-platform-android@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-6.3.0.tgz#ab7d156bd69a392493323eeaba839a874c0e201f"
+  integrity sha512-d5ufyYcvrZoHznYm5bjBXaiHIJv552t5gYtQpnUsxBhHSQ8QlaNmlLUyeSPRDfOw4ND9b0tPHqs4ufwx6vp/fQ==
+  dependencies:
+    "@react-native-community/cli-tools" "^6.2.0"
+    chalk "^4.1.2"
+    execa "^1.0.0"
+    fs-extra "^8.1.0"
+    glob "^7.1.3"
+    jetifier "^1.6.2"
+    lodash "^4.17.15"
+    logkitty "^0.7.1"
+    slash "^3.0.0"
+    xmldoc "^1.1.2"
 
 "@react-native-community/cli-platform-android@^7.0.1":
   version "7.0.1"
@@ -1124,13 +1108,13 @@
     plist "^3.0.2"
     xcode "^3.0.0"
 
-"@react-native-community/cli-plugin-metro@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-7.0.1.tgz#c7a04651fe96dbb4d0534cd9efef1b044d899dfa"
-  integrity sha512-kM6vN5/38e9ldl30fUSVEB1sdB3a9W11N/HdU+7I3ujWsPdqu6DRiAaUV/L6y6az/QFBHKwAK0EZvROhY7G0vA==
+"@react-native-community/cli-plugin-metro@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-7.0.3.tgz#b381ed2f68a0b126e4fa238f1956a44846e1ef8a"
+  integrity sha512-HJrEkFbxv9DNixsGwO+Q0zCcZMghDltyzeB9yQ//D5ZR4ZUEuAIPrRDdEp9xVw0WkBxAIZs6KXLux2/yPMwLhA==
   dependencies:
-    "@react-native-community/cli-server-api" "^7.0.1"
-    "@react-native-community/cli-tools" "^7.0.1"
+    "@react-native-community/cli-server-api" "^7.0.3"
+    "@react-native-community/cli-tools" "^6.2.0"
     chalk "^4.1.2"
     metro "^0.67.0"
     metro-config "^0.67.0"
@@ -1140,20 +1124,34 @@
     metro-runtime "^0.67.0"
     readline "^1.3.0"
 
-"@react-native-community/cli-server-api@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-7.0.1.tgz#8fde9d615cf2cb296d0bed2933cf38d36af6f539"
-  integrity sha512-kquJcQ2PcrwYmbHakOxFsNIylM1tZM/+n7Wgy65dXMafA0cpEPDsOEdRHx2wfsqIavoxNLMliCu3NX5HM9DP2Q==
+"@react-native-community/cli-server-api@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-7.0.3.tgz#ba9695a2fdfef22750d141153efd94baf641129b"
+  integrity sha512-JDrLsrkBgNxbG2u3fouoVGL9tKrXUrTsaNwr+oCV+3XyMwbVe42r/OaQ681/iW/7mHXjuVkDnMcp7BMg7e2yJg==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "^7.0.1"
-    "@react-native-community/cli-tools" "^7.0.1"
+    "@react-native-community/cli-debugger-ui" "^7.0.3"
+    "@react-native-community/cli-tools" "^6.2.0"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.0"
-    nocache "^3.0.1"
+    nocache "^2.1.0"
     pretty-format "^26.6.2"
     serve-static "^1.13.1"
-    ws "^1.1.0"
+    ws "^7.5.1"
+
+"@react-native-community/cli-tools@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz#8f4adc2d83ab96e5654348533c8fa602742c4fce"
+  integrity sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==
+  dependencies:
+    appdirsjs "^1.2.4"
+    chalk "^4.1.2"
+    lodash "^4.17.15"
+    mime "^2.4.1"
+    node-fetch "^2.6.0"
+    open "^6.2.0"
+    semver "^6.3.0"
+    shell-quote "1.6.1"
 
 "@react-native-community/cli-tools@^7.0.1":
   version "7.0.1"
@@ -1170,35 +1168,49 @@
     semver "^6.3.0"
     shell-quote "^1.7.3"
 
-"@react-native-community/cli-types@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-7.0.1.tgz#c3de43d45866804c5c15251a014402da5853b7b1"
-  integrity sha512-8QedX5vagXoKFLzoyAEGeg2aOzNghjoXFP0Tm6LszdnFuNee03DLkGP7cKCEY+gtuhXLhdfd6XmK+ROgWqBEMQ==
-
-"@react-native-community/cli@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-7.0.1.tgz#6ece01540b855e0c5f1d24db43cb4c48854301c7"
-  integrity sha512-FjF+jszHNcmfzKvZ6Y9cp6jAuigc+JvyKmgtB5syj2nkjKNUMLY7gFkFV6ULAzLrg+IasMIImVSkN39+L1Pa9g==
+"@react-native-community/cli-types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-6.0.0.tgz#90269fbdc7229d5e3b8f2f3e029a94083551040d"
+  integrity sha512-K493Fk2DMJC0ZM8s8gnfseKxGasIhuDaCUDeLZcoCSFlrjKEuEs1BKKEJiev0CARhKEXKOyyp/uqYM9nWhisNw==
   dependencies:
-    "@react-native-community/cli-config" "^7.0.1"
-    "@react-native-community/cli-debugger-ui" "^7.0.1"
-    "@react-native-community/cli-doctor" "^7.0.1"
-    "@react-native-community/cli-hermes" "^7.0.1"
-    "@react-native-community/cli-plugin-metro" "^7.0.1"
-    "@react-native-community/cli-server-api" "^7.0.1"
-    "@react-native-community/cli-tools" "^7.0.1"
-    "@react-native-community/cli-types" "^7.0.1"
+    ora "^3.4.0"
+
+"@react-native-community/cli@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-7.0.3.tgz#1addb462d71786fcbbd266fbceb41819b8cf7839"
+  integrity sha512-WyJOA829KAhU1pw2MDQt0YhOS9kyR2KqyqgJyTuQhzFVCBPX4F5aDEkZYYn4jdldaDHCPrLJ3ho3gxYTXy+x7w==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "^7.0.3"
+    "@react-native-community/cli-hermes" "^6.3.0"
+    "@react-native-community/cli-plugin-metro" "^7.0.3"
+    "@react-native-community/cli-server-api" "^7.0.3"
+    "@react-native-community/cli-tools" "^6.2.0"
+    "@react-native-community/cli-types" "^6.0.0"
+    appdirsjs "^1.2.4"
     chalk "^4.1.2"
+    command-exists "^1.2.8"
     commander "^2.19.0"
+    cosmiconfig "^5.1.0"
+    deepmerge "^3.2.0"
+    envinfo "^7.7.2"
     execa "^1.0.0"
     find-up "^4.1.0"
     fs-extra "^8.1.0"
+    glob "^7.1.3"
     graceful-fs "^4.1.3"
+    joi "^17.2.1"
     leven "^3.1.0"
     lodash "^4.17.15"
     minimist "^1.2.0"
+    node-stream-zip "^1.9.1"
+    ora "^3.4.0"
+    pretty-format "^26.6.2"
     prompts "^2.4.0"
     semver "^6.3.0"
+    serve-static "^1.13.1"
+    strip-ansi "^5.2.0"
+    sudo-prompt "^9.0.0"
+    wcwidth "^1.0.1"
 
 "@react-native-community/eslint-config@^2.0.0":
   version "2.0.0"
@@ -1741,6 +1753,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+  integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
+
 array-includes@^3.1.3, array-includes@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
@@ -1751,6 +1768,16 @@ array-includes@^3.1.3, array-includes@^3.1.4:
     es-abstract "^1.19.1"
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
+
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+  integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
+  integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -2154,7 +2181,7 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2162,14 +2189,6 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
@@ -2209,6 +2228,13 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -2216,7 +2242,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-spinners@^2.5.0:
+cli-spinners@^2.0.0, cli-spinners@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
@@ -4486,6 +4512,11 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
@@ -4600,6 +4631,13 @@ lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -4971,6 +5009,11 @@ mime@^2.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -5065,10 +5108,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nocache@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/nocache/-/nocache-3.0.1.tgz#54d8b53a7e0a0aa1a288cfceab8a3cefbcde67d4"
-  integrity sha512-Gh39xwJwBKy0OvFmWfBs/vDO4Nl7JhnJtkqNP76OUinQz7BiMoszHYrIDHHAaqVl/QKVxCEy4ZxC/XZninu7nQ==
+nocache@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
+  integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
 
 node-dir@^0.1.17:
   version "0.1.17"
@@ -5264,6 +5307,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
+
 onetime@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
@@ -5302,10 +5352,17 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-options@>=0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
-  integrity sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=
+ora@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
+  dependencies:
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-spinners "^2.0.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
 
 ora@^5.4.1:
   version "5.4.1"
@@ -5639,17 +5696,10 @@ react-native-gesture-handler@^2.2.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
-react-native-gradle-plugin@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.3.tgz#6a51edfcff6a37b9de7bc1deea51fc53eff5de76"
-  integrity sha512-mvkntuCKpKL26XV54XVBGt2hJWGh6IJc5rjOEXQ/9jd9FNhsbRnqdOjI8XMy1gLvK2X8xwbbpEym+QKunV658g==
-  dependencies:
-    react-native-codegen "*"
-
-react-native-gradle-plugin@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.4.tgz#47adcc4f1e1f2c1558811ad78ad39546007d8667"
-  integrity sha512-D0lFhHy9uSkiPKsGEdEoFtN/jCjS70OxxzBXfq0s9J3ie8GXRBEDHsZuuX/enfRq5fvbCnhKjuYezf+DVYTNnw==
+react-native-gradle-plugin@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.5.tgz#1f20d437b140eda65b6e3bdf6eb102bbab1a5a10"
+  integrity sha512-kGupXo+pD2mB6Z+Oyowor3qlCroiS32FNGoiGQdwU19u8o+NNhEZKwoKfC5Qt03bMZSmFlcAlTyf79vrS2BZKQ==
   dependencies:
     react-native-codegen "*"
 
@@ -5695,13 +5745,13 @@ react-native-screens@^3.4.0:
   version "0.0.0"
   uid ""
 
-react-native@0.68.0-rc.1:
-  version "0.68.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.0-rc.1.tgz#30001533b4126fe4c29a9fb2f63b459769878dbc"
-  integrity sha512-8y7QZTwLrxl4WUoDCS78ttY17YgM46PjciQQIJK31sw7huFXLM6J9r4KhMc3cs97c+ZlI23KvLaExfEKy5KK5Q==
+react-native@0.68.0-rc.2:
+  version "0.68.0-rc.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.0-rc.2.tgz#6b826810355e70193fcc3a4f4c862767e5c2cce2"
+  integrity sha512-PdaPs+g5DCZdWTFScZ42nv6m+iTvLSo34efxDiWBwrkU7kr6M9WjNSnPhd07KAOxHWBOQKZgV0UwwlN2ugvqtw==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
-    "@react-native-community/cli" "^7.0.1"
+    "@react-native-community/cli" "^7.0.3"
     "@react-native-community/cli-platform-android" "^7.0.1"
     "@react-native-community/cli-platform-ios" "^7.0.1"
     "@react-native/assets" "1.0.0"
@@ -5723,6 +5773,7 @@ react-native@0.68.0-rc.1:
     promise "^8.0.3"
     react-devtools-core "^4.23.0"
     react-native-codegen "^0.0.13"
+    react-native-gradle-plugin "^0.0.5"
     react-refresh "^0.4.0"
     react-shallow-renderer "16.14.1"
     regenerator-runtime "^0.13.2"
@@ -5978,6 +6029,14 @@ resolve@^2.0.0-next.3:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -6185,6 +6244,16 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
 
 shell-quote@^1.6.1, shell-quote@^1.7.3:
   version "1.7.3"
@@ -6762,11 +6831,6 @@ uglify-es@^3.1.9:
     commander "~2.13.0"
     source-map "~0.6.1"
 
-ultron@1.0.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
-  integrity sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=
-
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -7053,14 +7117,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-ws@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
-  integrity sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
 
 ws@^6.1.4:
   version "6.2.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "homepage": "https://github.com/software-mansion/react-native-screens#readme",
   "dependencies": {
     "react-freeze": "^1.0.0",
-    "react-native-gradle-plugin": "^0.0.3",
     "warn-once": "^0.1.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9434,15 +9434,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-codegen@*:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.12.tgz#390712551e29f00cc9963e93fb4b6458b64dcf04"
-  integrity sha512-o0zsGR2vjG2o4heEpr5JBl03I73PhT7jvzdNRewu43aXvc6M5kXICv+0ccJlP7dHjgcgkKqM/CuHqpV9gDc+Tw==
-  dependencies:
-    flow-parser "^0.121.0"
-    jscodeshift "^0.11.0"
-    nullthrows "^1.1.1"
-
 react-native-codegen@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.6.tgz#b3173faa879cf71bfade8d030f9c4698388f6909"
@@ -9451,13 +9442,6 @@ react-native-codegen@^0.0.6:
     flow-parser "^0.121.0"
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
-
-react-native-gradle-plugin@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.3.tgz#6a51edfcff6a37b9de7bc1deea51fc53eff5de76"
-  integrity sha512-mvkntuCKpKL26XV54XVBGt2hJWGh6IJc5rjOEXQ/9jd9FNhsbRnqdOjI8XMy1gLvK2X8xwbbpEym+QKunV658g==
-  dependencies:
-    react-native-codegen "*"
 
 react-native-iphone-x-helper@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## Description

This PR fixes ` react-native-screens` crash on the newest `react-native` release candidate - `0.68-rc2` which was caused by the presence of `react-native-gradle-plugin` in the Screens dependencies. This caused two separate versions of the lib to be installed in the project.

Thanks to @tido64 for pinpointing the solution 🙌 

Also, this PR [bumps react-native to `0.68.0-rc2`](https://react-native-community.github.io/upgrade-helper/?from=0.68.0-rc.1&to=0.68.0-rc.2) in TestsExample/ in order to test this change. 

Fixes https://github.com/software-mansion/react-native-screens/issues/1345

## Test code and steps to reproduce

In `TestsExample/`, `Example/` and `FabricExample` project run:

```
cd android/ && ./gradlew assembleDebug
```

Remember to clean cache (and probably delete `node_modules` folder)!

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
