### PR TITLE
fix: wrap Screen component with React.forwardRef on Fabric

### DIFF
--- a/src/fabric/Screen.js
+++ b/src/fabric/Screen.js
@@ -1,12 +1,15 @@
-import * as React from 'react';
+import React from 'react';
 import ScreenNativeComponent from './ScreenNativeComponent';
 import { StyleSheet } from 'react-native';
 
-export default function Screen(props) {
+function Screen(props, ref) {
   return (
     <ScreenNativeComponent
+      ref={ref}
       {...props}
       style={[props.style, StyleSheet.absoluteFill]}
     />
   );
 }
+
+export default React.forwardRef(Screen);

--- a/src/fabric/ScreenStack.js
+++ b/src/fabric/ScreenStack.js
@@ -1,8 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import ScreenStackNativeComponent from './ScreenStackNativeComponent';
 
-export default function ScreenStack(props) {
+function ScreenStack(props) {
   return (
     <ScreenStackNativeComponent {...props} style={[{ flex: 1 }, props.style]} />
   );
 }
+
+export default ScreenStack;

--- a/src/fabric/ScreenStackHeaderSubview.js
+++ b/src/fabric/ScreenStackHeaderSubview.js
@@ -13,8 +13,10 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function ScreenStackHeaderSubview(props) {
+function ScreenStackHeaderSubview(props) {
   return (
     <NativeScreenStackHeaderSubview {...props} style={styles.headerSubview} />
   );
 }
+
+export default ScreenStackHeaderSubview;


### PR DESCRIPTION
## Description

This PR fixes `Warning: Function components cannot be given refs. Attempts to access this ref will fail` warning by wrapping Screen component in `src/fabric` with React.forwardRef.

The warning is caused by the use of refs in the Screen component in `index.native.tsx` [here](https://github.com/software-mansion/react-native-screens/blob/main/src/index.native.tsx#L217).

Also, this PR unifies import/export statements in JS components used on Fabric.

Fixes https://github.com/software-mansion/react-native-screens/issues/1347

## Screenshots

### Before

![Screenshot 2022-03-02 at 12 19 47](https://user-images.githubusercontent.com/39658211/156352382-06cde446-885a-4ff3-9c64-9cc43964ecb6.png)

### After

![Screenshot 2022-03-02 at 12 10 24](https://user-images.githubusercontent.com/39658211/156352666-e0c1bbdf-db97-407f-ac9a-ff79ffa26bcc.png)



## Test code and steps to reproduce

Run `FabricExample/` project 

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
