### PR TITLE
fix: iOS Fabric snapshotting mechanism

### DIFF
--- a/ios/RNSScreenComponentView.mm
+++ b/ios/RNSScreenComponentView.mm
@@ -1,5 +1,4 @@
 #import "RNSScreenComponentView.h"
-#import <UIKit/UIKit.h>
 #import "RNSScreenStackHeaderConfigComponentView.h"
 
 #import <React/RCTConversions.h>

--- a/ios/RNSScreenComponentView.mm
+++ b/ios/RNSScreenComponentView.mm
@@ -63,6 +63,11 @@ using namespace facebook::react;
   return _reactSuperview;
 }
 
+- (UIViewController *)reactViewController
+{
+  return _controller;
+}
+
 - (void)notifyWillAppear
 {
   // If screen is already unmounted then there will be no event emitter

--- a/ios/RNSScreenComponentView.mm
+++ b/ios/RNSScreenComponentView.mm
@@ -1,8 +1,8 @@
 #import "RNSScreenComponentView.h"
+#import <UIKit/UIKit.h>
 #import "RNSScreenStackHeaderConfigComponentView.h"
 
 #import <React/RCTConversions.h>
-#import <React/RCTMountingTransactionObserving.h>
 
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -13,7 +13,7 @@
 
 using namespace facebook::react;
 
-@interface RNSScreenComponentView () <RCTRNSScreenViewProtocol, RCTMountingTransactionObserving>
+@interface RNSScreenComponentView () <RCTRNSScreenViewProtocol>
 @end
 
 @implementation RNSScreenComponentView {
@@ -43,7 +43,6 @@ using namespace facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [self.controller setViewToSnapshot];
   if ([childComponentView isKindOfClass:[RNSScreenStackHeaderConfigComponentView class]]) {
     _config = nil;
   }
@@ -53,8 +52,7 @@ using namespace facebook::react;
 - (void)updateBounds
 {
   if (_state != nullptr) {
-    auto boundsSize = self.bounds.size;
-    auto newState = RNSScreenState{RCTSizeFromCGSize(boundsSize)};
+    auto newState = RNSScreenState{RCTSizeFromCGSize(self.bounds.size)};
     _state->updateState(std::move(newState));
     UINavigationController *navctr = _controller.navigationController;
     [navctr.view setNeedsLayout];
@@ -113,13 +111,6 @@ using namespace facebook::react;
     std::dynamic_pointer_cast<const RNSScreenEventEmitter>(_eventEmitter)
         ->onDisappear(RNSScreenEventEmitter::OnDisappear{});
   }
-}
-
-#pragma mark - RCTMountingTransactionObserving
-
-- (void)mountingTransactionWillMountWithMetadata:(MountingTransactionMetadata const &)metadata
-{
-  [self.controller takeSnapshot];
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/RNSScreenController.h
+++ b/ios/RNSScreenController.h
@@ -3,8 +3,7 @@
 @interface RNSScreenController : UIViewController
 
 - (instancetype)initWithView:(UIView *)view;
-- (void)takeSnapshot;
-- (void)setViewToSnapshot;
+- (void)setViewToSnapshot:(UIView *)snapshot;
 - (void)resetViewToScreen;
 
 @end

--- a/ios/RNSScreenController.h
+++ b/ios/RNSScreenController.h
@@ -4,6 +4,7 @@
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)setViewToSnapshot:(UIView *)snapshot;
+
 - (void)resetViewToScreen;
 
 @end

--- a/ios/RNSScreenController.h
+++ b/ios/RNSScreenController.h
@@ -4,7 +4,6 @@
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)setViewToSnapshot:(UIView *)snapshot;
-
 - (void)resetViewToScreen;
 
 @end

--- a/ios/RNSScreenController.mm
+++ b/ios/RNSScreenController.mm
@@ -2,9 +2,7 @@
 #import "RNSScreenComponentView.h"
 
 @implementation RNSScreenController {
-  CGRect _lastViewFrame;
   RNSScreenComponentView *_initialView;
-  UIView *_snapshot;
 }
 
 - (instancetype)initWithView:(UIView *)view
@@ -20,15 +18,10 @@
   return self;
 }
 
-- (void)takeSnapshot
-{
-  _snapshot = [self.view snapshotViewAfterScreenUpdates:NO];
-}
-
-- (void)setViewToSnapshot
+- (void)setViewToSnapshot:(UIView *)snapshot
 {
   [self.view removeFromSuperview];
-  self.view = _snapshot;
+  self.view = snapshot;
 }
 
 - (void)resetViewToScreen
@@ -69,11 +62,7 @@
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[UINavigationController class]];
-  if (isDisplayedWithinUINavController && !CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
-    _lastViewFrame = self.view.frame;
-    [_initialView updateBounds];
-  }
+  [_initialView updateBounds];
 }
 
 @end

--- a/ios/RNSScreenController.mm
+++ b/ios/RNSScreenController.mm
@@ -62,7 +62,10 @@
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-  [_initialView updateBounds];
+  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[UINavigationController class]];
+  if (isDisplayedWithinUINavController) {
+    [_initialView updateBounds];
+  }
 }
 
 @end

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -193,8 +193,6 @@ using namespace facebook::react;
   // controller is still there
   BOOL firstTimePush = ![previousTop isKindOfClass:[RNSScreenController class]];
 
-  BOOL shouldAnimate = YES;
-
   if (firstTimePush) {
     // nothing pushed yet
     [_controller setViewControllers:controllers animated:NO];
@@ -214,7 +212,7 @@ using namespace facebook::react;
         NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
         [newControllers addObject:previousTop];
         [_controller setViewControllers:newControllers animated:NO];
-        [_controller popViewControllerAnimated:shouldAnimate];
+        [_controller popViewControllerAnimated:YES];
       }
     } else if (![_controller.viewControllers containsObject:top]) {
       // new top controller is not on the stack
@@ -225,11 +223,11 @@ using namespace facebook::react;
       [_controller setViewControllers:newControllers animated:NO];
       auto screenController = (RNSScreenController *)top;
       [screenController resetViewToScreen];
-      [_controller pushViewController:top animated:shouldAnimate];
+      [_controller pushViewController:top animated:YES];
     } else {
       // don't really know what this case could be, but may need to handle it
       // somehow
-      [_controller setViewControllers:controllers animated:shouldAnimate];
+      [_controller setViewControllers:controllers animated:YES];
     }
   } else {
     // change wasn't on the top of the stack. We don't need animation.

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -268,11 +268,12 @@ using namespace facebook::react;
   [screenController resetViewToScreen];
 }
 
-#pragma mark methods connected to transitioning
+#pragma mark - methods connected to transitioning
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-  return YES;
+  // you shouldn't be able to use gesture to go back when there is just one screen
+  return _controller.viewControllers.count >= 2;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -78,8 +78,12 @@ using namespace facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
+  NSLog(@"%ld", index);
   RNSScreenComponentView *screenChildComponent = (RNSScreenComponentView *)childComponentView;
-  [screenChildComponent.controller setViewToSnapshot:_snapshot];
+  // We should only do a snapshot of a screen that is on the top
+  if (screenChildComponent == _controller.topViewController.view) {
+    [screenChildComponent.controller setViewToSnapshot:_snapshot];
+  }
 
   RCTAssert(
       screenChildComponent.reactSuperview == self,
@@ -255,12 +259,7 @@ using namespace facebook::react;
   NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
   for (RNSScreenComponentView *screen in _reactSubviews) {
     if (screen.controller != nil) {
-      if (pushControllers.count == 0) {
-        // first screen on the list needs to be places as "push controller"
-        [pushControllers addObject:screen.controller];
-      } else {
-        [pushControllers addObject:screen.controller];
-      }
+      [pushControllers addObject:screen.controller];
     }
   }
 
@@ -275,7 +274,7 @@ using namespace facebook::react;
 
 - (void)dismissOnReload
 {
-  auto screenController = (RNSScreenController *)_controller.viewControllers.lastObject;
+  auto screenController = (RNSScreenController *)_controller.topViewController;
   [screenController resetViewToScreen];
 }
 

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -67,7 +67,6 @@ using namespace facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  NSLog(@"%ld", index);
   RNSScreenComponentView *screenChildComponent = (RNSScreenComponentView *)childComponentView;
   // We should only do a snapshot of a screen that is on the top
   if (screenChildComponent == _controller.topViewController.view) {

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -38,7 +38,6 @@ using namespace facebook::react;
     _controller = [[UINavigationController alloc] init];
     _controller.delegate = self;
     [_controller setViewControllers:@[ [UIViewController new] ]];
-    _invalidated = NO;
   }
 
   return self;
@@ -115,13 +114,8 @@ using namespace facebook::react;
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  if (!_invalidated) {
-    // We check whether the view has been invalidated before running side-effects in didMoveToWindow
-    // This is needed because when LayoutAnimations are used it is possible for view to be re-attached
-    // to a window despite the fact it has been removed from the React Native view hierarchy.
-    // See https://github.com/software-mansion/react-native-screens/pull/700
-    [self maybeAddToParentAndUpdateContainer];
-  }
+  // for handling nested stacks
+  [self maybeAddToParentAndUpdateContainer];
 }
 
 - (void)navigationController:(UINavigationController *)navigationController
@@ -283,9 +277,9 @@ using namespace facebook::react;
   [super prepareForRecycle];
   _reactSubviews = [NSMutableArray new];
   [self dismissOnReload];
-  _invalidated = YES;
   [_controller willMoveToParentViewController:nil];
   [_controller removeFromParentViewController];
+  [_controller setViewControllers:@[ [UIViewController new] ]];
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -44,16 +44,6 @@ using namespace facebook::react;
   return self;
 }
 
-- (void)markChildUpdated
-{
-  // do nothing
-}
-
-- (void)didUpdateChildren
-{
-  // do nothing
-}
-
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   if (![childComponentView isKindOfClass:[RNSScreenComponentView class]]) {

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -164,6 +164,7 @@ using namespace facebook::react;
         _controller.interactivePopGestureRecognizer.delegate = self;
 #endif
         [self navigationController:_controller willShowViewController:_controller.topViewController animated:NO];
+        break;
       }
       parentView = (UIView *)parentView.reactSuperview;
     }

--- a/ios/RNSScreenStackComponentView.mm
+++ b/ios/RNSScreenStackComponentView.mm
@@ -202,21 +202,21 @@ using namespace facebook::react;
   }
 
   UIViewController *top = controllers.lastObject;
-  UIViewController *lastTop = _controller.viewControllers.lastObject;
+  UIViewController *previousTop = _controller.topViewController;
 
-  // at the start we set viewControllers to contain a single UIVIewController
+  // At the start we set viewControllers to contain a single UIViewController
   // instance. This is a workaround for header height adjustment bug (see comment
   // in the init function). Here, we need to detect if the initial empty
   // controller is still there
-  BOOL firstTimePush = ![lastTop isKindOfClass:[RNSScreenController class]];
+  BOOL firstTimePush = ![previousTop isKindOfClass:[RNSScreenController class]];
 
   BOOL shouldAnimate = YES;
 
   if (firstTimePush) {
     // nothing pushed yet
     [_controller setViewControllers:controllers animated:NO];
-  } else if (top != lastTop) {
-    if (![controllers containsObject:lastTop]) {
+  } else if (top != previousTop) {
+    if (![controllers containsObject:previousTop]) {
       // if the previous top screen does not exist anymore and the new top was not on the stack before, probably replace
       // was called, so we check the animation
       if (![_controller.viewControllers containsObject:top]) {
@@ -229,7 +229,7 @@ using namespace facebook::react;
         // in this case we set the controllers stack to the new list with
         // added the last top element to it and perform (animated) pop
         NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
-        [newControllers addObject:lastTop];
+        [newControllers addObject:previousTop];
         [_controller setViewControllers:newControllers animated:NO];
         [_controller popViewControllerAnimated:shouldAnimate];
       }


### PR DESCRIPTION
## Description

This PR moves the snapshotting logic from Screen to ScreenStack. From now on a snapshot is made from only the top-most screen on the stack.

Snapshots are used in order to have a transition animation during the go-back invoked from the JS side. 

Problems:
- [x] - fix snapshots in nested stacks that break the flow
- [x] - only make a snapshot of the top-most screen
- [x] - swipe to go back gesture shouldn't be invoked on the first screen in a stack
- [ ] - layout shift on initial render
- [x] - lack of animation in the nested stack on initial app load

_____

### Layout shift on initial render

Layout shift on app reload is partly fixed by simplifying logic in `resetViewToScreen` method in `RNSScreenController` by running `[_initialView updateBounds];` on every re-render. This will finally properly set the layout.

It leaves a slight issue with a layout jump on the initial render which offsets the Screen by the height of the header. The problem is probably caused by [the asynchronous layout calculation in the commit phase of the Fabric render pipeline](https://reactnative.dev/architecture/render-pipeline#phase-2-commit) that incorrectly calculates the layout values in its nodes. These values, in the end, after the mount are getting corrected by the iOS system. Well, probably.

The height of the Screen is determined by the fact that it has a Header as its child or not. This is probably way too late for Fabric to figure out that it changes the layout. After the screen is mounted iOS system correctly shrinks the screen to the expected size.

_____

### Lack of animation in the nested stack on initial app load

The current problem we are unable to tackle is the lack of screen animation in a nested stack on initial app load:

https://user-images.githubusercontent.com/39658211/157474725-18745672-9f08-4615-9ba3-f3abe8191d1b.mp4



The issue doesn't occur after the application is refreshed (eg. by tapping R on the keyboard):


https://user-images.githubusercontent.com/39658211/157474736-dedcd32b-4a98-4aaf-a770-57f268483723.mp4


**Removing call to `[_controller removeFromParentViewController];` from `prepareForRecycle` method in RNScreenStackComponentView reproduces the problem (lack of animation) also after refresh.**


<details>
<summary>Repro used to test the changes</summary>
<br>

```jsx
import {NavigationContainer} from '@react-navigation/native';
import React from 'react';
import {View, StyleSheet, Button} from 'react-native';
import {createNativeStackNavigator} from '@react-navigation/native-stack';

const MainScreen = ({navigation}) => {
  return (
    <View style={{...styles.container, backgroundColor: 'aliceblue'}}>
      <Button
        title="Go to chats"
        onPress={() => navigation.navigate('Chats')}
      />
    </View>
  );
};

const ChatsScreen = ({navigation}) => {
  return (
    <NestedStack.Navigator>
      <NestedStack.Screen name="Privacy" component={PrivacyScreen} />
      <NestedStack.Screen name="Options" component={OptionsScreen} />
    </NestedStack.Navigator>
  );
};

const PrivacyScreen = ({navigation}) => {
  return (
    <View style={{...styles.container, backgroundColor: 'honeydew'}}>
      <Button
        title="Go to options"
        onPress={() => navigation.navigate('Options')}
      />
    </View>
  );
};

const OptionsScreen = ({navigation}) => {
  return (
    <View style={{...styles.container, backgroundColor: 'moccasin'}}>
      <Button onPress={() => navigation.goBack()} title="Go back" />
      <Button title="Go back to parent" onPress={() => navigation.getParent().goBack()} />
    </View>
  );
};

const Stack = createNativeStackNavigator();
const NestedStack = createNativeStackNavigator();

const App = () => {
  return (
    <NavigationContainer>
      <Stack.Navigator>
        <Stack.Screen
          name="Main"
          options={{title: 'Events'}}
          component={MainScreen}
        />
        <Stack.Screen name="Chats" component={ChatsScreen} />
      </Stack.Navigator>
    </NavigationContainer>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    paddingTop: 10,
  },
});

export default App;

```

</details>

We suspect that the nested stacks are improperly hooked to the highest UIViewController in the hierarchy even tho we explicitly connect the nested screen to the screen to its parent stack navigator. It might be the reason why the system doesn't know how to handle the animation.
____

Thank you so much @WoLewicki for help with this. You are a legend 🙌 