### PR TITLE
Use c++17 for fabric on iOS

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -25,7 +25,8 @@ Pod::Spec.new do |s|
 
   if fabric_enabled
     s.pod_target_xcconfig = {
-      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly"'
+      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly"',
+      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     }
     s.platforms       = { ios: '11.0', tvos: '11.0' }
     s.compiler_flags  = folly_compiler_flags


### PR DESCRIPTION
## Description

Latest version of RN requires c++17 for fabric (https://github.com/facebook/react-native/commit/c2e4ae39b8a5c6534a3fa4dae4130166eda15169)

## Changes

Set CLANG_CXX_LANGUAGE_STANDARD to c++17

## Test code and steps to reproduce

Test fabric with latest RN and make sure it builds

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
