### PR TITLE
feat: Screen props: `screenOrientation` (3)

### DIFF
--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -546,8 +546,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: 07eb8bb0d56ecb0c16f771d81f0f25008bc403b5
-  FBReactNativeSpec: c62f65a739e96e76f4a0fd2f1fbf412e1faf84d5
+  FBLazyVector: bcdeff523be9f87a135b7c6fde8736db94904716
+  FBReactNativeSpec: 87ff61e326f0827d55bb888c274b0f5a9b4f2e33
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c

--- a/ios/RNSScreenComponentView.mm
+++ b/ios/RNSScreenComponentView.mm
@@ -250,12 +250,18 @@ using namespace facebook::react;
   }
 
   if (newScreenProps.statusBarStyle != oldScreenProps.statusBarStyle) {
-    [self setStatusBarStyle:[RCTConvert RNSStatusBarStyle:[self stringToPropValue:newScreenProps.statusBarStyle]]];
+    [self setStatusBarStyle:[RCTConvert
+                                RNSStatusBarStyle:[self stringToPropValue:newScreenProps.statusBarStyle]]];
   }
 
   if (newScreenProps.statusBarAnimation != oldScreenProps.statusBarAnimation) {
     [self setStatusBarAnimation:[RCTConvert
                                     UIStatusBarAnimation:[self stringToPropValue:newScreenProps.statusBarAnimation]]];
+  }
+
+  if (newScreenProps.screenOrientation != oldScreenProps.screenOrientation) {
+    [self setScreenOrientation:[RCTConvert
+                                  UIInterfaceOrientationMask:[self stringToPropValue:newScreenProps.screenOrientation]]];
   }
 
   if (newScreenProps.statusBarColor) {


### PR DESCRIPTION
## Description

Support screen props on Fabric

Part of stack PR:
* https://github.com/software-mansion/react-native-screens/pull/1362
* https://github.com/software-mansion/react-native-screens/pull/1363
* https://github.com/software-mansion/react-native-screens/pull/1364
* https://github.com/software-mansion/react-native-screens/pull/1365


## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
