### PR TITLE
fix: remove processColor

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -1,12 +1,8 @@
 package com.swmansion.rnscreens
 
-import androidx.annotation.NonNull
-import androidx.annotation.Nullable
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.ReactStylesDiffMap
-import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
@@ -105,7 +101,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
         view.isStatusBarAnimated = animated
     }
 
-    @ReactProp(name = "statusBarColor")
+    @ReactProp(name = "statusBarColor", customType = "Color")
     override fun setStatusBarColor(view: Screen, statusBarColor: Int?) {
         view.statusBarColor = statusBarColor
     }

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -11,9 +11,6 @@ import {
   ViewProps,
 } from 'react-native';
 import { Freeze } from 'react-freeze';
-// @ts-ignore Getting private component
-// eslint-disable-next-line import/default
-import processColor from 'react-native/Libraries/StyleSheet/processColor';
 import { version } from 'react-native/package.json';
 
 import TransitionProgressContext from './TransitionProgressContext';
@@ -251,7 +248,6 @@ class Screen extends React.Component<ScreenProps> {
         activityState,
         children,
         isNativeStack,
-        statusBarColor,
         ...props
       } = rest;
 
@@ -261,8 +257,6 @@ class Screen extends React.Component<ScreenProps> {
         );
         activityState = active !== 0 ? 2 : 0; // in the new version, we need one of the screens to have value of 2 after the transition
       }
-
-      const processedColor = processColor(statusBarColor);
 
       const handleRef = (ref: ViewConfig) => {
         if (!ENABLE_FABRIC) {
@@ -280,7 +274,6 @@ class Screen extends React.Component<ScreenProps> {
         <MaybeFreeze freeze={activityState === 0}>
           <AnimatedNativeScreen
             {...props}
-            statusBarColor={processedColor}
             activityState={activityState}
             // This prevents showing blank screen when navigating between multiple screens with freezing
             // https://github.com/software-mansion/react-native-screens/pull/1208


### PR DESCRIPTION
## Description

Removed unnecessary `processColor` which was added by mistake since the `statusBarColor` did not work without `customType = "Color"` in its `@ReactProp`.

## Test code and steps to reproduce

`Test860.tsx` to see that it still works correctly after this change.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
