### PR TITLE
[iOS] Fix edge swipe (interactive pop) gesture recognition

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -655,6 +655,29 @@
 #endif
 }
 
+- (BOOL)isScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+  // NOTE: This hack is required to restore native behavior of edge swipe (interactive pop gesture)
+  // without this, on a screen with a scroll view, it's only possible to pop view by panning horizontally
+  // if even slightly diagonal (or if in motion), scroll view will scroll, and edge swipe will be cancelled
+  if (![[gestureRecognizer view] isKindOfClass:[UIScrollView class]]) {
+    return NO;
+  }
+  UIScrollView *scrollView = gestureRecognizer.view;
+  return scrollView.panGestureRecognizer == gestureRecognizer;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return [self isScrollViewPanGestureRecognizer: otherGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return [self isScrollViewPanGestureRecognizer: otherGestureRecognizer];
+}
+
+
 #if !TARGET_OS_TV
 - (void)setupGestureHandlers
 {


### PR DESCRIPTION
## Description

See video here: https://twitter.com/radexp/status/1506981953156927499

react-native-screens accidentally broke a subtle behavior of the edge swipe/interactive pop gesture recognition. In simple vanilla iOS app, the edge swipe is easily recognized even when touch is panning across a scroll view diagonally or while scroll view is in motion. Because RNS does not have a normal view/view controller hierarchy (or some other subtle reason), the pop gesture breaks.

RNS sets `_controller.interactivePopGestureRecognizer.delegate = self;` so it's not completely broken… but this subtle behavior was still broken, driving me bonkers over the past couple of years :) 

I don't know the true root cause of this issue, this could require deeper changes to RNS, for the default native behavior to _just work_. Regardless, setting interactive pop gesture recognizer to recognize simultaneously with scroll view's pan gesture recognizer fixes popping, while setting it to fail by scroll view's pan recognizer fixes scroll view still moving together with the edge swipe.

## Changes

- Fix edge swipe (interactive pop) on iOS when dragging diagonally over a scroll view



<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
