### PR TITLE
fix: add check for if container is null

### DIFF
--- a/ios/RNSFullWindowOverlay.m
+++ b/ios/RNSFullWindowOverlay.m
@@ -63,20 +63,13 @@
   [window addSubview:_container];
 }
 
-- (void)hide
-{
-  if (!_container) {
-    return;
-  }
-
-  [_container removeFromSuperview];
-}
-
 - (void)didMoveToWindow
 {
   if (self.window == nil) {
-    [self hide];
-    [_touchHandler detachFromView:_container];
+    if (_container != nil) {
+      [_container removeFromSuperview];
+      [_touchHandler detachFromView:_container];
+    }
   } else {
     if (_touchHandler == nil) {
       _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
@@ -87,7 +80,7 @@
 
 - (void)invalidate
 {
-  [self hide];
+  [_container removeFromSuperview];
   _container = nil;
 }
 


### PR DESCRIPTION
## Description

Added check for if `_container` is `nil` which leads to app crash if `invalidate` was called before `didMoveToWindow` (e.g. navigating back from screen with `navigation.goBack()`). Should fix #1374.

## Test code and steps to reproduce

Example from https://github.com/software-mansion/react-native-screens/issues/1374

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
