### PR TITLE
fix: blurView integration with ScreenStack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -15,7 +15,7 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     private val mStack = ArrayList<ScreenStackFragment>()
     private val mDismissed: MutableSet<ScreenStackFragment> = HashSet()
     private val drawingOpPool: MutableList<DrawingOp> = ArrayList()
-    private val drawingOps: MutableList<DrawingOp> = ArrayList()
+    private var drawingOps: MutableList<DrawingOp> = ArrayList()
     private var mTopScreen: ScreenStackFragment? = null
     private var mRemovalTransitionStarted = false
     private var isDetachingCurrentScreen = false
@@ -273,12 +273,12 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun drawAndRelease() {
-        for (i in drawingOps.indices) {
-            val op = drawingOps[i]
+        val drawingOpsCopy = drawingOps
+        drawingOps = mutableListOf()
+        for (op in drawingOpsCopy) {
             op.draw()
             drawingOpPool.add(op)
         }
-        drawingOps.clear()
     }
 
     override fun dispatchDraw(canvas: Canvas) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -273,8 +273,12 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun drawAndRelease() {
+        // We make a copy of the drawingOps and use it to dispatch draws in order to be sure
+        // that we do not modify the original list. There are cases when `op.draw` can call
+        // `drawChild` which would modify the list through which we are iterating. See more:
+        // https://github.com/software-mansion/react-native-screens/pull/1406
         val drawingOpsCopy = drawingOps
-        drawingOps = mutableListOf()
+        drawingOps = ArrayList()
         for (op in drawingOpsCopy) {
             op.draw()
             drawingOpPool.add(op)


### PR DESCRIPTION
## Description

`BlurView` sometimes calls `draw` method of the app's rootView, causing unexpected behavior in our library. Since `BlurView` is a child of `ScreenStack` in the crashing example, calling [`op.draw()`](https://github.com/software-mansion/react-native-screens/blob/d5f7374ada7421aeaa132c53653fed19992a0ba6/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt#L278) calls `BlurView` `onDraw` method, which then sometimes calls `draw` method in app's `rootView`. It results in visiting the [`drawAndRelease` method](https://github.com/software-mansion/react-native-screens/blob/d5f7374ada7421aeaa132c53653fed19992a0ba6/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt#L275) again. The important thing is [`drawingOps.indices`](https://github.com/software-mansion/react-native-screens/blob/d5f7374ada7421aeaa132c53653fed19992a0ba6/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt#L276) makes `IntRange` under the hood, which is then used in next loop calls. At the same time, after the most nested `for` loop ends, it [clears](https://github.com/software-mansion/react-native-screens/blob/d5f7374ada7421aeaa132c53653fed19992a0ba6/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt#L281) the `drawingOps`, but this change is not visible in the former `for` since it just loops over `IntRange` created before. This results in `indexOutOfBounds` crash when we try to obtain an `op` from empty `drawingOps`. As an addition, If we didn't use `indices`, but `for (op in drawingOps)`, it would result in `ConcurrentModificationException`.

Current fix makes a copy of `drawingOps` which is then used in `for` loop, and clearing the `drawingOps` so the nested calls cannot change the original one.


## Test code and steps to reproduce

https://github.com/mjm918/RNScreensBlurViewCrash-Repro/blob/master/AppCrash.tsx

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
