### PR TITLE
feat: add iOS search bar tint color

### DIFF
--- a/TestsExample/src/Test758.tsx
+++ b/TestsExample/src/Test758.tsx
@@ -39,6 +39,7 @@ function First({navigation}: NativeStackScreenProps<ParamListBase>) {
 
   const searchBarOptions: SearchBarProps = {
     barTintColor: 'powderblue',
+    tintColor: 'red',
     textColor: 'red',
     hideWhenScrolling: true,
     obscureBackground: false,

--- a/createNativeStackNavigator/README.md
+++ b/createNativeStackNavigator/README.md
@@ -398,6 +398,10 @@ The search field background color.
 
 By default bar tint color is translucent.
 
+#### `tintColor`
+
+The color for the cursor caret and cancel button text.
+
 #### `cancelButtonText`
 
 The text to be used instead of default `Cancel` button text.

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -292,6 +292,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `autoCapitalize` - Controls whether the text is automatically auto-capitalized as it is entered by the user. Can be one of these: `none`, `words`, `sentences`, `characters`. Defaults to `sentences` on iOS and `'none'` on Android.
 - `autoFocus` - If `true` automatically focuses search bar when screen is appearing. (Android only)
 - `barTintColor` - The search field background color. By default bar tint color is translucent.
+- `tintColor` - The color for the cursor caret and cancel button text. (iOS only)
 - `cancelButtonText` - The text to be used instead of default `Cancel` button text. (iOS only)
 - `disableBackButtonOverride` - Default behavior is to prevent screen from going back when search bar is open (`disableBackButtonOverride: false`). If you don't want this to happen set `disableBackButtonOverride` to `true`. (Android only)
 - `hideNavigationBar` - Boolean indicating whether to hide the navigation bar during searching. Defaults to `true`. (iOS only)

--- a/ios/RNSSearchBar.m
+++ b/ios/RNSSearchBar.m
@@ -62,6 +62,11 @@
 #endif
 }
 
+- (void)setTintColor:(UIColor *)tintColor
+{
+  [_controller.searchBar setTintColor:tintColor];
+}
+
 - (void)setTextColor:(UIColor *)textColor
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
@@ -186,6 +191,7 @@ RCT_EXPORT_VIEW_PROPERTY(hideWhenScrolling, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoCapitalize, UITextAutocapitalizationType)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -434,6 +434,10 @@ The search field background color.
 
 By default bar tint color is translucent.
 
+#### `tintColor` (iOS only)
+
+The color for the cursor caret and cancel button text.
+
 #### `cancelButtonText` (iOS only)
 
 The text to be used instead of default `Cancel` button text.

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -439,6 +439,12 @@ export interface SearchBarProps {
    */
   barTintColor?: string;
   /**
+   * The color for the cursor caret and cancel button text.
+   *
+   * @platform ios
+   */
+  tintColor?: string;
+  /**
    * The text to be used instead of default `Cancel` button text
    *
    * @platform ios


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->
Adds support for setting the tint color of the native stack search bar on iOS.  This will change the color of the cursor/caret and the cancel button text.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

-->

RNSSearchBar.m has been modified to accept a `tintColor` option, the SearchBarProps  interface has been updated as well as the documentation.   I based my changes off of [this pull request](https://github.com/software-mansion/react-native-screens/pull/1108/commits/d4a0020591004a2d16ebd19845ec41c41fcf2a52).   Let me know if I missed any doc updates.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.


You can add before / after section if you're changing some behavior.

-->


### Before
<img width="428" alt="before" src="https://user-images.githubusercontent.com/19569469/163176681-33159f29-7547-4cf6-95e7-5034f62161c2.png">

### After
<img width="428" alt="after" src="https://user-images.githubusercontent.com/19569469/163176733-5b5c74aa-f8bb-472a-8da8-76ca7d9e70f4.png">


## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
```js
useLayoutEffect(() => {
  navigation.setOptions({
    headerSearchBarOptions: {
      tintColor: "red",
    }
  })
},[navigation])
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
