### PR TITLE
fix: reattach FullWindowOverlay content when refocusing on current UI…

### DIFF
--- a/ios/RNSFullWindowOverlay.m
+++ b/ios/RNSFullWindowOverlay.m
@@ -74,6 +74,18 @@
     if (_touchHandler == nil) {
       _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
     }
+
+    /**
+     * Reattach the RNSFullWindowOverlayContainer to the current
+     * window if it's not nil and has no superview. This scenario
+     * happens when another UIWindow is opened, causing the
+     * current RNSFullWindowOverlayContainer to be removed (see the 
+     * `removeFromSuperview` logic above) from its superview.
+     */
+    if (_container != nil && _container.superview == nil) {
+      [self show];
+    }
+
     [_touchHandler attachToView:_container];
   }
 }


### PR DESCRIPTION
## Description

I recently noticed an issue where any views rendered under `FullScreenOverlay` would disappear and never come back after opening an image picker (e.g. `PHPickerViewController`) in my React Native application. 

## Changes

I added some conditional logic to the `didMoveToWindow` delegate that checks whether the existing `RNSFullWindowOverlayContainer` is not `nil` & has no `superview`, and if that's the case, reattaches it to the current UIWindow.

## Test code and steps to reproduce

1. Using the example app, render anything under a `<FullScreenOverlay>` component.
2. Add the `react-native-image-crop-picker` package and call its `openPicker` function.
3. This will invoke the existing `didMoveToWindow` delegate, resulting in the first instance of `RNSFullWindowOverlayContainer` to be unmounted & removed from the superview.
4. After closing the image picker, `didMoveToWindow` will be invoked again but the `RNSFullWindowOverlayContainer` is never re-attached to the current window.
