### PR TITLE
fix: check ios version for home indicator hiding

### DIFF
--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -55,7 +55,9 @@
   } else
 #endif
   {
-    [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+    if (@available(iOS 11.0, *)) {
+      [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+    }
   }
 #endif
 }


### PR DESCRIPTION
## Description

Add check for `iOS` version in `setNeedsUpdateOfHomeIndicatorAutoHidden` since it is available from `iOS` 11.

## Checklist

- [ ] Ensured that CI passes
