### PR TITLE
chore: add `replaceAnimation` prop for Fabric (2)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
@@ -139,10 +140,20 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
         view.nativeBackButtonDismissalEnabled = nativeBackButtonDismissalEnabled
     }
 
-    // these props are not available on Android, however we must override their getters
+    // these props are not available on Android, however we must override their setters
     override fun setFullScreenSwipeEnabled(view: Screen?, value: Boolean) = Unit
 
     override fun setTransitionDuration(view: Screen?, value: Int) = Unit
+
+    override fun setHideKeyboardOnSwipe(view: Screen?, value: Boolean) = Unit
+
+    override fun setCustomAnimationOnSwipe(view: Screen?, value: Boolean) = Unit
+
+    override fun setGestureResponseDistance(view: Screen?, value: ReadableMap?) = Unit
+
+    override fun setHomeIndicatorHidden(view: Screen?, value: Boolean) = Unit
+
+    override fun setPreventNativeDismiss(view: Screen?, value: Boolean) = Unit
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         val map: MutableMap<String, Any> = MapBuilder.of(

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -12,6 +12,7 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -22,8 +23,17 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
+      case "customAnimationOnSwipe":
+        mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);
+        break;
       case "fullScreenSwipeEnabled":
         mViewManager.setFullScreenSwipeEnabled(view, value == null ? false : (boolean) value);
+        break;
+      case "homeIndicatorHidden":
+        mViewManager.setHomeIndicatorHidden(view, value == null ? false : (boolean) value);
+        break;
+      case "preventNativeDismiss":
+        mViewManager.setPreventNativeDismiss(view, value == null ? false : (boolean) value);
         break;
       case "gestureEnabled":
         mViewManager.setGestureEnabled(view, value == null ? true : (boolean) value);
@@ -46,6 +56,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "statusBarTranslucent":
         mViewManager.setStatusBarTranslucent(view, value == null ? false : (boolean) value);
         break;
+      case "gestureResponseDistance":
+        mViewManager.setGestureResponseDistance(view, (ReadableMap) value);
+        break;
       case "stackPresentation":
         mViewManager.setStackPresentation(view, (String) value);
         break;
@@ -58,6 +71,12 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "replaceAnimation":
         mViewManager.setReplaceAnimation(view, (String) value);
         break;
+      case "hideKeyboardOnSwipe":
+        mViewManager.setHideKeyboardOnSwipe(view, value == null ? false : (boolean) value);
+        break;
+      case "activityState":
+        mViewManager.setActivityState(view, value == null ? -1 : ((Double) value).intValue());
+        break;
       case "navigationBarColor":
         mViewManager.setNavigationBarColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
@@ -66,9 +85,6 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
         break;
       case "nativeBackButtonDismissalEnabled":
         mViewManager.setNativeBackButtonDismissalEnabled(view, value == null ? false : (boolean) value);
-        break;
-      case "activityState":
-        mViewManager.setActivityState(view, value == null ? -1 : ((Double) value).intValue());
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -11,9 +11,13 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSScreenManagerInterface<T extends View> {
+  void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, boolean value);
+  void setHomeIndicatorHidden(T view, boolean value);
+  void setPreventNativeDismiss(T view, boolean value);
   void setGestureEnabled(T view, boolean value);
   void setStatusBarColor(T view, @Nullable Integer value);
   void setStatusBarHidden(T view, boolean value);
@@ -21,12 +25,14 @@ public interface RNSScreenManagerInterface<T extends View> {
   void setStatusBarAnimation(T view, @Nullable String value);
   void setStatusBarStyle(T view, @Nullable String value);
   void setStatusBarTranslucent(T view, boolean value);
+  void setGestureResponseDistance(T view, @Nullable ReadableMap value);
   void setStackPresentation(T view, @Nullable String value);
   void setStackAnimation(T view, @Nullable String value);
   void setTransitionDuration(T view, int value);
   void setReplaceAnimation(T view, @Nullable String value);
+  void setHideKeyboardOnSwipe(T view, boolean value);
+  void setActivityState(T view, int value);
   void setNavigationBarColor(T view, @Nullable Integer value);
   void setNavigationBarHidden(T view, boolean value);
   void setNativeBackButtonDismissalEnabled(T view, boolean value);
-  void setActivityState(T view, int value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
@@ -91,11 +91,11 @@ public class RNSScreenStackHeaderConfigManagerDelegate<T extends View, U extends
       case "hideBackButton":
         mViewManager.setHideBackButton(view, value == null ? false : (boolean) value);
         break;
-      case "topInsetEnabled":
-        mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
-        break;
       case "backButtonInCustomView":
         mViewManager.setBackButtonInCustomView(view, value == null ? false : (boolean) value);
+        break;
+      case "topInsetEnabled":
+        mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -36,6 +36,6 @@ public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> {
   void setTitleColor(T view, @Nullable Integer value);
   void setDisableBackButtonMenu(T view, boolean value);
   void setHideBackButton(T view, boolean value);
-  void setTopInsetEnabled(T view, boolean value);
   void setBackButtonInCustomView(T view, boolean value);
+  void setTopInsetEnabled(T view, boolean value);
 }

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -16,6 +16,9 @@
 + (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
     (facebook::react::RNSScreenReplaceAnimation)replaceAnimation;
 
++ (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
+    (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
+
 @end
 
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -13,6 +13,9 @@
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewTypeFromCppEquivalent:
     (facebook::react::RNSScreenStackHeaderSubviewType)subviewType;
 
++ (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
+    (facebook::react::RNSScreenReplaceAnimation)replaceAnimation;
+
 @end
 
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -77,6 +77,18 @@
       return RNSScreenReplaceAnimationPush;
   }
 }
+
++ (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
+    (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
+{
+  return @{
+    @"start" : @(gestureResponseDistance.start),
+    @"end" : @(gestureResponseDistance.end),
+    @"top" : @(gestureResponseDistance.top),
+    @"bottom" : @(gestureResponseDistance.bottom),
+  };
+}
+
 @end
 
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -66,6 +66,17 @@
       return RNSScreenStackHeaderSubviewTypeBackButton;
   }
 }
+
++ (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
+    (facebook::react::RNSScreenReplaceAnimation)replaceAnimation
+{
+  switch (replaceAnimation) {
+    case facebook::react::RNSScreenReplaceAnimation::Pop:
+      return RNSScreenReplaceAnimationPop;
+    case facebook::react::RNSScreenReplaceAnimation::Push:
+      return RNSScreenReplaceAnimationPush;
+  }
+}
 @end
 
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -29,11 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
+- (void)notifyFinishTransitioning;
 #ifdef RN_FABRIC_ENABLED
 - (void)setViewToSnapshot:(UIView *)snapshot;
 - (void)resetViewToScreen;
-#else
-- (void)notifyFinishTransitioning;
 #endif
 
 @end
@@ -58,7 +57,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
 @property (nonatomic, retain) NSNumber *transitionDuration;
 @property (nonatomic, readonly) BOOL dismissed;
+@property (nonatomic) BOOL hideKeyboardOnSwipe;
+@property (nonatomic) BOOL customAnimationOnSwipe;
+@property (nonatomic) BOOL preventNativeDismiss;
 @property (nonatomic, retain) RNSScreen *controller;
+@property (nonatomic, copy) NSDictionary *gestureResponseDistance;
+@property (nonatomic) int activityState;
+@property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
@@ -70,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #ifdef RN_FABRIC_ENABLED
 @property (weak, nonatomic) UIView *config;
-@property (weak, nonatomic) UIView *reactSuperview;
 #else
 @property (nonatomic, copy) RCTDirectEventBlock onAppear;
 @property (nonatomic, copy) RCTDirectEventBlock onDisappear;
@@ -79,14 +83,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
-
-@property (nonatomic) BOOL hideKeyboardOnSwipe;
-@property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
-@property (nonatomic) int activityState;
-@property (nonatomic) BOOL preventNativeDismiss;
-@property (nonatomic) BOOL customAnimationOnSwipe;
-@property (nonatomic, copy) NSDictionary *gestureResponseDistance;
 #endif
+
+- (void)notifyFinishTransitioning;
 
 #ifdef RN_FABRIC_ENABLED
 - (void)notifyWillAppear;
@@ -96,7 +95,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateBounds;
 - (void)notifyDismissedWithCount:(int)dismissCount;
 #else
-- (void)notifyFinishTransitioning;
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
 #endif
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -16,11 +16,11 @@
 #import "RNSConvert.h"
 #else
 #import <React/RCTTouchHandler.h>
-#import "RNSScreenStack.h"
 #endif
 
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
+#import "RNSScreenStack.h"
 #import "RNSScreenStackHeaderConfig.h"
 
 @interface RNSScreenView ()
@@ -192,6 +192,19 @@
   _replaceAnimation = replaceAnimation;
 }
 
+// Nil will be provided when activityState is set as an animated value and we change
+// it from JS to be a plain value (non animated).
+// In case when nil is received, we want to ignore such value and not make
+// any updates as the actual non-nil value will follow immediately.
+- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
+{
+  int activityState = [activityStateOrNil intValue];
+  if (activityStateOrNil != nil && activityState != -1 && activityState != _activityState) {
+    _activityState = activityState;
+    [_reactSuperview markChildUpdated];
+  }
+}
+
 #if !TARGET_OS_TV
 - (void)setStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
@@ -287,6 +300,9 @@
 
 - (void)notifyWillDisappear
 {
+  if (_hideKeyboardOnSwipe) {
+    [self endEditing:YES];
+  }
 #ifdef RN_FABRIC_ENABLED
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
@@ -295,9 +311,6 @@
         ->onWillDisappear(facebook::react::RNSScreenEventEmitter::OnWillDisappear{});
   }
 #else
-  if (_hideKeyboardOnSwipe) {
-    [self endEditing:YES];
-  }
   if (self.onWillDisappear) {
     self.onWillDisappear(nil);
   }
@@ -393,6 +406,11 @@
   return nil;
 }
 
+- (void)notifyFinishTransitioning
+{
+  [_controller notifyFinishTransitioning];
+}
+
 #pragma mark - Fabric specific
 #ifdef RN_FABRIC_ENABLED
 
@@ -441,6 +459,18 @@
 
   [self setTransitionDuration:[NSNumber numberWithInt:newScreenProps.transitionDuration]];
 
+  [self setHideKeyboardOnSwipe:newScreenProps.hideKeyboardOnSwipe];
+
+  [self setCustomAnimationOnSwipe:newScreenProps.customAnimationOnSwipe];
+
+  [self
+      setGestureResponseDistance:[RNSConvert
+                                     gestureResponseDistanceDictFromCppStruct:newScreenProps.gestureResponseDistance]];
+
+  [self setPreventNativeDismiss:newScreenProps.preventNativeDismiss];
+
+  [self setActivityStateOrNil:[NSNumber numberWithInt:newScreenProps.activityState]];
+  
 #if !TARGET_OS_TV
   if (newScreenProps.statusBarHidden != oldScreenProps.statusBarHidden) {
     [self setStatusBarHidden:newScreenProps.statusBarHidden];
@@ -460,6 +490,10 @@
     [self setScreenOrientation:[RCTConvert UIInterfaceOrientationMask:RCTNSStringFromStringNilIfEmpty(
                                                                           newScreenProps.screenOrientation)]];
   }
+
+  if (newScreenProps.homeIndicatorHidden != oldScreenProps.homeIndicatorHidden) {
+    [self setHomeIndicatorHidden:newScreenProps.homeIndicatorHidden];
+  }
 #endif
 
   if (newScreenProps.stackPresentation != oldScreenProps.stackPresentation) {
@@ -474,7 +508,7 @@
   if (newScreenProps.replaceAnimation != oldScreenProps.replaceAnimation) {
     [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
   }
-
+  
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -486,11 +520,6 @@
 
 #pragma mark - Paper specific
 #else
-
-- (void)notifyFinishTransitioning
-{
-  [_controller notifyFinishTransitioning];
-}
 
 - (void)notifyDismissCancelledWithDismissCount:(int)dismissCount
 {
@@ -507,19 +536,6 @@
       @"closing" : @(closing ? 1 : 0),
       @"goingForward" : @(goingForward ? 1 : 0),
     });
-  }
-}
-
-// Nil will be provided when activityState is set as an animated value and we change
-// it from JS to be a plain value (non animated).
-// In case when nil is received, we want to ignore such value and not make
-// any updates as the actual non-nil value will follow immediately.
-- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
-{
-  int activityState = [activityStateOrNil intValue];
-  if (activityStateOrNil != nil && activityState != _activityState) {
-    _activityState = activityState;
-    [_reactSuperview markChildUpdated];
   }
 }
 
@@ -594,11 +610,11 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 #pragma mark - RNSScreen
 
 @implementation RNSScreen {
+  __weak id _previousFirstResponder;
+  CGRect _lastViewFrame;
 #ifdef RN_FABRIC_ENABLED
   RNSScreenView *_initialView;
 #else
-  __weak id _previousFirstResponder;
-  CGRect _lastViewFrame;
   UIView *_fakeView;
   CADisplayLink *_animationTimer;
   CGFloat _currentAlpha;
@@ -756,12 +772,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-#ifdef RN_FABRIC_ENABLED
-  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[UINavigationController class]];
-  if (isDisplayedWithinUINavController) {
-    [_initialView updateBounds];
-  }
-#else
+
   // The below code makes the screen view adapt dimensions provided by the system. We take these
   // into account only when the view is mounted under RNScreensNavigationController in which case system
   // provides additional padding to account for possible header, and in the case when screen is
@@ -770,12 +781,50 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   BOOL isDisplayedWithinUINavController =
       [self.parentViewController isKindOfClass:[RNScreensNavigationController class]];
   BOOL isPresentedAsNativeModal = self.parentViewController == nil && self.presentingViewController != nil;
-  if ((isDisplayedWithinUINavController || isPresentedAsNativeModal) &&
-      !CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
-    _lastViewFrame = self.view.frame;
-    [((RNSScreenView *)self.viewIfLoaded) updateBounds];
-  }
+
+  if (isDisplayedWithinUINavController || isPresentedAsNativeModal) {
+#ifdef RN_FABRIC_ENABLED
+    [_initialView updateBounds];
+#else
+    if (!CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
+      _lastViewFrame = self.view.frame;
+      [((RNSScreenView *)self.viewIfLoaded) updateBounds];
+    }
 #endif
+  }
+}
+
+- (void)notifyFinishTransitioning
+{
+  [_previousFirstResponder becomeFirstResponder];
+  _previousFirstResponder = nil;
+  // the correct Screen for appearance is set after the transition, same for orientation.
+  [RNSScreenWindowTraits updateWindowTraits];
+}
+
+- (void)willMoveToParentViewController:(UIViewController *)parent
+{
+  [super willMoveToParentViewController:parent];
+  if (parent == nil) {
+    id responder = [self findFirstResponder:self.view];
+    if (responder != nil) {
+      _previousFirstResponder = responder;
+    }
+  }
+}
+
+- (id)findFirstResponder:(UIView *)parent
+{
+  if (parent.isFirstResponder) {
+    return parent;
+  }
+  for (UIView *subView in parent.subviews) {
+    id responder = [self findFirstResponder:subView];
+    if (responder != nil) {
+      return responder;
+    }
+  }
+  return nil;
 }
 
 #if !TARGET_OS_TV
@@ -920,31 +969,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 #else
 #pragma mark - Paper specific
 
-- (id)findFirstResponder:(UIView *)parent
-{
-  if (parent.isFirstResponder) {
-    return parent;
-  }
-  for (UIView *subView in parent.subviews) {
-    id responder = [self findFirstResponder:subView];
-    if (responder != nil) {
-      return responder;
-    }
-  }
-  return nil;
-}
-
-- (void)willMoveToParentViewController:(UIViewController *)parent
-{
-  [super willMoveToParentViewController:parent];
-  if (parent == nil) {
-    id responder = [self findFirstResponder:self.view];
-    if (responder != nil) {
-      _previousFirstResponder = responder;
-    }
-  }
-}
-
 - (void)hideHeaderIfNecessary
 {
 #if !TARGET_OS_TV
@@ -1000,14 +1024,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 }
 
 #pragma mark - transition progress related methods
-
-- (void)notifyFinishTransitioning
-{
-  [_previousFirstResponder becomeFirstResponder];
-  _previousFirstResponder = nil;
-  // the correct Screen for appearance is set after the transition, same for orientation.
-  [RNSScreenWindowTraits updateWindowTraits];
-}
 
 - (void)setupProgressNotification
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -471,6 +471,10 @@
     [self setStackAnimation:[RNSConvert RNSScreenStackAnimationFromCppEquivalent:newScreenProps.stackAnimation]];
   }
 
+  if (newScreenProps.replaceAnimation != oldScreenProps.replaceAnimation) {
+    [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -141,7 +141,6 @@
 
 - (void)updateContainer
 {
-#ifndef RN_FABRIC_ENABLED
   BOOL screenRemoved = NO;
   // remove screens that are no longer active
   NSMutableSet *orphaned = [NSMutableSet setWithSet:_activeScreens];
@@ -191,7 +190,6 @@
   if (screenRemoved || screenAdded) {
     [self maybeDismissVC];
   }
-#endif
 }
 
 - (void)maybeDismissVC

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSScreenStackView :
 #ifdef RN_FABRIC_ENABLED
-    RCTViewComponentView
+    RCTViewComponentView <RNSScreenContainerDelegate>
 #else
     UIView <RNSScreenContainerDelegate, RCTInvalidating>
 #endif

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -608,13 +608,8 @@
   if (topScreen.fullScreenSwipeEnabled) {
     // we want only `RNSPanGestureRecognizer` to be able to recognize when
     // `fullScreenSwipeEnabled` is set, and we are in the bounds set by user
-#ifdef RN_FABRIC_ENABLED
-    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]])
-#else
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
-        [self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen])
-#endif
-    {
+        [self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
       _isFullWidthSwiping = YES;
       [self cancelTouchesInParent];
       return YES;
@@ -622,17 +617,6 @@
     return NO;
   }
 
-#ifdef RN_FABRIC_ENABLED
-  if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
-    // it should only recognize with `customAnimationOnSwipe` set
-    return NO;
-  } else if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    // it should only recognize with `fullScreenSwipeEnabled` set
-    return NO;
-  }
-  [self cancelTouchesInParent];
-  return _controller.viewControllers.count >= 2;
-#else
   if (topScreen.customAnimationOnSwipe && [RNSScreenStackAnimator isCustomAnimation:topScreen.stackAnimation]) {
     if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
       // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
@@ -658,7 +642,6 @@
     [self cancelTouchesInParent];
     return YES;
   }
-#endif // RN_FABRIC_ENABLED
 
 #endif // TARGET_OS_TV
 }
@@ -757,6 +740,72 @@
 - (UIViewController *)reactViewController
 {
   return _controller;
+}
+
+- (BOOL)isInGestureResponseDistance:(UIGestureRecognizer *)gestureRecognizer topScreen:(RNSScreenView *)topScreen
+{
+  NSDictionary *gestureResponseDistanceValues = topScreen.gestureResponseDistance;
+  float x = [gestureRecognizer locationInView:gestureRecognizer.view].x;
+  float y = [gestureRecognizer locationInView:gestureRecognizer.view].y;
+  BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
+  if (isRTL) {
+    x = _controller.view.frame.size.width - x;
+  }
+  
+  // see: https://github.com/software-mansion/react-native-screens/pull/1442/commits/74d4bae321875d8305ad021b3d448ebf713e7d56
+  // this prop is always default initialized so we do not expect any nils
+  float start = [gestureResponseDistanceValues[@"start"] floatValue];
+  float end = [gestureResponseDistanceValues[@"end"] floatValue];
+  float top = [gestureResponseDistanceValues[@"top"] floatValue];
+  float bottom = [gestureResponseDistanceValues[@"bottom"] floatValue];
+
+  // we check if any of the constraints are violated and return NO if so
+  return !(
+      (start != -1 && x < start) ||
+      (end != -1 && x > end) ||
+      (top != -1 && y < top) ||
+      (bottom != -1 && y > bottom));
+}
+
+// By default, the header buttons that are not inside the native hit area
+// cannot be clicked, so we check it by ourselves
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if (CGRectContainsPoint(_controller.navigationBar.frame, point)) {
+    // headerConfig should be the first subview of the topmost screen
+    UIView *headerConfig = [[_reactSubviews.lastObject reactSubviews] firstObject];
+    if ([headerConfig isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+      UIView *headerHitTestResult = [headerConfig hitTest:point withEvent:event];
+      if (headerHitTestResult != nil) {
+        return headerHitTestResult;
+      }
+    }
+  }
+  return [super hitTest:point withEvent:event];
+}
+
+- (BOOL)isScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+  // NOTE: This hack is required to restore native behavior of edge swipe (interactive pop gesture)
+  // without this, on a screen with a scroll view, it's only possible to pop view by panning horizontally
+  // if even slightly diagonal (or if in motion), scroll view will scroll, and edge swipe will be cancelled
+  if (![[gestureRecognizer view] isKindOfClass:[UIScrollView class]]) {
+    return NO;
+  }
+  UIScrollView *scrollView = (UIScrollView *)gestureRecognizer.view;
+  return scrollView.panGestureRecognizer == gestureRecognizer;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
 }
 
 #ifdef RN_FABRIC_ENABLED
@@ -884,23 +933,6 @@
   });
 }
 
-// By default, the header buttons that are not inside the native hit area
-// cannot be clicked, so we check it by ourselves
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
-{
-  if (CGRectContainsPoint(_controller.navigationBar.frame, point)) {
-    // headerConfig should be the first subview of the topmost screen
-    UIView *headerConfig = [[_reactSubviews.lastObject reactSubviews] firstObject];
-    if ([headerConfig isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
-      UIView *headerHitTestResult = [headerConfig hitTest:point withEvent:event];
-      if (headerHitTestResult != nil) {
-        return headerHitTestResult;
-      }
-    }
-  }
-  return [super hitTest:point withEvent:event];
-}
-
 - (void)invalidate
 {
   _invalidated = YES;
@@ -910,48 +942,6 @@
   [_presentedModals removeAllObjects];
   [_controller willMoveToParentViewController:nil];
   [_controller removeFromParentViewController];
-}
-
-- (BOOL)isInGestureResponseDistance:(UIGestureRecognizer *)gestureRecognizer topScreen:(RNSScreenView *)topScreen
-{
-  NSDictionary *gestureResponseDistanceValues = topScreen.gestureResponseDistance;
-  float x = [gestureRecognizer locationInView:gestureRecognizer.view].x;
-  float y = [gestureRecognizer locationInView:gestureRecognizer.view].y;
-  BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
-  if (isRTL) {
-    x = _controller.view.frame.size.width - x;
-  }
-  // we check if any of the constraints are violated and return NO if so
-  return !(
-      (gestureResponseDistanceValues[@"start"] && x < [gestureResponseDistanceValues[@"start"] floatValue]) ||
-      (gestureResponseDistanceValues[@"end"] && x > [gestureResponseDistanceValues[@"end"] floatValue]) ||
-      (gestureResponseDistanceValues[@"top"] && y < [gestureResponseDistanceValues[@"top"] floatValue]) ||
-      (gestureResponseDistanceValues[@"bottom"] && y > [gestureResponseDistanceValues[@"bottom"] floatValue]));
-  return NO;
-}
-
-- (BOOL)isScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-{
-  // NOTE: This hack is required to restore native behavior of edge swipe (interactive pop gesture)
-  // without this, on a screen with a scroll view, it's only possible to pop view by panning horizontally
-  // if even slightly diagonal (or if in motion), scroll view will scroll, and edge swipe will be cancelled
-  if (![[gestureRecognizer view] isKindOfClass:[UIScrollView class]]) {
-    return NO;
-  }
-  UIScrollView *scrollView = gestureRecognizer.view;
-  return scrollView.panGestureRecognizer == gestureRecognizer;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-    shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
 }
 
 - (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -66,15 +66,12 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
   if (screen != nil) {
     if (screen.fullScreenSwipeEnabled && transitionContext.isInteractive) {
       // we are swiping with full width gesture
-#ifndef RN_FABRIC_ENABLED
       if (screen.customAnimationOnSwipe) {
         [self animateTransitionWithStackAnimation:screen.stackAnimation
                                 transitionContext:transitionContext
                                              toVC:toViewController
                                            fromVC:fromViewController];
-      } else
-#endif
-      {
+      } else {
         // we have to provide an animation when swiping, otherwise the screen will be popped immediately,
         // so in case of no custom animation on swipe set, we provide the one closest to the default
         [self animateSimplePushWithTransitionContext:transitionContext toVC:toViewController fromVC:fromViewController];

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -24,7 +24,6 @@
 #else
 @property (nonatomic) UIBlurEffectStyle blurEffect;
 @property (nonatomic) BOOL hide;
-@property (nonatomic) BOOL backButtonInCustomView;
 #endif
 
 @property (nonatomic, retain) NSString *title;
@@ -48,6 +47,7 @@
 @property (nonatomic) BOOL disableBackButtonMenu;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
+@property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) UISemanticContentAttribute direction;
 
 + (void)willShowViewController:(UIViewController *)vc

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -543,12 +543,9 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
-#ifdef RN_FABRIC_ENABLED
-#else
 #if !TARGET_OS_TV
         navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
 #endif
-#endif // RN_FABRIC_ENABLED
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
         navitem.leftBarButtonItem = buttonItem;
         break;
@@ -705,6 +702,10 @@
   if (newScreenProps.translucent != _translucent) {
     _translucent = newScreenProps.translucent;
     needsNavigationControllerLayout = YES;
+  }
+  
+  if (newScreenProps.backButtonInCustomView != _backButtonInCustomView) {
+    [self setBackButtonInCustomView:newScreenProps.backButtonInCustomView];
   }
 
   _title = RCTNSStringFromStringNilIfEmpty(newScreenProps.title);

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -18,9 +18,9 @@
 #import "RNSSearchBar.h"
 #endif
 #import <React/RCTFont.h>
-#import "RNSUIBarButtonItem.h"
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
+#import "RNSUIBarButtonItem.h"
 
 #ifdef RN_FABRIC_ENABLED
 #else
@@ -539,7 +539,7 @@
   navitem.leftBarButtonItem = nil;
   navitem.rightBarButtonItem = nil;
   navitem.titleView = nil;
-  
+
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -19,6 +19,13 @@ type ScreenDismissedEvent = $ReadOnly<{|
   dismissCount: Int32,
 |}>;
 
+type GestureResponseDistanceType = $ReadOnly<{|
+  start: Float,
+  end: Float,
+  top: Float,
+  bottom: Float,
+|}>;
+
 type StackPresentation =
   | 'push'
   | 'modal'
@@ -48,7 +55,10 @@ export type NativeProps = $ReadOnly<{|
   onDismissed?: ?BubblingEventHandler<ScreenDismissedEvent>,
   onWillAppear?: ?BubblingEventHandler<ScreenEvent>,
   onWillDisappear?: ?BubblingEventHandler<ScreenEvent>,
+  customAnimationOnSwipe?: boolean,
   fullScreenSwipeEnabled?: boolean,
+  homeIndicatorHidden?: boolean,
+  preventNativeDismiss?: boolean,
   gestureEnabled?: WithDefault<boolean, true>,
   statusBarColor?: ColorValue,
   statusBarHidden?: boolean,
@@ -56,15 +66,17 @@ export type NativeProps = $ReadOnly<{|
   statusBarAnimation?: string,
   statusBarStyle?: string,
   statusBarTranslucent?: boolean,
+  gestureResponseDistance?: GestureResponseDistanceType,
   stackPresentation?: WithDefault<StackPresentation, 'push'>,
   stackAnimation?: WithDefault<StackAnimation, 'default'>,
   transitionDuration?: WithDefault<Int32, 350>,
   replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>,
+  hideKeyboardOnSwipe?: boolean,
+  activityState?: WithDefault<Int32, -1>,
   // TODO: implement these props on iOS
   navigationBarColor?: ColorValue,
   navigationBarHidden?: boolean,
   nativeBackButtonDismissalEnabled?: boolean,
-  activityState?: WithDefault<Int32, -1>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.js
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.js
@@ -41,9 +41,9 @@ export type NativeProps = $ReadOnly<{|
   titleColor?: ColorValue,
   disableBackButtonMenu?: boolean,
   hideBackButton?: boolean,
+  backButtonInCustomView?: boolean,
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean,
-  backButtonInCustomView?: boolean,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -150,7 +150,6 @@ const RouteView = ({
   const { options, render: renderScene } = descriptors[route.key];
   const {
     gestureEnabled,
-    gestureResponseDistance,
     headerShown,
     hideKeyboardOnSwipe,
     homeIndicatorHidden,
@@ -171,6 +170,7 @@ const RouteView = ({
   let {
     customAnimationOnSwipe,
     fullScreenSwipeEnabled,
+    gestureResponseDistance,
     stackAnimation,
     stackPresentation = 'push',
   } = options;
@@ -189,6 +189,29 @@ const RouteView = ({
     }
     if (stackAnimation === undefined) {
       stackAnimation = 'slide_from_bottom';
+    }
+  }
+
+  if (gestureResponseDistance === undefined) {
+    // default values, required for unification of Fabric & Paper implementation
+    gestureResponseDistance = {
+      start: -1,
+      end: -1,
+      top: -1,
+      bottom: -1,
+    };
+  } else {
+    if (gestureResponseDistance.start === undefined) {
+      gestureResponseDistance.start = -1;
+    }
+    if (gestureResponseDistance.end === undefined) {
+      gestureResponseDistance.end = -1;
+    }
+    if (gestureResponseDistance.top === undefined) {
+      gestureResponseDistance.top = -1;
+    }
+    if (gestureResponseDistance.bottom === undefined) {
+      gestureResponseDistance.bottom = -1;
     }
   }
 


### PR DESCRIPTION
## Description

Part of stack PR. See: 

* https://github.com/software-mansion/react-native-screens/pull/1430

This PR adds `replaceAnimation` prop for Fabric.

## Changes

See [commits](https://github.com/software-mansion/react-native-screens/pull/1432/commits).

## Test code and steps to reproduce

TODO

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
