### PR TITLE
chore: add `homeIndicatorHidden` & `activityState` props for Fabric (6)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -153,6 +153,8 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
 
     override fun setHomeIndicatorHidden(view: Screen?, value: Boolean) = Unit
 
+    override fun setPreventNativeDismiss(view: Screen?, value: Boolean) = Unit
+
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         val map: MutableMap<String, Any> = MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -140,7 +140,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
         view.nativeBackButtonDismissalEnabled = nativeBackButtonDismissalEnabled
     }
 
-    // these props are not available on Android, however we must override their getters
+    // these props are not available on Android, however we must override their setters
     override fun setFullScreenSwipeEnabled(view: Screen?, value: Boolean) = Unit
 
     override fun setTransitionDuration(view: Screen?, value: Int) = Unit
@@ -150,6 +150,8 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     override fun setCustomAnimationOnSwipe(view: Screen?, value: Boolean) = Unit
 
     override fun setGestureResponseDistance(view: Screen?, value: ReadableMap?) = Unit
+
+    override fun setHomeIndicatorHidden(view: Screen?, value: Boolean) = Unit
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         val map: MutableMap<String, Any> = MapBuilder.of(

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -12,6 +12,7 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -22,8 +23,17 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
+      case "customAnimationOnSwipe":
+        mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);
+        break;
       case "fullScreenSwipeEnabled":
         mViewManager.setFullScreenSwipeEnabled(view, value == null ? false : (boolean) value);
+        break;
+      case "homeIndicatorHidden":
+        mViewManager.setHomeIndicatorHidden(view, value == null ? false : (boolean) value);
+        break;
+      case "preventNativeDismiss":
+        mViewManager.setPreventNativeDismiss(view, value == null ? false : (boolean) value);
         break;
       case "gestureEnabled":
         mViewManager.setGestureEnabled(view, value == null ? true : (boolean) value);
@@ -46,6 +56,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "statusBarTranslucent":
         mViewManager.setStatusBarTranslucent(view, value == null ? false : (boolean) value);
         break;
+      case "gestureResponseDistance":
+        mViewManager.setGestureResponseDistance(view, (ReadableMap) value);
+        break;
       case "stackPresentation":
         mViewManager.setStackPresentation(view, (String) value);
         break;
@@ -58,6 +71,12 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "replaceAnimation":
         mViewManager.setReplaceAnimation(view, (String) value);
         break;
+      case "hideKeyboardOnSwipe":
+        mViewManager.setHideKeyboardOnSwipe(view, value == null ? false : (boolean) value);
+        break;
+      case "activityState":
+        mViewManager.setActivityState(view, value == null ? -1 : ((Double) value).intValue());
+        break;
       case "navigationBarColor":
         mViewManager.setNavigationBarColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
@@ -66,9 +85,6 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
         break;
       case "nativeBackButtonDismissalEnabled":
         mViewManager.setNativeBackButtonDismissalEnabled(view, value == null ? false : (boolean) value);
-        break;
-      case "activityState":
-        mViewManager.setActivityState(view, value == null ? -1 : ((Double) value).intValue());
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -11,9 +11,13 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSScreenManagerInterface<T extends View> {
+  void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, boolean value);
+  void setHomeIndicatorHidden(T view, boolean value);
+  void setPreventNativeDismiss(T view, boolean value);
   void setGestureEnabled(T view, boolean value);
   void setStatusBarColor(T view, @Nullable Integer value);
   void setStatusBarHidden(T view, boolean value);
@@ -21,12 +25,14 @@ public interface RNSScreenManagerInterface<T extends View> {
   void setStatusBarAnimation(T view, @Nullable String value);
   void setStatusBarStyle(T view, @Nullable String value);
   void setStatusBarTranslucent(T view, boolean value);
+  void setGestureResponseDistance(T view, @Nullable ReadableMap value);
   void setStackPresentation(T view, @Nullable String value);
   void setStackAnimation(T view, @Nullable String value);
   void setTransitionDuration(T view, int value);
   void setReplaceAnimation(T view, @Nullable String value);
+  void setHideKeyboardOnSwipe(T view, boolean value);
+  void setActivityState(T view, int value);
   void setNavigationBarColor(T view, @Nullable Integer value);
   void setNavigationBarHidden(T view, boolean value);
   void setNativeBackButtonDismissalEnabled(T view, boolean value);
-  void setActivityState(T view, int value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
@@ -91,11 +91,11 @@ public class RNSScreenStackHeaderConfigManagerDelegate<T extends View, U extends
       case "hideBackButton":
         mViewManager.setHideBackButton(view, value == null ? false : (boolean) value);
         break;
-      case "topInsetEnabled":
-        mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
-        break;
       case "backButtonInCustomView":
         mViewManager.setBackButtonInCustomView(view, value == null ? false : (boolean) value);
+        break;
+      case "topInsetEnabled":
+        mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -36,6 +36,6 @@ public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> {
   void setTitleColor(T view, @Nullable Integer value);
   void setDisableBackButtonMenu(T view, boolean value);
   void setHideBackButton(T view, boolean value);
-  void setTopInsetEnabled(T view, boolean value);
   void setBackButtonInCustomView(T view, boolean value);
+  void setTopInsetEnabled(T view, boolean value);
 }

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -29,11 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
+- (void)notifyFinishTransitioning;
 #ifdef RN_FABRIC_ENABLED
 - (void)setViewToSnapshot:(UIView *)snapshot;
 - (void)resetViewToScreen;
-#else
-- (void)notifyFinishTransitioning;
 #endif
 
 @end
@@ -87,6 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL preventNativeDismiss;
 #endif
 
+- (void)notifyFinishTransitioning;
+
 #ifdef RN_FABRIC_ENABLED
 - (void)notifyWillAppear;
 - (void)notifyWillDisappear;
@@ -95,7 +96,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateBounds;
 - (void)notifyDismissedWithCount:(int)dismissCount;
 #else
-- (void)notifyFinishTransitioning;
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
 #endif
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, retain) RNSScreen *controller;
 @property (nonatomic, copy) NSDictionary *gestureResponseDistance;
 @property (nonatomic) int activityState;
+@property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
@@ -74,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #ifdef RN_FABRIC_ENABLED
 @property (weak, nonatomic) UIView *config;
-@property (weak, nonatomic) UIView *reactSuperview;
 #else
 @property (nonatomic, copy) RCTDirectEventBlock onAppear;
 @property (nonatomic, copy) RCTDirectEventBlock onDisappear;
@@ -84,7 +84,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
 
-@property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic) BOOL preventNativeDismiss;
 #endif
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL dismissed;
 @property (nonatomic) BOOL hideKeyboardOnSwipe;
 @property (nonatomic) BOOL customAnimationOnSwipe;
+@property (nonatomic) BOOL preventNativeDismiss;
 @property (nonatomic, retain) RNSScreen *controller;
 @property (nonatomic, copy) NSDictionary *gestureResponseDistance;
 @property (nonatomic) int activityState;
@@ -82,8 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
-
-@property (nonatomic) BOOL preventNativeDismiss;
 #endif
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL customAnimationOnSwipe;
 @property (nonatomic, retain) RNSScreen *controller;
 @property (nonatomic, copy) NSDictionary *gestureResponseDistance;
+@property (nonatomic) int activityState;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
@@ -84,7 +85,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
 
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
-@property (nonatomic) int activityState;
 @property (nonatomic) BOOL preventNativeDismiss;
 #endif
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -457,8 +457,10 @@
   [self setHideKeyboardOnSwipe:newScreenProps.hideKeyboardOnSwipe];
 
   [self setCustomAnimationOnSwipe:newScreenProps.customAnimationOnSwipe];
-  
-  [self setGestureResponseDistance:[RNSConvert gestureResponseDistanceDictFromCppStruct:newScreenProps.gestureResponseDistance]];
+
+  [self
+      setGestureResponseDistance:[RNSConvert
+                                     gestureResponseDistanceDictFromCppStruct:newScreenProps.gestureResponseDistance]];
 
 #if !TARGET_OS_TV
   if (newScreenProps.statusBarHidden != oldScreenProps.statusBarHidden) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -199,7 +199,7 @@
 - (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
   int activityState = [activityStateOrNil intValue];
-  if (activityStateOrNil != nil && activityState != _activityState) {
+  if (activityStateOrNil != nil && activityState != -1 && activityState != _activityState) {
     _activityState = activityState;
     [_reactSuperview markChildUpdated];
   }
@@ -467,6 +467,8 @@
       setGestureResponseDistance:[RNSConvert
                                      gestureResponseDistanceDictFromCppStruct:newScreenProps.gestureResponseDistance]];
 
+  [self setActivityStateOrNil:[NSNumber numberWithInt:newScreenProps.activityState]];
+  
 #if !TARGET_OS_TV
   if (newScreenProps.statusBarHidden != oldScreenProps.statusBarHidden) {
     [self setStatusBarHidden:newScreenProps.statusBarHidden];
@@ -504,7 +506,7 @@
   if (newScreenProps.replaceAnimation != oldScreenProps.replaceAnimation) {
     [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
   }
-
+  
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -466,6 +466,10 @@
     [self setScreenOrientation:[RCTConvert UIInterfaceOrientationMask:RCTNSStringFromStringNilIfEmpty(
                                                                           newScreenProps.screenOrientation)]];
   }
+  
+  if (newScreenProps.homeIndicatorHidden != oldScreenProps.homeIndicatorHidden) {
+    [self setHomeIndicatorHidden:newScreenProps.homeIndicatorHidden];
+  }
 #endif
 
   if (newScreenProps.stackPresentation != oldScreenProps.stackPresentation) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -192,6 +192,19 @@
   _replaceAnimation = replaceAnimation;
 }
 
+// Nil will be provided when activityState is set as an animated value and we change
+// it from JS to be a plain value (non animated).
+// In case when nil is received, we want to ignore such value and not make
+// any updates as the actual non-nil value will follow immediately.
+- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
+{
+  int activityState = [activityStateOrNil intValue];
+  if (activityStateOrNil != nil && activityState != _activityState) {
+    _activityState = activityState;
+    [_reactSuperview markChildUpdated];
+  }
+}
+
 #if !TARGET_OS_TV
 - (void)setStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
@@ -466,7 +479,7 @@
     [self setScreenOrientation:[RCTConvert UIInterfaceOrientationMask:RCTNSStringFromStringNilIfEmpty(
                                                                           newScreenProps.screenOrientation)]];
   }
-  
+
   if (newScreenProps.homeIndicatorHidden != oldScreenProps.homeIndicatorHidden) {
     [self setHomeIndicatorHidden:newScreenProps.homeIndicatorHidden];
   }
@@ -517,19 +530,6 @@
       @"closing" : @(closing ? 1 : 0),
       @"goingForward" : @(goingForward ? 1 : 0),
     });
-  }
-}
-
-// Nil will be provided when activityState is set as an animated value and we change
-// it from JS to be a plain value (non animated).
-// In case when nil is received, we want to ignore such value and not make
-// any updates as the actual non-nil value will follow immediately.
-- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
-{
-  int activityState = [activityStateOrNil intValue];
-  if (activityStateOrNil != nil && activityState != _activityState) {
-    _activityState = activityState;
-    [_reactSuperview markChildUpdated];
   }
 }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -16,11 +16,11 @@
 #import "RNSConvert.h"
 #else
 #import <React/RCTTouchHandler.h>
-#import "RNSScreenStack.h"
 #endif
 
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
+#import "RNSScreenStack.h"
 #import "RNSScreenStackHeaderConfig.h"
 
 @interface RNSScreenView ()
@@ -467,6 +467,8 @@
       setGestureResponseDistance:[RNSConvert
                                      gestureResponseDistanceDictFromCppStruct:newScreenProps.gestureResponseDistance]];
 
+  [self setPreventNativeDismiss:newScreenProps.preventNativeDismiss];
+
   [self setActivityStateOrNil:[NSNumber numberWithInt:newScreenProps.activityState]];
   
 #if !TARGET_OS_TV
@@ -609,10 +611,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 @implementation RNSScreen {
   __weak id _previousFirstResponder;
+  CGRect _lastViewFrame;
 #ifdef RN_FABRIC_ENABLED
   RNSScreenView *_initialView;
 #else
-  CGRect _lastViewFrame;
   UIView *_fakeView;
   CADisplayLink *_animationTimer;
   CGFloat _currentAlpha;
@@ -770,12 +772,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-#ifdef RN_FABRIC_ENABLED
-  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[UINavigationController class]];
-  if (isDisplayedWithinUINavController) {
-    [_initialView updateBounds];
-  }
-#else
+
   // The below code makes the screen view adapt dimensions provided by the system. We take these
   // into account only when the view is mounted under RNScreensNavigationController in which case system
   // provides additional padding to account for possible header, and in the case when screen is
@@ -784,12 +781,17 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   BOOL isDisplayedWithinUINavController =
       [self.parentViewController isKindOfClass:[RNScreensNavigationController class]];
   BOOL isPresentedAsNativeModal = self.parentViewController == nil && self.presentingViewController != nil;
-  if ((isDisplayedWithinUINavController || isPresentedAsNativeModal) &&
-      !CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
-    _lastViewFrame = self.view.frame;
-    [((RNSScreenView *)self.viewIfLoaded) updateBounds];
-  }
+
+  if (isDisplayedWithinUINavController || isPresentedAsNativeModal) {
+#ifdef RN_FABRIC_ENABLED
+    [_initialView updateBounds];
+#else
+    if (!CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
+      _lastViewFrame = self.view.frame;
+      [((RNSScreenView *)self.viewIfLoaded) updateBounds];
+    }
 #endif
+  }
 }
 
 - (void)notifyFinishTransitioning

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -141,7 +141,6 @@
 
 - (void)updateContainer
 {
-#ifndef RN_FABRIC_ENABLED
   BOOL screenRemoved = NO;
   // remove screens that are no longer active
   NSMutableSet *orphaned = [NSMutableSet setWithSet:_activeScreens];
@@ -191,7 +190,6 @@
   if (screenRemoved || screenAdded) {
     [self maybeDismissVC];
   }
-#endif
 }
 
 - (void)maybeDismissVC

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSScreenStackView :
 #ifdef RN_FABRIC_ENABLED
-    RCTViewComponentView
+    RCTViewComponentView <RNSScreenContainerDelegate>
 #else
     UIView <RNSScreenContainerDelegate, RCTInvalidating>
 #endif

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -24,7 +24,6 @@
 #else
 @property (nonatomic) UIBlurEffectStyle blurEffect;
 @property (nonatomic) BOOL hide;
-@property (nonatomic) BOOL backButtonInCustomView;
 #endif
 
 @property (nonatomic, retain) NSString *title;
@@ -48,6 +47,7 @@
 @property (nonatomic) BOOL disableBackButtonMenu;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
+@property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) UISemanticContentAttribute direction;
 
 + (void)willShowViewController:(UIViewController *)vc

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -543,12 +543,9 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
-#ifdef RN_FABRIC_ENABLED
-#else
 #if !TARGET_OS_TV
         navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
 #endif
-#endif // RN_FABRIC_ENABLED
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
         navitem.leftBarButtonItem = buttonItem;
         break;
@@ -705,6 +702,10 @@
   if (newScreenProps.translucent != _translucent) {
     _translucent = newScreenProps.translucent;
     needsNavigationControllerLayout = YES;
+  }
+  
+  if (newScreenProps.backButtonInCustomView != _backButtonInCustomView) {
+    [self setBackButtonInCustomView:newScreenProps.backButtonInCustomView];
   }
 
   _title = RCTNSStringFromStringNilIfEmpty(newScreenProps.title);

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -71,11 +71,11 @@ export type NativeProps = $ReadOnly<{|
   transitionDuration?: WithDefault<Int32, 350>,
   replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>,
   hideKeyboardOnSwipe?: boolean,
+  activityState?: WithDefault<Int32, -1>,
   // TODO: implement these props on iOS
   navigationBarColor?: ColorValue,
   navigationBarHidden?: boolean,
   nativeBackButtonDismissalEnabled?: boolean,
-  activityState?: WithDefault<Int32, -1>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -57,6 +57,7 @@ export type NativeProps = $ReadOnly<{|
   onWillDisappear?: ?BubblingEventHandler<ScreenEvent>,
   customAnimationOnSwipe?: boolean,
   fullScreenSwipeEnabled?: boolean,
+  homeIndicatorHidden?: boolean,
   gestureEnabled?: WithDefault<boolean, true>,
   statusBarColor?: ColorValue,
   statusBarHidden?: boolean,

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -58,6 +58,7 @@ export type NativeProps = $ReadOnly<{|
   customAnimationOnSwipe?: boolean,
   fullScreenSwipeEnabled?: boolean,
   homeIndicatorHidden?: boolean,
+  preventNativeDismiss?: boolean,
   gestureEnabled?: WithDefault<boolean, true>,
   statusBarColor?: ColorValue,
   statusBarHidden?: boolean,

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.js
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.js
@@ -41,9 +41,9 @@ export type NativeProps = $ReadOnly<{|
   titleColor?: ColorValue,
   disableBackButtonMenu?: boolean,
   hideBackButton?: boolean,
+  backButtonInCustomView?: boolean,
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean,
-  backButtonInCustomView?: boolean,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
## Description

Part of stack PR. See: 

* https://github.com/software-mansion/react-native-screens/pull/1430

This PR adds `homeIndicatorHidden` & `activityState` props for Fabric.

## Changes

See [commits](https://github.com/software-mansion/react-native-screens/pull/1443/commits).

## Test code and steps to reproduce

TODO

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
