### PR TITLE
fix: add better fabric_enabled check

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 # folly_version must match the version used in React Native
 # See folly_version in react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec


### PR DESCRIPTION
Added check for if env var is set to `1` instead of if it exists, based on https://github.com/software-mansion/react-native-reanimated/blob/e49e1abea60badb0bfb7666389adfa29093bf697/RNReanimated.podspec#L41 and suggestion from @tomekzaw and @piaskowyk 