### PR TITLE
feat: use recommended WindowInsetsControllerCompat for StatusBar management

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -8,9 +8,7 @@ import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Build
-import android.view.View
 import android.view.ViewParent
-import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -64,12 +62,12 @@ object ScreenWindowTraits {
         UiThreadUtil.runOnUiThread(
             object : GuardedRunnable(context) {
                 override fun runGuarded() {
-                    activity
-                        .window
-                        .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-                    val curColor = activity.window.statusBarColor
+                    val window = activity.window
+                    val curColor: Int = window.statusBarColor
                     val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), curColor, color)
-                    colorAnimation.addUpdateListener { animator -> activity.window.statusBarColor = (animator.animatedValue as Int) }
+                    colorAnimation.addUpdateListener { animator ->
+                        window.statusBarColor = animator.animatedValue as Int
+                    }
                     if (animated) {
                         colorAnimation.setDuration(300).startDelay = 0
                     } else {
@@ -89,13 +87,10 @@ object ScreenWindowTraits {
 
         UiThreadUtil.runOnUiThread {
             val decorView = activity.window.decorView
-            var systemUiVisibilityFlags = decorView.systemUiVisibility
-            systemUiVisibilityFlags = if ("dark" == style) {
-                systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-            } else {
-                systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-            }
-            decorView.systemUiVisibility = systemUiVisibilityFlags
+            val window = activity.window
+            val controller = WindowInsetsControllerCompat(window, decorView)
+
+            controller.isAppearanceLightStatusBars = style == "dark"
         }
     }
 
@@ -140,13 +135,14 @@ object ScreenWindowTraits {
         }
         val screenForHidden = findScreenForTrait(screen, WindowTraits.HIDDEN)
         val hidden = screenForHidden?.isStatusBarHidden ?: false
+        val window = activity.window
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+
         UiThreadUtil.runOnUiThread {
             if (hidden) {
-                activity.window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+                controller.hide(WindowInsetsCompat.Type.statusBars())
             } else {
-                activity.window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
-                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                controller.show(WindowInsetsCompat.Type.statusBars())
             }
         }
     }


### PR DESCRIPTION
## Description

Rewrote:
- setStyle;
- setHidden;
- setColor

methods to use `WindowInsetsControllerCompat` for StatusBar management (instead of old approach with changing window flags).

## Context And Motivation

I'm currently working on [react-native-keyboard-controller](https://github.com/kirillzyusko/react-native-keyboard-controller) library which heavily relies on `WindowInsets*` API. However if the code uses old way with window flags management - it breaks `WindowInsets*` API and I can not listen for keyboard events anymore using `ViewCompat.setWindowInsetsAnimationCallback`. So in this PR I rewrote some methods to new style and used `WindowInsetsControllerCompat` instead of managing window flags.

However I couldn't find a way how to rewrite `setTranslucent` method 🤔 (though in your example app it works without any issues, I mean old and new approach can live together without any conflicts). But I think it would be better to rewrite everything to one style and I would be highly appreciate you if you could help me to find a way how to rewrite it 😊 

## Changes

- Used `WindowInsetsControllerCompat` for `StatusBar` management

## Screenshots / GIFs

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img width="764" alt="image" src="https://user-images.githubusercontent.com/22820318/168859833-91ad8566-9543-4ebc-b268-ba2212df3155.png"></td>
    <td><img width="766" alt="image" src="https://user-images.githubusercontent.com/22820318/168859661-57366ec4-59c2-41c8-8bf9-e286ce8a9d6f.png"></td>
  </tr>
</table>

Before we had a lot of places using deprecated API.

## Test code and steps to reproduce

I have used your example with StatusBar settings - everything works as before, I didn't notice any differences 🤷‍♂️ 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
