### PR TITLE
feat: missing Screen prop: swipeDirection

### DIFF
--- a/FabricTestExample/src/Test1260.tsx
+++ b/FabricTestExample/src/Test1260.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {Button, View} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{
+        swipeDirection: 'vertical',
+      }}>
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen
+          name="Second"
+          component={Second}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function First({navigation}: {navigation: NativeStackNavigationProp<ParamListBase>}) {
+  return (
+    <View style={{flex: 1, backgroundColor: 'red'}}>
+      <Button title="Tap me for second screen" onPress={() => navigation.navigate('Second')} />
+    </View>
+
+  );
+}
+
+function Second({navigation}: {navigation: NativeStackNavigationProp<ParamListBase>}) {
+  return (
+    <View style={{flex: 1, backgroundColor: 'blue'}}>
+      <Button title="Tap me for second screen" onPress={() => navigation.navigate('First')} />
+    </View>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -155,6 +155,8 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
 
     override fun setPreventNativeDismiss(view: Screen?, value: Boolean) = Unit
 
+    override fun setSwipeDirection(view: Screen?, value: String?) = Unit
+
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         val map: MutableMap<String, Any> = MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -71,6 +71,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "replaceAnimation":
         mViewManager.setReplaceAnimation(view, (String) value);
         break;
+      case "swipeDirection":
+        mViewManager.setSwipeDirection(view, (String) value);
+        break;
       case "hideKeyboardOnSwipe":
         mViewManager.setHideKeyboardOnSwipe(view, value == null ? false : (boolean) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -30,6 +30,7 @@ public interface RNSScreenManagerInterface<T extends View> {
   void setStackAnimation(T view, @Nullable String value);
   void setTransitionDuration(T view, int value);
   void setReplaceAnimation(T view, @Nullable String value);
+  void setSwipeDirection(T view, @Nullable String value);
   void setHideKeyboardOnSwipe(T view, boolean value);
   void setActivityState(T view, int value);
   void setNavigationBarColor(T view, @Nullable Integer value);

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -16,6 +16,9 @@
 + (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
     (facebook::react::RNSScreenReplaceAnimation)replaceAnimation;
 
++ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
+    (facebook::react::RNSScreenSwipeDirection)swipeDirection;
+
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -78,6 +78,17 @@
   }
 }
 
++ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
+    (facebook::react::RNSScreenSwipeDirection)swipeDirection
+{
+  switch (swipeDirection) {
+    case facebook::react::RNSScreenSwipeDirection::Horizontal:
+      return RNSScreenSwipeDirectionHorizontal;
+    case facebook::react::RNSScreenSwipeDirection::Vertical:
+      return RNSScreenSwipeDirectionVertical;
+  }
+}
+
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -471,6 +471,8 @@
 
   [self setActivityStateOrNil:[NSNumber numberWithInt:newScreenProps.activityState]];
   
+  [self setSwipeDirection:[RNSConvert RNSScreenSwipeDirectionFromCppEquivalent:newScreenProps.swipeDirection]];
+
 #if !TARGET_OS_TV
   if (newScreenProps.statusBarHidden != oldScreenProps.statusBarHidden) {
     [self setStatusBarHidden:newScreenProps.statusBarHidden];
@@ -508,7 +510,7 @@
   if (newScreenProps.replaceAnimation != oldScreenProps.replaceAnimation) {
     [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
   }
-  
+
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -751,8 +751,9 @@
   if (isRTL) {
     x = _controller.view.frame.size.width - x;
   }
-  
-  // see: https://github.com/software-mansion/react-native-screens/pull/1442/commits/74d4bae321875d8305ad021b3d448ebf713e7d56
+
+  // see:
+  // https://github.com/software-mansion/react-native-screens/pull/1442/commits/74d4bae321875d8305ad021b3d448ebf713e7d56
   // this prop is always default initialized so we do not expect any nils
   float start = [gestureResponseDistanceValues[@"start"] floatValue];
   float end = [gestureResponseDistanceValues[@"end"] floatValue];
@@ -761,10 +762,7 @@
 
   // we check if any of the constraints are violated and return NO if so
   return !(
-      (start != -1 && x < start) ||
-      (end != -1 && x > end) ||
-      (top != -1 && y < top) ||
-      (bottom != -1 && y > bottom));
+      (start != -1 && x < start) || (end != -1 && x > end) || (top != -1 && y < top) || (bottom != -1 && y > bottom));
 }
 
 // By default, the header buttons that are not inside the native hit area

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -806,6 +806,19 @@
   return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
 }
 
+- (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
+                         interactionControllerForAnimationController:
+                             (id<UIViewControllerAnimatedTransitioning>)animationController
+{
+  return _interactionController;
+}
+
+- (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:
+    (id<UIViewControllerAnimatedTransitioning>)animator
+{
+  return _interactionController;
+}
+
 #ifdef RN_FABRIC_ENABLED
 #pragma mark - Fabric specific
 
@@ -940,19 +953,6 @@
   [_presentedModals removeAllObjects];
   [_controller willMoveToParentViewController:nil];
   [_controller removeFromParentViewController];
-}
-
-- (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
-                         interactionControllerForAnimationController:
-                             (id<UIViewControllerAnimatedTransitioning>)animationController
-{
-  return _interactionController;
-}
-
-- (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:
-    (id<UIViewControllerAnimatedTransitioning>)animator
-{
-  return _interactionController;
 }
 #endif // RN_FABRIC_ENABLED
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -703,7 +703,7 @@
     _translucent = newScreenProps.translucent;
     needsNavigationControllerLayout = YES;
   }
-  
+
   if (newScreenProps.backButtonInCustomView != _backButtonInCustomView) {
     [self setBackButtonInCustomView:newScreenProps.backButtonInCustomView];
   }

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -46,6 +46,8 @@ type StackAnimation =
   | 'slide_from_bottom'
   | 'fade_from_bottom';
 
+type SwipeDirection = 'vertical' | 'horizontal';
+
 type ReplaceAnimation = 'pop' | 'push';
 
 export type NativeProps = $ReadOnly<{|
@@ -71,6 +73,7 @@ export type NativeProps = $ReadOnly<{|
   stackAnimation?: WithDefault<StackAnimation, 'default'>,
   transitionDuration?: WithDefault<Int32, 350>,
   replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>,
+  swipeDirection?: WithDefault<SwipeDirection, 'horizontal'>,
   hideKeyboardOnSwipe?: boolean,
   activityState?: WithDefault<Int32, -1>,
   // TODO: implement these props on iOS


### PR DESCRIPTION
## Description

Added support for `swipeDirection` (iOS only) prop on Fabric

## Changes

* added it to `SceenNativeComponent.js` (for codegen)
* added prop update inside `RNSScreenView#updateProps:oldProps:`
* added noop for Android
* copied newly generated interfaces to paper directory

## Test code and steps to reproduce

* `Test1260` in FabricTestExample

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
