### PR TITLE
feat: implement `onFinishTransitioning` event for ScreenStack for Fabric

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -146,7 +146,7 @@
 {
 #ifdef RN_FABRIC_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<facebook::react::RNSScreenStackEventEmitter>(_eventEmitter)
+    std::dynamic_pointer_cast<const facebook::react::RNSScreenStackEventEmitter>(_eventEmitter)
         ->onFinishTransitioning(facebook::react::RNSScreenStackEventEmitter::OnFinishTransitioning{});
   }
 #else

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -142,6 +142,20 @@
 
 #pragma mark - Common
 
+- (void)emitOnFinishTransitioningEvent
+{
+#ifdef RN_FABRIC_ENABLED
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<facebook::react::RNSScreenStackEventEmitter>(_eventEmitter)
+        ->onFinishTransitioning(facebook::react::RNSScreenStackEventEmitter::OnFinishTransitioning{});
+  }
+#else
+  if (self.onFinishTransitioning) {
+    self.onFinishTransitioning(nil);
+  }
+#endif
+}
+
 - (void)navigationController:(UINavigationController *)navigationController
       willShowViewController:(UIViewController *)viewController
                     animated:(BOOL)animated
@@ -179,17 +193,15 @@
     // have tried to push another one during the transition
     _updatingModals = NO;
     [self updateContainer];
-    // TODO: implement onFinishTransitioning on Fabric
 #ifdef RN_FABRIC_ENABLED
+    [self emitOnFinishTransitioningEvent];
 #else
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the
       // main queue. We do that because onDismiss event is also enqueued and we want for the transition
       // finish event to arrive later than onDismiss (see RNSScreen#notifyDismiss)
       dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.onFinishTransitioning) {
-          self.onFinishTransitioning(nil);
-        }
+        [self emitOnFinishTransitioningEvent];
       });
     }
 #endif
@@ -327,13 +339,7 @@
   __weak RNSScreenStackView *weakSelf = self;
 
   void (^afterTransitions)(void) = ^{
-  // TODO: Implement onFinishTransitioning on Fabric
-#ifdef RN_FABRIC_ENABLED
-#else
-    if (weakSelf.onFinishTransitioning) {
-      weakSelf.onFinishTransitioning(nil);
-    }
-#endif
+    [weakSelf emitOnFinishTransitioningEvent];
     weakSelf.updatingModals = NO;
     if (weakSelf.scheduleModalsUpdate) {
       // if modals update was requested during setModalViewControllers we set scheduleModalsUpdate
@@ -743,12 +749,7 @@
        didShowViewController:(UIViewController *)viewController
                     animated:(BOOL)animated
 {
-#ifdef RN_FABRIC_ENABLED
-#else
-  if (self.onFinishTransitioning) {
-    self.onFinishTransitioning(nil);
-  }
-#endif
+  [self emitOnFinishTransitioningEvent];
   [RNSScreenWindowTraits updateWindowTraits];
 }
 #endif

--- a/src/fabric/ScreenStackNativeComponent.js
+++ b/src/fabric/ScreenStackNativeComponent.js
@@ -6,9 +6,13 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+
+type FinishTransitioningEvent = $ReadOnly<{||}>;
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
+  onFinishTransitioning?: ?DirectEventHandler<FinishTransitioningEvent>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
## Description

Implemented `onFinishTransitioning` event for ScreenStack on Fabric. 

## Changes

* Added event type to codegen 
* Added event dispatch on Fabric
* Small refactoring of event emitting methods so they are shared between architerctures.

## Test code and steps to reproduce

No new tests

This event was used only with react-naviagation v4.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
