### PR TITLE
fix: `hideHeaderIfNecessary` for Fabric

### DIFF
--- a/FabricTestExample/src/Test1153.tsx
+++ b/FabricTestExample/src/Test1153.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import {Button, View} from 'react-native';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import { ScrollView } from 'react-native-gesture-handler';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <View style={{flex: 1}}>
+      <NavigationContainer>
+        <Stack.Navigator screenOptions={{gestureEnabled: true}}>
+          <Stack.Screen
+            name="First"
+            component={First}
+            options={{
+              gestureEnabled: true,
+              headerTranslucent: true,
+              searchBar: {
+                placeholder: 'Interesting places...',
+                obscureBackground: false,
+                hideWhenScrolling: false,
+              },
+            }}
+          />
+          <Stack.Screen
+            name="Second"
+            component={Second}
+            options={{
+              headerShown: false,
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </View>
+  );
+}
+
+function First({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <ScrollView
+      style={{
+        backgroundColor: '#000',
+        flex: 1,
+      }}
+      contentInsetAdjustmentBehavior="automatic">
+      <SafeAreaView>
+        <Button
+          title="Tap me for second screen"
+          onPress={() => {
+            navigation.push('Second');
+          }}
+        />
+      </SafeAreaView>
+    </ScrollView>
+  );
+}
+
+function Second({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <View style={{backgroundColor: '#777', flex: 1, justifyContent: 'center'}}>
+      <Button
+        title="Tap me to go back"
+        onPress={() => {
+          navigation.pop();
+        }}
+      />
+      <Button
+        title="Open this screen again"
+        onPress={() => navigation.push('Second')}
+      />
+    </View>
+  );
+}

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1078,7 +1078,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
     // we need to check whether reactSubviews array is empty, because on Fabric child nodes are unmounted first ->
     // reactSubviews array may be empty
-    if (currentIndex > 0 && [self.screenView.reactSubviews count] &&
+    if (currentIndex > 0 && [self.screenView.reactSubviews count] > 0 &&
         [self.screenView.reactSubviews[0] isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
       UINavigationItem *prevNavigationItem =
           [self.navigationController.viewControllers objectAtIndex:currentIndex - 1].navigationItem;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -728,10 +728,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     // The _isSwiping is still true, but we don't want to notify then
     _shouldNotify = NO;
   }
-#ifdef RN_FABRIC_ENABLED
-#else
+
   [self hideHeaderIfNecessary];
-#endif // RN_FABRIC_ENABLED
   // as per documentation of these methods
   _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1068,35 +1068,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 #endif
 }
 
-#ifdef RN_FABRIC_ENABLED
-#pragma mark - Fabric specific
-
-- (void)setViewToSnapshot:(UIView *)snapshot
-{
-  // modals of native stack seem not to support
-  // changing their view by just setting the view
-  if (_initialView.stackPresentation != RNSScreenStackPresentationPush) {
-    UIView *superView = self.view.superview;
-    [self.view removeFromSuperview];
-    self.view = snapshot;
-    [superView addSubview:self.view];
-  } else {
-    [self.view removeFromSuperview];
-    self.view = snapshot;
-  }
-}
-
-- (void)resetViewToScreen
-{
-  if (self.view != _initialView) {
-    [self.view removeFromSuperview];
-    self.view = _initialView;
-  }
-}
-
-#else
-#pragma mark - Paper specific
-
 - (void)hideHeaderIfNecessary
 {
 #if !TARGET_OS_TV
@@ -1130,6 +1101,35 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   }
 #endif
 }
+
+#ifdef RN_FABRIC_ENABLED
+#pragma mark - Fabric specific
+
+- (void)setViewToSnapshot:(UIView *)snapshot
+{
+  // modals of native stack seem not to support
+  // changing their view by just setting the view
+  if (_initialView.stackPresentation != RNSScreenStackPresentationPush) {
+    UIView *superView = self.view.superview;
+    [self.view removeFromSuperview];
+    self.view = snapshot;
+    [superView addSubview:self.view];
+  } else {
+    [self.view removeFromSuperview];
+    self.view = snapshot;
+  }
+}
+
+- (void)resetViewToScreen
+{
+  if (self.view != _initialView) {
+    [self.view removeFromSuperview];
+    self.view = _initialView;
+  }
+}
+
+#else
+#pragma mark - Paper specific
 
 - (void)traverseForScrollView:(UIView *)view
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1076,7 +1076,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (@available(iOS 13.0, *)) {
     NSUInteger currentIndex = [self.navigationController.viewControllers indexOfObject:self];
 
-    if (currentIndex > 0 && [self.screenView.reactSubviews[0] isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+    // we need to check whether reactSubviews array is empty, because on Fabric child nodes are unmounted first ->
+    // reactSubviews array may be empty
+    if (currentIndex > 0 && [self.screenView.reactSubviews count] &&
+        [self.screenView.reactSubviews[0] isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
       UINavigationItem *prevNavigationItem =
           [self.navigationController.viewControllers objectAtIndex:currentIndex - 1].navigationItem;
       RNSScreenStackHeaderConfig *config = ((RNSScreenStackHeaderConfig *)self.screenView.reactSubviews[0]);


### PR DESCRIPTION
## Description

Added the fix introduced here: 

* https://github.com/software-mansion/react-native-screens/pull/1153

for Fabric.

## Changes

* Moved `hideHeaderIfNecessary` method to common section
* Added fix for Fabric: when returning from second screen application would crash due to order of view unmounting (child-first) on Fabric (calling `view.reactSubviews[0]` would cause application to crash)


## Test code and steps to reproduce

* Moved `Test1153`. See: https://github.com/software-mansion/react-native-screens/pull/1153

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
