### PR TITLE
fix: reset values after animations and make snapshot only when necessary

### DIFF
--- a/FabricTestExample/src/Test887.tsx
+++ b/FabricTestExample/src/Test887.tsx
@@ -46,7 +46,8 @@ export default function App(): JSX.Element {
       <Stack.Navigator
         screenOptions={{
           stackAnimation: 'fade_from_bottom',
-          headerShown: false,
+          headerShown: true,
+          customAnimationOnSwipe: true,
           // stackPresentation: 'transparentModal',
         }}>
         <Stack.Screen name="First" component={NestedFirst} />

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.69.0-rc.6)
-  - FBReactNativeSpec (0.69.0-rc.6):
+  - FBLazyVector (0.69.0)
+  - FBReactNativeSpec (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.6)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Core (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -86,203 +86,203 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.69.0-rc.6)
-  - RCTTypeSafety (0.69.0-rc.6):
-    - FBLazyVector (= 0.69.0-rc.6)
-    - RCTRequired (= 0.69.0-rc.6)
-    - React-Core (= 0.69.0-rc.6)
-  - React (0.69.0-rc.6):
-    - React-Core (= 0.69.0-rc.6)
-    - React-Core/DevSupport (= 0.69.0-rc.6)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.6)
-    - React-RCTActionSheet (= 0.69.0-rc.6)
-    - React-RCTAnimation (= 0.69.0-rc.6)
-    - React-RCTBlob (= 0.69.0-rc.6)
-    - React-RCTImage (= 0.69.0-rc.6)
-    - React-RCTLinking (= 0.69.0-rc.6)
-    - React-RCTNetwork (= 0.69.0-rc.6)
-    - React-RCTSettings (= 0.69.0-rc.6)
-    - React-RCTText (= 0.69.0-rc.6)
-    - React-RCTVibration (= 0.69.0-rc.6)
-  - React-bridging (0.69.0-rc.6):
+  - RCTRequired (0.69.0)
+  - RCTTypeSafety (0.69.0):
+    - FBLazyVector (= 0.69.0)
+    - RCTRequired (= 0.69.0)
+    - React-Core (= 0.69.0)
+  - React (0.69.0):
+    - React-Core (= 0.69.0)
+    - React-Core/DevSupport (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-RCTActionSheet (= 0.69.0)
+    - React-RCTAnimation (= 0.69.0)
+    - React-RCTBlob (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+    - React-RCTLinking (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - React-RCTSettings (= 0.69.0)
+    - React-RCTText (= 0.69.0)
+    - React-RCTVibration (= 0.69.0)
+  - React-bridging (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi (= 0.69.0-rc.6)
-  - React-callinvoker (0.69.0-rc.6)
-  - React-Codegen (0.69.0-rc.6):
-    - FBReactNativeSpec (= 0.69.0-rc.6)
+    - React-jsi (= 0.69.0)
+  - React-callinvoker (0.69.0)
+  - React-Codegen (0.69.0):
+    - FBReactNativeSpec (= 0.69.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.6)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Core (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-Core (0.69.0-rc.6):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Core (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.6)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-Core/Default (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.69.0-rc.6):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-    - Yoga
-  - React-Core/Default (0.69.0-rc.6):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-    - Yoga
-  - React-Core/DevSupport (0.69.0-rc.6):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.6)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.6)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-jsinspector (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.69.0-rc.6):
+  - React-Core/CoreModulesHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.69.0-rc.6):
+  - React-Core/Default (0.69.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-Core/DevSupport (0.69.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-jsinspector (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.69.0-rc.6):
+  - React-Core/RCTAnimationHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.69.0-rc.6):
+  - React-Core/RCTBlobHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.69.0-rc.6):
+  - React-Core/RCTImageHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.69.0-rc.6):
+  - React-Core/RCTLinkingHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.69.0-rc.6):
+  - React-Core/RCTNetworkHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.69.0-rc.6):
+  - React-Core/RCTSettingsHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.69.0-rc.6):
+  - React-Core/RCTTextHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.69.0-rc.6):
+  - React-Core/RCTVibrationHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.6)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsiexecutor (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
+    - React-Core/Default
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-CoreModules (0.69.0-rc.6):
+  - React-Core/RCTWebSocket (0.69.0):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/CoreModulesHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-RCTImage (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-cxxreact (0.69.0-rc.6):
+    - React-Core/Default (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-CoreModules (0.69.0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/CoreModulesHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-cxxreact (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-jsinspector (= 0.69.0-rc.6)
-    - React-logger (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-    - React-runtimeexecutor (= 0.69.0-rc.6)
-  - React-jsi (0.69.0-rc.6):
+    - React-callinvoker (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsinspector (= 0.69.0)
+    - React-logger (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - React-runtimeexecutor (= 0.69.0)
+  - React-jsi (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.69.0-rc.6)
-  - React-jsi/Default (0.69.0-rc.6):
+    - React-jsi/Default (= 0.69.0)
+  - React-jsi/Default (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.69.0-rc.6):
+  - React-jsiexecutor (0.69.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-  - React-jsinspector (0.69.0-rc.6)
-  - React-logger (0.69.0-rc.6):
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+  - React-jsinspector (0.69.0)
+  - React-logger (0.69.0):
     - glog
   - react-native-safe-area-context (4.0.1-rc.5):
     - RCT-Folly
@@ -290,75 +290,75 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.69.0-rc.6)
-  - React-RCTActionSheet (0.69.0-rc.6):
-    - React-Core/RCTActionSheetHeaders (= 0.69.0-rc.6)
-  - React-RCTAnimation (0.69.0-rc.6):
+  - React-perflogger (0.69.0)
+  - React-RCTActionSheet (0.69.0):
+    - React-Core/RCTActionSheetHeaders (= 0.69.0)
+  - React-RCTAnimation (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTAnimationHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTBlob (0.69.0-rc.6):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTAnimationHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTBlob (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTBlobHeaders (= 0.69.0-rc.6)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-RCTNetwork (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTImage (0.69.0-rc.6):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTBlobHeaders (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTImage (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTImageHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-RCTNetwork (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTLinking (0.69.0-rc.6):
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTLinkingHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTNetwork (0.69.0-rc.6):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTImageHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTLinking (0.69.0):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTLinkingHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTNetwork (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTNetworkHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTSettings (0.69.0-rc.6):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTNetworkHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTSettings (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.6)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTSettingsHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-RCTText (0.69.0-rc.6):
-    - React-Core/RCTTextHeaders (= 0.69.0-rc.6)
-  - React-RCTVibration (0.69.0-rc.6):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTSettingsHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTText (0.69.0):
+    - React-Core/RCTTextHeaders (= 0.69.0)
+  - React-RCTVibration (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.0-rc.6)
-    - React-Core/RCTVibrationHeaders (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.6)
-  - React-runtimeexecutor (0.69.0-rc.6):
-    - React-jsi (= 0.69.0-rc.6)
-  - ReactCommon/turbomodule/core (0.69.0-rc.6):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTVibrationHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-runtimeexecutor (0.69.0):
+    - React-jsi (= 0.69.0)
+  - ReactCommon/turbomodule/core (0.69.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.0-rc.6)
-    - React-callinvoker (= 0.69.0-rc.6)
-    - React-Core (= 0.69.0-rc.6)
-    - React-cxxreact (= 0.69.0-rc.6)
-    - React-jsi (= 0.69.0-rc.6)
-    - React-logger (= 0.69.0-rc.6)
-    - React-perflogger (= 0.69.0-rc.6)
-  - RNGestureHandler (2.4.2):
+    - React-bridging (= 0.69.0)
+    - React-callinvoker (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-logger (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+  - RNGestureHandler (2.5.0):
     - React-Core
-  - RNReanimated (2.4.1):
+  - RNReanimated (3.0.0-rc.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -366,7 +366,6 @@ PODS:
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
-    - React
     - React-callinvoker
     - React-Core
     - React-Core/DevSupport
@@ -552,8 +551,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: b6acb6d704a0717abd7bb02179aac6c7c37d8cc0
-  FBReactNativeSpec: 142bbe3cb60842c7672d2e91b64f0e09a3a514e5
+  FBLazyVector: f98dec9f199b7b51db586fe0140f509fabd5cc54
+  FBReactNativeSpec: 56c4cf7cce9f95fd386001dba21437b7d6b33993
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -568,37 +567,37 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: aed6e42c1978aaa117dae6b497267dca30dce893
-  RCTTypeSafety: 2735ccba1ca830b3e3fe9cff68068041201f8d25
-  React: 746177da6f0367906bef8b55c132834238ed5d5e
-  React-bridging: 651b17d2c68ff4a7070e8593853f71ec64ed0bab
-  React-callinvoker: e8445e06b6689d72afd08a21dae78d8c3ce549ed
-  React-Codegen: c6249a6462a4080702f1ca0ae369341abfe7c444
-  React-Core: f98f6863386ad6e3d3d87f81897908b1027df813
-  React-CoreModules: 751e6549964a6b324c9e53baf66fd59ea30700c6
-  React-cxxreact: 2559337179ac227869521e71f5323199688f8340
-  React-jsi: 80f72ff07392324f4bdd95dc2eee30daf0d6d3cb
-  React-jsiexecutor: ed108fa941c623dda1cf25b0487e506ae5cd597f
-  React-jsinspector: 96a6f470b24a0918d6f207c55f9186ee6d987ab8
-  React-logger: 4542bced257f3ef658671bbe354a27d76070bee9
+  RCTRequired: eff60a46da0f496a6c76c8f60108c20626860d27
+  RCTTypeSafety: 8cc8a45d0e2f93f1b42b5b2bbf23c4143f19935a
+  React: 8a8fc19196a41141ecb5bde33c97091cdc25ccd8
+  React-bridging: 543858c1fc01ed8264585c5a2646305d20225840
+  React-callinvoker: cc62aa541f261cee6f990f870dbf6aff38f97eef
+  React-Codegen: a80f7ec979174e44dcaecc9d5639ac84a7077a71
+  React-Core: 7faa8679c6f38b5462a71d55b399483f46365e44
+  React-CoreModules: 3a51e8d50928a8593ea44606c00ffa60db95222f
+  React-cxxreact: 51a2239091bc13a3c0b5b1cb445b1585a483df2d
+  React-jsi: 80aef7359ddaacd86f7247fec6a8dff4db099dc6
+  React-jsiexecutor: b2a049b9f156342f6037ccb0c8acf69f923d3089
+  React-jsinspector: 6aced68014b275b7abd073c9598b0affd0e1669c
+  React-logger: bcf33ce10afa135158c72635e621ddb94126c610
   react-native-safe-area-context: 44537ac9078b2e1e23fef0079cd70fbbf46f1f4c
-  React-perflogger: e3265731a720bfd153640721f0234e8167c49c2a
-  React-RCTActionSheet: ea6a00519ba55aec249f940e388b95432478a70e
-  React-RCTAnimation: 3896fcda72ab94404f77ea65710e702b0f044c3d
-  React-RCTBlob: 117334251c649e1ab67b24e04e326c33a373fbfd
-  React-RCTImage: 338d915f2373ee2ca624976300ce160fa783d1d5
-  React-RCTLinking: 290daa02ce5f24ebb67ffd40eb41891f4382d5d6
-  React-RCTNetwork: be3d45b2ae0c9d8f73198822804bccb44cca9c97
-  React-RCTSettings: f61c934c029eae49fab4e28529445eb2608c86c0
-  React-RCTText: 737cb3c804d6b2495650f6dac73059a3483c58ec
-  React-RCTVibration: d4b0d435822e7631abd0f6d0f9fd471f0aedbe28
-  React-runtimeexecutor: 2771ef006f731bb0286309c73c0d7ba95371d648
-  ReactCommon: d6a7231176ff71a199b61048d02a69210db589a2
-  RNGestureHandler: 61628a2c859172551aa2100d3e73d1e57878392f
-  RNReanimated: d425aed81d7a904a078ed80b06ac2f8461922936
-  RNScreens: d5f6ac8fd3625c330a184bfd5835039250591387
+  React-perflogger: aa48956d87bae67fc847acc196fae97928b96cd3
+  React-RCTActionSheet: 4eaab2b885130ce9a88c8fdac5f1992315da80f6
+  React-RCTAnimation: 5e91e3ceb988838fa43615bb602181be30d2b26e
+  React-RCTBlob: 4fc8f15c018635668dec9b577f46acf75f604a68
+  React-RCTImage: 53ece22415c499ea18f0acafc2bc7ea89517a78c
+  React-RCTLinking: 0211dd109987c22d9b51d187498cac55a43fe24e
+  React-RCTNetwork: 540c0087fd0382c9b959169eb0e3727306f5d812
+  React-RCTSettings: d1e584c83392d1babbe5e731af10c2726d2545e2
+  React-RCTText: 9c5de1f593a548a2dbeb991ee01c88bef86f0659
+  React-RCTVibration: 7549ef7b07aad1cc629f4c6d88c325366f26423c
+  React-runtimeexecutor: 7ad268dee53d001697e13264c6bc8e95a902352e
+  ReactCommon: 74a3b8ee497c6d50ce86ef57e15c4c5bf654b83d
+  RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
+  RNReanimated: 89886d02e4748077c0dd3c645286b15a9bca097b
+  RNScreens: d50711364166e9ab83230898b64f09dcd6e0a4f1
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 30757bd18db6ed14e9788f601e375a563f08d525
+  Yoga: 4935173923cabaa830e195be3e8e4cac045a8f90
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 3727d4ab25e50d746b1f28ba129496b94b712f4b

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -543,11 +543,6 @@
   // TODO: Make sure that there is no edge case when this should be uncommented
   // _controller=nil;
   _dismissed = NO;
-  // we don't reset the transform of view at the end of custom transitions,
-  // so in order not to add code to all transitions, we just reset it here.
-  // Maybe it would be better to do it in each animation since we could change other
-  // view props there too and they need to be reset due to view recycling.
-  self.transform = CGAffineTransformIdentity;
   _state.reset();
   _touchHandler = nil;
 }

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -112,6 +112,7 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
         }
         completion:^(BOOL finished) {
           fromViewController.view.transform = CGAffineTransformIdentity;
+          toViewController.view.transform = CGAffineTransformIdentity;
           [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
   } else if (_operation == UINavigationControllerOperationPop) {
@@ -123,9 +124,8 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
       fromViewController.view.transform = rightTransform;
     };
     void (^completionBlock)(BOOL) = ^(BOOL finished) {
-      if (transitionContext.transitionWasCancelled) {
-        toViewController.view.transform = CGAffineTransformIdentity;
-      }
+      fromViewController.view.transform = CGAffineTransformIdentity;
+      toViewController.view.transform = CGAffineTransformIdentity;
       [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
     };
 
@@ -158,6 +158,7 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
           toViewController.view.alpha = 1.0;
         }
         completion:^(BOOL finished) {
+          toViewController.view.alpha = 1.0;
           [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
   } else if (_operation == UINavigationControllerOperationPop) {
@@ -168,9 +169,8 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
           fromViewController.view.alpha = 0.0;
         }
         completion:^(BOOL finished) {
-          if (transitionContext.transitionWasCancelled) {
-            toViewController.view.transform = CGAffineTransformIdentity;
-          }
+          fromViewController.view.alpha = 1.0;
+
           [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
   }
@@ -193,6 +193,7 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
         }
         completion:^(BOOL finished) {
           fromViewController.view.transform = CGAffineTransformIdentity;
+          toViewController.view.transform = CGAffineTransformIdentity;
           [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
   } else if (_operation == UINavigationControllerOperationPop) {
@@ -204,9 +205,8 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
       fromViewController.view.transform = topBottomTransform;
     };
     void (^completionBlock)(BOOL) = ^(BOOL finished) {
-      if (transitionContext.transitionWasCancelled) {
-        toViewController.view.transform = CGAffineTransformIdentity;
-      }
+      fromViewController.view.transform = CGAffineTransformIdentity;
+      toViewController.view.transform = CGAffineTransformIdentity;
       [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
     };
 
@@ -274,6 +274,10 @@ static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
           fromViewController.view.transform = topBottomTransform;
         }
         completion:^(BOOL finished) {
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          toViewController.view.transform = CGAffineTransformIdentity;
+          fromViewController.view.alpha = 1.0;
+          toViewController.view.alpha = 1.0;
           [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
     [UIView animateWithDuration:transitionDuration * RNSFadeCloseTransitionDurationProportion // defaults to 0.15 s


### PR DESCRIPTION
## Description

PR adding logic of resetting screens props after transition animations since they are recycled afterwards and often have wrong alpha/transform then. Also added application of snapshot only if `window` is present which should mean that screen has been removed via JS navigation actions.

## Test code and steps to reproduce

Mainly `Test887.tsx` with going to different modal and non-modal screens to see if they all work correctly.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
