### PR TITLE
fix: bring back iOS Paper compatibility with `react-native@0.63`

### DIFF
--- a/ios/RNSScreenViewEvent.h
+++ b/ios/RNSScreenViewEvent.h
@@ -1,3 +1,5 @@
+#ifdef RN_FABRIC_ENABLED
+
 #import <React/RCTBridge+Private.h>
 #import <React/RCTEventDispatcherProtocol.h>
 
@@ -10,3 +12,5 @@
                      goingForward:(int)goingForward;
 
 @end
+
+#endif // RN_FABRIC_ENABLED

--- a/ios/RNSScreenViewEvent.mm
+++ b/ios/RNSScreenViewEvent.mm
@@ -1,3 +1,5 @@
+#ifdef RN_FABRIC_ENABLED
+
 #import "RNSScreenViewEvent.h"
 #import <React/RCTAssert.h>
 
@@ -57,3 +59,5 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 }
 
 @end
+
+#endif // RN_FABRIC_ENABLED


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-screens/issues/1501

#1472 introduced `RNSScreenViewEvent` which uses `React/RCTEventDispatcherProtocol.h` header. Before `react-native@0.64` this header was named `React/RCTEventDispatcher.h`, so now, when using `react-native@0.63.x` with `react-native-screens@3.14.0` the build fails as the header can not be found. 

## Changes

* As `RNSScreenViewEvent` is used only on Fabric (& on Fabric we support `react-native@0.69+`, I "ifdefed" it, so on Paper it is not defined.

## Test code and steps to reproduce

1. `npx react-native init TestProject --version 0.63.2`
2. `yarn add react-native-screens@3.14.0`
3. Try to build iOS


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
