### PR TITLE
fix: default value for `gestureResponseDistance` 

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -253,13 +253,6 @@ class Screen extends React.Component<ScreenProps> {
         ...props
       } = rest;
 
-      const defaultedGestureResponseDistance = {
-        start: gestureResponseDistance?.start ?? -1,
-        end: gestureResponseDistance?.end ?? -1,
-        top: gestureResponseDistance?.top ?? -1,
-        bottom: gestureResponseDistance?.bottom ?? -1,
-      };
-
       if (active !== undefined && activityState === undefined) {
         console.warn(
           'It appears that you are using old version of react-navigation library. Please update @react-navigation/bottom-tabs, @react-navigation/stack and @react-navigation/drawer to version 5.10.0 or above to take full advantage of new functionality added to react-native-screens'
@@ -284,7 +277,12 @@ class Screen extends React.Component<ScreenProps> {
           <AnimatedNativeScreen
             {...props}
             activityState={activityState}
-            gestureResponseDistance={defaultedGestureResponseDistance}
+            gestureResponseDistance={{
+              start: gestureResponseDistance?.start ?? -1,
+              end: gestureResponseDistance?.end ?? -1,
+              top: gestureResponseDistance?.top ?? -1,
+              bottom: gestureResponseDistance?.bottom ?? -1,
+            }}
             // This prevents showing blank screen when navigating between multiple screens with freezing
             // https://github.com/software-mansion/react-native-screens/pull/1208
             ref={handleRef}

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -249,8 +249,16 @@ class Screen extends React.Component<ScreenProps> {
         activityState,
         children,
         isNativeStack,
+        gestureResponseDistance,
         ...props
       } = rest;
+
+      const defaultedGestureResponseDistance = {
+        start: gestureResponseDistance?.start ?? -1,
+        end: gestureResponseDistance?.end ?? -1,
+        top: gestureResponseDistance?.top ?? -1,
+        bottom: gestureResponseDistance?.bottom ?? -1,
+      };
 
       if (active !== undefined && activityState === undefined) {
         console.warn(
@@ -276,6 +284,7 @@ class Screen extends React.Component<ScreenProps> {
           <AnimatedNativeScreen
             {...props}
             activityState={activityState}
+            gestureResponseDistance={defaultedGestureResponseDistance}
             // This prevents showing blank screen when navigating between multiple screens with freezing
             // https://github.com/software-mansion/react-native-screens/pull/1208
             ref={handleRef}

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -192,29 +192,6 @@ const RouteView = ({
     }
   }
 
-  if (gestureResponseDistance === undefined) {
-    // default values, required for unification of Fabric & Paper implementation
-    gestureResponseDistance = {
-      start: -1,
-      end: -1,
-      top: -1,
-      bottom: -1,
-    };
-  } else {
-    if (gestureResponseDistance.start === undefined) {
-      gestureResponseDistance.start = -1;
-    }
-    if (gestureResponseDistance.end === undefined) {
-      gestureResponseDistance.end = -1;
-    }
-    if (gestureResponseDistance.top === undefined) {
-      gestureResponseDistance.top = -1;
-    }
-    if (gestureResponseDistance.bottom === undefined) {
-      gestureResponseDistance.bottom = -1;
-    }
-  }
-
   if (index === 0) {
     // first screen should always be treated as `push`, it resolves problems with no header animation
     // for navigator with first screen as `modal` and the next as `push`


### PR DESCRIPTION
## Description

Moved code that sets default value for `gestureResponseDistance` prop on `Screen` component "deeper", so that, when 3rd party library uses our primitives it does not have to set the default value by itself. Behaviour is unchanged.


## Changes

* The code was moved to `index.native.tsx`


## Test code and steps to reproduce

`Test1296` -- see that `gestureResponseDistance` prop works just fine

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
