### PR TITLE
fix: handle multiple gesture recognizers

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -600,11 +600,6 @@
 {
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
 
-  if (![topScreen isKindOfClass:[RNSScreenView class]] || !topScreen.gestureEnabled ||
-      _controller.viewControllers.count < 2) {
-    return NO;
-  }
-
 #if TARGET_OS_TV
   [self cancelTouchesInParent];
   return YES;
@@ -817,6 +812,19 @@
   }
   UIScrollView *scrollView = (UIScrollView *)gestureRecognizer.view;
   return scrollView.panGestureRecognizer == gestureRecognizer;
+}
+
+// RNSScreenStackView is a UIGestureRecognizerDelegate for two types of gesture recognizers:
+// RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
+{
+  RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
+
+  if (![topScreen isKindOfClass:[RNSScreenView class]] || !topScreen.gestureEnabled ||
+      _controller.viewControllers.count < 2) {
+    return NO;
+  }
+  return YES;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -604,11 +604,10 @@
   [self cancelTouchesInParent];
   return YES;
 #else
-  if (topScreen.fullScreenSwipeEnabled) {
-    // we want only `RNSPanGestureRecognizer` to be able to recognize when
-    // `fullScreenSwipeEnabled` is set, and we are in the bounds set by user
-    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
-        [self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
+  // RNSPanGestureRecognizer will receive events iff topScreen.fullScreenSwipeEnabled == YES;
+  // Events are filtered in gestureRecognizer:shouldReceiveEvent: method
+  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
+    if ([self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
       _isFullWidthSwiping = YES;
       [self cancelTouchesInParent];
       return YES;
@@ -616,6 +615,7 @@
     return NO;
   }
 
+  // Now we're dealing with RNSScreenEdgeGestureRecognizer (or _UIParallaxTransitionPanGestureRecognizer)
   if (topScreen.customAnimationOnSwipe && [RNSScreenStackAnimator isCustomAnimation:topScreen.stackAnimation]) {
     if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
       // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
@@ -634,10 +634,8 @@
     if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
       // it should only recognize with `customAnimationOnSwipe` set
       return NO;
-    } else if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      // it should only recognize with `fullScreenSwipeEnabled` set
-      return NO;
     }
+    // _UIParallaxTransitionPanGestureRecognizer (other...)
     [self cancelTouchesInParent];
     return YES;
   }
@@ -814,8 +812,9 @@
   return scrollView.panGestureRecognizer == gestureRecognizer;
 }
 
-// RNSScreenStackView is a UIGestureRecognizerDelegate for two types of gesture recognizers:
-// RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer
+// RNSScreenStackView is a UIGestureRecognizerDelegate for three types of gesture recognizers:
+// RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer, _UIParallaxTransitionPanGestureRecognizer
+// Be careful when adding another type of gesture recognizer.
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
 {
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
@@ -824,6 +823,13 @@
       _controller.viewControllers.count < 2) {
     return NO;
   }
+
+  // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
+  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
+    return topScreen.fullScreenSwipeEnabled;
+  }
+
+  // RNSScreenEdgeGestureRecognizer || _UIParallaxTransitionPanGestureRecognizer
   return YES;
 }
 
@@ -833,16 +839,13 @@
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
       [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
     RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
-    BOOL isBackGesture =
-        [panGestureRecognizer translationInView:_controller.view].x > 0 && _controller.viewControllers.count > 1;
+    BOOL isBackGesture = [panGestureRecognizer translationInView:panGestureRecognizer.view].x > 0 &&
+        _controller.viewControllers.count > 1;
 
-    if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
+    if (gestureRecognizer.state == UIGestureRecognizerStateBegan || isBackGesture) {
       return NO;
     }
 
-    if (isBackGesture) {
-      return NO;
-    }
     return YES;
   }
   return NO;
@@ -851,17 +854,9 @@
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]] &&
-      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
-    RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
-    BOOL isBackGesture =
-        [panGestureRecognizer translationInView:_controller.view].x > 0 && _controller.viewControllers.count > 1;
-
-    if (isBackGesture) {
-      return YES;
-    }
-  }
-  return NO;
+  return (
+      [gestureRecognizer isKindOfClass:[UIScreenEdgePanGestureRecognizer class]] &&
+      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]);
 }
 
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -822,13 +822,17 @@
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
+  return (
+      [gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
+      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]);
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  return [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
+  return (
+      [gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]] &&
+      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]);
 }
 
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -822,17 +822,38 @@
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  return (
-      [gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
-      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]);
+  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
+      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
+    RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
+    BOOL isBackGesture =
+        [panGestureRecognizer translationInView:_controller.view].x > 0 && _controller.viewControllers.count > 1;
+
+    if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
+      return NO;
+    }
+
+    if (isBackGesture) {
+      return NO;
+    }
+    return YES;
+  }
+  return NO;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  return (
-      [gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]] &&
-      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]);
+  if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]] &&
+      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
+    RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
+    BOOL isBackGesture =
+        [panGestureRecognizer translationInView:_controller.view].x > 0 && _controller.viewControllers.count > 1;
+
+    if (isBackGesture) {
+      return YES;
+    }
+  }
+  return NO;
 }
 
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex


### PR DESCRIPTION
## Description

Fixes #1510

Fixed & improved `RNSScreenStackView` logic regarding `UIGestureRecognizerDelegate` protocol.

## Changes

* Added `gestureRecognizer:shouldReceiveEvent:`. Events for particular gesture recognisers are now filtered before `gestureRecognizerShouldBegin` method is called.
* Any `UIScreenEdgePanGestureRecognizer` must fail for scroll view gesture recogniser to begin.
* When `fullScreenSwipeEnabled == true` scroll view gesture recogniser is prioritised before our `RNSPanGestureRecognizer`.
* Simplified logic in `gestureRecognzerShouldBegin`.

Now, when adding another gesture recogniser with screen stack as delegate one must make sure that events are properly filtered.


## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

As on screen recordings attached in #1510

### After

```
fullScreenSwipeEnabled: true,
gestureEnabled: true,
stackAnimation: 'simple_push',
customAnimationOnSwipe: true,
```

https://user-images.githubusercontent.com/50801299/177521059-56d015c7-763f-4cb7-a6d3-030a48bb8e2b.mov


```
fullScreenSwipeEnabled: false,
gestureEnabled: true,
stackAnimation: 'simple_push',
customAnimationOnSwipe: false,
```

https://user-images.githubusercontent.com/50801299/177521435-4e4bcd48-de22-4ace-9355-32cf99f2ba3d.mov



## Test code and steps to reproduce

`Test1072`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
