### PR TITLE
refactor: use ViewCompat for status bar translucency management

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -112,8 +112,8 @@ object ScreenWindowTraits {
                     // and consume all the top insets so no padding will be added under the status bar.
                     val decorView = activity.window.decorView
                     if (translucent) {
-                        decorView.setOnApplyWindowInsetsListener { v, insets ->
-                            val defaultInsets = v.onApplyWindowInsets(insets)
+                        ViewCompat.setOnApplyWindowInsetsListener(decorView) { v, insets ->
+                            val defaultInsets = ViewCompat.onApplyWindowInsets(v, insets)
                             defaultInsets.replaceSystemWindowInsets(
                                 defaultInsets.systemWindowInsetLeft,
                                 0,
@@ -122,7 +122,7 @@ object ScreenWindowTraits {
                             )
                         }
                     } else {
-                        decorView.setOnApplyWindowInsetsListener(null)
+                        ViewCompat.setOnApplyWindowInsetsListener(decorView, null)
                     }
                     ViewCompat.requestApplyInsets(decorView)
                 }


### PR DESCRIPTION
## Description

Used `ViewCompat` for setting `setOnApplyWindowInsetsListener` and `onApplyWindowInsets`.

It's needed because of `ViewCompat.setWindowInsetsAnimationCallback` - if we use direct methods it breaks compat layer and as a result compat listeners will not receive updates.

It's a follow-up PR to https://github.com/software-mansion/react-native-screens/pull/1451

## Changes

- Used `ViewCompat` in `setTranslucent` method;

## Screenshots / GIFs

No changes from UI perspective.

## Test code and steps to reproduce

I used this code: https://github.com/kirillzyusko/react-native-keyboard-controller/compare/main...issue/rns-status-bar-translucency

Without these changes animation stucks, since callback in `setWindowInsetsAnimationCallback` is not receiving updates (once the screen is mounted `setTranslucent` method is getting called, and since it works without `compat` mode - it breaks other places, which are using `compat` mode 🤷‍♂️ ).

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
