### PR TITLE
fix: add usage of older API for older iOS versions

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -834,11 +834,6 @@
   return YES;
 }
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
-{
-  return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:event];
-}
-
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceivePress:(UIPress *)press;
 {
   return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:press];

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -817,7 +817,8 @@
 // RNSScreenStackView is a UIGestureRecognizerDelegate for three types of gesture recognizers:
 // RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer, _UIParallaxTransitionPanGestureRecognizer
 // Be careful when adding another type of gesture recognizer.
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveEvent:(UIEvent *)event API_AVAILABLE(ios(13.4))
 {
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -812,6 +812,8 @@
   return scrollView.panGestureRecognizer == gestureRecognizer;
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_4) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4
 // RNSScreenStackView is a UIGestureRecognizerDelegate for three types of gesture recognizers:
 // RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer, _UIParallaxTransitionPanGestureRecognizer
 // Be careful when adding another type of gesture recognizer.
@@ -832,6 +834,7 @@
   // RNSScreenEdgeGestureRecognizer || _UIParallaxTransitionPanGestureRecognizer
   return YES;
 }
+#endif // check for 13.4 iOS version
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -18,7 +18,6 @@
 #import <React/RCTUIManagerUtils.h>
 #endif // RN_FABRIC_ENABLED
 
-#import <Availability.h>
 #import "RNSScreen.h"
 #import "RNSScreenStack.h"
 #import "RNSScreenStackAnimator.h"
@@ -835,8 +834,7 @@
   return YES;
 }
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-       shouldReceiveEvent:(UIEvent *)event API_AVAILABLE(ios(13.4))
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
 {
   return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:event];
 }

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -835,14 +835,12 @@
   return YES;
 }
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && defined(__IPHONE_13_4) && \
-    __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_4
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
        shouldReceiveEvent:(UIEvent *)event API_AVAILABLE(ios(13.4))
 {
   return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:event];
 }
-#else
+
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceivePress:(UIPress *)press;
 {
   return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:press];
@@ -852,7 +850,6 @@
 {
   return [self gestureRecognizer:gestureRecognizer shouldReceivePressOrTouchEvent:touch];
 }
-#endif // check for 13.4 iOS version
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer


### PR DESCRIPTION
## Description

`gestureRecognizer:shouldReceiveEvent` method is unfortunately available only since iOS 3.14, so I decided to replave it with calls to methods from older apis (9.0+).

## Changes

* Overrided methods from older api: `gestureRecognizer:shouldReceivePress:` && `gestureRecognizer:shouldReceiveTouch:`. 
* Removed override of `gestureRecognizer:shouldReceiveEvent:`

It seems likely to me, that overriding `gestureRecognizer:shouldReceiveTouch:` should be enough but basing on apple developer docs - I'm not sure, thus this PR is introducing some dead code (`gestureRecognizer:shouldReceivePress:` method).

## Test code and steps to reproduce

`Test1072` -- see that the behaviour restored in #1512 works also on older iPhones.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
