### PR TITLE
fix: restore working events on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.graphics.Canvas
 import android.view.View
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.uimanager.UIManagerModule
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.EventDispatcher
 import com.swmansion.rnscreens.Screen.StackAnimation
 import com.swmansion.rnscreens.events.StackFinishTransitioningEvent
 import java.util.Collections
@@ -67,10 +68,11 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun dispatchOnFinishTransitioning() {
-        (context as ReactContext)
-            .getNativeModule(UIManagerModule::class.java)
-            ?.eventDispatcher
-            ?.dispatchEvent(StackFinishTransitioningEvent(id))
+        val eventDispatcher: EventDispatcher? =
+            UIManagerHelper.getEventDispatcherForReactTag((context as ReactContext), id)
+        eventDispatcher?.dispatchEvent(
+            StackFinishTransitioningEvent(id)
+        )
     }
 
     override fun removeScreenAt(index: Int) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ThemedReactContext
@@ -10,6 +11,7 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.viewmanagers.RNSScreenStackManagerDelegate
 import com.facebook.react.viewmanagers.RNSScreenStackManagerInterface
+import com.swmansion.rnscreens.events.StackFinishTransitioningEvent
 
 @ReactModule(name = ScreenStackViewManager.REACT_CLASS)
 class ScreenStackViewManager : ViewGroupManager<ScreenStack>(), RNSScreenStackManagerInterface<ScreenStack> {
@@ -79,6 +81,13 @@ class ScreenStackViewManager : ViewGroupManager<ScreenStack>(), RNSScreenStackMa
 
     protected override fun getDelegate(): ViewManagerDelegate<ScreenStack> {
         return mDelegate
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        return MapBuilder.of(
+            StackFinishTransitioningEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onFinishTransitioning"),
+        )
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -162,7 +162,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     override fun setSwipeDirection(view: Screen?, value: String?) = Unit
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-        val map: MutableMap<String, Any> = MapBuilder.of(
+        return MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onDismissed"),
             ScreenWillAppearEvent.EVENT_NAME,
@@ -173,14 +173,11 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
             MapBuilder.of("registrationName", "onWillDisappear"),
             ScreenDisappearEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onDisappear"),
-            StackFinishTransitioningEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onFinishTransitioning"),
+            HeaderBackButtonClickedEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onHeaderBackButtonClicked"),
             ScreenTransitionProgressEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onTransitionProgress")
         )
-        // there is no `MapBuilder.of` with more than 7 items
-        map[HeaderBackButtonClickedEvent.EVENT_NAME] = MapBuilder.of("registrationName", "onHeaderBackButtonClicked")
-        return map
     }
 
     protected override fun getDelegate(): ViewManagerDelegate<Screen> {

--- a/src/fabric/ScreenNativeComponent.js
+++ b/src/fabric/ScreenNativeComponent.js
@@ -84,10 +84,10 @@ export type NativeProps = $ReadOnly<{|
   swipeDirection?: WithDefault<SwipeDirection, 'horizontal'>,
   hideKeyboardOnSwipe?: boolean,
   activityState?: WithDefault<Float, -1.0>,
-  // TODO: implement these props on iOS
   navigationBarColor?: ColorValue,
   navigationBarHidden?: boolean,
   nativeBackButtonDismissalEnabled?: boolean,
+  onHeaderBackButtonClicked?: ?BubblingEventHandler<ScreenEvent>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
## Description

Changed Android event implementation from `getNativeModule(UIManagerModule::class.java)` to `UIManagerHelper.getEventDispatcherForReactTag` since it works correctly on Paper and makes the code work on `Fabric`.

## Test code and steps to reproduce

e.g. `Test593.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
