### PR TITLE
Add API for imperative actions on RNSSearchBar

### DIFF
--- a/Example/src/screens/SearchBar.tsx
+++ b/Example/src/screens/SearchBar.tsx
@@ -1,6 +1,6 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import { I18nManager, ScrollView, Text, StyleSheet } from 'react-native';
-import { SearchBarProps } from 'react-native-screens';
+import { SearchBarRef, SearchBarProps } from 'react-native-screens';
 import {
   createNativeStackNavigator,
   NativeStackNavigationProp,
@@ -49,10 +49,12 @@ const MainScreen = ({ navigation }: MainScreenProps): JSX.Element => {
     'sentences'
   );
   const [inputType, setInputType] = useState<InputType>('text');
+  const searchBarRef = useRef<SearchBarRef>(null);
 
   useLayoutEffect(() => {
     navigation.setOptions({
       searchBar: {
+        ref: searchBarRef,
         barTintColor,
         hintTextColor,
         headerIconColor,
@@ -172,6 +174,21 @@ const MainScreen = ({ navigation }: MainScreenProps): JSX.Element => {
         label="Show search hint icon"
         value={shouldShowHintSearchIcon}
         onValueChange={setShouldShowHintSearchIcon}
+      />
+      <Text style={styles.heading}>Imperative actions</Text>
+      <Button onPress={() => searchBarRef.current?.blur()} title="Blur" />
+      <Button onPress={() => searchBarRef.current?.focus()} title="Focus" />
+      <Button
+        onPress={() => searchBarRef.current?.clearText()}
+        title="Clear Text"
+      />
+      <Button
+        onPress={() => searchBarRef.current?.toggleCancelButton(true)}
+        title="Show cancel"
+      />
+      <Button
+        onPress={() => searchBarRef.current?.toggleCancelButton(false)}
+        title="Hide cancel"
       />
       <Text style={styles.heading}>Other</Text>
       <Button

--- a/TestsExample/src/Test1097.tsx
+++ b/TestsExample/src/Test1097.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import {Button, NativeSyntheticEvent, ScrollView} from 'react-native';
+import {
+  NavigationContainer,
+  NavigationProp,
+  ParamListBase,
+} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from 'react-native-screens/native-stack';
+import {SearchBarProps} from 'react-native-screens';
+
+const AppStack = createNativeStackNavigator();
+
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <AppStack.Navigator
+        screenOptions={{
+          headerLargeTitle: true,
+          headerTranslucent: true,
+        }}>
+        <AppStack.Screen name="First" component={First} />
+        <AppStack.Screen name="Second" component={Second} />
+      </AppStack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function First({navigation}: NativeStackScreenProps<ParamListBase>) {
+  const searchBarRef = React.useRef();
+
+  React.useEffect(() => {
+    navigation.setOptions({
+      searchBar: searchBarOptions,
+    });
+  }, [navigation]);
+
+  const [search, setSearch] = React.useState('');
+
+  const searchBarOptions: SearchBarProps = {
+    // @ts-ignore
+    ref: searchBarRef,
+    barTintColor: 'powderblue',
+    hideWhenScrolling: true,
+    obscureBackground: false,
+    hideNavigationBar: false,
+    autoCapitalize: 'sentences',
+    placeholder: 'Some text',
+    onChangeText: (e: NativeSyntheticEvent<{text: string}>) =>
+      setSearch(e.nativeEvent.text),
+    onCancelButtonPress: () => console.warn('Cancel button pressed'),
+    onSearchButtonPress: () => console.warn('Search button pressed'),
+    onFocus: () => console.warn('onFocus event'),
+    onBlur: () => console.warn('onBlur event'),
+  };
+
+  const items = [
+    'Apples',
+    'Pie',
+    'Juice',
+    'Cake',
+    'Nuggets',
+    'Some',
+    'Other',
+    'Stuff',
+    'To',
+    'Fill',
+    'The',
+    'Scrolling',
+    'Space',
+  ];
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      keyboardDismissMode="on-drag">
+      <Button
+        title="Tap me for second screen"
+        onPress={() => navigation.navigate('Second')}
+      />
+      <Button
+        title="Tap me for ref"
+        onPress={() => (searchBarRef.current as any).focus()}
+      />
+      {items
+        .filter(
+          (item) => item.toLowerCase().indexOf(search.toLowerCase()) !== -1,
+        )
+        .map((item) => (
+          <Button
+            title={item}
+            key={item}
+            onPress={() => {
+              console.warn(`${item} clicked`);
+            }}
+          />
+        ))}
+    </ScrollView>
+  );
+}
+
+function Second({navigation}: {navigation: NavigationProp<ParamListBase>}) {
+  return (
+    <ScrollView contentInsetAdjustmentBehavior="automatic">
+      <Button
+        title="Tap me for first screen"
+        onPress={() => navigation.navigate('First')}
+      />
+    </ScrollView>
+  );
+}

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -316,6 +316,14 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `hintTextColor` - The search hint text color. (Android only)
 - `headerIconColor` - The search and close icon color shown in the header. (Android only)
 - `shouldShowHintSearchIcon` - Show the search hint icon when search bar is focused. (Android only)
+- `ref` - A React ref to imperatively modify search bar.
+
+Allowed imperative actions on search bar are:
+
+- `focus` - Function to focus on search bar. (iOS only)
+- `blur` - Function to remove focus from search bar. (iOS only)
+- `clearText` - Function to clear text in search bar. (iOS only)
+- `toggleCancelButton` - Function toggle cancel button display near search bar. (iOS only)
 
 Below is a list of properties that can be set with `ScreenStackHeaderConfig` component:
 

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -348,4 +348,40 @@ RCT_EXPORT_VIEW_PROPERTY(onSearchButtonPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFocus, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBlur, RCTBubblingEventBlock)
 
+RCT_EXPORT_METHOD(focus : (NSNumber *_Nonnull)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
+    RNSSearchBar *searchBar = viewRegistry[reactTag];
+    UISearchController *searchBarController = searchBar.controller;
+    [searchBarController.searchBar becomeFirstResponder];
+  }];
+}
+
+RCT_EXPORT_METHOD(blur : (NSNumber *_Nonnull)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
+    RNSSearchBar *searchBar = viewRegistry[reactTag];
+    UISearchController *searchBarController = searchBar.controller;
+    [searchBarController.searchBar resignFirstResponder];
+  }];
+}
+
+RCT_EXPORT_METHOD(clearText : (NSNumber *_Nonnull)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
+    RNSSearchBar *searchBar = viewRegistry[reactTag];
+    UISearchController *searchBarController = searchBar.controller;
+    [searchBarController.searchBar setText:@""];
+  }];
+}
+
+RCT_EXPORT_METHOD(toggleCancelButton : (NSNumber *_Nonnull)reactTag flag : (BOOL *)flag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
+    RNSSearchBar *searchBar = viewRegistry[reactTag];
+    UISearchController *searchBarController = searchBar.controller;
+    [searchBarController.searchBar setShowsCancelButton:flag ? YES : NO animated:YES];
+  }];
+}
+
 @end

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -542,6 +542,28 @@ The search and close icon color shown in the header. (Android only)
 
 Show the search hint icon when search bar is focused. (Android only)
 
+#### `ref`
+
+A React ref to imperatively modify search bar.
+
+#### Imperative actions
+
+##### `focus` (iOS only)
+
+Focus on search bar.
+
+##### `blur` (iOS only)
+
+Remove focus from search bar.
+
+##### `clearText` (iOS only)
+
+Clear text in search bar.
+
+##### `toggleCancelButton` (iOS only)
+
+Toggle cancel button display near search bar.
+
 ### Events
 
 The navigator can [emit events](https://reactnavigation.org/docs/navigation-events) on certain actions. Supported events are:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,7 +97,7 @@ export const ScreenStackHeaderCenterView = (
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderSearchBarView = (
-  props: React.PropsWithChildren<SearchBarProps>
+  props: React.PropsWithChildren<Omit<SearchBarProps, 'ref'>>
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderConfig: React.ComponentType<ScreenStackHeaderConfigProps> = View;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -7,6 +7,15 @@ import {
   TextInputFocusEventData,
 } from 'react-native';
 
+type SearchBarRefObject = React.RefObject<{
+  focus: () => void;
+  blur: () => void;
+  clearText: () => void;
+  toggleCancelButton: (flag: boolean) => void;
+}>;
+
+export type SearchBarRef = NonNullable<SearchBarRefObject['current']>;
+
 export type StackPresentationTypes =
   | 'push'
   | 'modal'
@@ -430,6 +439,8 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
 }
 
 export interface SearchBarProps {
+  ref?: React.RefObject<SearchBarRef>;
+
   /**
    * The auto-capitalization behavior
    */


### PR DESCRIPTION
## Description

This changes allow users to manipulate the RNSSearchBar. For use cases please see [discussions/1323](https://github.com/software-mansion/react-native-screens/discussions/1323).

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

- Exported 5 new methods from RNSSearchBarManager in `ios/RNSSearchBar.mm`.
  1. focus
  2. blur
  3. toggleCancelButton
  4. clearText
- Also added the same methods to SearchBar in `src/index.native.tsx` to call native ones
- Added `ref` key to `SearchBarProps` in `src/types.tsx`

## Test code and steps to reproduce

Added buttons to Example app to test each action:
1. Focus
2. Blur
3. ToggleCancelButton
4. ClearText

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
