### PR TITLE
fix: reject all gestures when modal is presented

### DIFF
--- a/TestsExample/src/Test1476.tsx
+++ b/TestsExample/src/Test1476.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, Text, View, StyleSheet} from 'react-native';
+import {Button, Text, View, StyleSheet, ScrollView} from 'react-native';
 import {NavigationContainer as NavigationContainerNative} from '@react-navigation/native';
 
 // remember to change prop names in ScreenGroup && ModalGroup
@@ -61,11 +61,10 @@ function ModalA(props: Props) {
         justifyContent: 'center',
       }}>
       <View style={{backgroundColor: 'white'}}>
-
-      <Text>ModalA, with opacity and backgroundColor</Text>
-        <Text>
-          At ModalA, we still can gesture swipe the screenB back to screenA,{' '}
-        </Text>
+        <Text>ModalA, with opacity and backgroundColor</Text>
+          <Text>
+            At ModalA, we still can gesture swipe the screenB back to screenA,{' '}
+          </Text>
         <Button title={'pop modal'} onPress={() => props.navigation.pop()} />
       </View>
     </View>
@@ -111,7 +110,7 @@ const ModalGroup = StackBuilder([
   {
     name: 'modalA',
     component: ModalA,
-    options: { animation: 'fade' },
+    // options: { stackAnimation: 'fade' },
   }], {
   headerShown: false,
 
@@ -122,6 +121,8 @@ const ModalGroup = StackBuilder([
   // props for react-native-screens/native-stack
   stackAnimation: 'fade_from_bottom',
   stackPresentation: 'containedTransparentModal',
+  fullScreenSwipeEnabled: true,
+  customAnimationOnSwipe: true,
 });
 
 export default function TestModalPresentation() {

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -103,6 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
+- (BOOL)isModal;
 
 @end
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -508,6 +508,13 @@
   }
 }
 
+- (BOOL)isModal
+{
+  return !(
+      self.stackPresentation == RNSScreenStackPresentationPush ||
+      self.stackPresentation == RNSScreenStackPresentationFormSheet);
+}
+
 #pragma mark - Fabric specific
 #ifdef RN_FABRIC_ENABLED
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -510,9 +510,7 @@
 
 - (BOOL)isModal
 {
-  return !(
-      self.stackPresentation == RNSScreenStackPresentationPush ||
-      self.stackPresentation == RNSScreenStackPresentationFormSheet);
+  return self.stackPresentation != RNSScreenStackPresentationPush;
 }
 
 #pragma mark - Fabric specific

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -823,9 +823,10 @@
   RNSScreenView *topScreen = _reactSubviews.lastObject;
 
   if (![topScreen isKindOfClass:[RNSScreenView class]] || !topScreen.gestureEnabled ||
-      _controller.viewControllers.count < 2 || [_presentedModals containsObject:topScreen.controller]) {
+      _controller.viewControllers.count < 2 || [topScreen isModal]) {
     return NO;
   }
+
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
     return topScreen.fullScreenSwipeEnabled;

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -823,10 +823,9 @@
   RNSScreenView *topScreen = _reactSubviews.lastObject;
 
   if (![topScreen isKindOfClass:[RNSScreenView class]] || !topScreen.gestureEnabled ||
-      _controller.viewControllers.count < 2) {
+      _controller.viewControllers.count < 2 || [_presentedModals containsObject:topScreen.controller]) {
     return NO;
   }
-
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
     return topScreen.fullScreenSwipeEnabled;


### PR DESCRIPTION
## Description

The issue reported in #1476 was resolved "in normal cases" by #1521
 & #1509. 

However if **on screen with modal presentation** `fullScreenSwipeEnabled` is set to `true` ***or*** custom animation is set the gesture recognisers still handle the gesture (it depends on configuration of these props which gesture recogniser applies, but the buggy behaviour occurs). 

Case described above is pretty rare, as it does not make much sense to set `fullScreenSwipeEnabled` or `stackAnimation` & `customAnimationOnSwipe` on screen with modal presentation but this is exactly what happens when using native stack from `@react-navigation` (since [this PR](https://github.com/react-navigation/react-navigation/pull/10674) was released)

It seems to me that there are three reasonable solutions:

1. We can reject all native gesture events when any modal is being presented (current solution)
2. We can trust developers with not setting these props on modals & fix the issue with `@react-navigation`
3. Handle this specific case in native code 

Fixes #1476

## Changes

* Filter out native gesture events when any modal is being presented


## Test code and steps to reproduce

`Test1476` & test different configuration of props mentioned above

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
