### PR TITLE
fix: iOS multiple windows scenario

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -83,7 +83,7 @@
 
 - (void)show
 {
-  UIWindow *window = RCTSharedApplication().delegate.window;
+  UIWindow *window = RCTSharedApplication().keyWindow;
   [window addSubview:_container];
 }
 


### PR DESCRIPTION
Using RNSFullWindowOverlay in multiple windows scenarios is causing weird presentation issues and it's causing a crash for applications which use UISceneDelegate. This is a fix I propose for these issues.
For fixing this I ended up using keyWindow, even though it's deprecated starting with iOS 13. After doing some research I found that filtering for the foreground active scene, and retrieve the keyWindow this way won't cover all the cases (more details in this post: https://teng.pub/technical/2021/11/9/uiapplication-key-window-replacement).