### PR TITLE
fix: invalid dismissCount value when closing modals

### DIFF
--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -78,6 +78,7 @@ import Test1260 from './src/Test1260';
 import Test1296 from './src/Test1296';
 import Test1299 from './src/Test1299';
 import Test1419 from './src/Test1419';
+import Test1473 from './src/Test1473';
 import Test1476 from './src/Test1476';
 
 enableFreeze(true);

--- a/FabricTestExample/src/Test1473.tsx
+++ b/FabricTestExample/src/Test1473.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {StyleSheet, View, Text, Button} from 'react-native';
+import {NavigationContainer} from '@react-navigation/native';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+function First(props) {
+  return (
+    <View style={styles.container}>
+      <Text>This is the first screen</Text>
+      <Button 
+        onPress={() => props.navigation.navigate('Second')}
+        title="Navigate to second screen"
+      />
+    </View>
+  );
+}
+
+function Second(props) {
+  return (
+    <View style={styles.container}>
+      <Text>This is the second screen</Text>
+      <Button
+        onPress={() => props.navigation.navigate('Modal')}
+        title="Open modal"
+      />
+    </View>
+  );
+}
+
+function Modal(props) {
+  return (
+    <View style={{
+      ...styles.container,
+      backgroundColor: 'rgba(0, 170, 0, 0.5)',
+    }}>
+      <Text>This is the modal</Text>
+      <Button
+        onPress={() => props.navigation.goBack()}
+        title="Close the modal"
+      />
+    </View>
+  )
+}
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="First">
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen name="Second" component={Second} options={{
+          fullScreenSwipeEnabled: true,
+        }}/>
+        <Stack.Screen
+          name="Modal"
+          component={Modal}
+          options={{
+            stackPresentation: 'modal',
+            stackAnimation: 'slide_from_bottom',
+            gestureEnabled: true,
+            headerShown: false,
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -78,6 +78,7 @@ import Test1260 from './src/Test1260';
 import Test1296 from './src/Test1296';
 import Test1299 from './src/Test1299';
 import Test1419 from './src/Test1419';
+import Test1473 from './src/Test1473';
 import Test1476 from './src/Test1476';
 import Test1509 from './src/Test1509';
 

--- a/TestsExample/src/Test1473.tsx
+++ b/TestsExample/src/Test1473.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {StyleSheet, View, Text, Button} from 'react-native';
+import {NavigationContainer} from '@react-navigation/native';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+function First(props) {
+  return (
+    <View style={styles.container}>
+      <Text>This is the first screen</Text>
+      <Button 
+        onPress={() => props.navigation.navigate('Second')}
+        title="Navigate to second screen"
+      />
+    </View>
+  );
+}
+
+function Second(props) {
+  return (
+    <View style={styles.container}>
+      <Text>This is the second screen</Text>
+      <Button
+        onPress={() => props.navigation.navigate('Modal')}
+        title="Open modal"
+      />
+    </View>
+  );
+}
+
+function Modal(props) {
+  return (
+    <View style={{
+      ...styles.container,
+      backgroundColor: 'rgba(0, 170, 0, 0.5)',
+    }}>
+      <Text>This is the modal</Text>
+      <Button
+        onPress={() => props.navigation.goBack()}
+        title="Close the modal"
+      />
+    </View>
+  )
+}
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="First">
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen name="Second" component={Second} options={{
+          fullScreenSwipeEnabled: true,
+        }}/>
+        <Stack.Screen
+          name="Modal"
+          component={Modal}
+          options={{
+            stackPresentation: 'modal',
+            stackAnimation: 'slide_from_bottom',
+            gestureEnabled: true,
+            headerShown: false,
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -744,7 +744,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewWillDisappear:(BOOL)animated
 {
   [super viewWillDisappear:animated];
-  if (!self.transitionCoordinator.isInteractive) {
+  // self.navigationController might be null when we are dismissing a modal
+  if (!self.transitionCoordinator.isInteractive && self.navigationController != nil) {
     // user might have long pressed ios 14 back button item,
     // so he can go back more than one screen and we need to dismiss more screens in JS stack then.
     // We check it by calculating the difference between the index of currently displayed screen


### PR DESCRIPTION
## Description

Fixes #1473 

When modals are pushed onto the stack, in view hierarchy they end up not being descendants of `RNSScreenNavigationController` -> [When a modal is dismissed & we ask `RNSScreen` with modal view for its navigation controller](https://github.com/software-mansion/react-native-screens/blob/cc5de7ba28e90ecce9bbb3464ef0a625eaae032f/ios/RNSScreen.mm#L753-L755) (`[self navigationController]`) we receive null. This caused `getIndexOfView:` method to return `-1` (as the view was not found) what resulted in wrong value of `_dismissCount`. 

## Changes

Added a check for case when `navigationController` of `RNSScreen` is null - now in such case we default to `_dismissCount == 1`

## Screenshots / GIFs

### Before

https://user-images.githubusercontent.com/50801299/179496086-0064e0bd-bf0e-4475-8a46-01432c75ec73.mov

### After

https://user-images.githubusercontent.com/50801299/179495969-403d0cd0-ee9f-4439-8d3e-febf6f4c6498.mov




## Test code and steps to reproduce

`Test1473` in test example apps.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
