### PR TITLE
chore: avoid unnecessary struct copying in iOS code

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -969,7 +969,7 @@
 - (void)mountingTransactionWillMount:(facebook::react::MountingTransaction const &)transaction
                 withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry
 {
-  for (auto mutation : transaction.getMutations()) {
+  for (auto &mutation : transaction.getMutations()) {
     if (mutation.type == facebook::react::ShadowViewMutation::Type::Remove &&
         mutation.parentShadowView.componentName != nil &&
         strcmp(mutation.parentShadowView.componentName, "RNSScreenStack") == 0) {


### PR DESCRIPTION
## Description

Minor improvement to avoid creating copy of every mutation in for loop. 

## Changes

* Changed `auto` -> `auto&` inside C++ style for loop.

## Test code and steps to reproduce

Run `FabricTestExample` & see it works fine.

## Checklist

- [x] Ensured that CI passes
