### PR TITLE
fix: set VCs of views from recycling pool as UIAdaptivePresentationControllerDelegate

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -614,9 +614,12 @@
   }
 #endif
 
-  if (newScreenProps.stackPresentation != oldScreenProps.stackPresentation) {
-    [self
-        setStackPresentation:[RNSConvert RNSScreenStackPresentationFromCppEquivalent:newScreenProps.stackPresentation]];
+  // Notice that we compare against _stackPresentation, not oldScreenProps.stackPresentation.
+  // See comment in prepareForRecycle method for explanation.
+  RNSScreenStackPresentation newStackPresentation =
+      [RNSConvert RNSScreenStackPresentationFromCppEquivalent:newScreenProps.stackPresentation];
+  if (newStackPresentation != _stackPresentation) {
+    [self setStackPresentation:newStackPresentation];
   }
 
   if (newScreenProps.stackAnimation != oldScreenProps.stackAnimation) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -550,6 +550,17 @@
   _dismissed = NO;
   _state.reset();
   _touchHandler = nil;
+
+  // We set this prop to default value here to workaround view-recycling.
+  // Let's assume the view has had _stackPresentation == <some modal stack presentation> set
+  // before below line was executed. Then, when instantiated again (with the same modal presentation)
+  // updateProps:oldProps: method would be called and setter for stack presentation would not be called.
+  // This is crucial as in that setter we register `self` as a delegate (UIAdaptivePresentationControllerDelegate) to
+  // presentation controller and this leads to buggy modal behaviour as we rely on
+  // UIAdaptivePresentationControllerDelegate callbacks. Restoring the default value and then comparing against it in
+  // updateProps:oldProps: allows for setter to be called, however if there was some additional logic to execute when
+  // stackPresentation is set to "push" the setter would not be triggered.
+  _stackPresentation = RNSScreenStackPresentationPush;
 }
 
 - (void)updateProps:(facebook::react::Props::Shared const &)props

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -555,11 +555,11 @@
   // Let's assume the view has had _stackPresentation == <some modal stack presentation> set
   // before below line was executed. Then, when instantiated again (with the same modal presentation)
   // updateProps:oldProps: method would be called and setter for stack presentation would not be called.
-  // This is crucial as in that setter we register `self` as a delegate (UIAdaptivePresentationControllerDelegate) to
-  // presentation controller and this leads to buggy modal behaviour as we rely on
-  // UIAdaptivePresentationControllerDelegate callbacks. Restoring the default value and then comparing against it in
-  // updateProps:oldProps: allows for setter to be called, however if there was some additional logic to execute when
-  // stackPresentation is set to "push" the setter would not be triggered.
+  // This is crucial as in that setter we register `self.controller` as a delegate
+  // (UIAdaptivePresentationControllerDelegate) to presentation controller and this leads to buggy modal behaviour as we
+  // rely on UIAdaptivePresentationControllerDelegate callbacks. Restoring the default value and then comparing against
+  // it in updateProps:oldProps: allows for setter to be called, however if there was some additional logic to execute
+  // when stackPresentation is set to "push" the setter would not be triggered.
   _stackPresentation = RNSScreenStackPresentationPush;
 }
 


### PR DESCRIPTION
## Description

Fixes #1299 **on Fabric**. I was not able to reproduce this issue on Paper -> changes introduced in this PR do not change behaviour on Paper. 

View recycling caused behaviour such that VCs of views that returned from recycle pool were not set as delegates for presentation controller. This caused `presentationControllerDidDismiss:` method not to be called and in consequence we did not receive information that modal transition had finished -> we did not allow for another one to start. 

## Changes

Set `stackPresentation` to default value in `prepareForRecycle` method to workaround view-recycling & check incoming new prop value (in `updateProps:oldProps:`) against actual state not old props. I pasted just below (a little bit paraphased) comment I placed in code in `prepareForRecycle` method with better explanation how the bug worked.

Let's assume the view has had `_stackPresentation == <some modal stack presentation>` set
before below line was executed. 

```
_stackPresentation = RNSScreenStackPresentationPush
```

Then, when instantiated again (with the same modal presentation) `updateProps:oldProps:` method would be called and setter for stack presentation would not be called. This is crucial as in that setter we register `self.controller` as a delegate (`UIAdaptivePresentationControllerDelegate`) to
presentation controller and this leads to buggy modal behaviour as we rely on
`UIAdaptivePresentationControllerDelegate` callbacks. Restoring the default value and then comparing against it in `updateProps:oldProps:` allows for setter to be called, however if there was some additional logic to execute when `stackPresentation` is set to `push` the setter would not be triggered.

## Test code and steps to reproduce

See `Test1299` in `FabricTestExample` & description of #1299 to see what & how to test.

## Checklist

- [x] Ensured that CI passes
