### PR TITLE
Fix typo subivew

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -580,7 +580,7 @@
       }
       case RNSScreenStackHeaderSubviewTypeBackButton: {
 #ifdef RN_FABRIC_ENABLED
-        RCTLogWarn(@"Back button subivew is not yet Fabric compatible in react-native-screens");
+        RCTLogWarn(@"Back button subview is not yet Fabric compatible in react-native-screens");
 #endif
         break;
       }


### PR DESCRIPTION
Fabric warning contained this typo:

> Back button subivew is not yet Fabric compatible in react-native-screens

![Simulator Screen Shot - iPhone 13 - 2022-07-19 at 08 38 09](https://user-images.githubusercontent.com/791189/179682671-0f901d44-5113-4a09-a0f4-c1c40489bab8.png)
