### PR TITLE
feat: add screenEdgesDeferringSystemGestures

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -19,6 +19,7 @@ import Test619 from './src/Test619';
 import Test624 from './src/Test624';
 import Test640 from './src/Test640';
 import Test642 from './src/Test642';
+import Test643 from './src/Test643';
 import Test645 from './src/Test645';
 import Test648 from './src/Test648';
 import Test649 from './src/Test649';
@@ -87,7 +88,7 @@ enableFreeze(true);
 export default function App() {
   return (
     <ReanimatedScreenProvider>
-      <Test42 />
+      <Test643 />
     </ReanimatedScreenProvider>
   );
 }

--- a/TestsExample/src/Test643.tsx
+++ b/TestsExample/src/Test643.tsx
@@ -1,0 +1,142 @@
+// connected PRs: 
+import React from 'react';
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import {ScrollView, View, Button} from 'react-native';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import { ScreenEdge } from 'react-native-screens';
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
+
+const Stack = createNativeStackNavigator();
+
+export default function App(): JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          stackPresentation: "modal",
+        }}>
+        <Stack.Screen
+          name="Home"
+          component={Home}
+          options={{
+            statusBarStyle: 'dark',
+            homeIndicatorHidden: false,
+            screenEdgesDeferringSystemGestures: ScreenEdge.Top
+          }}
+        />
+        <Stack.Screen
+          name="TabNavigator"
+          component={TabNavigator}
+          options={{
+            statusBarStyle: 'dark',
+            screenEdgesDeferringSystemGestures: ScreenEdge.All
+          }}
+        />
+        <Stack.Screen
+          name="Home2"
+          component={Home}
+          options={{
+            statusBarStyle: 'light',
+            stackPresentation: "fullScreenModal",
+            screenOrientation: 'default',
+            screenEdgesDeferringSystemGestures: ScreenEdge.Top | ScreenEdge.Bottom
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const Tab = createBottomTabNavigator();
+
+const TabNavigator = () => (
+  <Tab.Navigator>
+    <Tab.Screen name="Tab1" component={Home} />
+    <Tab.Screen name="Tab2" component={Inner} />
+    <Tab.Screen name="Tab3" component={Home} />
+  </Tab.Navigator>
+);
+
+const InnerStack = createNativeStackNavigator();
+
+const Inner = () => (
+  <InnerStack.Navigator
+    screenOptions={{
+      statusBarStyle: 'dark',
+      homeIndicatorHidden: true,
+    }}>
+    <InnerStack.Screen name="DeeperHome" component={Home} />
+  </InnerStack.Navigator>
+);
+
+function Home({navigation}: Props) {
+  const [yes, setYes] = React.useState(true);
+  const [hidden, setHidden] = React.useState(true);
+  const [animation, setAnimation] = React.useState(true);
+  return (
+    <ScrollView
+      style={{backgroundColor: 'rgba(255,255,0,0.5)'}}
+      contentInsetAdjustmentBehavior="automatic"
+      >
+      <View />
+      <Button
+        title="TabNavigator"
+        onPress={() => {
+          navigation.push('TabNavigator');
+        }}
+      />
+      <Button
+        title="Home2"
+        onPress={() => {
+          navigation.push('Home2');
+        }}
+      />
+      <Button
+        title="status bar style"
+        onPress={() => {
+          navigation.setOptions({
+            statusBarStyle: yes ? 'light' : 'dark',
+          });
+          setYes(!yes);
+        }}
+      />
+      <Button
+        title="status bar animation"
+        onPress={() => {
+          navigation.setOptions({
+            statusBarAnimation: animation ? 'fade' : 'none',
+          });
+          setAnimation(!animation);
+        }}
+      />
+      <Button
+        title="status bar hidden"
+        onPress={() => {
+          navigation.setOptions({
+            statusBarHidden: hidden,
+          });
+          setHidden(!hidden);
+        }}
+      />
+      <Button
+        title="Change title"
+        onPress={() => {
+          navigation.setOptions({
+            title: yes ? 'Home' : 'NotHome',
+          });
+          setYes(!yes);
+        }}
+      />
+      <Button
+        title="Pop one modal"
+        onPress={() => {
+          navigation.pop();
+        }}
+      />
+    </ScrollView>
+  );
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -17,7 +17,6 @@ import com.swmansion.rnscreens.events.ScreenDismissedEvent
 import com.swmansion.rnscreens.events.ScreenTransitionProgressEvent
 import com.swmansion.rnscreens.events.ScreenWillAppearEvent
 import com.swmansion.rnscreens.events.ScreenWillDisappearEvent
-import com.swmansion.rnscreens.events.StackFinishTransitioningEvent
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
 class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<Screen> {
@@ -156,6 +155,8 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
     override fun setGestureResponseDistance(view: Screen?, value: ReadableMap?) = Unit
 
     override fun setHomeIndicatorHidden(view: Screen?, value: Boolean) = Unit
+
+    override fun setScreenEdgesDeferringSystemGestures(view: Screen?, value: Int?) = Unit
 
     override fun setPreventNativeDismiss(view: Screen?, value: Boolean) = Unit
 

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -32,6 +32,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
       case "homeIndicatorHidden":
         mViewManager.setHomeIndicatorHidden(view, value == null ? false : (boolean) value);
         break;
+      case "screenEdgesDeferringSystemGestures":
+        mViewManager.setScreenEdgesDeferringSystemGestures(view, value == null ? 0 : ((Double) value).intValue());
+        break;
       case "preventNativeDismiss":
         mViewManager.setPreventNativeDismiss(view, value == null ? false : (boolean) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -17,6 +17,7 @@ public interface RNSScreenManagerInterface<T extends View> {
   void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, boolean value);
   void setHomeIndicatorHidden(T view, boolean value);
+  void setScreenEdgesDeferringSystemGestures(T view, @Nullable Integer value);
   void setPreventNativeDismiss(T view, boolean value);
   void setGestureEnabled(T view, boolean value);
   void setStatusBarColor(T view, @Nullable Integer value);

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -69,6 +69,10 @@ Whether the keyboard should hide when swiping to the previous screen. Defaults t
 
 Whether the home indicator should be hidden on this screen. Defaults to `false`.
 
+### `screenEdgesDeferringSystemGestures` (iOS only)
+
+The screen edges for which you want your gestures to take precedence over the system gestures on this screen. Defaults to `ScreenEdge.None`. `ScreenEdge` is an option set, so you can combine multiple edges via bitmasking. E.g.: `screenEdgesDeferringSystemGestures: ScreenEdge.Top | ScreenEdge.Bottom`.
+
 ### `nativeBackButtonDismissalEnabled` (Android only)
 
 Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -47,6 +47,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
   RNSWindowTraitHidden,
   RNSWindowTraitOrientation,
   RNSWindowTraitHomeIndicatorHidden,
+  RNSWindowTraitScreenEdgesDeferringSystemGestures,
 };
 
 typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL hasStatusBarStyleSet;
 @property (nonatomic) BOOL hasStatusBarAnimationSet;
 @property (nonatomic) BOOL hasHomeIndicatorHiddenSet;
+@property (nonatomic) BOOL hasScreenEdgesDeferringSystemGesturesSet;
 @property (nonatomic) BOOL hasOrientationSet;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
@@ -74,6 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 @property (nonatomic) BOOL statusBarHidden;
 @property (nonatomic) BOOL homeIndicatorHidden;
+@property (nonatomic) UIRectEdge screenEdgesDeferringSystemGestures;
 #endif
 
 #ifdef RN_FABRIC_ENABLED

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -82,6 +82,7 @@
   _hasStatusBarHiddenSet = NO;
   _hasOrientationSet = NO;
   _hasHomeIndicatorHiddenSet = NO;
+  _hasScreenEdgesDeferringSystemGesturesSet = NO;
 }
 
 - (UIViewController *)reactViewController
@@ -257,6 +258,13 @@
   _hasHomeIndicatorHiddenSet = YES;
   _homeIndicatorHidden = homeIndicatorHidden;
   [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
+}
+
+- (void)setScreenEdgesDeferringSystemGestures:(UIRectEdge)edges
+{
+  _hasScreenEdgesDeferringSystemGesturesSet = YES;
+  _screenEdgesDeferringSystemGestures = edges;
+  [RNSScreenWindowTraits updateScreenEdgesDeferringSystemGestures];
 }
 #endif
 
@@ -600,6 +608,11 @@
 
   if (newScreenProps.homeIndicatorHidden != oldScreenProps.homeIndicatorHidden) {
     [self setHomeIndicatorHidden:newScreenProps.homeIndicatorHidden];
+  }
+
+  if (newScreenProps.screenEdgesDeferringSystemGestures != oldScreenProps.screenEdgesDeferringSystemGestures) {
+    [self setScreenEdgesDeferringSystemGestures:[RCTConvert
+                                                    UIRectEdge:newScreenProps.screenEdgesDeferringSystemGestures]];
   }
 #endif
 
@@ -985,6 +998,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     case RNSWindowTraitHomeIndicatorHidden: {
       return self.screenView.hasHomeIndicatorHiddenSet;
     }
+    case RNSWindowTraitScreenEdgesDeferringSystemGestures: {
+      return self.screenView.hasScreenEdgesDeferringSystemGesturesSet;
+    }
     default: {
       RCTLogError(@"Unknown trait passed: %d", (int)trait);
     }
@@ -1044,6 +1060,19 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 {
   return self.screenView.homeIndicatorHidden;
 }
+
+- (UIViewController *)childViewControllerForScreenEdgesDeferringSystemGestures
+{
+  UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitScreenEdgesDeferringSystemGestures
+                                            includingModals:YES];
+  return vc == self ? nil : vc;
+}
+
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+  return self.screenView.screenEdgesDeferringSystemGestures;
+}
+
 - (int)getParentChildrenCount
 {
   return (int)[[self.screenView.reactSuperview reactSubviews] count];
@@ -1182,6 +1211,7 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(homeIndicatorHidden, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(screenEdgesDeferringSystemGestures, UIRectEdge)
 #endif
 
 - (UIView *)view
@@ -1284,6 +1314,27 @@ RCT_ENUM_CONVERTER(
     return UIInterfaceOrientationMaskLandscapeRight;
   }
   return UIInterfaceOrientationMaskAllButUpsideDown;
+}
+
++ (UIRectEdge)UIRectEdge:(id)json
+{
+  UIRectEdge edge = UIRectEdgeNone;
+  NSInteger raw = [[self NSNumber:json] integerValue];
+
+  if (raw & UIRectEdgeTop) {
+    edge |= UIRectEdgeTop;
+  }
+  if (raw & UIRectEdgeLeft) {
+    edge |= UIRectEdgeLeft;
+  }
+  if (raw & UIRectEdgeBottom) {
+    edge |= UIRectEdgeBottom;
+  }
+  if (raw & UIRectEdgeRight) {
+    edge |= UIRectEdgeRight;
+  }
+
+  return edge;
 }
 #endif
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -35,6 +35,11 @@
 {
   return [self findActiveChildVC];
 }
+
+- (UIViewController *)childViewControllerForScreenEdgesDeferringSystemGestures
+{
+  return [self findActiveChildVC];
+}
 #endif
 
 - (UIViewController *)findActiveChildVC

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -68,6 +68,11 @@
 {
   return [self topViewController];
 }
+
+- (UIViewController *)childViewControllerForScreenEdgesDeferringSystemGestures
+{
+  return [self topViewController];
+}
 #endif
 
 @end

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -10,6 +10,7 @@
 + (void)updateStatusBarAppearance;
 + (void)enforceDesiredDeviceOrientation;
 + (void)updateHomeIndicatorAutoHidden;
++ (void)updateScreenEdgesDeferringSystemGestures;
 
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -62,6 +62,27 @@
 #endif
 }
 
++ (void)updateScreenEdgesDeferringSystemGestures
+{
+#if !TARGET_OS_TV
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13, *)) {
+    UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+    if (firstWindow != nil) {
+      [[firstWindow rootViewController] setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+    }
+  } else
+#endif
+  {
+    if (@available(iOS 11.0, *)) {
+      [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+    }
+  }
+#endif
+}
+
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
@@ -186,6 +207,7 @@
   [RNSScreenWindowTraits updateStatusBarAppearance];
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
   [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
+  [RNSScreenWindowTraits updateScreenEdgesDeferringSystemGestures];
 }
 
 #if !TARGET_OS_TV

--- a/ios/UIViewController+RNScreens.mm
+++ b/ios/UIViewController+RNScreens.mm
@@ -37,6 +37,12 @@
   return childVC ?: [self reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden];
 }
 
+- (UIViewController *)reactNativeScreensChildViewControllerForScreenEdgesDeferringSystemGestures
+{
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ?: [self reactNativeScreensChildViewControllerForScreenEdgesDeferringSystemGestures];
+}
+
 - (UIViewController *)findChildRNScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
@@ -71,6 +77,11 @@
     method_exchangeImplementations(
         class_getInstanceMethod(uiVCClass, @selector(childViewControllerForHomeIndicatorAutoHidden)),
         class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden)));
+
+    method_exchangeImplementations(
+        class_getInstanceMethod(uiVCClass, @selector(childViewControllerForScreenEdgesDeferringSystemGestures)),
+        class_getInstanceMethod(
+            uiVCClass, @selector(reactNativeScreensChildViewControllerForScreenEdgesDeferringSystemGestures)));
   });
 }
 #endif

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -203,6 +203,10 @@ Whether the keyboard should hide when swiping to the previous screen. Defaults t
 
 Whether the home indicator should be hidden on this screen. Defaults to `false`.
 
+### `screenEdgesDeferringSystemGestures` (iOS only)
+
+The screen edges for which you want your gestures to take precedence over the system gestures on this screen. Defaults to `ScreenEdge.None`. `ScreenEdge` is an option set, so you can combine multiple edges via bitmasking. E.g.: `screenEdgesDeferringSystemGestures: ScreenEdge.Top | ScreenEdge.Bottom`.
+
 #### `nativeBackButtonDismissalEnabled` (Android only)
 
 Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native side or on the JS side to be able to prevent it.

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -32,6 +32,7 @@ import {
   isSearchBarAvailableForCurrentPlatform,
   executeNativeBackPress,
 } from './utils';
+import { ScreenEdge } from './screenEdge';
 
 // web implementation is taken from `index.tsx`
 const isPlatformSupported =
@@ -418,6 +419,7 @@ module.exports = {
   ScreenContainer,
   ScreenContext,
   ScreenStack,
+  ScreenEdge,
 
   get NativeScreen() {
     return ScreensNativeModules.NativeScreen;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export {
   isSearchBarAvailableForCurrentPlatform,
   executeNativeBackPress,
 } from './utils';
+export { ScreenEdge } from './screenEdge';
 
 let ENABLE_SCREENS = true;
 

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -256,6 +256,13 @@ export type NativeStackNavigationOptions = {
    */
   homeIndicatorHidden?: boolean;
   /**
+   * The screen edges for which you want your gestures to take precedence over the system gestures on this screen. Defaults to `ScreenEdge.None`.
+   * `ScreenEdge` is an option set, so you can combine multiple edges via bitmasking. E.g.: `screenEdgesDeferringSystemGestures: ScreenEdge.Top | ScreenEdge.Bottom`.
+   *
+   * @platform ios
+   */
+  screenEdgesDeferringSystemGestures?: ScreenProps['screenEdgesDeferringSystemGestures'];
+  /**
    * Whether the keyboard should hide when swiping to the previous screen. Defaults to `false`.
    *
    * @platform ios

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -153,6 +153,7 @@ const RouteView = ({
     headerShown,
     hideKeyboardOnSwipe,
     homeIndicatorHidden,
+    screenEdgesDeferringSystemGestures,
     nativeBackButtonDismissalEnabled = false,
     navigationBarColor,
     navigationBarHidden,
@@ -222,6 +223,7 @@ const RouteView = ({
       fullScreenSwipeEnabled={fullScreenSwipeEnabled}
       hideKeyboardOnSwipe={hideKeyboardOnSwipe}
       homeIndicatorHidden={homeIndicatorHidden}
+      screenEdgesDeferringSystemGestures={screenEdgesDeferringSystemGestures}
       gestureEnabled={isAndroid ? false : gestureEnabled}
       gestureResponseDistance={gestureResponseDistance}
       nativeBackButtonDismissalEnabled={nativeBackButtonDismissalEnabled}

--- a/src/screenEdge.ts
+++ b/src/screenEdge.ts
@@ -1,0 +1,8 @@
+export enum ScreenEdge {
+  None = 0b0000,
+  Top = 0b0001,
+  Left = 0b0010,
+  Bottom = 0b0100,
+  Right = 0b1000,
+  All = Top | Left | Bottom | Right,
+}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -6,6 +6,7 @@ import {
   TargetedEvent,
   TextInputFocusEventData,
 } from 'react-native';
+import { ScreenEdge } from './screenEdge';
 
 export type StackPresentationTypes =
   | 'push'
@@ -121,6 +122,13 @@ export interface ScreenProps extends ViewProps {
    * @platform ios
    */
   homeIndicatorHidden?: boolean;
+  /**
+   * The screen edges for which you want your gestures to take precedence over the system gestures on this screen. Defaults to `ScreenEdge.None`.
+   * `ScreenEdge` is an option set, so you can combine multiple edges via bitmasking. E.g.: `screenEdgesDeferringSystemGestures: ScreenEdge.Top | ScreenEdge.Bottom`.
+   *
+   * @platform ios
+   */
+  screenEdgesDeferringSystemGestures?: ScreenEdge;
   /**
    * Whether the keyboard should hide when swiping to the previous screen. Defaults to `false`.
    *


### PR DESCRIPTION
## Description

Added prop `screenEdgesDeferringSystemGestures` for on iOS.
This is an addendum to `homeIndicatorHidden` introduced in https://github.com/software-mansion/react-native-screens/pull/1267. Setting `homeIndicatorHidden` to `true` will show the home indicator when the user touches the screen. This is suboptimal for highly interactive apps like games for e-learning content. `screenEdgesDeferringSystemGestures` allows us to keep the home indicator hidden. Additionally, we can also 'hide' the control center and notification screen, which additionally benefits applications that need as much focus on fullscreen content as possible.

## Changes

- Added prop `screenEdgesDeferringSystemGestures`
- Introduced `ScreenEdge` option set to allow for fine-grained control that resembles the native API.

## Test code and steps to reproduce

`Test643.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
