### PR TITLE
fix: manually enable device orientation notifications

### DIFF
--- a/Example/ios/ScreensExample/AppDelegate.m
+++ b/Example/ios/ScreensExample/AppDelegate.m
@@ -31,6 +31,10 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
 
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
+  
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"ScreensExample"
@@ -47,6 +51,13 @@ static void InitializeFlipper(UIApplication *application) {
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 }
 
 

--- a/FabricExample/ios/FabricExample/AppDelegate.mm
+++ b/FabricExample/ios/FabricExample/AppDelegate.mm
@@ -43,6 +43,10 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
+  
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"FabricExample", initProps);
@@ -59,6 +63,13 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
+++ b/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
@@ -42,6 +42,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
+  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
 
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"FabricTestExample", initProps);
@@ -57,6 +58,12 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (BOOL)applicationWillTerminate
+{
+  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
   return YES;
 }
 

--- a/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
+++ b/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
@@ -42,7 +42,9 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
+#if !TARGET_OS_TV
   [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"FabricTestExample", initProps);
@@ -61,10 +63,11 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return YES;
 }
 
-- (BOOL)applicationWillTerminate
+- (void)applicationWillTerminate
 {
+#if !TARGET_OS_TV
   [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-  return YES;
+#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To make sure that there are no issues with screen orientation you should put fol
 }
 ```
 
+You can see example of these changes being introduced in our [example applications](https://github.com/software-mansion/react-native-screens/blob/main/TestsExample/ios/TestsExample/AppDelegate.mm)
+
 Other aspects of installation should be completely handled with auto-linking, just ensure you installed pods after adding this module.
 
 ### Android

--- a/README.md
+++ b/README.md
@@ -18,7 +18,25 @@ To learn about how to use `react-native-screens` with Fabric architecture, head 
 
 ### iOS
 
-Installation on iOS should be completely handled with auto-linking, if you have ensured pods are installed after adding this module, no other actions should be necessary.
+On iOS obtaining current device orientation [requires asking the system to generate orientation notifications](https://developer.apple.com/documentation/uikit/uidevice/1620053-orientation?language=objc). Our library uses them to enforce correct interface orientation when navigating between screens. 
+To make sure that there are no issues with screen orientation you should put following code in your `AppDelegate.m`:
+
+```objective-c
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    ... 
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    ...
+    return YES:
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+}
+```
+
+Other aspects of installation should be completely handled with auto-linking, just ensure you installed pods after adding this module.
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To make sure that there are no issues with screen orientation you should put fol
 }
 ```
 
-You can see example of these changes being introduced in our [example applications](https://github.com/software-mansion/react-native-screens/blob/main/TestsExample/ios/TestsExample/AppDelegate.mm)
+You can see example of these changes being introduced in our [example applications](https://github.com/software-mansion/react-native-screens/blob/main/TestsExample/ios/TestsExample/AppDelegate.mm).
 
 Other aspects of installation should be completely handled with auto-linking, just ensure you installed pods after adding this module.
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ To make sure that there are no issues with screen orientation you should put fol
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     ... 
+#if !TARGET_OS_TV
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
     ...
     return YES:
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
 {
+#if !TARGET_OS_TV
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 }
 ```
 

--- a/TestsExample/ios/TestsExample/AppDelegate.mm
+++ b/TestsExample/ios/TestsExample/AppDelegate.mm
@@ -42,6 +42,11 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
+
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
+
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"TestsExample", initProps);
 
@@ -57,6 +62,13 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+#if !TARGET_OS_TV
+  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.


### PR DESCRIPTION
## Description

According to the Apple docs a call to ... must be made for `UIDevice` `orientation` property to work correctly. 

I checked and neither we call `[[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications]` nor any dependency does this for us (I looked up in node_modules with `grep --include=\*.{m,mm} -rnw './node_modules/' -e "beginGeneratingDeviceOrientationNotifications"`), however it worked properly. I also checked with [`generatesDeviceOrientationNotifications`](https://developer.apple.com/documentation/uikit/uidevice/1620055-generatesdeviceorientationnotifi?language=objc) method whether orientation notifications were enabled or not. They were on. This nudges me towards conclusion that it possible that these notifications are enabled in some internal Apple code. 

However, according to issue https://github.com/software-mansion/react-native-screens/issues/1540 there are some cases when orientation notifications are not enabled "by default", thus we need to manually register for them. As [documentation states](https://developer.apple.com/documentation/uikit/uidevice/1620041-begingeneratingdeviceorientation?language=objc) it is fine to nest calls to the `begin...` method as long as we also match it with call to the `end...` method.

Fixes #1540 

## Changes

* Updated `README.md` to include extended installation instructions.
  
  I recommended adding calls to `[[UIDevice currentDevice] {begin,end}GeneratingDeviceOrientationNotifications]` to `AppDelegate.m` to lifecycle methods.

* Updated AppDelegates in our example applications.

## Test code and steps to reproduce

e.g. `Test1198` -- navigate to second screen, rotate your device to change interface orientation & go back to first screen -- it's orientation should be correctly adjusted.

## Checklist

- [x] Ensured that CI passes
