### PR TITLE
fix: remove explicit folly version

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -355,7 +355,7 @@ PODS:
     - React-Core
   - RNReanimated (1.13.2):
     - React-Core
-  - RNScreens (3.12.0):
+  - RNScreens (3.15.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (8.0.0):
@@ -575,11 +575,11 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
-  RNScreens: 2559f98b0835103cbef3b26ba77fa61d4bb37ae7
+  RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   RNVectorIcons: f67a1abce2ec73e62fe4606e8110e95a832bc859
   Yoga: c11abbf5809216c91fcd62f5571078b83d9b6720
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 459089ec5d136d365c5a2280990b9d638cbda105
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.69.0-rc.6)
+  - hermes-engine (0.69.1)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -720,17 +720,17 @@ PODS:
     - React-jsi (= 0.69.1)
     - React-logger (= 0.69.1)
     - React-perflogger (= 0.69.1)
-  - RNScreens (3.14.0):
-    - RCT-Folly (= 2021.06.28.00-v2)
+  - RNScreens (3.15.0):
+    - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.14.0)
-  - RNScreens/common (3.14.0):
-    - RCT-Folly (= 2021.06.28.00-v2)
+    - RNScreens/common (= 3.15.0)
+  - RNScreens/common (3.15.0):
+    - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
@@ -914,7 +914,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 068141206af867f72854753423d0117c4bf53419
   FBReactNativeSpec: 035cd010765c7e1349c39649579934df6ef42fb2
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -927,11 +927,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  hermes-engine: 2e82f88c31292b562cbc210540be4258dbf44b5f
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
+  hermes-engine: ece2bfa9bdb7f77f393cb2b41edf638eb086ec1a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: ae07282b2ec9c90d7eb98251603bc3f82403d239
   RCTTypeSafety: a04dc1339af2e1da759ccd093bf11c310dce1ef6
   React: dbd201f781b180eab148aa961683943c72f67dcf
@@ -963,7 +963,7 @@ SPEC CHECKSUMS:
   React-rncore: cb0378f68684034519651b7472af51c1a0321f41
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
-  RNScreens: 38985c8ae6321eb650fa035429a574e010ccfa7f
+  RNScreens: 865ade69cfb9cc9d3bb3b42131dfa83855b5e7a0
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/FabricTestExample/ios/Podfile.lock
+++ b/FabricTestExample/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.69.0)
+  - hermes-engine (0.69.1)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -757,17 +757,17 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.14.1):
-    - RCT-Folly (= 2021.06.28.00-v2)
+  - RNScreens (3.15.0):
+    - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.14.1)
-  - RNScreens/common (3.14.1):
-    - RCT-Folly (= 2021.06.28.00-v2)
+    - RNScreens/common (= 3.15.0)
+  - RNScreens/common (3.15.0):
+    - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
@@ -971,10 +971,10 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  hermes-engine: 03851318b18b534b671ea435fad2202154135c72
+  hermes-engine: ece2bfa9bdb7f77f393cb2b41edf638eb086ec1a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: ae07282b2ec9c90d7eb98251603bc3f82403d239
   RCTTypeSafety: a04dc1339af2e1da759ccd093bf11c310dce1ef6
   React: dbd201f781b180eab148aa961683943c72f67dcf
@@ -1008,7 +1008,7 @@ SPEC CHECKSUMS:
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNGestureHandler: 28c0a447ceb87b96c4045c2f786f67958837f320
   RNReanimated: 94d4e56073c2989550dba1ce29d41a5fe9d74e7f
-  RNScreens: 53cf515660c20820bf0ecc9795718c3484d6321f
+  RNScreens: 865ade69cfb9cc9d3bb3b42131dfa83855b5e7a0
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -4,9 +4,6 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-# folly_version must match the version used in React Native
-# See folly_version in react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec
-folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -36,7 +33,7 @@ Pod::Spec.new do |s|
     s.dependency "React"
     s.dependency "React-RCTFabric"
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
+    s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.14.0):
+  - RNScreens (3.15.0):
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
@@ -595,7 +595,7 @@ SPEC CHECKSUMS:
   ReactCommon: 74a3b8ee497c6d50ce86ef57e15c4c5bf654b83d
   RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
   RNReanimated: 2cf7451318bb9cc430abeec8d67693f9cf4e039c
-  RNScreens: 4830eb40e0793b38849965cd27f4f3a7d7bc65c1
+  RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 4935173923cabaa830e195be3e8e4cac045a8f90
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a


### PR DESCRIPTION
## Description

As a version of folly can change between versions of React-Native we need to remove an explicit version of `folly_version` from our libraries to let RN infer the correct version.

Change based on https://github.com/th3rdwave/react-native-safe-area-context/commit/eb111ff4eebc8d06ca01e7d12d9661147d03da20

## Changes

Removed explicit folly version from RNScreens.podspec

## Test code and steps to reproduce

Build FabricExample/

## Checklist

- [x] Ensured that CI passes