### PR TITLE
fix: handle React Native loaded on Fragment

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -177,8 +177,17 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         while (context !is FragmentActivity && context is ContextWrapper) {
             context = context.baseContext
         }
+
         check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactActivity" }
-        setFragmentManager(context.supportFragmentManager)
+
+        // In case React Native is loaded on a Fragment (not directly in activity) we need to find fragment manager
+        // whose root view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
+        // to activity which hosts ReactRootView.
+        if (context.supportFragmentManager.fragments.isNotEmpty()) {
+            setFragmentManager(resolveChildFragmentManagerOfReactRootView(context.supportFragmentManager)!!)
+        } else {
+            setFragmentManager(context.supportFragmentManager)
+        }
     }
 
     protected fun createTransaction(): FragmentTransaction {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -178,7 +178,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // Otherwise we expect to connect directly with root view and get root fragment manager
         if (parent is Screen) {
             val screenFragment = parent.fragment
-            check(screenFragment != null) { "Parent Screen does not have its Fragment attached" }
+            checkNotNull(screenFragment) { "Parent Screen does not have its Fragment attached" }
             mParentScreenFragment = screenFragment
             screenFragment.registerChildScreenContainer(this)
             setFragmentManager(screenFragment.childFragmentManager)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -136,16 +136,24 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
     }
 
     private fun findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager {
-        for (fragment in fragmentManager.fragments) {
-            return if (fragment.view is ReactRootView) {
-                fragment.childFragmentManager
-            } else {
-                findReactRootViewChildVM(fragment.childFragmentManager)
+        fun _findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager? {
+            for (fragment in fragmentManager.fragments) {
+                return if (fragment.view is ReactRootView) {
+                    fragment.childFragmentManager
+                } else {
+                    findReactRootViewChildVM(fragment.childFragmentManager)
+                }
             }
+            return null
         }
 
-        // In case there are no hosted fragments we just return passed fragment manager
-        return fragmentManager;
+        return if (fragmentManager.fragments.isEmpty()) {
+            fragmentManager
+        } else {
+            checkNotNull(_findReactRootViewChildVM(fragmentManager)) {
+                "Failed to resolve fragment manager for ScreenContainer"
+            }
+        }
     }
 
     private fun setupFragmentManager() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -135,13 +135,13 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         performUpdatesNow()
     }
 
-    private fun findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager {
-        fun _findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager? {
+    private fun findReactRootViewChildFM(fragmentManager: FragmentManager): FragmentManager {
+        fun _findReactRootViewChildFM(fragmentManager: FragmentManager): FragmentManager? {
             for (fragment in fragmentManager.fragments) {
                 return if (fragment.view is ReactRootView) {
                     fragment.childFragmentManager
                 } else {
-                    _findReactRootViewChildVM(fragment.childFragmentManager)
+                    _findReactRootViewChildFM(fragment.childFragmentManager)
                 }
             }
             return null
@@ -150,7 +150,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         return if (fragmentManager.fragments.isEmpty()) {
             fragmentManager
         } else {
-            checkNotNull(_findReactRootViewChildVM(fragmentManager)) {
+            checkNotNull(_findReactRootViewChildFM(fragmentManager)) {
                 "Failed to resolve fragment manager for ScreenContainer"
             }
         }
@@ -193,7 +193,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // In case React Native is loaded on a Fragment (not directly in activity) we need to find fragment manager
         // whose fragment's view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
         // to activity which hosts ReactRootView.
-        setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager))
+        setFragmentManager(findReactRootViewChildFM(context.supportFragmentManager))
     }
 
     protected fun createTransaction(): FragmentTransaction {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -135,6 +135,17 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         performUpdatesNow()
     }
 
+    private fun resolveChildFragmentManagerOfReactRootView(fragmentManager: FragmentManager): FragmentManager? {
+        for (fragment in fragmentManager.fragments) {
+            return if (fragment.view is ReactRootView) {
+                fragment.childFragmentManager
+            } else {
+                resolveChildFragmentManagerOfReactRootView(fragment.childFragmentManager)
+            }
+        }
+        return null;
+    }
+
     private fun setupFragmentManager() {
         var parent: ViewParent = this
         // We traverse view hierarchy up until we find screen parent or a root view

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -135,12 +135,12 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         performUpdatesNow()
     }
 
-    private fun resolveChildFragmentManagerOfReactRootView(fragmentManager: FragmentManager): FragmentManager? {
+    private fun findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager? {
         for (fragment in fragmentManager.fragments) {
             return if (fragment.view is ReactRootView) {
                 fragment.childFragmentManager
             } else {
-                resolveChildFragmentManagerOfReactRootView(fragment.childFragmentManager)
+                findReactRootViewChildVM(fragment.childFragmentManager)
             }
         }
         return null;
@@ -184,7 +184,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // whose root view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
         // to activity which hosts ReactRootView.
         if (context.supportFragmentManager.fragments.isNotEmpty()) {
-            setFragmentManager(resolveChildFragmentManagerOfReactRootView(context.supportFragmentManager)!!)
+            setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager)!!)
         } else {
             setFragmentManager(context.supportFragmentManager)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -151,6 +151,8 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // In case React Native is loaded on a Fragment (not directly in activity) we need to find
         // fragment manager whose fragment's view is ReactRootView. As of now, we detect such case by
         // checking whether any fragments are attached to activity which hosts ReactRootView.
+        // See: https://github.com/software-mansion/react-native-screens/issues/1506 on why the cases
+        // must be treated separately.
         return if (context.supportFragmentManager.fragments.isEmpty()) {
             // We are in standard React Native application w/o custom native navigation based on fragments.
            context.supportFragmentManager

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -135,7 +135,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         performUpdatesNow()
     }
 
-    private fun findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager? {
+    private fun findReactRootViewChildVM(fragmentManager: FragmentManager): FragmentManager {
         for (fragment in fragmentManager.fragments) {
             return if (fragment.view is ReactRootView) {
                 fragment.childFragmentManager
@@ -143,7 +143,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
                 findReactRootViewChildVM(fragment.childFragmentManager)
             }
         }
-        return null;
+        return fragmentManager;
     }
 
     private fun setupFragmentManager() {
@@ -184,7 +184,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // whose root view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
         // to activity which hosts ReactRootView.
         if (context.supportFragmentManager.fragments.isNotEmpty()) {
-            setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager)!!)
+            setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager))
         } else {
             setFragmentManager(context.supportFragmentManager)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -143,6 +143,8 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
                 findReactRootViewChildVM(fragment.childFragmentManager)
             }
         }
+
+        // In case there are no hosted fragments we just return passed fragment manager
         return fragmentManager;
     }
 
@@ -181,13 +183,9 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactActivity" }
 
         // In case React Native is loaded on a Fragment (not directly in activity) we need to find fragment manager
-        // whose root view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
+        // whose fragment's view is ReactRootView. As of now, we detect such case by checking whether any fragments are attached
         // to activity which hosts ReactRootView.
-        if (context.supportFragmentManager.fragments.isNotEmpty()) {
-            setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager))
-        } else {
-            setFragmentManager(context.supportFragmentManager)
-        }
+        setFragmentManager(findReactRootViewChildVM(context.supportFragmentManager))
     }
 
     protected fun createTransaction(): FragmentTransaction {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -177,11 +177,11 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
         // If parent is of type Screen it means we are inside a nested fragment structure.
         // Otherwise we expect to connect directly with root view and get root fragment manager
         if (parent is Screen) {
-            val screenFragment = parent.fragment
-            checkNotNull(screenFragment) { "Parent Screen does not have its Fragment attached" }
-            mParentScreenFragment = screenFragment
-            screenFragment.registerChildScreenContainer(this)
-            setFragmentManager(screenFragment.childFragmentManager)
+            checkNotNull(parent.fragment?.let { screenFragment ->
+                mParentScreenFragment = screenFragment
+                screenFragment.registerChildScreenContainer(this)
+                setFragmentManager(screenFragment.childFragmentManager)
+            }) { "Parent Screen does not have its Fragment attached" }
         } else {
             // we expect top level view to be of type ReactRootView, this isn't really necessary but in
             // order to find root view we test if parent is null. This could potentially happen also when

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -141,7 +141,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
                 return if (fragment.view is ReactRootView) {
                     fragment.childFragmentManager
                 } else {
-                    findReactRootViewChildVM(fragment.childFragmentManager)
+                    _findReactRootViewChildVM(fragment.childFragmentManager)
                 }
             }
             return null


### PR DESCRIPTION
## Description

Fixes #1506 

`ScreenContainer#setupFragmentManager` method resolves `FragmentManager` instance for `ScreenContainer` to use for conducting transactions. Until now, when first (not nested) `ScreenContainer` was initialised we took `FragmentManager` from top level activity, but it leads to conflicts with native Android navigation when React Native is not loaded directly in main activity (there are cases (see #1506) when both `react-native-screens` & Android native navigation use simultaneously the same FragmentManager leading to crashes).

## Changes

Added a method resolving fragment manager whose fragment's view is `ReactRootView`.

## Test code and steps to reproduce

See #1506 for crash description and how to reproduce. 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
