### PR TITLE
chore: throw error when failed to find fragment for react root view

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -161,11 +161,11 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
             // `findFragment` method throws IllegalStateException when it fails to resolve appropriate
             // fragment. It might happen when e.g. React Native is loaded directly in Activity
             // but some custom fragments are still used. Such use case seems highly unlikely
-            // so, as for now we fallback to activity's FragmentManager in hope for the best.
+            // so, as for now we let application crash.
             try {
                 FragmentManager.findFragment<Fragment>(rootView).childFragmentManager
             } catch (ex: IllegalStateException) {
-                context.supportFragmentManager
+                throw IllegalStateException("Failed to find fragment for React Root View")
             }
         }
     }


### PR DESCRIPTION
## Description

Changes introduced in https://github.com/software-mansion/react-native-screens/pull/1553 in case of `FragmentManager.findFragment` method throwing an exception could lead to some hard to debug behaviour. Now in case something goes wrong, we will get clear error message. 

## Changes

Code responsible for resolving `FragmentManager` when React Native is loaded of fragment now throws uncaught exception. 

## Test code and steps to reproduce

See #1553 and #1506

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
