### PR TITLE
fix: fallback to default behaviour when fragment not found

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -161,11 +161,11 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
             // `findFragment` method throws IllegalStateException when it fails to resolve appropriate
             // fragment. It might happen when e.g. React Native is loaded directly in Activity
             // but some custom fragments are still used. Such use case seems highly unlikely
-            // so, as for now we let application crash.
+            // so, as for now we fallback to activity's FragmentManager in hope for the best.
             try {
                 FragmentManager.findFragment<Fragment>(rootView).childFragmentManager
             } catch (ex: IllegalStateException) {
-                throw IllegalStateException("Failed to find fragment for React Root View")
+                context.supportFragmentManager
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #1565

See first #1553 and #1562 

This PR reverts changes introduced in #1562 - as for now this is a best known solution to a problem. 

## Changes

**Silently** fallback to activity's `FragmentManager` in case there is a `Fragment` under activity, but it is not the one with `ReactRootView`. 

Thing to note is that we are falling back silently w/o any warning. 

## Test code and steps to reproduce

See #1565, #1553

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
