### PR TITLE
fix: upgrade iOS CI runner image

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 40
     env:
       WORKING_DIRECTORY: Example

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -2,6 +2,10 @@ name: Test Android e2e
 on:
   pull_request:
     paths:
+      - '.github/workflows/android-e2e-test.yml'
+      - 'package.json'
+      - 'android/**'
+      - 'common/**'
       - 'Example/**'
   push:
     branches:

--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       WORKING_DIRECTORY: FabricExample
     concurrency:

--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -4,12 +4,13 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/ios-build-test-fabric.yml'
+      - 'RNScreens.podspec'
+      - 'package.json'
       - 'ios/**'
       - 'common/**'
       - 'src/fabric/**'
       - 'FabricExample/**'
-      - 'package.json'
-      - 'RNScreens.podspec'
   push:
     branches:
       - main

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -4,7 +4,12 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/ios-build-test.yml'
+      - 'RNScreens.podspec'
+      - 'package.json'
       - 'ios/**'
+      - 'common/**'
+      - 'TestsExample/**'
   push:
     branches:
       - main

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       WORKING_DIRECTORY: TestsExample
     concurrency:

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -2,6 +2,11 @@ name: Test iOS e2e
 on:
   pull_request:
     paths:
+      - '.github/workflows/ios-e2e-test.yml'
+      - 'RNScreens.podspec'
+      - 'package.json'
+      - 'ios/**'
+      - 'common/**'
       - 'Example/**'
   push:
     branches:

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 40
     env:
       WORKING_DIRECTORY: Example

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 40
     env:
       WORKING_DIRECTORY: Example

--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -4,7 +4,12 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/tv-os-build-test.yml'
+      - 'RNScreens.podspec'
+      - 'package.json'
       - 'ios/**'
+      - 'common/**'
+      - 'TVOSExample/**'
   push:
     branches:
       - main

--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       WORKING_DIRECTORY: TVOSExample
     concurrency:


### PR DESCRIPTION
## Description

This PR  upgrades macOS runner image to `macos-12` to fix `kLSNoExecutableErr: The executable is missing` error.

Also, path patterns were improved to trigger CI in more cases.

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
