### PR TITLE
chore: build only arm64-v8a architecture on CI for Fabric Android build

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -35,4 +35,4 @@ jobs:
         run: yarn
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}/android
-        run: ./gradlew assembleDebug --console=plain
+        run: ./gradlew assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a

--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -9,6 +9,7 @@ on:
       - 'src/fabric/**'
       - 'FabricTestExample/**'
       - 'package.json'
+      - '.github/workflows/android-build-test-fabric.yml'
   push:
     branches:
       - main

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -5,6 +5,9 @@ on:
       - main
     paths:
       - 'android/**'
+      - 'package.json'
+      - 'TestsExample/**'
+      - '.github/workflows/android-build-test.yml'
   push:
     branches:
       - main

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -7,6 +7,7 @@ on:
       - 'android/**'
       - 'common/**'
       - 'Example/**'
+      - 'TestsExample/**'
   push:
     branches:
       - main

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -8,6 +8,7 @@ on:
       - 'ios/**'
       - 'common/**'
       - 'Example/**'
+      - 'TestsExample/**'
   push:
     branches:
       - main

--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -154,6 +154,11 @@ android {
                         "-DANDROID_STL=c++_shared"
                 }
             }
+            if (!enableSeparateBuildPerCPUArchitecture) {
+                ndk {
+                    abiFilters (*reactNativeArchitectures())
+                }
+            }
         }
     }
 

--- a/FabricTestExample/android/app/build.gradle
+++ b/FabricTestExample/android/app/build.gradle
@@ -152,11 +152,19 @@ android {
                         "-DANDROID_STL=c++_shared"
                 }
             }
+            if (!enableSeparateBuildPerCPUArchitecture) {
+                ndk {
+                    abiFilters (*reactNativeArchitectures())
+                }
+            }
         }
     }
 
     if (isNewArchitectureEnabled()) {
         // We configure the NDK build only if you decide to opt-in for the New Architecture.
+        println "REACT NATIVE ARCHITECTURES"
+        println reactNativeArchitectures()
+
         externalNativeBuild {
             cmake {
                 path "$projectDir/src/main/jni/CMakeLists.txt"

--- a/FabricTestExample/android/app/build.gradle
+++ b/FabricTestExample/android/app/build.gradle
@@ -162,9 +162,6 @@ android {
 
     if (isNewArchitectureEnabled()) {
         // We configure the NDK build only if you decide to opt-in for the New Architecture.
-        println "REACT NATIVE ARCHITECTURES"
-        println reactNativeArchitectures()
-
         externalNativeBuild {
             cmake {
                 path "$projectDir/src/main/jni/CMakeLists.txt"


### PR DESCRIPTION
## Description

[Following `react-native-gesture-handler`](https://github.com/software-mansion/react-native-gesture-handler/blob/9d8a460de8337daf41ecd92a4b71bde2dc95dd1d/.github/workflows/android-build.yml#L35) as it takes over 1h to complete the workflow.

## Changes

* used `-PreactNativeArchitectures=arm64-v8a` gradle option to build only arm64-v8a architecture
* added paths to dependency list of workflows, so they get triggered when their configuration changes
* added abi filters to `FabricExample` & `FabricTestExample` so single architecture builds are respected

## Test code and steps to reproduce

Run the workflows


## Checklist

- [ ] Ensured that CI passes
