### PR TITLE
fix: potentially fix iOS 16.0 navigation header title bug

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -4,11 +4,11 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #else
 #import <React/RCTTouchHandler.h>
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -6,13 +6,13 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTRootComponentView.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #import <rnscreens/RNSScreenComponentDescriptor.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSConvert.h"
 #import "RNSScreenViewEvent.h"
 #else

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -3,9 +3,9 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #endif
 
 @implementation RNScreensViewController

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -3,9 +3,9 @@
 #import "RNSScreenContainer.h"
 
 #ifdef RN_FABRIC_ENABLED
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #endif
 
 @implementation RNScreensContainerNavigationController

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -1,11 +1,11 @@
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/UIView+React.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #else
 #import <React/RCTBridge.h>
 #import <React/RCTImageLoader.h>
@@ -459,7 +459,7 @@
     return;
   }
 
-  navitem.title = config.title;
+//  navitem.title = config.title;
 #if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize ||
       config.disableBackButtonMenu) {
@@ -586,6 +586,8 @@
       }
     }
   }
+
+  navitem.title = config.title;
 
   if (animated && vc.transitionCoordinator != nil &&
       vc.transitionCoordinator.presentationStyle == UIModalPresentationNone && !wasHidden) {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -586,6 +586,8 @@
     }
   }
 
+  // This assignment should be done after `navitem.titleView = ...` assignment (iOS 16.0 bug).
+  // See: https://github.com/software-mansion/react-native-screens/issues/1570 (comments)
   navitem.title = config.title;
 
   if (animated && vc.transitionCoordinator != nil &&

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -459,7 +459,6 @@
     return;
   }
 
-//  navitem.title = config.title;
 #if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize ||
       config.disableBackButtonMenu) {

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -8,11 +8,11 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSConvert.h"
 #endif
 


### PR DESCRIPTION
## Description

Potentially fixes #1570 as suggested in [comments](https://github.com/software-mansion/react-native-screens/issues/1570#issuecomment-1233329916). 

I tested it on iOS 16.0 simulator & device - worked for me. However when I passed this solution to other team @software-mansion, it was reported back to me that there is no change (buggy behaviour still occurs).

I'm gonna merge this PR, as it introduces only `line-swap` change, which should not introduce any regression and potentially fixes the bug.

**NOTE**: this issue seems to be already fixed internally by Apple as reported [here](https://github.com/react-navigation/react-navigation/issues/10840#issuecomment-1248117850).

## Changes

Just moved `navitem.title = ...` assignment below `navitem.titleView = ...` one.

## Test code and steps to reproduce

See #1570

## Checklist

- [ ] Ensured that CI passes
