### PR TITLE
feat(iOS): back button subview for Fabric

### DIFF
--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -86,5 +86,5 @@ import Test1649 from './src/Test1649';
 enableFreeze(true);
 
 export default function App() {
-  return <Test42 />;
+  return <Test1157 />;
 }

--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -86,5 +86,5 @@ import Test1649 from './src/Test1649';
 enableFreeze(true);
 
 export default function App() {
-  return <Test1157 />;
+  return <Test42 />;
 }

--- a/FabricTestExample/src/Test1157.tsx
+++ b/FabricTestExample/src/Test1157.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable react-native/no-inline-styles */
 import * as React from 'react';
 import {Button, View, TouchableOpacity} from 'react-native';
 import {NavigationContainer, ParamListBase} from '@react-navigation/native';
-import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
 
 function First({
   navigation,
@@ -25,7 +29,10 @@ function Second({
 }) {
   return (
     <View style={{flex: 1, backgroundColor: 'yellow'}}>
-      <Button title="Tap me for first screen" onPress={() => navigation.goBack()} />
+      <Button
+        title="Tap me for first screen"
+        onPress={() => navigation.goBack()}
+      />
     </View>
   );
 }
@@ -33,8 +40,17 @@ function Second({
 const Stack = createNativeStackNavigator();
 
 const ButtonWithBiggerChild = () => (
-  <TouchableOpacity style={{width: 30, height: 30, backgroundColor: 'red'}} onPress={() => console.log("hello")}>
-      <View style={{width: 30, height: 30, backgroundColor: 'yellow', marginLeft: -15}}/>
+  <TouchableOpacity
+    style={{width: 30, height: 30, backgroundColor: 'red'}}
+    onPress={() => console.log('hello')}>
+    <View
+      style={{
+        width: 30,
+        height: 30,
+        backgroundColor: 'yellow',
+        marginLeft: -15,
+      }}
+    />
   </TouchableOpacity>
 );
 
@@ -42,11 +58,23 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{stackPresentation: 'modal'}}>
-        <Stack.Screen name="First" component={First} 
-          options={{headerShown: true,
+        <Stack.Screen
+          name="First"
+          component={First}
+          options={{
+            headerShown: true,
             // headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -15}}/>,
             headerLeft: () => <ButtonWithBiggerChild />,
-            headerRight: () => <TouchableOpacity onPress={() => console.log("there")} style={{width: 30, height: 30, backgroundColor: 'red', marginRight: -15}}/>,
+            headerRight: () => (
+              <TouchableOpacity
+                onPress={() => console.log('there')}
+                style={{
+                  width: 30,
+                  height: 30,
+                  backgroundColor: 'red',
+                  marginRight: -15,
+                }}
+              />
             }}
         />
         <Stack.Screen

--- a/FabricTestExample/src/Test1157.tsx
+++ b/FabricTestExample/src/Test1157.tsx
@@ -74,7 +74,7 @@ export default function App() {
                   backgroundColor: 'red',
                   marginRight: -15,
                 }}
-              />
+              />)
             }}
         />
         <Stack.Screen

--- a/FabricTestExample/src/Test1157.tsx
+++ b/FabricTestExample/src/Test1157.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unstable-nested-components */
 /* eslint-disable react-native/no-inline-styles */
 import * as React from 'react';
 import {Button, View, TouchableOpacity} from 'react-native';
@@ -39,20 +40,28 @@ function Second({
 
 const Stack = createNativeStackNavigator();
 
-const ButtonWithBiggerChild = () => (
-  <TouchableOpacity
-    style={{width: 30, height: 30, backgroundColor: 'red'}}
-    onPress={() => console.log('hello')}>
-    <View
-      style={{
-        width: 30,
-        height: 30,
-        backgroundColor: 'yellow',
-        marginLeft: -15,
-      }}
-    />
-  </TouchableOpacity>
-);
+function ButtonWithBiggerChild(props: {
+  tintColor?: string | undefined;
+  onClickText?: string | undefined;
+  backgroundColor?: string | undefined;
+}): JSX.Element {
+  const {onClickText = 'Hello there General Kenobi', backgroundColor = 'red'} =
+    props;
+  return (
+    <TouchableOpacity
+      style={{width: 30, height: 30, backgroundColor: 'red'}}
+      onPress={() => console.log(onClickText)}>
+      <View
+        style={{
+          width: 30,
+          height: 30,
+          backgroundColor: backgroundColor,
+          marginLeft: -15,
+        }}
+      />
+    </TouchableOpacity>
+  );
+}
 
 export default function App() {
   return (
@@ -62,9 +71,14 @@ export default function App() {
           name="First"
           component={First}
           options={{
+            backButtonInCustomView: true,
             headerShown: true,
-            // headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -15}}/>,
-            headerLeft: () => <ButtonWithBiggerChild />,
+            headerLeft: () => (
+              <ButtonWithBiggerChild
+                onClickText={'Hello'}
+                backgroundColor={'yellow'}
+              />
+            ),
             headerRight: () => (
               <TouchableOpacity
                 onPress={() => console.log('there')}
@@ -74,14 +88,25 @@ export default function App() {
                   backgroundColor: 'red',
                   marginRight: -15,
                 }}
-              />)
-            }}
+              />
+            ),
+          }}
         />
         <Stack.Screen
           name="Second"
           component={Second}
           options={{
-            headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 50, height: 50, backgroundColor: 'red', marginLeft: -15}}/>
+            headerLeft: () => (
+              <TouchableOpacity
+                onPress={() => console.log('General Kenobi')}
+                style={{
+                  width: 50,
+                  height: 50,
+                  backgroundColor: 'red',
+                  marginLeft: -15,
+                }}
+              />
+            ),
           }}
         />
       </Stack.Navigator>

--- a/TestsExample/src/Test1157.tsx
+++ b/TestsExample/src/Test1157.tsx
@@ -1,7 +1,12 @@
+/* eslint-disable react/display-name */
+/* eslint-disable react-native/no-inline-styles */
 import * as React from 'react';
 import {Button, View, TouchableOpacity} from 'react-native';
 import {NavigationContainer, ParamListBase} from '@react-navigation/native';
-import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
 
 function First({
   navigation,
@@ -25,28 +30,59 @@ function Second({
 }) {
   return (
     <View style={{flex: 1, backgroundColor: 'yellow'}}>
-      <Button title="Tap me for first screen" onPress={() => navigation.goBack()} />
+      <Button
+        title="Tap me for first screen"
+        onPress={() => navigation.goBack()}
+      />
     </View>
   );
 }
 
+console.log("Test1157 module")
+
 const Stack = createNativeStackNavigator();
 
 const ButtonWithBiggerChild = () => (
-  <TouchableOpacity style={{width: 30, height: 30, backgroundColor: 'red'}} onPress={() => console.log("hello")}>
-      <View style={{width: 30, height: 30, backgroundColor: 'yellow', marginLeft: -15}}/>
+  <TouchableOpacity
+    style={{width: 30, height: 30, backgroundColor: 'red'}}
+    onPress={() => console.log('hello')}>
+    <View
+      style={{
+        width: 30,
+        height: 30,
+        backgroundColor: 'yellow',
+        marginLeft: -15,
+      }}
+    />
   </TouchableOpacity>
 );
 
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{stackPresentation: 'modal'}}>
-        <Stack.Screen name="First" component={First} 
-          options={{headerShown: true,
+      <Stack.Navigator screenOptions={{
+        stackPresentation: 'modal',
+        backButtonImage: require("../assets/backButton.png"),
+        // headerBackTitleVisible: false
+        }}>
+        <Stack.Screen
+          name="First"
+          component={First}
+          options={{
+            // headerShown: true,
             // headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -15}}/>,
-            headerLeft: () => <ButtonWithBiggerChild />,
-            headerRight: () => <TouchableOpacity onPress={() => console.log("there")} style={{width: 30, height: 30, backgroundColor: 'red', marginRight: -15}}/>,
+            // backButtonImage: require('../assets/backButton.png'),
+            // headerLeft: () => <ButtonWithBiggerChild />,
+            headerRight: () => (
+              <TouchableOpacity
+                onPress={() => console.log('there')}
+                style={{
+                  width: 30,
+                  height: 30,
+                  backgroundColor: 'red',
+                  marginRight: -15,
+                }}
+              />)
             }}
         />
         <Stack.Screen

--- a/TestsExample/src/Test1157.tsx
+++ b/TestsExample/src/Test1157.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint-disable react/no-unstable-nested-components */
 /* eslint-disable react-native/no-inline-styles */
 import * as React from 'react';
 import {Button, View, TouchableOpacity} from 'react-native';
@@ -38,41 +38,47 @@ function Second({
   );
 }
 
-console.log("Test1157 module")
-
 const Stack = createNativeStackNavigator();
 
-const ButtonWithBiggerChild = () => (
-  <TouchableOpacity
-    style={{width: 30, height: 30, backgroundColor: 'red'}}
-    onPress={() => console.log('hello')}>
-    <View
-      style={{
-        width: 30,
-        height: 30,
-        backgroundColor: 'yellow',
-        marginLeft: -15,
-      }}
-    />
-  </TouchableOpacity>
-);
+function ButtonWithBiggerChild(props: {
+  tintColor?: string | undefined;
+  onClickText?: string | undefined;
+  backgroundColor?: string | undefined;
+}): JSX.Element {
+  const {onClickText = 'Hello there General Kenobi', backgroundColor = 'red'} =
+    props;
+  return (
+    <TouchableOpacity
+      style={{width: 30, height: 30, backgroundColor: 'red'}}
+      onPress={() => console.log(onClickText)}>
+      <View
+        style={{
+          width: 30,
+          height: 30,
+          backgroundColor: backgroundColor,
+          marginLeft: -15,
+        }}
+      />
+    </TouchableOpacity>
+  );
+}
 
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{
-        stackPresentation: 'modal',
-        backButtonImage: require("../assets/backButton.png"),
-        // headerBackTitleVisible: false
-        }}>
+      <Stack.Navigator screenOptions={{stackPresentation: 'modal'}}>
         <Stack.Screen
           name="First"
           component={First}
           options={{
-            // headerShown: true,
-            // headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 30, height: 30, backgroundColor: 'red', marginLeft: -15}}/>,
-            // backButtonImage: require('../assets/backButton.png'),
-            // headerLeft: () => <ButtonWithBiggerChild />,
+            backButtonInCustomView: true,
+            headerShown: true,
+            headerLeft: () => (
+              <ButtonWithBiggerChild
+                onClickText={'Hello'}
+                backgroundColor={'yellow'}
+              />
+            ),
             headerRight: () => (
               <TouchableOpacity
                 onPress={() => console.log('there')}
@@ -82,14 +88,25 @@ export default function App() {
                   backgroundColor: 'red',
                   marginRight: -15,
                 }}
-              />)
-            }}
+              />
+            ),
+          }}
         />
         <Stack.Screen
           name="Second"
           component={Second}
           options={{
-            headerLeft: () => <TouchableOpacity onPress={() => console.log("hello")} style={{width: 50, height: 50, backgroundColor: 'red', marginLeft: -15}}/>
+            headerLeft: () => (
+              <TouchableOpacity
+                onPress={() => console.log('General Kenobi')}
+                style={{
+                  width: 50,
+                  height: 50,
+                  backgroundColor: 'red',
+                  marginLeft: -15,
+                }}
+              />
+            ),
           }}
         />
       </Stack.Navigator>

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -244,9 +244,6 @@
 
 + (UIImage *)loadBackButtonImageInViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
-#ifdef RN_FABRIC_ENABLED
-  @throw([NSException exceptionWithName:@"UNIMPLEMENTED" reason:@"Implement" userInfo:nil]);
-#else
   BOOL hasBackButtonImage = NO;
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     if (subview.type == RNSScreenStackHeaderSubviewTypeBackButton && subview.subviews.count > 0) {
@@ -313,7 +310,6 @@
       }
     }
   }
-#endif // RN_FABRIC_ENABLED
   return nil;
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -31,10 +31,6 @@
 - (id<RCTImageCache>)imageCache;
 @end
 
-@interface RCTBridge (Private)
-+ (RCTBridge *)currentBridge;
-@end
-
 @implementation RNSScreenStackHeaderConfig {
   NSMutableArray<RNSScreenStackHeaderSubview *> *_reactSubviews;
 #ifdef RN_FABRIC_ENABLED

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -7,11 +7,11 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #else
-#import <React/RCTBridge.h>
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerUtils.h>
 #endif
+#import <React/RCTBridge.h>
 #import <React/RCTFont.h>
 #import <React/RCTImageLoader.h>
 #import <React/RCTImageSource.h>

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -8,21 +8,19 @@
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #else
 #import <React/RCTBridge.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTImageSource.h>
-#import <React/RCTImageView.h>
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerUtils.h>
 #endif
 #import <React/RCTFont.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTImageSource.h>
+#import <React/RCTImageView.h>
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
 #import "RNSSearchBar.h"
 #import "RNSUIBarButtonItem.h"
 
-#ifdef RN_FABRIC_ENABLED
-#else
 // Some RN private method hacking below. Couldn't figure out better way to access image data
 // of a given RCTImageView. See more comments in the code section processing SubviewTypeBackButton
 @interface RCTImageView (Private)
@@ -32,7 +30,10 @@
 @interface RCTImageLoader (Private)
 - (id<RCTImageCache>)imageCache;
 @end
-#endif
+
+@interface RCTBridge (Private)
++ (RCTBridge *)currentBridge;
+@end
 
 @implementation RNSScreenStackHeaderConfig {
   NSMutableArray<RNSScreenStackHeaderSubview *> *_reactSubviews;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -409,7 +409,7 @@
 #endif // RN_FABRIC_ENABLED
   return appearance;
 }
-#endif
+#endif // Check for >= iOS 13.0
 
 + (void)updateViewController:(UIViewController *)vc
                   withConfig:(RNSScreenStackHeaderConfig *)config

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -583,9 +583,6 @@
         break;
       }
       case RNSScreenStackHeaderSubviewTypeBackButton: {
-#ifdef RN_FABRIC_ENABLED
-        RCTLogWarn(@"Back button subview is not yet Fabric compatible in react-native-screens");
-#endif
         break;
       }
     }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -397,16 +397,12 @@
     appearance.largeTitleTextAttributes = largeAttrs;
   }
 
-#ifdef RN_FABRIC_ENABLED
-  [appearance setBackIndicatorImage:nil transitionMaskImage:nil];
-#else
   UIImage *backButtonImage = [self loadBackButtonImageInViewController:vc withConfig:config];
   if (backButtonImage) {
     [appearance setBackIndicatorImage:backButtonImage transitionMaskImage:backButtonImage];
   } else if (appearance.backIndicatorImage) {
     [appearance setBackIndicatorImage:nil transitionMaskImage:nil];
   }
-#endif // RN_FABRIC_ENABLED
   return appearance;
 }
 #endif // Check for >= iOS 13.0
@@ -710,8 +706,6 @@
 - (void)updateProps:(facebook::react::Props::Shared const &)props
            oldProps:(facebook::react::Props::Shared const &)oldProps
 {
-  [super updateProps:props oldProps:oldProps];
-
   const auto &oldScreenProps =
       *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigProps>(_props);
   const auto &newScreenProps = *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigProps>(props);
@@ -775,6 +769,8 @@
 
   _initialPropsSet = YES;
   _props = std::static_pointer_cast<facebook::react::RNSScreenStackHeaderConfigProps const>(props);
+
+  [super updateProps:props oldProps:oldProps];
 }
 
 #else

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -20,13 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) UIView *reactSuperview;
 
-#ifdef RN_FABRIC_ENABLED
-#else
 @property (nonatomic, weak) RCTBridge *bridge;
 
+#ifdef RN_FABRIC_ENABLED
+#else
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
-
-#endif
+#endif // RN_FABRIC_ENABLED
 
 @end
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -10,6 +10,10 @@
 #import <React/RCTFabricComponentsPlugins.h>
 #endif
 
+@interface RCTBridge (Private)
++ (RCTBridge *)currentBridge;
+@end
+
 @implementation RNSScreenStackHeaderSubview
 
 #pragma mark - Common
@@ -94,6 +98,16 @@
 }
 
 #endif // RN_FABRIC_ENABLED
+
+- (RCTBridge *)bridge
+{
+#ifdef RN_FABRIC_ENABLED
+  return [RCTBridge currentBridge];
+#else
+  return _bridge;
+#endif // RN_FABRIC_ENABLED
+}
+
 @end
 
 @implementation RNSScreenStackHeaderSubviewManager

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -44,14 +44,8 @@
 {
   const auto &newHeaderSubviewProps =
       *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(props);
-  const auto &oldHeaderSubviewProps =
-      *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(oldProps);
 
   [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
-  //  if (newHeaderSubviewProps.type != oldHeaderSubviewProps.type) {
-  //    [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
-  //  }
-
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -45,11 +45,12 @@
   const auto &newHeaderSubviewProps =
       *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(props);
   const auto &oldHeaderSubviewProps =
-      *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(_props);
+      *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(oldProps);
 
-  if (newHeaderSubviewProps.type != oldHeaderSubviewProps.type) {
-    _type = [RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type];
-  }
+  [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
+  //  if (newHeaderSubviewProps.type != oldHeaderSubviewProps.type) {
+  //    [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
+  //  }
 
   [super updateProps:props oldProps:oldProps];
 }


### PR DESCRIPTION
## Description

Resolves #1563 

The issue was tricky & deceptive.

In `RNSScreenStackHeaderSubview` during initialisation we assigned to `_prop` default prop values. We used it later in `updateProps:oldProps:` to check whether the `type` changed - if it was the case we called `setType`, otherwise there was no action taken. 

With such setup, in case of `newProps.type` value, being the same as `_prop.type` the `type` property would not get initialised and default to `0` leading to crashes later on. 

**NOTE**: We need to verify this in other components, as we are using there the same faulty mechanism. 

## Changes

* Removed if-check whether the `type` property should be updated
* Unified ifdef'd (`RN_NEW_ARCH_ENABLED`) sections of code
* Updated test screen & added it to `FabricTestExample`
* Removed the warning

## Test code and steps to reproduce

See `Test1157`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes (known issue with iOS e2e)
