### PR TITLE
chore: remove unused project property in FabricTestExample

### DIFF
--- a/FabricTestExample/android/gradle.properties
+++ b/FabricTestExample/android/gradle.properties
@@ -41,6 +41,3 @@ newArchEnabled=true
 
 disableMultipleInstancesCheck=true
 
-# This can be removed, when https://github.com/software-mansion/react-native-reanimated/pull/3493
-# gets merged.
-assertNoMultipleInstallations=false


### PR DESCRIPTION
## Description

As the comment in the code says: this line is no longer needed since https://github.com/software-mansion/react-native-reanimated/pull/3493 got merged and dependency on `react-native-reanimated` [was updated](https://github.com/software-mansion/react-native-screens/pull/1584/commits/06f2a4fbf6373e86ad26dc081af06910b68e3369).


## Changes

Removed unused line.


## Test code and steps to reproduce

Build & run `FabricTestExample` and see that it works.

## Checklist

- [ ] Ensured that CI passes
