### PR TITLE
docs: update supported RN version for Fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,14 @@ Screens are already integrated with the React Native's most popular navigation l
 | 2.0.0+  | 0.60.0+              |
 
 ### Support for Fabric
-[Fabric](https://reactnative.dev/architecture/fabric-renderer) is React Native's new rendering system. As of [version `3.14.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.14.0) of this project, Fabric is supported only for react-native 0.69+. Support for `0.68.x` has been dropped.
+[Fabric](https://reactnative.dev/architecture/fabric-renderer) is React Native's new rendering system. 
+
+* As of [version `3.18.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.18.0) of this project, Fabric is supported only for react-native 0.70+. Support for lower versions has been dropped.
+* As of [version `3.14.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.14.0) of this project, Fabric is supported only for react-native 0.69+. Support for lower versions has been dropped.
 
 | version | react-native version |
 | ------- | -------------------- |
+| 3.18.0+ | 0.70.0+              |
 | 3.14.0+ | 0.69.0+              |
 
 


### PR DESCRIPTION
## Description

Update supported React Native version for Fabric in library's main readme.

Support for older versions has been dropped as we added autolinking in #1585 (it [requires `@react-native-community/cli` 9.1.0 or newer](https://github.com/react-native-community/cli/releases/tag/v9.1.0) (support for `cmakeListsPath` in config) which is shipped with React Native since 0.70.0) 



## Changes

Since 3.18.0 Fabric will be supported only with React Native 0.70.0 or newer.


## Test code and steps to reproduce

--

## Checklist

- [ ] Ensured that CI passes
