### PR TITLE
fix: make enabling device orientation notifications internal

### DIFF
--- a/Example/ios/ScreensExample/AppDelegate.m
+++ b/Example/ios/ScreensExample/AppDelegate.m
@@ -31,10 +31,6 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
 
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
-  
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"ScreensExample"
@@ -52,14 +48,6 @@ static void InitializeFlipper(UIApplication *application) {
   [self.window makeKeyAndVisible];
   return YES;
 }
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
-}
-
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {

--- a/FabricExample/ios/FabricExample/AppDelegate.mm
+++ b/FabricExample/ios/FabricExample/AppDelegate.mm
@@ -43,10 +43,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
-  
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
 
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"FabricExample", initProps);
@@ -63,13 +59,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
+++ b/FabricTestExample/ios/FabricTestExample/AppDelegate.mm
@@ -42,9 +42,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
 
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"FabricTestExample", initProps);
@@ -61,13 +58,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
-}
-
-- (void)applicationWillTerminate
-{
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/README.md
+++ b/README.md
@@ -18,31 +18,7 @@ To learn about how to use `react-native-screens` with Fabric architecture, head 
 
 ### iOS
 
-On iOS obtaining current device orientation [requires asking the system to generate orientation notifications](https://developer.apple.com/documentation/uikit/uidevice/1620053-orientation?language=objc). Our library uses them to enforce correct interface orientation when navigating between screens. 
-To make sure that there are no issues with screen orientation you should put following code in your `AppDelegate.m`:
-
-```objective-c
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-    ... 
-#if !TARGET_OS_TV
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
-    ...
-    return YES:
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-#if !TARGET_OS_TV
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
-}
-```
-
-You can see example of these changes being introduced in our [example applications](https://github.com/software-mansion/react-native-screens/blob/main/TestsExample/ios/TestsExample/AppDelegate.mm).
-
-Other aspects of installation should be completely handled with auto-linking, just ensure you installed pods after adding this module.
+Installation on iOS is completely handled with auto-linking, if you have ensured pods are installed after adding this module, no other actions are necessary.
 
 ### Android
 
@@ -81,6 +57,7 @@ buildscript {
 ```
 
 **Disclaimer**: `react-native-screens` requires Kotlin `1.3.50` or higher.
+
 </details>
 
 ### Windows
@@ -100,16 +77,16 @@ Screens are already integrated with the React Native's most popular navigation l
 | 2.0.0+  | 0.60.0+              |
 
 ### Support for Fabric
-[Fabric](https://reactnative.dev/architecture/fabric-renderer) is React Native's new rendering system. 
 
-* As of [version `3.18.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.18.0) of this project, Fabric is supported only for react-native 0.70+. Support for lower versions has been dropped.
-* As of [version `3.14.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.14.0) of this project, Fabric is supported only for react-native 0.69+. Support for lower versions has been dropped.
+[Fabric](https://reactnative.dev/architecture/fabric-renderer) is React Native's new rendering system.
+
+- As of [version `3.18.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.18.0) of this project, Fabric is supported only for react-native 0.70+. Support for lower versions has been dropped.
+- As of [version `3.14.0`](https://github.com/software-mansion/react-native-screens/releases/tag/3.14.0) of this project, Fabric is supported only for react-native 0.69+. Support for lower versions has been dropped.
 
 | version | react-native version |
 | ------- | -------------------- |
 | 3.18.0+ | 0.70.0+              |
 | 3.14.0+ | 0.69.0+              |
-
 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation)
 
@@ -194,12 +171,12 @@ Use `ScrollView` with prop `contentInsetAdjustmentBehavior=“automatic”` as a
 
 ### Other problems
 
-| Problem                                                                                                                                      | Solution                                                                                                    |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [SVG component becomes transparent when goBack](https://github.com/software-mansion/react-native-screens/issues/773)                         | [related PRs](https://github.com/software-mansion/react-native-screens/issues/773#issuecomment-783469792)           |
-| [Memory leak while moving from one screen to another in the same stack](https://github.com/software-mansion/react-native-screens/issues/843) | [explanation](https://github.com/software-mansion/react-native-screens/issues/843#issuecomment-832034119)   |
-| [LargeHeader stays small after pop/goBack/swipe gesture on iOS 14+](https://github.com/software-mansion/react-native-screens/issues/649)     | [potential fix](https://github.com/software-mansion/react-native-screens/issues/649#issuecomment-712199895) |
-| [`onScroll` and `onMomentumScrollEnd` of previous screen triggered in bottom tabs](https://github.com/software-mansion/react-native-screens/issues/1183)     | [explanation](https://github.com/software-mansion/react-native-screens/issues/1183#issuecomment-949313111) |
+| Problem                                                                                                                                                  | Solution                                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [SVG component becomes transparent when goBack](https://github.com/software-mansion/react-native-screens/issues/773)                                     | [related PRs](https://github.com/software-mansion/react-native-screens/issues/773#issuecomment-783469792)   |
+| [Memory leak while moving from one screen to another in the same stack](https://github.com/software-mansion/react-native-screens/issues/843)             | [explanation](https://github.com/software-mansion/react-native-screens/issues/843#issuecomment-832034119)   |
+| [LargeHeader stays small after pop/goBack/swipe gesture on iOS 14+](https://github.com/software-mansion/react-native-screens/issues/649)                 | [potential fix](https://github.com/software-mansion/react-native-screens/issues/649#issuecomment-712199895) |
+| [`onScroll` and `onMomentumScrollEnd` of previous screen triggered in bottom tabs](https://github.com/software-mansion/react-native-screens/issues/1183) | [explanation](https://github.com/software-mansion/react-native-screens/issues/1183#issuecomment-949313111)  |
 
 ## Contributing
 

--- a/TestsExample/ios/TestsExample/AppDelegate.mm
+++ b/TestsExample/ios/TestsExample/AppDelegate.mm
@@ -43,10 +43,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
 
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
-
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"TestsExample", initProps);
 
@@ -62,13 +58,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-#if !TARGET_OS_TV
-  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-#endif // !TARGET_OS_TV
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -4,11 +4,11 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #else
 #import <React/RCTTouchHandler.h>
 #endif // RN_FABRIC_ENABLED

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -45,14 +45,6 @@
 #endif
 }
 
-#if !TARGET_OS_TV
-// See:
-// 1. https://github.com/software-mansion/react-native-screens/pull/1543
-// 2. https://github.com/software-mansion/react-native-screens/pull/1596
-// This line aims to ensure that device orientation notifications are enabled
-static RNSScreenWindowTraits *orientationNotificationLifecycle = [RNSScreenWindowTraits new];
-#endif
-
 #ifdef RN_FABRIC_ENABLED
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -1205,6 +1197,29 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 RCT_EXPORT_VIEW_PROPERTY(homeIndicatorHidden, BOOL)
 #endif
+
+#if !TARGET_OS_TV
+// See:
+// 1. https://github.com/software-mansion/react-native-screens/pull/1543
+// 2. https://github.com/software-mansion/react-native-screens/pull/1596
+// This class is instatiated from React Native's internals during application startup
+- (instancetype)init
+{
+  if (self = [super init]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    });
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+  });
+}
+#endif // !TARGET_OS_TV
 
 - (UIView *)view
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -6,13 +6,13 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTRootComponentView.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #import <rnscreens/RNSScreenComponentDescriptor.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSConvert.h"
 #import "RNSScreenViewEvent.h"
 #else
@@ -44,6 +44,8 @@
   CGRect _reactFrame;
 #endif
 }
+
+static RNSScreenWindowTraits *orientationNotificationLifecycle = [RNSScreenWindowTraits new];
 
 #ifdef RN_FABRIC_ENABLED
 - (instancetype)initWithFrame:(CGRect)frame

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -45,7 +45,13 @@
 #endif
 }
 
+#if !TARGET_OS_TV
+// See:
+// 1. https://github.com/software-mansion/react-native-screens/pull/1543
+// 2. https://github.com/software-mansion/react-native-screens/pull/1596
+// This line aims to ensure that device orientation notifications are enabled
 static RNSScreenWindowTraits *orientationNotificationLifecycle = [RNSScreenWindowTraits new];
+#endif
 
 #ifdef RN_FABRIC_ENABLED
 - (instancetype)initWithFrame:(CGRect)frame

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -3,9 +3,9 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #endif
 
 @implementation RNScreensViewController

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -3,9 +3,9 @@
 #import "RNSScreenContainer.h"
 
 #ifdef RN_FABRIC_ENABLED
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #endif
 
 @implementation RNScreensContainerNavigationController

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -1,11 +1,11 @@
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/UIView+React.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #else
 #import <React/RCTBridge.h>
 #import <React/RCTImageLoader.h>

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -4,6 +4,25 @@
 
 @implementation RNSScreenWindowTraits
 
+- (instancetype)init
+{
+#if !TARGET_OS_TV
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+  });
+#endif
+  return self;
+}
+
+- (void)dealloc
+{
+#if !TARGET_OS_TV
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+  });
+#endif
+}
+
 #if !TARGET_OS_TV
 + (void)assertViewControllerBasedStatusBarAppearenceSet
 {

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -4,6 +4,11 @@
 
 @implementation RNSScreenWindowTraits
 
+// See:
+// 1. https://github.com/software-mansion/react-native-screens/pull/1543
+// 2. https://github.com/software-mansion/react-native-screens/pull/1596
+// This class is instatiated from RNSScreen when static variables are initialized
+// (in the beginning of runtime)
 - (instancetype)init
 {
 #if !TARGET_OS_TV

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -4,30 +4,6 @@
 
 @implementation RNSScreenWindowTraits
 
-// See:
-// 1. https://github.com/software-mansion/react-native-screens/pull/1543
-// 2. https://github.com/software-mansion/react-native-screens/pull/1596
-// This class is instatiated from RNSScreen when static variables are initialized
-// (in the beginning of runtime)
-- (instancetype)init
-{
-#if !TARGET_OS_TV
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-  });
-#endif
-  return self;
-}
-
-- (void)dealloc
-{
-#if !TARGET_OS_TV
-  dispatch_sync(dispatch_get_main_queue(), ^{
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-  });
-#endif
-}
-
 #if !TARGET_OS_TV
 + (void)assertViewControllerBasedStatusBarAppearenceSet
 {

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -8,11 +8,11 @@
 
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
-#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSConvert.h"
 #endif
 


### PR DESCRIPTION
## Description

UIKit documentation states that in order to successfully use orientation in iOS apps the orientation has to be enabled via [the `beginGeneratingDeviceOrientationNotifications ` method](https://developer.apple.com/documentation/uikit/uidevice/1620041-begingeneratingdeviceorientation?language=objc). This was addressed in https://github.com/software-mansion/react-native-screens/pull/1543.


This PR attempts to make this change internal and also removing an additional `react-native-screens` installation step from README.

PR made based on code from `expo-screen-orientation` package [from this line](https://github.com/expo/expo/blob/519ac3d86864da9dd920a9ff8d0c880f6ec81a58/ios/versioned/sdk46/EXScreenOrientation/EXScreenOrientation/ABI46_0_0EXScreenOrientationRegistry.m#L38). 

Fixes https://github.com/react-navigation/react-navigation.github.io/issues/1177 

Note by @kkafar:

For now I went with placing the code in ctor/dtor of `RNSScreen` view manager.
The view manager construction & lifecycle is managed by React Native's internals (and is executed during application startup). This behaviour is considered stable (changing this would be braking change for RN Paper architecture).

I considered also:

1. Creating a native module, so we can execute required code in its lifetime (ctor, dtor) methods -- but it seemed too much... Also we would have to load this module from JS (prevent lazy loading).
2. Using `dispatch_once` in `+ (voi)enforceDesiredDeviceOrientation` method - and calling only the `begin...` method (as there would be no place to call the responding `end...` method.
3. Calling `begin...`/`end...` methods every time `enforceDesiredDeviceOrientation` is being called.
4. Adding the code to ctor/dtor of `RNSScreenWindowTraits` and creating a static object. But I had objections. I feared  that compiler might optimise-out (remove) this static variable since it is unused. I've found some [mails](https://gcc.gnu.org/pipermail/gcc-help/2021-April/140125.html) form [gcc-help mailing list](https://gcc.gnu.org/mailman/listinfo/gcc-help) indicating that it might be the case. 

## Changes

- Moved `beginGeneratingDeviceOrientationNotifications` and `endGeneratingDeviceOrientationNotifications` methods from applications `AppDelegate`s to `RNSScreenManager` `init`/`dealloc` methods.

## Testing

I attached a breakpoint to see that added code ends actually being called. 

Orientation playground in `Example/` app.

## Checklist

- [x] Ensured that CI passes
