### PR TITLE
fix: drop usage of removed Platform.isTVOS field

### DIFF
--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -22,7 +22,7 @@ export default function getDefaultHeaderHeight(
       statusBarHeight = 0;
     }
 
-    if (Platform.isPad || Platform.isTVOS) {
+    if (Platform.isPad || Platform.isTV) {
       headerHeight = isFromSheetModal ? formSheetModalHeight : 50;
     } else {
       if (isLandscape) {


### PR DESCRIPTION
## Description

Fixes #1604 

`Platform.isTVOS` check was removed with `react-native@0.70` [(see the PR)](https://github.com/facebook/react-native/pull/34071) as it was only wrapper for `Platform.isTV` check (which exists since `0.61`). 

## Changes

Dropped usage of removed `Platform.isTVOS` check in favour of `Platform.isTV`.

## Test code and steps to reproduce

See #1604 -- check on any app that the library now works with `@types/react-native@0.70.*`

## Checklist

- [x] Ensured that CI passes
