### PR TITLE
#1045 Fix keyboard navigation in headers

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -112,6 +113,10 @@ class ScreenStackFragment : ScreenFragment {
             layoutParams = AppBarLayout.LayoutParams(
                 AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
             )
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setKeyboardNavigationCluster(true)
+            }
         }
 
         view?.addView(mAppBarLayout)


### PR DESCRIPTION
## Description
Fixes #1045 

Adds an option to reach header buttons with keyboard navigation

## Changes

Based on the documentation https://developer.android.com/about/versions/oreo/android-8.0#kbnc I have set the header AppBarLayout to be keyboard navigation cluster. This way the user can switch between content cluster and header cluster with meta+tab keyboard combination.



## Screenshots / GIFs

Tabbing through content buttons, switching to header cluster, tabbing through header buttons and then back.

![out](https://user-images.githubusercontent.com/6961047/194504934-a6a92b9b-5389-4347-b993-b4242a454dc5.gif)

<!--
### Before

### After
-->

## Test code and steps to reproduce

1. Create an app with header button or just a back button in the header
2. Use tab key to go through components in the screen content cluster
3. Press keyboard combination meta+tab, to get to header cluster
4. Now you can use tab key to go through components in header cluster
5. Pressing meta+tab will get you back to screen content cluster

\* This has been tested on Xiaomi phone with Android 8.1 and chromebook with Android 11 runtime. On Samsung with Android 9 this keyboard meta+tab combination is reserved for app switching, probably bug on Samsung side.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
