### PR TITLE
fix: add `react-native.config.js` to npm package

### DIFF
--- a/FabricTestExample/package.json
+++ b/FabricTestExample/package.json
@@ -21,7 +21,7 @@
     "react-native-codegen": "^0.69.1",
     "react-native-gesture-handler": "^2.6.0",
     "react-native-reanimated": "software-mansion/react-native-reanimated#c2a9b84a88ac26d5ed318036c32d4af346bfdfa4",
-    "react-native-safe-area-context": "^4.3.1",
+    "react-native-safe-area-context": "^4.4.1",
     "react-native-screens": "link:../",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0"

--- a/FabricTestExample/yarn.lock
+++ b/FabricTestExample/yarn.lock
@@ -6178,10 +6178,10 @@ react-native-reanimated@software-mansion/react-native-reanimated#c2a9b84a88ac26d
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
-react-native-safe-area-context@^4.3.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
-  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
+react-native-safe-area-context@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz#239c60b8a9a80eac70a38a822b04c0f1d15ffc01"
+  integrity sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==
 
 "react-native-screens@link:..":
   version "0.0.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ios/",
     "windows/",
     "RNScreens.podspec",
+    "react-native.config.js",
     "README.md",
     "!**/__tests__",
     "!android/src/main/java/com/swmansion/rnscreens/LifecycleHelper.kt"


### PR DESCRIPTION
## Description

 Autolinking was added with #1585 and it added `react-native.config.js` file with codegen configuration, **but** it did not add this file to npm include list causing its absence in final released package...

Fixes #1608

## Changes

Added `react-native.config.js` to npm file list in main `package.json`


## Test code and steps to reproduce

See #1608 for reproductions.

## Checklist

- [x] Ensured that CI passes
