### PR TITLE
chore: bump react-native-safe-area-context to 4.4.1 in FabricTestExample

### DIFF
--- a/FabricTestExample/package.json
+++ b/FabricTestExample/package.json
@@ -21,7 +21,7 @@
     "react-native-codegen": "^0.69.1",
     "react-native-gesture-handler": "^2.6.0",
     "react-native-reanimated": "software-mansion/react-native-reanimated#c2a9b84a88ac26d5ed318036c32d4af346bfdfa4",
-    "react-native-safe-area-context": "^4.3.1",
+    "react-native-safe-area-context": "^4.4.1",
     "react-native-screens": "link:../",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0"

--- a/FabricTestExample/yarn.lock
+++ b/FabricTestExample/yarn.lock
@@ -6178,10 +6178,10 @@ react-native-reanimated@software-mansion/react-native-reanimated#c2a9b84a88ac26d
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
-react-native-safe-area-context@^4.3.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
-  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
+react-native-safe-area-context@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz#239c60b8a9a80eac70a38a822b04c0f1d15ffc01"
+  integrity sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==
 
 "react-native-screens@link:..":
   version "0.0.0"


### PR DESCRIPTION
## Description

Earlier version caused some problems with existence of `CMakeLists.txt` in `safe-area-context` `android/src/main/jni` directory on React Native `0.70.2`.

## Changes

Bumped the version in `FabricTestExample`

## Test code and steps to reproduce

See that `FabricTestExample works`

## Checklist

- [ ] Ensured that CI passes
