### PR TITLE
fix: configure cli for Android only when RNCLI version >= 9.0.0

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,7 +1,17 @@
+let supportsCodegenConfig = false;
+try {
+  const rnCliAndroidVersion =
+    require('@react-native-community/cli-platform-android/package.json').version;
+  const [major] = rnCliAndroidVersion.split('.');
+  supportsCodegenConfig = major >= 9;
+} catch (e) {
+  // ignore
+}
+
 module.exports = {
   dependency: {
     platforms: {
-      android: {
+      android: supportsCodegenConfig ? {
         componentDescriptors: [
           "RNSFullWindowOverlayComponentDescriptor",
           "RNSScreenContainerComponentDescriptor",
@@ -13,7 +23,7 @@ module.exports = {
           'RNSScreenComponentDescriptor'
         ],
         cmakeListsPath: "../android/src/main/jni/CMakeLists.txt"
-      },
+      } : {},
     },
   },
 }


### PR DESCRIPTION
## Description

Fixes #1614

#1611 added `react-native.config.js` file to the library which uses features supported since `@react-native-cli@9.0.0` thus causing library fail to link while on Paper with React Native < 0.70.

This fix is borrowed from `react-native-safe-area-context`.

## Changes

Added check for `@react-native-community/cli-platform-android` version in `react-native.config.js`.

## Test code and steps to reproduce

--

## Checklist

- [x] Ensured that CI passes
