### PR TITLE
chore: clarify installation instructions for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ On Android the View state is not persisted consistently across Activity restarts
 
 For most people using an app built from the react-native template, that means editing `MainActivity.java`, likely located in `android/app/src/main/java/<your package name>/MainActivity.java`
 
-You should add this code, which specifically discards any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes. You should place this in the parent MainActivity and not inside the MainActivityDelegate.
+You should add this code, which specifically discards any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes.
+Please note that the override code should not be placed inside `MainActivityDelegate`, but rather directly in `MainActivity`.
 
 ```java
 import android.os.Bundle;

--- a/README.md
+++ b/README.md
@@ -50,14 +50,24 @@ On Android the View state is not persisted consistently across Activity restarts
 
 For most people using an app built from the react-native template, that means editing `MainActivity.java`, likely located in `android/app/src/main/java/<your package name>/MainActivity.java`
 
-You should add this code, which specifically discards any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes.
+You should add this code, which specifically discards any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes. You should place this in the parent MainActivity and not inside the MainActivityDelegate.
 
 ```java
 import android.os.Bundle;
 
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(null);
+public class MainActivity extends ReactActivity {
+
+    //...code
+
+    //react-native-screens override
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(null);
+    }
+
+    public static class MainActivityDelegate extends ReactActivityDelegate {
+        //...code
+    }
 }
 ```
 


### PR DESCRIPTION
Giving more detail to where the override should be.

## Description


Description and motivation for this PR.

Helps users who are experiencing crashing from react-native-screens on Android who have placed the override in the wrong location. This modifies the readme for more clear instructions on what to do. When placed in the MainActivityDelegate, the crash still occurs, while placing it in the parent, it seems to be fine.

Fixes #1481 .


## Test code and steps to reproduce
N/A

## Checklist
N/A
