### PR TITLE
chore: exclude android/.settings file form repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ lib/
 # CMake cache
 .cxx/
 
+android/.settings
+


### PR DESCRIPTION
I'm not sure what generates it, but it should not be included anyway

## Description

Just a small update, so it won't get checked-in into version control accidentally. 

## Changes

Added `android/.settings` to lib-wide git ignore list

## Test code and steps to reproduce

N/A

## Checklist

- [x] Ensured that CI passes
