### PR TITLE
Ensure full typings generation from index.native.tsx

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -440,7 +440,7 @@ class Screen extends React.Component<ScreenProps> {
   }
 }
 
-module.exports = {
+export {
   // these are classes so they are not evaluated until used
   // so no need to use getters for them
   Screen,
@@ -449,7 +449,19 @@ module.exports = {
   ScreenStack,
   InnerScreen,
   FullWindowOverlay,
+};
 
+// since these are hard-coded as getters and not exported, declare them for typings generation
+export declare const NativeScreen: React.ComponentType<ScreenProps>;
+export declare const NativeScreenContainer: React.ComponentType<ScreenContainerProps>;
+export declare const NativeScreenNavigationContainer: React.ComponentType<ScreenContainerProps>;
+export declare const ScreenStackHeaderConfig: React.ComponentType<ScreenStackHeaderConfigProps>;
+export declare const ScreenStackHeaderSubview: React.ComponentType<React.PropsWithChildren<
+  ViewProps & { type?: HeaderSubviewTypes }
+>>;
+export declare const SearchBar: View | React.ComponentType<SearchBarProps>;
+
+Object.defineProperties(module.exports, Object.getOwnPropertyDescriptors({
   get NativeScreen() {
     return ScreensNativeModules.NativeScreen;
   },
@@ -478,6 +490,9 @@ module.exports = {
 
     return ScreensNativeModules.NativeSearchBar;
   },
+}));
+
+export {
   // these are functions and will not be evaluated until used
   // so no need to use getters for them
   ScreenStackHeaderBackButtonImage,


### PR DESCRIPTION
## Description

The `index.native.d.ts` file that is generated during build doesn't contain all exported symbols because the source file doesn't use proper `export` statements, but instead assigns to the CommonJS `module.exports` variable.

This is a problem when consuming the package with tools that support suffix-based module resolution like the `moduleSuffixes` setting of `tsc`. The tool resolves the `index` to `index.native` and tries to use the corresponding declaration file, which is incomplete and the compilation fails.

Note: this change doesn't address the problem that assigning to `module.exports` is incompatible with ES6 modules and therefore the "module" build target is unusable in that context.

## Changes

- export symbols that are exportable as-is
- export declarations for symbols that are exported as getters on
  `module.exports` object
- instead of assigning to `module.exports`, use `Object.defineProperties` which
  doesn't conflict with the regular `export` statements
