### PR TITLE
fix: override requiresMainQueueSetup in RNSScreenManager

### DIFF
--- a/FabricTestExample/ios/Podfile.lock
+++ b/FabricTestExample/ios/Podfile.lock
@@ -728,7 +728,7 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - RNReanimated (3.0.0-rc.2):
+  - RNReanimated (3.0.0-rc.8):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -1007,7 +1007,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7401c4a40f8728fd89df4a56104541b760876117
   ReactCommon: c9246996e73bf75a2c6c3ff15f1e16707cdc2da9
   RNGestureHandler: 182b4e135cc4fec4988687e2f123e302dc6b4b71
-  RNReanimated: a91b2ed2ac39b96a6a024ab55a6b546b1ec10f84
+  RNReanimated: 5fe97ed1710f9d0c90bd97b275c4ba6b58fa9b45
   RNScreens: 208223c783496e6d0aa92ffdf307f61d58756fc1
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1316,6 +1316,11 @@ RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
   return [[RNSScreenView alloc] initWithBridge:self.bridge];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 @end
 
 @implementation RCTConvert (RNSScreen)

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1318,6 +1318,9 @@ RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
 
 + (BOOL)requiresMainQueueSetup
 {
+  // Returning NO here despite the fact some initialization in -init method dispatches tasks
+  // on main queue, because the comments in RN source code states that modules which return YES
+  // here will be constructed ahead-of-time -- and this is not required in our case.
   return NO;
 }
 


### PR DESCRIPTION
## Description

RN logs a warning when this method is not overridden and at the same time `-init` method is. 

I decided to return NO despite the fact that we dispatch taks on main
queue in init, becuase comments in RN interals state that modules that
require main queue setup will be initialised ahead of time -- and I
believe we do not need it.

## Changes

`RNSScreenManager` now explicitly states that it does not require main queue setup.

## Test code and steps to reproduce

--

## Checklist

- [x] Ensured that CI passes
