### PR TITLE
chore: unify CI between platforms

### DIFF
--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -10,7 +10,7 @@ on:
       - 'ios/**'
       - 'common/**'
       - 'src/fabric/**'
-      - 'FabricExample/**'
+      - 'FabricTestExample/**'
   push:
     branches:
       - main
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: macos-12
     env:
-      WORKING_DIRECTORY: FabricExample
+      WORKING_DIRECTORY: FabricTestExample
     concurrency:
       group: ios-fabric-${{ github.ref }}
       cancel-in-progress: true
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 14
           cache: 'yarn'
-          cache-dependency-path: 'FabricExample/yarn.lock'
+          cache-dependency-path: 'FabricTestExample/yarn.lock'
 
       - name: Install node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}


### PR DESCRIPTION
## Description

Make `ios-build-test-fabric` workflow build `FabricTestExample` instead of `FabricExample`

This is done to unify behaviour between platforms as `android-build-test-fabric` builds `FabricTestExample`. 

## Changes

Edited working directory of workflow.

## Checklist

- [x] Ensured that CI passes
