### PR TITLE
fix(iOS): image loading for back button on Fabric

### DIFF
--- a/FabricTestExample/src/Test550.js
+++ b/FabricTestExample/src/Test550.js
@@ -1,23 +1,21 @@
 import React from 'react';
-import {Button, ScrollView} from 'react-native';
+import {Button, ScrollView, StyleSheet} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';
 
 function HomeScreen({navigation}) {
   return (
-    <ScrollView contentContainerStyle={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
-        <Button
-          onPress={() => navigation.navigate('Details')}
-          title="Go to Details"
-        />
+    <ScrollView contentContainerStyle={styles.contentContainer}>
+      <Button
+        onPress={() => navigation.navigate('Details')}
+        title="Go to Details"
+      />
     </ScrollView>
   );
 }
 
 function DetailsScreen() {
-  return (
-    <ScrollView />
-  );
+  return <ScrollView />;
 }
 
 const RootStack = createNativeStackNavigator();
@@ -30,11 +28,12 @@ function RootStackScreen() {
         headerBackTitleVisible: false,
         headerTintColor: 'red',
       }}>
-      <RootStack.Screen name="Home" component={HomeScreen} options={{headerShown: false}}/>
       <RootStack.Screen
-        name="Details"
-        component={DetailsScreen}
+        name="Home"
+        component={HomeScreen}
+        options={{headerShown: false}}
       />
+      <RootStack.Screen name="Details" component={DetailsScreen} />
     </RootStack.Navigator>
   );
 }
@@ -46,3 +45,11 @@ export default function App() {
     </NavigationContainer>
   );
 }
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/TestsExample/src/Test550.js
+++ b/TestsExample/src/Test550.js
@@ -1,23 +1,21 @@
 import React from 'react';
-import {Button, ScrollView} from 'react-native';
+import {Button, ScrollView, StyleSheet} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from 'react-native-screens/native-stack';
 
 function HomeScreen({navigation}) {
   return (
-    <ScrollView contentContainerStyle={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
-        <Button
-          onPress={() => navigation.navigate('Details')}
-          title="Go to Details"
-        />
+    <ScrollView contentContainerStyle={styles.contentContainer}>
+      <Button
+        onPress={() => navigation.navigate('Details')}
+        title="Go to Details"
+      />
     </ScrollView>
   );
 }
 
 function DetailsScreen() {
-  return (
-    <ScrollView />
-  );
+  return <ScrollView />;
 }
 
 const RootStack = createNativeStackNavigator();
@@ -30,11 +28,12 @@ function RootStackScreen() {
         headerBackTitleVisible: false,
         headerTintColor: 'red',
       }}>
-      <RootStack.Screen name="Home" component={HomeScreen} options={{headerShown: false}}/>
       <RootStack.Screen
-        name="Details"
-        component={DetailsScreen}
+        name="Home"
+        component={HomeScreen}
+        options={{headerShown: false}}
       />
+      <RootStack.Screen name="Details" component={DetailsScreen} />
     </RootStack.Navigator>
   );
 }
@@ -46,3 +45,11 @@ export default function App() {
     </NavigationContainer>
   );
 }
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h
+++ b/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h
@@ -1,0 +1,11 @@
+#ifdef RN_FABRIC_ENABLED
+
+#include <React/RCTImageComponentView.h>
+
+@interface RCTImageComponentView (RNSScreenStackHeaderConfig)
+
+- (UIImage *)image;
+
+@end
+
+#endif // RN_FABRIC_ENABLED

--- a/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm
+++ b/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm
@@ -6,7 +6,7 @@
 
 - (UIImage *)image
 {
-  return self._imageView.image;
+  return _imageView.image;
 }
 
 @end

--- a/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm
+++ b/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.mm
@@ -1,0 +1,14 @@
+#ifdef RN_FABRIC_ENABLED
+
+#include "RCTImageComponentView+RNSScreenStackHeaderConfig.h"
+
+@implementation RCTImageComponentView (RNSScreenStackHeaderConfig)
+
+- (UIImage *)image
+{
+  return self._imageView.image;
+}
+
+@end
+
+#endif // RN_FABRIC_ENABLED

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -24,6 +24,10 @@
 #import "RNSSearchBar.h"
 #import "RNSUIBarButtonItem.h"
 
+#ifdef RN_FABRIC_ENABLED
+namespace rct = facebook::react;
+#endif // RN_FABRIC_ENABLED
+
 #ifndef RN_FABRIC_ENABLED
 // Some RN private method hacking below. Couldn't figure out better way to access image data
 // of a given RCTImageView. See more comments in the code section processing SubviewTypeBackButton
@@ -48,7 +52,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSScreenStackHeaderConfigProps>();
+    static const auto defaultProps = std::make_shared<const rct::RNSScreenStackHeaderConfigProps>();
     _props = defaultProps;
     self.hidden = YES;
     _show = YES;
@@ -252,8 +256,8 @@
 #ifdef RN_FABRIC_ENABLED
       RCTImageComponentView *imageView = subview.subviews[0];
       if (imageView.image == nil) {
-        auto const imageProps = *std::static_pointer_cast<const facebook::react::ImageProps>(imageView.props);
-        facebook::react::ImageSource cppImageSource = imageProps.sources.at(0);
+        auto const imageProps = *std::static_pointer_cast<const rct::ImageProps>(imageView.props);
+        rct::ImageSource cppImageSource = imageProps.sources.at(0);
         NSLog(@"[HeaderConfig] imageSource: %s", cppImageSource.uri.c_str());
         auto imageSize = CGSize{cppImageSource.size.width, cppImageSource.size.height};
         auto imageScale = cppImageSource.scale;
@@ -271,8 +275,8 @@
 
       UIImage *image = imageView.image;
       if (image == nil) {
-        auto const imageProps = *std::static_pointer_cast<const facebook::react::ImageProps>(imageView.props);
-        facebook::react::ImageSource cppImageSource = imageProps.sources.at(0);
+        auto const imageProps = *std::static_pointer_cast<const rct::ImageProps>(imageView.props);
+        rct::ImageSource cppImageSource = imageProps.sources.at(0);
         NSLog(@"[HeaderConfig] imageSource: %s", cppImageSource.uri.c_str());
         auto imageSize = CGSize{cppImageSource.size.width, cppImageSource.size.height};
         auto imageScale = cppImageSource.scale;
@@ -738,18 +742,18 @@
   [childComponentView removeFromSuperview];
 }
 
-static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode resizeMode)
+static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
 {
   switch (resizeMode) {
-    case facebook::react::ImageResizeMode::Cover:
+    case rct::ImageResizeMode::Cover:
       return RCTResizeModeCover;
-    case facebook::react::ImageResizeMode::Contain:
+    case rct::ImageResizeMode::Contain:
       return RCTResizeModeContain;
-    case facebook::react::ImageResizeMode::Stretch:
+    case rct::ImageResizeMode::Stretch:
       return RCTResizeModeStretch;
-    case facebook::react::ImageResizeMode::Center:
+    case rct::ImageResizeMode::Center:
       return RCTResizeModeCenter;
-    case facebook::react::ImageResizeMode::Repeat:
+    case rct::ImageResizeMode::Repeat:
       return RCTResizeModeRepeat;
   }
 }
@@ -762,10 +766,9 @@ static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode res
   _initialPropsSet = NO;
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (rct::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<
-      facebook::react::RNSScreenStackHeaderConfigComponentDescriptor>();
+  return rct::concreteComponentDescriptorProvider<rct::RNSScreenStackHeaderConfigComponentDescriptor>();
 }
 
 - (NSNumber *)getFontSizePropValue:(int)value
@@ -775,22 +778,20 @@ static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode res
   return nil;
 }
 
-- (UISemanticContentAttribute)getDirectionPropValue:(facebook::react::RNSScreenStackHeaderConfigDirection)direction
+- (UISemanticContentAttribute)getDirectionPropValue:(rct::RNSScreenStackHeaderConfigDirection)direction
 {
   switch (direction) {
-    case facebook::react::RNSScreenStackHeaderConfigDirection::Rtl:
+    case rct::RNSScreenStackHeaderConfigDirection::Rtl:
       return UISemanticContentAttributeForceRightToLeft;
-    case facebook::react::RNSScreenStackHeaderConfigDirection::Ltr:
+    case rct::RNSScreenStackHeaderConfigDirection::Ltr:
       return UISemanticContentAttributeForceLeftToRight;
   }
 }
 
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps
+- (void)updateProps:(rct::Props::Shared const &)props oldProps:(rct::Props::Shared const &)oldProps
 {
-  const auto &oldScreenProps =
-      *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigProps>(_props);
-  const auto &newScreenProps = *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigProps>(props);
+  const auto &oldScreenProps = *std::static_pointer_cast<const rct::RNSScreenStackHeaderConfigProps>(_props);
+  const auto &newScreenProps = *std::static_pointer_cast<const rct::RNSScreenStackHeaderConfigProps>(props);
 
   BOOL needsNavigationControllerLayout = !_initialPropsSet;
 
@@ -850,7 +851,7 @@ static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode res
   }
 
   _initialPropsSet = YES;
-  _props = std::static_pointer_cast<facebook::react::RNSScreenStackHeaderConfigProps const>(props);
+  _props = std::static_pointer_cast<rct::RNSScreenStackHeaderConfigProps const>(props);
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -1,12 +1,15 @@
 #ifdef RN_FABRIC_ENABLED
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTImageComponentView.h>
 #import <React/UIView+React.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+#import "RCTImageComponentView+RNSScreenStackHeaderConfig.h"
 #else
+#import <React/RCTImageView.h>
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerUtils.h>
@@ -15,17 +18,18 @@
 #import <React/RCTFont.h>
 #import <React/RCTImageLoader.h>
 #import <React/RCTImageSource.h>
-#import <React/RCTImageView.h>
 #import "RNSScreen.h"
 #import "RNSScreenStackHeaderConfig.h"
 #import "RNSSearchBar.h"
 #import "RNSUIBarButtonItem.h"
 
+#ifndef RN_FABRIC_ENABLED
 // Some RN private method hacking below. Couldn't figure out better way to access image data
 // of a given RCTImageView. See more comments in the code section processing SubviewTypeBackButton
 @interface RCTImageView (Private)
 - (UIImage *)image;
 @end
+#end // !RN_FABRIC_ENABLED
 
 @interface RCTImageLoader (Private)
 - (id<RCTImageCache>)imageCache;
@@ -244,6 +248,15 @@
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
     if (subview.type == RNSScreenStackHeaderSubviewTypeBackButton && subview.subviews.count > 0) {
       hasBackButtonImage = YES;
+#ifdef RN_FABRIC_ENABLED
+      RCTImageComponentView *imageView = subview.subviews[0];
+      UIImage *image = imageView.image;
+      if (image == nill) {
+        return [UIImage new];
+      } else {
+        return image;
+      }
+#else
       RCTImageView *imageView = subview.subviews[0];
       if (imageView.image == nil) {
         // This is yet another workaround for loading custom back icon. It turns out that under
@@ -304,6 +317,7 @@
       } else {
         return image;
       }
+#endif // RN_FABRIC_ENABLED
     }
   }
   return nil;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -251,7 +251,7 @@
 #ifdef RN_FABRIC_ENABLED
       RCTImageComponentView *imageView = subview.subviews[0];
       UIImage *image = imageView.image;
-      if (image == nill) {
+      if (image == nil) {
         return [UIImage new];
       } else {
         return image;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -24,11 +24,6 @@
 #import "RNSSearchBar.h"
 #import "RNSUIBarButtonItem.h"
 
-// Just a convenience alias. For some weird reason aliasing:
-// namespace rct = facebook::react;
-// won't compile (with error: "Expected alias name")...
-namespace fb = facebook;
-
 #ifndef RN_FABRIC_ENABLED
 // Some RN private method hacking below. Couldn't figure out better way to access image data
 // of a given RCTImageView. See more comments in the code section processing SubviewTypeBackButton
@@ -248,18 +243,18 @@ namespace fb = facebook;
   [button setTitleTextAttributes:attrs forState:UIControlStateFocused];
 }
 
-static RCTResizeMode resizeModeFromCppEquiv(fb::react::ImageResizeMode resizeMode)
+static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode resizeMode)
 {
   switch (resizeMode) {
-    case fb::react::ImageResizeMode::Cover:
+    case facebook::react::ImageResizeMode::Cover:
       return RCTResizeModeCover;
-    case fb::react::ImageResizeMode::Contain:
+    case facebook::react::ImageResizeMode::Contain:
       return RCTResizeModeContain;
-    case fb::react::ImageResizeMode::Stretch:
+    case facebook::react::ImageResizeMode::Stretch:
       return RCTResizeModeStretch;
-    case fb::react::ImageResizeMode::Center:
+    case facebook::react::ImageResizeMode::Center:
       return RCTResizeModeCenter;
-    case fb::react::ImageResizeMode::Repeat:
+    case facebook::react::ImageResizeMode::Repeat:
       return RCTResizeModeRepeat;
   }
 }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -243,22 +243,6 @@
   [button setTitleTextAttributes:attrs forState:UIControlStateFocused];
 }
 
-static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode resizeMode)
-{
-  switch (resizeMode) {
-    case facebook::react::ImageResizeMode::Cover:
-      return RCTResizeModeCover;
-    case facebook::react::ImageResizeMode::Contain:
-      return RCTResizeModeContain;
-    case facebook::react::ImageResizeMode::Stretch:
-      return RCTResizeModeStretch;
-    case facebook::react::ImageResizeMode::Center:
-      return RCTResizeModeCenter;
-    case facebook::react::ImageResizeMode::Repeat:
-      return RCTResizeModeRepeat;
-  }
-}
-
 + (UIImage *)loadBackButtonImageInViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   BOOL hasBackButtonImage = NO;
@@ -752,6 +736,22 @@ static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode res
 {
   [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
+}
+
+static RCTResizeMode resizeModeFromCppEquiv(facebook::react::ImageResizeMode resizeMode)
+{
+  switch (resizeMode) {
+    case facebook::react::ImageResizeMode::Cover:
+      return RCTResizeModeCover;
+    case facebook::react::ImageResizeMode::Contain:
+      return RCTResizeModeContain;
+    case facebook::react::ImageResizeMode::Stretch:
+      return RCTResizeModeStretch;
+    case facebook::react::ImageResizeMode::Center:
+      return RCTResizeModeCenter;
+    case facebook::react::ImageResizeMode::Repeat:
+      return RCTResizeModeRepeat;
+  }
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -29,7 +29,7 @@
 @interface RCTImageView (Private)
 - (UIImage *)image;
 @end
-#end // !RN_FABRIC_ENABLED
+#endif // !RN_FABRIC_ENABLED
 
 @interface RCTImageLoader (Private)
 - (id<RCTImageCache>)imageCache;


### PR DESCRIPTION
## Description

Up to now there was missing implementation of back button image loading logic on Fabric.
I managed to implement it using only RN API (I avoided creation of custom image component with custom state as it is done in `react-native-svg`).

It is worth to notice that there might be still some buggy behaviour present, as instead of provided asset (an arrow, see examples) a red rectangle is rendered. However I decided to not include further fix in this PR, as current behaviour is the same on both architectures. Most likely there will be a follow up PR.

## Changes

* Implemented missing logic
* Added some needed categories (see changes)

## Test code and steps to reproduce

See `Test550` in `FabricTestExample`. 

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes (failure of iOS e2e is a known issue)
