### PR TITLE
chore: refactor medium detent iOS implementation 

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -693,11 +693,6 @@
     [self setStackPresentation:newStackPresentation];
   }
 
-#if !TARGET_OS_TV
-  // This must be called after setter for stackPresentation
-  [self updatePresentationStyle];
-#endif // !TARGET_OS_TV
-
   if (newScreenProps.stackAnimation != oldScreenProps.stackAnimation) {
     [self setStackAnimation:[RNSConvert RNSScreenStackAnimationFromCppEquivalent:newScreenProps.stackAnimation]];
   }
@@ -731,6 +726,13 @@
   // pass the dimensions to ui view manager to take into account when laying out
   // subviews
   // Explanation taken from `reactSetFrame`, which is old arch equivalent of this code.
+}
+
+- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
+{
+#if !TARGET_OS_TV
+  [self updatePresentationStyle];
+#endif // !TARGET_OS_TV
 }
 
 #pragma mark - Paper specific


### PR DESCRIPTION
## Description

Earlier when calling `updatePresentationStyle` in `RNSScreen` we have relied on order of method calls and kept our fingers crossed that the order would not be violated with future changes. 

Now we leverage `finalizeUpdates:` method from `RCTComponentViewProtocol` which is called after all updates are applied to the component. 

For broader context see #1649 (comments).

## Changes

Moved call to `updatePresentationStyle` from `updateProps` to `finalizeUpdates`. 


## Test code and steps to reproduce

See `Test1649` (everything should work as before)

## Checklist

- [ ] Ensured that CI passes
