### PR TITLE
Add onMenuButton event to RNSScreenView

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -89,6 +89,10 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
 
+#if TARGET_OS_TV
+@property (nonatomic, copy) RCTDirectEventBlock onMenuButton;
+#endif
+
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic, readonly) BOOL dismissed;

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -18,6 +18,9 @@
   RNSScreen *_controller;
   RCTTouchHandler *_touchHandler;
   CGRect _reactFrame;
+#if TARGET_OS_TV
+  UITapGestureRecognizer *_menuButtonRecognizer;
+#endif
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
@@ -35,6 +38,11 @@
     _hasStatusBarHiddenSet = NO;
     _hasOrientationSet = NO;
     _hasHomeIndicatorHiddenSet = NO;
+#if TARGET_OS_TV
+    _menuButtonRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(notifyMenuButton:)];
+    [_menuButtonRecognizer setAllowedPressTypes:@[[NSNumber numberWithInt: UIPressTypeMenu]]];
+    [self addGestureRecognizer:_menuButtonRecognizer];
+#endif
   }
 
   return self;
@@ -299,6 +307,19 @@
     });
   }
 }
+
+#if TARGET_OS_TV
+- (void)notifyMenuButton:(UITapGestureRecognizer *)recognizer
+{
+  if (self.onMenuButton) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (self.onMenuButton) {
+        self.onMenuButton(nil);
+      }
+    });
+  }
+}
+#endif
 
 - (BOOL)isMountedUnderScreenOrReactRoot
 {
@@ -803,6 +824,9 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeDismissCancelled, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
+#if TARGET_OS_TV
+RCT_EXPORT_VIEW_PROPERTY(onMenuButton, RCTDirectEventBlock);
+#endif
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)


### PR DESCRIPTION
Implement recogniser to trigger mentioned event.

## Description

Implements a recogniser on `RNSScreenView` for the tvOS remote that watches for the menu button being pressed.
When this happens, a JS event named `onMenuButton` is triggered.

## **NOTE**

This branch / PR is based on the 3.13.1 tag, since that was the version that was used in the example application we used for investigation and development.

Before merging (automatic merge should not be possible) the changes should be based (and modified to match) from the version that'll be used.

It seems Fabric support was added in later versions and some substantial changes were introduced. This should not affect the functionality, but a manual merge will be needed first.