### PR TITLE
fix(iOS): status bar does not respect app theme

### DIFF
--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -82,6 +82,7 @@ import Test1473 from './src/Test1473';
 import Test1476 from './src/Test1476';
 import Test1646 from './src/Test1646';
 import Test1649 from './src/Test1649';
+import Test1683 from './src/Test1683';
 
 enableFreeze(true);
 

--- a/FabricTestExample/src/Test1683.tsx
+++ b/FabricTestExample/src/Test1683.tsx
@@ -1,0 +1,74 @@
+import {View, StyleSheet, Button, useColorScheme} from 'react-native';
+import {
+  NavigationContainer,
+  DarkTheme,
+  DefaultTheme,
+  LightTheme,
+  Theme,
+} from '@react-navigation/native';
+// import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+import React, {createContext, useContext, useState} from 'react';
+
+const RootStack = createNativeStackNavigator();
+
+const ThemeContext = createContext({
+  theme: DefaultTheme,
+  setTheme: (theme: Theme) => {},
+});
+
+const HomeScreen = () => {
+  const {theme, setTheme} = useContext(ThemeContext);
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Toggle theme"
+        onPress={() => {
+          console.log('Button pressed');
+          setTheme(theme === DefaultTheme ? DarkTheme : DefaultTheme);
+        }}
+      />
+    </View>
+  );
+};
+
+const Navigator = () => {
+  const {theme} = useContext(ThemeContext);
+  // const scheme = useColorScheme();
+  return (
+    <NavigationContainer
+      // theme={scheme === 'dark' ? DarkTheme : DefaultTheme}
+      theme={theme}
+      // theme={DarkTheme}
+    >
+      <RootStack.Navigator>
+        <RootStack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{
+            // headerSearchBarOptions: {},
+            searchBar: {},
+            // statusBarStyle: 'dark',
+          }}
+        />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+export default function App() {
+  const [theme, setTheme] = useState(DefaultTheme);
+  return (
+    <ThemeContext.Provider value={{theme: theme, setTheme: setTheme}}>
+      <Navigator />
+    </ThemeContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 8,
+  },
+});

--- a/FabricTestExample/src/Test1683.tsx
+++ b/FabricTestExample/src/Test1683.tsx
@@ -1,9 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {View, StyleSheet, Button, useColorScheme} from 'react-native';
 import {
   NavigationContainer,
   DarkTheme,
   DefaultTheme,
-  LightTheme,
   Theme,
 } from '@react-navigation/native';
 // import {createNativeStackNavigator} from '@react-navigation/native-stack';
@@ -14,6 +14,7 @@ const RootStack = createNativeStackNavigator();
 
 const ThemeContext = createContext({
   theme: DefaultTheme,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setTheme: (theme: Theme) => {},
 });
 
@@ -48,7 +49,7 @@ const Navigator = () => {
           options={{
             // headerSearchBarOptions: {},
             searchBar: {},
-            // statusBarStyle: 'dark',
+            // statusBarStyle: 'light',
           }}
         />
       </RootStack.Navigator>

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -84,6 +84,7 @@ import Test1509 from './src/Test1509';
 import Test1539 from './src/Test1539';
 import Test1646 from './src/Test1646';
 import Test1649 from './src/Test1649';
+import Test1683 from './src/Test1683';
 
 enableFreeze(true);
 

--- a/TestsExample/src/Test1683.tsx
+++ b/TestsExample/src/Test1683.tsx
@@ -1,38 +1,68 @@
-import { View, StyleSheet } from 'react-native';
-import { NavigationContainer, DarkTheme, DefaultTheme, LightTheme } from '@react-navigation/native'
-import { createNativeStackNavigator } from '@react-navigation/native-stack'
-import React from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import {View, StyleSheet, Button, useColorScheme} from 'react-native';
+import {
+  NavigationContainer,
+  DarkTheme,
+  DefaultTheme,
+  Theme,
+} from '@react-navigation/native';
+// import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+import React, {createContext, useContext, useState} from 'react';
 
-const RootStack = createNativeStackNavigator()
+const RootStack = createNativeStackNavigator();
+
+const ThemeContext = createContext({
+  theme: DefaultTheme,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setTheme: (theme: Theme) => {},
+});
 
 const HomeScreen = () => {
+  const {theme, setTheme} = useContext(ThemeContext);
   return (
-    <View style={styles.container} />
-  )
-}
+    <View style={styles.container}>
+      <Button
+        title="Toggle theme"
+        onPress={() => {
+          console.log('Button pressed');
+          setTheme(theme === DefaultTheme ? DarkTheme : DefaultTheme);
+        }}
+      />
+    </View>
+  );
+};
 
 const Navigator = () => {
+  const {theme} = useContext(ThemeContext);
+  // const scheme = useColorScheme();
   return (
-      <NavigationContainer
-        // theme={DefaultTheme}
-        theme={DarkTheme}
-      >
-        <RootStack.Navigator>
-          <RootStack.Screen
-            name="Home"
-            component={HomeScreen}
-            options={{
-              headerSearchBarOptions: {}
-            }}
-          />
-        </RootStack.Navigator>
-      </NavigationContainer>
-  )
-}
+    <NavigationContainer
+      // theme={scheme === 'dark' ? DarkTheme : DefaultTheme}
+      theme={theme}
+      // theme={DarkTheme}
+    >
+      <RootStack.Navigator>
+        <RootStack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{
+            // headerSearchBarOptions: {},
+            searchBar: {},
+            // statusBarStyle: 'light',
+          }}
+        />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+};
 
 export default function App() {
+  const [theme, setTheme] = useState(DefaultTheme);
   return (
-    <Navigator />
+    <ThemeContext.Provider value={{theme: theme, setTheme: setTheme}}>
+      <Navigator />
+    </ThemeContext.Provider>
   );
 }
 

--- a/TestsExample/src/Test1683.tsx
+++ b/TestsExample/src/Test1683.tsx
@@ -1,0 +1,45 @@
+import { View, StyleSheet } from 'react-native';
+import { NavigationContainer, DarkTheme, DefaultTheme, LightTheme } from '@react-navigation/native'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import React from 'react';
+
+const RootStack = createNativeStackNavigator()
+
+const HomeScreen = () => {
+  return (
+    <View style={styles.container} />
+  )
+}
+
+const Navigator = () => {
+  return (
+      <NavigationContainer
+        // theme={DefaultTheme}
+        theme={DarkTheme}
+      >
+        <RootStack.Navigator>
+          <RootStack.Screen
+            name="Home"
+            component={HomeScreen}
+            options={{
+              headerSearchBarOptions: {}
+            }}
+          />
+        </RootStack.Navigator>
+      </NavigationContainer>
+  )
+}
+
+export default function App() {
+  return (
+    <Navigator />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 8,
+  },
+});

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -125,7 +125,6 @@ const MaybeNestedStack = ({
       </ScreenStack>
     );
   }
-
   return content;
 };
 
@@ -220,6 +219,8 @@ const RouteView = ({
   const parentHeaderHeight = React.useContext(HeaderHeightContext);
   const Screen = React.useContext(ScreenContext);
 
+  const { dark } = useTheme();
+
   return (
     <Screen
       key={route.key}
@@ -248,7 +249,7 @@ const RouteView = ({
       statusBarAnimation={statusBarAnimation}
       statusBarColor={statusBarColor}
       statusBarHidden={statusBarHidden}
-      statusBarStyle={statusBarStyle}
+      statusBarStyle={statusBarStyle ?? (dark ? 'light' : 'dark')}
       statusBarTranslucent={statusBarTranslucent}
       swipeDirection={swipeDirection}
       transitionDuration={transitionDuration}


### PR DESCRIPTION
## Description

Resolves #1683 

At the moment, when user set theme on `NavigationContainer` the status bar does not adapt. It keeps following OS theme. You have to set theme for status bar separately in screens options.
Everything works fine when the app theme is following the OS theme (vast majority of cases I guess):

```
const scheme = useColorScheme(); // From RN API
...
<NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
...
```

The issue appears when for example OS theme is `dark`, but the app wants to force display in `light` -> then the status bar keeps respecting OS theme and rest of the application does not (except few other components such as search bar, but they will be handled in separate PR's).

Proposed changes fix the problem & modify the default behaviour in following ways:

* when following system theme everything works as it used to + there is a possibility to override status bar theme by applying a screen option directly on the `Screen` component,
* when forcing custom theme the status bar style will respect it unless it is overridden directly on the `Screen` component,
* when forcing custom theme you can still get the old behaviour (if for some reason you wish) by setting `statusBarStyle: 'auto'` directly on the screen / in `screenOptions`


**NOTE**: This changes apply only to native stack v5 (`react-native-screens`), not to `react-navigation`. The fix will have to be implemented separately there. 

**NOTE**: TBH I'm not really sure what is the desired look on Android, will eventually fix it in separate PR.

## Changes

* Enforced `light` or `dark` theme for status bar basing on theme from navigation context, when the user does not provide a value.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

See `Test1683` in `FabricTestExample` && `TestsExamples`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
