### PR TITLE
chore(CI): extend timeout for Android e2e 

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     runs-on: macos-12
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example
     concurrency:


### PR DESCRIPTION
## Description

After #1681 updated `Example` to RN 69, Jest to 29.x.x, and few other packages it now takes few minutes longer to complete the e2e tests. 

## Changes

Set timeout to 60 min (same as for iOS)


## Test code and steps to reproduce

CI Passes

## Checklist

- [ ] Ensured that CI passes
