### PR TITLE
chore: set library namespace in build script

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,8 @@ def reactNativeArchitectures() {
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
+    namespace "com.swmansion.rnscreens"
+
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.swmansion.rnscreens">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.swmansion.rnscreens">
 
 </manifest>


### PR DESCRIPTION
## Description

Warning during Android build:

> package="com.swmansion.rnscreens" found in source AndroidManifest.xml: /home/dee/mobile/node_modules/react-native-screens/android/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace

## Changes

- Updated `android/build.gradle` 
- ~Updated `android/src/main/AndroidManifest.xml`~ (@kkafar: please see [this commit description](https://github.com/software-mansion/react-native-screens/pull/1717/commits/e62dc0e3a6b56020dfbb8fc6a39beb2678a100f8)) and review notes.

## Test code and steps to reproduce

Build test examples and notice that the warning no longer appears.

## Checklist

- [x] Ensured that CI passes
