### PR TITLE
fix: Android build for `compileSdk < 33`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,10 +43,6 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
-int resolveTargetSdkVersion() {
-    return project.ext.safeExtGet('targetSdkVersion', rnsDefaultTargetSdkVersion)
-}
-
 def findAndroidResourceDir() {
     def resDirCandidate = file("${project.projectDir}/src/main/res")
     if (resDirCandidate.isDirectory()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ def reactNativeArchitectures() {
 }
 
 int resolveTargetSdkVersion() {
-    return project.ext.safeExtGet('targetSdkVersion', 22)
+    return project.ext.safeExtGet('targetSdkVersion', rnsDefaultTargetSdkVersion)
 }
 
 def findAndroidResourceDir() {
@@ -61,7 +61,7 @@ task manageV33Animations {
     def animDir = file("${project.projectDir}/versioned-res/anim-v33")
 
     if (resDir == null) {
-        println "[RNScreens] Failed to locate resource directory"
+        println "[RNScreens] Failed to locate Android resource directory"
         return
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,17 +64,18 @@ task manageV33Animations {
         return
     }
 
+    def targetDir = file{"${resDir}/anim-v33"}
+
     def targetSdkVersion = resolveTargetSdkVersion()
 
     if (targetSdkVersion >= 33) {
         copy {
             from animDir
-            into resDir
+            into targetDir
         }
     } else {
-        def copiedAnimations = file("${resDir}/anim-v33")
-        if (copiedAnimations.isDirectory()) {
-            delete copiedAnimations
+        if (targetDir.isDirectory()) {
+            delete targetDir
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,8 +38,7 @@ def reactNativeArchitectures() {
 }
 
 int resolveTargetSdkVersion() {
-//    return safeExtGet('targetSdkVersion', 22)
-    return 31
+    return project.ext.safeExtGet('targetSdkVersion', 22)
 }
 
 def findAndroidResourceDir() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,49 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+int resolveTargetSdkVersion() {
+//    return safeExtGet('targetSdkVersion', 22)
+    return 31
+}
+
+def findAndroidResourceDir() {
+    def resDirCandidate = file("${project.projectDir}/src/main/res")
+    if (resDirCandidate.isDirectory()) {
+        return file(resDirCandidate)
+    }
+    return null;
+}
+
+task manageV33Animations {
+    // This task is executed during configuration phase on purpose
+    def resDir = findAndroidResourceDir()
+    def animDir = file("${project.projectDir}/versioned-res/anim-v33")
+
+    if (resDir == null) {
+        println "[RNScreens] Failed to locate resource directory"
+        return
+    }
+
+    if (!animDir.isDirectory()) {
+        println "[RNScreens] Failed to locate directory with animation resources for Android 13+"
+        return
+    }
+
+    def targetSdkVersion = resolveTargetSdkVersion()
+
+    if (targetSdkVersion >= 33) {
+        copy {
+            from animDir
+            into resDir
+        }
+    } else {
+        def copiedAnimations = file("${resDir}/anim-v33")
+        if (copiedAnimations.isDirectory()) {
+            delete copiedAnimations
+        }
+    }
+}
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,10 @@
 buildscript {
+    ext {
+        rnsDefaultTargetSdkVersion = 31
+        rnsDefaultCompileSdkVersion = 31
+        rnsDefaultMinSdkVersion = 21
+        rnsDefaultKotlinVersion = '1.6.21'
+    }
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
     }
@@ -8,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.21')}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
 }
@@ -66,22 +72,20 @@ task manageV33Animations {
 
     def targetDir = file{"${resDir}/anim-v33"}
 
-    def targetSdkVersion = resolveTargetSdkVersion()
+    def compileSdkVersion = project.ext.safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
 
-    if (targetSdkVersion >= 33) {
+    if (compileSdkVersion >= 33) {
         copy {
             from animDir
             into targetDir
         }
-    } else {
-        if (targetDir.isDirectory()) {
-            delete targetDir
-        }
+    } else if (targetDir.isDirectory()) {
+        delete targetDir
     }
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
 
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
@@ -93,8 +97,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 21)
-        targetSdkVersion safeExtGet('targetSdkVersion', 22)
+        minSdkVersion safeExtGet('minSdkVersion', rnsDefaultMinSdkVersion)
+        targetSdkVersion safeExtGet('targetSdkVersion', rnsDefaultTargetSdkVersion)
         versionCode 1
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()

--- a/android/versioned-res/anim-v33/rns_default_enter_in.xml
+++ b/android/versioned-res/anim-v33/rns_default_enter_in.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+
+    <alpha
+        android:fromAlpha="0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:startOffset="50"
+        android:duration="83" />
+
+    <translate
+        android:fromXDelta="10%"
+        android:toXDelta="0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:duration="450" />
+
+    <extend
+        android:fromExtendLeft="10%"
+        android:fromExtendTop="0"
+        android:fromExtendRight="0"
+        android:fromExtendBottom="0"
+        android:toExtendLeft="10%"
+        android:toExtendTop="0"
+        android:toExtendRight="0"
+        android:toExtendBottom="0"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+</set>

--- a/android/versioned-res/anim-v33/rns_default_enter_out.xml
+++ b/android/versioned-res/anim-v33/rns_default_enter_out.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@anim/rns_standard_accelerate_interpolator"
+        android:startOffset="0"
+        android:duration="450" />
+
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="-10%"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+
+    <extend
+        android:fromExtendLeft="0"
+        android:fromExtendTop="0"
+        android:fromExtendRight="10%"
+        android:fromExtendBottom="0"
+        android:toExtendLeft="0"
+        android:toExtendTop="0"
+        android:toExtendRight="10%"
+        android:toExtendBottom="0"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+</set>

--- a/android/versioned-res/anim-v33/rns_default_exit_in.xml
+++ b/android/versioned-res/anim-v33/rns_default_exit_in.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/linear"
+        android:startOffset="0"
+        android:duration="450" />
+
+    <translate
+        android:fromXDelta="-10%"
+        android:toXDelta="0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+
+    <extend
+        android:fromExtendLeft="0"
+        android:fromExtendTop="0"
+        android:fromExtendRight="10%"
+        android:fromExtendBottom="0"
+        android:toExtendLeft="0"
+        android:toExtendTop="0"
+        android:toExtendRight="10%"
+        android:toExtendBottom="0"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+</set>

--- a/android/versioned-res/anim-v33/rns_default_exit_out.xml
+++ b/android/versioned-res/anim-v33/rns_default_exit_out.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/linear"
+        android:startOffset="35"
+        android:duration="83" />
+
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="10%"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+
+    <extend
+        android:fromExtendLeft="10%"
+        android:fromExtendTop="0"
+        android:fromExtendRight="0"
+        android:fromExtendBottom="0"
+        android:toExtendLeft="10%"
+        android:toExtendTop="0"
+        android:toExtendRight="0"
+        android:toExtendBottom="0"
+        android:interpolator="@android:interpolator/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+</set>


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-screens/pull/1693 introduced new animation xml's with features available only since API level 33 (Android 13). This resulted in build failures in cases where `compileSdk`/`targetSdk` is set to value lower than 33.

Note: placing these animations in qualified resource directory `res/anim-v33` did not resolve the issue, because the qualifier is only used during runtime - in build phase all resources must be valid from the perspective of given SDK (at least it seems so).

I thought of few options: 

1. Having separate `res` directories for `compileSdk >= 33` and `compileSdk < 33` and selecting appropriate in `build.gradle`.
The main disadvantage is that most of the animation resources are being duplicated and any future modifications will require us to remember to modify both versions of resources. 

2. Keeping only new animation files in separate directory and copying them into `res/anim-v33` **during gradle configuration phase** only when appropriate.
This also would require us to modify files in two places, but only few ones, which is slightly better IMO.
The emphasis on configuration phase comes from the fact, that it will work Android Studio nicely (`gradle sync`).

As for now I went with option 2.

## Changes

Added `manageV33Animations` task to `build.gradle` which:

1. Copies v33 xmls inside `res/anim-v33` when `compileSdk >= 33`
2. Deletes `res/anim-v33` when `compileSdk < 33` 


## Test code and steps to reproduce

Build any Android example with various `compileSdk` set and observe how resource files change (also check out #1693)


## Checklist

- [x] Ensured that CI passes
