### PR TITLE
feat: remove title with search bar

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -597,13 +597,13 @@ namespace rct = facebook::react;
 #if !TARGET_OS_TV
           if (@available(iOS 11.0, *)) {
             RNSSearchBar *searchBar = subview.subviews[0];
-            if(searchBar.removeTitle) {
+            navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
+
+            if(searchBar.hideTitle) {
               [navitem.searchController.searchBar sizeToFit];
               navitem.titleView = searchBar.controller.searchBar;
-              searchBar.controller.hidesNavigationBarDuringPresentation = false;
             } else {
               navitem.searchController = searchBar.controller;
-              navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
             }
           }
 #endif

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -597,8 +597,14 @@ namespace rct = facebook::react;
 #if !TARGET_OS_TV
           if (@available(iOS 11.0, *)) {
             RNSSearchBar *searchBar = subview.subviews[0];
-            navitem.searchController = searchBar.controller;
-            navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
+            if(searchBar.removeTitle) {
+              [navitem.searchController.searchBar sizeToFit];
+              navitem.titleView = searchBar.controller.searchBar;
+              searchBar.controller.hidesNavigationBarDuringPresentation = false;
+            } else {
+              navitem.searchController = searchBar.controller;
+              navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
+            }
           }
 #endif
         }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -602,6 +602,7 @@ namespace rct = facebook::react;
             if (searchBar.hideTitle) {
               [navitem.searchController.searchBar sizeToFit];
               navitem.titleView = searchBar.controller.searchBar;
+              searchBar.controller.hidesNavigationBarDuringPresentation = false;
             } else {
               navitem.searchController = searchBar.controller;
             }

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -17,7 +17,7 @@
 #endif
 
 @property (nonatomic) BOOL hideWhenScrolling;
-@property (nonatomic) BOOL removeTitle;
+@property (nonatomic) BOOL hideTitle;
 
 @property (nonatomic, retain) UISearchController *controller;
 

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -17,6 +17,7 @@
 #endif
 
 @property (nonatomic) BOOL hideWhenScrolling;
+@property (nonatomic) BOOL removeTitle;
 
 @property (nonatomic, retain) UISearchController *controller;
 

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -49,7 +49,7 @@
   _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
   _controller.searchBar.delegate = self;
   _hideWhenScrolling = YES;
-  _removeTitle = NO;
+  _hideTitle = NO;
 }
 
 - (void)emitOnFocusEvent
@@ -142,11 +142,6 @@
 - (void)setHideWhenScrolling:(BOOL)hideWhenScrolling
 {
   _hideWhenScrolling = hideWhenScrolling;
-}
-
-- (void)setRemoveTitle:(BOOL)removeTitle
-{
-  _removeTitle = removeTitle;
 }
 
 - (void)setAutoCapitalize:(UITextAutocapitalizationType)autoCapitalize
@@ -367,7 +362,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(obscureBackground, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideWhenScrolling, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(removeTitle, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(hideTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoCapitalize, UITextAutocapitalizationType)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -49,6 +49,7 @@
   _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
   _controller.searchBar.delegate = self;
   _hideWhenScrolling = YES;
+  _removeTitle = NO;
 }
 
 - (void)emitOnFocusEvent
@@ -141,6 +142,11 @@
 - (void)setHideWhenScrolling:(BOOL)hideWhenScrolling
 {
   _hideWhenScrolling = hideWhenScrolling;
+}
+
+- (void)setRemoveTitle:(BOOL)removeTitle
+{
+  _removeTitle = removeTitle;
 }
 
 - (void)setAutoCapitalize:(UITextAutocapitalizationType)autoCapitalize
@@ -361,6 +367,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(obscureBackground, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideWhenScrolling, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(removeTitle, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoCapitalize, UITextAutocapitalizationType)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -516,6 +516,12 @@ Boolean indicating whether to hide the search bar when scrolling.
 
 Defaults to `true`.
 
+#### `removeTitle` (iOS only)
+
+Boolean indicating whether to hide the title.
+
+Defaults to `false`.
+
 #### `inputType` (Android only)
 
 This prop is used to change type of the input and keyboard. Default value is `'text'`.

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -516,7 +516,7 @@ Boolean indicating whether to hide the search bar when scrolling.
 
 Defaults to `true`.
 
-#### `removeTitle` (iOS only)
+#### `hideTitle` (iOS only)
 
 Boolean indicating whether to hide the title.
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -651,5 +651,5 @@ export interface SearchBarProps {
      * @plaform ios
      * @default false
      */
-   removeTitle?:boolean;
+   hideTitle?:boolean;
 }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -645,4 +645,11 @@ export interface SearchBarProps {
    * @default true
    */
   shouldShowHintSearchIcon?: boolean;
+   /**
+     * Places the search bar in the title
+     *
+     * @plaform ios
+     * @default false
+     */
+   removeTitle?:boolean;
 }


### PR DESCRIPTION
## Description
When using a search bar in react navigation, there's currently no option to have a search bar without title.
Specifying a blank title leaves a blank area

Fixes https://github.com/react-navigation/react-navigation/issues/11257


## Changes
Added `removeTitle` property, which will place the search bar in the title



## Screenshots / GIFs
### Before
![Screenshot 2023-03-06 at 10 23 32](https://user-images.githubusercontent.com/12223738/223072815-b521d589-2005-44b7-987d-d308aa7b5cef.png)

### After
![Screenshot 2023-03-06 at 10 23 52](https://user-images.githubusercontent.com/12223738/223072785-3cc117c6-c482-4908-8658-0973a19161da.png)


## Test code and steps to reproduce

```jsx
  <Stack.Navigator>
     <Stack.Screen name="SearchScreen" component={SearchView} 
        options={{
          title: 'Search',
          headerSearchBarOptions: {
            placeholder: 'Search',
            removeTitle: true,
          },
        }}
      />
  </Stack.Navigator>
```
