### PR TITLE
chore: override `onCreate` in example apps

### DIFF
--- a/Example/android/app/src/main/java/com/swmansion/rnscreens/example/MainActivity.java
+++ b/Example/android/app/src/main/java/com/swmansion/rnscreens/example/MainActivity.java
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens.example;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
@@ -24,6 +25,11 @@ public class MainActivity extends ReactActivity {
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
     return new MainActivityDelegate(this, getMainComponentName());
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 
   public static class MainActivityDelegate extends ReactActivityDelegate {

--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.java
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.fabricexample;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
@@ -14,6 +15,11 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "FabricExample";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 
   /**

--- a/FabricTestExample/android/app/src/main/java/com/fabrictestexample/MainActivity.java
+++ b/FabricTestExample/android/app/src/main/java/com/fabrictestexample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.fabrictestexample;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
@@ -14,6 +15,11 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "FabricTestExample";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 
   /**

--- a/TestsExample/android/app/src/main/java/com/testsexample/MainActivity.java
+++ b/TestsExample/android/app/src/main/java/com/testsexample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.testsexample;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
@@ -14,6 +15,11 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "TestsExample";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 
   /**


### PR DESCRIPTION
## Description


This override was accidentally removed during bumping examples to RN 0.71 (in some cases it was never added, but it should be).

## Changes

Override `onCreate` method in apps `MainActivity` as the installation guide says (see project readme).

## Test code and steps to reproduce

Build & run test examples

## Checklist

- [x] Ensured that CI passes
