### PR TITLE
make RNSFullWindowOverlay a modal for accessibility

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -15,6 +15,15 @@
 
 @implementation RNSFullWindowOverlayContainer
 
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  self = [super initWithFrame:frame];
+  if (self) {
+    self.accessibilityViewIsModal = YES;
+  }
+  return self;
+}
+
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
   for (UIView *view in [self subviews]) {
@@ -127,6 +136,9 @@
       [_touchHandler detachFromView:_container];
     }
   } else {
+    if (_container != nil) {
+      UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _container);
+    }
     if (_touchHandler == nil) {
 #ifdef RCT_NEW_ARCH_ENABLED
       _touchHandler = [RCTSurfaceTouchHandler new];


### PR DESCRIPTION
## Description

`RNSFullWindowOverlay` is meant to cover the entire window, but at the moment VoiceOver doesn't know this and you can still navigate other views underneath this one. 

## Changes

This sets the `accessibilityViewIsModal` to `YES`, which tells VoiceOver that it should ignore all sibling views (which in this case would be basically everything else since this is a subview of the `UIWindow`) and means VoiceOver can no longer escape this view and navigate hidden content.

It also adds `UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _container)` to tell VoiceOver that it should move focus into this view when its added to the window.

## Test code and steps to reproduce

* Use any existing example where `FullWindowOverlay` is covering content on iOS
* Enable VoiceOver and attempt to navigate the screen with up/down swipe gesture
* Note that without this change you can access content outside the `FullWindowOverlay`; with this change you cannot

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
