### PR TITLE
feat(iOS): add support `blurEffect` for fabric

### DIFF
--- a/FabricExample/src/HeaderDemo.js
+++ b/FabricExample/src/HeaderDemo.js
@@ -13,6 +13,31 @@ import {SettingsNumberInput} from './shared/SettingsNumberInput';
 
 const COLORS_FOR_PICKER = [PRIMARY, SECONDARY, WHITE, BLACK];
 
+const NONE_EFFECT = '-';
+const HEADER_BLUR_EFFECTS = [
+  NONE_EFFECT,
+  'extraLight',
+  'light',
+  'dark',
+  'regular',
+  'prominent',
+  'systemUltraThinMaterial',
+  'systemThinMaterial',
+  'systemMaterial',
+  'systemThickMaterial',
+  'systemChromeMaterial',
+  'systemUltraThinMaterialLight',
+  'systemThinMaterialLight',
+  'systemMaterialLight',
+  'systemThickMaterialLight',
+  'systemChromeMaterialLight',
+  'systemUltraThinMaterialDark',
+  'systemThinMaterialDark',
+  'systemMaterialDark',
+  'systemThickMaterialDark',
+  'systemChromeMaterialDark',
+];
+
 export default function HeaderDemo({navigation}) {
   const [headerTitle, setHeaderTitle] = useState('Settings');
   // const [backButtonVisible, setBackButtonVisible] = useState(true);
@@ -26,6 +51,7 @@ export default function HeaderDemo({navigation}) {
   const [headerColor, setHeaderColor] = useState(WHITE);
   const [fontSize, setFontSize] = useState();
   const [largeFontSize, setLargeFontSize] = useState();
+  const [headerBlurEffect, setHeaderBlurEffect] = useState(NONE_EFFECT);
 
   const square = props => <Square {...props} color="green" size={20} />;
 
@@ -49,6 +75,8 @@ export default function HeaderDemo({navigation}) {
       headerLargeTitleStyle: {
         fontSize: largeFontSize,
       },
+      headerBlurEffect:
+        headerBlurEffect === NONE_EFFECT ? undefined : headerBlurEffect,
       headerTitleStyle: {
         fontSize,
       },
@@ -68,6 +96,7 @@ export default function HeaderDemo({navigation}) {
     headerColor,
     fontSize,
     largeFontSize,
+    headerBlurEffect,
   ]);
 
   return (
@@ -132,6 +161,12 @@ export default function HeaderDemo({navigation}) {
         label="Header back title"
         value={headerBackTitle}
         onValueChange={setHeaderBackTitle}
+      />
+      <SettingsPicker
+        label="Header blur effect"
+        value={headerBlurEffect ?? NONE_EFFECT}
+        items={HEADER_BLUR_EFFECTS}
+        onValueChange={setHeaderBlurEffect}
       />
       <Button title="Go back" onPress={() => navigation.goBack()} />
     </ScrollView>

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -27,7 +27,6 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 @property (nonatomic) BOOL show;
 #else
-@property (nonatomic) UIBlurEffectStyle blurEffect;
 @property (nonatomic) BOOL hide;
 #endif
 
@@ -55,6 +54,7 @@
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) UISemanticContentAttribute direction;
+@property (nonatomic) UIBlurEffectStyle blurEffect;
 
 + (void)willShowViewController:(UIViewController *)vc
                       animated:(BOOL)animated

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -374,13 +374,9 @@ namespace rct = facebook::react;
     appearance.backgroundColor = config.backgroundColor;
   }
 
-  // TODO: implement blurEffect on Fabric
-#ifdef RCT_NEW_ARCH_ENABLED
-#else
   if (config.blurEffect) {
     appearance.backgroundEffect = [UIBlurEffect effectWithStyle:config.blurEffect];
   }
-#endif
 
   if (config.hideShadow) {
     appearance.shadowColor = nil;
@@ -761,6 +757,75 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
   }
 }
 
+- (UIBlurEffectStyle)getBlurEffectPropValue:(rct::RNSScreenStackHeaderConfigBlurEffect)blurEffect
+{
+#if !TARGET_OS_TV && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    switch (blurEffect) {
+      case rct::RNSScreenStackHeaderConfigBlurEffect::ExtraLight:
+        return UIBlurEffectStyleExtraLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::Light:
+        return UIBlurEffectStyleLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::Dark:
+        return UIBlurEffectStyleDark;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::Regular:
+        return UIBlurEffectStyleRegular;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::Prominent:
+        return UIBlurEffectStyleProminent;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemUltraThinMaterial:
+        return UIBlurEffectStyleSystemUltraThinMaterial;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThinMaterial:
+        return UIBlurEffectStyleSystemThinMaterial;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemMaterial:
+        return UIBlurEffectStyleSystemMaterial;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThickMaterial:
+        return UIBlurEffectStyleSystemThickMaterial;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemChromeMaterial:
+        return UIBlurEffectStyleSystemChromeMaterial;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemUltraThinMaterialLight:
+        return UIBlurEffectStyleSystemUltraThinMaterialLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThinMaterialLight:
+        return UIBlurEffectStyleSystemThinMaterialLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemMaterialLight:
+        return UIBlurEffectStyleSystemMaterialLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThickMaterialLight:
+        return UIBlurEffectStyleSystemThickMaterialLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemChromeMaterialLight:
+        return UIBlurEffectStyleSystemChromeMaterialLight;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemUltraThinMaterialDark:
+        return UIBlurEffectStyleSystemUltraThinMaterialDark;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThinMaterialDark:
+        return UIBlurEffectStyleSystemThinMaterialDark;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemMaterialDark:
+        return UIBlurEffectStyleSystemMaterialDark;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemThickMaterialDark:
+        return UIBlurEffectStyleSystemThickMaterialDark;
+      case rct::RNSScreenStackHeaderConfigBlurEffect::SystemChromeMaterialDark:
+        return UIBlurEffectStyleSystemChromeMaterialDark;
+    }
+  }
+#endif
+
+  if (@available(iOS 10.0, *)) {
+    if (blurEffect == rct::RNSScreenStackHeaderConfigBlurEffect::Regular) {
+      return UIBlurEffectStyleRegular;
+    }
+    if (blurEffect == rct::RNSScreenStackHeaderConfigBlurEffect::Prominent) {
+      return UIBlurEffectStyleProminent;
+    }
+  }
+
+  if (blurEffect == rct::RNSScreenStackHeaderConfigBlurEffect::Light) {
+    return UIBlurEffectStyleLight;
+  }
+  if (blurEffect == rct::RNSScreenStackHeaderConfigBlurEffect::Dark) {
+    return UIBlurEffectStyleDark;
+  }
+
+  return UIBlurEffectStyleExtraLight;
+}
+
 - (void)updateProps:(rct::Props::Shared const &)props oldProps:(rct::Props::Shared const &)oldProps
 {
   const auto &oldScreenProps = *std::static_pointer_cast<const rct::RNSScreenStackHeaderConfigProps>(_props);
@@ -808,6 +873,10 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
 
   if (newScreenProps.direction != oldScreenProps.direction) {
     _direction = [self getDirectionPropValue:newScreenProps.direction];
+  }
+
+  if (newScreenProps.blurEffect != oldScreenProps.blurEffect) {
+    _blurEffect = [self getBlurEffectPropValue:newScreenProps.blurEffect];
   }
 
   _backTitleVisible = newScreenProps.backTitleVisible;

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -6,6 +6,27 @@ import type {
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 type DirectionType = 'rtl' | 'ltr';
+type BlurEffectTypes =
+  | 'extraLight'
+  | 'light'
+  | 'dark'
+  | 'regular'
+  | 'prominent'
+  | 'systemUltraThinMaterial'
+  | 'systemThinMaterial'
+  | 'systemMaterial'
+  | 'systemThickMaterial'
+  | 'systemChromeMaterial'
+  | 'systemUltraThinMaterialLight'
+  | 'systemThinMaterialLight'
+  | 'systemMaterialLight'
+  | 'systemThickMaterialLight'
+  | 'systemChromeMaterialLight'
+  | 'systemUltraThinMaterialDark'
+  | 'systemThinMaterialDark'
+  | 'systemMaterialDark'
+  | 'systemThickMaterialDark'
+  | 'systemChromeMaterialDark';
 
 export interface NativeProps extends ViewProps {
   backgroundColor?: ColorValue;
@@ -13,6 +34,7 @@ export interface NativeProps extends ViewProps {
   backTitleFontFamily?: string;
   backTitleFontSize?: Int32;
   backTitleVisible?: WithDefault<boolean, 'true'>;
+  blurEffect?: WithDefault<BlurEffectTypes, 'extraLight'>;
   color?: ColorValue;
   direction?: WithDefault<DirectionType, 'ltr'>;
   hidden?: boolean;


### PR DESCRIPTION
## Description
Implement blurEffect for RN fabric.

## Changes
Added `bluerEffect` for fabric

## Screenshots / GIFs
### After
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-04-06 at 02 43 17](https://user-images.githubusercontent.com/16930958/230161095-eef585b6-16c9-4deb-aaf0-ef9b36a47fd3.png)

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
