### PR TITLE
chore: improve Android 13 animations

### DIFF
--- a/android/src/main/res/v33/anim-v33/rns_default_enter_in.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_enter_in.xml
@@ -4,7 +4,7 @@
     android:shareInterpolator="false">
 
     <alpha
-        android:fromAlpha="0"
+        android:fromAlpha="0.0"
         android:toAlpha="1.0"
         android:fillEnabled="true"
         android:fillBefore="true"
@@ -19,6 +19,7 @@
         android:fillEnabled="true"
         android:fillBefore="true"
         android:fillAfter="true"
+        android:startOffset="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:duration="450" />
 

--- a/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
@@ -5,7 +5,7 @@
 
     <alpha
         android:fromAlpha="1.0"
-        android:toAlpha="1.0"
+        android:toAlpha="0.0"
         android:fillEnabled="true"
         android:fillBefore="true"
         android:fillAfter="true"


### PR DESCRIPTION
## Description

New Android animations introduced in https://github.com/software-mansion/react-native-screens/pull/1693 were laggy (especially enter-out / enter-in animations).

This was caused by [these lines](https://cs.android.com/android/platform/superproject/+/android-platform-13.0.0_r6:frameworks/base/core/res/res/anim/activity_open_exit.xml;l=23-24) in Android source code -- alpha was not animated.

## Changes

Set more reasonable target value for alpha animation & explicitly set start offset on enter out animation.



## Test code and steps to reproduce

See #1693 for description.

## Checklist

- [x] Ensured that CI passes (Android e2e do fail for unrelated reasons)
