### PR TITLE
fix: ScreenStackHeaderConfig type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,8 +104,9 @@ export const ScreenStackHeaderSearchBarView = (
   props: React.PropsWithChildren<Omit<SearchBarProps, 'ref'>>
 ): JSX.Element => <View {...props} />;
 
-export const ScreenStackHeaderConfig: React.ComponentType<ScreenStackHeaderConfigProps> =
-  View;
+export const ScreenStackHeaderConfig = (
+  props: React.PropsWithChildren<ScreenStackHeaderConfigProps>
+): JSX.Element => <View {...props} />;
 
 // @ts-expect-error: search bar props have no common props with View
 export const SearchBar: React.ComponentType<SearchBarProps> = View;


### PR DESCRIPTION
## Description

This PR changes the type of `ScreenStackHeaderConfig` so it can be passed to `Animated.createAnimatedComponent` from Reanimated.

## Changes

- Updated `ScreenStackHeaderConfig` type in `index.tsx`

## Test code and steps to reproduce

Previously, the following code in [ScreenStackHeaderConfigBackgroundColorExample.tsx](https://github.com/software-mansion/react-native-reanimated/blob/b44920c101778de8566a3247061b14775cb21737/app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx#L22-L25) would throw the following error:

```ts
const AnimatedScreenStackHeaderConfig = Animated.createAnimatedComponent(ScreenStackHeaderConfig);
```

```
No overload matches this call.
  Overload 1 of 2, '(component: ComponentClass<ScreenStackHeaderConfigProps, any>, options?: Options<ScreenStackHeaderConfigProps> | undefined): ComponentClass<...>', gave the following error.
    Argument of type 'ComponentType<ScreenStackHeaderConfigProps>' is not assignable to parameter of type 'ComponentClass<ScreenStackHeaderConfigProps, any>'.
      Type 'FunctionComponent<ScreenStackHeaderConfigProps>' is not assignable to type 'ComponentClass<ScreenStackHeaderConfigProps, any>'.
        Type 'FunctionComponent<ScreenStackHeaderConfigProps>' provides no match for the signature 'new (props: ScreenStackHeaderConfigProps, context?: any): Component<ScreenStackHeaderConfigProps, any, any>'.
  Overload 2 of 2, '(component: FunctionComponent<ScreenStackHeaderConfigProps>, options?: Options<ScreenStackHeaderConfigProps> | undefined): FunctionComponent<...>', gave the following error.
    Argument of type 'ComponentType<ScreenStackHeaderConfigProps>' is not assignable to parameter of type 'FunctionComponent<ScreenStackHeaderConfigProps>'.
      Type 'ComponentClass<ScreenStackHeaderConfigProps, any>' is not assignable to type 'FunctionComponent<ScreenStackHeaderConfigProps>'.
        Type 'ComponentClass<ScreenStackHeaderConfigProps, any>' provides no match for the signature '(props: ScreenStackHeaderConfigProps, context?: any): ReactElement<any, any> | null'.ts(2769)
```

After this change, the error should go away, so `// @ts-ignore` should be redundant.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
