### PR TITLE
fix:Compatible with version 0.72

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <react/renderer/graphics/Float.h>
-#include <react/renderer/graphics/Geometry.h>
-#include <react/renderer/graphics/conversions.h>
+#include <react/renderer/core/graphicsConversions.h>
 
 #ifdef ANDROID
 #include <folly/dynamic.h>


### PR DESCRIPTION

## Description

The Geometry.h file is deprecated and will be removed in the next version of React Native.
`graphics/conversions.h` is deprecated and will be removed in the future.

## Changes

- Updated `RNScreenState.h`
