### PR TITLE
Fixes the glitching of UI when using all detents

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -939,11 +939,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (isDisplayedWithinUINavController || isPresentedAsNativeModal) {
 #ifdef RCT_NEW_ARCH_ENABLED
     [self.screenView updateBounds];
-#else
-    if (!CGRectEqualToRect(_lastViewFrame, self.screenView.frame)) {
-      _lastViewFrame = self.screenView.frame;
-      [((RNSScreenView *)self.viewIfLoaded) updateBounds];
-    }
 #endif
   }
 }


### PR DESCRIPTION
## Description

Fixes the glitching of UI when using all indents

Fixes #[1722](https://github.com/software-mansion/react-native-screens/issues/1722) 

## Changes

The change remove the update bounds on iOS. It seems that the bounds effect the height of the content within the modal then causing the glitching seen. 

## Screenshots / GIFs

Here you can see behaviour of the bottom of the modal

### Before
https://user-images.githubusercontent.com/217790/235911736-4f85cb64-e380-41e3-aa90-f467b5c1db12.MP4

### After
https://user-images.githubusercontent.com/217790/235911759-a1d4ad05-9280-4e7b-892f-3238e052cd4f.MP4

## Test code and steps to reproduce

To test this in the `Example` app, go to `StackPresentation.tsx`, and change this example:

```
    <Stack.Screen
      name="FormSheet"
      component={FormScreen}
      options={{ stackPresentation: 'formSheet', sheetAllowedDetents: 'all' }}
    />
```

## Checklist

- [X] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
