### PR TITLE
feat: prevent native back button dismissal on iOS

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -111,6 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
+- (void)notifyDismissCancelledWithDismissCount:(int)dismissCount;
 - (BOOL)isModal;
 
 @end

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -739,7 +739,8 @@
       self->_interactionController = nil;
       int sourceIndex = (int)[[self reactSubviews] indexOfObject:sourceView];
       int targetIndex = (int)[[self reactSubviews] indexOfObject:targetView];
-      int dismissCount = sourceIndex - targetIndex > 0 ? sourceIndex - targetIndex : 1;
+      int indexDiff = sourceIndex - targetIndex;
+      int dismissCount = indexDiff > 0 ? indexDiff : 1;
       [self updateContainer];
       [sourceView notifyDismissCancelledWithDismissCount:dismissCount];
     });

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -140,6 +140,21 @@
   [_controller setViewControllers:@[ [UIViewController new] ]];
 }
 
+#pragma mark - helper methods
+
+- (BOOL)shouldCancelDismissFromView:(RNSScreenView *)fromView toView:(RNSScreenView *)toView
+{
+  int fromIndex = (int)[_reactSubviews indexOfObject:fromView];
+  int toIndex = (int)[_reactSubviews indexOfObject:toView];
+  for (int i = fromIndex; i > toIndex; i--) {
+    if (_reactSubviews[i].preventNativeDismiss) {
+      return YES;
+      break;
+    }
+  }
+  return NO;
+}
+
 #pragma mark - Common
 
 - (void)emitOnFinishTransitioningEvent
@@ -566,11 +581,13 @@
   } else if (operation == UINavigationControllerOperationPop) {
     screen = ((RNSScreen *)fromVC).screenView;
   }
+  BOOL shouldCancelDismiss = [self shouldCancelDismissFromView:(RNSScreenView *)fromVC.view
+                                                        toView:(RNSScreenView *)toVC.view];
   if (screen != nil &&
       // when preventing the native dismiss with back button, we have to return the animator.
       // Also, we need to return the animator when full width swiping even if the animation is not custom,
       // otherwise the screen will be just popped immediately due to no animation
-      ((operation == UINavigationControllerOperationPop && screen.preventNativeDismiss) || _isFullWidthSwiping ||
+      ((operation == UINavigationControllerOperationPop && shouldCancelDismiss) || _isFullWidthSwiping ||
        [RNSScreenStackAnimator isCustomAnimation:screen.stackAnimation])) {
     return [[RNSScreenStackAnimator alloc] initWithOperation:operation];
   }
@@ -729,21 +746,25 @@
                          interactionControllerForAnimationController:
                              (id<UIViewControllerAnimatedTransitioning>)animationController
 {
-  RNSScreenView *sourceView = [_controller.transitionCoordinator viewForKey:UITransitionContextFromViewKey];
-  RNSScreenView *targetView = [_controller.transitionCoordinator viewForKey:UITransitionContextToViewKey];
+  RNSScreenView *fromView = [_controller.transitionCoordinator viewForKey:UITransitionContextFromViewKey];
+  RNSScreenView *toView = [_controller.transitionCoordinator viewForKey:UITransitionContextToViewKey];
   // we can intercept clicking back button here, we check reactSuperview since this method also fires when
-  if (_interactionController == nil && sourceView.reactSuperview && sourceView.preventNativeDismiss) {
-    _interactionController = [UIPercentDrivenInteractiveTransition new];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      [self->_interactionController cancelInteractiveTransition];
-      self->_interactionController = nil;
-      int sourceIndex = (int)[[self reactSubviews] indexOfObject:sourceView];
-      int targetIndex = (int)[[self reactSubviews] indexOfObject:targetView];
-      int indexDiff = sourceIndex - targetIndex;
-      int dismissCount = indexDiff > 0 ? indexDiff : 1;
-      [self updateContainer];
-      [sourceView notifyDismissCancelledWithDismissCount:dismissCount];
-    });
+  // navigating back from JS
+  if (_interactionController == nil && fromView.reactSuperview) {
+    BOOL shouldCancelDismiss = [self shouldCancelDismissFromView:fromView toView:toView];
+    if (shouldCancelDismiss) {
+      _interactionController = [UIPercentDrivenInteractiveTransition new];
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self->_interactionController cancelInteractiveTransition];
+        self->_interactionController = nil;
+        int fromIndex = (int)[self->_reactSubviews indexOfObject:fromView];
+        int toIndex = (int)[self->_reactSubviews indexOfObject:toView];
+        int indexDiff = fromIndex - toIndex;
+        int dismissCount = indexDiff > 0 ? indexDiff : 1;
+        [self updateContainer];
+        [fromView notifyDismissCancelledWithDismissCount:dismissCount];
+      });
+    }
   }
   return _interactionController;
 }

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -730,14 +730,18 @@
                              (id<UIViewControllerAnimatedTransitioning>)animationController
 {
   RNSScreenView *sourceView = [_controller.transitionCoordinator viewForKey:UITransitionContextFromViewKey];
+  RNSScreenView *targetView = [_controller.transitionCoordinator viewForKey:UITransitionContextToViewKey];
   // we can intercept clicking back button here, we check reactSuperview since this method also fires when
-  // going back from JS
   if (_interactionController == nil && sourceView.reactSuperview && sourceView.preventNativeDismiss) {
     _interactionController = [UIPercentDrivenInteractiveTransition new];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       [self->_interactionController cancelInteractiveTransition];
       self->_interactionController = nil;
-      [sourceView notifyDismissCancelledWithDismissCount:1];
+      int sourceIndex = (int)[[self reactSubviews] indexOfObject:sourceView];
+      int targetIndex = (int)[[self reactSubviews] indexOfObject:targetView];
+      int dismissCount = sourceIndex - targetIndex > 0 ? sourceIndex - targetIndex : 1;
+      [self updateContainer];
+      [sourceView notifyDismissCancelledWithDismissCount:dismissCount];
     });
   }
   return _interactionController;


### PR DESCRIPTION
## Description

PR adding intercepting of native header back button on `iOS`, so the back animation does not fire there if it should have been intercepted.

## Test code and steps to reproduce

https://github.com/react-navigation/react-navigation/blob/9fe34b445fcb86e5666f61e144007d7540f014fa/example/src/Screens/NativeStackPreventRemove.tsx with those changes applied.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
