### PR TITLE
fix: headerheight incorrect on phones with dynamic island

### DIFF
--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -6,12 +6,11 @@ const formSheetModalHeight = 56;
 
 export default function getDefaultHeaderHeight(
   layout: Layout,
-  topInset: number,
+  statusBarHeight: number,
   stackPresentation: StackPresentationTypes
 ): number {
   // default header heights
   let headerHeight = Platform.OS === 'android' ? 56 : 64;
-  let statusBarHeight = topInset;
 
   if (Platform.OS === 'ios') {
     const isLandscape = layout.width > layout.height;

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -105,11 +105,17 @@ const MaybeNestedStack = ({
     </Container>
   );
 
-  const topInset = useSafeAreaInsets().top;
   const dimensions = useSafeAreaFrame();
+  const topInset = useSafeAreaInsets().top;
+  let statusBarHeight = topInset;
+  const hasDynamicIsland = Platform.OS === 'ios' && topInset === 59;
+  if (hasDynamicIsland) {
+    // On models with Dynamic Island the status bar height is smaller than the safe area top inset.
+    statusBarHeight = 54;
+  }
   const headerHeight = getDefaultHeaderHeight(
     dimensions,
-    topInset,
+    statusBarHeight,
     stackPresentation
   );
 
@@ -211,9 +217,15 @@ const RouteView = ({
 
   const dimensions = useSafeAreaFrame();
   const topInset = useSafeAreaInsets().top;
+  let statusBarHeight = topInset;
+  const hasDynamicIsland = Platform.OS === 'ios' && topInset === 59;
+  if (hasDynamicIsland) {
+    // On models with Dynamic Island the status bar height is smaller than the safe area top inset.
+    statusBarHeight = 54;
+  }
   const headerHeight = getDefaultHeaderHeight(
     dimensions,
-    topInset,
+    statusBarHeight,
     stackPresentation
   );
   const parentHeaderHeight = React.useContext(HeaderHeightContext);


### PR DESCRIPTION
## Description
On phones with Dynamic Island (iPhone 14 Pro) the statusbar became larger and the header below smaller.
This is not reflected yet in code, which leads to bugs using for e.g. the useHeaderHeight() hook.

Fixes #1671

See also my PR in react-navigation:
https://github.com/react-navigation/react-navigation/pull/11338

Sizes can be verified with:
https://www.figma.com/community/file/1248375255495415511/Apple-Design-Resources-%E2%80%93-iOS-17-and-iPadOS-17
https://useyourloaf.com/blog/iphone-14-screen-sizes/#iphone-14-pro