### PR TITLE
fix: ifdef orientation code that requries iOS 16

### DIFF
--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -174,6 +174,8 @@
       }
     }
     if (newOrientation != UIInterfaceOrientationUnknown) {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
       if (@available(iOS 16.0, *)) {
         NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
         UIWindowScene *scene = (UIWindowScene *)array[0];
@@ -191,13 +193,15 @@
         }
 
         [topController setNeedsUpdateOfSupportedInterfaceOrientations];
-      } else {
+      } else
+#endif // Check for iOS 16
+      {
         [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
         [UIViewController attemptRotationToDeviceOrientation];
       }
     }
   });
-#endif
+#endif // !TARGET_TV_OS
 }
 
 + (void)updateWindowTraits


### PR DESCRIPTION
## Description

Currently when XCode w/o support for iOS 16 is used the RNSScreens compilation will most surely fail due to unrecognized symbols being present in the `RNSScreenWindowTraints` code.
See [this discussion](https://github.com/software-mansion/react-native-screens/pull/1732#issuecomment-1594455264).

## Changes

Added compilation guards for iOS sdk version. When not present old implementation is used. 


## Test code and steps to reproduce

See #1732 & try to compile & test on different major versions of xcode (e.g. 12 & 14)

## Checklist

- [ ] Ensured that CI passes
