### PR TITLE
fix: canvas nullability in ScreenStack for Android SDK 34

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -303,7 +303,9 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun performDraw(op: DrawingOp) {
-        super.drawChild(op.canvas, op.child, op.drawingTime)
+        // Canvas parameter can not be null here https://developer.android.com/reference/android/view/ViewGroup#drawChild(android.graphics.Canvas,%20android.view.View,%20long)
+        // So if we are passing null here, we would crash anyway
+        super.drawChild(op.canvas!!, op.child, op.drawingTime)
     }
 
     private fun obtainDrawingOp(): DrawingOp =

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -292,7 +292,13 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
-        drawingOps.add(obtainDrawingOp().set(canvas, child, drawingTime))
+        drawingOps.add(
+            obtainDrawingOp().apply {
+                this.canvas = canvas
+                this.child = child
+                this.drawingTime = drawingTime
+            }
+        )
         return true
     }
 
@@ -307,13 +313,6 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
         var canvas: Canvas? = null
         var child: View? = null
         var drawingTime: Long = 0
-
-        operator fun set(canvas: Canvas?, child: View?, drawingTime: Long): DrawingOp {
-            this.canvas = canvas
-            this.child = child
-            this.drawingTime = drawingTime
-            return this
-        }
 
         fun draw() {
             performDraw(this)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -301,7 +301,7 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun obtainDrawingOp(): DrawingOp =
-        if (drawingOpPool.isEmpty()) DrawingOp() else drawingOpPool.removeAt(drawingOpPool.size - 1)
+        if (drawingOpPool.isEmpty()) DrawingOp() else drawingOpPool.removeLast()
 
     private inner class DrawingOp {
         var canvas: Canvas? = null


### PR DESCRIPTION
## Description

Due to [Android docs](https://developer.android.com/reference/android/view/ViewGroup#drawChild(android.graphics.Canvas,%20android.view.View,%20long)) the canvas parameter in  `ViewGroup.drawChild(canvas, ...)`
method must not be null. This restriction was enforced on type level in sdk 34 thus our code was no longer valid.

Closes #1787

## Changes

Removed type nullability using `!!` operator. I decided to go with this solution, because:

1. With current implementation `DrawingOp.canvas` has to be nullable (as after performing the draw we do not drop the object, but invalidate it instead and we do not want
to hold no longer requried reference to canvas).
2. In case we actually pass null there -- we will crash anyway. 

## Test code and steps to reproduce

Set `compileSdkVersion` & `targetSdkVersion` to 34 in `TestExample` & see that the issue is resolved (& app works fine).

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
