### PR TITLE
fix: memory leak due to retain cycle between view & controller

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -87,6 +87,7 @@ import Test1646 from './src/Test1646';
 import Test1649 from './src/Test1649';
 import Test1683 from './src/Test1683';
 import Test1726 from './src/Test1726';
+import Test1754 from './src/Test1754';
 import Test1791 from './src/Test1791';
 
 enableFreeze(true);

--- a/TestsExample/src/Test1754.tsx
+++ b/TestsExample/src/Test1754.tsx
@@ -1,0 +1,107 @@
+import {NavigationContainer, ParamListBase} from '@react-navigation/native';
+import React, {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import {useEffect} from 'react';
+
+const Stack = createNativeStackNavigator();
+
+type NavigationProps = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+};
+
+type ListElementProps = {
+  id: number;
+};
+
+function ListElement(props: ListElementProps) {
+  return (
+    <View style={styles.container}>
+      <Text>{props.id}</Text>
+    </View>
+  );
+}
+
+function First(props: NavigationProps) {
+  const handlePress = function () {
+    props.navigation.navigate('Second');
+  };
+
+  // useEffect(() => {
+  //   const intervalHandle = setInterval(() => {
+  //     handlePress();
+  //   }, 1000);
+  //
+  //   return () => {
+  //     clearInterval(intervalHandle);
+  //   };
+  // }, []);
+
+  return (
+    <View>
+      <Button title="Navigate to the second screen" onPress={handlePress} />
+    </View>
+  );
+}
+
+function Second(props: NavigationProps) {
+  const handlePress = function () {
+    props.navigation.navigate('First');
+  };
+
+  // useEffect(() => {
+  //   const intervalHandle = setInterval(() => {
+  //     handlePress();
+  //   }, 1000);
+  //
+  //   return () => {
+  //     clearInterval(intervalHandle);
+  //   };
+  // }, []);
+
+  return (
+    // <View>
+    //   <Button title="Navigate to the first screen" onPress={handlePress} />
+    <ScrollView contentInsetAdjustmentBehavior='automatic'>
+      {[...Array(100).keys()].map(i => (
+        <ListElement key={i} id={i} />
+      ))}
+    </ScrollView>
+    // </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="First">
+        <Stack.Screen
+          name="First"
+          component={First}
+          options={{
+            fullScreenGestureEnabled: true,
+          }}
+        />
+        <Stack.Screen
+          name="Second"
+          component={Second}
+          options={{
+            fullScreenGestureEnabled: true,
+            headerLargeTitle: true,
+            headerTitle: 'omega',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/TestsExample/src/Test1754.tsx
+++ b/TestsExample/src/Test1754.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import {NavigationContainer, ParamListBase} from '@react-navigation/native';
 import React, {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {
@@ -64,7 +65,7 @@ function Second(props: NavigationProps) {
   return (
     // <View>
     //   <Button title="Navigate to the first screen" onPress={handlePress} />
-    <ScrollView contentInsetAdjustmentBehavior='automatic'>
+    <ScrollView contentInsetAdjustmentBehavior="automatic">
       {[...Array(100).keys()].map(i => (
         <ListElement key={i} id={i} />
       ))}

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -904,6 +904,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
     [self setupProgressNotification];
   }
+
+  if (!_goingForward) {
+    self.screenView.controller = nil;
+  }
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -904,10 +904,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
     [self setupProgressNotification];
   }
-
-  if (!_goingForward) {
-    self.screenView.controller = nil;
-  }
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -955,6 +951,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 #else
   [self traverseForScrollView:self.screenView];
 #endif
+
+  if (!_goingForward) {
+    self.screenView.controller = nil;
+  }
 }
 
 - (void)viewDidLayoutSubviews

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -952,7 +952,13 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   [self traverseForScrollView:self.screenView];
 #endif
 
-  if (!_goingForward) {
+  // TODO: Describe:
+  // 1. Why navigation controller has to be used here
+  // 2. What use case does the following code handle
+  UINavigationController *navigationController = self.navigationController;
+  BOOL isGoingForward =
+      [navigationController isBeingDismissed] || [navigationController isMovingFromParentViewController];
+  if (!isGoingForward) {
     self.screenView.controller = nil;
   }
 }


### PR DESCRIPTION
## Description

In our Paper code we rely on React Native to invalidate our views* -- that always happens when changes in view hierarchy are triggered by JS side (standard React Native application). However in brownfield applications (iOS) there are some flows in which React Native cleanup (see `RCTInvalidate` protocol) does not get triggered (see https://github.com/software-mansion/react-native-screens/issues/1754 for context).

\* The cleanup is required because `RNSScreenView` retains `RNSScreen` by holding a reference. In `invalidate` method of `RNSScreenView` we just release the controller by setting `_controller = nil`. 

Closes #1754

## Changes

Added check in `viewDidDisappear` method for situation when whole navigation controller gets dismissed and if so, we manually release view controller.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
