### PR TITLE
chore: add onGestureCancel event

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -97,6 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
+@property (nonatomic, copy) RCTDirectEventBlock onSwipeDismiss;
 #endif // RCT_NEW_ARCH_ENABLED
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
-@property (nonatomic, copy) RCTDirectEventBlock onSwipeDismiss;
+@property (nonatomic, copy) RCTDirectEventBlock onSwipeCanceled;
 #endif // RCT_NEW_ARCH_ENABLED
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
-@property (nonatomic, copy) RCTDirectEventBlock onSwipeCanceled;
+@property (nonatomic, copy) RCTDirectEventBlock onGestureCancel;
 #endif // RCT_NEW_ARCH_ENABLED
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -392,6 +392,20 @@
 #endif
 }
 
+- (void)notifySwipeCanceled
+{
+#ifdef RCT_NEW_ARCH_ENABLED
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onSwipeCanceled(facebook::react::RNSScreenEventEmitter::OnSwipeCanceled{});
+  }
+#else
+  if (self.onSwipeCanceled) {
+    self.onSwipeCanceled(nil);
+  }
+#endif
+}
+
 - (BOOL)isMountedUnderScreenOrReactRoot
 {
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -886,6 +900,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     // or successfully swiped back
     [self.screenView notifyAppear];
     [self notifyTransitionProgress:1.0 closing:NO goingForward:_goingForward];
+  } else {
+    [self.screenView notifySwipeDismiss];
   }
 
   _isSwiping = NO;
@@ -1275,6 +1291,7 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeDismissCancelled, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSwipeDismiss, RCTDirectEventBlock);
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -392,16 +392,16 @@
 #endif
 }
 
-- (void)notifySwipeCanceled
+- (void)notifyGestureCancel
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
     std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onSwipeCanceled(facebook::react::RNSScreenEventEmitter::OnSwipeCanceled{});
+        ->onGestureCancel(facebook::react::RNSScreenEventEmitter::OnGestureCancel{});
   }
 #else
-  if (self.onSwipeCanceled) {
-    self.onSwipeCanceled(nil);
+  if (self.onGestureCancel) {
+    self.onGestureCancel(nil);
   }
 #endif
 }
@@ -901,7 +901,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self.screenView notifyAppear];
     [self notifyTransitionProgress:1.0 closing:NO goingForward:_goingForward];
   } else {
-    [self.screenView notifySwipeCanceled];
+    [self.screenView notifyGestureCancel];
   }
 
   _isSwiping = NO;
@@ -1291,7 +1291,7 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeDismissCancelled, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onSwipeCanceled, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onGestureCancel, RCTDirectEventBlock);
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -901,7 +901,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self.screenView notifyAppear];
     [self notifyTransitionProgress:1.0 closing:NO goingForward:_goingForward];
   } else {
-    [self.screenView notifySwipeDismiss];
+    [self.screenView notifySwipeCanceled];
   }
 
   _isSwiping = NO;
@@ -1291,7 +1291,7 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeDismissCancelled, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onSwipeDismiss, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSwipeCanceled, RCTDirectEventBlock);
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -62,7 +62,7 @@ export interface NativeProps extends ViewProps {
   onWillAppear?: BubblingEventHandler<ScreenEvent>;
   onWillDisappear?: BubblingEventHandler<ScreenEvent>;
   onTransitionProgress?: BubblingEventHandler<TransitionProgressEvent>;
-  onSwipeCanceled?: BubblingEventHandler<ScreenEvent>;
+  onGestureCancel?: BubblingEventHandler<ScreenEvent>;
   sheetAllowedDetents?: WithDefault<SheetDetentTypes, 'large'>;
   sheetLargestUndimmedDetent?: WithDefault<SheetDetentTypes, 'all'>;
   sheetGrabberVisible?: WithDefault<boolean, false>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -62,6 +62,7 @@ export interface NativeProps extends ViewProps {
   onWillAppear?: BubblingEventHandler<ScreenEvent>;
   onWillDisappear?: BubblingEventHandler<ScreenEvent>;
   onTransitionProgress?: BubblingEventHandler<TransitionProgressEvent>;
+  onSwipeCanceled?: BubblingEventHandler<ScreenEvent>;
   sheetAllowedDetents?: WithDefault<SheetDetentTypes, 'large'>;
   sheetLargestUndimmedDetent?: WithDefault<SheetDetentTypes, 'all'>;
   sheetGrabberVisible?: WithDefault<boolean, false>;

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -275,6 +275,7 @@ class InnerScreen extends React.Component<ScreenProps> {
         children,
         isNativeStack,
         gestureResponseDistance,
+        onGestureCancel,
         ...props
       } = rest;
 
@@ -325,9 +326,12 @@ class InnerScreen extends React.Component<ScreenProps> {
                     { useNativeDriver: true }
                   )
             }
-            onSwipeCanceled={() => {
-              // NOOP
-            }}
+            onGestureCancel={
+              onGestureCancel ??
+              (() => {
+                // for internal use
+              })
+            }
           >
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
               children

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -325,6 +325,9 @@ class InnerScreen extends React.Component<ScreenProps> {
                     { useNativeDriver: true }
                   )
             }
+            onSwipeCanceled={() => {
+              // NOOP
+            }}
           >
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
               children

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -37,6 +37,10 @@ export type NativeStackNavigationEventMap = {
    * Event which fires when a transition animation ends.
    */
   transitionEnd: { data: { closing: boolean } };
+  /**
+   * Event which fires when a swipe back is canceled on iOS.
+   */
+  gestureCancel: { data: undefined };
 };
 
 export type NativeStackNavigationProp<

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -307,6 +307,12 @@ const RouteView = ({
           target: stateKey,
         });
       }}
+      onGestureCancel={() => {
+        navigation.emit({
+          type: 'gestureCancel',
+          target: route.key,
+        });
+      }}
     >
       <HeaderHeightContext.Provider
         value={

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -177,6 +177,10 @@ export interface ScreenProps extends ViewProps {
    */
   onDismissed?: (e: NativeSyntheticEvent<{ dismissCount: number }>) => void;
   /**
+   * A callback that gets called after swipe back is canceled.
+   */
+  onSwipeCanceled?: (e: NativeSyntheticEvent<null>) => void;
+  /**
    * An internal callback that gets called when the native header back button is clicked on Android and `enableNativeBackButtonDismissal` is set to `false`. It dismises the screen using `navigation.pop()`.
    *
    * @platform android

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -179,7 +179,7 @@ export interface ScreenProps extends ViewProps {
   /**
    * A callback that gets called after swipe back is canceled.
    */
-  onSwipeCanceled?: (e: NativeSyntheticEvent<null>) => void;
+  onGestureCancel?: (e: NativeSyntheticEvent<null>) => void;
   /**
    * An internal callback that gets called when the native header back button is clicked on Android and `enableNativeBackButtonDismissal` is set to `false`. It dismises the screen using `navigation.pop()`.
    *


### PR DESCRIPTION
## Description

This PR adds new iOS only event. Event is triggered after canceled swipe back (as on video)

https://github.com/software-mansion/react-native-screens/assets/36106620/e9f63c7c-e6b4-4444-895a-d6b41c725963

