### PR TITLE
fix: move setting default values of medium-detent related props to `InnerScreen`

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -254,10 +254,16 @@ class InnerScreen extends React.Component<ScreenProps> {
     this.props.onComponentRef?.(ref);
   };
 
+  // Setting resonable defaults for medium detents
   render() {
     const {
       enabled = ENABLE_SCREENS,
       freezeOnBlur = ENABLE_FREEZE,
+      sheetAllowedDetents = 'large',
+      sheetLargestUndimmedDetent = 'all',
+      sheetGrabberVisible = false,
+      sheetCornerRadius = -1.0,
+      sheetExpandsWhenScrolledToEdge = true,
       ...rest
     } = this.props;
 
@@ -300,6 +306,11 @@ class InnerScreen extends React.Component<ScreenProps> {
           <AnimatedNativeScreen
             {...props}
             activityState={activityState}
+            sheetAllowedDetents={sheetAllowedDetents}
+            sheetLargestUndimmedDetent={sheetLargestUndimmedDetent}
+            sheetGrabberVisible={sheetGrabberVisible}
+            sheetCornerRadius={sheetCornerRadius}
+            sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
             gestureResponseDistance={{
               start: gestureResponseDistance?.start ?? -1,
               end: gestureResponseDistance?.end ?? -1,

--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -254,18 +254,22 @@ class InnerScreen extends React.Component<ScreenProps> {
     this.props.onComponentRef?.(ref);
   };
 
-  // Setting resonable defaults for medium detents
   render() {
     const {
       enabled = ENABLE_SCREENS,
       freezeOnBlur = ENABLE_FREEZE,
+      ...rest
+    } = this.props;
+
+    // To maintain default behaviour of formSheet stack presentation style & and to have resonable
+    // defaults for new medium-detent iOS API we need to set defaults here
+    const {
       sheetAllowedDetents = 'large',
       sheetLargestUndimmedDetent = 'all',
       sheetGrabberVisible = false,
       sheetCornerRadius = -1.0,
       sheetExpandsWhenScrolledToEdge = true,
-      ...rest
-    } = this.props;
+    } = rest;
 
     if (enabled && isPlatformSupported) {
       AnimatedNativeScreen =


### PR DESCRIPTION
## Description

Default values for medium-detent related props were set only in `NativeStackView` so only in case user used native stack directly from `react-native-screens`. This led to buggy behaviour when `@react-navigation/native-stack` was in use. 

See conversation: https://github.com/software-mansion/react-native-screens/issues/1686#issuecomment-1621899668

## Changes

Default prop values are now set in `InnerScreen` in `index.native.tsx` which is used internally by `@react-navigation/native-stack` package.

# Test case

See conversation: https://github.com/software-mansion/react-native-screens/issues/1686#issuecomment-1621899668 (and below).

Use `stackPresentation: 'formSheet'` with native stack from `@react-navigation/native-stack` and see that the modal is opened by default to full height. 

## Checklist

- [x] Ensured that CI passes
