### PR TITLE
Remove type exports from index.native.tsx

### DIFF
--- a/src/index.native.tsx
+++ b/src/index.native.tsx
@@ -541,20 +541,6 @@ const ScreenStackHeaderSearchBarView = (
   />
 );
 
-export type {
-  StackPresentationTypes,
-  StackAnimationTypes,
-  BlurEffectTypes,
-  ScreenReplaceTypes,
-  ScreenOrientationTypes,
-  HeaderSubviewTypes,
-  ScreenProps,
-  ScreenContainerProps,
-  ScreenStackProps,
-  ScreenStackHeaderConfigProps,
-  SearchBarProps,
-};
-
 // context to be used when the user wants to use enhanced implementation
 // e.g. to use `useReanimatedTransitionProgress` (see `reanimated` folder in repo)
 const ScreenContext = React.createContext(InnerScreen);


### PR DESCRIPTION
## Description

In `src/index.native.tsx` there's a mix of both ESM (`import/export`) and CJS (`module.exports`). This is all fine if one uses babel to transpile the app, since it transforms all ESM to CJS, but it's technically invalid javascript. So with modern bundlers like esbuild gets confused about what export to use. By removing the type export (which is stripped by babel anyways) esbuild is no longer confused and picks the CJS export. 

## Changes

- Improved esbuild support

## Test code and steps to reproduce

Integrate [`react-native-esbuild`](https://github.com/oblador/react-native-esbuild) on a fresh project using RN Screens.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
