### PR TITLE
fix(Android): shorten alpha animation to 83ms on default enter-out

### DIFF
--- a/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
@@ -11,7 +11,7 @@
         android:fillAfter="true"
         android:interpolator="@anim/rns_standard_accelerate_interpolator"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="83" />
 
     <translate
         android:fromXDelta="0"


### PR DESCRIPTION
## Description

The issue was reported [here](https://github.com/react-navigation/react-navigation/issues/11438) on `@react-navigation` repo.

*Note* Awaiting for response from people that reported the issue

## Changes

Adjusted alpha animation duration as suggested in one of the comments. 

## Test code and steps to reproduce

Basing on people opinion that this improves the situation.

## Checklist

- [x] Ensured that CI passes
