### PR TITLE
refact(iOS): unify class & method naming with respect to conventions

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSScreenView;
 
-@interface RNSScreen : UIViewController <RNSScreensViewControllerDelegate>
+@interface RNSScreen : UIViewController <RNSViewControllerDelegate>
 
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSScreenView;
 
-@interface RNSScreen : UIViewController <RNScreensViewControllerDelegate>
+@interface RNSScreen : UIViewController <RNSScreensViewControllerDelegate>
 
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -747,7 +747,7 @@
   if (parentVC != nil && ![parentVC isKindOfClass:[RNSNavigationController class]]) {
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
   }
-  // when screen is mounted under RNScreensNavigationController it's size is controller
+  // when screen is mounted under RNSNavigationController it's size is controller
   // by the navigation controller itself. That is, it is set to fill space of
   // the controller. In that case we ignore react layout system from managing
   // the screen dimensions and we wait for the screen VC to update and then we
@@ -784,10 +784,10 @@
 {
   _reactFrame = frame;
   UIViewController *parentVC = self.reactViewController.parentViewController;
-  if (parentVC != nil && ![parentVC isKindOfClass:[RNScreensNavigationController class]]) {
+  if (parentVC != nil && ![parentVC isKindOfClass:[RNSNavigationController class]]) {
     [super reactSetFrame:frame];
   }
-  // when screen is mounted under RNScreensNavigationController it's size is controller
+  // when screen is mounted under RNSNavigationController it's size is controller
   // by the navigation controller itself. That is, it is set to fill space of
   // the controller. In that case we ignore react layout system from managing
   // the screen dimensions and we wait for the screen VC to update and then we
@@ -958,7 +958,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   [super viewDidLayoutSubviews];
 
   // The below code makes the screen view adapt dimensions provided by the system. We take these
-  // into account only when the view is mounted under RNScreensNavigationController in which case system
+  // into account only when the view is mounted under RNSNavigationController in which case system
   // provides additional padding to account for possible header, and in the case when screen is
   // shown as a native modal, as the final dimensions of the modal on iOS 12+ are shorter than the
   // screen size

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -744,7 +744,7 @@
   _newLayoutMetrics = layoutMetrics;
   _oldLayoutMetrics = oldLayoutMetrics;
   UIViewController *parentVC = self.reactViewController.parentViewController;
-  if (parentVC != nil && ![parentVC isKindOfClass:[RNScreensNavigationController class]]) {
+  if (parentVC != nil && ![parentVC isKindOfClass:[RNSNavigationController class]]) {
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
   }
   // when screen is mounted under RNScreensNavigationController it's size is controller
@@ -962,8 +962,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // provides additional padding to account for possible header, and in the case when screen is
   // shown as a native modal, as the final dimensions of the modal on iOS 12+ are shorter than the
   // screen size
-  BOOL isDisplayedWithinUINavController =
-      [self.parentViewController isKindOfClass:[RNScreensNavigationController class]];
+  BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
   BOOL isPresentedAsNativeModal = self.parentViewController == nil && self.presentingViewController != nil;
 
   if (isDisplayedWithinUINavController || isPresentedAsNativeModal) {
@@ -1078,7 +1077,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (lastViewController == nil) {
     return selfOrNil;
   } else {
-    if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
+    if ([lastViewController conformsToProtocol:@protocol(RNSViewControllerDelegate)]) {
       // If there is a child (should be VC of ScreenContainer or ScreenStack), that has a child that could provide the
       // trait, we recursively go into its findChildVCForConfig, and if one of the children has the trait set, we return
       // it, otherwise we return self if this VC has config, and nil if it doesn't we use

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1078,7 +1078,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (lastViewController == nil) {
     return selfOrNil;
   } else {
-    if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+    if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
       // If there is a child (should be VC of ScreenContainer or ScreenStack), that has a child that could provide the
       // trait, we recursively go into its findChildVCForConfig, and if one of the children has the trait set, we return
       // it, otherwise we return self if this VC has config, and nil if it doesn't we use

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -14,11 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@protocol RNScreensViewControllerDelegate
+@protocol RNSScreensViewControllerDelegate
 
 @end
 
-@interface RNScreensViewController : UIViewController <RNScreensViewControllerDelegate>
+@interface RNScreensViewController : UIViewController <RNSScreensViewControllerDelegate>
 
 - (UIViewController *)findActiveChildVC;
 

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -14,11 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@protocol RNSScreensViewControllerDelegate
+@protocol RNSViewControllerDelegate
 
 @end
 
-@interface RNSScreensViewController : UIViewController <RNSScreensViewControllerDelegate>
+@interface RNSViewController : UIViewController <RNSViewControllerDelegate>
 
 - (UIViewController *)findActiveChildVC;
 

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface RNScreensViewController : UIViewController <RNSScreensViewControllerDelegate>
+@interface RNSScreensViewController : UIViewController <RNSScreensViewControllerDelegate>
 
 - (UIViewController *)findActiveChildVC;
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -8,7 +8,7 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #endif
 
-@implementation RNScreensViewController
+@implementation RNSScreensViewController
 
 #if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
@@ -72,7 +72,7 @@
 
 - (void)setupController
 {
-  _controller = [[RNScreensViewController alloc] init];
+  _controller = [[RNSScreensViewController alloc] init];
   [self addSubview:_controller.view];
 }
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -8,7 +8,7 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #endif
 
-@implementation RNSScreensViewController
+@implementation RNSViewController
 
 #if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
@@ -72,7 +72,7 @@
 
 - (void)setupController
 {
-  _controller = [[RNSScreensViewController alloc] init];
+  _controller = [[RNSViewController alloc] init];
   [self addSubview:_controller.view];
 }
 

--- a/ios/RNSScreenNavigationContainer.h
+++ b/ios/RNSScreenNavigationContainer.h
@@ -3,7 +3,7 @@
 #import "RNSScreenContainer.h"
 #import "RNSScreenStack.h"
 
-@interface RNScreensContainerNavigationController : RNScreensNavigationController
+@interface RNSContainerNavigationController : RNSNavigationController
 
 @end
 

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -8,7 +8,7 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #endif
 
-@implementation RNScreensContainerNavigationController
+@implementation RNSContainerNavigationController
 
 @end
 
@@ -16,8 +16,8 @@
 
 - (void)setupController
 {
-  self.controller = [[RNScreensContainerNavigationController alloc] init];
-  [(RNScreensContainerNavigationController *)self.controller setNavigationBarHidden:YES animated:NO];
+  self.controller = [[RNSContainerNavigationController alloc] init];
+  [(RNSContainerNavigationController *)self.controller setNavigationBarHidden:YES animated:NO];
   [self addSubview:self.controller.view];
 }
 
@@ -27,7 +27,7 @@
     if (screen.activityState == RNSActivityStateOnTop) {
       // there should never be more than one screen with `RNSActivityStateOnTop`
       // since this component should be used for `tabs` and `drawer` navigators
-      [(RNScreensContainerNavigationController *)self.controller setViewControllers:@[ screen.controller ] animated:NO];
+      [(RNSContainerNavigationController *)self.controller setViewControllers:@[ screen.controller ] animated:NO];
       [screen notifyFinishTransitioning];
     }
   }

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNScreensNavigationController : UINavigationController <RNSScreensViewControllerDelegate>
+@interface RNSNavigationController : UINavigationController <RNSViewControllerDelegate>
 
 @end
 

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNScreensNavigationController : UINavigationController <RNScreensViewControllerDelegate>
+@interface RNScreensNavigationController : UINavigationController <RNSScreensViewControllerDelegate>
 
 @end
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -39,7 +39,7 @@
 
 @end
 
-@implementation RNScreensNavigationController
+@implementation RNSNavigationController
 
 #if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
@@ -126,7 +126,7 @@
 {
   _reactSubviews = [NSMutableArray new];
   _presentedModals = [NSMutableArray new];
-  _controller = [RNScreensNavigationController new];
+  _controller = [RNSNavigationController new];
   _controller.delegate = self;
 #if !TARGET_OS_TV
   [self setupGestureHandlers];

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -242,12 +242,12 @@
                 inViewController:(UIViewController *)vc
 {
   UIViewController *lastViewController = [[vc childViewControllers] lastObject];
-  if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
+  if ([lastViewController conformsToProtocol:@protocol(RNSViewControllerDelegate)]) {
     UIViewController *vc = nil;
-    if ([lastViewController isKindOfClass:[RNSScreensViewController class]]) {
-      vc = [(RNSScreensViewController *)lastViewController findActiveChildVC];
-    } else if ([lastViewController isKindOfClass:[RNScreensNavigationController class]]) {
-      vc = [(RNScreensNavigationController *)lastViewController topViewController];
+    if ([lastViewController isKindOfClass:[RNSViewController class]]) {
+      vc = [(RNSViewController *)lastViewController findActiveChildVC];
+    } else if ([lastViewController isKindOfClass:[RNSNavigationController class]]) {
+      vc = [(RNSNavigationController *)lastViewController topViewController];
     }
     return [vc isKindOfClass:[RNSScreen class]] &&
         [(RNSScreen *)vc findChildVCForConfigAndTrait:trait includingModals:includingModals] != nil;

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -244,8 +244,8 @@
   UIViewController *lastViewController = [[vc childViewControllers] lastObject];
   if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
     UIViewController *vc = nil;
-    if ([lastViewController isKindOfClass:[RNScreensViewController class]]) {
-      vc = [(RNScreensViewController *)lastViewController findActiveChildVC];
+    if ([lastViewController isKindOfClass:[RNSScreensViewController class]]) {
+      vc = [(RNSScreensViewController *)lastViewController findActiveChildVC];
     } else if ([lastViewController isKindOfClass:[RNScreensNavigationController class]]) {
       vc = [(RNScreensNavigationController *)lastViewController topViewController];
     }

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -242,7 +242,7 @@
                 inViewController:(UIViewController *)vc
 {
   UIViewController *lastViewController = [[vc childViewControllers] lastObject];
-  if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+  if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
     UIViewController *vc = nil;
     if ([lastViewController isKindOfClass:[RNScreensViewController class]]) {
       vc = [(RNScreensViewController *)lastViewController findActiveChildVC];

--- a/ios/UIViewController+RNScreens.mm
+++ b/ios/UIViewController+RNScreens.mm
@@ -8,36 +8,36 @@
 #if !TARGET_OS_TV
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarStyle
 {
-  UIViewController *childVC = [self findChildRNScreensViewController];
+  UIViewController *childVC = [self findChildRNSScreensViewController];
   return childVC ?: [self reactNativeScreensChildViewControllerForStatusBarStyle];
 }
 
 - (UIViewController *)reactNativeScreensChildViewControllerForStatusBarHidden
 {
-  UIViewController *childVC = [self findChildRNScreensViewController];
+  UIViewController *childVC = [self findChildRNSScreensViewController];
   return childVC ?: [self reactNativeScreensChildViewControllerForStatusBarHidden];
 }
 
 - (UIStatusBarAnimation)reactNativeScreensPreferredStatusBarUpdateAnimation
 {
-  UIViewController *childVC = [self findChildRNScreensViewController];
+  UIViewController *childVC = [self findChildRNSScreensViewController];
   return childVC ? childVC.preferredStatusBarUpdateAnimation
                  : [self reactNativeScreensPreferredStatusBarUpdateAnimation];
 }
 
 - (UIInterfaceOrientationMask)reactNativeScreensSupportedInterfaceOrientations
 {
-  UIViewController *childVC = [self findChildRNScreensViewController];
+  UIViewController *childVC = [self findChildRNSScreensViewController];
   return childVC ? childVC.supportedInterfaceOrientations : [self reactNativeScreensSupportedInterfaceOrientations];
 }
 
 - (UIViewController *)reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden
 {
-  UIViewController *childVC = [self findChildRNScreensViewController];
+  UIViewController *childVC = [self findChildRNSScreensViewController];
   return childVC ?: [self reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden];
 }
 
-- (UIViewController *)findChildRNScreensViewController
+- (UIViewController *)findChildRNSScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
   if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {

--- a/ios/UIViewController+RNScreens.mm
+++ b/ios/UIViewController+RNScreens.mm
@@ -40,7 +40,7 @@
 - (UIViewController *)findChildRNSScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
+  if ([lastViewController conformsToProtocol:@protocol(RNSViewControllerDelegate)]) {
     return lastViewController;
   }
   return nil;

--- a/ios/UIViewController+RNScreens.mm
+++ b/ios/UIViewController+RNScreens.mm
@@ -40,7 +40,7 @@
 - (UIViewController *)findChildRNScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
-  if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+  if ([lastViewController conformsToProtocol:@protocol(RNSScreensViewControllerDelegate)]) {
     return lastViewController;
   }
   return nil;


### PR DESCRIPTION
## Description

Up to this moment it was distrubing that some of our classes were prefixed with `RNS`, some with `RNScreens` and some with `RN`...
This PR aligns all class names to use `RNS` prefix according to [iOS conventions](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Conventions/Conventions.html)

TODO:

* [x] Check whether any native component was renamed, if so update it's component descriptor & codegen spec

## Changes

Renamed all classes to comply to aforementioned conventions.

## Checklist

- [ ] Ensured that CI passes
