### PR TITLE
feat(iOS): add support for search bar placement

### DIFF
--- a/FabricTestExample/src/Test1097.tsx
+++ b/FabricTestExample/src/Test1097.tsx
@@ -49,6 +49,7 @@ function First({ navigation }: NativeStackScreenProps<ParamListBase>) {
     hideNavigationBar: false,
     autoCapitalize: 'sentences',
     placeholder: 'Some text',
+    placement: 'stacked',
     onChangeText: (e: NativeSyntheticEvent<{ text: string }>) =>
       setSearch(e.nativeEvent.text),
     onCancelButtonPress: () => console.warn('Cancel button pressed'),

--- a/TestsExample/src/Test1097.tsx
+++ b/TestsExample/src/Test1097.tsx
@@ -50,6 +50,7 @@ function First({ navigation }: NativeStackScreenProps<ParamListBase>) {
     hideNavigationBar: false,
     autoCapitalize: 'sentences',
     placeholder: 'Some text',
+    placement: 'stacked',
     onChangeText: (e: NativeSyntheticEvent<{ text: string }>) =>
       setSearch(e.nativeEvent.text),
     onCancelButtonPress: () => console.warn('Cancel button pressed'),

--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
@@ -97,6 +97,8 @@ class SearchBarManager : ViewGroupManager<SearchBarView>() {
         view.shouldShowHintSearchIcon = shouldShowHintSearchIcon ?: true
     }
 
+    fun setPlacement(view: SearchBarView, placeholder: String?) = Unit
+
     override fun receiveCommand(root: SearchBarView, commandId: String?, args: ReadableArray?) {
         when (commandId) {
             "focus" -> root.handleFocusJsRequest()

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -386,6 +386,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `onOpen` - A callback that gets called when search bar is expanding. (Android only)
 - `onSearchButtonPress` - A callback that gets called when the search button is pressed. It receives the current text value of the search bar.
 - `placeholder` - Text displayed when search field is empty. Defaults to an empty string.
+- `placement` - Placement of the search bar in the navigation bar. (iOS only)
 - `textColor` - The search field text color.
 - `hintTextColor` - The search hint text color. (Android only)
 - `headerIconColor` - The search and close icon color shown in the header. (Android only)

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -31,6 +31,8 @@
 + (UITextAutocapitalizationType)UITextAutocapitalizationTypeFromCppEquivalent:
     (facebook::react::RNSSearchBarAutoCapitalize)autoCapitalize;
 
++ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(facebook::react::RNSSearchBarPlacement)placement;
+
 @end
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -141,6 +141,18 @@
   }
 }
 
++ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(facebook::react::RNSSearchBarPlacement)placement
+{
+  switch (placement) {
+    case facebook::react::RNSSearchBarPlacement::Stacked:
+      return RNSSearchBarPlacementStacked;
+    case facebook::react::RNSSearchBarPlacement::Automatic:
+      return RNSSearchBarPlacementAutomatic;
+    case facebook::react::RNSSearchBarPlacement::Inline:
+      return RNSSearchBarPlacementInline;
+  }
+}
+
 @end
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -65,7 +65,6 @@ typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
 };
 
 typedef NS_ENUM(NSInteger, RNSSearchBarPlacement) {
-  RNSSearchBarPlacementDefault,
   RNSSearchBarPlacementAutomatic,
   RNSSearchBarPlacementInline,
   RNSSearchBarPlacementStacked,

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -63,3 +63,10 @@ typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
   RNSScreenDetentTypeLarge,
   RNSScreenDetentTypeAll,
 };
+
+typedef NS_ENUM(NSInteger, RNSSearchBarPlacement) {
+  RNSSearchBarPlacementDefault,
+  RNSSearchBarPlacementAutomatic,
+  RNSSearchBarPlacementInline,
+  RNSSearchBarPlacementStacked,
+};

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -606,9 +606,14 @@ namespace rct = facebook::react;
             RNSSearchBar *searchBar = subview.subviews[0];
             navitem.searchController = searchBar.controller;
             navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
-            navitem.preferredSearchBarPlacement = searchBar.placement;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
+            if (@available(iOS 16.0, *)) {
+              navitem.preferredSearchBarPlacement = [searchBar placementAsUINavigationItemSearchBarPlacement];
+            }
+#endif /* Check for iOS 16.0 */
           }
-#endif
+#endif /* !TARGET_OS_TV */
         }
         break;
       }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -606,6 +606,7 @@ namespace rct = facebook::react;
             RNSSearchBar *searchBar = subview.subviews[0];
             navitem.searchController = searchBar.controller;
             navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
+            navitem.preferredSearchBarPlacement = searchBar.placement;
           }
 #endif
         }

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -17,6 +17,7 @@
 #endif
 
 @property (nonatomic) BOOL hideWhenScrolling;
+@property (nonatomic) UINavigationItemSearchBarPlacement placement;
 
 @property (nonatomic, retain) UISearchController *controller;
 

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -8,6 +8,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTComponent.h>
 #import <React/RCTViewManager.h>
+#import "RNSEnums.h"
 
 @interface RNSSearchBar :
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -17,9 +18,11 @@
 #endif
 
 @property (nonatomic) BOOL hideWhenScrolling;
-@property (nonatomic) UINavigationItemSearchBarPlacement placement;
-
+@property (nonatomic) RNSSearchBarPlacement placement;
 @property (nonatomic, retain) UISearchController *controller;
+
+- (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement API_AVAILABLE(ios(16.0))
+    API_UNAVAILABLE(tvos, watchos);
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #else

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -49,6 +49,7 @@
   _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
   _controller.searchBar.delegate = self;
   _hideWhenScrolling = YES;
+  _placement = UINavigationItemSearchBarPlacementAutomatic;
 }
 
 - (void)emitOnFocusEvent
@@ -372,6 +373,7 @@ RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
+RCT_EXPORT_VIEW_PROPERTY(placement, UINavigationItemSearchBarPlacement)
 
 RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTBubblingEventBlock)
@@ -422,5 +424,19 @@ RCT_EXPORT_METHOD(setText : (NSNumber *_Nonnull)reactTag text : (NSString *)text
 }
 
 #endif /* !RCT_NEW_ARCH_ENABLED */
+
+@end
+
+@implementation RCTConvert (RNSScreen)
+
+RCT_ENUM_CONVERTER(
+    UINavigationItemSearchBarPlacement,
+    (@{
+      @"automatic" : @(UINavigationItemSearchBarPlacementAutomatic),
+      @"inline" : @(UINavigationItemSearchBarPlacementInline),
+      @"stacked" : @(UINavigationItemSearchBarPlacementStacked),
+    }),
+    UINavigationItemSearchBarPlacementAutomatic,
+    integerValue)
 
 @end

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -49,7 +49,7 @@
   _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
   _controller.searchBar.delegate = self;
   _hideWhenScrolling = YES;
-  _placement = UINavigationItemSearchBarPlacementAutomatic;
+  _placement = RNSSearchBarPlacementStacked;
 }
 
 - (void)emitOnFocusEvent
@@ -209,6 +209,18 @@
 #endif
 }
 
+- (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement
+{
+  switch (_placement) {
+    case RNSSearchBarPlacementStacked:
+      return UINavigationItemSearchBarPlacementStacked;
+    case RNSSearchBarPlacementAutomatic:
+      return UINavigationItemSearchBarPlacementAutomatic;
+    case RNSSearchBarPlacementInline:
+      return UINavigationItemSearchBarPlacementInline;
+  }
+}
+
 #pragma mark delegate methods
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
@@ -327,6 +339,10 @@
     [self setTextColor:RCTUIColorFromSharedColor(newScreenProps.textColor)];
   }
 
+  if (oldScreenProps.placement != newScreenProps.placement) {
+    self.placement = [RNSConvert RNSScreenSearchBarPlacementFromCppEquivalent:newScreenProps.placement];
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -373,7 +389,7 @@ RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
-RCT_EXPORT_VIEW_PROPERTY(placement, UINavigationItemSearchBarPlacement)
+RCT_EXPORT_VIEW_PROPERTY(placement, RNSSearchBarPlacement)
 
 RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTBubblingEventBlock)
@@ -430,13 +446,13 @@ RCT_EXPORT_METHOD(setText : (NSNumber *_Nonnull)reactTag text : (NSString *)text
 @implementation RCTConvert (RNSScreen)
 
 RCT_ENUM_CONVERTER(
-    UINavigationItemSearchBarPlacement,
+    RNSSearchBarPlacement,
     (@{
-      @"automatic" : @(UINavigationItemSearchBarPlacementAutomatic),
-      @"inline" : @(UINavigationItemSearchBarPlacementInline),
-      @"stacked" : @(UINavigationItemSearchBarPlacementStacked),
+      @"automatic" : @(RNSSearchBarPlacementAutomatic),
+      @"inline" : @(RNSSearchBarPlacementInline),
+      @"stacked" : @(RNSSearchBarPlacementStacked),
     }),
-    UINavigationItemSearchBarPlacementAutomatic,
+    RNSSearchBarPlacementStacked,
     integerValue)
 
 @end

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -561,7 +561,6 @@ React.useLayoutEffect(() => {
 
 A callback that gets called when search bar is closing
 
-
 #### `onFocus`
 
 A callback that gets called when search bar has received focus.
@@ -580,6 +579,18 @@ Text displayed when search field is empty.
 
 Defaults to an empty string.
 
+#### `placement` (iOS only)
+
+Position of the search bar
+   
+Supported values:
+ 
+* `automatic` - the search bar is placed according to current layout
+* `inline` - the search bar is placed on the trailing edge of navigation bar
+* `stacked` - the searcr bar is placed below the other content in navigation bar
+
+Defaults to `stacked`
+  
 #### `textColor`
 
 The search field text color.

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -587,7 +587,7 @@ Supported values:
  
 * `automatic` - the search bar is placed according to current layout
 * `inline` - the search bar is placed on the trailing edge of navigation bar
-* `stacked` - the searcr bar is placed below the other content in navigation bar
+* `stacked` - the search bar is placed below the other content in navigation bar
 
 Defaults to `stacked`
   

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -17,6 +17,8 @@ type ChangeTextEvent = Readonly<{
   text?: string;
 }>;
 
+type SearchBarPlacement = 'automatic' | 'inline' | 'stacked';
+
 type AutoCapitalizeType = 'none' | 'words' | 'sentences' | 'characters';
 
 interface NativeProps extends ViewProps {
@@ -28,6 +30,7 @@ interface NativeProps extends ViewProps {
   hideWhenScrolling?: boolean;
   autoCapitalize?: WithDefault<AutoCapitalizeType, 'none'>;
   placeholder?: string;
+  placement?: WithDefault<SearchBarPlacement, 'stacked'>;
   obscureBackground?: boolean;
   hideNavigationBar?: boolean;
   cancelButtonText?: string;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -86,6 +86,7 @@ export type GestureResponseDistanceType = {
 };
 
 export type SheetDetentTypes = 'medium' | 'large' | 'all';
+export type SearchBarPlacement = 'automatic' | 'inline' | 'stacked';
 
 export interface ScreenProps extends ViewProps {
   active?: 0 | 1 | Animated.AnimatedInterpolation<number>;
@@ -633,6 +634,20 @@ export interface SearchBarProps {
    * Text displayed when search field is empty
    */
   placeholder?: string;
+  /**
+   * Position of the search bar
+   *
+   * Supported values:
+   *
+   * * `automatic` - the search bar is placed according to current layout
+   * * `inline` - the search bar is placed on the trailing edge of navigation bar
+   * * `stacked` - the searcr bar is placed below the other content in navigation bar
+   *
+   * Defaults to `stacked`
+   *
+   * @platform iOS (>= 16.0)
+   */
+  placement?: SearchBarPlacement;
   /**
    * The search field text color
    */

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -641,7 +641,7 @@ export interface SearchBarProps {
    *
    * * `automatic` - the search bar is placed according to current layout
    * * `inline` - the search bar is placed on the trailing edge of navigation bar
-   * * `stacked` - the searcr bar is placed below the other content in navigation bar
+   * * `stacked` - the search bar is placed below the other content in navigation bar
    *
    * Defaults to `stacked`
    *


### PR DESCRIPTION
## Description

Add support for [search bar placement](https://developer.apple.com/documentation/uikit/uinavigationitemsearchbarplacement?language=objc) prop on iOS.

## Changes

Added both Fabric & paper native impl and exposed the prop on JS side.

## Test code and steps to reproduce

`Test1097` in `TestExample` and `FabricTestExample`. 

Play around with value of `placement` prop in search bar configuration.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
