### PR TITLE
fix: Calculate large headers in `useHeaderHeight` hook

### DIFF
--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -85,6 +85,7 @@ import Test1646 from './src/Test1646';
 import Test1649 from './src/Test1649';
 import Test1683 from './src/Test1683';
 import Test1726 from './src/Test1726';
+import Test1844 from './src/Test1844';
 
 enableFreeze(true);
 

--- a/FabricTestExample/src/Test1844.tsx
+++ b/FabricTestExample/src/Test1844.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+  useHeaderHeight,
+} from 'react-native-screens/native-stack';
+import {
+  GestureHandlerRootView,
+  ScrollView,
+  State,
+  TapGestureHandler,
+} from 'react-native-gesture-handler';
+import { FullWindowOverlay } from 'react-native-screens';
+
+const Stack = createNativeStackNavigator();
+
+function HeaderOverlay() {
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <FullWindowOverlay>
+      <View
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+
+          backgroundColor: 'red',
+          width: '100%',
+          opacity: 0.5,
+          height: headerHeight,
+        }}>
+        <Text>Header height: {headerHeight}</Text>
+      </View>
+    </FullWindowOverlay>
+  );
+}
+
+function First({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <ScrollView>
+      <HeaderOverlay />
+      <Post onPress={() => navigation.navigate('Second')} />
+    </ScrollView>
+  );
+}
+
+function Second() {
+  return (
+    <ScrollView>
+      <Text style={styles.subTitle}>
+        Use swipe back gesture to go back (iOS only)
+      </Text>
+      <Post />
+    </ScrollView>
+  );
+}
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <Stack.Navigator
+          screenOptions={{
+            fullScreenSwipeEnabled: true,
+            stackAnimation: 'default',
+            customAnimationOnSwipe: true,
+            // headerLargeTitle: true,
+          }}>
+          <Stack.Screen name="First" component={First} />
+          <Stack.Screen name="Second" component={Second} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  );
+}
+
+// components
+
+function Post({ onPress }: { onPress?: () => void }) {
+  const [width] = useState(Math.round(Dimensions.get('screen').width));
+
+  return (
+    <TapGestureHandler
+      onHandlerStateChange={e =>
+        e.nativeEvent.oldState === State.ACTIVE && onPress?.()
+      }>
+      <View style={styles.post}>
+        <Text style={styles.title}>Post</Text>
+        <ScrollView horizontal>{generatePhotos(4, width, 400)}</ScrollView>
+        <Text style={styles.caption}>Scroll right for more photos</Text>
+      </View>
+    </TapGestureHandler>
+  );
+}
+
+// helpers
+function generatePhotos(
+  amount: number,
+  width: number,
+  height: number,
+): JSX.Element[] {
+  const startFrom = Math.floor(Math.random() * 20) + 10;
+  return Array.from({ length: amount }, (_, index) => {
+    const uri = `https://picsum.photos/id/${
+      startFrom + index
+    }/${width}/${height}`;
+    return <Image style={{ width, height }} key={uri} source={{ uri }} />;
+  });
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontWeight: 'bold',
+    fontSize: 32,
+    marginBottom: 8,
+    marginLeft: 8,
+  },
+  subTitle: {
+    fontSize: 18,
+    marginVertical: 16,
+    textAlign: 'center',
+  },
+  caption: {
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  post: {
+    borderColor: '#ccc',
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    paddingVertical: 10,
+    marginBottom: 16,
+    backgroundColor: 'white',
+  },
+});

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -88,6 +88,7 @@ import Test1649 from './src/Test1649';
 import Test1683 from './src/Test1683';
 import Test1726 from './src/Test1726';
 import Test1791 from './src/Test1791';
+import Test1844 from './src/Test1844';
 
 enableFreeze(true);
 

--- a/TestsExample/src/Test1844.tsx
+++ b/TestsExample/src/Test1844.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+  useHeaderHeight,
+} from 'react-native-screens/native-stack';
+import {
+  GestureHandlerRootView,
+  ScrollView,
+  State,
+  TapGestureHandler,
+} from 'react-native-gesture-handler';
+import { FullWindowOverlay } from 'react-native-screens';
+
+const Stack = createNativeStackNavigator();
+
+function HeaderOverlay() {
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <FullWindowOverlay>
+      <View
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+
+          backgroundColor: 'red',
+          width: '100%',
+          opacity: 0.5,
+          height: headerHeight,
+        }}>
+        <Text>Header height: {headerHeight}</Text>
+      </View>
+    </FullWindowOverlay>
+  );
+}
+
+function First({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) {
+  return (
+    <ScrollView>
+      <HeaderOverlay />
+      <Post onPress={() => navigation.navigate('Second')} />
+    </ScrollView>
+  );
+}
+
+function Second() {
+  return (
+    <ScrollView>
+      <Text style={styles.subTitle}>
+        Use swipe back gesture to go back (iOS only)
+      </Text>
+      <Post />
+    </ScrollView>
+  );
+}
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <Stack.Navigator
+          screenOptions={{
+            fullScreenSwipeEnabled: true,
+            stackAnimation: 'default',
+            customAnimationOnSwipe: true,
+            headerLargeTitle: true,
+          }}>
+          <Stack.Screen name="First" component={First} />
+          <Stack.Screen name="Second" component={Second} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  );
+}
+
+// components
+
+function Post({ onPress }: { onPress?: () => void }) {
+  const [width] = useState(Math.round(Dimensions.get('screen').width));
+
+  return (
+    <TapGestureHandler
+      onHandlerStateChange={e =>
+        e.nativeEvent.oldState === State.ACTIVE && onPress?.()
+      }>
+      <View style={styles.post}>
+        <Text style={styles.title}>Post</Text>
+        <ScrollView horizontal>{generatePhotos(4, width, 400)}</ScrollView>
+        <Text style={styles.caption}>Scroll right for more photos</Text>
+      </View>
+    </TapGestureHandler>
+  );
+}
+
+// helpers
+function generatePhotos(
+  amount: number,
+  width: number,
+  height: number,
+): JSX.Element[] {
+  const startFrom = Math.floor(Math.random() * 20) + 10;
+  return Array.from({ length: amount }, (_, index) => {
+    const uri = `https://picsum.photos/id/${
+      startFrom + index
+    }/${width}/${height}`;
+    return <Image style={{ width, height }} key={uri} source={{ uri }} />;
+  });
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontWeight: 'bold',
+    fontSize: 32,
+    marginBottom: 8,
+    marginLeft: 8,
+  },
+  subTitle: {
+    fontSize: 18,
+    marginVertical: 16,
+    textAlign: 'center',
+  },
+  caption: {
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  post: {
+    borderColor: '#ccc',
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    paddingVertical: 10,
+    marginBottom: 16,
+    backgroundColor: 'white',
+  },
+});

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -29,7 +29,7 @@ export default function getDefaultHeaderHeight(
         headerHeight = 32;
       } else {
         if (isFormSheetModal) headerHeight = formSheetModalHeight;
-        headerHeight = isLargeHeader ? 96 : 44;
+        else headerHeight = isLargeHeader ? 96 : 44;
       }
     }
   }

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -7,7 +7,8 @@ const formSheetModalHeight = 56;
 export default function getDefaultHeaderHeight(
   layout: Layout,
   statusBarHeight: number,
-  stackPresentation: StackPresentationTypes
+  stackPresentation: StackPresentationTypes,
+  isLargeHeader: boolean
 ): number {
   // default header heights
   let headerHeight = Platform.OS === 'android' ? 56 : 64;
@@ -27,7 +28,9 @@ export default function getDefaultHeaderHeight(
       if (isLandscape) {
         headerHeight = 32;
       } else {
-        headerHeight = isFromSheetModal ? formSheetModalHeight : 44;
+        if (isFromSheetModal) headerHeight = formSheetModalHeight;
+        else if (isLargeHeader) headerHeight = 96;
+        else headerHeight = 44;
       }
     }
   }

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -8,7 +8,7 @@ export default function getDefaultHeaderHeight(
   layout: Layout,
   statusBarHeight: number,
   stackPresentation: StackPresentationTypes,
-  isLargeHeader: boolean
+  isLargeHeader = false
 ): number {
   // default header heights
   let headerHeight = Platform.OS === 'android' ? 56 : 64;

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -15,20 +15,20 @@ export default function getDefaultHeaderHeight(
 
   if (Platform.OS === 'ios') {
     const isLandscape = layout.width > layout.height;
-    const isFromSheetModal =
+    const isFormSheetModal =
       stackPresentation === 'modal' || stackPresentation === 'formSheet';
-    if (isFromSheetModal && !isLandscape) {
+    if (isFormSheetModal && !isLandscape) {
       // `modal` and `formSheet` presentations do not take whole screen, so should not take the inset.
       statusBarHeight = 0;
     }
 
     if (Platform.isPad || Platform.isTV) {
-      headerHeight = isFromSheetModal ? formSheetModalHeight : 50;
+      headerHeight = isFormSheetModal ? formSheetModalHeight : 50;
     } else {
       if (isLandscape) {
         headerHeight = 32;
       } else {
-        if (isFromSheetModal) headerHeight = formSheetModalHeight;
+        if (isFormSheetModal) headerHeight = formSheetModalHeight;
         headerHeight = isLargeHeader ? 96 : 44;
       }
     }

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -28,8 +28,11 @@ export default function getDefaultHeaderHeight(
       if (isLandscape) {
         headerHeight = 32;
       } else {
-        if (isFormSheetModal) headerHeight = formSheetModalHeight;
-        else headerHeight = isLargeHeader ? 96 : 44;
+        if (isFormSheetModal) {
+          headerHeight = formSheetModalHeight;
+        } else {
+          headerHeight = isLargeHeader ? 96 : 44;
+        }
       }
     }
   }

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -29,8 +29,7 @@ export default function getDefaultHeaderHeight(
         headerHeight = 32;
       } else {
         if (isFromSheetModal) headerHeight = formSheetModalHeight;
-        else if (isLargeHeader) headerHeight = 96;
-        else headerHeight = 44;
+        headerHeight = isLargeHeader ? 96 : 44;
       }
     }
   }

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -113,6 +113,7 @@ const MaybeNestedStack = ({
   const topInset = useSafeAreaInsets().top;
   let statusBarHeight = topInset;
   const hasDynamicIsland = Platform.OS === 'ios' && topInset === 59;
+  const isLargeHeader = options.headerLargeTitle ?? false;
   if (hasDynamicIsland) {
     // On models with Dynamic Island the status bar height is smaller than the safe area top inset.
     statusBarHeight = 54;
@@ -120,7 +121,8 @@ const MaybeNestedStack = ({
   const headerHeight = getDefaultHeaderHeight(
     dimensions,
     statusBarHeight,
-    stackPresentation
+    stackPresentation,
+    isLargeHeader
   );
 
   if (isHeaderInModal) {
@@ -223,6 +225,8 @@ const RouteView = ({
   const topInset = useSafeAreaInsets().top;
   let statusBarHeight = topInset;
   const hasDynamicIsland = Platform.OS === 'ios' && topInset === 59;
+  const isLargeHeader = options.headerLargeTitle ?? false;
+
   if (hasDynamicIsland) {
     // On models with Dynamic Island the status bar height is smaller than the safe area top inset.
     statusBarHeight = 54;
@@ -230,7 +234,8 @@ const RouteView = ({
   const headerHeight = getDefaultHeaderHeight(
     dimensions,
     statusBarHeight,
-    stackPresentation
+    stackPresentation,
+    isLargeHeader
   );
   const parentHeaderHeight = React.useContext(HeaderHeightContext);
   const Screen = React.useContext(ScreenContext);


### PR DESCRIPTION
## Description

Currently, `useHeaderHeight()` hook returns wrong values for using large headers on iOS. This PR introduces a fix that adds a logic for calculating large headers.

This change is also a part of ongoing work on completely new `useAnimatedHeaderHeight` hook, introduced in #1802. 

## Changes

- Added an if statement in `useHeaderHeight` that sets correct value for `headerHeight`.

## Screenshots / GIFs

### Before

<details>
<summary>iPhone 14 Pro (iOS 16.4)</summary>
<img width="469" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/23281839/adc1304f-9b0e-48ac-9d48-ebf928828182">
</details>

<details>
<summary>iPhone 8 (iOS 16.4)</summary>
<img width="467" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/23281839/1421e9ae-b93e-465a-b078-37e27f2ef230">
</details>

### After

<details>
<summary>iPhone 14 Pro (iOS 16.4)</summary>
<img width="486" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/23281839/508bb247-8875-4bf9-b227-e83b88923d52">
</details>

<details>
<summary>iPhone 8 (iOS 16.4)</summary>
<img width="468" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/23281839/3a773473-0e26-4d70-921e-5e4201f03f47">
</details>

## Test code and steps to reproduce

You can test changes, included in PR by selecting `Test1844` from `TestsExample`/`FabricTestExample`.

## Checklist

- [X] Included code example that can be used to test this change
- [x] Ensured that CI passes
