### PR TITLE
docs: annotate `sheetExpandsWhenScrollingToEdge` prop as iOS specific

### DIFF
--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -333,6 +333,8 @@ export type NativeStackNavigationOptions = {
    * Whether the sheet should expand to larger detent when scrolling.
    * Works only when `stackPresentation` is set to `formSheet`.
    * Defaults to `true`.
+   *
+   * @platform ios
    */
   sheetExpandsWhenScrolledToEdge?: boolean;
   /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -255,6 +255,8 @@ export interface ScreenProps extends ViewProps {
    * Whether the sheet should expand to larger detent when scrolling.
    * Works only when `stackPresentation` is set to `formSheet`.
    * Defaults to `true`.
+   *
+   * @platform ios
    */
   sheetExpandsWhenScrolledToEdge?: boolean;
   /**


### PR DESCRIPTION
## Description

`sheetExpandsWhenScrollingToEdge` prop is iOS specific and this fact is not described in type info. 

## Changes

Added a note in type docs that this prop is iOS specific.


## Test code and steps to reproduce

## Checklist

- [ ] Ensured that CI passes
