### PR TITLE
fix(iOS): bad parameter type in `toggleCancelButton` search bar command

### DIFF
--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -423,7 +423,7 @@ RCT_EXPORT_METHOD(clearText : (NSNumber *_Nonnull)reactTag)
   }];
 }
 
-RCT_EXPORT_METHOD(toggleCancelButton : (NSNumber *_Nonnull)reactTag flag : (BOOL *)flag)
+RCT_EXPORT_METHOD(toggleCancelButton : (NSNumber *_Nonnull)reactTag flag : (BOOL)flag)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
     RNSSearchBar *searchBar = viewRegistry[reactTag];


### PR DESCRIPTION
## Description

Fixes #1853

Looks like I've made a typo while implemnenting `toggleCancelButton:flag:` (flag has `BOOL *` type instead of just `BOOL`) leading to compile errors as reported in #1853.

## Changes

Changed (fixed) the type of `flag` parameter from `BOOL *` to just plain `BOOL`.


## Test code and steps to reproduce

See #1853 & try to build on macOS Catalyst

## Checklist

- [ ] Ensured that CI passes
