### PR TITLE
fix(iOS): add missing call to super method in `RNSScreenView#finalizeUpdates`

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -758,6 +758,7 @@
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
+  [super finalizeUpdates:updateMask];
 #if !TARGET_OS_TV
   [self updatePresentationStyle];
 #endif // !TARGET_OS_TV


### PR DESCRIPTION
## Description

`RNSScreenView` (iOS) inherits from `RCTViewComponentView` which has custom implementation of `finalizeUpdates:` method, thus we should call it.

## Changes

Added missing call to `[super finalizeUpdates:]` in `RNSScreenView`.

## Test code and steps to reproduce

WIP

## Checklist

- [x] Ensured that CI passes
