### PR TITLE
chore: improve readability of C++ namespaced types

### DIFF
--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -2,36 +2,34 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #import "RNSEnums.h"
 
+namespace react = facebook::react;
+
 @interface RNSConvert : NSObject
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentationFromCppEquivalent:
-    (facebook::react::RNSScreenStackPresentation)stackPresentation;
+    (react::RNSScreenStackPresentation)stackPresentation;
 
-+ (RNSScreenStackAnimation)RNSScreenStackAnimationFromCppEquivalent:
-    (facebook::react::RNSScreenStackAnimation)stackAnimation;
++ (RNSScreenStackAnimation)RNSScreenStackAnimationFromCppEquivalent:(react::RNSScreenStackAnimation)stackAnimation;
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewTypeFromCppEquivalent:
-    (facebook::react::RNSScreenStackHeaderSubviewType)subviewType;
+    (react::RNSScreenStackHeaderSubviewType)subviewType;
 
 + (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
-    (facebook::react::RNSScreenReplaceAnimation)replaceAnimation;
+    (react::RNSScreenReplaceAnimation)replaceAnimation;
 
-+ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
-    (facebook::react::RNSScreenSwipeDirection)swipeDirection;
++ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:(react::RNSScreenSwipeDirection)swipeDirection;
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
-    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents;
++ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:(react::RNSScreenSheetAllowedDetents)allowedDetents;
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
-    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent;
++ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:(react::RNSScreenSheetLargestUndimmedDetent)detent;
 
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
-    (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
+    (const react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
 
 + (UITextAutocapitalizationType)UITextAutocapitalizationTypeFromCppEquivalent:
-    (facebook::react::RNSSearchBarAutoCapitalize)autoCapitalize;
+    (react::RNSSearchBarAutoCapitalize)autoCapitalize;
 
-+ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(facebook::react::RNSSearchBarPlacement)placement;
++ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(react::RNSSearchBarPlacement)placement;
 
 @end
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -4,119 +4,115 @@
 @implementation RNSConvert
 
 + (RNSScreenStackPresentation)RNSScreenStackPresentationFromCppEquivalent:
-    (facebook::react::RNSScreenStackPresentation)stackPresentation
+    (react::RNSScreenStackPresentation)stackPresentation
 {
   switch (stackPresentation) {
-    case facebook::react::RNSScreenStackPresentation::Push:
+    case react::RNSScreenStackPresentation::Push:
       return RNSScreenStackPresentationPush;
-    case facebook::react::RNSScreenStackPresentation::Modal:
+    case react::RNSScreenStackPresentation::Modal:
       return RNSScreenStackPresentationModal;
-    case facebook::react::RNSScreenStackPresentation::FullScreenModal:
+    case react::RNSScreenStackPresentation::FullScreenModal:
       return RNSScreenStackPresentationFullScreenModal;
-    case facebook::react::RNSScreenStackPresentation::FormSheet:
+    case react::RNSScreenStackPresentation::FormSheet:
       return RNSScreenStackPresentationFormSheet;
-    case facebook::react::RNSScreenStackPresentation::ContainedModal:
+    case react::RNSScreenStackPresentation::ContainedModal:
       return RNSScreenStackPresentationContainedModal;
-    case facebook::react::RNSScreenStackPresentation::TransparentModal:
+    case react::RNSScreenStackPresentation::TransparentModal:
       return RNSScreenStackPresentationTransparentModal;
-    case facebook::react::RNSScreenStackPresentation::ContainedTransparentModal:
+    case react::RNSScreenStackPresentation::ContainedTransparentModal:
       return RNSScreenStackPresentationContainedTransparentModal;
   }
 }
 
-+ (RNSScreenStackAnimation)RNSScreenStackAnimationFromCppEquivalent:
-    (facebook::react::RNSScreenStackAnimation)stackAnimation
++ (RNSScreenStackAnimation)RNSScreenStackAnimationFromCppEquivalent:(react::RNSScreenStackAnimation)stackAnimation
 {
   switch (stackAnimation) {
     // these three are intentionally grouped
-    case facebook::react::RNSScreenStackAnimation::Slide_from_right:
-    case facebook::react::RNSScreenStackAnimation::Slide_from_left:
-    case facebook::react::RNSScreenStackAnimation::Default:
+    case react::RNSScreenStackAnimation::Slide_from_right:
+    case react::RNSScreenStackAnimation::Slide_from_left:
+    case react::RNSScreenStackAnimation::Default:
       return RNSScreenStackAnimationDefault;
-    case facebook::react::RNSScreenStackAnimation::Flip:
+    case react::RNSScreenStackAnimation::Flip:
       return RNSScreenStackAnimationFlip;
-    case facebook::react::RNSScreenStackAnimation::Simple_push:
+    case react::RNSScreenStackAnimation::Simple_push:
       return RNSScreenStackAnimationSimplePush;
-    case facebook::react::RNSScreenStackAnimation::None:
+    case react::RNSScreenStackAnimation::None:
       return RNSScreenStackAnimationNone;
-    case facebook::react::RNSScreenStackAnimation::Fade:
+    case react::RNSScreenStackAnimation::Fade:
       return RNSScreenStackAnimationFade;
-    case facebook::react::RNSScreenStackAnimation::Slide_from_bottom:
+    case react::RNSScreenStackAnimation::Slide_from_bottom:
       return RNSScreenStackAnimationSlideFromBottom;
-    case facebook::react::RNSScreenStackAnimation::Fade_from_bottom:
+    case react::RNSScreenStackAnimation::Fade_from_bottom:
       return RNSScreenStackAnimationFadeFromBottom;
   }
 }
 
 + (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewTypeFromCppEquivalent:
-    (facebook::react::RNSScreenStackHeaderSubviewType)subviewType
+    (react::RNSScreenStackHeaderSubviewType)subviewType
 {
   switch (subviewType) {
-    case facebook::react::RNSScreenStackHeaderSubviewType::Left:
+    case react::RNSScreenStackHeaderSubviewType::Left:
       return RNSScreenStackHeaderSubviewTypeLeft;
-    case facebook::react::RNSScreenStackHeaderSubviewType::Right:
+    case react::RNSScreenStackHeaderSubviewType::Right:
       return RNSScreenStackHeaderSubviewTypeRight;
-    case facebook::react::RNSScreenStackHeaderSubviewType::Title:
+    case react::RNSScreenStackHeaderSubviewType::Title:
       return RNSScreenStackHeaderSubviewTypeTitle;
-    case facebook::react::RNSScreenStackHeaderSubviewType::Center:
+    case react::RNSScreenStackHeaderSubviewType::Center:
       return RNSScreenStackHeaderSubviewTypeCenter;
-    case facebook::react::RNSScreenStackHeaderSubviewType::SearchBar:
+    case react::RNSScreenStackHeaderSubviewType::SearchBar:
       return RNSScreenStackHeaderSubviewTypeSearchBar;
-    case facebook::react::RNSScreenStackHeaderSubviewType::Back:
+    case react::RNSScreenStackHeaderSubviewType::Back:
       return RNSScreenStackHeaderSubviewTypeBackButton;
   }
 }
 
 + (RNSScreenReplaceAnimation)RNSScreenReplaceAnimationFromCppEquivalent:
-    (facebook::react::RNSScreenReplaceAnimation)replaceAnimation
+    (react::RNSScreenReplaceAnimation)replaceAnimation
 {
   switch (replaceAnimation) {
-    case facebook::react::RNSScreenReplaceAnimation::Pop:
+    case react::RNSScreenReplaceAnimation::Pop:
       return RNSScreenReplaceAnimationPop;
-    case facebook::react::RNSScreenReplaceAnimation::Push:
+    case react::RNSScreenReplaceAnimation::Push:
       return RNSScreenReplaceAnimationPush;
   }
 }
 
-+ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
-    (facebook::react::RNSScreenSwipeDirection)swipeDirection
++ (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:(react::RNSScreenSwipeDirection)swipeDirection
 {
   switch (swipeDirection) {
-    case facebook::react::RNSScreenSwipeDirection::Horizontal:
+    case react::RNSScreenSwipeDirection::Horizontal:
       return RNSScreenSwipeDirectionHorizontal;
-    case facebook::react::RNSScreenSwipeDirection::Vertical:
+    case react::RNSScreenSwipeDirection::Vertical:
       return RNSScreenSwipeDirectionVertical;
   }
 }
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
-    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents
++ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:(react::RNSScreenSheetAllowedDetents)allowedDetents
 {
   switch (allowedDetents) {
-    case facebook::react::RNSScreenSheetAllowedDetents::All:
+    case react::RNSScreenSheetAllowedDetents::All:
       return RNSScreenDetentTypeAll;
-    case facebook::react::RNSScreenSheetAllowedDetents::Large:
+    case react::RNSScreenSheetAllowedDetents::Large:
       return RNSScreenDetentTypeLarge;
-    case facebook::react::RNSScreenSheetAllowedDetents::Medium:
+    case react::RNSScreenSheetAllowedDetents::Medium:
       return RNSScreenDetentTypeMedium;
   }
 }
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
-    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent
++ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:(react::RNSScreenSheetLargestUndimmedDetent)detent
 {
   switch (detent) {
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::All:
+    case react::RNSScreenSheetLargestUndimmedDetent::All:
       return RNSScreenDetentTypeAll;
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Large:
+    case react::RNSScreenSheetLargestUndimmedDetent::Large:
       return RNSScreenDetentTypeLarge;
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Medium:
+    case react::RNSScreenSheetLargestUndimmedDetent::Medium:
       return RNSScreenDetentTypeMedium;
   }
 }
 
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
-    (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
+    (const react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
 {
   return @{
     @"start" : @(gestureResponseDistance.start),
@@ -127,28 +123,28 @@
 }
 
 + (UITextAutocapitalizationType)UITextAutocapitalizationTypeFromCppEquivalent:
-    (facebook::react::RNSSearchBarAutoCapitalize)autoCapitalize
+    (react::RNSSearchBarAutoCapitalize)autoCapitalize
 {
   switch (autoCapitalize) {
-    case facebook::react::RNSSearchBarAutoCapitalize::Words:
+    case react::RNSSearchBarAutoCapitalize::Words:
       return UITextAutocapitalizationTypeWords;
-    case facebook::react::RNSSearchBarAutoCapitalize::Sentences:
+    case react::RNSSearchBarAutoCapitalize::Sentences:
       return UITextAutocapitalizationTypeSentences;
-    case facebook::react::RNSSearchBarAutoCapitalize::Characters:
+    case react::RNSSearchBarAutoCapitalize::Characters:
       return UITextAutocapitalizationTypeAllCharacters;
-    case facebook::react::RNSSearchBarAutoCapitalize::None:
+    case react::RNSSearchBarAutoCapitalize::None:
       return UITextAutocapitalizationTypeNone;
   }
 }
 
-+ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(facebook::react::RNSSearchBarPlacement)placement
++ (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(react::RNSSearchBarPlacement)placement
 {
   switch (placement) {
-    case facebook::react::RNSSearchBarPlacement::Stacked:
+    case react::RNSSearchBarPlacement::Stacked:
       return RNSSearchBarPlacementStacked;
-    case facebook::react::RNSSearchBarPlacement::Automatic:
+    case react::RNSSearchBarPlacement::Automatic:
       return RNSSearchBarPlacementAutomatic;
-    case facebook::react::RNSSearchBarPlacement::Inline:
+    case react::RNSSearchBarPlacement::Inline:
       return RNSSearchBarPlacementInline;
   }
 }

--- a/ios/RNSFullWindowOverlay.h
+++ b/ios/RNSFullWindowOverlay.h
@@ -7,6 +7,10 @@
 #import <React/RCTView.h>
 #endif
 
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
+
 @interface RNSFullWindowOverlayManager : RCTViewManager
 
 @end
@@ -23,8 +27,8 @@
 #endif // RCT_NEW_ARCH_ENABLED
 
 #ifdef RCT_NEW_ARCH_ENABLED
-@property (nonatomic) facebook::react::LayoutMetrics oldLayoutMetrics;
-@property (nonatomic) facebook::react::LayoutMetrics newLayoutMetrics;
+@property (nonatomic) react::LayoutMetrics oldLayoutMetrics;
+@property (nonatomic) react::LayoutMetrics newLayoutMetrics;
 #endif // RCT_NEW_ARCH_ENABLED
 
 @end

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -82,7 +82,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSFullWindowOverlayProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSFullWindowOverlayProps>();
     _props = defaultProps;
     [self _initCommon];
   }
@@ -162,10 +162,9 @@
   }
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<
-      facebook::react::RNSFullWindowOverlayComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSFullWindowOverlayComponentDescriptor>();
 }
 
 - (void)prepareForRecycle
@@ -193,8 +192,8 @@
   [childComponentView removeFromSuperview];
 }
 
-- (void)updateLayoutMetrics:(facebook::react::LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(facebook::react::LayoutMetrics const &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(react::LayoutMetrics const &)layoutMetrics
+           oldLayoutMetrics:(react::LayoutMetrics const &)oldLayoutMetrics
 {
   CGRect frame = RCTCGRectFromRect(layoutMetrics.frame);
   _reactFrame = frame;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -8,9 +8,13 @@
 #import <React/RCTViewComponentView.h>
 #else
 #import <React/RCTView.h>
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
 
 NS_ASSUME_NONNULL_BEGIN
+
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
 
 @interface RCTConvert (RNSScreen)
 
@@ -88,8 +92,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #ifdef RCT_NEW_ARCH_ENABLED
 // we recreate the behavior of `reactSetFrame` on new architecture
-@property (nonatomic) facebook::react::LayoutMetrics oldLayoutMetrics;
-@property (nonatomic) facebook::react::LayoutMetrics newLayoutMetrics;
+@property (nonatomic) react::LayoutMetrics oldLayoutMetrics;
+@property (nonatomic) react::LayoutMetrics newLayoutMetrics;
 @property (weak, nonatomic) RNSScreenStackHeaderConfig *config;
 @property (nonatomic, readonly) BOOL hasHeaderConfig;
 #else

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -24,6 +24,10 @@
 #import "RNSScreenStack.h"
 #import "RNSScreenStackHeaderConfig.h"
 
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
+
 @interface RNSScreenView ()
 #ifdef RCT_NEW_ARCH_ENABLED
     <RCTRNSScreenViewProtocol, UIAdaptivePresentationControllerDelegate>
@@ -36,7 +40,7 @@
   __weak RCTBridge *_bridge;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
-  facebook::react::RNSScreenShadowNode::ConcreteState::Shared _state;
+  react::RNSScreenShadowNode::ConcreteState::Shared _state;
   // on fabric, they are not available by default so we need them exposed here too
   NSMutableArray<UIView *> *_reactSubviews;
 #else
@@ -49,7 +53,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSScreenProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSScreenProps>();
     _props = defaultProps;
     _reactSubviews = [NSMutableArray new];
     [self initCommonProps];
@@ -102,7 +106,7 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_state != nullptr) {
-    auto newState = facebook::react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size)};
+    auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size)};
     _state->updateState(std::move(newState));
     UINavigationController *navctr = _controller.navigationController;
     [navctr.view setNeedsLayout];
@@ -283,8 +287,8 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onDismissed(facebook::react::RNSScreenEventEmitter::OnDismissed{.dismissCount = dismissCount});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onDismissed(react::RNSScreenEventEmitter::OnDismissed{.dismissCount = dismissCount});
   }
 #else
   // TODO: hopefully problems connected to dismissed prop are only the case on paper
@@ -305,9 +309,9 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
         ->onNativeDismissCancelled(
-            facebook::react::RNSScreenEventEmitter::OnNativeDismissCancelled{.dismissCount = dismissCount});
+            react::RNSScreenEventEmitter::OnNativeDismissCancelled{.dismissCount = dismissCount});
   }
 #else
   if (self.onNativeDismissCancelled) {
@@ -322,8 +326,8 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onWillAppear(facebook::react::RNSScreenEventEmitter::OnWillAppear{});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onWillAppear(react::RNSScreenEventEmitter::OnWillAppear{});
   }
   [self updateLayoutMetrics:_newLayoutMetrics oldLayoutMetrics:_oldLayoutMetrics];
 #else
@@ -345,8 +349,8 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onWillDisappear(facebook::react::RNSScreenEventEmitter::OnWillDisappear{});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onWillDisappear(react::RNSScreenEventEmitter::OnWillDisappear{});
   }
 #else
   if (self.onWillDisappear) {
@@ -361,8 +365,8 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onAppear(facebook::react::RNSScreenEventEmitter::OnAppear{});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onAppear(react::RNSScreenEventEmitter::OnAppear{});
   }
 #else
   if (self.onAppear) {
@@ -381,8 +385,8 @@
   // If screen is already unmounted then there will be no event emitter
   // it will be cleaned in prepareForRecycle
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onDisappear(facebook::react::RNSScreenEventEmitter::OnDisappear{});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onDisappear(react::RNSScreenEventEmitter::OnDisappear{});
   }
 #else
   if (self.onDisappear) {
@@ -395,8 +399,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onGestureCancel(facebook::react::RNSScreenEventEmitter::OnGestureCancel{});
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onGestureCancel(react::RNSScreenEventEmitter::OnGestureCancel{});
   }
 #else
   if (self.onGestureCancel) {
@@ -467,8 +471,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onTransitionProgress(facebook::react::RNSScreenEventEmitter::OnTransitionProgress{
+    std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
+        ->onTransitionProgress(react::RNSScreenEventEmitter::OnTransitionProgress{
             .progress = progress, .closing = closing ? 1 : 0, .goingForward = goingForward ? 1 : 0});
   }
   RNSScreenViewEvent *event = [[RNSScreenViewEvent alloc] initWithEventName:@"onTransitionProgress"
@@ -602,9 +606,9 @@
   return _config != nil;
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<facebook::react::RNSScreenComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenComponentDescriptor>();
 }
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
@@ -649,11 +653,10 @@
   _stackPresentation = RNSScreenStackPresentationPush;
 }
 
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps
+- (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::Shared const &)oldProps
 {
-  const auto &oldScreenProps = *std::static_pointer_cast<const facebook::react::RNSScreenProps>(_props);
-  const auto &newScreenProps = *std::static_pointer_cast<const facebook::react::RNSScreenProps>(props);
+  const auto &oldScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(_props);
+  const auto &newScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(props);
 
   [self setFullScreenSwipeEnabled:newScreenProps.fullScreenSwipeEnabled];
 
@@ -732,14 +735,13 @@
   [super updateProps:props oldProps:oldProps];
 }
 
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState
+- (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState
 {
-  _state = std::static_pointer_cast<const facebook::react::RNSScreenShadowNode::ConcreteState>(state);
+  _state = std::static_pointer_cast<const react::RNSScreenShadowNode::ConcreteState>(state);
 }
 
-- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
-           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
 {
   _newLayoutMetrics = layoutMetrics;
   _oldLayoutMetrics = oldLayoutMetrics;

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -6,7 +6,10 @@
 #import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#endif
+
+namespace react = facebook::react;
+
+#endif // RCT_NEW_ARCH_ENABLED
 
 @implementation RNSViewController
 
@@ -59,7 +62,7 @@
 {
   if (self = [super init]) {
 #ifdef RCT_NEW_ARCH_ENABLED
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSScreenContainerProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSScreenContainerProps>();
     _props = defaultProps;
 #endif
     _activeScreens = [NSMutableSet new];
@@ -235,7 +238,7 @@
   _controller.view.frame = self.bounds;
   for (RNSScreenView *subview in _reactSubviews) {
 #ifdef RCT_NEW_ARCH_ENABLED
-    facebook::react::LayoutMetrics screenLayoutMetrics = subview.newLayoutMetrics;
+    react::LayoutMetrics screenLayoutMetrics = subview.newLayoutMetrics;
     screenLayoutMetrics.frame = RCTRectFromCGRect(CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height));
     [subview updateLayoutMetrics:screenLayoutMetrics oldLayoutMetrics:subview.oldLayoutMetrics];
 #else
@@ -267,7 +270,7 @@
 
   [_reactSubviews insertObject:screenView atIndex:index];
   screenView.reactSuperview = self;
-  facebook::react::LayoutMetrics screenLayoutMetrics = screenView.newLayoutMetrics;
+  react::LayoutMetrics screenLayoutMetrics = screenView.newLayoutMetrics;
   screenLayoutMetrics.frame = RCTRectFromCGRect(CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height));
   [screenView updateLayoutMetrics:screenLayoutMetrics oldLayoutMetrics:screenView.oldLayoutMetrics];
   [self markChildUpdated];
@@ -295,9 +298,9 @@
   [self markChildUpdated];
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<facebook::react::RNSScreenContainerComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenContainerComponentDescriptor>();
 }
 
 - (void)prepareForRecycle

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -6,7 +6,9 @@
 #import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#endif
+
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
 
 @implementation RNSContainerNavigationController
 
@@ -37,10 +39,9 @@
 
 #pragma mark-- Fabric specific
 #ifdef RCT_NEW_ARCH_ENABLED
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<
-      facebook::react::RNSScreenNavigationContainerComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenNavigationContainerComponentDescriptor>();
 }
 #endif
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -22,6 +22,10 @@
 #import "RNSScreenStackHeaderConfig.h"
 #import "RNSScreenWindowTraits.h"
 
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
+
 @interface RNSScreenStackView () <
     UINavigationControllerDelegate,
     UIAdaptivePresentationControllerDelegate,
@@ -102,7 +106,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSScreenStackProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSScreenStackProps>();
     _props = defaultProps;
     [self initCommonProps];
   }
@@ -159,8 +163,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSScreenStackEventEmitter>(_eventEmitter)
-        ->onFinishTransitioning(facebook::react::RNSScreenStackEventEmitter::OnFinishTransitioning{});
+    std::dynamic_pointer_cast<const react::RNSScreenStackEventEmitter>(_eventEmitter)
+        ->onFinishTransitioning(react::RNSScreenStackEventEmitter::OnFinishTransitioning{});
   }
 #else
   if (self.onFinishTransitioning) {
@@ -1003,12 +1007,11 @@
   _snapshot = [_controller.visibleViewController.view snapshotViewAfterScreenUpdates:NO];
 }
 
-- (void)mountingTransactionWillMount:(facebook::react::MountingTransaction const &)transaction
-                withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry
+- (void)mountingTransactionWillMount:(react::MountingTransaction const &)transaction
+                withSurfaceTelemetry:(react::SurfaceTelemetry const &)surfaceTelemetry
 {
   for (auto &mutation : transaction.getMutations()) {
-    if (mutation.type == facebook::react::ShadowViewMutation::Type::Remove &&
-        mutation.parentShadowView.componentName != nil &&
+    if (mutation.type == react::ShadowViewMutation::Type::Remove && mutation.parentShadowView.componentName != nil &&
         strcmp(mutation.parentShadowView.componentName, "RNSScreenStack") == 0) {
       [self takeSnapshot];
       return;
@@ -1032,9 +1035,9 @@
   [_controller setViewControllers:@[ [UIViewController new] ]];
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<facebook::react::RNSScreenStackComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenStackComponentDescriptor>();
 }
 #else
 #pragma mark - Paper specific

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -25,7 +25,7 @@
 #import "RNSUIBarButtonItem.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
-namespace rct = facebook::react;
+namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
 #ifndef RCT_NEW_ARCH_ENABLED
@@ -64,7 +64,7 @@ namespace rct = facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const rct::RNSScreenStackHeaderConfigProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSScreenStackHeaderConfigProps>();
     _props = defaultProps;
     _show = YES;
     _translucent = NO;
@@ -315,7 +315,7 @@ namespace rct = facebook::react;
                   scale:imageSource.scale
 #ifdef RCT_NEW_ARCH_ENABLED
              resizeMode:resizeModeFromCppEquiv(
-                            std::static_pointer_cast<const rct::ImageProps>(imageView.props)->resizeMode)];
+                            std::static_pointer_cast<const react::ImageProps>(imageView.props)->resizeMode)];
 #else
              resizeMode:imageView.resizeMode];
 #endif // RCT_NEW_ARCH_ENABLED
@@ -704,18 +704,18 @@ namespace rct = facebook::react;
   [childComponentView removeFromSuperview];
 }
 
-static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
+static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 {
   switch (resizeMode) {
-    case rct::ImageResizeMode::Cover:
+    case react::ImageResizeMode::Cover:
       return RCTResizeModeCover;
-    case rct::ImageResizeMode::Contain:
+    case react::ImageResizeMode::Contain:
       return RCTResizeModeContain;
-    case rct::ImageResizeMode::Stretch:
+    case react::ImageResizeMode::Stretch:
       return RCTResizeModeStretch;
-    case rct::ImageResizeMode::Center:
+    case react::ImageResizeMode::Center:
       return RCTResizeModeCenter;
-    case rct::ImageResizeMode::Repeat:
+    case react::ImageResizeMode::Repeat:
       return RCTResizeModeRepeat;
   }
 }
@@ -726,8 +726,8 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
  */
 + (RCTImageSource *)imageSourceFromImageView:(RCTImageComponentView *)view
 {
-  auto const imageProps = *std::static_pointer_cast<const rct::ImageProps>(view.props);
-  rct::ImageSource cppImageSource = imageProps.sources.at(0);
+  auto const imageProps = *std::static_pointer_cast<const react::ImageProps>(view.props);
+  react::ImageSource cppImageSource = imageProps.sources.at(0);
   auto imageSize = CGSize{cppImageSource.size.width, cppImageSource.size.height};
   NSURLRequest *request =
       [NSURLRequest requestWithURL:[NSURL URLWithString:RCTNSStringFromStringNilIfEmpty(cppImageSource.uri)]];
@@ -745,9 +745,9 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
   _initialPropsSet = NO;
 }
 
-+ (rct::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return rct::concreteComponentDescriptorProvider<rct::RNSScreenStackHeaderConfigComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenStackHeaderConfigComponentDescriptor>();
 }
 
 - (NSNumber *)getFontSizePropValue:(int)value
@@ -757,20 +757,20 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
   return nil;
 }
 
-- (UISemanticContentAttribute)getDirectionPropValue:(rct::RNSScreenStackHeaderConfigDirection)direction
+- (UISemanticContentAttribute)getDirectionPropValue:(react::RNSScreenStackHeaderConfigDirection)direction
 {
   switch (direction) {
-    case rct::RNSScreenStackHeaderConfigDirection::Rtl:
+    case react::RNSScreenStackHeaderConfigDirection::Rtl:
       return UISemanticContentAttributeForceRightToLeft;
-    case rct::RNSScreenStackHeaderConfigDirection::Ltr:
+    case react::RNSScreenStackHeaderConfigDirection::Ltr:
       return UISemanticContentAttributeForceLeftToRight;
   }
 }
 
-- (void)updateProps:(rct::Props::Shared const &)props oldProps:(rct::Props::Shared const &)oldProps
+- (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::Shared const &)oldProps
 {
-  const auto &oldScreenProps = *std::static_pointer_cast<const rct::RNSScreenStackHeaderConfigProps>(_props);
-  const auto &newScreenProps = *std::static_pointer_cast<const rct::RNSScreenStackHeaderConfigProps>(props);
+  const auto &oldScreenProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderConfigProps>(_props);
+  const auto &newScreenProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderConfigProps>(props);
 
   BOOL needsNavigationControllerLayout = !_initialPropsSet;
 
@@ -832,7 +832,7 @@ static RCTResizeMode resizeModeFromCppEquiv(rct::ImageResizeMode resizeMode)
   }
 
   _initialPropsSet = YES;
-  _props = std::static_pointer_cast<rct::RNSScreenStackHeaderConfigProps const>(props);
+  _props = std::static_pointer_cast<react::RNSScreenStackHeaderConfigProps const>(props);
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -8,7 +8,11 @@
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
+
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
 
 @interface RCTBridge (Private)
 + (RCTBridge *)currentBridge;
@@ -25,7 +29,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSScreenStackHeaderSubviewProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSScreenStackHeaderSubviewProps>();
     _props = defaultProps;
   }
 
@@ -39,24 +43,21 @@
   [super prepareForRecycle];
 }
 
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps
+- (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::Shared const &)oldProps
 {
-  const auto &newHeaderSubviewProps =
-      *std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderSubviewProps>(props);
+  const auto &newHeaderSubviewProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewProps>(props);
 
   [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
   [super updateProps:props oldProps:oldProps];
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<
-      facebook::react::RNSScreenStackHeaderSubviewComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSScreenStackHeaderSubviewComponentDescriptor>();
 }
 
-- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
-           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
 {
   CGRect frame = RCTCGRectFromRect(layoutMetrics.frame);
   // CALayer will crash if we pass NaN or Inf values.

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -13,7 +13,11 @@
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import "RNSConvert.h"
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
+
+#ifdef RCT_NEW_ARCH_ENABLED
+namespace react = facebook::react;
+#endif // RCT_NEW_ARCH_ENABLED
 
 @implementation RNSSearchBar {
   __weak RCTBridge *_bridge;
@@ -36,7 +40,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    static const auto defaultProps = std::make_shared<const facebook::react::RNSSearchBarProps>();
+    static const auto defaultProps = std::make_shared<const react::RNSSearchBarProps>();
     _props = defaultProps;
     [self initCommonProps];
   }
@@ -56,8 +60,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSSearchBarEventEmitter>(_eventEmitter)
-        ->onFocus(facebook::react::RNSSearchBarEventEmitter::OnFocus{});
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
+        ->onFocus(react::RNSSearchBarEventEmitter::OnFocus{});
   }
 #else
   if (self.onFocus) {
@@ -70,8 +74,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSSearchBarEventEmitter>(_eventEmitter)
-        ->onBlur(facebook::react::RNSSearchBarEventEmitter::OnBlur{});
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
+        ->onBlur(react::RNSSearchBarEventEmitter::OnBlur{});
   }
 #else
   if (self.onBlur) {
@@ -84,9 +88,9 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSSearchBarEventEmitter>(_eventEmitter)
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
         ->onSearchButtonPress(
-            facebook::react::RNSSearchBarEventEmitter::OnSearchButtonPress{.text = RCTStringFromNSString(text)});
+            react::RNSSearchBarEventEmitter::OnSearchButtonPress{.text = RCTStringFromNSString(text)});
   }
 #else
   if (self.onSearchButtonPress) {
@@ -101,8 +105,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSSearchBarEventEmitter>(_eventEmitter)
-        ->onCancelButtonPress(facebook::react::RNSSearchBarEventEmitter::OnCancelButtonPress{});
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
+        ->onCancelButtonPress(react::RNSSearchBarEventEmitter::OnCancelButtonPress{});
   }
 #else
   if (self.onCancelButtonPress) {
@@ -115,8 +119,8 @@
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
-    std::dynamic_pointer_cast<const facebook::react::RNSSearchBarEventEmitter>(_eventEmitter)
-        ->onChangeText(facebook::react::RNSSearchBarEventEmitter::OnChangeText{.text = RCTStringFromNSString(text)});
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
+        ->onChangeText(react::RNSSearchBarEventEmitter::OnChangeText{.text = RCTStringFromNSString(text)});
   }
 #else
   if (self.onChangeText) {
@@ -299,11 +303,10 @@
 #pragma mark-- Fabric specific
 
 #ifdef RCT_NEW_ARCH_ENABLED
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps
+- (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::Shared const &)oldProps
 {
-  const auto &oldScreenProps = *std::static_pointer_cast<const facebook::react::RNSSearchBarProps>(_props);
-  const auto &newScreenProps = *std::static_pointer_cast<const facebook::react::RNSSearchBarProps>(props);
+  const auto &oldScreenProps = *std::static_pointer_cast<const react::RNSSearchBarProps>(_props);
+  const auto &newScreenProps = *std::static_pointer_cast<const react::RNSSearchBarProps>(props);
 
   [self setHideWhenScrolling:newScreenProps.hideWhenScrolling];
 
@@ -346,9 +349,9 @@
   [super updateProps:props oldProps:oldProps];
 }
 
-+ (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return facebook::react::concreteComponentDescriptorProvider<facebook::react::RNSSearchBarComponentDescriptor>();
+  return react::concreteComponentDescriptorProvider<react::RNSSearchBarComponentDescriptor>();
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args


### PR DESCRIPTION
## Description

1. Typing `facebook::react` is tedious (XCode completion does not work correctly in case of namespaces for some reason I do not want to spend any more time investigating)
2. `facebook` prefix does not convey any useful meaning from the perspective of this library -- we can achieve the same code-isolation by using just `react` or `rct`
3. We can not resign completely from using this prefix (by putting `using namespace facebook::react` in our `.mm` files) because some C++ codegened types have the same names as their counterparts from Objective-C and we need to distinguish between them (take a look into `RNSConvert.h`).

## Changes

Replace all usages of `facebook::react::` with `react::`.

Added `namespace react = facebook::react;` where necessary.

## Checklist

- [ ] Ensured that CI passes
