### PR TITLE
fix(iOS): add missing iOS API availbility checks

### DIFF
--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -21,8 +21,11 @@
 @property (nonatomic) RNSSearchBarPlacement placement;
 @property (nonatomic, retain) UISearchController *controller;
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0 && !TARGET_OS_TV
 - (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement API_AVAILABLE(ios(16.0))
     API_UNAVAILABLE(tvos, watchos);
+#endif // Check for iOS >= 16 && !TARGET_OS_TV
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #else

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -213,6 +213,8 @@ namespace react = facebook::react;
 #endif
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0 && !TARGET_OS_TV
 - (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement API_AVAILABLE(ios(16.0))
     API_UNAVAILABLE(tvos, watchos)
 {
@@ -225,6 +227,7 @@ namespace react = facebook::react;
       return UINavigationItemSearchBarPlacementInline;
   }
 }
+#endif // Check for iOS >= 16 && !TARGET_OS_TV
 
 #pragma mark delegate methods
 

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -213,7 +213,8 @@ namespace react = facebook::react;
 #endif
 }
 
-- (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement
+- (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement API_AVAILABLE(ios(16.0))
+    API_UNAVAILABLE(tvos, watchos)
 {
   switch (_placement) {
     case RNSSearchBarPlacementStacked:


### PR DESCRIPTION
## Description

When adding 

https://github.com/software-mansion/react-native-screens/pull/1843

I've forgotten to add API avaibility checks for method definitions (usage and declarations were guarded). This caused build problems when deploying for lower iOS versions.

Fixes #1859

## Changes

Added missing availbility checks.

## Test code and steps to reproduce

Build iOS without having iOS 16 installed (or somehow disabled?).

## Checklist

- [x] Ensured that CI passes
