### PR TITLE
chore: reinstall deps & pods in example apps after release

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -364,7 +364,7 @@ PODS:
     - React
   - RNGestureHandler (2.12.0):
     - React-Core
-  - RNScreens (3.22.1):
+  - RNScreens (3.24.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (8.1.0):
@@ -587,7 +587,7 @@ SPEC CHECKSUMS:
   ReactCommon: 1e783348b9aa73ae68236271df972ba898560a95
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
-  RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
+  RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1109,7 +1109,7 @@ PODS:
     - React-jsi (= 0.72.3)
     - React-logger (= 0.72.3)
     - React-perflogger (= 0.72.3)
-  - RNScreens (3.23.0):
+  - RNScreens (3.24.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1117,8 +1117,8 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.23.0)
-  - RNScreens/common (3.23.0):
+    - RNScreens/common (= 3.24.0)
+  - RNScreens/common (3.24.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1365,7 +1365,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 837c1bebd2f84572db17698cd702ceaf585b0d9a
   React-utils: bcb57da67eec2711f8b353f6e3d33bd8e4b2efa3
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
-  RNScreens: 95b62f9fb2aa427d7c1a2a2d127a72edb7450390
+  RNScreens: e114ddbc9b91fbde662870c4256196ab0833314b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/FabricTestExample/ios/Podfile.lock
+++ b/FabricTestExample/ios/Podfile.lock
@@ -1147,7 +1147,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.23.0):
+  - RNScreens (3.24.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1155,8 +1155,8 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.23.0)
-  - RNScreens/common (3.23.0):
+    - RNScreens/common (= 3.24.0)
+  - RNScreens/common (3.24.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1411,7 +1411,7 @@ SPEC CHECKSUMS:
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
   RNGestureHandler: d8224aad6d7081834ae6e6cf925397059485b69e
   RNReanimated: 3ce2aec600ad2ef47a5927abf2742329d7a190e9
-  RNScreens: 95b62f9fb2aa427d7c1a2a2d127a72edb7450390
+  RNScreens: e114ddbc9b91fbde662870c4256196ab0833314b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/TestsExample/ios/Podfile.lock
+++ b/TestsExample/ios/Podfile.lock
@@ -518,7 +518,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.23.0):
+  - RNScreens (3.24.0):
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.1)
@@ -755,7 +755,7 @@ SPEC CHECKSUMS:
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNReanimated: 020859659f64be2d30849a1fe88c821a7c3e0cbf
-  RNScreens: 6a8a3c6b808aa48dca1780df7b73ea524f602c63
+  RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a


### PR DESCRIPTION
## Description

Reinstalling pods & deps in example apps after `3.24.0` was released, so that `Podfile.lock` is up to date on any new branch.

## Test code and steps to reproduce

Create new branch, reinstall pods and notice that no changes were generated in `Podfile.lock`.


TODO: We should really make CI for this


## Checklist

- [ ] Ensured that CI passes
