### PR TITLE
chore(Android): migrate from deprecated `RCTEventEmitter`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -296,9 +296,10 @@ open class ScreenFragment : Fragment {
             // we only send dismissed even when the screen has been removed from its container
             val screenContext = screen.context
             if (screenContext is ReactContext) {
+                val surfaceId = UIManagerHelper.getSurfaceId(screenContext)
                 UIManagerHelper
                     .getEventDispatcherForReactTag(screenContext, screen.id)
-                    ?.dispatchEvent(ScreenDismissedEvent(screen.id))
+                    ?.dispatchEvent(ScreenDismissedEvent(surfaceId, screen.id))
             }
         }
         mChildScreenContainers.clear()

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -194,9 +194,9 @@ open class ScreenFragment : Fragment {
                 fragment.setLastEventDispatched(event)
                 val surfaceId = UIManagerHelper.getSurfaceId(it)
                 val lifecycleEvent: Event<*> = when (event) {
-                    ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(it.id)
+                    ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(surfaceId, it.id)
                     ScreenLifecycleEvent.Appear -> ScreenAppearEvent(surfaceId, it.id)
-                    ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(it.id)
+                    ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(surfaceId, it.id)
                     ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(surfaceId, it.id)
                 }
                 val screenContext = screen.context as ReactContext
@@ -239,6 +239,7 @@ open class ScreenFragment : Fragment {
                     .getEventDispatcherForReactTag(screenContext, screen.id)
                     ?.dispatchEvent(
                         ScreenTransitionProgressEvent(
+                            UIManagerHelper.getSurfaceId(screenContext),
                             screen.id, mProgress, closing, goingForward, coalescingKey
                         )
                     )

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -192,9 +192,10 @@ open class ScreenFragment : Fragment {
         if (fragment is ScreenStackFragment && fragment.canDispatchEvent(event)) {
             fragment.screen.let {
                 fragment.setLastEventDispatched(event)
+                val surfaceId = UIManagerHelper.getSurfaceId(it)
                 val lifecycleEvent: Event<*> = when (event) {
                     ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(it.id)
-                    ScreenLifecycleEvent.Appear -> ScreenAppearEvent(it.id)
+                    ScreenLifecycleEvent.Appear -> ScreenAppearEvent(surfaceId, it.id)
                     ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(it.id)
                     ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(it.id)
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -215,9 +215,10 @@ open class ScreenFragment : Fragment {
 
     fun dispatchHeaderBackButtonClickedEvent() {
         val screenContext = screen.context as ReactContext
+        val surfaceId = UIManagerHelper.getSurfaceId(screenContext)
         UIManagerHelper
             .getEventDispatcherForReactTag(screenContext, screen.id)
-            ?.dispatchEvent(HeaderBackButtonClickedEvent(screen.id))
+            ?.dispatchEvent(HeaderBackButtonClickedEvent(surfaceId, screen.id))
     }
 
     fun dispatchTransitionProgress(alpha: Float, closing: Boolean) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -197,7 +197,7 @@ open class ScreenFragment : Fragment {
                     ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(it.id)
                     ScreenLifecycleEvent.Appear -> ScreenAppearEvent(surfaceId, it.id)
                     ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(it.id)
-                    ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(it.id)
+                    ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(surfaceId, it.id)
                 }
                 val screenContext = screen.context as ReactContext
                 val eventDispatcher: EventDispatcher? =

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -64,9 +64,10 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
     }
 
     private fun dispatchOnFinishTransitioning() {
+        val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper
             .getEventDispatcherForReactTag((context as ReactContext), id)
-            ?.dispatchEvent(StackFinishTransitioningEvent(id))
+            ?.dispatchEvent(StackFinishTransitioningEvent(surfaceId, id))
     }
 
     override fun removeScreenAt(index: Int) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -76,8 +76,9 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         mIsAttachedToWindow = true
+        val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
-            ?.dispatchEvent(HeaderAttachedEvent(id))
+            ?.dispatchEvent(HeaderAttachedEvent(surfaceId, id))
         // we want to save the top inset before the status bar can be hidden, which would resolve in
         // inset being 0
         if (headerTopInset == null) {
@@ -93,8 +94,9 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         mIsAttachedToWindow = false
+        val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
-            ?.dispatchEvent(HeaderDetachedEvent(id))
+            ?.dispatchEvent(HeaderDetachedEvent(surfaceId, id))
     }
 
     private val screen: Screen?

--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
@@ -101,23 +101,23 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     }
 
     private fun handleTextChange(newText: String?) {
-        sendEvent(SearchBarChangeTextEvent(id, newText))
+        sendEvent(SearchBarChangeTextEvent(surfaceId, id, newText))
     }
 
     private fun handleFocusChange(hasFocus: Boolean) {
-        sendEvent(if (hasFocus) SearchBarFocusEvent(id) else SearchBarBlurEvent(id))
+        sendEvent(if (hasFocus) SearchBarFocusEvent(surfaceId, id) else SearchBarBlurEvent(surfaceId, id))
     }
 
     private fun handleClose() {
-        sendEvent(SearchBarCloseEvent(id))
+        sendEvent(SearchBarCloseEvent(surfaceId, id))
     }
 
     private fun handleOpen() {
-        sendEvent(SearchBarOpenEvent(id))
+        sendEvent(SearchBarOpenEvent(surfaceId, id))
     }
 
     private fun handleTextSubmit(newText: String?) {
-        sendEvent(SearchBarSearchButtonPressEvent(id, newText))
+        sendEvent(SearchBarSearchButtonPressEvent(surfaceId, id, newText))
     }
 
     private fun sendEvent(event: Event<*>) {
@@ -143,6 +143,8 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     fun handleSetTextJsRequest(text: String?) {
         text?.let { screenStackFragment?.searchView?.setText(it) }
     }
+
+    private val surfaceId = UIManagerHelper.getSurfaceId(this)
 
     enum class SearchBarAutoCapitalize {
         NONE, WORDS, SENTENCES, CHARACTERS

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class HeaderAttachedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class HeaderAttachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class HeaderAttachedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topAttached"

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class HeaderBackButtonClickedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class HeaderBackButtonClickedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class HeaderBackButtonClickedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewI
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topHeaderBackButtonClickedEvent"

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class HeaderDetachedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class HeaderDetachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class HeaderDetachedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topDetached"

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenAppearEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenAppearEvent.kt
@@ -1,18 +1,16 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class ScreenAppearEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class ScreenAppearEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topAppear"

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt
@@ -3,7 +3,6 @@ package com.swmansion.rnscreens.events
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenDisappearEvent(surfaceId: Int, viewId: Int) : Event<ScreenDisappearEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenDisappearEvent.kt
@@ -1,18 +1,17 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class ScreenDisappearEvent(viewId: Int) : Event<ScreenDisappearEvent>(viewId) {
+class ScreenDisappearEvent(surfaceId: Int, viewId: Int) : Event<ScreenDisappearEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topDisappear"

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenDismissedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenDismissedEvent.kt
@@ -1,20 +1,17 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class ScreenDismissedEvent(viewId: Int) : Event<ScreenDismissedEvent>(viewId) {
+class ScreenDismissedEvent(surfaceId: Int, viewId: Int) : Event<ScreenDismissedEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        val args = Arguments.createMap()
-        // on Android we always dismiss one screen at a time
-        args.putInt("dismissCount", 1)
-        rctEventEmitter.receiveEvent(viewTag, eventName, args)
+    override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+        putInt("dismissCount", 1)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
@@ -1,16 +1,17 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenTransitionProgressEvent(
+    surfaceId: Int,
     viewId: Int,
     private val mProgress: Float,
     private val mClosing: Boolean,
     private val mGoingForward: Boolean,
     private val mCoalescingKey: Short
-) : Event<ScreenAppearEvent?>(viewId) {
+) : Event<ScreenAppearEvent?>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -19,12 +20,10 @@ class ScreenTransitionProgressEvent(
         return mCoalescingKey
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        val map = Arguments.createMap()
-        map.putDouble("progress", mProgress.toDouble())
-        map.putInt("closing", if (mClosing) 1 else 0)
-        map.putInt("goingForward", if (mGoingForward) 1 else 0)
-        rctEventEmitter.receiveEvent(viewTag, eventName, map)
+    override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+        putDouble("progress", mProgress.toDouble())
+        putInt("closing", if (mClosing) 1 else 0)
+        putInt("goingForward", if (mGoingForward) 1 else 0)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillAppearEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillAppearEvent.kt
@@ -1,18 +1,16 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class ScreenWillAppearEvent(viewId: Int) : Event<ScreenWillAppearEvent>(viewId) {
+class ScreenWillAppearEvent(surfaceId: Int, viewId: Int) : Event<ScreenWillAppearEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topWillAppear"

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillDisappearEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenWillDisappearEvent.kt
@@ -1,18 +1,16 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class ScreenWillDisappearEvent(viewId: Int) : Event<ScreenWillDisappearEvent>(viewId) {
+class ScreenWillDisappearEvent(surfaceId: Int, viewId: Int) : Event<ScreenWillDisappearEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topWillDisappear"

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class SearchBarBlurEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class SearchBarBlurEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class SearchBarBlurEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topBlur"

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
@@ -1,13 +1,14 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class SearchBarChangeTextEvent(
+    surfaceId: Int,
     viewId: Int,
     private val text: String?,
-) : Event<ScreenAppearEvent>(viewId) {
+) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -17,10 +18,8 @@ class SearchBarChangeTextEvent(
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        val map = Arguments.createMap()
-        map.putString("text", text)
-        rctEventEmitter.receiveEvent(viewTag, eventName, map)
+    override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+        putString("text", text)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class SearchBarCloseEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class SearchBarCloseEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class SearchBarCloseEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topClose"

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class SearchBarFocusEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class SearchBarFocusEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class SearchBarFocusEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topFocus"

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class SearchBarOpenEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
+class SearchBarOpenEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,9 +14,7 @@ class SearchBarOpenEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topOpen"

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
@@ -1,10 +1,10 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class SearchBarSearchButtonPressEvent(viewId: Int, private val text: String?) : Event<ScreenAppearEvent>(viewId) {
+class SearchBarSearchButtonPressEvent(surfaceId: Int, viewId: Int, private val text: String?) : Event<ScreenAppearEvent>(surfaceId, viewId) {
     override fun getEventName(): String {
         return EVENT_NAME
     }
@@ -14,10 +14,8 @@ class SearchBarSearchButtonPressEvent(viewId: Int, private val text: String?) : 
         return 0
     }
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        val map = Arguments.createMap()
-        map.putString("text", text)
-        rctEventEmitter.receiveEvent(viewTag, eventName, map)
+    override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+        putString("text", text)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/StackFinishTransitioningEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/StackFinishTransitioningEvent.kt
@@ -1,18 +1,16 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class StackFinishTransitioningEvent(viewId: Int) : Event<StackFinishTransitioningEvent>(viewId) {
+class StackFinishTransitioningEvent(surfaceId: Int, viewId: Int) : Event<StackFinishTransitioningEvent>(surfaceId, viewId) {
     override fun getEventName() = EVENT_NAME
 
     // All events for a given view can be coalesced.
     override fun getCoalescingKey(): Short = 0
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-    }
+    override fun getEventData(): WritableMap? = Arguments.createMap()
 
     companion object {
         const val EVENT_NAME = "topFinishTransitioning"


### PR DESCRIPTION
## Description

Fixes #1759

`RCTEventEmitter` was deprecated over 3 years ago in [this commit](https://github.com/facebook/react-native/commit/2fbbdbb2ce897e8da3f471b08b93f167d566db1d)

I don't know when it will be finally deleted, but: 

1. There is no reason to wait for this moment with migration
2. According to the [commit message](https://github.com/facebook/react-native/commit/2fbbdbb2ce897e8da3f471b08b93f167d566db1d) there can be some minor performance improvements on Fabric
3. People complain on wall of warnings during build process

I inspected ReactNative's source code and it seems that parent class impl of `Event.dispatch` method we used up to this point calls `Event.getEventData` internally and if anything is returned it dispatches the event using appropriate event emitter ([see here](https://github.com/facebook/react-native/blob/e2ef6b98a061508bdd70a4c2747fe061c49b5c39/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java#L154-L168)).

**Note**: This PR breaks support for versions of `react-native` lower than `0.65.x`.

## Changes

In all event classes:

1. Removed `Event.dispatch` override
2. Overrided `Event.getEventData`
3. Added `surfaceId` to event ctor

In all event construction places: 

1. Resolved appropriate (🤞🏻) `surfaceId`
2. Updated event construction



## Test code and steps to reproduce

My empirical impression: it works as earlier.
My methodical attempt to test it: 

1. Add console logs to event handlers in `RouteView` in `src/native-stack/views/NativeStackView.tsx` use e.g. `Test1072` or different ones
5. Play around with text example
6. Notice that events are received in JS as expected. 

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Ensured that CI passes
