### PR TITLE
chore: migrate `replaceSystemWindowInsets` to `Builder.setSystemWindowInsets`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -9,6 +9,7 @@ import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Build
 import android.view.ViewParent
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -115,12 +116,21 @@ object ScreenWindowTraits {
                     if (translucent) {
                         ViewCompat.setOnApplyWindowInsetsListener(decorView) { v, insets ->
                             val defaultInsets = ViewCompat.onApplyWindowInsets(v, insets)
-                            defaultInsets.replaceSystemWindowInsets(
-                                defaultInsets.systemWindowInsetLeft,
-                                0,
-                                defaultInsets.systemWindowInsetRight,
-                                defaultInsets.systemWindowInsetBottom
-                            )
+                            val windowInsets =
+                                defaultInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+
+                            WindowInsetsCompat
+                                .Builder()
+                                .setInsets(
+                                    WindowInsetsCompat.Type.statusBars(),
+                                    Insets.of(
+                                        windowInsets.left,
+                                        0,
+                                        windowInsets.right,
+                                        windowInsets.bottom
+                                    )
+                                )
+                                .build()
                         }
                     } else {
                         ViewCompat.setOnApplyWindowInsetsListener(decorView, null)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -117,7 +117,7 @@ object ScreenWindowTraits {
                         ViewCompat.setOnApplyWindowInsetsListener(decorView) { v, insets ->
                             val defaultInsets = ViewCompat.onApplyWindowInsets(v, insets)
 
-                            if (Build.VERSION.SDK_INT >= 30) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                                 val windowInsets =
                                     defaultInsets.getInsets(WindowInsetsCompat.Type.statusBars())
 
@@ -133,6 +133,8 @@ object ScreenWindowTraits {
                                         )
                                     )
                                     .build()
+
+                                insets
                             } else {
                                 defaultInsets.replaceSystemWindowInsets(
                                     defaultInsets.systemWindowInsetLeft,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -116,21 +116,31 @@ object ScreenWindowTraits {
                     if (translucent) {
                         ViewCompat.setOnApplyWindowInsetsListener(decorView) { v, insets ->
                             val defaultInsets = ViewCompat.onApplyWindowInsets(v, insets)
-                            val windowInsets =
-                                defaultInsets.getInsets(WindowInsetsCompat.Type.statusBars())
 
-                            WindowInsetsCompat
-                                .Builder()
-                                .setInsets(
-                                    WindowInsetsCompat.Type.statusBars(),
-                                    Insets.of(
-                                        windowInsets.left,
-                                        0,
-                                        windowInsets.right,
-                                        windowInsets.bottom
+                            if (Build.VERSION.SDK_INT >= 30) {
+                                val windowInsets =
+                                    defaultInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+
+                                WindowInsetsCompat
+                                    .Builder()
+                                    .setInsets(
+                                        WindowInsetsCompat.Type.statusBars(),
+                                        Insets.of(
+                                            windowInsets.left,
+                                            0,
+                                            windowInsets.right,
+                                            windowInsets.bottom
+                                        )
                                     )
+                                    .build()
+                            } else {
+                                defaultInsets.replaceSystemWindowInsets(
+                                    defaultInsets.systemWindowInsetLeft,
+                                    0,
+                                    defaultInsets.systemWindowInsetRight,
+                                    defaultInsets.systemWindowInsetBottom
                                 )
-                                .build()
+                            }
                         }
                     } else {
                         ViewCompat.setOnApplyWindowInsetsListener(decorView, null)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -133,8 +133,6 @@ object ScreenWindowTraits {
                                         )
                                     )
                                     .build()
-
-                                insets
                             } else {
                                 defaultInsets.replaceSystemWindowInsets(
                                     defaultInsets.systemWindowInsetLeft,


### PR DESCRIPTION
## Description

`replaceSystemWindowInsets` is deprecated. Now it's recommended to use `WindowInsetsCompat.Builder().setInsets` so in this PR I'm adding this new API for Android API >= 30.

Feel free to test my changes because maybe I'm not aware about some specific logic behind `replaceSystemWindowInsets` API and these changes are introducing breaking changes (I hopefully it will not, but still better to double test) 🙌 

These changes were inspired by https://android-review.googlesource.com/c/platform/frameworks/support/+/1254619/1/viewpager/viewpager/src/main/java/androidx/viewpager/widget/ViewPager.java#440

## Changes

- started to use `Builder.setSystemWindowInsets` instead of `replaceSystemWindowInsets` for Android API >= 30

## Screenshots / GIFs

Nothing is changed from UI perspective 🙂 

## Test code and steps to reproduce

I've tested example application and didn't notice any regressions.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
