### PR TITLE
fix: full window overlay cannot receive tap when modal is full screen

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -127,9 +127,9 @@
   [window addSubview:_container];
 }
 
-- (void)didMoveToWindow
+- (void)didMoveToSuperview
 {
-  if (self.window == nil) {
+  if (self.superview == nil) {
     if (_container != nil) {
       [_container removeFromSuperview];
       [_touchHandler detachFromView:_container];


### PR DESCRIPTION
## Description
- `FullWindowOverlay` cannot receive tap events when it is shown on top of `UIModalPresentationFullScreen` Modal which is the default presentation style of the react native Modal.

- UIKit changes the layout hierarchy when the modal is full screen. It is mentioned in the below docs. The view does not move to the window if a full-screen modal is being presented. However, the `_container` moves to the window as it is appended explicitly using `addSubview` in the key window. 
- https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/PresentingaViewController.html


<img width="678" alt="Screenshot 2023-08-21 at 9 45 19 AM" src="https://github.com/software-mansion/react-native-screens/assets/23293248/f743dff1-8ba8-40bd-9016-4ae09a77847d">

- So the `RNSFullWindowOverlay` view gets attached to the superview but they are not moved to the window. This PR adds a simple fix to replace `didMoveToWindow` with `didMoveToSuperview`. I considered an approach to move `didMoveToWindow` in the `RNSFullWindowOverlayContainer` but I don't see any potential issues with the current approach. Let me know.
<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
Attach touch handlers to the container in `didMoveToSuperview` instead of `didMoveToWindow`
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before
Touch events don't work on Views under FullWindowOverlay

### After
Touch events should work on Views under FullWindowOverlay

-->

## Test code and steps to reproduce

Run the below snack on iOS.

- https://snack.expo.dev/@nishanbende/fullwindowoverlay-tap-events-on-full-screen-modal

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes

