### PR TITLE
fix(Android): Change implementation of `headerConfig` prop on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -8,6 +8,7 @@ import android.util.SparseArray
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
+import androidx.core.view.children
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerModule
@@ -84,7 +85,15 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
     }
 
     val headerConfig: ScreenStackHeaderConfig?
-        get() = getChildAt(0) as? ScreenStackHeaderConfig
+        get() {
+            for (child in children) {
+                if (child is ScreenStackHeaderConfig) {
+                    return child
+                }
+            }
+
+            return null
+        }
 
     /**
      * While transitioning this property allows to optimize rendering behavior on Android and provide


### PR DESCRIPTION
## Description

It looks like the change introduced in #1825 has also came with a bug where at least Search Bar was not working on Android.
The reason for that has turned out to be the wrong implementation of `headerConfig` property on Android, which was looking for the first child and assuming that it is ScreenStackHeaderConfig - which was wrong, because the change in #1825 has moved the ScreenStackHeaderConfig to the bottom of the hierarchy.

Fixes not working Search Bar on Android (and some other unknown things maybe?).

## Changes

From now `Screen#headerConfig` will traverse through all children of the View and will check if one of them is `ScreenStackHeaderConfig`.

## Test code and steps to reproduce

You can check Test1166 if SearchBar is working right now; from now the Search Bar in Example section should work properly.

## Checklist

- [ ] Ensured that CI passes
