### PR TITLE
chore: remove MaxPerm args from JVM invocation

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Description

MaxPerm option does not work with Java version >= 17 and it was deprecated many many years ago (looks like it was ignored [since Java 8](https://stackoverflow.com/questions/12114174/what-does-xxmaxpermsize-do))
and recently it was completely removed (using it throws an error). 

From the information I've gathered in "recent" Java versions (>= 8) permament generation space size is not limited thus this options is redundant.

## Changes

Removed `-XX:MaxPermSize=512m` arg from gradle deamon invocation.

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes
