### PR TITLE
chore: bump library native Android deps & config

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"
-        kotlinVersion = "1.6.21"
+        kotlinVersion = "1.8.22"
     }
     repositories {
         google()

--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
+        kotlinVersion = "1.8.22"
     }
     repositories {
         google()

--- a/FabricTestExample/android/build.gradle
+++ b/FabricTestExample/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
+        kotlinVersion = "1.8.22"
     }
     repositories {
         google()

--- a/TestsExample/android/build.gradle
+++ b/TestsExample/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
-        kotlinVersion = "1.6.21"
+        kotlinVersion = "1.8.22"
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.core:core-ktx:1.5.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        rnsDefaultTargetSdkVersion = 31
-        rnsDefaultCompileSdkVersion = 31
+        rnsDefaultTargetSdkVersion = 34
+        rnsDefaultCompileSdkVersion = 34
         rnsDefaultMinSdkVersion = 21
         rnsDefaultKotlinVersion = '1.6.21'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,7 +125,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.fragment:fragment:1.2.1'
+    implementation 'androidx.fragment:fragment:1.6.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.11.0"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         rnsDefaultTargetSdkVersion = 34
         rnsDefaultCompileSdkVersion = 34
         rnsDefaultMinSdkVersion = 21
-        rnsDefaultKotlinVersion = '1.6.21'
+        rnsDefaultKotlinVersion = '1.8.0'
     }
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,7 +125,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.fragment:fragment:1.6.1'
+    implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,6 +128,6 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.core:core-ktx:1.12.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,5 +129,5 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation "androidx.core:core-ktx:1.5.0"
+    implementation "androidx.core:core-ktx:1.12.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,5 +129,5 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
-    implementation "androidx.core:core-ktx:1.12.0"
+    implementation "androidx.core:core-ktx:1.10.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,7 +124,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.fragment:fragment:1.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.1'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.core:core-ktx:1.5.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import com.android.Version
+
 buildscript {
     ext {
         rnsDefaultTargetSdkVersion = 34
@@ -45,7 +47,7 @@ def reactNativeArchitectures() {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace "com.swmansion.rnscreens"
     }

--- a/android/spotless.gradle
+++ b/android/spotless.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.diffplug.spotless'
 spotless {
   kotlin {
     target 'src/**/*.kt'
-    ktlint("0.40.0")
+    ktlint("0.43.0")
     trimTrailingWhitespace()
     indentWithSpaces()
     endWithNewline()


### PR DESCRIPTION
## Description

~Won't merge it RN as recent versions of these libraries require sdk >= 33 while current RN setup (clean app) requires >= 31.~

While the statement above holds true new context emerged: since August 2023 all Android apps have to target sdk >= 33 ([link](https://developer.android.com/google/play/requirements/target-sdk))

Thus this should not be a problem. 

## Changes

* Bumped default Kotlin version to `1.8.22` in example apps
* Bumped default Kotlin version to `1.8.0` in lib (this aligns it with RN 0.73 template)
* Bumped default target & compile target to 34 (notice that this is the default value used by the library, this can be overriden by user in application build.gradle)
* Bumped series of lib depenencies (Android ones) to decently recent versions.



## Test code and steps to reproduce

Ci works

## Checklist

- [x] Ensured that CI passes
