### PR TITLE
fix(CI): run Android e2e with JDK 17

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -25,9 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-13
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example


### PR DESCRIPTION
## Description

Attempt to improve our e2e CI run time by adding cache for JDK setup. 
Also use JDK 17, it is not necessary yet, but it will be soon as AGP 8.0 requires it. 

## Changes

Upgraded JDK to 17 & added JDK cache.

I've also experimented with running on `ubuntu-latest` instead of `macos-12` however emulator fails to start in such case. 


## Checklist

- [x] Ensured that CI passes
