### PR TITLE
chore(CI): put timelimit on execution of each workflow

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: FabricTestExample
     concurrency:

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: TestsExample
     concurrency:

--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   build:
     runs-on: macos-12
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: FabricTestExample
     concurrency:

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     runs-on: macos-12
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: TestsExample
     concurrency:

--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     runs-on: macos-12
+    timeout-minutes: 60
     env:
       WORKING_DIRECTORY: TVOSExample
     concurrency:


### PR DESCRIPTION
## Description

After having iOS build lasting almost 3h (due to poor internet connection on worker, long download time & the machine was extremely slow) I've decided to put timelimit on each workflow run. 

I took a quick look at workflow durations in the past month and it looks like 60 minutes should be enough.

## Changes

Added `timeout-minutes: 60` for each CI workflow

## Checklist

- [x] Ensured that CI passes
