### PR TITLE
fix(temp, iOS): Fix missing weak linking for Xcode 15

### DIFF
--- a/Example/ios/Podfile
+++ b/Example/ios/Podfile
@@ -58,5 +58,19 @@ target 'ScreensExample' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    projects = installer.aggregate_targets
+        .map{ |t| t.user_project }
+        .uniq{ |p| p.path }
+    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    projects.each do |project|
+      if should_use_classic_linker
+        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        project.build_configurations.each do |config|
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+        end
+        project.save()
+      end
+    end
   end
 end

--- a/Example/ios/Podfile
+++ b/Example/ios/Podfile
@@ -62,12 +62,12 @@ target 'ScreensExample' do
     projects = installer.aggregate_targets
         .map{ |t| t.user_project }
         .uniq{ |p| p.path }
-    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    should_use_classic_linker = File.exist?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
     projects.each do |project|
       if should_use_classic_linker
-        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        Pod::UI.puts("Applying flags '-Wl -ld_classic' for Xcode 15 on #{ project.path }")
         project.build_configurations.each do |config|
-          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -Wl -ld_classic'
         end
         project.save()
       end

--- a/Example/ios/ScreensExample.xcodeproj/project.pbxproj
+++ b/Example/ios/ScreensExample.xcodeproj/project.pbxproj
@@ -941,10 +941,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ld_classic",
-				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -1001,10 +997,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ld_classic",
-				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/Example/ios/ScreensExample.xcodeproj/project.pbxproj
+++ b/Example/ios/ScreensExample.xcodeproj/project.pbxproj
@@ -941,6 +941,10 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -997,6 +1001,10 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -61,16 +61,15 @@ target 'FabricExample' do
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
 
-
     projects = installer.aggregate_targets
         .map{ |t| t.user_project }
         .uniq{ |p| p.path }
-    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    should_use_classic_linker = File.exist?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
     projects.each do |project|
       if should_use_classic_linker
-        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        Pod::UI.puts("Applying flags '-Wl -ld_classic' for Xcode 15 on #{ project.path }")
         project.build_configurations.each do |config|
-          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -Wl -ld_classic'
         end
         project.save()
       end

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -60,5 +60,20 @@ target 'FabricExample' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+
+    projects = installer.aggregate_targets
+        .map{ |t| t.user_project }
+        .uniq{ |p| p.path }
+    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    projects.each do |project|
+      if should_use_classic_linker
+        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        project.build_configurations.each do |config|
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+        end
+        project.save()
+      end
+    end
   end
 end

--- a/FabricTestExample/ios/Podfile
+++ b/FabricTestExample/ios/Podfile
@@ -60,5 +60,20 @@ target 'FabricTestExample' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+
+    projects = installer.aggregate_targets
+        .map{ |t| t.user_project }
+        .uniq{ |p| p.path }
+    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    projects.each do |project|
+      if should_use_classic_linker
+        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        project.build_configurations.each do |config|
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+        end
+        project.save()
+      end
+    end
   end
 end

--- a/FabricTestExample/ios/Podfile
+++ b/FabricTestExample/ios/Podfile
@@ -64,12 +64,12 @@ target 'FabricTestExample' do
     projects = installer.aggregate_targets
         .map{ |t| t.user_project }
         .uniq{ |p| p.path }
-    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    should_use_classic_linker = File.exist?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
     projects.each do |project|
       if should_use_classic_linker
-        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        Pod::UI.puts("Applying flags '-Wl -ld_classic' for Xcode 15 on #{ project.path }")
         project.build_configurations.each do |config|
-          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -Wl -ld_classic'
         end
         project.save()
       end

--- a/FabricTestExample/ios/Podfile
+++ b/FabricTestExample/ios/Podfile
@@ -61,7 +61,6 @@ target 'FabricTestExample' do
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
 
-
     projects = installer.aggregate_targets
         .map{ |t| t.user_project }
         .uniq{ |p| p.path }

--- a/TestsExample/ios/Podfile
+++ b/TestsExample/ios/Podfile
@@ -58,5 +58,19 @@ target 'TestsExample' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    projects = installer.aggregate_targets
+        .map{ |t| t.user_project }
+        .uniq{ |p| p.path }
+    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    projects.each do |project|
+      if should_use_classic_linker
+        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        project.build_configurations.each do |config|
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+        end
+        project.save()
+      end
+    end
   end
 end

--- a/TestsExample/ios/Podfile
+++ b/TestsExample/ios/Podfile
@@ -62,12 +62,12 @@ target 'TestsExample' do
     projects = installer.aggregate_targets
         .map{ |t| t.user_project }
         .uniq{ |p| p.path }
-    should_use_classic_linker = File.exists?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
+    should_use_classic_linker = File.exist?(File.join(`xcode-select -p`.strip, 'Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic'))
     projects.each do |project|
       if should_use_classic_linker
-        Pod::UI.puts("Applying -ld_classic for Xcode 15 on #{ project.path }")
+        Pod::UI.puts("Applying flags '-Wl -ld_classic' for Xcode 15 on #{ project.path }")
         project.build_configurations.each do |config|
-          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ld_classic'
+          config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -Wl -ld_classic'
         end
         project.save()
       end


### PR DESCRIPTION
## Description

Currently it's not possible to build our example apps because of the recent changes in the newest Xcode 15.
In the changelog they're mentioning a new linter, which lacks the support of weak linking.

This PR introduces changes in Podfiles that are required to launch our example apps. They are mainly adding required flag (`-ld_classic`) that is restoring the support for the classic linter.

**This change is temporary!** We should observe and wait for the 0.72.5 patch in React Native that adds the support for classic linter inside their Podfiles.

You can check for more information about the newest changes in linter [here](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking).

## Helpful links
- https://github.com/reactwg/react-native-releases/discussions/85#discussioncomment-7043457
- https://github.com/reactwg/react-native-releases/discussions/87#discussioncomment-7043465
- https://github.com/reactwg/react-native-releases/discussions/84#discussioncomment-7043469

## Checklist

- [ ] Ensured that CI passes
