### PR TITLE
fix(Android): Change elements visibility on search bar open

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
@@ -32,14 +32,18 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
 
     private var mAreListenersSet: Boolean = false
 
-    private val screenStackFragment: ScreenStackFragment?
+    private val headerConfig: ScreenStackHeaderConfig?
         get() {
             val currentParent = parent
             if (currentParent is ScreenStackHeaderSubview) {
-                return currentParent.config?.screenFragment
+                return currentParent.config
             }
+
             return null
         }
+
+    private val screenStackFragment: ScreenStackFragment?
+        get() = headerConfig?.screenFragment
 
     fun onUpdate() {
         setSearchViewProps()
@@ -110,10 +114,12 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
 
     private fun handleClose() {
         sendEvent(SearchBarCloseEvent(surfaceId, id))
+        setToolbarElementsVisibility(VISIBLE)
     }
 
     private fun handleOpen() {
         sendEvent(SearchBarOpenEvent(surfaceId, id))
+        setToolbarElementsVisibility(GONE)
     }
 
     private fun handleTextSubmit(newText: String?) {
@@ -142,6 +148,14 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
 
     fun handleSetTextJsRequest(text: String?) {
         text?.let { screenStackFragment?.searchView?.setText(it) }
+    }
+
+    private fun setToolbarElementsVisibility(visibility: Int) {
+        for (i in 0..(headerConfig?.configSubviewsCount?.minus(1) ?: 0)) {
+            val subview = headerConfig?.getConfigSubview(i)
+            if (subview?.type != ScreenStackHeaderSubview.Type.SEARCH_BAR)
+                subview?.visibility = visibility
+        }
     }
 
     private val surfaceId = UIManagerHelper.getSurfaceId(this)


### PR DESCRIPTION
## Description

Currently, when user opens the search bar all of the subviews on the toolbar are being pushed to the left.
Instead, we want to hide them or even remove them so that they won't be visible during the layout.
This PR fixes that problem by secretly hiding the toolbar elements, changing their visibility to `GONE`.

Fixes #1450.

## Changes

- Added a fix that is being controlled by `handleOpen` and `handleClose` methods in SearchBarView.

## Screenshots / GIFs

### Before

https://github.com/software-mansion/react-native-screens/assets/23281839/8ca8e18e-2cf6-4c04-85c8-51b5d69f1a61

### After

https://github.com/software-mansion/react-native-screens/assets/23281839/41330ea7-a12b-4e14-9a1e-2207a54ebed0

## Test code and steps to reproduce

In our example app open `SearchBar.tsx` and add `headerRight: () => <Button title="Test"/> to the `navigation.setOptions({` declaration. Then launch the app and open `Search bar` example.

## Checklist

- [ ] Ensured that CI passes
