### PR TITLE
chore: Update Kotlin to 1.9.10

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"
-        kotlinVersion = "1.8.22"
+        kotlinVersion = "1.9.10"
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         rnsDefaultTargetSdkVersion = 34
         rnsDefaultCompileSdkVersion = 34
         rnsDefaultMinSdkVersion = 21
-        rnsDefaultKotlinVersion = '1.8.0'
+        rnsDefaultKotlinVersion = '1.9.10'
     }
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback


### PR DESCRIPTION
## Description

Since we're still using Kotlin 1.8 I think it's a good idea to update kotlin to the newest 1.9.10 version.
Specifically I want to use one of the benefits of this new version in #1903 where I could use new `rangeUntil` method in `for` statement.

## Checklist

- [x] Ensured that CI passes
