### PR TITLE
fix(iOS): change implementation of calculating status bar, refactor methods used on header height change

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1040,12 +1040,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (BOOL)assertModalHierarchy
 {
-  if (self.childViewControllers.count == 0) {
+  if (self.childViewControllers.count > 1) {
     RCTLogError(
-        @"Modal has been rendered without the navigation controller, which is not allowed. Ensure that modal has RNSNavigationController mounted as a child view controller.");
-  } else if (self.childViewControllers.count > 1) {
-    RCTLogError(
-        @"Modal has been rendered with more than one navigation controller, which is not allowed. Ensure that modal has only one RNSNavigationController mounted as a child view controller.");
+        @"Modal has been rendered with more than one navigation controller, which is not allowed. Ensure that modal has none or only one RNSNavigationController mounted as a child view controller.");
   }
 
   return self.childViewControllers.count == 1 &&

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1074,20 +1074,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     return CGSizeMake(0, 0);
   }
 
-  CGSize fallbackStatusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
-
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    CGSize primaryStatusBarSize = self.view.window.windowScene.statusBarManager.statusBarFrame.size;
-    if (primaryStatusBarSize.height == 0 || primaryStatusBarSize.width == 0)
-      return fallbackStatusBarSize;
-
-    return primaryStatusBarSize;
-  } else {
-    return fallbackStatusBarSize;
-  }
-#endif /* Check for iOS 13.0 */
+  CGFloat statusBarSize = self.navigationController.navigationBar.frame.origin.y;
+  return CGSizeMake(statusBarSize, statusBarSize);
 
 #else
   // On TVOS, status bar doesn't exist

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1038,14 +1038,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   }
 }
 
-- (BOOL)assertModalHierarchy
+- (BOOL)isModalWithHeader
 {
-  if (self.childViewControllers.count > 1) {
-    RCTLogError(
-        @"Modal has been rendered with more than one navigation controller, which is not allowed. Ensure that modal has none or only one RNSNavigationController mounted as a child view controller.");
-  }
-
-  return self.childViewControllers.count == 1 &&
+  return self.screenView.isModal && self.childViewControllers.count == 1 &&
       [self.childViewControllers[0] isKindOfClass:UINavigationController.class];
 }
 
@@ -1093,7 +1088,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (isModal) {
     // In case where screen is a modal, we want to calculate childViewController's
     // navigation bar height instead of the navigation controller from RNSScreen.
-    if (self.assertModalHierarchy) {
+    if (self.isModalWithHeader) {
       navctr = self.childViewControllers[0];
     } else {
       // If the modal does not meet requirements (there's no RNSNavigationController which means that probably it
@@ -1109,17 +1104,18 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
 {
   UINavigationController *navctr = [self getVisibleNavigationControllerIsModal:isModal];
-  CGSize statusBarSize = [self getStatusBarHeightIsModal:isModal];
 
   // If navigation controller doesn't exists (or it is hidden) we want to handle two possible cases.
   // If there's no navigation controller for the modal, we simply don't want to return header height, as modal possibly
   // does not have header and we don't want to count status bar. If there's no navigation controller for the view we
   // just want to return status bar height (if it's hidden, it will simply return 0).
   if (navctr == nil || navctr.isNavigationBarHidden) {
-    if (isModal)
+    if (isModal) {
       return 0;
-    else
+    } else {
+      CGSize statusBarSize = [self getStatusBarHeightIsModal:isModal];
       return MIN(statusBarSize.width, statusBarSize.height);
+    }
   }
 
   CGFloat navbarHeight = navctr.navigationBar.frame.size.height;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -563,6 +563,12 @@ namespace react = facebook::react;
   return nil;
 }
 
+- (BOOL)hasModalOpened
+{
+  return self.controller.childViewControllers.count > 0 &&
+      [self.controller.childViewControllers[0] isKindOfClass:UINavigationController.class];
+}
+
 - (BOOL)isModal
 {
   return self.stackPresentation != RNSScreenStackPresentationPush;
@@ -1046,16 +1052,15 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (CGFloat)getNavigationBarHeightIsModal:(BOOL)isModal
 {
-  CGFloat navbarHeight = self.navigationController.navigationBar.frame.size.height;
+  UINavigationController *navctr = self.navigationController;
 
-  // In case where screen is a modal, we want to calculate just its childViewController's height
-  if (isModal && self.childViewControllers.count > 0 &&
-      [self.childViewControllers[0] isKindOfClass:UINavigationController.class]) {
-    UINavigationController *childNavCtr = self.childViewControllers[0];
-    navbarHeight = childNavCtr.navigationBar.frame.size.height;
+  // In case where screen is a modal, we want to calculate childViewController's
+  // navigation bar height instead of the navigation controller from RNSScreen.
+  if (isModal && self.screenView.hasModalOpened) {
+    navctr = self.childViewControllers[0];
   }
 
-  return navbarHeight;
+  return navctr.navigationBar.frame.size.height;
 }
 
 - (CGFloat)getNavigationBarInsetIsModal:(BOOL)isModal
@@ -1064,8 +1069,15 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // On TVOS there's no inset of navigation bar.
   return 0;
 #endif // TARGET_OS_TV
+  UINavigationController *navctr = self.navigationController;
 
-  return self.navigationController.navigationBar.frame.origin.y;
+  // In case where screen is a modal, we want to calculate childViewController's
+  // navigation bar inset instead of the navigation controller from RNSScreen.
+  if (isModal && self.screenView.hasModalOpened) {
+    navctr = self.childViewControllers[0];
+  }
+
+  return navctr.navigationBar.frame.origin.y;
 }
 
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -251,6 +251,9 @@ namespace react = facebook::react;
   _statusBarHidden = statusBarHidden;
   [RNSScreenWindowTraits assertViewControllerBasedStatusBarAppearenceSet];
   [RNSScreenWindowTraits updateStatusBarAppearance];
+  // As the status bar could change its visibility, we need to calculate header height
+  // for the correct value in `onHeaderHeightChange` event.
+  [self.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
 }
 
 - (void)setScreenOrientation:(UIInterfaceOrientationMask)screenOrientation

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -563,12 +563,6 @@ namespace react = facebook::react;
   return nil;
 }
 
-- (BOOL)hasModalOpened
-{
-  return self.controller.childViewControllers.count > 0 &&
-      [self.controller.childViewControllers[0] isKindOfClass:UINavigationController.class];
-}
-
 - (BOOL)isModal
 {
   return self.stackPresentation != RNSScreenStackPresentationPush;
@@ -1037,6 +1031,20 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   }
 }
 
+- (BOOL)assertModalHierarchy
+{
+  if (self.childViewControllers.count == 0) {
+    RCTLogError(
+        @"Modal has been rendered without the navigation controller, which is not allowed. Ensure that modal has RNSNavigationController mounted as a child view controller.");
+  } else if (self.childViewControllers.count > 1) {
+    RCTLogError(
+        @"Modal has been rendered with more than one navigation controller, which is not allowed. Ensure that modal has only one RNSNavigationController mounted as a child view controller.");
+  }
+
+  return self.childViewControllers.count == 1 &&
+      [self.childViewControllers[0] isKindOfClass:UINavigationController.class];
+}
+
 // Checks whether this screen has any child view controllers of type RNSNavigationController.
 // Useful for checking if this screen has nested stack or is displayed at the top.
 - (BOOL)hasNestedStack
@@ -1056,7 +1064,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
   // In case where screen is a modal, we want to calculate childViewController's
   // navigation bar height instead of the navigation controller from RNSScreen.
-  if (isModal && self.screenView.hasModalOpened) {
+  if (isModal && self.assertModalHierarchy) {
     navctr = self.childViewControllers[0];
   }
 
@@ -1073,7 +1081,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
   // In case where screen is a modal, we want to calculate childViewController's
   // navigation bar inset instead of the navigation controller from RNSScreen.
-  if (isModal && self.screenView.hasModalOpened) {
+  if (isModal && self.assertModalHierarchy) {
     navctr = self.childViewControllers[0];
   }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1060,23 +1060,12 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (CGFloat)getNavigationBarInsetIsModal:(BOOL)isModal
 {
-#if !TARGET_OS_TV
-  BOOL isDraggableModal = isModal && ![self.screenView isFullscreenModal];
-  BOOL isDraggableModalWithChildViewCtr =
-      isDraggableModal && self.childViewControllers.count > 0 && self.childViewControllers[0] != nil;
-
-  // When modal is floating (we can grab its header), we don't want to get inset of the navigation bar.
-  // Thus, we return '0' as an inset.
-  if (isDraggableModalWithChildViewCtr || self.screenView.isTransparentModal) {
-    return 0;
-  }
-
-  return self.navigationController.navigationBar.frame.origin.y;
-
-#else
+#if TARGET_OS_TV
   // On TVOS there's no inset of navigation bar.
   return 0;
-#endif // !TARGET_OS_TV
+#endif // TARGET_OS_TV
+
+  return self.navigationController.navigationBar.frame.origin.y;
 }
 
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1044,7 +1044,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   return NO;
 }
 
-- (CGFloat)getCalculatedHeaderHeightIsModal:(BOOL)isModal
+- (CGFloat)getNavigationBarHeightIsModal:(BOOL)isModal
 {
   CGFloat navbarHeight = self.navigationController.navigationBar.frame.size.height;
 
@@ -1058,38 +1058,32 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   return navbarHeight;
 }
 
-- (CGSize)getCalculatedStatusBarHeightIsModal:(BOOL)isModal
+- (CGFloat)getNavigationBarInsetIsModal:(BOOL)isModal
 {
 #if !TARGET_OS_TV
   BOOL isDraggableModal = isModal && ![self.screenView isFullscreenModal];
   BOOL isDraggableModalWithChildViewCtr =
       isDraggableModal && self.childViewControllers.count > 0 && self.childViewControllers[0] != nil;
 
-  // When modal is floating (we can grab its header), we don't want to calculate status bar in it.
-  // Thus, we return '0' as a height of status bar.
+  // When modal is floating (we can grab its header), we don't want to get inset of the navigation bar.
+  // Thus, we return '0' as an inset.
   if (isDraggableModalWithChildViewCtr || self.screenView.isTransparentModal) {
-    return CGSizeMake(0, 0);
+    return 0;
   }
 
-  CGFloat statusBarSize = self.navigationController.navigationBar.frame.origin.y;
-  return CGSizeMake(statusBarSize, statusBarSize);
+  return self.navigationController.navigationBar.frame.origin.y;
 
 #else
-  // On TVOS, status bar doesn't exist
-  return CGSizeMake(0, 0);
+  // On TVOS there's no inset of navigation bar.
+  return 0;
 #endif // !TARGET_OS_TV
 }
 
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
 {
-  CGFloat navbarHeight = [self getCalculatedHeaderHeightIsModal:isModal];
-  CGSize statusBarSize = [self getCalculatedStatusBarHeightIsModal:isModal];
-
-  // Unfortunately, UIKit doesn't care about switching width and height options on screen rotation.
-  // We should check if user has rotated its screen, so we're choosing the minimum value between the
-  // width and height.
-  CGFloat statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);
-  return navbarHeight + statusBarHeight;
+  CGFloat navbarHeight = [self getNavigationBarHeightIsModal:isModal];
+  CGFloat navbarInset = [self getNavigationBarInsetIsModal:isModal];
+  return navbarHeight + navbarInset;
 }
 
 - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -251,9 +251,6 @@ namespace react = facebook::react;
   _statusBarHidden = statusBarHidden;
   [RNSScreenWindowTraits assertViewControllerBasedStatusBarAppearenceSet];
   [RNSScreenWindowTraits updateStatusBarAppearance];
-  // As the status bar could change its visibility, we need to calculate header height
-  // for the correct value in `onHeaderHeightChange` event.
-  [self.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
 }
 
 - (void)setScreenOrientation:(UIInterfaceOrientationMask)screenOrientation

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -255,7 +255,7 @@ namespace react = facebook::react;
   // As the status bar could change its visibility, we need to calculate header
   // height for the correct value in `onHeaderHeightChange` event when navigation
   // bar is not visible.
-  if (self.controller.navigationController.navigationBarHidden) {
+  if (self.controller.navigationController.navigationBarHidden && !self.isModal) {
     [self.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
   }
 }

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -71,7 +71,7 @@ namespace react = facebook::react;
     // If RNSScreen includes a navigation controller of type RNSNavigationController, it should not calculate
     // header height, as it could have nested stack.
     if (![screenController hasNestedStack]) {
-      [(RNSScreen *)self.topViewController calculateAndNotifyHeaderHeightChangeIsModal:NO];
+      [screenController calculateAndNotifyHeaderHeightChangeIsModal:NO];
     }
   }
 }

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -66,11 +66,14 @@ namespace react = facebook::react;
   [super viewDidLayoutSubviews];
   if ([self.topViewController isKindOfClass:[RNSScreen class]]) {
     RNSScreen *screenController = (RNSScreen *)self.topViewController;
+    BOOL isNotDismissingModal = screenController.presentedViewController == nil ||
+        (screenController.presentedViewController != nil &&
+         ![screenController.presentedViewController isBeingDismissed]);
 
     // Calculate header height during simple transition from one screen to another.
     // If RNSScreen includes a navigation controller of type RNSNavigationController, it should not calculate
     // header height, as it could have nested stack.
-    if (![screenController hasNestedStack]) {
+    if (![screenController hasNestedStack] && isNotDismissingModal) {
       [screenController calculateAndNotifyHeaderHeightChangeIsModal:NO];
     }
   }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -149,9 +149,7 @@ namespace react = facebook::react;
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self animated:YES];
     // As the header might have change in `updateViewController` we need to ensure that header height
     // returned by the `onHeaderHeightChange` event is correct.
-    if ([vc isKindOfClass:[RNSScreen class]]) {
-      [(RNSScreen *)self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
-    }
+    [(RNSScreen *)self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -149,7 +149,7 @@ namespace react = facebook::react;
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self animated:YES];
     // As the header might have change in `updateViewController` we need to ensure that header height
     // returned by the `onHeaderHeightChange` event is correct.
-    [(RNSScreen *)self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
+    [self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -147,6 +147,11 @@ namespace react = facebook::react;
   // if nav is nil, it means we can be in a fullScreen modal, so there is no nextVC, but we still want to update
   if (vc != nil && (nextVC == vc || isInFullScreenModal || isPresentingVC)) {
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self animated:YES];
+    // As the header might have change in `updateViewController` we need to ensure that header height
+    // returned by the `onHeaderHeightChange` event is correct.
+    if ([vc isKindOfClass:[RNSScreen class]]) {
+      [(RNSScreen *)vc calculateAndNotifyHeaderHeightChangeIsModal:NO];
+    }
   }
 }
 
@@ -353,6 +358,11 @@ namespace react = facebook::react;
                     withConfig:(RNSScreenStackHeaderConfig *)config
 {
   [self updateViewController:vc withConfig:config animated:animated];
+  // As the header might have change in `updateViewController` we need to ensure that header height
+  // returned by the `onHeaderHeightChange` event is correct.
+  if ([vc isKindOfClass:[RNSScreen class]]) {
+    [(RNSScreen *)vc calculateAndNotifyHeaderHeightChangeIsModal:NO];
+  }
 }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
@@ -665,10 +675,6 @@ namespace react = facebook::react;
         }];
   } else {
     [self setAnimatedConfig:vc withConfig:config];
-  }
-
-  if ([vc isKindOfClass:[RNSScreen class]]) {
-    [((RNSScreen *)vc) calculateAndNotifyHeaderHeightChangeIsModal:NO];
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -666,6 +666,10 @@ namespace react = facebook::react;
   } else {
     [self setAnimatedConfig:vc withConfig:config];
   }
+
+  if ([vc isKindOfClass:[RNSScreen class]]) {
+    [((RNSScreen *)vc) calculateAndNotifyHeaderHeightChangeIsModal:NO];
+  }
 }
 
 - (void)insertReactSubview:(RNSScreenStackHeaderSubview *)subview atIndex:(NSInteger)atIndex

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -150,7 +150,7 @@ namespace react = facebook::react;
     // As the header might have change in `updateViewController` we need to ensure that header height
     // returned by the `onHeaderHeightChange` event is correct.
     if ([vc isKindOfClass:[RNSScreen class]]) {
-      [(RNSScreen *)vc calculateAndNotifyHeaderHeightChangeIsModal:NO];
+      [(RNSScreen *)self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
     }
   }
 }

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -248,7 +248,7 @@ const RouteView = ({
   // We need to ensure the first retrieved header height will be cached and set in animatedHeaderHeight.
   // We're caching the header height here, as on iOS native side events are not always coming to the JS on first notify.
   // TODO: Check why first event is not being received once it is cached on the native side.
-  const cachedAnimatedHeaderHeight = React.useRef(statusBarHeight);
+  const cachedAnimatedHeaderHeight = React.useRef(defaultHeaderHeight);
   const animatedHeaderHeight = React.useRef(
     new Animated.Value(staticHeaderHeight, {
       useNativeDriver: true,


### PR DESCRIPTION
## Description

It looks that sometimes when you're most likely on the first screen the initial header height (taken from the `getDefaultHeaderHeight` method) stays and is not being updated from the `onHeaderHeightChange` event. Also, when user hides the status bar it wasn't counted to the final value of header height. This PR fixes those problems and also other minor issues, related to the calculating header height.

## Changes

- Added calls for calculating header height on setting animated config and changing `statusBarHidden` prop.
- Changed implementation of `getCalculatedStatusBarHeightIsModal` method.
- Refactorized naming of the methods, related to the header height.
- Added asserting modal hierarchy.

## Test code and steps to reproduce

You can change `Modals.tsx` file by adding this snippet:

```js
    const headerHeight = useAnimatedHeaderHeight();
    headerHeight.addListener((height) => console.log(height.value))
```

to the components and listen to the changes in `Modals` example. Then try to hide header in modals - there should be `0` value as a header height.

## Checklist

- [X] Included code example that can be used to test this change
- [ ] Ensured that CI passes
