### PR TITLE
fix: Unresolved reference: attr after upgrading to 0.73.0-rc.2

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -390,7 +390,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
         // set primary color as background by default
         val tv = TypedValue()
-        if (context.theme.resolveAttribute(R.attr.colorPrimary, tv, true)) {
+        if (context.theme.resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
             toolbar.setBackgroundColor(tv.data)
         }
         toolbar.clipChildren = false


### PR DESCRIPTION
## Description

Small PR which probably resolves [#1515](https://github.com/software-mansion/react-native-screens/issues/1515). 

For my case, I got this build issue after upgrading from 0.72.5 to 0.73.0-rc.2:

```
> Task :react-native-screens:compileDebugKotlin FAILED
e: file:///Users/ivanignatiev/GitHub/****/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt:391:46 Unresolved reference: attr
```

I do not know Java or Kotlin, so, please guide me if additional work is needed.

@kkafar: Since AGP 8.0 the default value for `android.nonTransitiveRClass` property [has changed from `false` to `true`](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes). This requires resource file names to be fully qualified. React Native 0.73 depends on AGP 8.0 thus we get the build issues.

