### PR TITLE
fix(Android): Fix calculating header height when changing status/action bar visibility

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -253,14 +253,16 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
         // Check if it's possible to get an attribute from theme context and assign a value from it.
         // Otherwise, the default value will be returned.
         val actionBarHeight = TypedValue.complexToDimensionPixelSize(actionBarTv.data, resources.displayMetrics)
+            .takeIf { headerConfig?.mIsHidden != true }
             .takeIf { resolvedActionBarSize }
-            ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 56.0
+            ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 0.0
 
         val statusBarHeight = context.resources.getIdentifier("status_bar_height", "dimen", "android")
             .takeIf { it > 0 }
+            .takeIf { isStatusBarHidden != true }
             ?.let { (context.resources::getDimensionPixelSize)(it) }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() }
-            ?: 24.0
+            ?: 0.0
 
         val totalHeight = actionBarHeight + statusBarHeight
         UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -246,20 +246,18 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
             mNativeBackButtonDismissalEnabled = enableNativeBackButtonDismissal
         }
 
-    fun calculateHeaderHeight() {
+    private fun calculateHeaderHeight() {
         val actionBarTv = TypedValue()
         val resolvedActionBarSize = context.theme.resolveAttribute(android.R.attr.actionBarSize, actionBarTv, true)
 
         // Check if it's possible to get an attribute from theme context and assign a value from it.
         // Otherwise, the default value will be returned.
         val actionBarHeight = TypedValue.complexToDimensionPixelSize(actionBarTv.data, resources.displayMetrics)
-            .takeIf { headerConfig?.mIsHidden != true }
-            .takeIf { resolvedActionBarSize }
+            .takeIf { resolvedActionBarSize && headerConfig?.mIsHidden != true }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 0.0
 
         val statusBarHeight = context.resources.getIdentifier("status_bar_height", "dimen", "android")
-            .takeIf { it > 0 }
-            .takeIf { isStatusBarHidden != true }
+            .takeIf { it > 0 && isStatusBarHidden != true }
             ?.let { (context.resources::getDimensionPixelSize)(it) }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() }
             ?: 0.0

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -24,6 +24,7 @@ import com.swmansion.rnscreens.events.HeaderDetachedEvent
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)
     val toolbar: CustomToolbar
+    var mIsHidden = false
     private var headerTopInset: Int? = null
     private var mTitle: String? = null
     private var mTitleColor = 0
@@ -32,7 +33,6 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private var mTitleFontSize = 0f
     private var mTitleFontWeight = 0
     private var mBackgroundColor: Int? = null
-    private var mIsHidden = false
     private var mIsBackButtonHidden = false
     private var mIsShadowHidden = false
     private var mDestroyed = false


### PR DESCRIPTION
## Description

Currently when user changes status bar and action bar visibility header height is not being changed on `use(Re)animatedHeaderHeight`. This PR fixes this by checking if status bar or action bar has been hidden.

## Changes

- Fixed calculating header height by taking into account status bar height and action bar height.

## Test code and steps to reproduce

You can check how those change works by changing `statusBarHidden` / `headerShown` in Test1802.tsx test.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
