### PR TITLE
fix(iOS): add `canCoalesce` method to RNSHeaderHeightChangeEvent

### DIFF
--- a/ios/events/RNSHeaderHeightChangeEvent.mm
+++ b/ios/events/RNSHeaderHeightChangeEvent.mm
@@ -33,7 +33,17 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (BOOL)canCoalesce
 {
-  return NO;
+  return YES;
+}
+
+- (uint16_t)coalescingKey
+{
+  return _headerHeight;
+}
+
+- (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent
+{
+  return newEvent;
 }
 
 + (NSString *)moduleDotMethod

--- a/ios/events/RNSHeaderHeightChangeEvent.mm
+++ b/ios/events/RNSHeaderHeightChangeEvent.mm
@@ -31,6 +31,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   return body;
 }
 
+- (BOOL)canCoalesce
+{
+  return NO;
+}
+
 + (NSString *)moduleDotMethod
 {
   return @"RCTEventEmitter.receiveEvent";


### PR DESCRIPTION
## Description

It looks like when I was implementing class that is representing the `onHeaderHeightChange` I made a mistake and I forgot / accidentally removed `canCoalesce` method which led to displaying `RNSHeaderHeightChangeEvent: unrecognized selector sent to instance` for a couple of users.

This issue resolves that error by adding `canCoalesce` method to the event.
Fixes #1932.

## Changes

- Added `canCoalesce` method to `RNSHeaderHeightChangeEvent` file

## Test code and steps to reproduce

You can test the changes by checking `Test1802.tsx` component in FabricTestExample.

## Checklist

- [ ] Ensured that CI passes
