### PR TITLE
fix(Android): update status bar & orientation in screen stack fragment

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -77,6 +77,7 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
     }
 
     override fun onContainerUpdate() {
+        super.onContainerUpdate()
         screen.headerConfig?.onUpdate()
     }
 


### PR DESCRIPTION
## Description

I found this working on my app going in portrait mode on Android quite aleatory, when it was supposed to be locked on React Navigation - using the `orientation: "portrait"` on my screens.

(Note : orientation was not locked on the AndroidManifest file, I actually need the landscape mode elsewhere in the app.)

**What is the fix?**

Sometimes when the props `orientation` is set, the fragment and its activity associated are not yet available. So doing a setOrientation in the updateProps function does not work. 
They can also be set directly on the onUpdate function of the ScreenFragment itself, using the `trySetWindowTrait` function and the main activity; but the "super" allowing this behavior to the ScreenStackFragment (=the ones that I use) were not here. 

A similar fix is also done in the ScreenStackHeaderConfig `onUpdate` function. But in my case, I did not have a headerConfig: so the `trySetWindowTrait` was not called at all ... and my app could go landscape just after the opening. 

After adding the `super`, bug was fixed and my app was well locked in portrait mode 👌 👌 

## Screenshots / GIFs

Here is the scheme that I made during my debugging session:

![image](https://github.com/software-mansion/react-native-screens/assets/67843879/1fd2af1b-ca61-4333-8eec-8b4662f78740)

Here is just for fun my app going in portrait mode when it was **not** suppose to go: 

<image src="https://github.com/software-mansion/react-native-screens/assets/67843879/cb5860e4-9392-4257-aa3a-29d0292bffd4" width=300/>


## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types -> no need I think
- [ ] Ensured that CI passes
