### PR TITLE
fix(Android): Fix project doesn't compile when `nonTransitiveRClass` is set to true

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -390,7 +390,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
         // set primary color as background by default
         val tv = TypedValue()
-        if (context.theme.resolveAttribute(R.attr.colorPrimary, tv, true)) {
+        if (context.theme.resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
             toolbar.setBackgroundColor(tv.data)
         }
         toolbar.clipChildren = false


### PR DESCRIPTION
## Description

A follow-up to the https://github.com/software-mansion/react-native-screens/issues/1515.
Fixes:
```
e: .../ScreenStackHeaderConfig.kt:391:46 Unresolved reference: attr
```
when the `nonTransitiveRClass` option is set to true.

The `nonTransitiveRClass` is a handy tool that can significantly reduce the size of your app and speed up the build time. It is important to support it. There is one reference to a resource incompatible with this rule: ' R.attr.colorPrimary`. To make it work, you must import it from the `android` package to indicate the build system where that resource is located.

## Changes

Use the absolute path to import the attribute.

## Test code and steps to reproduce

- create a new RN project 
- add react-native-screens
- add `android.nonTransitiveRClass=true` to `gradle.properties` 

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
