### PR TITLE
fix: downgrade native deps to avoid conflicts with other libs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,10 +124,10 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.fragment:fragment-ktx:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.fragment:fragment:1.3.6'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
-    implementation "androidx.core:core-ktx:1.10.1"
+    implementation "androidx.core:core-ktx:1.8.0"
 }


### PR DESCRIPTION
## Description

So I've recently bumped versions of few native library dependencies in https://github.com/software-mansion/react-native-screens/pull/1891, but it also bumped some transitive dependencies that conflicted with lower versions that are required by packages such as `gesture-handler`, `reanimated`, `safe-area-context` etc.
I'm downgrading the versions as much I as can while also keeping possible high `material` version.

## Test code and steps to reproduce

I downgraded kotlin to `1.6.21` in TestsExample && tested the build.

## Checklist

- [ ] Ensured that CI passes
