### PR TITLE
chore: use JDK 17 for CI builds as required for RN 0.73

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -24,8 +24,14 @@ jobs:
       group: android-fabric-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -22,8 +22,14 @@ jobs:
       group: android-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Description

Setting version of JDK to 17 for CI builds as it is required by 0.73 to run.

## Test code and steps to reproduce

CI passing should be enough

## Checklist

- [ ] Ensured that CI passes
