### PR TITLE
feat(iOS): introduce modal dismiss event on drag down attempt

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -31,7 +31,7 @@ namespace react = facebook::react;
 
 @class RNSScreenView;
 
-@interface RNSScreen : UIViewController <RNSViewControllerDelegate>
+@interface RNSScreen : UIViewController <RNSViewControllerDelegate, UIAdaptivePresentationControllerDelegate>
 
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
@@ -108,6 +108,7 @@ namespace react = facebook::react;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
 @property (nonatomic, copy) RCTDirectEventBlock onGestureCancel;
+@property (nonatomic, copy) RCTDirectEventBlock onModalDismiss;
 #endif // RCT_NEW_ARCH_ENABLED
 
 - (void)notifyFinishTransitioning;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -211,6 +211,13 @@ namespace react = facebook::react;
   _gestureEnabled = gestureEnabled;
 }
 
+- (void)setOnModalDismiss:(RCTDirectEventBlock)onModalDismiss {
+    _onModalDismiss = onModalDismiss;
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
+        _controller.modalInPresentation = onModalDismiss != nil;
+    }
+}
+
 - (void)setReplaceAnimation:(RNSScreenReplaceAnimation)replaceAnimation
 {
   _replaceAnimation = replaceAnimation;
@@ -977,6 +984,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
   _isSwiping = NO;
   _shouldNotify = YES;
+  self.presentationController.delegate = self;
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -1166,6 +1174,14 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     }
   }
   return nil;
+}
+
+#pragma mark - UIAdaptivePresentationControllerDelegate
+
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)presentationController {
+    if (self.screenView.onModalDismiss) {
+        self.screenView.onModalDismiss(nil);
+    }
 }
 
 #pragma mark - transition progress related methods
@@ -1462,6 +1478,7 @@ RCT_EXPORT_VIEW_PROPERTY(onTransitionProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onWillDisappear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onGestureCancel, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onModalDismiss, RCTDirectEventBlock);
 
 #if !TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -451,6 +451,12 @@ export type NativeStackNavigationOptions = {
    * @platform ios
    */
   transitionDuration?: number;
+  /**
+   * A callback that gets is called when an attempt is made to dismiss the presented view controller.
+   *
+   * @platform ios
+   */
+  onModalDismiss?: () => void;
 };
 
 export type NativeStackNavigatorProps =

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -190,6 +190,7 @@ const RouteView = ({
     swipeDirection = 'horizontal',
     transitionDuration,
     freezeOnBlur,
+    onModalDismiss,
   } = options;
 
   let {
@@ -277,6 +278,7 @@ const RouteView = ({
       sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
       customAnimationOnSwipe={customAnimationOnSwipe}
       freezeOnBlur={freezeOnBlur}
+      onModalDismiss={onModalDismiss}
       fullScreenSwipeEnabled={fullScreenSwipeEnabled}
       hideKeyboardOnSwipe={hideKeyboardOnSwipe}
       homeIndicatorHidden={homeIndicatorHidden}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -183,6 +183,13 @@ export interface ScreenProps extends ViewProps {
    */
   onDisappear?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
   /**
+  /**
+   * A callback that gets is called when an attempt is made to dismiss the presented view controller.
+   *
+   * @platform ios
+   */
+  onModalDismiss?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
+  /**
    * A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down).
    * The callback takes the number of dismissed screens as an argument since iOS 14 native header back button can pop more than 1 screen at a time.
    */


### PR DESCRIPTION
## Description

As described in this [discussion](https://github.com/software-mansion/react-native-screens/discussions/1950), this PR intercepts the event when a user tries to drag down the view, allowing to perform additional actions, such as displaying an Action Sheet for confirmation.

## Changes

- Updated `types.tsx`
- RNSScreen.h
- RNSScreen.mm

## Screenshots / GIFs

https://github.com/software-mansion/react-native-screens/assets/12258850/469aa86a-a79f-4a0d-a08b-37b82f1fcf20

## Test code and steps to reproduce

Not yet, but requires `gestureEnabled: false` and `onModalDismiss: () => showActionSheet()`

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
