### PR TITLE
fix(iOS): change RNSScreenDetentType enum to work correctly on Fabric

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -59,8 +59,8 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 };
 
 typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
-  RNSScreenDetentTypeMedium,
   RNSScreenDetentTypeLarge,
+  RNSScreenDetentTypeMedium,
   RNSScreenDetentTypeAll,
 };
 


### PR DESCRIPTION
## Description

When opening a formSheet (on iOS) from @react-navigation/native-stack on new arch I've experienced the same issue as https://github.com/software-mansion/react-native-screens/issues/1686 . After some debugging I've discovered that `sheetAllowedDetents={'large'}` transfers to **RNSScreenDetentTypeMedium** and `sheetAllowedDetents={'medium'}` to **RNSScreenDetentTypeLarge**. This PR fixes it.

## Changes

Updated _ios/RNSEnums.h_

## Test code and steps to reproduce

-

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
