### PR TITLE
fix(android): add buildFeatures.buildConfig true for AGP8+ compat

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -24,8 +24,14 @@ jobs:
       group: android-fabric-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -22,8 +22,14 @@ jobs:
       group: android-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v2
         with:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,9 @@ android {
     def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace "com.swmansion.rnscreens"
+        buildFeatures {
+            buildConfig true
+        }
     }
 
     // Used to override the NDK path/version on internal CI or by allowing


### PR DESCRIPTION
## Summary

Upcoming react-native 0.73+ includes android gradle plugin 8+ which needs namespace in build.gradle but also needs buildFeatures.buildConfig enabled as well for modules that use it

It is not sufficient to enable this at the top-level app build.gradle, specific modules that use it (such as those that implement new architecture, it seems) must also enable it at the module level

This change was necessary and is in-use in my work app via patch-package as I work through android-gradle-plugin 8+ issues in prep for react-native 0.73 launching for everyone

It should be backwards compatible with older gradle plugins in the exact same way the previous namespace change was, as it is wrapped in the same conditional

It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090

## Test Plan

### What's required for testing (prerequisites)?

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requires a large amount of transitive dependency changes in CI (see #1956 !)

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

### What are the steps to reproduce (after prerequisites)?

run the build for android