### PR TITLE
fix(iOS): Don't include AVPlayerView in `traverseForScrollView` method

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1423,6 +1423,15 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     // we don't want to send `scrollViewDidEndDecelerating` event to JS before the JS thread is ready
     return;
   }
+
+  if ([NSStringFromClass([view class]) isEqualToString:@"AVPlayerView"]) {
+    // Traversing through AVPlayerView is an uncommon edge case that causes the disappearing screen
+    // to an excessive traversal through all video player elements
+    // (e.g., for react-native-video, this includes all controls and additional video views).
+    // Thus, we want to avoid unnecessary traversals through these views.
+    return;
+  }
+
   if ([view isKindOfClass:[UIScrollView class]] &&
       ([[(UIScrollView *)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)])) {
     [[(UIScrollView *)view delegate] scrollViewDidEndDecelerating:(id)view];


### PR DESCRIPTION
## Description

Currently, in iOS 17.2 Beta 1-2 there's a bug that causes application to crash after going to the second screen with the video player that contains controls. This PR fixes this issue.

Closes #1967.

## Changes

- Added an if statement that returns if view is type of `AVPlayerView`, as we don't want to signal it about decelerating (sadly, this header file is not in UIKit's public API 😕.

## Screenshots / GIFs

### Before

https://github.com/software-mansion/react-native-screens/assets/23281839/6d040536-45fb-41ea-ad8a-1c86352bf199

### After

https://github.com/software-mansion/react-native-screens/assets/23281839/6da618e4-2bf9-47fb-be9f-e73ae560f081

## Test code and steps to reproduce

You can test this change on the repro, attached in the original issue: https://github.com/abanobmikaeel/react-native-video-crash/

## Checklist

- [X] Ensured that CI passes
