### PR TITLE
fix: build error with rn 0.73-rc.4

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
@@ -12,24 +12,24 @@ class RNSScreenComponentDescriptor final
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     react_native_assert(
-        std::dynamic_pointer_cast<RNSScreenShadowNode>(shadowNode));
-    auto screenShadowNode =
-        std::static_pointer_cast<RNSScreenShadowNode>(shadowNode);
+        dynamic_cast<RNSScreenShadowNode*>(&shadowNode));
+    auto& screenShadowNode =
+        static_cast<RNSScreenShadowNode&>(shadowNode);
 
     react_native_assert(
-        std::dynamic_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode));
-    auto layoutableShadowNode =
-        std::static_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode);
+        dynamic_cast<YogaLayoutableShadowNode*>(&screenShadowNode));
+    auto& layoutableShadowNode =
+        dynamic_cast<YogaLayoutableShadowNode&>(screenShadowNode);
 
     auto state =
         std::static_pointer_cast<const RNSScreenShadowNode::ConcreteState>(
-            shadowNode->getState());
+            shadowNode.getState());
     auto stateData = state->getData();
 
     if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
-      layoutableShadowNode->setSize(
+      layoutableShadowNode.setSize(
           Size{stateData.frameSize.width, stateData.frameSize.height});
     }
 


### PR DESCRIPTION
## Description

Fixes building agains react-native 0.73.0-rc4 in fabric mode

## Changes

Updated common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h to build with fabric on 0.73-rc4.

## Screenshots / GIFs

### Before

### After

## Test code and steps to reproduce



## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
