### PR TITLE
fix(Android): Fix error about duplicate class ViewModelLazy

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,6 +130,5 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.5.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,5 +130,10 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+
+    constraints {
+        implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
+            because("for some reason, on older React Native versions this dependency conflicts with this library")
+        }
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,7 +133,7 @@ dependencies {
 
     constraints {
         implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
-            because("for some reason, on older React Native versions this dependency conflicts with this library")
+            because("on older React Native versions this dependency conflicts with react-native-screens")
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,4 +130,6 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.core:core-ktx:1.8.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.5.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,5 +130,5 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 }


### PR DESCRIPTION
## Description

Users are reporting that they are receiving error while building their project with react-native-screens 3.27.0:

```
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class androidx.lifecycle.ViewModelLazy found in modules jetified-lifecycle-viewmodel-ktx-2.2.0-runtime (androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0) and lifecycle-viewmodel-2.5.0-runtime (androidx.lifecycle:lifecycle-viewmodel:2.5.0)
```

This error is fairly easy to fix and is related to the wrong imports of dependencies in gradle.
Closes #1947.

## Changes

- Added import for `lifecycle-viewmodel` and `lifecycle-viewmodel-ktx` (these two imports are necessary, as `lifecycle-viewmodel` evokes error for `lifecycle-viewmodel-ktx`.

## Checklist

- [ ] Ensured that CI passes
