### PR TITLE
fix(Android): modify the decorFitsSystemWindow parameter in setNavigationBarHidden

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -197,7 +197,7 @@ object ScreenWindowTraits {
         val screenForNavBarHidden = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_HIDDEN)
         val hidden = screenForNavBarHidden?.isNavigationBarHidden ?: false
 
-        WindowCompat.setDecorFitsSystemWindows(window, hidden)
+        WindowCompat.setDecorFitsSystemWindows(window, !hidden)
         if (hidden) {
             WindowInsetsControllerCompat(window, window.decorView).let { controller ->
                 controller.hide(WindowInsetsCompat.Type.navigationBars())

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -197,7 +197,6 @@ object ScreenWindowTraits {
         val screenForNavBarHidden = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_HIDDEN)
         val hidden = screenForNavBarHidden?.isNavigationBarHidden ?: false
 
-        WindowCompat.setDecorFitsSystemWindows(window, !hidden)
         if (hidden) {
             WindowInsetsControllerCompat(window, window.decorView).let { controller ->
                 controller.hide(WindowInsetsCompat.Type.navigationBars())


### PR DESCRIPTION
## Description

Currently when user tries to change the appearance of the navigation bar (using navigationBarHidden / navigationBarColor props) the content of the screen jumps to the place that does not respect safeAreaView. This PR fixes it by removing `decorFitsSystemWindow` declaration, as it breaks the interface by matching it to `fit system window`.

Resolves #1719.

## Changes

- Removed `decorFitsSystemWindow` call from `ScreenWindowTraits.kt`

## Checklist

- [X] Ensured that CI passes
