### PR TITLE
fix(iOS): PoC: initial content jump on screens with header

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -98,5 +98,6 @@ import Test1981 from './src/Test1981';
 enableFreeze(true);
 
 export default function App() {
-  return <Test42 />;
+  return <Test1981 />;
+  // return <Test1649 />;
 }

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -29,6 +29,41 @@
 namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
+@interface RNSScreenShadowView : RCTShadowView
+
+@end
+
+@implementation RNSScreenShadowView
+
+- (void)didSetProps:(NSArray<NSString *> *)changedProps
+{
+  [super didSetProps:changedProps];
+  self.top = YGValue{97.67, YGUnitPoint};
+}
+
+- (void)layoutWithMinimumSize:(CGSize)minimumSize
+                  maximumSize:(CGSize)maximumSize
+              layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection
+                layoutContext:(RCTLayoutContext)layoutContext
+{
+  [super layoutWithMinimumSize:minimumSize
+                   maximumSize:maximumSize
+               layoutDirection:layoutDirection
+                 layoutContext:layoutContext];
+}
+
+- (void)layoutSubviewsWithContext:(RCTLayoutContext)layoutContext
+{
+  [super layoutSubviewsWithContext:layoutContext];
+}
+
+- (void)layoutWithMetrics:(RCTLayoutMetrics)layoutMetrics layoutContext:(RCTLayoutContext)layoutContext
+{
+  [super layoutWithMetrics:layoutMetrics layoutContext:layoutContext];
+}
+
+@end
+
 @interface RNSScreenView ()
 #ifdef RCT_NEW_ARCH_ENABLED
     <RCTRNSScreenViewProtocol, UIAdaptivePresentationControllerDelegate>
@@ -89,6 +124,7 @@ namespace react = facebook::react;
 #if !TARGET_OS_TV
   _sheetExpandsWhenScrolledToEdge = YES;
 #endif // !TARGET_OS_TV
+  NSLog(@"CREATE ScreenView %p", self);
 }
 
 - (UIViewController *)reactViewController
@@ -344,7 +380,7 @@ namespace react = facebook::react;
   }
   // we do it here too because at this moment the `parentViewController` is already not nil,
   // so if the parent is not UINavCtr, the frame will be updated to the correct one.
-  [self reactSetFrame:_reactFrame];
+//  [self reactSetFrame:_reactFrame];
 #endif
 }
 
@@ -843,13 +879,43 @@ namespace react = facebook::react;
   // any attempt of setting that via React props
 }
 
+- (void)setFrame:(CGRect)frame
+{
+  NSLog(@"setFrame (%.2lf, %.2lf) %.2lf x %.2lf", frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+  [super setFrame:frame];
+}
+
+- (void)setBounds:(CGRect)bounds
+{
+  NSLog(
+      @"setBounds (%.2lf, %.2lf) %.2lf x %.2lf",
+      bounds.origin.x,
+      bounds.origin.y,
+      bounds.size.width,
+      bounds.size.height);
+  [super setBounds:bounds];
+}
+
+- (void)setCenter:(CGPoint)center
+{
+  NSLog(@"setCenter (%.2lf, %.2lf)", center.x, center.y);
+  [super setCenter:center];
+}
+
 - (void)reactSetFrame:(CGRect)frame
 {
+  NSLog(
+      @"reactSetFrame (%.2lf, %.2lf) %.2lf x %.2lf",
+      frame.origin.x,
+      frame.origin.y,
+      frame.size.width,
+      frame.size.height);
   _reactFrame = frame;
-  UIViewController *parentVC = self.reactViewController.parentViewController;
-  if (parentVC != nil && ![parentVC isKindOfClass:[RNSNavigationController class]]) {
-    [super reactSetFrame:frame];
-  }
+  [super reactSetFrame:frame];
+  //  UIViewController *parentVC = self.reactViewController.parentViewController;
+  //  if (parentVC != nil && ![parentVC isKindOfClass:[RNSNavigationController class]]) {
+  //    [super reactSetFrame:frame];
+  //  }
   // when screen is mounted under RNSNavigationController it's size is controller
   // by the navigation controller itself. That is, it is set to fill space of
   // the controller. In that case we ignore react layout system from managing
@@ -1518,6 +1584,11 @@ RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
 - (UIView *)view
 {
   return [[RNSScreenView alloc] initWithBridge:self.bridge];
+}
+
+- (RCTShadowView *)shadowView
+{
+  return [[RNSScreenShadowView alloc] init];
 }
 
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
## Description

Just my notes:

The idea is to set `top` property on shadow view depending whether the
screen has header or not.

The presence of the header can be detected via prop: shadow views do get
all the same initial props as normal views! (and maybe some extra), so
it is possible to pass this information down from JS, so that it is
available on first render (while the first layout is calculated).

Other option would be to defer setting the frame to the moment the UIKit
(native) layout is calculated & set the frame only after this is done.

We should also consider what should happen if the view is resized
dynamically e.g. by gesture on native side. The native layout gets
triggered no matter what and we can not prevent it. The question is
whether we should trigger RCT layout or not...

Triggering the layout could be problematic in context of view-clipping (especially on modals).
Not triggering it will **most likely** (maybe there is some workaround) cause centered-views, scrollviews, etc. to not function properly.

Some option would be to use `UIView.topLayoutGuide` (and remove `edgesForExtendedLayout` (it is not deprecated, but it is recommended against using it)) and instead of
calling `setSize` on `UIManager`, what results in scheduling a block on
`UIManager` thread that sets the size on shadow view & schedules the
layout, we could update shadow's view top property (or any other helper
property we define) to appropriate value, set appropriate size and just
then schedule the layout?

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
