### PR TITLE
refact(Android): unify member-field naming convention in Kotlin

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomSearchView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomSearchView.kt
@@ -13,17 +13,17 @@ class CustomSearchView(context: Context, fragment: Fragment) : SearchView(contex
         setOnSearchClickListener - https://developer.android.com/reference/android/widget/SearchView#setOnSearchClickListener(android.view.View.OnClickListener)
         setOnCloseListener - https://developer.android.com/reference/android/widget/SearchView#setOnCloseListener(android.widget.SearchView.OnCloseListener)
     */
-    private var mCustomOnCloseListener: OnCloseListener? = null
-    private var mCustomOnSearchClickedListener: OnClickListener? = null
+    private var onCloseListener: OnCloseListener? = null
+    private var onSearchClickedListener: OnClickListener? = null
 
-    private var mOnBackPressedCallback: OnBackPressedCallback =
+    private var onBackPressedCallback: OnBackPressedCallback =
         object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 isIconified = true
             }
         }
 
-    private val backPressOverrider = FragmentBackPressOverrider(fragment, mOnBackPressedCallback)
+    private val backPressOverrider = FragmentBackPressOverrider(fragment, onBackPressedCallback)
 
     var overrideBackAction: Boolean
         set(value) {
@@ -46,11 +46,11 @@ class CustomSearchView(context: Context, fragment: Fragment) : SearchView(contex
     }
 
     override fun setOnCloseListener(listener: OnCloseListener?) {
-        mCustomOnCloseListener = listener
+        onCloseListener = listener
     }
 
     override fun setOnSearchClickListener(listener: OnClickListener?) {
-        mCustomOnSearchClickedListener = listener
+        onSearchClickedListener = listener
     }
 
     override fun onAttachedToWindow() {
@@ -67,12 +67,12 @@ class CustomSearchView(context: Context, fragment: Fragment) : SearchView(contex
 
     init {
         super.setOnSearchClickListener { v ->
-            mCustomOnSearchClickedListener?.onClick(v)
+            onSearchClickedListener?.onClick(v)
             backPressOverrider.maybeAddBackCallback()
         }
 
         super.setOnCloseListener {
-            val result = mCustomOnCloseListener?.onClose() ?: false
+            val result = onCloseListener?.onClose() ?: false
             backPressOverrider.removeBackCallbackIfAdded()
             result
         }

--- a/android/src/main/java/com/swmansion/rnscreens/FragmentBackPressOverrider.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/FragmentBackPressOverrider.kt
@@ -5,25 +5,25 @@ import androidx.fragment.app.Fragment
 
 class FragmentBackPressOverrider(
     private val fragment: Fragment,
-    private val mOnBackPressedCallback: OnBackPressedCallback
+    private val onBackPressedCallback: OnBackPressedCallback
 ) {
-    private var mIsBackCallbackAdded: Boolean = false
+    private var isCallbackAdded: Boolean = false
     var overrideBackAction: Boolean = true
 
     fun maybeAddBackCallback() {
-        if (!mIsBackCallbackAdded && overrideBackAction) {
+        if (!isCallbackAdded && overrideBackAction) {
             fragment.activity?.onBackPressedDispatcher?.addCallback(
                 fragment,
-                mOnBackPressedCallback
+                onBackPressedCallback
             )
-            mIsBackCallbackAdded = true
+            isCallbackAdded = true
         }
     }
 
     fun removeBackCallbackIfAdded() {
-        if (mIsBackCallbackAdded) {
-            mOnBackPressedCallback.remove()
-            mIsBackCallbackAdded = false
+        if (isCallbackAdded) {
+            onBackPressedCallback.remove()
+            isCallbackAdded = false
         }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -236,7 +236,7 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
         // Check if it's possible to get an attribute from theme context and assign a value from it.
         // Otherwise, the default value will be returned.
         val actionBarHeight = TypedValue.complexToDimensionPixelSize(actionBarTv.data, resources.displayMetrics)
-            .takeIf { resolvedActionBarSize && headerConfig?.mIsHidden != true }
+            .takeIf { resolvedActionBarSize && headerConfig?.isHidden != true }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 0.0
 
         val statusBarHeight = context.resources.getIdentifier("status_bar_height", "dimen", "android")

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -19,7 +19,7 @@ import com.facebook.react.uimanager.UIManagerModule
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 
 @SuppressLint("ViewConstructor")
-class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(context) {
+class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
     val fragment: Fragment?
         get() = fragmentWrapper?.fragment
 
@@ -27,21 +27,14 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
     var container: ScreenContainer? = null
     var activityState: ActivityState? = null
         private set
-    private var mTransitioning = false
+    private var isTransitioning = false
     var stackPresentation = StackPresentation.PUSH
     var replaceAnimation = ReplaceAnimation.POP
     var stackAnimation = StackAnimation.DEFAULT
     var isGestureEnabled = true
     var screenOrientation: Int? = null
         private set
-    private var mStatusBarStyle: String? = null
-    private var mStatusBarHidden: Boolean? = null
-    private var mStatusBarTranslucent: Boolean? = null
-    private var mStatusBarColor: Int? = null
-    private var mNavigationBarColor: Int? = null
-    private var mNavigationBarHidden: Boolean? = null
     var isStatusBarAnimated: Boolean? = null
-    private var mNativeBackButtonDismissalEnabled = true
 
     init {
         // we set layout params as WindowManager.LayoutParams to workaround the issue with TextInputs
@@ -102,10 +95,10 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
      * container when transitioning is detected and turned off immediately after
      */
     fun setTransitioning(transitioning: Boolean) {
-        if (mTransitioning == transitioning) {
+        if (isTransitioning == transitioning) {
             return
         }
-        mTransitioning = transitioning
+        isTransitioning = transitioning
         val isWebViewInScreen = hasWebView(this)
         if (isWebViewInScreen && layerType != LAYER_TYPE_HARDWARE) {
             return
@@ -169,33 +162,30 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
         this.headerConfig?.toolbar?.importantForAccessibility = mode
     }
 
-    var statusBarStyle: String?
-        get() = mStatusBarStyle
+    var statusBarStyle: String? = null
         set(statusBarStyle) {
             if (statusBarStyle != null) {
                 ScreenWindowTraits.applyDidSetStatusBarAppearance()
             }
-            mStatusBarStyle = statusBarStyle
+            field = statusBarStyle
             fragmentWrapper?.let { ScreenWindowTraits.setStyle(this, it.tryGetActivity(), it.tryGetContext()) }
         }
 
-    var isStatusBarHidden: Boolean?
-        get() = mStatusBarHidden
+    var isStatusBarHidden: Boolean? = null
         set(statusBarHidden) {
             if (statusBarHidden != null) {
                 ScreenWindowTraits.applyDidSetStatusBarAppearance()
             }
-            mStatusBarHidden = statusBarHidden
+            field = statusBarHidden
             fragmentWrapper?.let { ScreenWindowTraits.setHidden(this, it.tryGetActivity()) }
         }
 
-    var isStatusBarTranslucent: Boolean?
-        get() = mStatusBarTranslucent
+    var isStatusBarTranslucent: Boolean? = null
         set(statusBarTranslucent) {
             if (statusBarTranslucent != null) {
                 ScreenWindowTraits.applyDidSetStatusBarAppearance()
             }
-            mStatusBarTranslucent = statusBarTranslucent
+            field = statusBarTranslucent
             fragmentWrapper?.let {
                 ScreenWindowTraits.setTranslucent(
                     this,
@@ -205,33 +195,30 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
             }
         }
 
-    var statusBarColor: Int?
-        get() = mStatusBarColor
+    var statusBarColor: Int? = null
         set(statusBarColor) {
             if (statusBarColor != null) {
                 ScreenWindowTraits.applyDidSetStatusBarAppearance()
             }
-            mStatusBarColor = statusBarColor
+            field = statusBarColor
             fragmentWrapper?.let { ScreenWindowTraits.setColor(this, it.tryGetActivity(), it.tryGetContext()) }
         }
 
-    var navigationBarColor: Int?
-        get() = mNavigationBarColor
+    var navigationBarColor: Int? = null
         set(navigationBarColor) {
             if (navigationBarColor != null) {
                 ScreenWindowTraits.applyDidSetNavigationBarAppearance()
             }
-            mNavigationBarColor = navigationBarColor
+            field = navigationBarColor
             fragmentWrapper?.let { ScreenWindowTraits.setNavigationBarColor(this, it.tryGetActivity()) }
         }
 
-    var isNavigationBarHidden: Boolean?
-        get() = mNavigationBarHidden
+    var isNavigationBarHidden: Boolean? = null
         set(navigationBarHidden) {
             if (navigationBarHidden != null) {
                 ScreenWindowTraits.applyDidSetNavigationBarAppearance()
             }
-            mNavigationBarHidden = navigationBarHidden
+            field = navigationBarHidden
             fragmentWrapper?.let {
                 ScreenWindowTraits.setNavigationBarHidden(
                     this,
@@ -240,11 +227,7 @@ class Screen constructor(context: ReactContext?) : FabricEnabledViewGroup(contex
             }
         }
 
-    var nativeBackButtonDismissalEnabled: Boolean
-        get() = mNativeBackButtonDismissalEnabled
-        set(enableNativeBackButtonDismissal) {
-            mNativeBackButtonDismissalEnabled = enableNativeBackButtonDismissal
-        }
+    var nativeBackButtonDismissalEnabled: Boolean = true
 
     private fun calculateHeaderHeight() {
         val actionBarTv = TypedValue()

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -236,7 +236,7 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
         // Check if it's possible to get an attribute from theme context and assign a value from it.
         // Otherwise, the default value will be returned.
         val actionBarHeight = TypedValue.complexToDimensionPixelSize(actionBarTv.data, resources.displayMetrics)
-            .takeIf { resolvedActionBarSize && headerConfig?.isHidden != true }
+            .takeIf { resolvedActionBarSize && headerConfig?.isHeaderHidden != true }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 0.0
 
         val statusBarHeight = context.resources.getIdentifier("status_bar_height", "dimen", "android")

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -191,7 +191,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
     }
 
     protected fun createTransaction(): FragmentTransaction {
-        return requireNotNull(fragmentManager) { "mFragmentManager is null when creating transaction" }
+        return requireNotNull(fragmentManager) { "fragment manager is null when creating transaction" }
             .beginTransaction()
             .setReorderingAllowed(true)
     }
@@ -316,7 +316,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
             // detach screens that are no longer active
             val orphaned: MutableSet<Fragment> = HashSet(
                 requireNotNull(fragmentManager) {
-                    "mFragmentManager is null when performing update in ScreenContainer"
+                    "fragment manager is null when performing update in ScreenContainer"
                 }.fragments
             )
             for (fragmentWrapper in screenWrappers) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -18,15 +18,15 @@ import com.swmansion.rnscreens.Screen.ActivityState
 
 open class ScreenContainer(context: Context?) : ViewGroup(context) {
     @JvmField
-    protected val mScreenFragments = ArrayList<ScreenFragmentWrapper>()
+    protected val screenWrappers = ArrayList<ScreenFragmentWrapper>()
     @JvmField
-    protected var mFragmentManager: FragmentManager? = null
-    private var mIsAttached = false
-    private var mNeedUpdate = false
-    private var mLayoutEnqueued = false
-    private val mLayoutCallback: ChoreographerCompat.FrameCallback = object : ChoreographerCompat.FrameCallback() {
+    protected var fragmentManager: FragmentManager? = null
+    private var isAttached = false
+    private var needsUpdate = false
+    private var isLayoutEnqueued = false
+    private val layoutCallback: ChoreographerCompat.FrameCallback = object : ChoreographerCompat.FrameCallback() {
         override fun doFrame(frameTimeNanos: Long) {
-            mLayoutEnqueued = false
+            isLayoutEnqueued = false
             measure(
                 MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
@@ -34,7 +34,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
             layout(left, top, right, bottom)
         }
     }
-    private var mParentScreenFragment: ScreenFragmentWrapper? = null
+    private var parentScreenWrapper: ScreenFragmentWrapper? = null
 
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         var i = 0
@@ -69,19 +69,19 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
     override fun requestLayout() {
         super.requestLayout()
         @Suppress("SENSELESS_COMPARISON") // mLayoutCallback can be null here since this method can be called in init
-        if (!mLayoutEnqueued && mLayoutCallback != null) {
-            mLayoutEnqueued = true
+        if (!isLayoutEnqueued && layoutCallback != null) {
+            isLayoutEnqueued = true
             // we use NATIVE_ANIMATED_MODULE choreographer queue because it allows us to catch the current
             // looper loop instead of enqueueing the update in the next loop causing a one frame delay.
             ReactChoreographer.getInstance()
                 .postFrameCallback(
-                    ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, mLayoutCallback
+                    ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, layoutCallback
                 )
         }
     }
 
     val isNested: Boolean
-        get() = mParentScreenFragment != null
+        get() = parentScreenWrapper != null
 
     fun notifyChildUpdate() {
         performUpdatesNow()
@@ -92,37 +92,37 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
     fun addScreen(screen: Screen, index: Int) {
         val fragment = adapt(screen)
         screen.fragmentWrapper = fragment
-        mScreenFragments.add(index, fragment)
+        screenWrappers.add(index, fragment)
         screen.container = this
         onScreenChanged()
     }
 
     open fun removeScreenAt(index: Int) {
-        mScreenFragments[index].screen.container = null
-        mScreenFragments.removeAt(index)
+        screenWrappers[index].screen.container = null
+        screenWrappers.removeAt(index)
         onScreenChanged()
     }
 
     open fun removeAllScreens() {
-        for (screenFragment in mScreenFragments) {
+        for (screenFragment in screenWrappers) {
             screenFragment.screen.container = null
         }
-        mScreenFragments.clear()
+        screenWrappers.clear()
         onScreenChanged()
     }
 
     val screenCount: Int
-        get() = mScreenFragments.size
+        get() = screenWrappers.size
 
-    fun getScreenAt(index: Int): Screen = mScreenFragments[index].screen
+    fun getScreenAt(index: Int): Screen = screenWrappers[index].screen
 
-    fun getScreenFragmentWrapperAt(index: Int): ScreenFragmentWrapper = mScreenFragments[index]
+    fun getScreenFragmentWrapperAt(index: Int): ScreenFragmentWrapper = screenWrappers[index]
 
     open val topScreen: Screen?
-        get() = mScreenFragments.firstOrNull { getActivityState(it) === ActivityState.ON_TOP }?.screen
+        get() = screenWrappers.firstOrNull { getActivityState(it) === ActivityState.ON_TOP }?.screen
 
     private fun setFragmentManager(fm: FragmentManager) {
-        mFragmentManager = fm
+        fragmentManager = fm
         performUpdatesNow()
     }
 
@@ -174,7 +174,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         if (parent is Screen) {
             checkNotNull(
                 parent.fragmentWrapper?.let { fragmentWrapper ->
-                    mParentScreenFragment = fragmentWrapper
+                    parentScreenWrapper = fragmentWrapper
                     fragmentWrapper.addChildScreenContainer(this)
                     setFragmentManager(fragmentWrapper.fragment.childFragmentManager)
                 }
@@ -191,7 +191,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
     }
 
     protected fun createTransaction(): FragmentTransaction {
-        return requireNotNull(mFragmentManager) { "mFragmentManager is null when creating transaction" }
+        return requireNotNull(fragmentManager) { "mFragmentManager is null when creating transaction" }
             .beginTransaction()
             .setReorderingAllowed(true)
     }
@@ -208,11 +208,11 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         screenFragmentWrapper.screen.activityState
 
     open fun hasScreen(screenFragmentWrapper: ScreenFragmentWrapper?): Boolean =
-        mScreenFragments.contains(screenFragmentWrapper)
+        screenWrappers.contains(screenFragmentWrapper)
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        mIsAttached = true
+        isAttached = true
         setupFragmentManager()
     }
 
@@ -238,18 +238,18 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // view. We also need to make sure all the fragments attached to the given container are removed
         // from fragment manager as in some cases fragment manager may be reused and in such case it'd
         // attempt to reattach previously registered fragments that are not removed
-        mFragmentManager?.let {
+        fragmentManager?.let {
             if (!it.isDestroyed) {
                 removeMyFragments(it)
                 it.executePendingTransactions()
             }
         }
 
-        mParentScreenFragment?.removeChildScreenContainer(this)
-        mParentScreenFragment = null
+        parentScreenWrapper?.removeChildScreenContainer(this)
+        parentScreenWrapper = null
 
         super.onDetachedFromWindow()
-        mIsAttached = false
+        isAttached = false
         // When fragment container view is detached we force all its children to be removed.
         // It is because children screens are controlled by their fragments, which can often have a
         // delayed lifecycle (due to transitions). As a result due to ongoing transitions the fragment
@@ -283,7 +283,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // before transition if also not dispatched after children updates.
         // The exception to this rule is `updateImmediately` which is triggered by actions
         // not connected to React view hierarchy changes, but rather internal events
-        mNeedUpdate = true
+        needsUpdate = true
         (context as? ReactContext)?.runOnUiQueueThread {
             // We schedule the update here because LayoutAnimations of `react-native-reanimated`
             // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
@@ -298,15 +298,15 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // we want to update immediately when the fragment manager is set or native back button
         // dismiss is dispatched or Screen's activityState changes since it is not connected to React
         // view hierarchy changes and will not trigger `onBeforeLayout` method of `ScreensShadowNode`
-        mNeedUpdate = true
+        needsUpdate = true
         performUpdates()
     }
 
     fun performUpdates() {
-        if (!mNeedUpdate || !mIsAttached || mFragmentManager == null || mFragmentManager?.isDestroyed == true) {
+        if (!needsUpdate || !isAttached || fragmentManager == null || fragmentManager?.isDestroyed == true) {
             return
         }
-        mNeedUpdate = false
+        needsUpdate = false
         onUpdate()
         notifyContainerUpdate()
     }
@@ -315,11 +315,11 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         createTransaction().let {
             // detach screens that are no longer active
             val orphaned: MutableSet<Fragment> = HashSet(
-                requireNotNull(mFragmentManager) {
+                requireNotNull(fragmentManager) {
                     "mFragmentManager is null when performing update in ScreenContainer"
                 }.fragments
             )
-            for (fragmentWrapper in mScreenFragments) {
+            for (fragmentWrapper in screenWrappers) {
                 if (getActivityState(fragmentWrapper) === ActivityState.INACTIVE &&
                     fragmentWrapper.fragment.isAdded
                 ) {
@@ -345,7 +345,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
             var addedBefore = false
             val pendingFront: ArrayList<ScreenFragmentWrapper> = ArrayList()
 
-            for (fragmentWrapper in mScreenFragments) {
+            for (fragmentWrapper in screenWrappers) {
                 val activityState = getActivityState(fragmentWrapper)
                 if (activityState !== ActivityState.INACTIVE && !fragmentWrapper.fragment.isAdded) {
                     addedBefore = true

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -27,7 +27,7 @@ import kotlin.math.min
 
 open class ScreenFragment : Fragment, ScreenFragmentWrapper {
     enum class ScreenLifecycleEvent {
-        Appear, WillAppear, Disappear, WillDisappear
+        DID_APPEAR, WILL_APPEAR, DID_DISAPPEAR, WILL_DISAPPEAR
     }
 
     override val fragment: Fragment
@@ -155,38 +155,38 @@ open class ScreenFragment : Fragment, ScreenFragmentWrapper {
     }
 
     override fun canDispatchLifecycleEvent(event: ScreenLifecycleEvent): Boolean = when (event) {
-        ScreenLifecycleEvent.WillAppear -> canDispatchWillAppear
-        ScreenLifecycleEvent.Appear -> canDispatchAppear
-        ScreenLifecycleEvent.WillDisappear -> !canDispatchWillAppear
-        ScreenLifecycleEvent.Disappear -> !canDispatchAppear
+        ScreenLifecycleEvent.WILL_APPEAR -> canDispatchWillAppear
+        ScreenLifecycleEvent.DID_APPEAR -> canDispatchAppear
+        ScreenLifecycleEvent.WILL_DISAPPEAR -> !canDispatchWillAppear
+        ScreenLifecycleEvent.DID_DISAPPEAR -> !canDispatchAppear
     }
 
     override fun updateLastEventDispatched(event: ScreenLifecycleEvent) {
         when (event) {
-            ScreenLifecycleEvent.WillAppear -> canDispatchWillAppear = false
-            ScreenLifecycleEvent.Appear -> canDispatchAppear = false
-            ScreenLifecycleEvent.WillDisappear -> canDispatchWillAppear = true
-            ScreenLifecycleEvent.Disappear -> canDispatchAppear = true
+            ScreenLifecycleEvent.WILL_APPEAR -> canDispatchWillAppear = false
+            ScreenLifecycleEvent.DID_APPEAR -> canDispatchAppear = false
+            ScreenLifecycleEvent.WILL_DISAPPEAR -> canDispatchWillAppear = true
+            ScreenLifecycleEvent.DID_DISAPPEAR -> canDispatchAppear = true
         }
     }
 
     private fun dispatchOnWillAppear() {
-        dispatchLifecycleEvent(ScreenLifecycleEvent.WillAppear, this)
+        dispatchLifecycleEvent(ScreenLifecycleEvent.WILL_APPEAR, this)
         dispatchTransitionProgressEvent(0.0f, false)
     }
 
     private fun dispatchOnAppear() {
-        dispatchLifecycleEvent(ScreenLifecycleEvent.Appear, this)
+        dispatchLifecycleEvent(ScreenLifecycleEvent.DID_APPEAR, this)
         dispatchTransitionProgressEvent(1.0f, false)
     }
 
     private fun dispatchOnWillDisappear() {
-        dispatchLifecycleEvent(ScreenLifecycleEvent.WillDisappear, this)
+        dispatchLifecycleEvent(ScreenLifecycleEvent.WILL_DISAPPEAR, this)
         dispatchTransitionProgressEvent(0.0f, true)
     }
 
     private fun dispatchOnDisappear() {
-        dispatchLifecycleEvent(ScreenLifecycleEvent.Disappear, this)
+        dispatchLifecycleEvent(ScreenLifecycleEvent.DID_DISAPPEAR, this)
         dispatchTransitionProgressEvent(1.0f, true)
     }
 
@@ -197,10 +197,10 @@ open class ScreenFragment : Fragment, ScreenFragmentWrapper {
                 fragmentWrapper.updateLastEventDispatched(event)
                 val surfaceId = UIManagerHelper.getSurfaceId(it)
                 val lifecycleEvent: Event<*> = when (event) {
-                    ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(surfaceId, it.id)
-                    ScreenLifecycleEvent.Appear -> ScreenAppearEvent(surfaceId, it.id)
-                    ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(surfaceId, it.id)
-                    ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(surfaceId, it.id)
+                    ScreenLifecycleEvent.WILL_APPEAR -> ScreenWillAppearEvent(surfaceId, it.id)
+                    ScreenLifecycleEvent.DID_APPEAR -> ScreenAppearEvent(surfaceId, it.id)
+                    ScreenLifecycleEvent.WILL_DISAPPEAR -> ScreenWillDisappearEvent(surfaceId, it.id)
+                    ScreenLifecycleEvent.DID_DISAPPEAR -> ScreenDisappearEvent(surfaceId, it.id)
                 }
                 val screenContext = screen.context as ReactContext
                 val eventDispatcher: EventDispatcher? =

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -12,30 +12,30 @@ import kotlin.collections.ArrayList
 import kotlin.collections.HashSet
 
 class ScreenStack(context: Context?) : ScreenContainer(context) {
-    private val mStack = ArrayList<ScreenStackFragmentWrapper>()
-    private val mDismissed: MutableSet<ScreenStackFragmentWrapper> = HashSet()
+    private val stack = ArrayList<ScreenStackFragmentWrapper>()
+    private val dismissedWrappers: MutableSet<ScreenStackFragmentWrapper> = HashSet()
     private val drawingOpPool: MutableList<DrawingOp> = ArrayList()
     private var drawingOps: MutableList<DrawingOp> = ArrayList()
-    private var mTopScreen: ScreenStackFragmentWrapper? = null
-    private var mRemovalTransitionStarted = false
+    private var topScreenWrapper: ScreenStackFragmentWrapper? = null
+    private var removalTransitionStarted = false
     private var isDetachingCurrentScreen = false
     private var reverseLastTwoChildren = false
     private var previousChildrenCount = 0
     var goingForward = false
 
     fun dismiss(screenFragment: ScreenStackFragmentWrapper) {
-        mDismissed.add(screenFragment)
+        dismissedWrappers.add(screenFragment)
         performUpdatesNow()
     }
 
     override val topScreen: Screen?
-        get() = mTopScreen?.screen
+        get() = topScreenWrapper?.screen
 
     val rootScreen: Screen
         get() {
             for (i in 0 until screenCount) {
                 val screenWrapper = getScreenFragmentWrapperAt(i)
-                if (!mDismissed.contains(screenWrapper)) {
+                if (!dismissedWrappers.contains(screenWrapper)) {
                     return screenWrapper.screen
                 }
             }
@@ -46,19 +46,19 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
 
     override fun startViewTransition(view: View) {
         super.startViewTransition(view)
-        mRemovalTransitionStarted = true
+        removalTransitionStarted = true
     }
 
     override fun endViewTransition(view: View) {
         super.endViewTransition(view)
-        if (mRemovalTransitionStarted) {
-            mRemovalTransitionStarted = false
+        if (removalTransitionStarted) {
+            removalTransitionStarted = false
             dispatchOnFinishTransitioning()
         }
     }
 
     fun onViewAppearTransitionEnd() {
-        if (!mRemovalTransitionStarted) {
+        if (!removalTransitionStarted) {
             dispatchOnFinishTransitioning()
         }
     }
@@ -71,17 +71,17 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
     }
 
     override fun removeScreenAt(index: Int) {
-        mDismissed.remove(getScreenFragmentWrapperAt(index))
+        dismissedWrappers.remove(getScreenFragmentWrapperAt(index))
         super.removeScreenAt(index)
     }
 
     override fun removeAllScreens() {
-        mDismissed.clear()
+        dismissedWrappers.clear()
         super.removeAllScreens()
     }
 
     override fun hasScreen(screenFragmentWrapper: ScreenFragmentWrapper?): Boolean =
-        super.hasScreen(screenFragmentWrapper) && !mDismissed.contains(screenFragmentWrapper)
+        super.hasScreen(screenFragmentWrapper) && !dismissedWrappers.contains(screenFragmentWrapper)
 
     override fun onUpdate() {
         // When going back from a nested stack with a single screen on it, we may hit an edge case
@@ -90,9 +90,9 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
         var newTop: ScreenFragmentWrapper? = null // newTop is nullable, see the above comment ^
         var visibleBottom: ScreenFragmentWrapper? = null // this is only set if newTop has TRANSPARENT_MODAL presentation mode
         isDetachingCurrentScreen = false // we reset it so the previous value is not used by mistake
-        for (i in mScreenFragments.indices.reversed()) {
+        for (i in screenWrappers.indices.reversed()) {
             val screen = getScreenFragmentWrapperAt(i)
-            if (!mDismissed.contains(screen)) {
+            if (!dismissedWrappers.contains(screen)) {
                 if (newTop == null) {
                     newTop = screen
                 } else {
@@ -105,29 +105,29 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
         }
         var shouldUseOpenAnimation = true
         var stackAnimation: StackAnimation? = null
-        if (!mStack.contains(newTop)) {
+        if (!stack.contains(newTop)) {
             // if new top screen wasn't on stack we do "open animation" so long it is not the very first
             // screen on stack
-            if (mTopScreen != null && newTop != null) {
+            if (topScreenWrapper != null && newTop != null) {
                 // there was some other screen attached before
                 // if the previous top screen does not exist anymore and the new top was not on the stack
                 // before, probably replace or reset was called, so we play the "close animation".
                 // Otherwise it's open animation
-                val containsTopScreen = mTopScreen?.let { mScreenFragments.contains(it) } == true
+                val containsTopScreen = topScreenWrapper?.let { screenWrappers.contains(it) } == true
                 val isPushReplace = newTop.screen.replaceAnimation === Screen.ReplaceAnimation.PUSH
                 shouldUseOpenAnimation = containsTopScreen || isPushReplace
                 // if the replace animation is `push`, the new top screen provides the animation, otherwise the previous one
-                stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
-            } else if (mTopScreen == null && newTop != null) {
+                stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else topScreenWrapper?.screen?.stackAnimation
+            } else if (topScreenWrapper == null && newTop != null) {
                 // mTopScreen was not present before so newTop is the first screen added to a stack
                 // and we don't want the animation when it is entering
                 stackAnimation = StackAnimation.NONE
                 goingForward = true
             }
-        } else if (mTopScreen != null && mTopScreen != newTop) {
+        } else if (topScreenWrapper != null && topScreenWrapper != newTop) {
             // otherwise if we are performing top screen change we do "close animation"
             shouldUseOpenAnimation = false
-            stackAnimation = mTopScreen?.screen?.stackAnimation
+            stackAnimation = topScreenWrapper?.screen?.stackAnimation
         }
 
         createTransaction().let {
@@ -180,19 +180,19 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
             }
 
             // remove all screens previously on stack
-            for (fragmentWrapper in mStack) {
-                if (!mScreenFragments.contains(fragmentWrapper) || mDismissed.contains(fragmentWrapper)) {
+            for (fragmentWrapper in stack) {
+                if (!screenWrappers.contains(fragmentWrapper) || dismissedWrappers.contains(fragmentWrapper)) {
                     it.remove(fragmentWrapper.fragment)
                 }
             }
-            for (fragmentWrapper in mScreenFragments) {
+            for (fragmentWrapper in screenWrappers) {
                 // Stop detaching screens when reaching visible bottom. All screens above bottom should be
                 // visible.
                 if (fragmentWrapper === visibleBottom) {
                     break
                 }
                 // detach all screens that should not be visible
-                if (fragmentWrapper !== newTop && !mDismissed.contains(fragmentWrapper)) {
+                if (fragmentWrapper !== newTop && !dismissedWrappers.contains(fragmentWrapper)) {
                     it.remove(fragmentWrapper.fragment)
                 }
             }
@@ -201,7 +201,7 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
             if (visibleBottom != null && !visibleBottom.fragment.isAdded) {
                 val top = newTop
                 var beneathVisibleBottom = true
-                for (fragmentWrapper in mScreenFragments) {
+                for (fragmentWrapper in screenWrappers) {
                     // ignore all screens beneath the visible bottom
                     if (beneathVisibleBottom) {
                         beneathVisibleBottom = if (fragmentWrapper === visibleBottom) {
@@ -214,9 +214,9 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
             } else if (newTop != null && !newTop.fragment.isAdded) {
                 it.add(id, newTop.fragment)
             }
-            mTopScreen = newTop as? ScreenStackFragmentWrapper
-            mStack.clear()
-            mStack.addAll(mScreenFragments.map { it as ScreenStackFragmentWrapper })
+            topScreenWrapper = newTop as? ScreenStackFragmentWrapper
+            stack.clear()
+            stack.addAll(screenWrappers.map { it as ScreenStackFragmentWrapper })
 
             turnOffA11yUnderTransparentScreen(visibleBottom)
 
@@ -226,10 +226,10 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
 
     // only top visible screen should be accessible
     private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenFragmentWrapper?) {
-        if (mScreenFragments.size > 1 && visibleBottom != null) {
-            mTopScreen?.let {
+        if (screenWrappers.size > 1 && visibleBottom != null) {
+            topScreenWrapper?.let {
                 if (isTransparent(it)) {
-                    val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1).asReversed()
+                    val screenFragmentsBeneathTop = screenWrappers.slice(0 until screenWrappers.size - 1).asReversed()
                     // go from the top of the stack excluding the top screen
                     for (fragmentWrapper in screenFragmentsBeneathTop) {
                         fragmentWrapper.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
@@ -247,7 +247,7 @@ class ScreenStack(context: Context?) : ScreenContainer(context) {
     }
 
     override fun notifyContainerUpdate() {
-        mStack.forEach { it.onContainerUpdate() }
+        stack.forEach { it.onContainerUpdate() }
     }
 
     // below methods are taken from

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -22,12 +22,12 @@ import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
 import com.swmansion.rnscreens.utils.DeviceUtils
 
 class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
-    private var mAppBarLayout: AppBarLayout? = null
-    private var mToolbar: Toolbar? = null
-    private var mShadowHidden = false
-    private var mIsTranslucent = false
+    private var appBarLayout: AppBarLayout? = null
+    private var toolbar: Toolbar? = null
+    private var isToolbarShadowHidden = false
+    private var isToolbarTranslucent = false
 
-    private var mLastFocusedChild: View? = null
+    private var lastFocusedChild: View? = null
 
     var searchView: CustomSearchView? = null
     var onSearchViewCreate: ((searchView: CustomSearchView) -> Unit)? = null
@@ -42,37 +42,37 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
     }
 
     override fun removeToolbar() {
-        mAppBarLayout?.let {
-            mToolbar?.let { toolbar ->
+        appBarLayout?.let {
+            toolbar?.let { toolbar ->
                 if (toolbar.parent === it) {
                     it.removeView(toolbar)
                 }
             }
         }
-        mToolbar = null
+        toolbar = null
     }
 
     override fun setToolbar(toolbar: Toolbar) {
-        mAppBarLayout?.addView(toolbar)
+        appBarLayout?.addView(toolbar)
         toolbar.layoutParams = AppBarLayout.LayoutParams(
             AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
         ).apply { scrollFlags = 0 }
-        mToolbar = toolbar
+        this.toolbar = toolbar
     }
 
     override fun setToolbarShadowHidden(hidden: Boolean) {
-        if (mShadowHidden != hidden) {
-            mAppBarLayout?.targetElevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
-            mShadowHidden = hidden
+        if (isToolbarShadowHidden != hidden) {
+            appBarLayout?.targetElevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
+            isToolbarShadowHidden = hidden
         }
     }
 
     override fun setToolbarTranslucent(translucent: Boolean) {
-        if (mIsTranslucent != translucent) {
+        if (isToolbarTranslucent != translucent) {
             val params = screen.layoutParams
             (params as CoordinatorLayout.LayoutParams).behavior =
                 if (translucent) null else ScrollingViewBehavior()
-            mIsTranslucent = translucent
+            isToolbarTranslucent = translucent
         }
     }
 
@@ -94,7 +94,7 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
     }
 
     override fun onStart() {
-        mLastFocusedChild?.requestFocus()
+        lastFocusedChild?.requestFocus()
         super.onStart()
     }
 
@@ -108,11 +108,11 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
 
         screen.layoutParams = CoordinatorLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT
-        ).apply { behavior = if (mIsTranslucent) null else ScrollingViewBehavior() }
+        ).apply { behavior = if (isToolbarTranslucent) null else ScrollingViewBehavior() }
 
         view?.addView(recycleView(screen))
 
-        mAppBarLayout = context?.let { AppBarLayout(it) }?.apply {
+        appBarLayout = context?.let { AppBarLayout(it) }?.apply {
             // By default AppBarLayout will have a background color set but since we cover the whole layout
             // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
             // role. On top of that it breaks screens animations when alfa offscreen compositing is off
@@ -123,18 +123,18 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
             )
         }
 
-        view?.addView(mAppBarLayout)
-        if (mShadowHidden) {
-            mAppBarLayout?.targetElevation = 0f
+        view?.addView(appBarLayout)
+        if (isToolbarShadowHidden) {
+            appBarLayout?.targetElevation = 0f
         }
-        mToolbar?.let { mAppBarLayout?.addView(recycleView(it)) }
+        toolbar?.let { appBarLayout?.addView(recycleView(it)) }
         setHasOptionsMenu(true)
         return view
     }
 
     override fun onStop() {
         if (DeviceUtils.isPlatformAndroidTV(context))
-            mLastFocusedChild = findLastFocusedChild()
+            lastFocusedChild = findLastFocusedChild()
 
         super.onStop()
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -22,28 +22,28 @@ import com.swmansion.rnscreens.events.HeaderAttachedEvent
 import com.swmansion.rnscreens.events.HeaderDetachedEvent
 
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
-    private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)
+    private val configSubviews = ArrayList<ScreenStackHeaderSubview>(3)
     val toolbar: CustomToolbar
-    var mIsHidden = false
+    var isHidden = false
     private var headerTopInset: Int? = null
-    private var mTitle: String? = null
-    private var mTitleColor = 0
-    private var mTitleFontFamily: String? = null
-    private var mDirection: String? = null
-    private var mTitleFontSize = 0f
-    private var mTitleFontWeight = 0
-    private var mBackgroundColor: Int? = null
-    private var mIsBackButtonHidden = false
-    private var mIsShadowHidden = false
-    private var mDestroyed = false
-    private var mBackButtonInCustomView = false
-    private var mIsTopInsetEnabled = true
-    private var mIsTranslucent = false
-    private var mTintColor = 0
-    private var mIsAttachedToWindow = false
-    private val mDefaultStartInset: Int
-    private val mDefaultStartInsetWithNavigation: Int
-    private val mBackClickListener = OnClickListener {
+    private var title: String? = null
+    private var titleColor = 0
+    private var titleFontFamily: String? = null
+    private var direction: String? = null
+    private var titleFontSize = 0f
+    private var titleFontWeight = 0
+    private var backgroundColor: Int? = null
+    private var isBackButtonHidden = false
+    private var isShadowHidden = false
+    private var isDestroyed = false
+    private var backButtonInCustomView = false
+    private var isTopInsetEnabled = true
+    private var isTranslucent = false
+    private var tintColor = 0
+    private var isAttachedToWindow = false
+    private val defaultStartInset: Int
+    private val defaultStartInsetWithNavigation: Int
+    private val backClickListener = OnClickListener {
         screenFragment?.let {
             val stack = screenStack
             if (stack != null && stack.rootScreen == it.screen) {
@@ -70,12 +70,12 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     }
 
     fun destroy() {
-        mDestroyed = true
+        isDestroyed = true
     }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        mIsAttachedToWindow = true
+        isAttachedToWindow = true
         val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
             ?.dispatchEvent(HeaderAttachedEvent(surfaceId, id))
@@ -93,7 +93,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        mIsAttachedToWindow = false
+        isAttachedToWindow = false
         val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
             ?.dispatchEvent(HeaderDetachedEvent(surfaceId, id))
@@ -101,8 +101,10 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
     private val screen: Screen?
         get() = parent as? Screen
+
     private val screenStack: ScreenStack?
         get() = screen?.container as? ScreenStack
+
     val screenFragment: ScreenStackFragment?
         get() {
             val screen = parent
@@ -119,15 +121,15 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         val stack = screenStack
         val isTop = stack == null || stack.topScreen == parent
 
-        if (!mIsAttachedToWindow || !isTop || mDestroyed) {
+        if (!isAttachedToWindow || !isTop || isDestroyed) {
             return
         }
 
         val activity = screenFragment?.activity as AppCompatActivity? ?: return
-        if (mDirection != null) {
-            if (mDirection == "rtl") {
+        if (direction != null) {
+            if (direction == "rtl") {
                 toolbar.layoutDirection = LAYOUT_DIRECTION_RTL
-            } else if (mDirection == "ltr") {
+            } else if (direction == "ltr") {
                 toolbar.layoutDirection = LAYOUT_DIRECTION_LTR
             }
         }
@@ -146,7 +148,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
             ScreenWindowTraits.trySetWindowTraits(it, activity, reactContext)
         }
 
-        if (mIsHidden) {
+        if (isHidden) {
             if (toolbar.parent != null) {
                 screenFragment?.removeToolbar()
             }
@@ -157,7 +159,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
             screenFragment?.setToolbar(toolbar)
         }
 
-        if (mIsTopInsetEnabled) {
+        if (isTopInsetEnabled) {
             headerTopInset.let {
                 toolbar.setPadding(0, it ?: 0, 0, 0)
             }
@@ -176,28 +178,28 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         // reset startWithNavigation inset which corresponds to the distance between navigation icon and
         // title. If title isn't set we clear that value few lines below to give more space to custom
         // center-mounted views.
-        toolbar.contentInsetStartWithNavigation = mDefaultStartInsetWithNavigation
-        toolbar.setContentInsetsRelative(mDefaultStartInset, mDefaultStartInset)
+        toolbar.contentInsetStartWithNavigation = defaultStartInsetWithNavigation
+        toolbar.setContentInsetsRelative(defaultStartInset, defaultStartInset)
 
         // hide back button
         actionBar.setDisplayHomeAsUpEnabled(
-            screenFragment?.canNavigateBack() == true && !mIsBackButtonHidden
+            screenFragment?.canNavigateBack() == true && !isBackButtonHidden
         )
 
         // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
         // navigation click listener. The default behavior set in the wrapper is to call into
         // menu options handlers, but we prefer the back handling logic to stay here instead.
-        toolbar.setNavigationOnClickListener(mBackClickListener)
+        toolbar.setNavigationOnClickListener(backClickListener)
 
         // shadow
-        screenFragment?.setToolbarShadowHidden(mIsShadowHidden)
+        screenFragment?.setToolbarShadowHidden(isShadowHidden)
 
         // translucent
-        screenFragment?.setToolbarTranslucent(mIsTranslucent)
+        screenFragment?.setToolbarTranslucent(isTranslucent)
 
         // title
-        actionBar.title = mTitle
-        if (TextUtils.isEmpty(mTitle)) {
+        actionBar.title = title
+        if (TextUtils.isEmpty(title)) {
             // if title is empty we set start  navigation inset to 0 to give more space to custom rendered
             // views. When it is set to default it'd take up additional distance from the back button
             // which would impact the position of custom header views rendered at the center.
@@ -205,28 +207,28 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         }
 
         val titleTextView = titleTextView
-        if (mTitleColor != 0) {
-            toolbar.setTitleTextColor(mTitleColor)
+        if (titleColor != 0) {
+            toolbar.setTitleTextColor(titleColor)
         }
 
         if (titleTextView != null) {
-            if (mTitleFontFamily != null || mTitleFontWeight > 0) {
+            if (titleFontFamily != null || titleFontWeight > 0) {
                 val titleTypeface = ReactTypefaceUtils.applyStyles(
-                    null, 0, mTitleFontWeight, mTitleFontFamily, context.assets
+                    null, 0, titleFontWeight, titleFontFamily, context.assets
                 )
                 titleTextView.typeface = titleTypeface
             }
-            if (mTitleFontSize > 0) {
-                titleTextView.textSize = mTitleFontSize
+            if (titleFontSize > 0) {
+                titleTextView.textSize = titleFontSize
             }
         }
 
         // background
-        mBackgroundColor?.let { toolbar.setBackgroundColor(it) }
+        backgroundColor?.let { toolbar.setBackgroundColor(it) }
 
         // color
-        if (mTintColor != 0) {
-            toolbar.navigationIcon?.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP)
+        if (tintColor != 0) {
+            toolbar.navigationIcon?.setColorFilter(tintColor, PorterDuff.Mode.SRC_ATOP)
         }
 
         // subviews
@@ -237,9 +239,9 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         }
 
         var i = 0
-        val size = mConfigSubviews.size
+        val size = configSubviews.size
         while (i < size) {
-            val view = mConfigSubviews[i]
+            val view = configSubviews[i]
             val type = view.type
             if (type === ScreenStackHeaderSubview.Type.BACK) {
                 // we special case BACK button header config type as we don't add it as a view into toolbar
@@ -257,7 +259,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
                 ScreenStackHeaderSubview.Type.LEFT -> {
                     // when there is a left item we need to disable navigation icon by default
                     // we also hide title as there is no other way to display left side items
-                    if (!mBackButtonInCustomView) {
+                    if (!backButtonInCustomView) {
                         toolbar.navigationIcon = null
                     }
                     toolbar.title = null
@@ -278,28 +280,28 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     }
 
     private fun maybeUpdate() {
-        if (parent != null && !mDestroyed) {
+        if (parent != null && !isDestroyed) {
             onUpdate()
         }
     }
 
-    fun getConfigSubview(index: Int): ScreenStackHeaderSubview = mConfigSubviews[index]
+    fun getConfigSubview(index: Int): ScreenStackHeaderSubview = configSubviews[index]
 
     val configSubviewsCount: Int
-        get() = mConfigSubviews.size
+        get() = configSubviews.size
 
     fun removeConfigSubview(index: Int) {
-        mConfigSubviews.removeAt(index)
+        configSubviews.removeAt(index)
         maybeUpdate()
     }
 
     fun removeAllConfigSubviews() {
-        mConfigSubviews.clear()
+        configSubviews.clear()
         maybeUpdate()
     }
 
     fun addConfigSubview(child: ScreenStackHeaderSubview, index: Int) {
-        mConfigSubviews.add(index, child)
+        configSubviews.add(index, child)
         maybeUpdate()
     }
 
@@ -317,59 +319,59 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         }
 
     fun setTitle(title: String?) {
-        mTitle = title
+        this.title = title
     }
 
     fun setTitleFontFamily(titleFontFamily: String?) {
-        mTitleFontFamily = titleFontFamily
+        this.titleFontFamily = titleFontFamily
     }
 
     fun setTitleFontWeight(fontWeightString: String?) {
-        mTitleFontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString)
+        titleFontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString)
     }
 
     fun setTitleFontSize(titleFontSize: Float) {
-        mTitleFontSize = titleFontSize
+        this.titleFontSize = titleFontSize
     }
 
     fun setTitleColor(color: Int) {
-        mTitleColor = color
+        titleColor = color
     }
 
     fun setTintColor(color: Int) {
-        mTintColor = color
+        tintColor = color
     }
 
     fun setTopInsetEnabled(topInsetEnabled: Boolean) {
-        mIsTopInsetEnabled = topInsetEnabled
+        isTopInsetEnabled = topInsetEnabled
     }
 
     fun setBackgroundColor(color: Int?) {
-        mBackgroundColor = color
+        backgroundColor = color
     }
 
     fun setHideShadow(hideShadow: Boolean) {
-        mIsShadowHidden = hideShadow
+        isShadowHidden = hideShadow
     }
 
     fun setHideBackButton(hideBackButton: Boolean) {
-        mIsBackButtonHidden = hideBackButton
+        isBackButtonHidden = hideBackButton
     }
 
     fun setHidden(hidden: Boolean) {
-        mIsHidden = hidden
+        isHidden = hidden
     }
 
     fun setTranslucent(translucent: Boolean) {
-        mIsTranslucent = translucent
+        isTranslucent = translucent
     }
 
     fun setBackButtonInCustomView(backButtonInCustomView: Boolean) {
-        mBackButtonInCustomView = backButtonInCustomView
+        this.backButtonInCustomView = backButtonInCustomView
     }
 
     fun setDirection(direction: String?) {
-        mDirection = direction
+        this.direction = direction
     }
 
     private class DebugMenuToolbar(context: Context, config: ScreenStackHeaderConfig) : CustomToolbar(context, config) {
@@ -385,8 +387,8 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     init {
         visibility = GONE
         toolbar = if (BuildConfig.DEBUG) DebugMenuToolbar(context, this) else CustomToolbar(context, this)
-        mDefaultStartInset = toolbar.contentInsetStart
-        mDefaultStartInsetWithNavigation = toolbar.contentInsetStartWithNavigation
+        defaultStartInset = toolbar.contentInsetStart
+        defaultStartInsetWithNavigation = toolbar.contentInsetStartWithNavigation
 
         // set primary color as background by default
         val tv = TypedValue()

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -24,7 +24,7 @@ import com.swmansion.rnscreens.events.HeaderDetachedEvent
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private val configSubviews = ArrayList<ScreenStackHeaderSubview>(3)
     val toolbar: CustomToolbar
-    var isHidden = false
+    var isHeaderHidden = false  // named this way to avoid conflict with platform's isHidden
     private var headerTopInset: Int? = null
     private var title: String? = null
     private var titleColor = 0
@@ -148,7 +148,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
             ScreenWindowTraits.trySetWindowTraits(it, activity, reactContext)
         }
 
-        if (isHidden) {
+        if (isHeaderHidden) {
             if (toolbar.parent != null) {
                 screenFragment?.removeToolbar()
             }
@@ -359,7 +359,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     }
 
     fun setHidden(hidden: Boolean) {
-        isHidden = hidden
+        isHeaderHidden = hidden
     }
 
     fun setTranslucent(translucent: Boolean) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -17,10 +17,10 @@ import javax.annotation.Nonnull
 
 @ReactModule(name = ScreenStackHeaderConfigViewManager.REACT_CLASS)
 class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderConfig>(), RNSScreenStackHeaderConfigManagerInterface<ScreenStackHeaderConfig> {
-    private val mDelegate: ViewManagerDelegate<ScreenStackHeaderConfig>
+    private val delegate: ViewManagerDelegate<ScreenStackHeaderConfig>
 
     init {
-        mDelegate = RNSScreenStackHeaderConfigManagerDelegate<ScreenStackHeaderConfig, ScreenStackHeaderConfigViewManager>(this)
+        delegate = RNSScreenStackHeaderConfigManagerDelegate<ScreenStackHeaderConfig, ScreenStackHeaderConfigViewManager>(this)
     }
 
     override fun getName(): String = REACT_CLASS
@@ -143,7 +143,7 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
         )
     }
 
-    protected override fun getDelegate(): ViewManagerDelegate<ScreenStackHeaderConfig> = mDelegate
+    protected override fun getDelegate(): ViewManagerDelegate<ScreenStackHeaderConfig> = delegate
 
     companion object {
         const val REACT_CLASS = "RNSScreenStackHeaderConfig"

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
@@ -7,8 +7,8 @@ import com.facebook.react.views.view.ReactViewGroup
 
 @SuppressLint("ViewConstructor")
 class ScreenStackHeaderSubview(context: ReactContext?) : ReactViewGroup(context) {
-    private var mReactWidth = 0
-    private var mReactHeight = 0
+    private var reactWidth = 0
+    private var reactHeight = 0
     var type = Type.RIGHT
 
     val config: ScreenStackHeaderConfig?
@@ -19,15 +19,15 @@ class ScreenStackHeaderSubview(context: ReactContext?) : ReactViewGroup(context)
             MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
         ) {
             // dimensions provided by react
-            mReactWidth = MeasureSpec.getSize(widthMeasureSpec)
-            mReactHeight = MeasureSpec.getSize(heightMeasureSpec)
+            reactWidth = MeasureSpec.getSize(widthMeasureSpec)
+            reactHeight = MeasureSpec.getSize(heightMeasureSpec)
             val parent = parent
             if (parent != null) {
                 forceLayout()
                 (parent as View).requestLayout()
             }
         }
-        setMeasuredDimension(mReactWidth, mReactHeight)
+        setMeasuredDimension(reactWidth, reactHeight)
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) = Unit

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt
@@ -11,10 +11,10 @@ import com.facebook.react.viewmanagers.RNSScreenStackHeaderSubviewManagerInterfa
 
 @ReactModule(name = ScreenStackHeaderSubviewManager.REACT_CLASS)
 class ScreenStackHeaderSubviewManager : ViewGroupManager<ScreenStackHeaderSubview>(), RNSScreenStackHeaderSubviewManagerInterface<ScreenStackHeaderSubview> {
-    private val mDelegate: ViewManagerDelegate<ScreenStackHeaderSubview>
+    private val delegate: ViewManagerDelegate<ScreenStackHeaderSubview>
 
     init {
-        mDelegate = RNSScreenStackHeaderSubviewManagerDelegate<ScreenStackHeaderSubview, ScreenStackHeaderSubviewManager>(this)
+        delegate = RNSScreenStackHeaderSubviewManagerDelegate<ScreenStackHeaderSubview, ScreenStackHeaderSubviewManager>(this)
     }
 
     override fun getName() = REACT_CLASS
@@ -33,7 +33,7 @@ class ScreenStackHeaderSubviewManager : ViewGroupManager<ScreenStackHeaderSubvie
         }
     }
 
-    protected override fun getDelegate(): ViewManagerDelegate<ScreenStackHeaderSubview> = mDelegate
+    protected override fun getDelegate(): ViewManagerDelegate<ScreenStackHeaderSubview> = delegate
 
     companion object {
         const val REACT_CLASS = "RNSScreenStackHeaderSubview"

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
@@ -14,10 +14,10 @@ import com.swmansion.rnscreens.events.StackFinishTransitioningEvent
 
 @ReactModule(name = ScreenStackViewManager.REACT_CLASS)
 class ScreenStackViewManager : ViewGroupManager<ScreenStack>(), RNSScreenStackManagerInterface<ScreenStack> {
-    private val mDelegate: ViewManagerDelegate<ScreenStack>
+    private val delegate: ViewManagerDelegate<ScreenStack>
 
     init {
-        mDelegate = RNSScreenStackManagerDelegate<ScreenStack, ScreenStackViewManager>(this)
+        delegate = RNSScreenStackManagerDelegate<ScreenStack, ScreenStackViewManager>(this)
     }
 
     override fun getName() = REACT_CLASS
@@ -63,7 +63,7 @@ class ScreenStackViewManager : ViewGroupManager<ScreenStack>(), RNSScreenStackMa
 
     override fun needsCustomLayoutForChildren() = true
 
-    protected override fun getDelegate(): ViewManagerDelegate<ScreenStack> = mDelegate
+    protected override fun getDelegate(): ViewManagerDelegate<ScreenStack> = delegate
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = mutableMapOf(
         StackFinishTransitioningEvent.EVENT_NAME to mutableMapOf("registrationName" to "onFinishTransitioning")

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -23,10 +23,10 @@ import com.swmansion.rnscreens.events.ScreenWillDisappearEvent
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
 class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<Screen> {
-    private val mDelegate: ViewManagerDelegate<Screen>
+    private val delegate: ViewManagerDelegate<Screen>
 
     init {
-        mDelegate = RNSScreenManagerDelegate<Screen, ScreenViewManager>(this)
+        delegate = RNSScreenManagerDelegate<Screen, ScreenViewManager>(this)
     }
 
     override fun getName() = REACT_CLASS
@@ -193,7 +193,7 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
         ScreenTransitionProgressEvent.EVENT_NAME to MapBuilder.of("registrationName", "onTransitionProgress")
     )
 
-    protected override fun getDelegate(): ViewManagerDelegate<Screen> = mDelegate
+    protected override fun getDelegate(): ViewManagerDelegate<Screen> = delegate
 
     companion object {
         const val REACT_CLASS = "RNSScreen"

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.view.ViewParent
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.GuardedRunnable
@@ -22,21 +21,21 @@ import com.swmansion.rnscreens.Screen.WindowTraits
 object ScreenWindowTraits {
     // Methods concerning statusBar management were taken from `react-native`'s status bar module:
     // https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
-    private var mDidSetOrientation = false
-    private var mDidSetStatusBarAppearance = false
-    private var mDidSetNavigationBarAppearance = false
-    private var mDefaultStatusBarColor: Int? = null
+    private var didSetOrientation = false
+    private var didSetStatusBarAppearance = false
+    private var didSetNavigationBarAppearance = false
+    private var defaultStatusBarColor: Int? = null
 
     internal fun applyDidSetOrientation() {
-        mDidSetOrientation = true
+        didSetOrientation = true
     }
 
     internal fun applyDidSetStatusBarAppearance() {
-        mDidSetStatusBarAppearance = true
+        didSetStatusBarAppearance = true
     }
 
     internal fun applyDidSetNavigationBarAppearance() {
-        mDidSetNavigationBarAppearance = true
+        didSetNavigationBarAppearance = true
     }
 
     internal fun setOrientation(screen: Screen, activity: Activity?) {
@@ -53,12 +52,12 @@ object ScreenWindowTraits {
         if (activity == null || context == null) {
             return
         }
-        if (mDefaultStatusBarColor == null) {
-            mDefaultStatusBarColor = activity.window.statusBarColor
+        if (defaultStatusBarColor == null) {
+            defaultStatusBarColor = activity.window.statusBarColor
         }
         val screenForColor = findScreenForTrait(screen, WindowTraits.COLOR)
         val screenForAnimated = findScreenForTrait(screen, WindowTraits.ANIMATED)
-        val color = screenForColor?.statusBarColor ?: mDefaultStatusBarColor
+        val color = screenForColor?.statusBarColor ?: defaultStatusBarColor
         val animated = screenForAnimated?.isStatusBarAnimated ?: false
 
         UiThreadUtil.runOnUiThread(
@@ -212,16 +211,16 @@ object ScreenWindowTraits {
     }
 
     internal fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?) {
-        if (mDidSetOrientation) {
+        if (didSetOrientation) {
             setOrientation(screen, activity)
         }
-        if (mDidSetStatusBarAppearance) {
+        if (didSetStatusBarAppearance) {
             setColor(screen, activity, context)
             setStyle(screen, activity, context)
             setTranslucent(screen, activity, context)
             setHidden(screen, activity)
         }
-        if (mDidSetNavigationBarAppearance) {
+        if (didSetNavigationBarAppearance) {
             setNavigationBarColor(screen, activity)
             setNavigationBarHidden(screen, activity)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreensShadowNode.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensShadowNode.kt
@@ -6,10 +6,10 @@ import com.facebook.react.uimanager.NativeViewHierarchyManager
 import com.facebook.react.uimanager.NativeViewHierarchyOptimizer
 import com.facebook.react.uimanager.UIManagerModule
 
-internal class ScreensShadowNode(private var mContext: ReactContext) : LayoutShadowNode() {
+internal class ScreensShadowNode(private var context: ReactContext) : LayoutShadowNode() {
     override fun onBeforeLayout(nativeViewHierarchyOptimizer: NativeViewHierarchyOptimizer) {
         super.onBeforeLayout(nativeViewHierarchyOptimizer)
-        (mContext.getNativeModule(UIManagerModule::class.java))?.addUIBlock { nativeViewHierarchyManager: NativeViewHierarchyManager ->
+        (context.getNativeModule(UIManagerModule::class.java))?.addUIBlock { nativeViewHierarchyManager: NativeViewHierarchyManager ->
             val view = nativeViewHierarchyManager.resolveView(reactTag)
             if (view is ScreenContainer) {
                 view.performUpdates()

--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
@@ -28,9 +28,9 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     var autoFocus: Boolean = false
     var shouldShowHintSearchIcon: Boolean = true
 
-    private var mSearchViewFormatter: SearchViewFormatter? = null
+    private var searchViewFormatter: SearchViewFormatter? = null
 
-    private var mAreListenersSet: Boolean = false
+    private var areListenersSet: Boolean = false
 
     private val headerConfig: ScreenStackHeaderConfig?
         get() {
@@ -52,17 +52,17 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     private fun setSearchViewProps() {
         val searchView = screenStackFragment?.searchView
         if (searchView != null) {
-            if (!mAreListenersSet) {
+            if (!areListenersSet) {
                 setSearchViewListeners(searchView)
-                mAreListenersSet = true
+                areListenersSet = true
             }
 
             searchView.inputType = inputType.toAndroidInputType(autoCapitalize)
-            mSearchViewFormatter?.setTextColor(textColor)
-            mSearchViewFormatter?.setTintColor(tintColor)
-            mSearchViewFormatter?.setHeaderIconColor(headerIconColor)
-            mSearchViewFormatter?.setHintTextColor(hintTextColor)
-            mSearchViewFormatter?.setPlaceholder(placeholder, shouldShowHintSearchIcon)
+            searchViewFormatter?.setTextColor(textColor)
+            searchViewFormatter?.setTintColor(tintColor)
+            searchViewFormatter?.setHeaderIconColor(headerIconColor)
+            searchViewFormatter?.setHintTextColor(hintTextColor)
+            searchViewFormatter?.setPlaceholder(placeholder, shouldShowHintSearchIcon)
             searchView.overrideBackAction = shouldOverrideBackButton
         }
     }
@@ -71,7 +71,7 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
         super.onAttachedToWindow()
 
         screenStackFragment?.onSearchViewCreate = { newSearchView ->
-            if (mSearchViewFormatter == null) mSearchViewFormatter =
+            if (searchViewFormatter == null) searchViewFormatter =
                 SearchViewFormatter(newSearchView)
             setSearchViewProps()
             if (autoFocus) {
@@ -151,7 +151,7 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     }
 
     fun handleCancelSearchJsRequest() {
-       screenStackFragment?.searchView?.cancelSearch() 
+        screenStackFragment?.searchView?.cancelSearch()
     }
 
     private fun setToolbarElementsVisibility(visibility: Int) {

--- a/android/src/main/java/com/swmansion/rnscreens/SearchViewFormatter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchViewFormatter.kt
@@ -8,8 +8,8 @@ import androidx.appcompat.R
 import androidx.appcompat.widget.SearchView
 
 class SearchViewFormatter(var searchView: SearchView) {
-    private var mDefaultTextColor: Int? = null
-    private var mDefaultTintBackground: Drawable? = null
+    private var defaultTextColor: Int? = null
+    private var defaultTintBackground: Drawable? = null
 
     private val searchEditText
         get() = searchView.findViewById<View>(R.id.search_src_text) as? EditText
@@ -21,10 +21,10 @@ class SearchViewFormatter(var searchView: SearchView) {
         get() = searchView.findViewById<ImageView>(R.id.search_close_btn)
 
     fun setTextColor(textColor: Int?) {
-        val currentDefaultTextColor = mDefaultTextColor
+        val currentDefaultTextColor = defaultTextColor
         if (textColor != null) {
-            if (mDefaultTextColor == null) {
-                mDefaultTextColor = searchEditText?.textColors?.defaultColor
+            if (defaultTextColor == null) {
+                defaultTextColor = searchEditText?.textColors?.defaultColor
             }
             searchEditText?.setTextColor(textColor)
         } else if (currentDefaultTextColor != null) {
@@ -33,10 +33,10 @@ class SearchViewFormatter(var searchView: SearchView) {
     }
 
     fun setTintColor(tintColor: Int?) {
-        val currentDefaultTintColor = mDefaultTintBackground
+        val currentDefaultTintColor = defaultTintBackground
         if (tintColor != null) {
-            if (mDefaultTintBackground == null) {
-                mDefaultTintBackground = searchTextPlate.background
+            if (defaultTintBackground == null) {
+                defaultTintBackground = searchTextPlate.background
             }
             searchTextPlate.setBackgroundColor(tintColor)
         } else if (currentDefaultTintColor != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class HeaderAttachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class HeaderBackButtonClickedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class HeaderDetachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
@@ -6,17 +6,17 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class HeaderHeightChangeEvent(
     viewId: Int,
-    private val mHeaderHeight: Double
+    private val headerHeight: Double
 ) : Event<HeaderHeightChangeEvent>(viewId) {
 
     override fun getEventName() = EVENT_NAME
 
     // As the same header height could appear twice, use header height as a coalescing key.
-    override fun getCoalescingKey(): Short = mHeaderHeight.toInt().toShort()
+    override fun getCoalescingKey(): Short = headerHeight.toInt().toShort()
 
     override fun dispatch(rctEventEmitter: RCTEventEmitter) {
         val map = Arguments.createMap()
-        map.putDouble("headerHeight", mHeaderHeight)
+        map.putDouble("headerHeight", headerHeight)
         rctEventEmitter.receiveEvent(viewTag, eventName, map)
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
@@ -7,23 +7,19 @@ import com.facebook.react.uimanager.events.Event
 class ScreenTransitionProgressEvent(
     surfaceId: Int,
     viewId: Int,
-    private val mProgress: Float,
-    private val mClosing: Boolean,
-    private val mGoingForward: Boolean,
-    private val mCoalescingKey: Short
+    private val progress: Float,
+    private val isClosing: Boolean,
+    private val isGoingForward: Boolean,
+    private val coalescingKey: Short
 ) : Event<ScreenAppearEvent?>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        return mCoalescingKey
-    }
+    override fun getCoalescingKey(): Short = coalescingKey
 
     override fun getEventData(): WritableMap? = Arguments.createMap().apply {
-        putDouble("progress", mProgress.toDouble())
-        putInt("closing", if (mClosing) 1 else 0)
-        putInt("goingForward", if (mGoingForward) 1 else 0)
+        putDouble("progress", progress.toDouble())
+        putInt("closing", if (isClosing) 1 else 0)
+        putInt("goingForward", if (isGoingForward) 1 else 0)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SearchBarBlurEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
@@ -9,14 +9,10 @@ class SearchBarChangeTextEvent(
     viewId: Int,
     private val text: String?,
 ) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap().apply {
         putString("text", text)

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SearchBarCloseEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SearchBarFocusEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SearchBarOpenEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap()
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
@@ -5,14 +5,10 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SearchBarSearchButtonPressEvent(surfaceId: Int, viewId: Int, private val text: String?) : Event<ScreenAppearEvent>(surfaceId, viewId) {
-    override fun getEventName(): String {
-        return EVENT_NAME
-    }
+    override fun getEventName(): String = EVENT_NAME
 
-    override fun getCoalescingKey(): Short {
-        // All events for a given view can be coalesced.
-        return 0
-    }
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
     override fun getEventData(): WritableMap? = Arguments.createMap().apply {
         putString("text", text)


### PR DESCRIPTION
## Description

Up to now we had mixed naming conventions -> I've applied [Android official ones](https://developer.android.com/kotlin/style-guide#naming_2)

## Changes

Refactored whole library code so that we stick to single naming convention

## Test code and steps to reproduce

Run any example & see that it runs as it should

## Checklist

- [x] Ensured that CI passes
