### PR TITLE
fix(TVOS): add searchResultsController for Search Bar on TVOS

### DIFF
--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -50,7 +50,13 @@ namespace react = facebook::react;
 
 - (void)initCommonProps
 {
+#if !TARGET_OS_TV
   _controller = [[UISearchController alloc] initWithSearchResultsController:nil];
+#else
+  // on TVOS UISearchController must contain searchResultsController.
+  _controller = [[UISearchController alloc] initWithSearchResultsController:[UIViewController new]];
+#endif
+
   _controller.searchBar.delegate = self;
   _hideWhenScrolling = YES;
   _placement = RNSSearchBarPlacementStacked;


### PR DESCRIPTION
## Description

On TVOS applications are crashing when user tries to open a screen with Search Bar. This happens because TVOS requires UISearchController to contain `searchResultsController`. this PR resolves it by adding simple `UIViewController` as searchResultsController.

Fixes #2003.

## Changes

- Fixed crash on TVOS when user tries to open screen with search bar.

## Screenshots / GIFs

### Before

https://github.com/software-mansion/react-native-screens/assets/23281839/4f7b727a-139e-45a0-8141-f40b3e45d101

### After

https://github.com/software-mansion/react-native-screens/assets/23281839/7138f27e-294b-4d66-b5aa-ff2745d0d406

## Checklist

- [X] Ensured that CI passes
