### PR TITLE
fix(iOS): stuttering back arrow animation when using headerLargeTitle

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -528,7 +528,7 @@ namespace react = facebook::react;
 
     // When backBarButtonItem's title is null, back menu will use value
     // of backButtonTitle
-    [backBarButtonItem setTitle:nil];
+    [backBarButtonItem setTitle:@" "];
     prevItem.backButtonTitle = resolvedBackTitle;
   }
   prevItem.backBarButtonItem = backBarButtonItem;


### PR DESCRIPTION
## Description
When navigating to a screen that has a large header title and the back title hidden, the back arrow animation bugs (kind of bounces in / stuttery animation).
I noticed that when setting the title to a string, it animates normally.
I found that using a space instead of a complete empty string, the title of the previous screen animates nicely, instead of disappearing instantly.
(Tested on iPhone 15 Pro, iOS 17.0)

EDIT:
I also just noticed that on an iPhone 8 plus (iOS 14.0) the back button completely disappears after the stuttery animation.
It seems that setting it to nil caused multiple bugs...

## Demo (bug)

https://github.com/software-mansion/react-native-screens/assets/12894112/3b104aab-0c03-4940-8692-905a664a5452

## Demo (fix)

https://github.com/software-mansion/react-native-screens/assets/12894112/d43b6c1e-4f62-4ab5-8954-6ad6f0792aac

## Reproduction
```
<Stack.Screen
  name="Home"
  component={HomeScreen}
  options={{ headerLargeTitle: true }}
/>
<Stack.Screen
  name="Details"
  component={DetailsScreen}
  options={{
    headerLargeTitle: true,
    headerBackTitleVisible: false,
  }}
/>

From Home Screen: navigation.navigate('Details')
```