### PR TITLE
fix: move GHContext from gesture-handler to native-stack

### DIFF
--- a/src/gesture-handler/GestureDetectorProvider.tsx
+++ b/src/gesture-handler/GestureDetectorProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GHContext } from './context/GHContext';
+import { GHContext } from 'react-native-screens';
 import ScreenGestureDetector from './ScreenGestureDetector';
 import type { GestureProviderProps } from '../native-stack/types';
 

--- a/src/gesture-handler/index.tsx
+++ b/src/gesture-handler/index.tsx
@@ -1,9 +1,4 @@
 /*
- * Context
- */
-export { GHContext } from './context/GHContext';
-
-/*
  * Providers
  */
 export { default as GestureDetectorProvider } from './GestureDetectorProvider';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,7 @@ export { default as NativeScreensModule } from './fabric/NativeScreensModule';
 /*
  * Gesture Handler
  */
-export { GHContext } from './gesture-handler';
+export { GHContext } from './gesture-handler/context/GHContext';
 
 /*
  * Utils

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,9 +53,9 @@ export { default as FullWindowOverlay } from './components/FullWindowOverlay';
 export { default as NativeScreensModule } from './fabric/NativeScreensModule';
 
 /*
- * Gesture Handler
+ * Contexts
  */
-export { GHContext } from './gesture-handler/context/GHContext';
+export { GHContext } from './native-stack/contexts/GHContext';
 
 /*
  * Utils

--- a/src/native-stack/contexts/GHContext.tsx
+++ b/src/native-stack/contexts/GHContext.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { GestureProviderProps } from '../../native-stack/types';
+import { GestureProviderProps } from '../types';
 
 // context to be used when the user wants full screen swipe (see `gesture-handler` folder in repo)
 export const GHContext = React.createContext(


### PR DESCRIPTION
## Description

Unfortunately, because of changing the way how we export the components, I didn't saw the wrong export of GHContext in gesture-handler's `index.tsx` file. To match the changes from the PR with full screen swipe (#1913), I've created the directory in a wrong place. This PR fixes this export by moving the context to native-stack and removing the export from the gesture-handler/index.tsx.
I'm also removing this export, because right now it's possible to import GHContext from `react-native-screens` and also from `react-native-screens/gesture-handler` which is wrong.

## Changes

- Changed the export of GHContext in index.tsx
- Moved GHContext from gesture-handler to native-stack

## Test code and steps to reproduce

Try to build and run TestsExample - see if the bundling state passes correctly. Then, try to import GestureDetectorProvider and wrap whole navigator in it.

## Checklist

- [X] Included code example that can be used to test this change
- [x] Ensured that CI passes
