### PR TITLE
fix(Android): change context while running `runOnUiQueueThread` on 0.73 with Bridgeless

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -318,7 +318,7 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // The exception to this rule is `updateImmediately` which is triggered by actions
         // not connected to React view hierarchy changes, but rather internal events
         needsUpdate = true
-        (context as? ReactContext)?.runOnUiQueueThread {
+        (context.applicationContext as? ReactContext)?.runOnUiQueueThread {
             // We schedule the update here because LayoutAnimations of `react-native-reanimated`
             // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
             // already run, and we want to update the container then too. In the other cases,


### PR DESCRIPTION
## Description

I've been discussing this change with @WoLewicki.
The problem here is that you're attempting to call `runOnUiQueueThread` on the wrong Context.

## Changes

Changes the `Context` where we invoke `.runOnUiQueueThread`

## Test code and steps to reproduce

Tested against this reproducer:
https://github.com/cortinico/reproducer-rnscreens-bridgeless

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
