### PR TITLE
feat: add visionOS support

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/software-mansion/react-native-screens"
   s.license      = "MIT"
   s.author       = { "author" => "author@domain.cn" }
-  s.platforms    = { :ios => platform, :tvos => "11.0" }
+  s.platforms    = { :ios => platform, :tvos => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/software-mansion/react-native-screens.git", :tag => "#{s.version}" }
   s.source_files = source_files
   s.requires_arc = true

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -26,8 +26,10 @@ namespace react = facebook::react;
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
 
+#if !TARGET_OS_VISION
 + (UITextAutocapitalizationType)UITextAutocapitalizationTypeFromCppEquivalent:
     (react::RNSSearchBarAutoCapitalize)autoCapitalize;
+#endif
 
 + (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(react::RNSSearchBarPlacement)placement;
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -123,6 +123,7 @@
   };
 }
 
+#if !TARGET_OS_VISION
 + (UITextAutocapitalizationType)UITextAutocapitalizationTypeFromCppEquivalent:
     (react::RNSSearchBarAutoCapitalize)autoCapitalize
 {
@@ -137,6 +138,7 @@
       return UITextAutocapitalizationTypeNone;
   }
 }
+#endif
 
 + (RNSSearchBarPlacement)RNSScreenSearchBarPlacementFromCppEquivalent:(react::RNSSearchBarPlacement)placement
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -604,7 +604,7 @@ namespace react = facebook::react;
       self.controller.modalPresentationStyle == UIModalPresentationOverCurrentContext;
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 /**
  * Updates settings for sheet presentation controller.
  * Note that this method should not be called inside `stackPresentation` setter, because on Paper we don't have
@@ -821,7 +821,7 @@ namespace react = facebook::react;
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
   [super finalizeUpdates:updateMask];
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   [self updatePresentationStyle];
 #endif // !TARGET_OS_TV
 }
@@ -1065,7 +1065,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (CGSize)getStatusBarHeightIsModal:(BOOL)isModal
 {
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   CGSize fallbackStatusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
@@ -1505,7 +1505,7 @@ RCT_EXPORT_VIEW_PROPERTY(sheetCornerRadius, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
 #endif
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 // See:
 // 1. https://github.com/software-mansion/react-native-screens/pull/1543
 // 2. https://github.com/software-mansion/react-native-screens/pull/1596

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -92,7 +92,7 @@ namespace react = facebook::react;
 
 @end
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 @interface RNSScreenEdgeGestureRecognizer : UIScreenEdgePanGestureRecognizer
 @end
 
@@ -150,7 +150,7 @@ namespace react = facebook::react;
   _presentedModals = [NSMutableArray new];
   _controller = [RNSNavigationController new];
   _controller.delegate = self;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   [self setupGestureHandlers];
 #endif
   // we have to initialize viewControllers with a non empty array for
@@ -731,7 +731,7 @@ namespace react = facebook::react;
   }
   RNSScreenView *topScreen = _reactSubviews.lastObject;
 
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_VISION
   [self cancelTouchesInParent];
   return YES;
 #else
@@ -774,7 +774,7 @@ namespace react = facebook::react;
 #endif // TARGET_OS_TV
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 - (void)setupGestureHandlers
 {
   // gesture recognizers for custom stack animations
@@ -951,7 +951,7 @@ namespace react = facebook::react;
   return [super hitTest:point withEvent:event];
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 
 - (BOOL)isScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 {

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -22,7 +22,7 @@
 
 + (void)updateStatusBarAppearance
 {
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   [UIView animateWithDuration:0.4
                    animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
@@ -56,7 +56,9 @@
 #endif
   {
     if (@available(iOS 11.0, *)) {
+#if !TARGET_OS_VISION
       [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+#endif
     }
   }
 #endif
@@ -134,7 +136,7 @@
 
 + (void)enforceDesiredDeviceOrientation
 {
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   dispatch_async(dispatch_get_main_queue(), ^{
     UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAllButUpsideDown;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
@@ -211,7 +213,7 @@
   [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
 // based on
 // https://stackoverflow.com/questions/57965701/statusbarorientation-was-deprecated-in-ios-13-0-when-attempting-to-get-app-ori/61249908#61249908
 + (UIInterfaceOrientation)interfaceOrientation

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -338,9 +338,11 @@ namespace react = facebook::react;
     [self setPlaceholder:RCTNSStringFromStringNilIfEmpty(newScreenProps.placeholder)];
   }
 
+#if !TARGET_OS_VISION
   if (oldScreenProps.autoCapitalize != newScreenProps.autoCapitalize) {
     [self setAutoCapitalize:[RNSConvert UITextAutocapitalizationTypeFromCppEquivalent:newScreenProps.autoCapitalize]];
   }
+#endif
 
   if (oldScreenProps.tintColor != newScreenProps.tintColor) {
     [self setTintColor:RCTUIColorFromSharedColor(newScreenProps.tintColor)];

--- a/ios/utils/RNSUIBarButtonItem.h
+++ b/ios/utils/RNSUIBarButtonItem.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIKit.h>
+
 @interface RNSUIBarButtonItem : UIBarButtonItem
 
 @property (nonatomic) BOOL menuHidden;


### PR DESCRIPTION
## Description

This PR adds visionOS support. Changes are mostly around the same places where tvOS had `ifdefs`. 

## Changes

- Added `visionos` support

## Screenshots / GIFs

https://github.com/software-mansion/react-native-screens/assets/52801365/7618d537-1e31-4cde-9610-da109295d800


## Test code and steps to reproduce

1. I've initialized new visionOS project inside of the repo and linked it (same as TVOS example) 

_Note: I didn't add new visionOS example (as they are many of them already) but soon `react-native-test-app` will support visionOS so that might be a solution to test visionOS in the long run_

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
