### PR TITLE
fix(iOS): Change retrieving window in FullWindowOverlay

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -123,7 +123,7 @@
 
 - (void)show
 {
-  UIWindow *window = RCTSharedApplication().delegate.window;
+  UIWindow *window = RCTKeyWindow();
   [window addSubview:_container];
 }
 
@@ -156,7 +156,7 @@
 // so when the component gets recycled we need to add it back.
 - (void)maybeShow
 {
-  UIWindow *window = RCTSharedApplication().delegate.window;
+  UIWindow *window = RCTKeyWindow();
   if (![[window subviews] containsObject:self]) {
     [window addSubview:_container];
   }


### PR DESCRIPTION
## Description

This PR is a follow up for the PR #1526.

Currently, in React Native there's `RCTKeyWindow()` method which goes through each window of `RCTSharedApplication()` and selects the window that is a key window of a given window. This is a better solution, since we don't rely on a single `keyWindow` from RCTSharedApplication.
I've also added a support for Fabric.

I've checked how does FullWindowOverlay work with the change and it works as usual.
Closes #1526.

## Changes

- Changed the method of retrieving window from `delegate.window` to `RCTKeyWindow()`

## Test code and steps to reproduce

You can run `Test1844` and check if FullWindowOverlay works correctly.

## Checklist

- [X] Included code example that can be used to test this change
- [X] Ensured that CI passes
