### PR TITLE
fix(iOS): Remove calculating status bar height in useAnimatedHeaderHeight when header is not shown

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1111,17 +1111,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 {
   UINavigationController *navctr = [self getVisibleNavigationControllerIsModal:isModal];
 
-  // If navigation controller doesn't exists (or it is hidden) we want to handle two possible cases.
-  // If there's no navigation controller for the modal, we simply don't want to return header height, as modal possibly
-  // does not have header and we don't want to count status bar. If there's no navigation controller for the view we
-  // just want to return status bar height (if it's hidden, it will simply return 0).
+  // If there's no navigation controller for the modal (or the navigation bar is hidden), we simply don't want to
+  // return header height, as modal possibly does not have header and we don't want to count status bar.
   if (navctr == nil || navctr.isNavigationBarHidden) {
-    if (isModal) {
-      return 0;
-    } else {
-      CGSize statusBarSize = [self getStatusBarHeightIsModal:isModal];
-      return MIN(statusBarSize.width, statusBarSize.height);
-    }
+    return 0;
   }
 
   CGFloat navbarHeight = navctr.navigationBar.frame.size.height;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1112,7 +1112,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   UINavigationController *navctr = [self getVisibleNavigationControllerIsModal:isModal];
 
   // If there's no navigation controller for the modal (or the navigation bar is hidden), we simply don't want to
-  // return header height, as modal possibly does not have header and we don't want to count status bar.
+  // return header height, as modal possibly does not have header when navigation controller is nil,
+  // and we don't want to count status bar if navigation bar is hidden (inset could be negative).
   if (navctr == nil || navctr.isNavigationBarHidden) {
     return 0;
   }


### PR DESCRIPTION
## Description

This PR fixes the behaviour of `useAnimatedHeaderHeight`, when header is not shown.
Currently, it includes the status bar height when `headerShown` prop is false. This is wrong, since we don't have a header in such scenario and we don't want to include status bar there. Therefore, when navigation controller does not exist or `isNavigationBarHidden` is set to true, we simply return 0.

## Changes

- Removed calculating status bar height when header is not shown.

## Test code and steps to reproduce

You can use `Test1802.tsx` to test these changes.

## Checklist

- [x] Ensured that CI passes
