### PR TITLE
fix(iOS): Check for multiple screens while changing screen orientation

### DIFF
--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -178,7 +178,21 @@
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
       if (@available(iOS 16.0, *)) {
         NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
-        UIWindowScene *scene = (UIWindowScene *)array[0];
+
+        // when an app supports multiple scenes (e.g. CarPlay), it is possible that
+        // UIWindowScene is not the first scene, or it may not be present at all
+        UIWindowScene *scene = nil;
+        for (id connectedScene in array) {
+          if ([connectedScene isKindOfClass:[UIWindowScene class]]) {
+            scene = connectedScene;
+            break;
+          }
+        }
+
+        if (scene == nil) {
+          return;
+        }
+
         UIWindowSceneGeometryPreferencesIOS *geometryPreferences =
             [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientationMask];
         [scene requestGeometryUpdateWithPreferences:geometryPreferences


### PR DESCRIPTION
## Description
This fixes two issues with scenes on iOS:

1. A casting issue, which allows non-window scenes on iOS, e.g. CarPlay's CPTemplateApplicationScene
3. An assumed loading order - the UIWindowScene is not guaranteed to be the first scene (or even present) in a multi-scene app

Fixes #1857

**Edit:** I originally reported that this would only fix the second crash reported in #1857. Upon review of the first crash in that issue, I believe this PR actually addresses both crashes.

## Test code and steps to reproduce
There really isn't any simple code that can be used to test this, as this scenario requires having an app that implements multiple scenes, at least one of which being CarPlay. It would be several hundred lines of code.

## Checklist

- [x] Ensured that CI passes
