### PR TITLE
fix(Android): use reactApplicationContext in onScreenChanged

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -14,6 +14,7 @@ import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.ChoreographerCompat
 import com.facebook.react.modules.core.ReactChoreographer
+import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.swmansion.rnscreens.Screen.ActivityState
 import com.swmansion.rnscreens.events.ScreenDismissedEvent
@@ -318,14 +319,10 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // The exception to this rule is `updateImmediately` which is triggered by actions
         // not connected to React view hierarchy changes, but rather internal events
         needsUpdate = true
-        (context.applicationContext as? ReactContext)?.runOnUiQueueThread {
-            // We schedule the update here because LayoutAnimations of `react-native-reanimated`
-            // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
-            // already run, and we want to update the container then too. In the other cases,
-            // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
-            // will already be false.
+        (context as ThemedReactContext).reactApplicationContext.runOnUiQueueThread {
             performUpdates()
         }
+
     }
 
     protected fun performUpdatesNow() {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -320,6 +320,11 @@ open class ScreenContainer(context: Context?) : ViewGroup(context) {
         // not connected to React view hierarchy changes, but rather internal events
         needsUpdate = true
         (context as ThemedReactContext).reactApplicationContext.runOnUiQueueThread {
+            // We schedule the update here because LayoutAnimations of `react-native-reanimated`
+            // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
+            // already run, and we want to update the container then too. In the other cases,
+            // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
+            // will already be false.
             performUpdates()
         }
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Potential fix for changes from https://github.com/software-mansion/react-native-screens/pull/2022, see comment https://github.com/software-mansion/react-native-screens/pull/2022#issuecomment-1957369797

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
