### PR TITLE
fix(iOS): Add view check for getting StackView in `goBackGesture`

### DIFF
--- a/ios/RNSModule.mm
+++ b/ios/RNSModule.mm
@@ -115,7 +115,7 @@ RCT_EXPORT_MODULE()
 - (RNSScreenStackView *)getStackView:(NSNumber *)stackTag
 {
   RNSScreenStackView *view = [self getScreenStackView:stackTag];
-  if (![view isKindOfClass:[RNSScreenStackView class]]) {
+  if (view != nil && ![view isKindOfClass:[RNSScreenStackView class]]) {
     RCTLogError(@"Invalid view type, expecting RNSScreenStackView, got: %@", view);
     return nil;
   }


### PR DESCRIPTION
## Description

This PR fixes problem with goBackGesture screen transition. If stackView can not be found, transition just shouldn't start instead of crashing app and throwing the `Invalid view type, expecting RNSScreenStackView` error.

## Checklist

- [x] Ensured that CI passes