### PR TITLE
fix: change the search icon's color according to search bar's state

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
@@ -60,7 +60,6 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
             searchView.inputType = inputType.toAndroidInputType(autoCapitalize)
             searchViewFormatter?.setTextColor(textColor)
             searchViewFormatter?.setTintColor(tintColor)
-            searchViewFormatter?.setHeaderIconColor(headerIconColor)
             searchViewFormatter?.setHintTextColor(hintTextColor)
             searchViewFormatter?.setPlaceholder(placeholder, shouldShowHintSearchIcon)
             searchView.overrideBackAction = shouldOverrideBackButton
@@ -74,6 +73,7 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
             if (searchViewFormatter == null) searchViewFormatter =
                 SearchViewFormatter(newSearchView)
             setSearchViewProps()
+            searchViewFormatter?.setHeaderIconColor(headerIconColor)
             if (autoFocus) {
                 screenStackFragment?.searchView?.focus()
             }
@@ -157,8 +157,10 @@ class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) 
     private fun setToolbarElementsVisibility(visibility: Int) {
         for (i in 0..(headerConfig?.configSubviewsCount?.minus(1) ?: 0)) {
             val subview = headerConfig?.getConfigSubview(i)
-            if (subview?.type != ScreenStackHeaderSubview.Type.SEARCH_BAR)
+            if (subview?.type != ScreenStackHeaderSubview.Type.SEARCH_BAR) {
+                searchViewFormatter?.setHeaderIconColor(if (visibility == 0) headerIconColor else hintTextColor)
                 subview?.visibility = visibility
+            }
         }
     }
 


### PR DESCRIPTION
## Description

In our project we have the following configuration:
```
{
  barTintColor: theme.neutral100w,
  hideWhenScrolling: false,
  tintColor: "white",
  headerIconColor: "white",
  hideNavigationBar: true,
  placeholder: LABELS.SEARCH_PLACEHOLDER,
  hintTextColor: "gray",
  shouldShowHintSearchIcon: false,
}
```

that on Android gives us: 

<img width="389" alt="Screenshot 2024-03-19 at 10 59 16" src="https://github.com/software-mansion/react-native-screens/assets/11654389/9e07097f-4d11-4d6f-9e33-6ed33d8223fe">

what happens is that because of `headerIconColor: "white"` we get this result on open: 

<img width="391" alt="Screenshot 2024-03-19 at 10 59 24" src="https://github.com/software-mansion/react-native-screens/assets/11654389/16b63453-7c95-4a99-a9e7-16f737d1a653">

What happens is that `headerIconColor` is applied to the clear icon too, making it blend with the background.

I've tried implementing a solution to set the same color as `hintTextColor` in our codebase using onOpen and onClose events but it was unstable.

## Changes

It makes sense to me that the color of the clear icon should follow `hintTextColor` when  search is opened.
What I propose is setting the color once when we land on the page and then setting it again according to search state each time `setToolbarElementsVisibility` gets called

## Screenshots / GIFs

The end result: 

<img width="394" alt="Screenshot 2024-03-19 at 11 12 53" src="https://github.com/software-mansion/react-native-screens/assets/11654389/a31ffdd4-ca30-4082-b718-985dd1bc8351">

<img width="391" alt="Screenshot 2024-03-19 at 11 12 48" src="https://github.com/software-mansion/react-native-screens/assets/11654389/01db90d0-a883-4c5d-a436-dbb81cc2c6a7">



## Test code and steps to reproduce

- Use the previous configuration as values for `headerSearchBarOptions` in any Screen.
- Open/close search field

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
