### PR TITLE
fix(Android): add notifying for header height change, fix header height values

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -68,7 +68,7 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
             val headerHeight = calculateHeaderHeight()
             val totalHeight = headerHeight.first + headerHeight.second // action bar height + status bar height
             if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-                updateScreenSizeFabric(width, height, headerHeight.first + headerHeight.second)
+                updateScreenSizeFabric(width, height, totalHeight)
             } else {
                 updateScreenSizePaper(width, height)
             }

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -65,12 +65,15 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
             val width = r - l
             val height = b - t
 
-            val headerHeight = calculateHeaderHeight().first
+            val headerHeight = calculateHeaderHeight()
+            val totalHeight = headerHeight.first + headerHeight.second // action bar height + status bar height
             if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-                updateScreenSizeFabric(width, height, headerHeight)
+                updateScreenSizeFabric(width, height, headerHeight.first + headerHeight.second)
             } else {
                 updateScreenSizePaper(width, height)
             }
+
+            notifyHeaderHeightChange(totalHeight)
         }
     }
 
@@ -236,16 +239,22 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
         // Check if it's possible to get an attribute from theme context and assign a value from it.
         // Otherwise, the default value will be returned.
         val actionBarHeight = TypedValue.complexToDimensionPixelSize(actionBarTv.data, resources.displayMetrics)
-            .takeIf { resolvedActionBarSize && headerConfig?.isHeaderHidden != true }
+            .takeIf { resolvedActionBarSize && headerConfig?.isHeaderHidden != true && headerConfig?.isHeaderTranslucent != true }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() } ?: 0.0
 
         val statusBarHeight = context.resources.getIdentifier("status_bar_height", "dimen", "android")
-            .takeIf { it > 0 && isStatusBarHidden != true }
+            // Count only status bar when action bar is visible and status bar is not hidden
+            .takeIf { it > 0 && isStatusBarHidden != true && actionBarHeight > 0 }
             ?.let { (context.resources::getDimensionPixelSize)(it) }
             ?.let { PixelUtil.toDIPFromPixel(it.toFloat()).toDouble() }
             ?: 0.0
 
         return actionBarHeight to statusBarHeight
+    }
+
+    private fun notifyHeaderHeightChange(headerHeight: Double) {
+        UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
+            ?.dispatchEvent(HeaderHeightChangeEvent(id, headerHeight))
     }
 
     enum class StackPresentation {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -25,6 +25,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private val configSubviews = ArrayList<ScreenStackHeaderSubview>(3)
     val toolbar: CustomToolbar
     var isHeaderHidden = false  // named this way to avoid conflict with platform's isHidden
+    var isHeaderTranslucent = false // named this way to avoid conflict with platform's isTranslucent
     private var headerTopInset: Int? = null
     private var title: String? = null
     private var titleColor = 0
@@ -38,7 +39,6 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     private var isDestroyed = false
     private var backButtonInCustomView = false
     private var isTopInsetEnabled = true
-    private var isTranslucent = false
     private var tintColor = 0
     private var isAttachedToWindow = false
     private val defaultStartInset: Int
@@ -195,7 +195,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         screenFragment?.setToolbarShadowHidden(isShadowHidden)
 
         // translucent
-        screenFragment?.setToolbarTranslucent(isTranslucent)
+        screenFragment?.setToolbarTranslucent(isHeaderTranslucent)
 
         // title
         actionBar.title = title
@@ -363,7 +363,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     }
 
     fun setTranslucent(translucent: Boolean) {
-        isTranslucent = translucent
+        isHeaderTranslucent = translucent
     }
 
     fun setBackButtonInCustomView(backButtonInCustomView: Boolean) {


### PR DESCRIPTION
## Description

This PR reverts the change from another PR #2028 that removed notifying about header height change event. Also, here I've also included changes that are fixing incorrect values being returned from `calculateHeaderHeight()` function, which causes to move the target of the touchables 🚀 

## Changes

- Fixed incorrect values, returned from `calculateHeaderHeight` method
- Reverted notifying about header height change

## Test code and steps to reproduce

You can check `Test556.tsx` and `Test1072.tsx` to check if touchables are working correctly.

## Checklist

- [ ] Ensured that CI passes
