### PR TITLE
Configure the yarn version this repository uses in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,5 +148,6 @@
     "android": {
       "javaPackageName": "com.swmansion.rnscreens"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
## Description

There's no explicit mention or configuration in this repository of which package manager version is used. Because of that contributors have to guess what version of yarn they're supposed to use, so they can prevent unnecessary changes to `yarn.lock`. It looks like this is Yarn 1.22.19, so this should be added to `package.json`.

## Changes

- Updated `package.json` with `packageManager` set to `yarn@1.22.19`.