### PR TITLE
fix: remove postinstall step from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.29.0",
   "description": "Native navigation primitives for your React Native app.",
   "scripts": {
-    "postinstall": "git submodule update --init --recursive && (cd react-navigation && yarn)",
     "check-types": "tsc --noEmit",
     "start": "react-native start",
     "test:unit": "jest --passWithNoTests",


### PR DESCRIPTION
## Description

This PR resolves issue with not working installation on react-native-screens on 3.30.0. It seems that `postinstall` step is breaking due to not finding `react-navigation` submodule.

## Changes

- Removed postinstall step from package.json

## Checklist

- [x] Ensured that CI passes
