### PR TITLE
chore(Android): fix emit type parameters

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -253,8 +253,10 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
     }
 
     private fun notifyHeaderHeightChange(headerHeight: Double) {
-        UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
-            ?.dispatchEvent(HeaderHeightChangeEvent(id, headerHeight))
+        val screenContext = context as ReactContext
+        val surfaceId = UIManagerHelper.getSurfaceId(screenContext)
+        UIManagerHelper.getEventDispatcherForReactTag(screenContext, id)
+            ?.dispatchEvent(HeaderHeightChangeEvent(surfaceId, id, headerHeight))
     }
 
     enum class StackPresentation {

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderAttachedEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class HeaderAttachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class HeaderAttachedEvent(surfaceId: Int, viewId: Int) : Event<HeaderAttachedEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderBackButtonClickedEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class HeaderBackButtonClickedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class HeaderBackButtonClickedEvent(surfaceId: Int, viewId: Int) : Event<HeaderBackButtonClickedEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderDetachedEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class HeaderDetachedEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class HeaderDetachedEvent(surfaceId: Int, viewId: Int) : Event<HeaderDetachedEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
@@ -1,23 +1,23 @@
 package com.swmansion.rnscreens.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class HeaderHeightChangeEvent(
+    surfaceId: Int,
     viewId: Int,
     private val headerHeight: Double
-) : Event<HeaderHeightChangeEvent>(viewId) {
+) : Event<HeaderHeightChangeEvent>(surfaceId, viewId) {
 
     override fun getEventName() = EVENT_NAME
 
     // As the same header height could appear twice, use header height as a coalescing key.
     override fun getCoalescingKey(): Short = headerHeight.toInt().toShort()
 
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-        val map = Arguments.createMap()
-        map.putDouble("headerHeight", headerHeight)
-        rctEventEmitter.receiveEvent(viewTag, eventName, map)
+    override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+        putDouble("headerHeight", headerHeight)
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenTransitionProgressEvent.kt
@@ -11,7 +11,7 @@ class ScreenTransitionProgressEvent(
     private val isClosing: Boolean,
     private val isGoingForward: Boolean,
     private val coalescingKey: Short
-) : Event<ScreenAppearEvent?>(surfaceId, viewId) {
+) : Event<ScreenTransitionProgressEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     override fun getCoalescingKey(): Short = coalescingKey

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarBlurEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class SearchBarBlurEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class SearchBarBlurEvent(surfaceId: Int, viewId: Int) : Event<SearchBarBlurEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarChangeTextEvent.kt
@@ -8,7 +8,7 @@ class SearchBarChangeTextEvent(
     surfaceId: Int,
     viewId: Int,
     private val text: String?,
-) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+) : Event<SearchBarChangeTextEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarCloseEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class SearchBarCloseEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class SearchBarCloseEvent(surfaceId: Int, viewId: Int) : Event<SearchBarCloseEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarFocusEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class SearchBarFocusEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class SearchBarFocusEvent(surfaceId: Int, viewId: Int) : Event<SearchBarFocusEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarOpenEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class SearchBarOpenEvent(surfaceId: Int, viewId: Int) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class SearchBarOpenEvent(surfaceId: Int, viewId: Int) : Event<SearchBarOpenEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.

--- a/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SearchBarSearchButtonPressEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-class SearchBarSearchButtonPressEvent(surfaceId: Int, viewId: Int, private val text: String?) : Event<ScreenAppearEvent>(surfaceId, viewId) {
+class SearchBarSearchButtonPressEvent(surfaceId: Int, viewId: Int, private val text: String?) : Event<SearchBarSearchButtonPressEvent>(surfaceId, viewId) {
     override fun getEventName(): String = EVENT_NAME
 
     // All events for a given view can be coalesced.


### PR DESCRIPTION
## Description

Currently, on Android every event has one class, putted in generic - `ScreenAppearEvent`. This seems to be wrong, as every event should have their own class inside `Event` generic. This PR changes this by replacing `ScreenAppearEvent` to the appropriate event class.

## Changes

- Replaced ScreenAppearEvent to appropriate event types inside generics.

## Checklist

- [x] Ensured that CI passes
