### PR TITLE
fix: don't use AnimatedNativeScreen when stackPresentation prop is not set

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -79,6 +79,7 @@ export class InnerScreen extends React.Component<ScreenProps> {
       // Due to how Yoga resolves layout, we need to have different components for modal nad non-modal screens
       const AnimatedScreen =
         Platform.OS === 'android' ||
+        stackPresentation === undefined ||
         stackPresentation === 'push' ||
         stackPresentation === 'containedModal' ||
         stackPresentation === 'containedTransparentModal'


### PR DESCRIPTION
## Description

All navigators except `native-stack` does not set `stackPresentation` so it resolved in `AnimatedNativeModalScreen` making all navigators that are nested or under some views not work with pressability. Follow-up to https://github.com/software-mansion/react-native-screens/pull/2028/

## Changes

- Added `undefined` case for setting AnimatedNativeScreen

## Test code and steps to reproduce

You can check `Test1214.tsx` or `Test2028.tsx` (after changing import to `@react-navigation/stack`) in order to test targets of touchables.

## Checklist

- [x] Ensured that CI passes
