### PR TITLE
fix: Change postinstall step to prepare and run prepare on release in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "lint-js": "eslint --ext '.js,.ts,.tsx' --fix src",
     "lint-android": "./android/gradlew -p android spotlessCheck -q",
     "lint": "yarn lint-js && yarn lint-android",
-    "release": "npm login && release-it",
-    "postinstall": "bob build && husky install"
+    "release": "yarn prepare && npm login && release-it",
+    "prepare": "bob build && husky install"
   },
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description

This PR intents to fix error, during the install step on other React Native applications. That's because of the name of the step - it shouldn't be named as `postinstall`, as method named this way is triggered by yarn v4. This was not an issue before, as we used yarn v1.

Fixes #2108.

## Changes

- Changed `postinstall` name to `prepare` in package.json
- Added `yarn prepare` command during the `yarn release`.

## Checklist

- [ ] Ensured that CI passes
