### PR TITLE
fix(Android): fix build deprecations

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -80,7 +80,7 @@ class Screen(context: ReactContext?) : FabricEnabledViewGroup(context) {
     private fun updateScreenSizePaper(width: Int, height: Int) {
         val reactContext = context as ReactContext
         reactContext.runOnNativeModulesQueueThread(
-            object : GuardedRunnable(reactContext) {
+            object : GuardedRunnable(reactContext.exceptionHandler) {
                 override fun runGuarded() {
                     reactContext
                         .getNativeModule(UIManagerModule::class.java)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -62,7 +62,8 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
 
     override fun setToolbarShadowHidden(hidden: Boolean) {
         if (isToolbarShadowHidden != hidden) {
-            appBarLayout?.targetElevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
+            appBarLayout?.elevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
+            appBarLayout?.stateListAnimator = null
             isToolbarShadowHidden = hidden
         }
     }
@@ -125,7 +126,7 @@ class ScreenStackFragment : ScreenFragment, ScreenStackFragmentWrapper {
 
         view?.addView(appBarLayout)
         if (isToolbarShadowHidden) {
-            appBarLayout?.targetElevation = 0f
+            appBarLayout?.elevation = 0f
         }
         toolbar?.let { appBarLayout?.addView(recycleView(it)) }
         setHasOptionsMenu(true)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -8,6 +8,7 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.View.OnClickListener
 import android.view.ViewGroup
+import android.view.WindowInsets
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -82,7 +83,9 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
         // we want to save the top inset before the status bar can be hidden, which would resolve in
         // inset being 0
         if (headerTopInset == null) {
-            headerTopInset = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            headerTopInset = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                rootWindowInsets.getInsets(WindowInsets.Type.systemBars()).top
+            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                 rootWindowInsets.systemWindowInsetTop
             else
             // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens
 
 import android.content.Context
 import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.os.Build
 import android.text.TextUtils
 import android.util.TypedValue
@@ -231,7 +232,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
         // color
         if (tintColor != 0) {
-            toolbar.navigationIcon?.setColorFilter(tintColor, PorterDuff.Mode.SRC_ATOP)
+            toolbar.navigationIcon?.colorFilter = PorterDuffColorFilter(tintColor, PorterDuff.Mode.SRC_ATOP)
         }
 
         // subviews

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -60,7 +60,7 @@ object ScreenWindowTraits {
         val animated = screenForAnimated?.isStatusBarAnimated ?: false
 
         UiThreadUtil.runOnUiThread(
-            object : GuardedRunnable(context) {
+            object : GuardedRunnable(context.exceptionHandler) {
                 override fun runGuarded() {
                     val window = activity.window
                     val curColor: Int = window.statusBarColor
@@ -105,7 +105,7 @@ object ScreenWindowTraits {
         val screenForTranslucent = findScreenForTrait(screen, WindowTraits.TRANSLUCENT)
         val translucent = screenForTranslucent?.isStatusBarTranslucent ?: false
         UiThreadUtil.runOnUiThread(
-            object : GuardedRunnable(context) {
+            object : GuardedRunnable(context.exceptionHandler) {
                 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
                 override fun runGuarded() {
                     // If the status bar is translucent hook into the window insets calculations

--- a/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt
@@ -3,7 +3,6 @@ package com.swmansion.rnscreens.events
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class HeaderHeightChangeEvent(
     surfaceId: Int,


### PR DESCRIPTION
## Description

This PR intents to fix some "Deprecated in Java" warnings when building on android. I decided not to suppress warnings manually when it is inescapable to avoid the warning.

Fixes #2018 

## Changes

- replaced deprecated targetElavation with elevation
- adjusted usage of porter duff color filter
- calculating header top inset using recent method if android API >= 30 (the warning persists as the previous APIs still require deprecated method)
- fixed guarded runnable deprecated warning
- removed unused import

## Screenshots / GIFs

### Before

```
> Task :react-native-screens:compileDebugKotlin
'compileDebugJavaWithJavac' task (current target is 11) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain

w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/Screen.kt:83:22 'constructor GuardedRunnable(ReactContext!)' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt:65:27 'setter for targetElevation: Float' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt:128:27 'setter for targetElevation: Float' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt:86:34 'getter for systemWindowInsetTop: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt:231:37 'setColorFilter(Int, PorterDuff.Mode): Unit' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:63:22 'constructor GuardedRunnable(ReactContext!)' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:108:22 'constructor GuardedRunnable(ReactContext!)' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:135:47 'replaceSystemWindowInsets(Int, Int, Int, Int): WindowInsetsCompat' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:136:51 'getter for systemWindowInsetLeft: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:138:51 'getter for systemWindowInsetRight: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:139:51 'getter for systemWindowInsetBottom: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt:100:22 Parameter 'view' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt:100:43 Parameter 'placeholder' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt:147:43 Parameter 'flag' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/events/HeaderHeightChangeEvent.kt:6:44 'RCTEventEmitter' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:42 Parameter 'width' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:54 Parameter 'height' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:67 Parameter 'headerHeight' is never used
```

### After

```
> Task :react-native-screens:compileDebugKotlin
'compileDebugJavaWithJavac' task (current target is 11) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain

w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt:90:34 'getter for systemWindowInsetTop: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:135:47 'replaceSystemWindowInsets(Int, Int, Int, Int): WindowInsetsCompat' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:136:51 'getter for systemWindowInsetLeft: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:138:51 'getter for systemWindowInsetRight: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt:139:51 'getter for systemWindowInsetBottom: Int' is deprecated. Deprecated in Java
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt:100:22 Parameter 'view' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt:100:43 Parameter 'placeholder' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt:147:43 Parameter 'flag' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:42 Parameter 'width' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:54 Parameter 'height' is never used
w: file:///Users/alexduzy/Projects/react-native-screens/Example/node_modules/react-native-screens/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt:11:67 Parameter 'headerHeight' is never used
```

## Test code and steps to reproduce

- build android app to compare deprecation warnings quantity
- run the example app and see wether the header shadow, backButton color and top inset behave correctly

## Checklist

- [ ] Ensured that CI passes
