### PR TITLE
Catch UnsatisfiedLinkError

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
@@ -25,7 +25,7 @@ class ScreensModule(private val reactContext: ReactApplicationContext)
             } else {
                 Log.e("[RNScreens]", "Could not install JSI bindings.")
             }
-        } catch (exception: Exception) {
+        } catch (exception: UnsatisfiedLinkError) {
             Log.w("[RNScreens]", "Could not load RNScreens module.")
         }
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens/issues/2115

The `System.loadLibrary("rnscreens")` can throw an exception that inherits from the `Error` class instead of the `Exception` class.