### PR TITLE
fix: Prevent setting RTL mode in test examples

### DIFF
--- a/FabricTestExample/App.js
+++ b/FabricTestExample/App.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
+import { I18nManager } from 'react-native';
 
 import { enableFreeze } from 'react-native-screens';
 
@@ -97,6 +98,10 @@ import Test2008 from './src/Test2008';
 import Test2028 from './src/Test2028';
 import Test2048 from './src/Test2048';
 import Test2069 from './src/Test2069';
+
+// Prevent RTL tests from propagating direction to other tests.
+// Remember to reload the app after switching from the test with RTL mode.
+I18nManager.forceRTL(false);
 
 enableFreeze(true);
 

--- a/FabricTestExample/src/Test654.js
+++ b/FabricTestExample/src/Test654.js
@@ -5,9 +5,9 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 const Stack = createNativeStackNavigator();
 
-I18nManager.forceRTL(true);
-
 export default function App() {
+  I18nManager.forceRTL(true);
+
   return (
     <NavigationContainer>
       <Stack.Navigator>

--- a/FabricTestExample/src/Test831.tsx
+++ b/FabricTestExample/src/Test831.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 const Stack = createNativeStackNavigator();
 
-I18nManager.forceRTL(true);
-
 export default function App(): JSX.Element {
+  I18nManager.forceRTL(true);
+
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }}>

--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
+import { I18nManager } from 'react-native';
 
 import { enableFreeze } from 'react-native-screens';
 
@@ -98,6 +99,10 @@ import Test1981 from './src/Test1981';
 import Test2008 from './src/Test2008';
 import Test2048 from './src/Test2048';
 import Test2069 from './src/Test2069';
+
+// Prevent RTL tests from propagating direction to other tests.
+// Remember to reload the app after switching from the test with RTL mode.
+I18nManager.forceRTL(false);
 
 enableFreeze(true);
 

--- a/TestsExample/src/Test654.js
+++ b/TestsExample/src/Test654.js
@@ -5,9 +5,9 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 const Stack = createNativeStackNavigator();
 
-I18nManager.forceRTL(true);
-
 export default function App() {
+  I18nManager.forceRTL(true);
+
   return (
     <NavigationContainer>
       <Stack.Navigator>

--- a/TestsExample/src/Test831.tsx
+++ b/TestsExample/src/Test831.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 const Stack = createNativeStackNavigator();
 
-I18nManager.forceRTL(true);
-
 export default function App(): JSX.Element {
+  I18nManager.forceRTL(true);
+
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }}>


### PR DESCRIPTION
## Description

This PR is a follow-up to #2084 that fixes setting incorrect RTL mode in our example apps.
The reason why it is being forced is that `I18nManager.forceRTL(true)` is being called from the global scope, which causes to force RTL, even if we're only importing the component **from file**.

## Changes

- Moved `I18nManager.forceRTL(true);` to inner scope of App components
- Added `I18nManager.forceRTL(false);` in App.js files to prevent propagating RTL mode to other tests.

## Test code and steps to reproduce

Just run TestsExample & FabricTestExample ¯\_(ツ)_/¯

## Checklist

- [X] Ensured that CI passes
