### PR TITLE
fix: error when building paper after fabric

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,7 +152,6 @@ android {
             } else {
                 srcDirs += [
                     "src/paper/java",
-                    "build/generated/source/codegen/java"
                 ]
             }
         }


### PR DESCRIPTION
## Description

Currently when you build Fabric app and then Paper app Android Studio has errors about duplicated classes. This should resolve that issue. 

**Test:**
Packed with `npm pack` and tested on new expo app. Seems that everything is fine.