### PR TITLE
Prevent iOS host object installation from getting the wrong bridge

### DIFF
--- a/ios/RNSModule.mm
+++ b/ios/RNSModule.mm
@@ -138,8 +138,7 @@ RCT_EXPORT_MODULE()
    because depending on the selected architecture, only one method will be called.
    For `Paper`, it will be constantsToExport, and for `Fabric`, it will be getTurboModule.
 */
-  RCTBridge *bridge = [RCTBridge currentBridge];
-  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
+  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
   if (cxxBridge != nil) {
     auto jsiRuntime = (jsi::Runtime *)cxxBridge.runtime;
     if (jsiRuntime != nil) {


### PR DESCRIPTION
## Description

Similar to https://github.com/software-mansion/react-native-reanimated/pull/5953,  using `[RCTBridge currentBridge]` may lead to the wrong bridge in apps that have multiple React instances, as is the case for expo-dev-client. This results in apps sometimes crashing when reloading the bundle after interacting with the DevMenu.


![image](https://github.com/software-mansion/react-native-screens/assets/11707729/df7c1a85-1975-4a30-b199-2460bd52a523)


## Changes

Instead of using `[RCTBridge currentBridge]` we can just call `self.bridge` and ensure the correct bridge is always used 

