### PR TITLE
Fix: Importing of project into Swift projects

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -63,6 +63,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => platform, :tvos => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/software-mansion/react-native-screens.git", :tag => "#{s.version}" }
   s.source_files = source_files
+  s.project_header_files = "cpp/**/*.h" # Don't expose C++ headers publicly to allow importing framework into Swift files
   s.requires_arc = true
 
   if defined?(install_modules_dependencies()) != nil


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens/issues/2158 by making C++ headers project instead of public.
Original code sample (in the issue) can be updated to include this change verifying the fix.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
