### PR TITLE
fix: change `-[RNSScreenContainer init]` to call `-[UIView initWithFrame:]` designated initalizer

### DIFF
--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -60,7 +60,7 @@ namespace react = facebook::react;
 
 - (instancetype)init
 {
-  if (self = [super init]) {
+  if (self = [super initWithFrame:CGRectZero]) {
 #ifdef RCT_NEW_ARCH_ENABLED
     static const auto defaultProps = std::make_shared<const react::RNSScreenContainerProps>();
     _props = defaultProps;


### PR DESCRIPTION
## Description

Ensures `RNSScreenContainer` `UIView` subclass calls a designated initializer, this fixes an issue where subclassing `RNSScreenContainer` would recursively loop through the inits - ending in a crash.

`UIView.h` has:
`- (instancetype)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
