### PR TITLE
feat: add basic React Server Component support

### DIFF
--- a/src/TransitionProgressContext.tsx
+++ b/src/TransitionProgressContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Animated } from 'react-native';
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { Animated, View, Platform } from 'react-native';
 

--- a/src/components/Screen.web.tsx
+++ b/src/components/Screen.web.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ScreenProps } from 'react-native-screens';
 import { Animated, View } from 'react-native';
 import React from 'react';
@@ -8,6 +10,7 @@ export const InnerScreen = View;
 
 // We're using class component here because of the error from reanimated:
 // createAnimatedComponent` does not support stateless functional components; use a class component instead.
+// NOTE: React Server Components do not support class components.
 export class NativeScreen extends React.Component<ScreenProps> {
   render(): JSX.Element {
     let {

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Platform, View } from 'react-native';
 import React from 'react';
 import { ScreenContainerProps } from 'react-native-screens';

--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { ScreenStackProps, freezeEnabled } from 'react-native-screens';
 import DelayedFreeze from './helpers/DelayedFreeze';

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   HeaderSubviewTypes,

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   isSearchBarAvailableForCurrentPlatform,

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Platform, UIManager } from 'react-native';
 
 // const that tells if the library should use new implementation, will be undefined for older versions

--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {

--- a/src/fabric/NativeScreensModule.ts
+++ b/src/fabric/NativeScreensModule.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint-disable @typescript-eslint/ban-types */
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';

--- a/src/fabric/ScreenContainerNativeComponent.ts
+++ b/src/fabric/ScreenContainerNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {

--- a/src/fabric/ScreenNavigationContainerNativeComponent.ts
+++ b/src/fabric/ScreenNavigationContainerNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {

--- a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';

--- a/src/fabric/ScreenStackNativeComponent.ts
+++ b/src/fabric/ScreenStackNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint-disable */
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue, HostComponent } from 'react-native';

--- a/src/native-stack/contexts/GHContext.tsx
+++ b/src/native-stack/contexts/GHContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { PropsWithChildren } from 'react';
 import { GestureProviderProps } from '../types';
 


### PR DESCRIPTION
## Description

Add basic support for React Server Components support.

Related PRs for more context:

- https://github.com/necolas/react-native-web/pull/2678
- https://github.com/th3rdwave/react-native-safe-area-context/pull/502
- https://github.com/software-mansion/react-native-svg/pull/2287

## Changes

- Added basic React Server Component support

## Test code and steps to reproduce

- It's kinda hard to test this E2E. I wrote a small jest runner in jest-expo which executes in RSC mode, but it requires React 19 to work. Here's where I tested this patch https://github.com/expo/expo/pull/29404
- It will likely break between now and the full release, but this should at least reduce the number of patches required to work on Expo Router support.
- There's pretty good compilation on web:
```
2:I["../../node_modules/react-native-web/dist/exports/View/index.js",[],""]
3:I["../../node_modules/react-native-web/dist/exports/Image/index.js",[],""]
1:{"name":"ScreenStackHeaderBackButtonImage","env":"Server","owner":null}
0:D"$1"
0:["$","$L2",null,{"children":["$","$L3",null,{"resizeMode":"center","fadeDuration":0},"$1"]},"$1"]
```
- And more opaque compilation on native platforms:
```
1:I["../../node_modules/react-native-screens/src/components/ScreenStackHeaderConfig.tsx",[],"ScreenStackHeaderBackButtonImage"]
0:["$","$L1",null,{},null]
```


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
