### PR TITLE
feat: call onGestureCancel in modal too

### DIFF
--- a/apps/test-examples/App.js
+++ b/apps/test-examples/App.js
@@ -101,6 +101,7 @@ import Test2028 from './src/Test2028';
 import Test2048 from './src/Test2048';
 import Test2069 from './src/Test2069';
 import Test2118 from './src/Test2118';
+import Test2184 from './src/Test2184';
 import TestScreenAnimation from './src/TestScreenAnimation';
 
 enableFreeze(true);

--- a/apps/test-examples/src/Test2184.tsx
+++ b/apps/test-examples/src/Test2184.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import { Button } from 'react-native';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="First" component={First} />
+        <Stack.Screen
+          name="Second"
+          component={Second}
+          options={{ presentation: 'modal', gestureEnabled: false }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+};
+
+const First = ({ navigation }: Props): JSX.Element => {
+  return (
+    <Button
+      title="Tap me for second screen"
+      onPress={() => navigation.navigate('Second')}
+    />
+  );
+};
+
+const Second = ({ navigation }: Props): JSX.Element => {
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('gestureCancel', () => {
+      console.log('gestureCancel');
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <Button
+      title="Tap me for first screen"
+      onPress={() => navigation.goBack()}
+    />
+  );
+};

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -521,6 +521,14 @@ namespace react = facebook::react;
 #endif
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)presentationController
+{
+  [self notifyGestureCancel];
+}
+#endif
+
 - (void)presentationControllerWillDismiss:(UIPresentationController *)presentationController
 {
   // We need to call both "cancel" and "reset" here because RN's gesture recognizer


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

PR adding calling `onGestureCancel` when trying to dismiss a modal with `gestureEnabled` set to `false`.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
