### PR TITLE
fix: bump gradle wrapper version to 7.5.1 & not use app node_modules when running tasks from repo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ buildscript {
     }
 }
 
+def isRunningInContextOfScreensRepo() {
+    return project == rootProject
+}
+
 def isNewArchitectureEnabled() {
     // To opt-in for the New Architecture, you can either:
     // - Set `newArchEnabled` to true inside the `gradle.properties` file
@@ -31,7 +35,7 @@ def isNewArchitectureEnabled() {
 }
 
 // spotless is only accessible within react-native-screens repo
-if (project == rootProject) {
+if (isRunningInContextOfScreensRepo()) {
     apply from: 'spotless.gradle'
 }
 
@@ -58,7 +62,7 @@ def resolveReactNativeDirectory() {
     }
 
     def reactNativeFromAppNodeModules = file("${projectDir}/../../react-native")
-    if (reactNativeFromAppNodeModules.exists()) {
+    if (!isRunningInContextOfScreensRepo() && reactNativeFromAppNodeModules.exists()) {
         return reactNativeFromAppNodeModules
     }
 
@@ -68,7 +72,7 @@ def resolveReactNativeDirectory() {
     }
 
     throw new GradleException(
-        "[RNScreens] Unable to resolve react-native location in node_modules. You should project extension property (in `app/build.gradle`) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+        "[RNScreens] Unable to resolve react-native location in node_modules. You should add project extension property (in `app/build.gradle`) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
     )
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip


### PR DESCRIPTION

## Description

Basically tasks run from react-native-screens repo (such as linting & formating) would fail due to outdated gradle wrapper version (and the fact that we re using newer JDK now).

There was a second issue: when running tasks from react-native-screens project as gradle's `rootProject` and simultaneously having `react-native` repo side-by-side to `react-native-screens`
repo on disk - our current react native directory resolution algorithm would have found it and attempt to use to retrieve RN version, but:

1. the gradle.properties file is not there,
2. retrieved version could be out of sync with what's in project.


## Changes

* Bumped gradle wrapper version to 7.5.1 (we were still on major 6).
* Adjusted the react native directory algorithm just a bit, so that when running in context of screens repo we skip one code path.

There was also possibility to "reorder the ifs" in `resolveReactNativeDir` function, however this could possible cause issues in user projects - we want first to look for app's node modules
and later for project node modules.


## Test code and steps to reproduce

`yarn lint-android`, `yarn format-android`, etc. should now work just fine when you re on JDK 17+ & have `react-native` repo side by side to `react-native-screens`.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
