### PR TITLE
chore: bump supported `react-native` versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Screens are already integrated with the React Native's most popular navigation l
 
 | library version | react-native version |
 | ------- | -------------------- |
+| 3.32.0+ | 0.71.0+              |
 | 3.30.0+ | 0.68.0+              |
 | 3.14.0+ | 0.64.0+              |
 | 3.0.0+  | 0.62.0+              |
@@ -119,6 +120,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 
 | library version | react-native version |
 | ------- | -------------------- |
+| 3.32.0+ | 0.74.0+              |
 | 3.28.0+ | 0.73.0+              |
 | 3.21.0+ | 0.72.0+              |
 | 3.19.0+ | 0.71.0+              |


### PR DESCRIPTION
## Description

Doing so just before 3.32.0 release

## Changes

Last supported RN version bumped to 0.71.0.

Last supported RN version for Fabric bumped to 0.74.0.

## Checklist

- [ ] Ensured that CI passes

