### PR TITLE
chore: make eps parameter const & functions constexpr in RectUtil

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h
+++ b/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h
@@ -11,7 +11,7 @@ namespace react = facebook::react;
 
 template <typename T>
   requires std::is_floating_point_v<T>
-inline bool equalWithRespectToEps(const T a, const T b, const T eps) {
+inline constexpr bool equalWithRespectToEps(const T a, const T b, const T eps) {
   return std::abs(a - b) <= eps;
 }
 
@@ -25,10 +25,10 @@ inline bool equalWithRespectToEps(const T a, const T b, const T eps) {
  * @return whether the frame dimensions are the same with respect to given
  * epsilon
  */
-inline bool compareFrameSizes(
+inline constexpr bool compareFrameSizes(
     const react::Size &first,
     const react::Size &second,
-    react::Float eps = 0.01) {
+    const react::Float eps = 0.01) {
   return equalWithRespectToEps(first.width, second.width, eps) &&
       equalWithRespectToEps(first.height, second.height, eps);
 }


### PR DESCRIPTION
## Description

The `eps` parameter in `compareFrameSizes` should be `const`. 

Both functions can be `constexpr` so I've marked them as such.

> [!note]
When doing a bit of research for this PR I've learned that [`constexpr` implies `inline` linkage (so also bending the ODR rule)](https://stackoverflow.com/a/14391320/8635522) for functions (and it seems that since C++17 also for namespace scoped variables) and must admit I was not aware of this before, thus I've come to conclusion that it will be ok to leave `inline` keyword there, so that the intent of `inline` linkage is clear.


## Test code and steps to reproduce

Build Android / iOS

## Checklist

- [ ] Ensured that CI passes

