### PR TITLE
chore: moved android e2e to ubuntu

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -54,10 +54,6 @@ jobs:
         name: Reinstall node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn
-      - name: Install AVD dependencies
-        run: |
-          sudo apt update
-          sudo apt-get install -y libpulse0 libgl1
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -52,6 +52,19 @@ jobs:
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
       - name: Run emulator and tests
         uses: reactivecircus/android-emulator-runner@v2.30.1
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -57,11 +57,6 @@ jobs:
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
       - name: Run emulator and tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -62,14 +62,6 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}
       - name: Run emulator and tests
         uses: reactivecircus/android-emulator-runner@v2.30.1
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run emulator and tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -14,24 +14,25 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example
+      API_LEVEL: 31
     concurrency:
       group: android-e2e-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'
           cache: 'gradle'
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -52,10 +53,10 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
       - name: Run emulator and tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.30.1
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
-          api-level: 31
+          api-level: ${{ env.API_LEVEL }}
           target: aosp_atd
           profile: pixel_2
           ram-size: '4096M'
@@ -64,7 +65,7 @@ jobs:
           avd-name: e2e_emulator
           arch: x86_64
           script: yarn test-e2e-android
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: android-fail-screen-shots

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
-      - name: Enable KVM group perms
+      - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run emulator and tests
-        uses: reactivecircus/android-emulator-runner@v2.30.1
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -62,6 +62,14 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
       - name: Run emulator and tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -54,6 +54,10 @@ jobs:
         name: Reinstall node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn
+      - name: Install AVD dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y libpulse0 libgl1
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android
@@ -67,7 +71,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
-          target: default
+          target: aosp_atd
           profile: pixel_2
           ram-size: '4096M'
           disk-size: '10G'

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example
-      API_LEVEL: 31
+      API_LEVEL: 28
     concurrency:
       group: android-e2e-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -54,6 +54,10 @@ jobs:
         name: Reinstall node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn
+      - name: Install AVD dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y libpulse0 libgl1
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build-e2e-android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -42,17 +42,6 @@ jobs:
         with:
           node-version: 18
           cache: 'yarn'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - name: Restore node_modules from cache
-        uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install root node dependencies
         run: yarn install && yarn submodules
       - name: Install shared app dependencies

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example
-      API_LEVEL: 31
+      API_LEVEL: 34
     concurrency:
       group: android-e2e-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: Example
-      API_LEVEL: 28
+      API_LEVEL: 31
     concurrency:
       group: android-e2e-${{ github.ref }}
       cancel-in-progress: true
@@ -35,12 +35,24 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
       - name: Use Node.js 18
         uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Restore node_modules from cache
+        uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install root node dependencies
         run: yarn install && yarn submodules
       - name: Install shared app dependencies

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
-          target: aosp_atd
+          target: default
           profile: pixel_2
           ram-size: '4096M'
           disk-size: '10G'

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -35,8 +35,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+          cache: 'gradle'
       - name: Use Node.js 18
         uses: actions/setup-node@v4
         with:
@@ -68,7 +67,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
-          target: aosp_atd
+          target: default
           profile: pixel_2
           ram-size: '4096M'
           disk-size: '10G'


### PR DESCRIPTION
## Description

This PR intents to move android e2e test to ubuntu to avoid random crashes. Inspired by changes made by @kirillzyusko in [react-native-keyboard-controller](https://github.com/kirillzyusko/react-native-keyboard-controller).

## Changes

- Changed workflow's `runs-on`
- Bump deps
- Added necessary extra steps

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Ensured that CI passes
