### PR TITLE
fix(Android, Paper): apps soft crash on exception due to detached context

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
@@ -25,7 +25,9 @@ class RNScreensPackage : TurboReactPackage() {
         // installing its C++ bindings - so we are safe in terms of creating this helper
         // before RN starts creating shadow nodes.
         // See https://github.com/software-mansion/react-native-screens/pull/2169
-        screenDummyLayoutHelper = ScreenDummyLayoutHelper(reactContext)
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+            screenDummyLayoutHelper = ScreenDummyLayoutHelper(reactContext)
+        }
 
         return listOf<ViewManager<*, *>>(
             ScreenContainerViewManager(),

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -8,7 +8,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.PixelUtil
 import com.google.android.material.appbar.AppBarLayout
-import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.ScreenStackHeaderConfig
 import java.lang.ref.WeakReference
 

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -8,6 +8,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.PixelUtil
 import com.google.android.material.appbar.AppBarLayout
+import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.ScreenStackHeaderConfig
 import java.lang.ref.WeakReference
 


### PR DESCRIPTION
## Description

My recent PR:

* https://github.com/software-mansion/react-native-screens/pull/2169

introduced creation of dummy layout, which requires react context to be attached to activity, as we need access
to the activity. Unfortunately when running on Paper the context is not attached to the activity yet, resulting 
in exception being thrown.

<details>
    <summary>Exception</summary>

```
Failed to create NativeModule 'UIManager'
    java.lang.IllegalArgumentException: [RNScreens] Attempt to use context detached from activity
        at com.swmansion.rnscreens.utils.ScreenDummyLayoutHelper.ensureDummyLayoutWithHeader(ScreenDummyLayoutHelper.kt:68)
        at com.swmansion.rnscreens.utils.ScreenDummyLayoutHelper.<init>(ScreenDummyLayoutHelper.kt:53)
        at com.swmansion.rnscreens.RNScreensPackage.createViewManagers(RNScreensPackage.kt:28)
        at com.facebook.react.ReactInstanceManager.getOrCreateViewManagers(ReactInstanceManager.java:933)
        at com.swmansion.reanimated.ReanimatedPackage.createUIManager(ReanimatedPackage.java:78)
        at com.swmansion.reanimated.ReanimatedPackage.getModule(ReanimatedPackage.java:38)
        at com.facebook.react.BaseReactPackage$ModuleHolderProvider.get(BaseReactPackage.java:156)
        at com.facebook.react.BaseReactPackage$ModuleHolderProvider.get(BaseReactPackage.java:144)
        at com.facebook.react.bridge.ModuleHolder.create(ModuleHolder.java:186)
        at com.facebook.react.bridge.ModuleHolder.getModule(ModuleHolder.java:151)
        at com.facebook.react.bridge.NativeModuleRegistry.getModule(NativeModuleRegistry.java:148)
        at com.facebook.react.bridge.CatalystInstanceImpl.getNativeModule(CatalystInstanceImpl.java:469)
        at com.facebook.react.bridge.CatalystInstanceImpl.getNativeModule(CatalystInstanceImpl.java:445)
        at com.facebook.react.uimanager.UIManagerHelper.getUIManager(UIManagerHelper.java:88)
        at com.facebook.react.uimanager.UIManagerHelper.getUIManager(UIManagerHelper.java:46)
        at com.facebook.react.ReactInstanceManager.attachRootViewToInstance(ReactInstanceManager.java:1231)
        at com.facebook.react.ReactInstanceManager.setupReactContext(ReactInstanceManager.java:1180)
        at com.facebook.react.ReactInstanceManager.lambda$runCreateReactContextOnNewThread$1(ReactInstanceManager.java:1143)
        at com.facebook.react.ReactInstanceManager.$r8$lambda$FD-H2RG7CdgXPtYJUBikxLbd8MA(Unknown Source:0)
        at com.facebook.react.ReactInstanceManager$$ExternalSyntheticLambda4.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:958)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loopOnce(Looper.java:205)
        at android.os.Looper.loop(Looper.java:294)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:233)
```

</details>

I'll need to sort that out when working on fix for jumping content on Android + Paper combination, however right now
it is more important for examples to work correctly.

## Changes

Creating `ScreenDummyLayoutHelper` now only when running on new architecture.

## Test code and steps to reproduce

Run `TestsExample` w/o this change, you will see the exception being thrown -> resulting in freeze on whitescreen.
With this change the example runs normally.

## Checklist

- [x] Ensured that CI passes

