### PR TITLE
chore(examples): use Material 3 in example applications

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -132,6 +132,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.google.android.material:material:1.9.0")
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/Example/android/app/src/main/res/values/styles.xml
+++ b/Example/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>

--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.google.android.material:material:1.9.0")
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/FabricExample/android/app/src/main/res/values/styles.xml
+++ b/FabricExample/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>

--- a/FabricTestExample/android/app/build.gradle
+++ b/FabricTestExample/android/app/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.google.android.material:material:1.9.0")
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/FabricTestExample/android/app/src/main/res/values/styles.xml
+++ b/FabricTestExample/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>

--- a/TestsExample/android/app/build.gradle
+++ b/TestsExample/android/app/build.gradle
@@ -114,6 +114,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.google.android.material:material:1.9.0")
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/TestsExample/android/app/src/main/res/values/styles.xml
+++ b/TestsExample/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>


### PR DESCRIPTION
## Description

Following up review discussion:

* https://github.com/software-mansion/react-native-screens/pull/2045#discussion_r1650813540

to PR 

* #2045

This PR introduces usage of Material 3 in our example applications, so that it is easier to test new Sheets & top app bar APIs.

The 1.9.0 version was chosen, because:

1. This is the version I did all the testing on in #2045 
2. 1.10.0 introduces many [dependency bumps](https://github.com/material-components/material-components-android/releases/tag/1.10.0), including `appcompat` & `activity` libs, which are known to be problematic with updates (we already had some issues in the past related to that)

## Changes

- **Bump material to 1.9.0 in TestsExample**
- **Bump material to 1.9.0 in Example**
- **Bump material to 1.9.0 in FabricExample**
- **Bump material to 1.9.0 in FabricTestExample**

## Test code and steps to reproduce

Application should work as normal & Material 3 components should be used. 


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
