### PR TITLE
fix: react-native-screens not building on visionOS

### DIFF
--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -1,6 +1,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <react/renderer/components/rnscreens/Props.h>
 #import "RNSEnums.h"
+#import <UIKit/UIKit.h>
 
 namespace react = facebook::react;
 

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -1,7 +1,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
+#import <UIKit/UIKit.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import "RNSEnums.h"
-#import <UIKit/UIKit.h>
 
 namespace react = facebook::react;
 


### PR DESCRIPTION
## Description

This PR fixes React Native screens not building on visionOS. As this platform needs explicit imports for used modules

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

- Fixed building `RNSConvert.h` for visionOS

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Compile on visionOS

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
