### PR TITLE
fix(iOS): fullscreenmodal color scheme adaptability

### DIFF
--- a/apps/test-examples/App.js
+++ b/apps/test-examples/App.js
@@ -96,6 +96,7 @@ import Test1844 from './src/Test1844';
 import Test1864 from './src/Test1864';
 import Test1970 from './src/Test1970';
 import Test1981 from './src/Test1981';
+import Test2002 from './src/Test2002';
 import Test2008 from './src/Test2008';
 import Test2028 from './src/Test2028';
 import Test2048 from './src/Test2048';

--- a/apps/test-examples/src/Test2002.tsx
+++ b/apps/test-examples/src/Test2002.tsx
@@ -42,14 +42,6 @@ function ModalScreen({ navigation }) {
   );
 }
 
-function DetailsScreen() {
-  return (
-    <View>
-      <Text>Details</Text>
-    </View>
-  );
-}
-
 const RootStack = createNativeStackNavigator();
 
 function App() {
@@ -60,7 +52,6 @@ function App() {
       <RootStack.Navigator>
         <RootStack.Group>
           <RootStack.Screen name="Home" component={HomeScreen} />
-          <RootStack.Screen name="Details" component={DetailsScreen} />
           <RootStack.Screen
             name="MyWorkingModal"
             component={ModalScreen}

--- a/apps/test-examples/src/Test2002.tsx
+++ b/apps/test-examples/src/Test2002.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, Button, useColorScheme, StyleSheet } from 'react-native';
+import { View, Button, useColorScheme, StyleSheet } from 'react-native';
 import {
   DarkTheme,
   DefaultTheme,
@@ -8,35 +8,23 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 function HomeScreen({ navigation }) {
-  const scheme = useColorScheme();
-
   return (
     <View style={styles.container}>
-      <Text
-        style={[styles.text, { color: scheme === 'dark' ? '#FFF' : '#000' }]}>
-        This is the home screen!
-      </Text>
       <Button
-        onPress={() => navigation.navigate('MyModal')}
-        title="Open Modal"
+        onPress={() => navigation.navigate('fullScreenModal')}
+        title="Open fullScreenModal"
       />
       <Button
-        onPress={() => navigation.navigate('MyWorkingModal')}
-        title="Open Working Modal"
+        onPress={() => navigation.navigate('formSheet')}
+        title="Open formSheet"
       />
     </View>
   );
 }
 
 function ModalScreen({ navigation }) {
-  const scheme = useColorScheme();
-
   return (
     <View style={styles.container}>
-      <Text
-        style={[styles.text, { color: scheme === 'dark' ? '#FFF' : '#000' }]}>
-        This is a modal!
-      </Text>
       <Button onPress={() => navigation.goBack()} title="Dismiss" />
     </View>
   );
@@ -44,31 +32,28 @@ function ModalScreen({ navigation }) {
 
 const RootStack = createNativeStackNavigator();
 
-function App() {
+export default function App() {
   const scheme = useColorScheme();
 
   return (
     <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
       <RootStack.Navigator>
-        <RootStack.Group>
-          <RootStack.Screen name="Home" component={HomeScreen} />
-          <RootStack.Screen
-            name="MyWorkingModal"
-            component={ModalScreen}
-            options={{ presentation: 'formSheet' }}
-          />
-        </RootStack.Group>
-        <RootStack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
-          <RootStack.Screen name="MyModal" component={ModalScreen} />
-        </RootStack.Group>
+        <RootStack.Screen name="Home" component={HomeScreen} />
+        <RootStack.Screen
+          name="formSheet"
+          component={ModalScreen}
+          options={{ presentation: 'formSheet' }}
+        />
+        <RootStack.Screen
+          name="fullScreenModal"
+          component={ModalScreen}
+          options={{ presentation: 'fullScreenModal' }}
+        />
       </RootStack.Navigator>
     </NavigationContainer>
   );
 }
 
-export default App;
-
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  text: { fontSize: 30, marginBottom: 20 },
 });

--- a/apps/test-examples/src/Test2002.tsx
+++ b/apps/test-examples/src/Test2002.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { View, Text, Button, useColorScheme } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+function HomeScreen({ navigation }) {
+  const scheme = useColorScheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontSize: 30 }}>This is the home screen!</Text>
+      <Button
+        onPress={() => navigation.navigate('MyModal')}
+        title="Open Modal"
+      />
+      <Button
+        onPress={() => navigation.navigate('MyWorkingModal')}
+        title="Open Working Modal"
+      />
+      <Text style={{ marginTop: 10 }}>current scheme is: {scheme}</Text>
+    </View>
+  );
+}
+
+function ModalScreen({ navigation }) {
+  const scheme = useColorScheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontSize: 30 }}>This is a modal!</Text>
+      <Button onPress={() => navigation.goBack()} title="Dismiss" />
+      <Text style={{ marginTop: 10 }}>current scheme is: {scheme}</Text>
+    </View>
+  );
+}
+
+function DetailsScreen() {
+  return (
+    <View>
+      <Text>Details</Text>
+    </View>
+  );
+}
+
+const RootStack = createNativeStackNavigator();
+
+function App() {
+  return (
+    <NavigationContainer>
+      <RootStack.Navigator>
+        <RootStack.Group>
+          <RootStack.Screen name="Home" component={HomeScreen} />
+          <RootStack.Screen name="Details" component={DetailsScreen} />
+          <RootStack.Screen
+            name="MyWorkingModal"
+            component={ModalScreen}
+            options={{ presentation: 'formSheet' }}
+          />
+        </RootStack.Group>
+        <RootStack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
+          <RootStack.Screen name="MyModal" component={ModalScreen} />
+        </RootStack.Group>
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default App;

--- a/apps/test-examples/src/Test2002.tsx
+++ b/apps/test-examples/src/Test2002.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
-import { View, Text, Button, useColorScheme } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
+import { View, Text, Button, useColorScheme, StyleSheet } from 'react-native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  NavigationContainer,
+} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 function HomeScreen({ navigation }) {
   const scheme = useColorScheme();
 
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ fontSize: 30 }}>This is the home screen!</Text>
+    <View style={styles.container}>
+      <Text
+        style={[styles.text, { color: scheme === 'dark' ? '#FFF' : '#000' }]}>
+        This is the home screen!
+      </Text>
       <Button
         onPress={() => navigation.navigate('MyModal')}
         title="Open Modal"
@@ -17,7 +24,13 @@ function HomeScreen({ navigation }) {
         onPress={() => navigation.navigate('MyWorkingModal')}
         title="Open Working Modal"
       />
-      <Text style={{ marginTop: 10 }}>current scheme is: {scheme}</Text>
+      <Text
+        style={[
+          styles.schemeText,
+          { color: scheme === 'dark' ? '#FFF' : '#000' },
+        ]}>
+        current scheme is: {scheme}
+      </Text>
     </View>
   );
 }
@@ -26,10 +39,19 @@ function ModalScreen({ navigation }) {
   const scheme = useColorScheme();
 
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ fontSize: 30 }}>This is a modal!</Text>
+    <View style={styles.container}>
+      <Text
+        style={[styles.text, { color: scheme === 'dark' ? '#FFF' : '#000' }]}>
+        This is a modal!
+      </Text>
       <Button onPress={() => navigation.goBack()} title="Dismiss" />
-      <Text style={{ marginTop: 10 }}>current scheme is: {scheme}</Text>
+      <Text
+        style={[
+          styles.schemeText,
+          { color: scheme === 'dark' ? '#FFF' : '#000' },
+        ]}>
+        current scheme is: {scheme}
+      </Text>
     </View>
   );
 }
@@ -45,8 +67,10 @@ function DetailsScreen() {
 const RootStack = createNativeStackNavigator();
 
 function App() {
+  const scheme = useColorScheme();
+
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
       <RootStack.Navigator>
         <RootStack.Group>
           <RootStack.Screen name="Home" component={HomeScreen} />
@@ -66,3 +90,9 @@ function App() {
 }
 
 export default App;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 30, marginBottom: 20 },
+  schemeText: { marginTop: 20 },
+});

--- a/apps/test-examples/src/Test2002.tsx
+++ b/apps/test-examples/src/Test2002.tsx
@@ -24,13 +24,6 @@ function HomeScreen({ navigation }) {
         onPress={() => navigation.navigate('MyWorkingModal')}
         title="Open Working Modal"
       />
-      <Text
-        style={[
-          styles.schemeText,
-          { color: scheme === 'dark' ? '#FFF' : '#000' },
-        ]}>
-        current scheme is: {scheme}
-      </Text>
     </View>
   );
 }
@@ -45,13 +38,6 @@ function ModalScreen({ navigation }) {
         This is a modal!
       </Text>
       <Button onPress={() => navigation.goBack()} title="Dismiss" />
-      <Text
-        style={[
-          styles.schemeText,
-          { color: scheme === 'dark' ? '#FFF' : '#000' },
-        ]}>
-        current scheme is: {scheme}
-      </Text>
     </View>
   );
 }
@@ -94,5 +80,4 @@ export default App;
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   text: { fontSize: 30, marginBottom: 20 },
-  schemeText: { marginTop: 20 },
 });

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -7,15 +7,13 @@
 
 @implementation RNSModalScreen
 
+// When using UIModalPresentationStyleFullScreen the views belonging to the presenting view controller are removed,
+// Thus there is no RCTRootView mounted and no trait observer working.
+// We have to set up an extra observer and send change notifications accoridngly
+// For more information, see https://github.com/software-mansion/react-native-screens/pull/2211.
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
   [super traitCollectionDidChange:previousTraitCollection];
-
-  // Describe following facts:
-  // 1. With full screen modal react root view is mounted in the initial view hierarchy
-  // 2. Thus the trait observation in react root view does not work anymore
-  // 3. we need to send theme-chanages notification our selves
-  // Describe this in-depth in PR and paste link here
   if (RCTSharedApplication().applicationState == UIApplicationStateBackground ||
       (self.stackPresentation != RNSScreenStackPresentationFullScreenModal)) {
     return;

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -7,9 +7,11 @@
 
 @implementation RNSModalScreen
 
-// When using UIModalPresentationStyleFullScreen the views belonging to the presenting view controller are removed,
-// Thus there is no RCTRootView mounted and no trait observer working.
-// We have to set up an extra observer and send change notifications accoridngly
+// When using UIModalPresentationStyleFullScreen the whole view hierarchy mounted under primary `UITransitionView` is
+// removed, including React's root view, which observes for trait collection changes & sends it to `Appearance` module
+// via system notification centre. To workaround this detached-root-view-situation we emit the event to React's
+// `Appearance` module ourselves. For the RCTRootView observer, visit:
+// https://github.com/facebook/react-native/blob/d3e0430deac573fd44792e6005d5de20e9ad2797/packages/react-native/React/Base/RCTRootView.m#L362
 // For more information, see https://github.com/software-mansion/react-native-screens/pull/2211.
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -15,7 +15,7 @@
 {
   [super traitCollectionDidChange:previousTraitCollection];
   if (RCTSharedApplication().applicationState == UIApplicationStateBackground ||
-      (self.stackPresentation != RNSScreenStackPresentationFullScreenModal)) {
+      self.stackPresentation != RNSScreenStackPresentationFullScreenModal) {
     return;
   }
 

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -10,7 +10,7 @@
 // When using UIModalPresentationStyleFullScreen the whole view hierarchy mounted under primary `UITransitionView` is
 // removed, including React's root view, which observes for trait collection changes & sends it to `Appearance` module
 // via system notification centre. To workaround this detached-root-view-situation we emit the event to React's
-// `Appearance` module ourselves. For the RCTRootView observer, visit:
+// `Appearance` module ourselves. For the RCTRootView observer, visit
 // https://github.com/facebook/react-native/blob/d3e0430deac573fd44792e6005d5de20e9ad2797/packages/react-native/React/Base/RCTRootView.m#L362
 // For more information, see https://github.com/software-mansion/react-native-screens/pull/2211.
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -7,6 +7,28 @@
 
 @implementation RNSModalScreen
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  // Describe following facts:
+  // 1. With full screen modal react root view is mounted in the initial view hierarchy
+  // 2. Thus the trait observation in react root view does not work anymore
+  // 3. we need to send theme-chanages notification our selves
+  // Describe this in-depth in PR and paste link here
+  if (RCTSharedApplication().applicationState == UIApplicationStateBackground ||
+      (self.stackPresentation != RNSScreenStackPresentationFullScreenModal)) {
+    return;
+  }
+
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:RCTUserInterfaceStyleDidChangeNotification
+                    object:self
+                  userInfo:@{
+                    RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey : self.traitCollection,
+                  }];
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {


### PR DESCRIPTION
## Description

This PR fixes the color scheme adaptability when using `presentation: fullScreenModal`.
When changing the appearance mode between `light` and `dark` the screens reacted immediately except for the fullScreenModal presentation style.

When using a `UIModalPresentationFullScreen` the views belonging to the presenting view controller are removed after the presentation completes. After investigating the view hierarchy for a screen with `presentation: fullScreenModal` it turned out that the `RCTRootView` is removed, thus the `traitCollectionDidChange` observer ([see here](https://github.com/facebook/react-native/blob/d3e0430deac573fd44792e6005d5de20e9ad2797/packages/react-native/React/Base/RCTRootView.m#L362)) is not working anymore.

The solution was to add an extra observer for `RNSScreenStackPresentationFullScreenModal` to be able to send proper notifications when no RCTRootView is present. As the observer is working synchronously it's usage is limited for this presentation style only.

Fixes #2002.


## Changes

- added repro `Test2002.tsx`
- added `traitCollectionDidChange` observer for fullScreenModal


## Screenshots / GIFs

### Before

https://github.com/software-mansion/react-native-screens/assets/91994767/52fa4e92-3baa-49e2-b278-7be57c4d28b3

### After
https://github.com/software-mansion/react-native-screens/assets/91994767/74c62c45-c793-4f63-81fc-d68d4000fea6


## Test code and steps to reproduce

- added `Test2002.tsx` to test examples

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
