### PR TITLE
chore(CI): close stale issues after 2 weeks

### DIFF
--- a/.github/workflows/close-when-stale.yml
+++ b/.github/workflows/close-when-stale.yml
@@ -30,4 +30,4 @@ jobs:
         uses: ./close-when-stale
         with:
           close-when-stale-label: 'Close when stale'
-          days-to-close: 20
+          days-to-close: 14


### PR DESCRIPTION
## Description

1. Aligning with recent move in Reanimated
2. This is purely subjective: stale issues hanging for three weeks is too much


## Changes

Changed `days-to-close` from 20 to 14.

## Test code and steps to reproduce

N/A

## Checklist

N/A

