### PR TITLE
refact(Android): rename `compareFrameSizes` to `checkFrameSizesEqualWithEps`

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
@@ -51,7 +51,7 @@ class RNSScreenComponentDescriptor final
       // state update.
       if (screenShadowNode.getFrameCorrectionModes().check(
               FrameCorrectionModes::Mode::FrameHeightCorrection) &&
-          !compareFrameSizes(
+          !checkFrameSizesEqualWithEps(
               screenShadowNode.layoutMetrics_.frame.size,
               stateData.frameSize)) {
         LOG(ERROR)

--- a/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h
+++ b/common/cpp/react/renderer/components/rnscreens/utils/RectUtil.h
@@ -25,7 +25,7 @@ inline constexpr bool equalWithRespectToEps(const T a, const T b, const T eps) {
  * @return whether the frame dimensions are the same with respect to given
  * epsilon
  */
-inline constexpr bool compareFrameSizes(
+inline constexpr bool checkFrameSizesEqualWithEps(
     const react::Size &first,
     const react::Size &second,
     const react::Float eps = 0.01) {


### PR DESCRIPTION
## Description

As suggested by @alduzy, new the new function name should better convey its behaviour.
Old came `compareFrameSizes` could suggest inequality.

## Changes

Renamed `compareFrameSizes` to `checkFrameSizesEqualWithEps`.

## Test code and steps to reproduce

Android should build on Fabric => CI

## Checklist

- [ ] Ensured that CI passes

