### PR TITLE
fix: properly lock orientation

### DIFF
--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -118,23 +118,17 @@
     UIInterfaceOrientation currentInterfaceOrientation = [RNSScreenWindowTraits interfaceOrientation];
     UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
     if ([RNSScreenWindowTraits maskFromOrientation:currentDeviceOrientation] & orientationMask) {
-      if (!([RNSScreenWindowTraits maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
-        // if the device orientation is in the mask, but interface orientation is not, we rotate to device's orientation
-        newOrientation = currentDeviceOrientation;
-      } else {
-        if (currentDeviceOrientation != currentInterfaceOrientation) {
-          // if both device orientation and interface orientation are in the mask, but in different orientations, we
-          // rotate to device's orientation
-          newOrientation = currentDeviceOrientation;
-        }
-      }
+      // force orientation to device orientation
+      newOrientation = currentDeviceOrientation;
     } else {
       if (!([RNSScreenWindowTraits maskFromOrientation:currentInterfaceOrientation] & orientationMask)) {
         // if both device orientation and interface orientation are not in the mask, we rotate to closest available
         // rotation from mask
         newOrientation = [RNSScreenWindowTraits defaultOrientationForOrientationMask:orientationMask];
       } else {
-        // if the device orientation is not in the mask, but interface orientation is in the mask, do nothing
+        // if the device orientation is not in the mask, but interface orientation is in the mask, rotate to interface
+        // orientation
+        newOrientation = currentInterfaceOrientation;
       }
     }
     if (newOrientation != UIInterfaceOrientationUnknown) {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Fixes #2197 
When set orientation into landscape while real device orientation is landscape, it is not locked into landscape properly(if I rotate device into portrait, it rotated).

## Changes
force to change orientation every time with proper value.
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->



## Screenshots / GIFs
### Before

https://github.com/software-mansion/react-native-screens/assets/58962402/96a82a9e-9c13-4caf-83d5-a72012fec137

### After
https://github.com/software-mansion/react-native-screens/assets/58962402/34425e87-3b5f-4a12-8bbc-3837ea4409fd



## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
