### PR TITLE
refact: remove unnecessary workflow step

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -43,8 +43,6 @@ jobs:
           cache: 'yarn'
       - name: Install root node dependencies
         run: yarn install && yarn submodules
-      - name: Install shared app dependencies
-        run: (cd apps/examples && yarn install)
       - name: Install node dependencies
         id: install_deps
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -40,8 +40,6 @@ jobs:
         run: brew tap wix/brew && brew install applesimutils
       - name: Install root node dependencies
         run: yarn install && yarn submodules
-      - name: Install shared app dependencies
-        run: (cd apps/examples && yarn install)
       - name: Install node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn


### PR DESCRIPTION
## Description

I noticed there's an unnecessary step in the worklfow both for iOS and android e2e tests. 
The step is supposed to install any dependencies inside `examples/app` but there's no `package.json` file.
This PR removes the step.

## Changes

- removed workflow step

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Ensured that CI passes
