### PR TITLE
fix(iOS): update HeaderConfig view controller after unmounting subviews

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -751,6 +751,7 @@ namespace react = facebook::react;
 {
   [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
+  [self updateViewControllerIfNeeded];
 }
 
 static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)


### PR DESCRIPTION
## Description

When using a header left view and then removing it the default back button doesn't reappear on new arch. This is because we do not call `updateViewControllerIfNeeded` when removing views.

## Changes

Call `updateViewControllerIfNeeded` in `unmountChildComponentView`.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

In the FabricExample HeaderOptions example:

- Open Header item setting
- Choose left
- Choose right
- See the back button is gone.

<img width="368" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/2677334/d5bfea6e-d0f4-4527-9f90-99f19c6045e5">

<img width="381" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/2677334/3338435c-c48f-4858-bd8a-97103a396fcd">

<img width="368" alt="image" src="https://github.com/software-mansion/react-native-screens/assets/2677334/143349b0-6f66-460b-9920-14e4a50f16bc">

When toggling state the default back button doesn't reappear.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
