### PR TITLE
fix(iOS): push and pop transitions change after full screen back swipe 

### DIFF
--- a/apps/test-examples/App.js
+++ b/apps/test-examples/App.js
@@ -104,6 +104,7 @@ import Test2069 from './src/Test2069';
 import Test2118 from './src/Test2118';
 import Test2184 from './src/Test2184';
 import Test2223 from './src/Test2223';
+import Test2227 from './src/Test2227';
 import Test2229 from './src/Test2229';
 import TestScreenAnimation from './src/TestScreenAnimation';
 import TestHeader from './src/TestHeader';

--- a/apps/test-examples/src/Test2227.tsx
+++ b/apps/test-examples/src/Test2227.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {NavigationContainer} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+import {Button, View, Text} from 'react-native';
+
+type RootStackParamList = {
+  Home: undefined;
+  Details: undefined;
+};
+
+type HomeScreenProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
+type DetailsScreenProps = NativeStackScreenProps<RootStackParamList, 'Details'>;
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+function HomeScreen({navigation}: HomeScreenProps) {
+  return (
+    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+      <Text>Home Screen</Text>
+      <Button
+        title="Go to Details"
+        onPress={() => navigation.navigate('Details')}
+      />
+    </View>
+  );
+}
+
+function DetailsScreen({navigation}: DetailsScreenProps) {
+  return (
+    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+      <Text>Details Screen</Text>
+      <Button
+        title="Go to Details Again"
+        onPress={() => navigation.push('Details')}
+      />
+      <Button title="Go Back" onPress={() => navigation.goBack()} />
+      <Button title="Go to Home" onPress={() => navigation.navigate('Home')} />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          fullScreenGestureEnabled: true,
+        }}>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Details" component={DetailsScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -872,6 +872,7 @@ namespace react = facebook::react;
         [_interactionController cancelInteractiveTransition];
       }
       _interactionController = nil;
+      _isFullWidthSwiping = NO;
     }
     default: {
       break;


### PR DESCRIPTION
## Description

Doing the swipe also caused programmatic push to use manual transition and have no shadow.
Fixes #2227.

## Changes

Set `_isFullWidthSwiping` to `NO` when swipe gesture ends in `handleSwipe:` so programmatic push and pop can use OS logic by default.

## Screenshots / GIFs

### Before
https://github.com/software-mansion/react-native-screens/assets/11507974/0f710aec-c8f0-4a3a-82df-d3edb5f0fb19

### After
https://github.com/software-mansion/react-native-screens/assets/11507974/51119c74-b2c3-4c32-9202-6954c3c70218

## Test code and steps to reproduce

1. Run `Test2227` in TestsExample app.
2. Push screen with `Go to Details`.
3. Swipe back with full screen swipe gesture.
4. Push screen with `Go to Details` again.
7. Before this fix there would be no shadow during transition after first full screen swipe back.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
