### PR TITLE
feat: added dark theme to example

### DIFF
--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -12,6 +12,7 @@ import {
   DarkTheme,
   DefaultTheme,
   NavigationContainer,
+  useTheme,
 } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -142,7 +143,7 @@ interface MainScreenProps {
 }
 
 const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <ScrollView testID="root-screen-examples-scrollview">
       <SettingsSwitch
@@ -155,10 +156,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         }}
       />
       <Text
-        style={[
-          styles.label,
-          scheme === 'dark' ? styles.labelDark : styles.labelLight,
-        ]}
+        style={[styles.label, isDark ? styles.labelDark : styles.labelLight]}
         testID="root-screen-examples-header">
         Examples
       </Text>
@@ -172,10 +170,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         />
       ))}
       <Text
-        style={[
-          styles.label,
-          scheme === 'dark' ? styles.labelDark : styles.labelLight,
-        ]}>
+        style={[styles.label, isDark ? styles.labelDark : styles.labelLight]}>
         Playgrounds
       </Text>
       {playgrounds.map(name => (

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -210,7 +210,10 @@ const ExampleApp = (): React.JSX.Element => {
         <ThemeToggle.Provider value={{ toggleTheme }}>
           <NavigationContainer theme={isDark ? DarkTheme : DefaultTheme}>
             <Stack.Navigator
-              screenOptions={{ statusBarStyle: isDark ? 'light' : 'dark' }}>
+              screenOptions={{
+                statusBarStyle: isDark ? 'light' : 'dark',
+                statusBarBackgroundColor: isDark ? 'black' : 'white',
+              }}>
               <Stack.Screen
                 name="Main"
                 options={{

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import {
   ScrollView,
   StyleSheet,
@@ -143,7 +143,9 @@ interface MainScreenProps {
 }
 
 const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
+  const { toggleTheme } = useContext(ThemeToggle);
   const isDark = useTheme().dark;
+
   return (
     <ScrollView testID="root-screen-examples-scrollview">
       <SettingsSwitch
@@ -154,6 +156,12 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
           I18nManager.forceRTL(!I18nManager.isRTL);
           RNRestart.Restart();
         }}
+      />
+      <SettingsSwitch
+        style={styles.switch}
+        label="Dark mode"
+        value={isDark}
+        onValueChange={toggleTheme}
       />
       <Text
         style={[styles.label, isDark ? styles.labelDark : styles.labelLight]}
@@ -186,33 +194,43 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
   );
 };
 
+const ThemeToggle = createContext<{ toggleTheme: () => void }>(null!);
+
 const ExampleApp = (): React.JSX.Element => {
   const scheme = useColorScheme();
+  const [isDark, setIsDark] = useState(scheme === 'dark');
+
+  useEffect(() => setIsDark(scheme === 'dark'), [scheme]);
+
+  const toggleTheme = () => setIsDark(prev => !prev);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <GestureDetectorProvider>
-        <NavigationContainer
-          theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <Stack.Navigator>
-            <Stack.Screen
-              name="Main"
-              options={{
-                title: `${
-                  Platform.isTV ? '📺' : '📱'
-                } React Native Screens Examples`,
-              }}
-              component={MainScreen}
-            />
-            {Object.keys(SCREENS).map(name => (
+        <ThemeToggle.Provider value={{ toggleTheme }}>
+          <NavigationContainer theme={isDark ? DarkTheme : DefaultTheme}>
+            <Stack.Navigator
+              screenOptions={{ statusBarStyle: isDark ? 'light' : 'dark' }}>
               <Stack.Screen
-                key={name}
-                name={name}
-                getComponent={() => SCREENS[name].component}
-                options={{ headerShown: false }}
+                name="Main"
+                options={{
+                  title: `${
+                    Platform.isTV ? '📺' : '📱'
+                  } React Native Screens Examples`,
+                }}
+                component={MainScreen}
               />
-            ))}
-          </Stack.Navigator>
-        </NavigationContainer>
+              {Object.keys(SCREENS).map(name => (
+                <Stack.Screen
+                  key={name}
+                  name={name}
+                  getComponent={() => SCREENS[name].component}
+                  options={{ headerShown: false }}
+                />
+              ))}
+            </Stack.Navigator>
+          </NavigationContainer>
+        </ThemeToggle.Provider>
       </GestureDetectorProvider>
     </GestureHandlerRootView>
   );

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -210,10 +210,7 @@ const ExampleApp = (): React.JSX.Element => {
         <ThemeToggle.Provider value={{ toggleTheme }}>
           <NavigationContainer theme={isDark ? DarkTheme : DefaultTheme}>
             <Stack.Navigator
-              screenOptions={{
-                statusBarStyle: isDark ? 'light' : 'dark',
-                statusBarBackgroundColor: isDark ? 'black' : 'white',
-              }}>
+              screenOptions={{ statusBarStyle: isDark ? 'light' : 'dark' }}>
               <Stack.Screen
                 name="Main"
                 options={{

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -6,8 +6,13 @@ import {
   I18nManager,
   Platform,
   StatusBar,
+  useColorScheme,
 } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  NavigationContainer,
+} from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import RNRestart from 'react-native-restart';
@@ -136,76 +141,99 @@ interface MainScreenProps {
   navigation: StackNavigationProp<RootStackParamList, 'Main'>;
 }
 
-const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => (
-  <ScrollView testID="root-screen-examples-scrollview">
-    <SettingsSwitch
-      style={styles.switch}
-      label="Right to left"
-      value={I18nManager.isRTL}
-      onValueChange={() => {
-        I18nManager.forceRTL(!I18nManager.isRTL);
-        RNRestart.Restart();
-      }}
-    />
-    <Text style={styles.label} testID="root-screen-examples-header">
-      Examples
-    </Text>
-    {examples.map(name => (
-      <ListItem
-        key={name}
-        testID={`root-screen-example-${name}`}
-        title={SCREENS[name].title}
-        onPress={() => navigation.navigate(name)}
-        disabled={!isPlatformReady(name)}
+const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
+  const scheme = useColorScheme();
+  return (
+    <ScrollView testID="root-screen-examples-scrollview">
+      <SettingsSwitch
+        style={styles.switch}
+        label="Right to left"
+        value={I18nManager.isRTL}
+        onValueChange={() => {
+          I18nManager.forceRTL(!I18nManager.isRTL);
+          RNRestart.Restart();
+        }}
       />
-    ))}
-    <Text style={styles.label}>Playgrounds</Text>
-    {playgrounds.map(name => (
-      <ListItem
-        key={name}
-        testID={`root-screen-playground-${name}`}
-        title={SCREENS[name].title}
-        onPress={() => navigation.navigate(name)}
-        disabled={!isPlatformReady(name)}
-      />
-    ))}
-  </ScrollView>
-);
+      <Text
+        style={[
+          styles.label,
+          scheme === 'dark' ? styles.labelDark : styles.labelLight,
+        ]}
+        testID="root-screen-examples-header">
+        Examples
+      </Text>
+      {examples.map(name => (
+        <ListItem
+          key={name}
+          testID={`root-screen-example-${name}`}
+          title={SCREENS[name].title}
+          onPress={() => navigation.navigate(name)}
+          disabled={!isPlatformReady(name)}
+        />
+      ))}
+      <Text
+        style={[
+          styles.label,
+          scheme === 'dark' ? styles.labelDark : styles.labelLight,
+        ]}>
+        Playgrounds
+      </Text>
+      {playgrounds.map(name => (
+        <ListItem
+          key={name}
+          testID={`root-screen-playground-${name}`}
+          title={SCREENS[name].title}
+          onPress={() => navigation.navigate(name)}
+          disabled={!isPlatformReady(name)}
+        />
+      ))}
+    </ScrollView>
+  );
+};
 
-const ExampleApp = (): React.JSX.Element => (
-  <GestureHandlerRootView style={{ flex: 1 }}>
-    <GestureDetectorProvider>
-      <NavigationContainer>
-        <Stack.Navigator>
-          <Stack.Screen
-            name="Main"
-            options={{
-              title: `${
-                Platform.isTV ? '📺' : '📱'
-              } React Native Screens Examples`,
-            }}
-            component={MainScreen}
-          />
-          {Object.keys(SCREENS).map(name => (
+const ExampleApp = (): React.JSX.Element => {
+  const scheme = useColorScheme();
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <GestureDetectorProvider>
+        <NavigationContainer
+          theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack.Navigator>
             <Stack.Screen
-              key={name}
-              name={name}
-              getComponent={() => SCREENS[name].component}
-              options={{ headerShown: false }}
+              name="Main"
+              options={{
+                title: `${
+                  Platform.isTV ? '📺' : '📱'
+                } React Native Screens Examples`,
+              }}
+              component={MainScreen}
             />
-          ))}
-        </Stack.Navigator>
-      </NavigationContainer>
-    </GestureDetectorProvider>
-  </GestureHandlerRootView>
-);
+            {Object.keys(SCREENS).map(name => (
+              <Stack.Screen
+                key={name}
+                name={name}
+                getComponent={() => SCREENS[name].component}
+                options={{ headerShown: false }}
+              />
+            ))}
+          </Stack.Navigator>
+        </NavigationContainer>
+      </GestureDetectorProvider>
+    </GestureHandlerRootView>
+  );
+};
 
 const styles = StyleSheet.create({
   label: {
     fontSize: 15,
-    color: 'black',
     margin: 10,
     marginTop: 15,
+  },
+  labelLight: {
+    color: DefaultTheme.colors.text,
+  },
+  labelDark: {
+    color: DarkTheme.colors.text,
   },
   switch: {
     marginTop: 15,

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import {
   ScrollView,
   StyleSheet,
-  Text,
   I18nManager,
   Platform,
   StatusBar,
@@ -18,7 +17,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import RNRestart from 'react-native-restart';
 
-import { ListItem, SettingsSwitch } from './src/shared';
+import { ListItem, SettingsSwitch, ThemedText } from './src/shared';
 
 import SimpleNativeStack from './src/screens/SimpleNativeStack';
 import SwipeBackAnimation from './src/screens/SwipeBackAnimation';
@@ -163,11 +162,9 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         value={isDark}
         onValueChange={toggleTheme}
       />
-      <Text
-        style={[styles.label, isDark ? styles.labelDark : styles.labelLight]}
-        testID="root-screen-examples-header">
+      <ThemedText style={styles.label} testID="root-screen-examples-header">
         Examples
-      </Text>
+      </ThemedText>
       {examples.map(name => (
         <ListItem
           key={name}
@@ -177,10 +174,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
           disabled={!isPlatformReady(name)}
         />
       ))}
-      <Text
-        style={[styles.label, isDark ? styles.labelDark : styles.labelLight]}>
-        Playgrounds
-      </Text>
+      <ThemedText style={styles.label}>Playgrounds</ThemedText>
       {playgrounds.map(name => (
         <ListItem
           key={name}
@@ -241,12 +235,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     margin: 10,
     marginTop: 15,
-  },
-  labelLight: {
-    color: DefaultTheme.colors.text,
-  },
-  labelDark: {
-    color: DarkTheme.colors.text,
   },
   switch: {
     marginTop: 15,

--- a/apps/src/screens/Events.tsx
+++ b/apps/src/screens/Events.tsx
@@ -170,7 +170,9 @@ interface PrivacyScreenProps {
   navigation: NativeStackNavigationProp<StackParamList, 'Main'>;
 }
 
-const PrivacyScreen = ({ navigation }: PrivacyScreenProps): React.JSX.Element => {
+const PrivacyScreen = ({
+  navigation,
+}: PrivacyScreenProps): React.JSX.Element => {
   const toast = useToast();
 
   useEffect(() => {
@@ -228,7 +230,9 @@ interface OptionsScreenProps {
   navigation: NativeStackNavigationProp<StackParamList, 'Main'>;
 }
 
-const OptionsScreen = ({ navigation }: OptionsScreenProps): React.JSX.Element => {
+const OptionsScreen = ({
+  navigation,
+}: OptionsScreenProps): React.JSX.Element => {
   const toast = useToast();
 
   useEffect(() => {

--- a/apps/src/screens/HeaderOptions.tsx
+++ b/apps/src/screens/HeaderOptions.tsx
@@ -203,7 +203,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 10,
-    backgroundColor: 'white',
   },
   heading: {
     marginLeft: 10,

--- a/apps/src/screens/SearchBar.tsx
+++ b/apps/src/screens/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { ScrollView, Text, StyleSheet, useColorScheme } from 'react-native';
+import { ScrollView, Text, StyleSheet } from 'react-native';
 import { SearchBarCommands, SearchBarProps } from 'react-native-screens';
 import {
   createNativeStackNavigator,
@@ -14,7 +14,7 @@ import {
   ToastProvider,
   useToast,
 } from '../shared';
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 
 type StackParamList = {
   Main: undefined;
@@ -32,7 +32,7 @@ interface MainScreenProps {
 
 const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
   const toast = useToast();
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
 
   const [search, setSearch] = useState('');
   const [placeholder, setPlaceholder] = useState('Search for something...');
@@ -137,7 +137,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
       <Text
         style={[
           styles.heading,
-          scheme === 'dark' ? styles.headingDark : styles.headingLight,
+          isDark ? styles.headingDark : styles.headingLight,
         ]}>
         iOS only
       </Text>
@@ -159,7 +159,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
       <Text
         style={[
           styles.heading,
-          scheme === 'dark' ? styles.headingDark : styles.headingLight,
+          isDark ? styles.headingDark : styles.headingLight,
         ]}>
         Android only
       </Text>

--- a/apps/src/screens/SearchBar.tsx
+++ b/apps/src/screens/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { ScrollView, Text, StyleSheet } from 'react-native';
+import { ScrollView, Text, StyleSheet, useColorScheme } from 'react-native';
 import { SearchBarCommands, SearchBarProps } from 'react-native-screens';
 import {
   createNativeStackNavigator,
@@ -14,6 +14,7 @@ import {
   ToastProvider,
   useToast,
 } from '../shared';
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 
 type StackParamList = {
   Main: undefined;
@@ -31,6 +32,7 @@ interface MainScreenProps {
 
 const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
   const toast = useToast();
+  const scheme = useColorScheme();
 
   const [search, setSearch] = useState('');
   const [placeholder, setPlaceholder] = useState('Search for something...');
@@ -132,7 +134,13 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         onValueChange={setAutoCapitalize}
         items={['none', 'words', 'sentences', 'characters']}
       />
-      <Text style={styles.heading}>iOS only</Text>
+      <Text
+        style={[
+          styles.heading,
+          scheme === 'dark' ? styles.headingDark : styles.headingLight,
+        ]}>
+        iOS only
+      </Text>
       <SettingsSwitch
         label="Hide navigation bar"
         value={hideNavigationBar}
@@ -148,7 +156,13 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         value={hideWhenScrolling}
         onValueChange={setHideWhenScrolling}
       />
-      <Text style={styles.heading}>Android only</Text>
+      <Text
+        style={[
+          styles.heading,
+          scheme === 'dark' ? styles.headingDark : styles.headingLight,
+        ]}>
+        Android only
+      </Text>
       <SettingsPicker<InputType>
         label="Input type"
         value={inputType}
@@ -291,6 +305,12 @@ const styles = StyleSheet.create({
     marginLeft: 10,
     fontWeight: 'bold',
     fontSize: 16,
+  },
+  headingLight: {
+    color: DefaultTheme.colors.text,
+  },
+  headingDark: {
+    color: DarkTheme.colors.text,
   },
 });
 

--- a/apps/src/screens/SearchBar.tsx
+++ b/apps/src/screens/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { ScrollView, Text, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { SearchBarCommands, SearchBarProps } from 'react-native-screens';
 import {
   createNativeStackNavigator,
@@ -11,10 +11,10 @@ import {
   SettingsInput,
   SettingsPicker,
   SettingsSwitch,
+  ThemedText,
   ToastProvider,
   useToast,
 } from '../shared';
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 
 type StackParamList = {
   Main: undefined;
@@ -32,7 +32,6 @@ interface MainScreenProps {
 
 const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
   const toast = useToast();
-  const isDark = useTheme().dark;
 
   const [search, setSearch] = useState('');
   const [placeholder, setPlaceholder] = useState('Search for something...');
@@ -134,13 +133,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         onValueChange={setAutoCapitalize}
         items={['none', 'words', 'sentences', 'characters']}
       />
-      <Text
-        style={[
-          styles.heading,
-          isDark ? styles.headingDark : styles.headingLight,
-        ]}>
-        iOS only
-      </Text>
+      <ThemedText style={styles.heading}>iOS only</ThemedText>
       <SettingsSwitch
         label="Hide navigation bar"
         value={hideNavigationBar}
@@ -156,13 +149,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         value={hideWhenScrolling}
         onValueChange={setHideWhenScrolling}
       />
-      <Text
-        style={[
-          styles.heading,
-          isDark ? styles.headingDark : styles.headingLight,
-        ]}>
-        Android only
-      </Text>
+      <ThemedText style={styles.heading}>Android only</ThemedText>
       <SettingsPicker<InputType>
         label="Input type"
         value={inputType}
@@ -186,7 +173,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         value={shouldShowHintSearchIcon}
         onValueChange={setShouldShowHintSearchIcon}
       />
-      <Text style={styles.heading}>Imperative actions</Text>
+      <ThemedText style={styles.heading}>Imperative actions</ThemedText>
       <Button onPress={() => searchBarRef.current?.blur()} title="Blur" />
       <Button onPress={() => searchBarRef.current?.focus()} title="Focus" />
       <Button
@@ -206,7 +193,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         onPress={() => searchBarRef.current?.cancelSearch()}
         title="Cancel search"
       />
-      <Text style={styles.heading}>Other</Text>
+      <ThemedText style={styles.heading}>Other</ThemedText>
       <Button
         onPress={() => navigation.navigate('Search')}
         title="Other Searchbar example"
@@ -305,12 +292,6 @@ const styles = StyleSheet.create({
     marginLeft: 10,
     fontWeight: 'bold',
     fontSize: 16,
-  },
-  headingLight: {
-    color: DefaultTheme.colors.text,
-  },
-  headingDark: {
-    color: DarkTheme.colors.text,
   },
 });
 

--- a/apps/src/screens/StackPresentation.tsx
+++ b/apps/src/screens/StackPresentation.tsx
@@ -76,7 +76,7 @@ interface FormScreenProps {
 }
 
 const FormScreen = ({ navigation }: FormScreenProps): React.JSX.Element => (
-  <View style={{ ...styles.container, backgroundColor: 'white' }}>
+  <View style={styles.container}>
     <Form />
     <Button
       testID="stack-presentation-form-screen-go-back-button"

--- a/apps/src/shared/Form.tsx
+++ b/apps/src/shared/Form.tsx
@@ -1,25 +1,53 @@
-import React from 'react';
-import { View, StyleSheet, Text, TextInput } from 'react-native';
+import React, { Fragment } from 'react';
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import {
+  View,
+  StyleSheet,
+  Text,
+  TextInput,
+  useColorScheme,
+} from 'react-native';
 
-export const Form = (): React.JSX.Element => (
-  <View testID="form" style={styles.wrapper}>
-    <Text testID="form-header" style={styles.heading}>
-      Example form
-    </Text>
-    <Text testID="form-first-name-label" style={styles.label}>
-      First Name *
-    </Text>
-    <TextInput testID="form-first-name-input" style={styles.input} />
-    <Text testID="form-last-name-label" style={styles.label}>
-      Last Name *
-    </Text>
-    <TextInput testID="form-last-name-input" style={styles.input} />
-    <Text testID="form-email-label" style={styles.label}>
-      Email *
-    </Text>
-    <TextInput testID="form-email-input" style={styles.input} />
-  </View>
-);
+const fields = [
+  { name: 'form-first-name', placeholder: 'First Name *' },
+  { name: 'form-last-name', placeholder: 'Last Name *' },
+  { name: 'form-email', placeholder: 'Email *' },
+];
+
+export const Form = (): React.JSX.Element => {
+  const scheme = useColorScheme();
+  return (
+    <View testID="form" style={styles.wrapper}>
+      <Text
+        testID="form-header"
+        style={[
+          styles.heading,
+          scheme === 'dark' ? styles.labelDark : styles.labelLight,
+        ]}>
+        Example form
+      </Text>
+      {fields.map(({ name, placeholder }) => (
+        <Fragment key={name}>
+          <Text
+            testID={`${name}-label`}
+            style={[
+              styles.label,
+              scheme === 'dark' ? styles.labelDark : styles.labelLight,
+            ]}>
+            {placeholder}
+          </Text>
+          <TextInput
+            testID={`${name}-input`}
+            style={[
+              styles.input,
+              scheme === 'dark' ? styles.inputDark : styles.inputLight,
+            ]}
+          />
+        </Fragment>
+      ))}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -28,20 +56,35 @@ const styles = StyleSheet.create({
   heading: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: 'black',
     marginBottom: 16,
   },
+  headingLight: {
+    color: DefaultTheme.colors.text,
+  },
+  headingDark: {
+    color: DarkTheme.colors.text,
+  },
   label: {
-    color: 'darkslategray',
     textTransform: 'capitalize',
     fontSize: 12,
     marginBottom: 8,
   },
+  labelLight: {
+    color: DefaultTheme.colors.text,
+  },
+  labelDark: {
+    color: DarkTheme.colors.text,
+  },
   input: {
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: 'black',
     marginBottom: 12,
     height: 40,
+  },
+  inputLight: {
+    borderColor: DefaultTheme.colors.border,
+  },
+  inputDark: {
+    borderColor: DarkTheme.colors.border,
   },
 });

--- a/apps/src/shared/Form.tsx
+++ b/apps/src/shared/Form.tsx
@@ -1,12 +1,6 @@
 import React, { Fragment } from 'react';
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
-import {
-  View,
-  StyleSheet,
-  Text,
-  TextInput,
-  useColorScheme,
-} from 'react-native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
+import { View, StyleSheet, Text, TextInput } from 'react-native';
 
 const fields = [
   { name: 'form-first-name', placeholder: 'First Name *' },
@@ -15,15 +9,12 @@ const fields = [
 ];
 
 export const Form = (): React.JSX.Element => {
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <View testID="form" style={styles.wrapper}>
       <Text
         testID="form-header"
-        style={[
-          styles.heading,
-          scheme === 'dark' ? styles.labelDark : styles.labelLight,
-        ]}>
+        style={[styles.heading, isDark ? styles.labelDark : styles.labelLight]}>
         Example form
       </Text>
       {fields.map(({ name, placeholder }) => (
@@ -32,7 +23,7 @@ export const Form = (): React.JSX.Element => {
             testID={`${name}-label`}
             style={[
               styles.label,
-              scheme === 'dark' ? styles.labelDark : styles.labelLight,
+              isDark ? styles.labelDark : styles.labelLight,
             ]}>
             {placeholder}
           </Text>
@@ -40,7 +31,7 @@ export const Form = (): React.JSX.Element => {
             testID={`${name}-input`}
             style={[
               styles.input,
-              scheme === 'dark' ? styles.inputDark : styles.inputLight,
+              isDark ? styles.inputDark : styles.inputLight,
             ]}
           />
         </Fragment>

--- a/apps/src/shared/Form.tsx
+++ b/apps/src/shared/Form.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
-import { View, StyleSheet, Text, TextInput } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { ThemedText, ThemedTextInput } from '.';
 
 const fields = [
   { name: 'form-first-name', placeholder: 'First Name *' },
@@ -9,31 +9,17 @@ const fields = [
 ];
 
 export const Form = (): React.JSX.Element => {
-  const isDark = useTheme().dark;
   return (
     <View testID="form" style={styles.wrapper}>
-      <Text
-        testID="form-header"
-        style={[styles.heading, isDark ? styles.labelDark : styles.labelLight]}>
+      <ThemedText testID="form-header" style={styles.heading}>
         Example form
-      </Text>
+      </ThemedText>
       {fields.map(({ name, placeholder }) => (
         <Fragment key={name}>
-          <Text
-            testID={`${name}-label`}
-            style={[
-              styles.label,
-              isDark ? styles.labelDark : styles.labelLight,
-            ]}>
+          <ThemedText testID={`${name}-label`} style={styles.label}>
             {placeholder}
-          </Text>
-          <TextInput
-            testID={`${name}-input`}
-            style={[
-              styles.input,
-              isDark ? styles.inputDark : styles.inputLight,
-            ]}
-          />
+          </ThemedText>
+          <ThemedTextInput testID={`${name}-input`} style={styles.input} />
         </Fragment>
       ))}
     </View>
@@ -49,33 +35,15 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 16,
   },
-  headingLight: {
-    color: DefaultTheme.colors.text,
-  },
-  headingDark: {
-    color: DarkTheme.colors.text,
-  },
   label: {
     textTransform: 'capitalize',
     fontSize: 12,
     marginBottom: 8,
-  },
-  labelLight: {
-    color: DefaultTheme.colors.text,
-  },
-  labelDark: {
-    color: DarkTheme.colors.text,
   },
   input: {
     borderWidth: 1,
     borderRadius: 5,
     marginBottom: 12,
     height: 40,
-  },
-  inputLight: {
-    borderColor: DefaultTheme.colors.border,
-  },
-  inputDark: {
-    borderColor: DarkTheme.colors.border,
   },
 });

--- a/apps/src/shared/ListItem.tsx
+++ b/apps/src/shared/ListItem.tsx
@@ -1,5 +1,12 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  useColorScheme,
+} from 'react-native';
 
 interface Props {
   title: string;
@@ -14,10 +21,22 @@ export const ListItem = ({
   testID,
   disabled,
 }: Props): React.JSX.Element => {
+  const scheme = useColorScheme();
   return (
     <TouchableOpacity onPress={onPress} testID={testID} disabled={disabled}>
-      <View style={styles.container}>
-        <Text style={[styles.title, disabled && styles.disabled]}>{disabled && '(N/A) '}{title}</Text>
+      <View
+        style={[
+          styles.container,
+          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+        ]}>
+        <Text
+          style={[
+            scheme === 'dark' ? styles.titleDark : styles.titleLight,
+            disabled && styles.disabled,
+          ]}>
+          {disabled && '(N/A) '}
+          {title}
+        </Text>
       </View>
     </TouchableOpacity>
   );
@@ -29,18 +48,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     padding: 10,
-    backgroundColor: 'white',
-    borderColor: '#ccc',
     borderWidth: 1,
+  },
+  containerLight: {
+    backgroundColor: DefaultTheme.colors.card,
+    borderColor: DefaultTheme.colors.border,
+  },
+  containerDark: {
+    backgroundColor: DarkTheme.colors.card,
+    borderColor: DarkTheme.colors.border,
   },
   disabled: {
     color: 'gray',
   },
-  title: {
-    color: 'black',
+  titleLight: {
+    color: DefaultTheme.colors.text,
   },
-  chevron: {
-    fontWeight: 'bold',
-    color: 'black',
+  titleDark: {
+    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/ListItem.tsx
+++ b/apps/src/shared/ListItem.tsx
@@ -1,12 +1,6 @@
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import React from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-  useColorScheme,
-} from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
 interface Props {
   title: string;
@@ -21,17 +15,17 @@ export const ListItem = ({
   testID,
   disabled,
 }: Props): React.JSX.Element => {
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <TouchableOpacity onPress={onPress} testID={testID} disabled={disabled}>
       <View
         style={[
           styles.container,
-          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+          isDark ? styles.containerDark : styles.containerLight,
         ]}>
         <Text
           style={[
-            scheme === 'dark' ? styles.titleDark : styles.titleLight,
+            isDark ? styles.titleDark : styles.titleLight,
             disabled && styles.disabled,
           ]}>
           {disabled && '(N/A) '}

--- a/apps/src/shared/ListItem.tsx
+++ b/apps/src/shared/ListItem.tsx
@@ -1,6 +1,7 @@
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
+import { useTheme } from '@react-navigation/native';
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import { ThemedText, ThemedView } from '.';
 
 interface Props {
   title: string;
@@ -15,23 +16,15 @@ export const ListItem = ({
   testID,
   disabled,
 }: Props): React.JSX.Element => {
-  const isDark = useTheme().dark;
+  const { colors } = useTheme();
   return (
     <TouchableOpacity onPress={onPress} testID={testID} disabled={disabled}>
-      <View
-        style={[
-          styles.container,
-          isDark ? styles.containerDark : styles.containerLight,
-        ]}>
-        <Text
-          style={[
-            isDark ? styles.titleDark : styles.titleLight,
-            disabled && styles.disabled,
-          ]}>
+      <ThemedView style={[styles.container, { borderColor: colors.border }]}>
+        <ThemedText style={disabled ? styles.disabled : undefined}>
           {disabled && '(N/A) '}
           {title}
-        </Text>
-      </View>
+        </ThemedText>
+      </ThemedView>
     </TouchableOpacity>
   );
 };
@@ -44,21 +37,7 @@ const styles = StyleSheet.create({
     padding: 10,
     borderWidth: 1,
   },
-  containerLight: {
-    backgroundColor: DefaultTheme.colors.card,
-    borderColor: DefaultTheme.colors.border,
-  },
-  containerDark: {
-    backgroundColor: DarkTheme.colors.card,
-    borderColor: DarkTheme.colors.border,
-  },
   disabled: {
     color: 'gray',
-  },
-  titleLight: {
-    color: DefaultTheme.colors.text,
-  },
-  titleDark: {
-    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsInput.tsx
+++ b/apps/src/shared/SettingsInput.tsx
@@ -1,4 +1,4 @@
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
 import {
   Text,
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   StyleSheet,
   TextInput,
-  useColorScheme,
 } from 'react-native';
 
 type Props = {
@@ -21,24 +20,24 @@ export const SettingsInput = ({
   onValueChange,
 }: Props): React.JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <TouchableOpacity onPress={() => setIsOpen(!isOpen)}>
       <View
         style={[
           styles.container,
-          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+          isDark ? styles.containerDark : styles.containerLight,
         ]}>
         <Text
           style={[
             styles.label,
-            scheme === 'dark' ? styles.labelDark : styles.labelLight,
+            isDark ? styles.labelDark : styles.labelLight,
           ]}>{`${label}: ${value}`}</Text>
         {isOpen ? (
           <TextInput
             style={[
               styles.input,
-              scheme === 'dark' ? styles.inputDark : styles.inputLight,
+              isDark ? styles.inputDark : styles.inputLight,
             ]}
             value={value}
             onChangeText={onValueChange}

--- a/apps/src/shared/SettingsInput.tsx
+++ b/apps/src/shared/SettingsInput.tsx
@@ -1,3 +1,4 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
 import {
   Text,
@@ -5,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   TextInput,
+  useColorScheme,
 } from 'react-native';
 
 type Props = {
@@ -19,13 +21,25 @@ export const SettingsInput = ({
   onValueChange,
 }: Props): React.JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
+  const scheme = useColorScheme();
   return (
     <TouchableOpacity onPress={() => setIsOpen(!isOpen)}>
-      <View style={styles.container}>
-        <Text style={styles.label}>{`${label}: ${value}`}</Text>
+      <View
+        style={[
+          styles.container,
+          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+        ]}>
+        <Text
+          style={[
+            styles.label,
+            scheme === 'dark' ? styles.labelDark : styles.labelLight,
+          ]}>{`${label}: ${value}`}</Text>
         {isOpen ? (
           <TextInput
-            style={styles.input}
+            style={[
+              styles.input,
+              scheme === 'dark' ? styles.inputDark : styles.inputLight,
+            ]}
             value={value}
             onChangeText={onValueChange}
             autoCapitalize="none"
@@ -46,16 +60,33 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 5,
     borderColor: '#039be5',
-    backgroundColor: 'white',
+  },
+  containerLight: {
+    backgroundColor: DefaultTheme.colors.card,
+  },
+  containerDark: {
+    backgroundColor: DarkTheme.colors.card,
   },
   label: {
     fontSize: 15,
-    color: 'black',
+  },
+  labelLight: {
+    color: DefaultTheme.colors.text,
+  },
+  labelDark: {
+    color: DarkTheme.colors.text,
   },
   input: {
     height: 40,
     width: '100%',
     borderWidth: 1,
-    borderColor: 'black',
+  },
+  inputLight: {
+    borderColor: DefaultTheme.colors.border,
+    color: DefaultTheme.colors.text,
+  },
+  inputDark: {
+    borderColor: DarkTheme.colors.border,
+    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsInput.tsx
+++ b/apps/src/shared/SettingsInput.tsx
@@ -1,12 +1,8 @@
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
-import {
-  Text,
-  View,
-  TouchableOpacity,
-  StyleSheet,
-  TextInput,
-} from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import ThemedText from './ThemedText';
+import ThemedView from './ThemedView';
+import ThemedTextInput from './ThemedTextInput';
 
 type Props = {
   label: string;
@@ -20,32 +16,20 @@ export const SettingsInput = ({
   onValueChange,
 }: Props): React.JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
-  const isDark = useTheme().dark;
   return (
     <TouchableOpacity onPress={() => setIsOpen(!isOpen)}>
-      <View
-        style={[
-          styles.container,
-          isDark ? styles.containerDark : styles.containerLight,
-        ]}>
-        <Text
-          style={[
-            styles.label,
-            isDark ? styles.labelDark : styles.labelLight,
-          ]}>{`${label}: ${value}`}</Text>
+      <ThemedView style={styles.container}>
+        <ThemedText style={styles.label}>{`${label}: ${value}`}</ThemedText>
         {isOpen ? (
-          <TextInput
-            style={[
-              styles.input,
-              isDark ? styles.inputDark : styles.inputLight,
-            ]}
+          <ThemedTextInput
+            style={styles.input}
             value={value}
             onChangeText={onValueChange}
             autoCapitalize="none"
             autoCorrect={false}
           />
         ) : null}
-      </View>
+      </ThemedView>
     </TouchableOpacity>
   );
 };
@@ -60,32 +44,12 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     borderColor: '#039be5',
   },
-  containerLight: {
-    backgroundColor: DefaultTheme.colors.card,
-  },
-  containerDark: {
-    backgroundColor: DarkTheme.colors.card,
-  },
   label: {
     fontSize: 15,
-  },
-  labelLight: {
-    color: DefaultTheme.colors.text,
-  },
-  labelDark: {
-    color: DarkTheme.colors.text,
   },
   input: {
     height: 40,
     width: '100%',
     borderWidth: 1,
-  },
-  inputLight: {
-    borderColor: DefaultTheme.colors.border,
-    color: DefaultTheme.colors.text,
-  },
-  inputDark: {
-    borderColor: DarkTheme.colors.border,
-    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsInput.tsx
+++ b/apps/src/shared/SettingsInput.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, StyleSheet } from 'react-native';
-import ThemedText from './ThemedText';
-import ThemedView from './ThemedView';
-import ThemedTextInput from './ThemedTextInput';
+import { ThemedText, ThemedView, ThemedTextInput } from '.';
 
 type Props = {
   label: string;

--- a/apps/src/shared/SettingsPicker.tsx
+++ b/apps/src/shared/SettingsPicker.tsx
@@ -1,5 +1,12 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
-import { Text, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
+import {
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ViewStyle,
+  useColorScheme,
+} from 'react-native';
 
 type Props<T = string> = {
   testID?: string;
@@ -19,21 +26,31 @@ export function SettingsPicker<T extends string>({
   style = {},
 }: Props<T>): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
+  const scheme = useColorScheme();
   return (
     <TouchableOpacity
-      style={{ ...styles.container, ...style }}
+      style={[
+        styles.container,
+        scheme === 'dark' ? styles.containerDark : styles.containerLight,
+        style,
+      ]}
       onPress={() => setIsOpen(!isOpen)}>
-      <Text testID={testID} style={styles.label}>{`${label}: ${value}`}</Text>
+      <Text
+        testID={testID}
+        style={[
+          styles.label,
+          scheme === 'dark' ? styles.labelDark : styles.labelLight,
+        ]}>{`${label}: ${value}`}</Text>
       {isOpen
         ? items.map(item => (
             <TouchableOpacity key={item} onPress={() => onValueChange(item)}>
               <Text
                 testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
-                style={
-                  item === value
-                    ? { ...styles.item, fontWeight: 'bold' }
-                    : styles.item
-                }>
+                style={[
+                  styles.item,
+                  scheme === 'dark' ? styles.itemDark : styles.itemLight,
+                  item === value && { fontWeight: 'bold' },
+                ]}>
                 {item}
               </Text>
             </TouchableOpacity>
@@ -52,11 +69,21 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 5,
     borderColor: '#039be5',
-    backgroundColor: 'white',
+  },
+  containerLight: {
+    backgroundColor: DefaultTheme.colors.card,
+  },
+  containerDark: {
+    backgroundColor: DarkTheme.colors.card,
   },
   label: {
     fontSize: 15,
-    color: 'black',
+  },
+  labelLight: {
+    color: DefaultTheme.colors.text,
+  },
+  labelDark: {
+    color: DarkTheme.colors.text,
   },
   picker: {
     height: 50,
@@ -65,6 +92,11 @@ const styles = StyleSheet.create({
   item: {
     paddingVertical: 5,
     paddingHorizontal: 20,
-    color: 'black',
+  },
+  itemLight: {
+    color: DefaultTheme.colors.text,
+  },
+  itemDark: {
+    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsPicker.tsx
+++ b/apps/src/shared/SettingsPicker.tsx
@@ -1,12 +1,6 @@
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
-import {
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ViewStyle,
-  useColorScheme,
-} from 'react-native';
+import { Text, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
 
 type Props<T = string> = {
   testID?: string;
@@ -26,12 +20,12 @@ export function SettingsPicker<T extends string>({
   style = {},
 }: Props<T>): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <TouchableOpacity
       style={[
         styles.container,
-        scheme === 'dark' ? styles.containerDark : styles.containerLight,
+        isDark ? styles.containerDark : styles.containerLight,
         style,
       ]}
       onPress={() => setIsOpen(!isOpen)}>
@@ -39,7 +33,7 @@ export function SettingsPicker<T extends string>({
         testID={testID}
         style={[
           styles.label,
-          scheme === 'dark' ? styles.labelDark : styles.labelLight,
+          isDark ? styles.labelDark : styles.labelLight,
         ]}>{`${label}: ${value}`}</Text>
       {isOpen
         ? items.map(item => (
@@ -48,7 +42,7 @@ export function SettingsPicker<T extends string>({
                 testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
                 style={[
                   styles.item,
-                  scheme === 'dark' ? styles.itemDark : styles.itemLight,
+                  isDark ? styles.itemDark : styles.itemLight,
                   item === value && { fontWeight: 'bold' },
                 ]}>
                 {item}

--- a/apps/src/shared/SettingsPicker.tsx
+++ b/apps/src/shared/SettingsPicker.tsx
@@ -1,6 +1,6 @@
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import React, { useState } from 'react';
-import { Text, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
+import { StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
+import { ThemedText, ThemedView } from '.';
 
 type Props<T = string> = {
   testID?: string;
@@ -20,36 +20,27 @@ export function SettingsPicker<T extends string>({
   style = {},
 }: Props<T>): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
-  const isDark = useTheme().dark;
   return (
-    <TouchableOpacity
-      style={[
-        styles.container,
-        isDark ? styles.containerDark : styles.containerLight,
-        style,
-      ]}
-      onPress={() => setIsOpen(!isOpen)}>
-      <Text
-        testID={testID}
-        style={[
-          styles.label,
-          isDark ? styles.labelDark : styles.labelLight,
-        ]}>{`${label}: ${value}`}</Text>
-      {isOpen
-        ? items.map(item => (
-            <TouchableOpacity key={item} onPress={() => onValueChange(item)}>
-              <Text
-                testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
-                style={[
-                  styles.item,
-                  isDark ? styles.itemDark : styles.itemLight,
-                  item === value && { fontWeight: 'bold' },
-                ]}>
-                {item}
-              </Text>
-            </TouchableOpacity>
-          ))
-        : null}
+    <TouchableOpacity onPress={() => setIsOpen(!isOpen)}>
+      <ThemedView style={[styles.container, style]}>
+        <ThemedText
+          testID={testID}
+          style={styles.label}>{`${label}: ${value}`}</ThemedText>
+        {isOpen
+          ? items.map(item => (
+              <TouchableOpacity key={item} onPress={() => onValueChange(item)}>
+                <ThemedText
+                  testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
+                  style={[
+                    styles.item,
+                    item === value && { fontWeight: 'bold' },
+                  ]}>
+                  {item}
+                </ThemedText>
+              </TouchableOpacity>
+            ))
+          : null}
+      </ThemedView>
     </TouchableOpacity>
   );
 }
@@ -64,20 +55,8 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     borderColor: '#039be5',
   },
-  containerLight: {
-    backgroundColor: DefaultTheme.colors.card,
-  },
-  containerDark: {
-    backgroundColor: DarkTheme.colors.card,
-  },
   label: {
     fontSize: 15,
-  },
-  labelLight: {
-    color: DefaultTheme.colors.text,
-  },
-  labelDark: {
-    color: DarkTheme.colors.text,
   },
   picker: {
     height: 50,
@@ -86,11 +65,5 @@ const styles = StyleSheet.create({
   item: {
     paddingVertical: 5,
     paddingHorizontal: 20,
-  },
-  itemLight: {
-    color: DefaultTheme.colors.text,
-  },
-  itemDark: {
-    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsSwitch.tsx
+++ b/apps/src/shared/SettingsSwitch.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import {
   Text,
   View,
   TouchableOpacity,
   StyleSheet,
   ViewStyle,
+  useColorScheme,
 } from 'react-native';
 
 type Props = {
@@ -20,10 +22,20 @@ export const SettingsSwitch = ({
   onValueChange,
   style = {},
 }: Props): React.JSX.Element => {
+  const scheme = useColorScheme();
   return (
     <TouchableOpacity onPress={() => onValueChange(!value)}>
-      <View style={{ ...styles.container, ...style }}>
-        <Text style={styles.label}>{`${label}: ${value}`}</Text>
+      <View
+        style={[
+          styles.container,
+          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+          style,
+        ]}>
+        <Text
+          style={[
+            styles.label,
+            scheme === 'dark' ? styles.labelDark : styles.labelLight,
+          ]}>{`${label}: ${value}`}</Text>
       </View>
     </TouchableOpacity>
   );
@@ -40,8 +52,19 @@ const styles = StyleSheet.create({
     borderColor: '#039be5',
     backgroundColor: 'white',
   },
+  containerLight: {
+    backgroundColor: DefaultTheme.colors.card,
+  },
+  containerDark: {
+    backgroundColor: DarkTheme.colors.card,
+  },
   label: {
     fontSize: 15,
-    color: 'black',
+  },
+  labelLight: {
+    color: DefaultTheme.colors.text,
+  },
+  labelDark: {
+    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsSwitch.tsx
+++ b/apps/src/shared/SettingsSwitch.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import {
   Text,
   View,
   TouchableOpacity,
   StyleSheet,
   ViewStyle,
-  useColorScheme,
 } from 'react-native';
 
 type Props = {
@@ -22,19 +21,19 @@ export const SettingsSwitch = ({
   onValueChange,
   style = {},
 }: Props): React.JSX.Element => {
-  const scheme = useColorScheme();
+  const isDark = useTheme().dark;
   return (
     <TouchableOpacity onPress={() => onValueChange(!value)}>
       <View
         style={[
           styles.container,
-          scheme === 'dark' ? styles.containerDark : styles.containerLight,
+          isDark ? styles.containerDark : styles.containerLight,
           style,
         ]}>
         <Text
           style={[
             styles.label,
-            scheme === 'dark' ? styles.labelDark : styles.labelLight,
+            isDark ? styles.labelDark : styles.labelLight,
           ]}>{`${label}: ${value}`}</Text>
       </View>
     </TouchableOpacity>

--- a/apps/src/shared/SettingsSwitch.tsx
+++ b/apps/src/shared/SettingsSwitch.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
-import { DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
-import {
-  Text,
-  View,
-  TouchableOpacity,
-  StyleSheet,
-  ViewStyle,
-} from 'react-native';
+import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
+import { ThemedText, ThemedView } from '.';
 
 type Props = {
   label: string;
@@ -21,21 +15,11 @@ export const SettingsSwitch = ({
   onValueChange,
   style = {},
 }: Props): React.JSX.Element => {
-  const isDark = useTheme().dark;
   return (
     <TouchableOpacity onPress={() => onValueChange(!value)}>
-      <View
-        style={[
-          styles.container,
-          isDark ? styles.containerDark : styles.containerLight,
-          style,
-        ]}>
-        <Text
-          style={[
-            styles.label,
-            isDark ? styles.labelDark : styles.labelLight,
-          ]}>{`${label}: ${value}`}</Text>
-      </View>
+      <ThemedView style={[styles.container, style]}>
+        <ThemedText style={styles.label}>{`${label}: ${value}`}</ThemedText>
+      </ThemedView>
     </TouchableOpacity>
   );
 };
@@ -51,19 +35,7 @@ const styles = StyleSheet.create({
     borderColor: '#039be5',
     backgroundColor: 'white',
   },
-  containerLight: {
-    backgroundColor: DefaultTheme.colors.card,
-  },
-  containerDark: {
-    backgroundColor: DarkTheme.colors.card,
-  },
   label: {
     fontSize: 15,
-  },
-  labelLight: {
-    color: DefaultTheme.colors.text,
-  },
-  labelDark: {
-    color: DarkTheme.colors.text,
   },
 });

--- a/apps/src/shared/SettingsSwitch.tsx
+++ b/apps/src/shared/SettingsSwitch.tsx
@@ -33,7 +33,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 5,
     borderColor: '#039be5',
-    backgroundColor: 'white',
   },
   label: {
     fontSize: 15,

--- a/apps/src/shared/ThemedText.tsx
+++ b/apps/src/shared/ThemedText.tsx
@@ -1,0 +1,13 @@
+import { useTheme } from '@react-navigation/native';
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+
+export const ThemedText = ({ children, style, ...props }: TextProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <Text style={[{ color: colors.text }, style]} {...props}>
+      {children}
+    </Text>
+  );
+};

--- a/apps/src/shared/ThemedTextInput.tsx
+++ b/apps/src/shared/ThemedTextInput.tsx
@@ -1,0 +1,14 @@
+import { useTheme } from '@react-navigation/native';
+import React from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+export const ThemedTextInput = ({ style, ...props }: TextInputProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <TextInput
+      style={[{ borderColor: colors.border, color: colors.text }, style]}
+      {...props}
+    />
+  );
+};

--- a/apps/src/shared/ThemedView.tsx
+++ b/apps/src/shared/ThemedView.tsx
@@ -1,0 +1,12 @@
+import { useTheme } from '@react-navigation/native';
+import React from 'react';
+import { View, ViewProps } from 'react-native';
+
+export const ThemedView = ({ children, style, ...props }: ViewProps) => {
+  const { colors } = useTheme();
+  return (
+    <View style={[{ backgroundColor: colors.card }, style]} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/apps/src/shared/index.ts
+++ b/apps/src/shared/index.ts
@@ -11,3 +11,6 @@ export * from './Choose';
 export * from './Dialog';
 export * from './Snack';
 export * from './Toast';
+export * from './ThemedText';
+export * from './ThemedView';
+export * from './ThemedTextInput';


### PR DESCRIPTION
## Description

This PR adds dark theme to the example app. The theme changes automatically based on the device's appearance setting and can be changed by clicking a button.

## Changes

- added dark styles to screens and components
- added a state and listener for basic theme management
- added a dark mode button

## Screenshots / GIFs

https://github.com/software-mansion/react-native-screens/assets/91994767/c156eaa7-7603-4f92-b1a2-5599e33ecc3f

https://github.com/software-mansion/react-native-screens/assets/91994767/5e479905-b046-4ea4-bfc1-1667837eee60

## Test code and steps to reproduce

- Use the Example app
- Toggle the theme with a button or by changing device's setting
- Browse screens

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
