### PR TITLE
fix(iOS): flickering custom header items

### DIFF
--- a/apps/src/tests/Test556.tsx
+++ b/apps/src/tests/Test556.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Text } from 'react-native';
+import { Button, StyleSheet, Text, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -11,8 +11,16 @@ export default function App() {
       <Stack.Navigator
         screenOptions={{
           animation: 'fade',
-          headerTitle: () => <Text>Simple Native Stack</Text>,
-          headerRight: () => <Text>Right</Text>,
+          headerTitle: () => (
+            <View style={styles.container}>
+              <Text>Simple Native Stack</Text>
+            </View>
+          ),
+          headerRight: () => (
+            <View style={styles.container}>
+              <Text>Right</Text>
+            </View>
+          ),
         }}>
         <Stack.Screen name="First" component={First} />
         <Stack.Screen name="Second" component={Second} />
@@ -38,3 +46,10 @@ function Second({ navigation }: any) {
     />
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 3,
+    backgroundColor: 'cyan',
+  },
+});

--- a/apps/src/tests/Test556.tsx
+++ b/apps/src/tests/Test556.tsx
@@ -12,6 +12,7 @@ export default function App() {
         screenOptions={{
           animation: 'fade',
           headerTitle: () => <Text>Simple Native Stack</Text>,
+          headerRight: () => <Text>Right</Text>,
         }}>
         <Stack.Screen name="First" component={First} />
         <Stack.Screen name="Second" component={Second} />

--- a/apps/src/tests/Test556.tsx
+++ b/apps/src/tests/Test556.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from 'react-native';
+import { Button, Text } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -8,7 +8,11 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
+      <Stack.Navigator
+        screenOptions={{
+          animation: 'fade',
+          headerTitle: () => <Text>Simple Native Stack</Text>,
+        }}>
         <Stack.Screen name="First" component={First} />
         <Stack.Screen name="Second" component={Second} />
       </Stack.Navigator>
@@ -16,7 +20,7 @@ export default function App() {
   );
 }
 
-function First({ navigation }) {
+function First({ navigation }: any) {
   return (
     <Button
       title="Tap me for second screen"
@@ -25,10 +29,10 @@ function First({ navigation }) {
   );
 }
 
-function Second({ navigation }) {
+function Second({ navigation }: any) {
   return (
     <Button
-      title="Tap me for second screen"
+      title="Tap me for first screen"
       onPress={() => navigation.popTo('First')}
     />
   );

--- a/apps/src/tests/Test556.tsx
+++ b/apps/src/tests/Test556.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 
 const Stack = createNativeStackNavigator();
+
+type ScreenBaseProps = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
 
 export default function App() {
   return (
@@ -41,7 +45,7 @@ export default function App() {
   );
 }
 
-function First({ navigation }: any) {
+function First({ navigation }: ScreenBaseProps) {
   return (
     <Button
       title="Tap me for second screen"
@@ -50,7 +54,7 @@ function First({ navigation }: any) {
   );
 }
 
-function Second({ navigation }: any) {
+function Second({ navigation }: ScreenBaseProps) {
   return (
     <Button
       title="Tap me for first screen"

--- a/apps/src/tests/Test556.tsx
+++ b/apps/src/tests/Test556.tsx
@@ -11,19 +11,31 @@ export default function App() {
       <Stack.Navigator
         screenOptions={{
           animation: 'fade',
+        }}>
+        <Stack.Screen name="First" component={First} options={{
           headerTitle: () => (
-            <View style={styles.container}>
-              <Text>Simple Native Stack</Text>
+            <View style={[styles.container, { backgroundColor: 'goldenrod' }]}>
+              <Text>Hello there!</Text>
             </View>
           ),
           headerRight: () => (
-            <View style={styles.container}>
-              <Text>Right</Text>
+            <View style={[styles.container, { backgroundColor: 'lightblue' }]}>
+              <Text>Right-1</Text>
             </View>
           ),
-        }}>
-        <Stack.Screen name="First" component={First} />
-        <Stack.Screen name="Second" component={Second} />
+        }} />
+        <Stack.Screen name="Second" component={Second} options={{
+          headerTitle: () => (
+            <View style={[styles.container, { backgroundColor: 'mediumseagreen' }]}>
+              <Text>General Kenobi</Text>
+            </View>
+          ),
+          headerRight: () => (
+            <View style={[styles.container, { backgroundColor: 'mediumvioletred' }]}>
+              <Text>Right-2</Text>
+            </View>
+          ),
+        }} />
       </Stack.Navigator>
     </NavigationContainer>
   );
@@ -50,6 +62,5 @@ function Second({ navigation }: any) {
 const styles = StyleSheet.create({
   container: {
     padding: 3,
-    backgroundColor: 'cyan',
   },
 });

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1384,9 +1384,19 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)setViewToSnapshot:(UIView *)snapshot
 {
   UIView *superView = self.view.superview;
-  [self.view removeFromSuperview];
-  self.view = snapshot;
-  [superView addSubview:self.view];
+  // if we dismissed the view natively, it will already be detached from view hierarchy
+  if (self.view.window != nil) {
+    UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:NO];
+    [self.view removeFromSuperview];
+    self.view = snapshot;
+    [superView addSubview:snapshot];
+  }
+
+  if (self.navigationItem.titleView.window != nil) {
+    UIView *navSnapshot = [self.navigationItem.titleView snapshotViewAfterScreenUpdates:NO];
+    [self.navigationItem.titleView removeFromSuperview];
+    self.navigationItem.titleView = navSnapshot;
+  }
 }
 
 #else

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -797,7 +797,6 @@ namespace react = facebook::react;
   // subviews
   // Explanation taken from `reactSetFrame`, which is old arch equivalent of this code.
 }
- 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
   [super finalizeUpdates:updateMask];

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -797,6 +797,7 @@ namespace react = facebook::react;
   // subviews
   // Explanation taken from `reactSetFrame`, which is old arch equivalent of this code.
 }
+
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
   [super finalizeUpdates:updateMask];

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -797,7 +797,7 @@ namespace react = facebook::react;
   // subviews
   // Explanation taken from `reactSetFrame`, which is old arch equivalent of this code.
 }
-
+ 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
   [super finalizeUpdates:updateMask];
@@ -1390,24 +1390,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self.view removeFromSuperview];
     self.view = snapshot;
     [superView addSubview:snapshot];
-  }
-
-  if (self.navigationItem.titleView.window != nil) {
-    UIView *titleSnapshot = [self.navigationItem.titleView snapshotViewAfterScreenUpdates:NO];
-    [self.navigationItem.titleView removeFromSuperview];
-    self.navigationItem.titleView = titleSnapshot;
-  }
-
-  if (self.navigationItem.rightBarButtonItem.customView.window != nil) {
-    UIView *rightSnapshot = [self.navigationItem.rightBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
-    [self.navigationItem.rightBarButtonItem.customView removeFromSuperview];
-    self.navigationItem.rightBarButtonItem.customView = rightSnapshot;
-  }
-
-  if (self.navigationItem.leftBarButtonItem.customView.window != nil) {
-    UIView *rightSnapshot = [self.navigationItem.leftBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
-    [self.navigationItem.leftBarButtonItem.customView removeFromSuperview];
-    self.navigationItem.leftBarButtonItem.customView = rightSnapshot;
   }
 }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1393,9 +1393,21 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   }
 
   if (self.navigationItem.titleView.window != nil) {
-    UIView *navSnapshot = [self.navigationItem.titleView snapshotViewAfterScreenUpdates:NO];
+    UIView *titleSnapshot = [self.navigationItem.titleView snapshotViewAfterScreenUpdates:NO];
     [self.navigationItem.titleView removeFromSuperview];
-    self.navigationItem.titleView = navSnapshot;
+    self.navigationItem.titleView = titleSnapshot;
+  }
+
+  if (self.navigationItem.rightBarButtonItem.customView.window != nil) {
+    UIView *rightSnapshot = [self.navigationItem.rightBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
+    [self.navigationItem.rightBarButtonItem.customView removeFromSuperview];
+    self.navigationItem.rightBarButtonItem.customView = rightSnapshot;
+  }
+
+  if (self.navigationItem.leftBarButtonItem.customView.window != nil) {
+    UIView *rightSnapshot = [self.navigationItem.leftBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
+    [self.navigationItem.leftBarButtonItem.customView removeFromSuperview];
+    self.navigationItem.leftBarButtonItem.customView = rightSnapshot;
   }
 }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1384,13 +1384,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)setViewToSnapshot:(UIView *)snapshot
 {
   UIView *superView = self.view.superview;
-  // if we dismissed the view natively, it will already be detached from view hierarchy
-  if (self.view.window != nil) {
-    UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:NO];
-    [self.view removeFromSuperview];
-    self.view = snapshot;
-    [superView addSubview:snapshot];
-  }
+  [self.view removeFromSuperview];
+  self.view = snapshot;
+  [superView addSubview:self.view];
 }
 
 #else

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -755,8 +755,8 @@ namespace react = facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [self setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView];
+  [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -763,12 +763,22 @@ namespace react = facebook::react;
 - (void)setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView
 {
   UINavigationItem *navitem = _screenView.controller.navigationItem;
-  if (childComponentView.type == RNSScreenStackHeaderSubviewTypeLeft) {
-    navitem.leftBarButtonItem.customView = [navitem.leftBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
-  } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeCenter) {
-    navitem.titleView = [navitem.titleView snapshotViewAfterScreenUpdates:NO];
-  } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeRight) {
-    navitem.rightBarButtonItem.customView = [navitem.rightBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
+  UIView *snapshot = [childComponentView snapshotViewAfterScreenUpdates:NO];
+
+  switch (childComponentView.type) {
+    case RNSScreenStackHeaderSubviewTypeLeft:
+      navitem.leftBarButtonItem.customView = snapshot;
+      break;
+    case RNSScreenStackHeaderSubviewTypeCenter:
+    case RNSScreenStackHeaderSubviewTypeTitle:
+      navitem.titleView = snapshot;
+      break;
+    case RNSScreenStackHeaderSubviewTypeRight:
+      navitem.rightBarButtonItem.customView = snapshot;
+      break;
+    case RNSScreenStackHeaderSubviewTypeSearchBar:
+    case RNSScreenStackHeaderSubviewTypeBackButton:
+      break;
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -760,22 +760,16 @@ namespace react = facebook::react;
   [childComponentView removeFromSuperview];
 }
 
-- (void)setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView {
-    UINavigationItem *navitem = _screenView.controller.navigationItem;
-    if(childComponentView.type == RNSScreenStackHeaderSubviewTypeLeft){
-        navitem.leftBarButtonItem.customView = [self takeSnapshot:navitem.leftBarButtonItem.customView ];
-    } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeCenter){
-        navitem.titleView = [self takeSnapshot:navitem.titleView];
-    } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeRight){
-        navitem.rightBarButtonItem.customView = [self takeSnapshot:navitem.rightBarButtonItem.customView];
-    }
-}
-
-- (UIView *)takeSnapshot:(UIView *)view {
-    if (view.window != nil) {
-        return [view snapshotViewAfterScreenUpdates:NO];
-    }
-    return view;
+- (void)setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView
+{
+  UINavigationItem *navitem = _screenView.controller.navigationItem;
+  if (childComponentView.type == RNSScreenStackHeaderSubviewTypeLeft) {
+    navitem.leftBarButtonItem.customView = [navitem.leftBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
+  } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeCenter) {
+    navitem.titleView = [navitem.titleView snapshotViewAfterScreenUpdates:NO];
+  } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeRight) {
+    navitem.rightBarButtonItem.customView = [navitem.rightBarButtonItem.customView snapshotViewAfterScreenUpdates:NO];
+  }
 }
 
 static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -628,6 +628,8 @@ namespace react = facebook::react;
   navitem.titleView = nil;
 
   for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
+    // This code should be kept in sync on Fabric with analogous switch statement in
+    // `- [RNSScreenStackHeaderConfig replaceNavigationBarViewsWithSnapshotOfSubview:]` method.
     switch (subview.type) {
       case RNSScreenStackHeaderSubviewTypeLeft: {
 #if !TARGET_OS_TV
@@ -755,16 +757,20 @@ namespace react = facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [self setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView];
+  // For explanation of why we can make a snapshot here despite the fact that our children are already
+  // unmounted see https://github.com/software-mansion/react-native-screens/pull/2261
+  [self replaceNavigationBarViewsWithSnapshotOfSubview:(RNSScreenStackHeaderSubview *)childComponentView];
   [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
 }
 
-- (void)setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView
+- (void)replaceNavigationBarViewsWithSnapshotOfSubview:(RNSScreenStackHeaderSubview *)childComponentView
 {
   UINavigationItem *navitem = _screenView.controller.navigationItem;
   UIView *snapshot = [childComponentView snapshotViewAfterScreenUpdates:NO];
 
+  // This code should be kept in sync with analogous switch statement in
+  // `+ [RNSScreenStackHeaderConfig updateViewController: withConfig: animated:]` method.
   switch (childComponentView.type) {
     case RNSScreenStackHeaderSubviewTypeLeft:
       navitem.leftBarButtonItem.customView = snapshot;
@@ -779,6 +785,8 @@ namespace react = facebook::react;
     case RNSScreenStackHeaderSubviewTypeSearchBar:
     case RNSScreenStackHeaderSubviewTypeBackButton:
       break;
+    default:
+      RCTLogError(@"[RNScreens] Unhandled subview type: %ld", childComponentView.type);
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -756,7 +756,26 @@ namespace react = facebook::react;
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
+  [self setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
+}
+
+- (void)setViewToSnapshot:(RNSScreenStackHeaderSubview *)childComponentView {
+    UINavigationItem *navitem = _screenView.controller.navigationItem;
+    if(childComponentView.type == RNSScreenStackHeaderSubviewTypeLeft){
+        navitem.leftBarButtonItem.customView = [self takeSnapshot:navitem.leftBarButtonItem.customView ];
+    } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeCenter){
+        navitem.titleView = [self takeSnapshot:navitem.titleView];
+    } else if (childComponentView.type == RNSScreenStackHeaderSubviewTypeRight){
+        navitem.rightBarButtonItem.customView = [self takeSnapshot:navitem.rightBarButtonItem.customView];
+    }
+}
+
+- (UIView *)takeSnapshot:(UIView *)view {
+    if (view.window != nil) {
+        return [view snapshotViewAfterScreenUpdates:NO];
+    }
+    return view;
 }
 
 static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)


### PR DESCRIPTION
## Description

This PR intents to fix flickering custom header items when going to a previous screen on `fabric` architecture.
The items are unmounted before the transition happens when `POP` action is dispatched on navigation from JS causing the items to vanish for a moment.
The adopted solution uses snapshots of the custom items to be used until the transition's done.

Fixes #2243.

## Changes

- added snapshots of the custom header items
- modified `Test556` for repro

## Screenshots / GIFs

### Before

https://github.com/user-attachments/assets/9da060ed-b65e-4b32-9ab1-debfc2bfd02d


### After

https://github.com/user-attachments/assets/0413fab0-05f6-4e55-adab-f283e01bc551


## Test code and steps to reproduce

- Use `Test556` repro

## Checklist

- [x] Ensured that CI passes
