### PR TITLE
fix: changed the minsdk from 21 to 23 to support RN 0.74.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext {
         rnsDefaultTargetSdkVersion = 34
         rnsDefaultCompileSdkVersion = 34
-        rnsDefaultMinSdkVersion = 21
+        rnsDefaultMinSdkVersion = 23
         rnsDefaultKotlinVersion = '1.8.0'
     }
     ext.safeExtGet = {prop, fallback ->


### PR DESCRIPTION
## Description

Fixes the minSdkVersion from 21 to 23 to support RN 0.74.3

## Changes

Updated the build.gradle file on the android level from rnsDefaultMinSdkVersion = 21 to rnsDefaultMinSdkVersion = 23

## Screenshots / GIFs


### Before
![Captura de Tela 2024-07-17 às 16 13 01](https://github.com/user-attachments/assets/3a873275-bd00-4eb5-a261-cccd81ce6896)

### After

![Captura de Tela 2024-07-17 às 16 12 37](https://github.com/user-attachments/assets/03b237d1-9241-4361-8912-7b3759735713)
