### PR TITLE
fix(Android): comply to breaking changes in Android SDK 35

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -345,7 +345,9 @@ class ScreenStack(
         super.drawChild(op.canvas!!, op.child, op.drawingTime)
     }
 
-    private fun obtainDrawingOp(): DrawingOp = if (drawingOpPool.isEmpty()) DrawingOp() else drawingOpPool.removeLast()
+    // Can't use `drawingOpPool.removeLast` here due to issues with static name resolution in Android SDK 35+.
+    // See: https://developer.android.com/about/versions/15/behavior-changes-15?hl=en#openjdk-api-changes
+    private fun obtainDrawingOp(): DrawingOp = if (drawingOpPool.isEmpty()) DrawingOp() else drawingOpPool.removeAt(drawingOpPool.lastIndex)
 
     private inner class DrawingOp {
         var canvas: Canvas? = null


### PR DESCRIPTION
## Description

Initially reported & solution proposed by @corbella83.

Newer OpenJDK versions have introduced `List.removeLast` / `List.removeFirst` methods, which haven't existed in JDK before and were provided by Kotlin std lib `kotlin-std`. Android SDK 35 aligns with recent OpenJDK versions & when compiling with SDK 35 the method call is statically resolved to the function from JDK and not to the one from `kotlin-std`. Thus when running on lower version of runtime (<= 34) there is no such method available at runtime (at address resolved in compile time) leading to runtime crash. 

Section in Android docs describing this: https://developer.android.com/about/versions/15/behavior-changes-15?hl=en#openjdk-api-changes

Fixes #2257

## Changes

* Replaced call to `drawingOpList.removeLast` with `drawingOpList.removeAt(drawingOpList.lastIndex)`.
* Added comment to ensure no one refactors this code bu accident at some later point.


## Test code and steps to reproduce

Bump sdk to 35 in Example / FabricExample & run the application. It won't fail in runtime anymore. 

## Checklist

- [x] Ensured that CI passes

CI fails sometimes with some `reanimated` / `gesture-handler` related reasons: 

<details><summary>Error message</summary>
<p>

```
> Task :react-native-gesture-handler:processDebugAndroidTestManifest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-gesture-handler:processDebugAndroidTestManifest'.
> Could not resolve all files for configuration ':react-native-gesture-handler:debugAndroidTestRuntimeClasspath'.
   > Failed to transform hermes-android-0.74.1-debug.aar (com.facebook.react:hermes-android:0.74.1) to match attributes {artifactType=android-manifest, com.android.build.api.attributes.BuildTypeAttr=debug, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: /home/runner/.gradle/caches/modules-2/files-2.1/com.facebook.react/hermes-android/0.74.1/16e198f2042f7758123b39bba3d5e3d6eb33ba8a/hermes-android-0.74.1-debug.aar.
         > Java heap space
```

</p>
</details> 

which seem unrelated to the PR, but might indicate either some issue with other lib **or** insufficient java heap size. 

Co-authored-by: Pau Corbella <corbella83@gmail.com>
