### PR TITLE
fix: removed duplicated modules from metro config

### DIFF
--- a/Example/metro.config.js
+++ b/Example/metro.config.js
@@ -16,7 +16,6 @@ const modules = [
   'react-native-reanimated',
   'react-native-safe-area-context',
   'react-native-gesture-handler',
-  'react-native-reanimated',
   ...Object.keys(pack.peerDependencies),
 ];
 

--- a/TVOSExample/metro.config.js
+++ b/TVOSExample/metro.config.js
@@ -16,7 +16,6 @@ const modules = [
   'react-native-reanimated',
   'react-native-safe-area-context',
   'react-native-gesture-handler',
-  'react-native-reanimated',
   ...Object.keys(pack.peerDependencies),
 ];
 


### PR DESCRIPTION
## Description

This PR removes duplicated `react-native-reanimated` modules from metro config files.

## Checklist

- [x] Ensured that CI passes
