### PR TITLE
fix(iOS,Fabric): WIP WIP dismissed screen does not respect navbar during transition

### DIFF
--- a/apps/src/tests/TestDismiss.tsx
+++ b/apps/src/tests/TestDismiss.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, View, Text, StyleSheet } from 'react-native';
+import { NativeStackNavigationProp } from 'react-native-screens/native-stack';
+
+const Stack = createNativeStackNavigator();
+const NestedStack = createNativeStackNavigator();
+
+type BaseRouteProps = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
+
+function FirstScreen({ navigation }: BaseRouteProps): React.JSX.Element {
+  return (
+    <View style={[styles.container, { backgroundColor: 'lightgreen' }]}>
+      <Button onPress={() => navigation.navigate('Second')} title='Navigate Second' />
+      <Button onPress={() => navigation.navigate('NestedStack')} title='Navigate NestedStack' />
+    </View>
+  );
+}
+
+function SecondScreen({ navigation }: BaseRouteProps): React.JSX.Element {
+  return (
+    <View style={[styles.container, { backgroundColor: 'indianred' }]}>
+      <Button onPress={() => navigation.pop()} title='PopTo First' />
+    </View>
+  );
+}
+
+function NestedFirstScreen({ navigation }: BaseRouteProps): React.JSX.Element {
+  return (
+    <View style={[styles.container, { backgroundColor: 'lightgreen' }]}>
+      <Button onPress={() => navigation.navigate('Second')} title='Navigate Second' />
+      <Button onPress={() => navigation.pop()} title='Pop back' />
+    </View>
+  );
+}
+
+
+function NestedStackScreen({ navigation }: BaseRouteProps): React.JSX.Element {
+  return (
+    <NestedStack.Navigator>
+      <NestedStack.Screen name='NestedFirst' component={NestedFirstScreen} />
+      <NestedStack.Screen name='Second' component={SecondScreen} />
+    </NestedStack.Navigator>
+  );
+}
+
+
+function App(): React.JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name='First' component={FirstScreen} />
+        <Stack.Screen name='Second' component={SecondScreen} />
+        <Stack.Screen name='NestedStack' component={NestedStackScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+
+  );
+}
+
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  }
+});
+
+export default App;

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -109,3 +109,5 @@ export { default as Test2232 } from './Test2232';
 export { default as Test2235 } from './Test2235';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestHeader } from './TestHeader';
+export { default as TestDismiss } from './TestDismiss';
+

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1132,7 +1132,7 @@ namespace react = facebook::react;
   if (screenChildComponent.window != nil &&
       ((screenChildComponent == _controller.visibleViewController.view && _presentedModals.count < 2) ||
        screenChildComponent == [_presentedModals.lastObject view])) {
-    [self takeSnapshot];
+    //    [self takeSnapshot];
     [screenChildComponent.controller setViewToSnapshot:_snapshot];
   }
 
@@ -1161,6 +1161,22 @@ namespace react = facebook::react;
     _snapshot = [_controller.visibleViewController.view snapshotViewAfterScreenUpdates:NO];
   } else {
     _snapshot = [[_presentedModals.lastObject view] snapshotViewAfterScreenUpdates:NO];
+  }
+}
+
+- (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction
+                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
+{
+  for (auto &mutation : transaction.getMutations()) {
+    if (mutation.type == react::ShadowViewMutation::Type::Remove && mutation.parentShadowView.componentName != nil &&
+        strcmp(mutation.parentShadowView.componentName, "RNSScreenStack") == 0) {
+      [self takeSnapshot];
+    }
+  }
+  for (const auto &mutation : transaction.getMutations()) {
+    if (mutation.parentShadowView.tag == self.tag && mutation.type == react::ShadowViewMutation::Remove) {
+      [self takeSnapshot];
+    }
   }
 }
 


### PR DESCRIPTION
Urządzenia z bugiem: (DI - dynamic island)

Fizyczny iPhone 15 Pro iOS 17 (DI) ❌   
Symulator iPhone 15 Pro iOS 17.5 (DI) ✅  
Symulator iPhone 15 iOS 17.5 (DI) ✅  
Symulator iPhone 15 Pro Max iOS 17.5 (DI) ✅ 
Fizyczny iPhone 15 Pro Max iOS 18.1 beta 1 (DI) :x: 
Fizyczny iPhone 11 iOS 16.3.1 :white_check_mark: 
Fizyczny iPhone 8 iOS 16.7.8 :white_check_mark: 

On Paper this works just fine on every device / simulator. Thus this is **Fabric specific**.

https://github.com/user-attachments/assets/35ba933a-3c5d-4cc1-8465-7e571d3930f8


## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
