### PR TITLE
fix(Fabric): not working animations on second-top screen

### DIFF
--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -7,6 +7,10 @@ import ScreenStackNativeComponent from '../fabric/ScreenStackNativeComponent';
 const NativeScreenStack: React.ComponentType<ScreenStackProps> =
   ScreenStackNativeComponent as any;
 
+function isFabric() {
+  return 'nativeFabricUIManager' in global;
+}
+
 function ScreenStack(props: ScreenStackProps) {
   const { children, gestureDetectorBridge, ...rest } = props;
   const ref = React.useRef(null);
@@ -19,8 +23,14 @@ function ScreenStack(props: ScreenStackProps) {
     const isFreezeEnabled =
       descriptor?.options?.freezeOnBlur ?? freezeEnabled();
 
+    // On Fabric, when screen is frozen, animated and reanimated values are not updated
+    // due to component being unmounted. To avoid this, we don't freeze the previous screen there
+    const freezePreviousScreen = isFabric()
+      ? size - index > 2
+      : size - index > 1;
+
     return (
-      <DelayedFreeze freeze={isFreezeEnabled && size - index > 1}>
+      <DelayedFreeze freeze={isFreezeEnabled && freezePreviousScreen}>
         {child}
       </DelayedFreeze>
     );


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

PR fixing animations on Fabric. 

The problem started in RN `0.74`, from which suspending the component triggers its `useLayoutEffect`. It has the consequences in `Animated` since detaching the native node happens then: https://github.com/facebook/react-native/blob/a5b84b925891fa509bec2e5ee5988bcb0326e198/packages/react-native/Libraries/Animated/useAnimatedProps.js#L221-L238. 

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Check `Test887.tsx` to see that on fabric, when going forward or back, without this change the screen below is not animating.