### PR TITLE
chore: update readme with supported RN versions since 3.33.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Screens are already integrated with the React Native's most popular navigation l
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 3.33.0+         | 0.72.0+
 | 3.32.0+         | 0.71.0+              |
 | 3.30.0+         | 0.68.0+              |
 | 3.14.0+         | 0.64.0+              |
@@ -122,6 +123,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 3.33.0+         | 0.75.0+              |
 | 3.32.0+         | 0.74.0+              |
 | 3.28.0+         | 0.73.0+              |
 | 3.21.0+         | 0.72.0+              |


### PR DESCRIPTION
## Description

Update readme with supported react-native versions since 3.33.0 version of this library.

## Changes

* Paper: support is declared for 0.72.0+

* Fabric: support is declared for 0.75.0+



## Test code and steps to reproduce

N/A

## Checklist

- [x] Ensured that CI passes
