### PR TITLE
fix(Android,Fabric,bridge-mode): patch crash with context detached from activity

### DIFF
--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
@@ -37,7 +37,7 @@ class MainApplication : Application(), ReactApplication {
     SoLoader.init(this, false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load()
+      load(bridgelessEnabled = false)
     }
   }
 }

--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
@@ -37,7 +37,7 @@ class MainApplication : Application(), ReactApplication {
     SoLoader.init(this, false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load(bridgelessEnabled = false)
+      load()
     }
   }
 }

--- a/FabricExample/android/settings.gradle
+++ b/FabricExample/android/settings.gradle
@@ -1,6 +1,16 @@
 pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+extensions.configure(com.facebook.react.ReactSettingsExtension) { ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'FabricExample'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
+
+includeBuild('../node_modules/react-native') {
+    dependencySubstitution {
+        substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
+        substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
+        substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+        substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+    }
+}
+

--- a/FabricExample/android/settings.gradle
+++ b/FabricExample/android/settings.gradle
@@ -4,13 +4,3 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex -> ex.autol
 rootProject.name = 'FabricExample'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
-
-includeBuild('../node_modules/react-native') {
-    dependencySubstitution {
-        substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
-        substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
-        substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
-        substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
-    }
-}
-

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -69,8 +69,6 @@ internal class ScreenDummyLayoutHelper(
             return false
         }
 
-        reactContext.isBridgeless
-
         // We need to use activity here, as react context does not have theme attributes required by
         // AppBarLayout attached leading to crash.
         val contextWithTheme =

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -218,9 +218,9 @@ internal class ScreenDummyLayoutHelper(
 
     override fun onHostResume() {
         // This is the earliest we have guarantee that the context has a reference to an activity.
-        maybeInitDummyLayoutWithHeader(requireReactContext())
-        requireReactContext { "[RNScreens] ReactContext missing in onHostResume! This should not happen." }
-            .removeLifecycleEventListener(this)
+        val reactContext = requireReactContext { "[RNScreens] ReactContext missing in onHostResume! This should not happen." }
+        check(maybeInitDummyLayoutWithHeader(reactContext)) { "[RNScreens] Failed to initialise dummy layout in onHostResume. This is not expected."}
+        reactContext.removeLifecycleEventListener(this)
     }
 
     override fun onHostPause() = Unit

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -50,17 +50,26 @@ internal class ScreenDummyLayoutHelper(
         }
 
         weakInstance = WeakReference(this)
-        ensureDummyLayoutWithHeader(reactContext)
+        maybeInitDummyLayoutWithHeader(reactContext)
     }
 
     /**
      * Initializes dummy view hierarchy with CoordinatorLayout, AppBarLayout and dummy View.
      * We utilize this to compute header height (app bar layout height) from C++ layer when its needed.
+     *
+     * @return boolean whether the layout was initialised or not
      */
-    private fun ensureDummyLayoutWithHeader(reactContext: ReactApplicationContext) {
+    private fun maybeInitDummyLayoutWithHeader(reactContext: ReactApplicationContext): Boolean {
         if (::coordinatorLayout.isInitialized) {
-            return
+            return true
         }
+
+        if (reactContext.currentActivity == null) {
+            Log.w(TAG, "[RNScreens] Attempt to use context detached from activity")
+            return false
+        }
+
+        reactContext.isBridgeless
 
         // We need to use activity here, as react context does not have theme attributes required by
         // AppBarLayout attached leading to crash.
@@ -108,6 +117,8 @@ internal class ScreenDummyLayoutHelper(
             addView(appBarLayout)
             addView(dummyContentView)
         }
+
+        return true
     }
 
     /**
@@ -121,12 +132,20 @@ internal class ScreenDummyLayoutHelper(
         fontSize: Int,
         isTitleEmpty: Boolean,
     ): Float {
-        if (!::coordinatorLayout.isInitialized) {
-            Log.e(
-                TAG,
-                "[RNScreens] Attempt to access dummy view hierarchy before it is initialized",
-            )
-            return 0.0f
+        if (!isDummyLayoutInitialised) {
+            // On Fabric & "bridgefull" context is not yet attached to activity at the moment
+            // of package creation, thus we need to initialize the view hierarchy lazily.
+
+            val reactContext = requireReactContext { "[RNScreens] Context was null-ed before dummy layout was initialized" }
+            if (!maybeInitDummyLayoutWithHeader(reactContext)) {
+                throw IllegalStateException("[RNScreens] Failed to lazy-init dummy layout")
+            }
+
+//            Log.e(
+//                TAG,
+//                "[RNScreens] Attempt to access dummy view hierarchy before it is initialized",
+//            )
+//            return 0.0f
         }
 
         if (cache.hasKey(CacheKey(fontSize, isTitleEmpty))) {
@@ -168,9 +187,13 @@ internal class ScreenDummyLayoutHelper(
         return headerHeight
     }
 
-    private fun requireReactContext(): ReactApplicationContext =
+    private fun requireReactContext(lazyMessage: (() -> Any)? = null): ReactApplicationContext =
         requireNotNull(reactContextRef.get()) {
-            "[RNScreens] Attempt to require missing react context"
+            if (lazyMessage != null) {
+                lazyMessage()
+            } else {
+                "[RNScreens] Attempt to require missing react context"
+            }
         }
 
     private fun requireActivity(): Activity =
@@ -195,6 +218,8 @@ internal class ScreenDummyLayoutHelper(
         @JvmStatic
         fun getInstance(): ScreenDummyLayoutHelper? = weakInstance.get()
     }
+
+    private val isDummyLayoutInitialised = ::coordinatorLayout.isInitialized
 }
 
 private data class CacheKey(


### PR DESCRIPTION
## Description

When running on Fabric + "bridgefull" combination, react packages are initialised very early in application lifetime (much earlier than in Fabric + bridgeless), when there is no activity injected to `ReactContext` yet. Thus when creating packages they do not have access to the activity and we relied on this access up to this moment to setup `ScreenDummyLayoutHelper` object, throwing exception if activity was not available. 

## Changes

This diff delays initialisation of the dummy layout in case there is no access to activity when creating the object up to the point of invocation of `onHostResume` callbacks of `ReactContext` (this is the very moment activity is injected into the context), avoiding the crash. There is also fallback mechanism added in `computeDummyLayout` method, so that when accessed from C++ layer it has another chance of initialising the dummy layout, before performing computations. If it fails (see below for reasons why it might fail) `0f` is returned as header height causing content jump, but not crashing the application.

> [!important]
**Most likely** there is a race condition in this code. `onHostResume` is called from UI thread at the execution point, when JS thread & first native render & thus commit & layout is  already in progress on background thread. In case JS thread proceeds to layout & `computeDummyLayout` is called from our Screen component descriptor before `onHostResume` is called on UI thread & the dummy layout is initialised, we hit the case when computing header height will not be possible due to uninitialised dummy layout. 
I failed to trigger this behaviour even once for ~30 min of testing with trying to put UI thread to sleep etc., however I've also failed to find a proof that it won't happen because of some synchronisation / execution order.

What's also important is that there is no good way to synchronise these threads, because it is not the matter of exclusive access to some critical section, but rather a order of access between UI & background thread. Some barrier mechanism would be required here, however we do not have thread references accessible from our code. 

> [!note] 
One possible solution would be to synchronise access to `maybeInitDummyLayoutWithHeader` method & in case the background thread hits it before UI, we could wait for UI in some kind of loop ("slow spinlock"). This could guarantee correctness, however it is crazy bad, because we would impede whole render process for possibly long time. Despite the flaws of this approach this might be something to consider for the future.

> [!caution]
One more thing to note is that I rely on [JVM atomicity guarantees](https://docs.oracle.com/javase/tutorial/essential/concurrency/atomic.html) when reading / writing `isDummyLayoutInitialized` variable. There is danger that both threads hit the layout initialisation code at the same time and thus leading to corruption. TODO: try to handle this case more gracefully. A lock for initialisation code should be enough. 

## Test code and steps to reproduce

Run `FabricExample` with `load(bridgelessEnabled = false)` set in `MainApplication` and see that it now works. 

## Checklist

- [x] Ensured that CI passes
