### PR TITLE
fix(Android,Fabric,bridgeless): crash on RN hot reload in dev mode when redbox in presentation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -237,7 +237,7 @@ internal class ScreenDummyLayoutHelper(
     }
 
     // This value is fetched / stored from UI and background thread. Volatile here ensures
-    // that updates are visible to the other thread. This
+    // that updates are visible to the other thread.
     @Volatile
     private var isLayoutInitialized = false
 

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -47,7 +47,7 @@ internal class ScreenDummyLayoutHelper(
         try {
             System.loadLibrary(LIBRARY_NAME)
         } catch (e: UnsatisfiedLinkError) {
-            Log.w(TAG, "Failed to load $LIBRARY_NAME")
+            Log.w(TAG, "[RNScreens] Failed to load $LIBRARY_NAME library.")
         }
 
         weakInstance = WeakReference(this)

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.utils
 
 import android.app.Activity
+import android.content.Context
 import android.util.Log
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -57,8 +58,12 @@ internal class ScreenDummyLayoutHelper(
     }
 
     /**
-     * Initializes dummy view hierarchy with CoordinatorLayout, AppBarLayout and dummy View.
+     * Tries to initialize dummy view hierarchy with CoordinatorLayout, AppBarLayout and dummy View.
      * We utilize this to compute header height (app bar layout height) from C++ layer when its needed.
+     *
+     * This method might fail in case there is activity attached to the react context.
+     *
+     * This method is called from various threads!
      *
      * @return boolean whether the layout was initialised or not
      */
@@ -67,6 +72,7 @@ internal class ScreenDummyLayoutHelper(
             return true
         }
 
+        // Possible data race here - activity is injected into context on UI thread.
         if (!reactContext.hasCurrentActivity()) {
             return false
         }
@@ -74,8 +80,25 @@ internal class ScreenDummyLayoutHelper(
         // We need to use activity here, as react context does not have theme attributes required by
         // AppBarLayout attached leading to crash.
         val contextWithTheme =
-            requireNotNull(reactContext.currentActivity) { "[RNScreens] Attempt to use context detached from activity" }
+            requireNotNull(reactContext.currentActivity) { "[RNScreens] Attempt to use context detached from activity. This could happen only due to race-condition." }
 
+        synchronized(this) {
+            // The layout could have been initialised when this thread waited for access to critical section.
+            if (isLayoutInitialized) {
+                return true
+            }
+            initDummyLayoutWithHeader(contextWithTheme)
+        }
+        return true
+    }
+
+    /**
+     * Initialises the dummy layout. This method is **not** thread-safe.
+     *
+     * @param contextWithTheme this function expects the context to have theme attributes required
+     * to initialize the AppBarLayout.
+     */
+    private fun initDummyLayoutWithHeader(contextWithTheme: Context) {
         coordinatorLayout = CoordinatorLayout(contextWithTheme)
 
         appBarLayout =
@@ -119,7 +142,6 @@ internal class ScreenDummyLayoutHelper(
         }
 
         isLayoutInitialized = true
-        return true
     }
 
     /**
@@ -141,7 +163,7 @@ internal class ScreenDummyLayoutHelper(
                 // is still null at this execution point. We don't wanna crash in such case, thus returning zeroed height.
                 Log.e(
                     TAG,
-                    "[RNScreens] Failed to late-init layout while computing header height. This is a race-condition-bug in react-native-screens, please file an issue at https://github.com/software-mansion/react-native-screens/issues"
+                    "[RNScreens] Failed to late-init layout while computing header height. This is most likely a race-condition-bug in react-native-screens, please file an issue at https://github.com/software-mansion/react-native-screens/issues"
                 )
                 return 0.0f
             }
@@ -214,18 +236,29 @@ internal class ScreenDummyLayoutHelper(
         fun getInstance(): ScreenDummyLayoutHelper? = weakInstance.get()
     }
 
+    // This value is fetched / stored from UI and background thread. Volatile here ensures
+    // that updates are visible to the other thread. This
+    @Volatile
     private var isLayoutInitialized = false
 
     override fun onHostResume() {
         // This is the earliest we have guarantee that the context has a reference to an activity.
         val reactContext = requireReactContext { "[RNScreens] ReactContext missing in onHostResume! This should not happen." }
-        check(maybeInitDummyLayoutWithHeader(reactContext)) { "[RNScreens] Failed to initialise dummy layout in onHostResume. This is not expected."}
-        reactContext.removeLifecycleEventListener(this)
+
+        // There are some exotic edge cases where activity might not be present in context
+        // at this point, e.g. when reloading RN in development after an error was reported with redbox.
+        if (maybeInitDummyLayoutWithHeader(reactContext)) {
+            reactContext.removeLifecycleEventListener(this)
+        } else {
+            Log.w(TAG, "[RNScreens] Failed to initialise dummy layout in onHostResume.")
+        }
     }
 
     override fun onHostPause() = Unit
 
-    override fun onHostDestroy() = Unit
+    override fun onHostDestroy() {
+        reactContextRef.get()?.removeLifecycleEventListener(this)
+    }
 }
 
 private data class CacheKey(


### PR DESCRIPTION
## Description

There was a crash on Android + Fabric + bridgeless:

1. trigger a redbox by triggering some JS error (e.g. call a method that does not exist),
2. fast refresh react-native,
3. see the crash in `onHostResume`.

The application crashed because we had a check for not null activity in reactContext. 
However after such reload ReactContext is recreated with null activity!!!.

In such case, when we don't have access to the activity, we're currently unable to create the dummy layout,
so the best we can do is not fail. The fix for jumping layout won't work, however.

This PR also adds synchornization on `synchornied` block in `maybeInitDummyLayoutWithHeaderMethod`, which should prevent
a possible data race, where both threads could try to create dummy layout simmultaneously. 

## Changes

* Do not fail in `onHostResume` when there is no activity present in the provided context,
* only log a warning in the described case,
* synchronize layout initialisation, so that there is no data race <- I'm not sure it was real due to JVM atomicity guarantees, however this time I prefer the "better safe than sorry" approach,
* mark `isLayoutInitialized` variable as `Volatile`, to ensure that updates from one thread are visible on the other thread.


## Test code and steps to reproduce

Desribed above ^ in the "Description" section.

## Checklist

- [ ] Ensured that CI passes

