### PR TITLE
fix(Android,Fabric): add missing `DoNotStrip` annotation to JNI-accessed methods

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -19,6 +19,7 @@ import java.lang.ref.WeakReference
  * See https://github.com/software-mansion/react-native-screens/pull/2169
  * for more detailed description of the issue this code solves.
  */
+@DoNotStrip
 internal class ScreenDummyLayoutHelper(
     reactContext: ReactApplicationContext,
 ) : LifecycleEventListener {

--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.PixelUtil
@@ -129,6 +130,7 @@ internal class ScreenDummyLayoutHelper(
      * @param fontSize font size value as passed from JS
      * @return header height in dp as consumed by Yoga
      */
+    @DoNotStrip
     private fun computeDummyLayout(
         fontSize: Int,
         isTitleEmpty: Boolean,
@@ -210,6 +212,7 @@ internal class ScreenDummyLayoutHelper(
         // dummy view hierarchy.
         private var weakInstance = WeakReference<ScreenDummyLayoutHelper>(null)
 
+        @DoNotStrip
         @JvmStatic
         fun getInstance(): ScreenDummyLayoutHelper? = weakInstance.get()
     }


### PR DESCRIPTION
## Description

Due to missing `DoNotStrip` annotations proguard could treat the class & methods as unused (as reported in #2286)
and remove them completely. 

Possibly fixes #2286.

## Changes

Annotate `ScreenDummyLayoutHelper` class & all method accessed via JNI.

## Test code and steps to reproduce

Haven't triggerred the error localy, relying on report in #2286

## Checklist

- [ ] Ensured that CI passes

