### PR TITLE
chore(deps): bump rexml from 3.2.8 to 3.3.3

### DIFF
--- a/FabricExample/Gemfile.lock
+++ b/FabricExample/Gemfile.lock
@@ -75,21 +75,21 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.3)
+      strscan
     ruby-macho (2.5.1)
     strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.2, < 4.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Description

This PR aggregates dependabot PRs to update rexml from 3.2.8 to 3.3.3 version in example apps.

## Changes

- https://github.com/software-mansion/react-native-screens/pull/2296

## Checklist

- [ ] Ensured that CI passes
