### PR TITLE
docs: Add workflow to publish GitHub pages

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,6 +12,9 @@ jobs:
   publish:
     if: github.repository == 'software-mansion/react-native-screens'
     runs-on: ubuntu-latest
+    concurrency:
+        group: docs-check-${{ github.ref }}
+        cancel-in-progress: true
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,32 @@
+name: Publish Screens landing page
+env:
+  YARN_ENABLE_HARDENED_MODE: 0
+on:
+  push:
+    branches:
+      - main
+    paths: docs/**
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: github.repository == 'software-mansion/react-native-screens'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Generate landing page content
+        run: >-
+          git config --local user.email "action@github.com"
+          && git config --local user.name "GitHub Action"
+          && cd docs
+          && yarn
+          && yarn build
+
+      - name: Publish generated content to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          FOLDER: docs/build
+          BRANCH: gh-pages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds additional workflow to publish landing page on GitHub pages whenever there's a change on main inside the `docs` directory.

## Changes

- Added workflow for publishing landing page
- Added .nojekyll file

## Checklist

- [x] Ensured that CI passes
