### PR TITLE
docs: Fix layout of screen sequence animation

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -14,7 +14,9 @@ import styles from './styles.module.css';
 export default function Home() {
   return (
     <Layout description="Native Navigation primitives for your React Native app.">
-      <LandingBackground />
+      <div>
+        <LandingBackground />
+      </div>
       <div className={styles.container}>
         <HomepageStartScreen />
       </div>


### PR DESCRIPTION
## Description

So previously, when there was a production build, screens from screen sequence in hero were wrongly moving into incorrect div. I've wrapped whole sequence into an additional div, so to disallow screens from moving there (somehow it fixes this issue).

## Changes

- Wrapped page with additional divs

## Screenshots / GIFs

### Before

![CleanShot 2024-08-13 at 16 40 24@2x](https://github.com/user-attachments/assets/4dc505df-66e7-40a3-bde9-6d334f384c7e)

### After

![CleanShot 2024-08-13 at 16 39 23@2x](https://github.com/user-attachments/assets/6bee706c-d642-4ef1-9d0f-d70105d711d9)

## Checklist

- [ ] Ensured that CI passes
