### PR TITLE
chore(Android): removed redundant FabricViewStateManager comment

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -87,7 +87,6 @@ open class ScreenViewManager :
         stateWrapper: StateWrapper?,
     ): Any? {
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // fabricViewStateManager should never be null in Fabric. The null check is only for Paper's empty impl.
             view.setStateWrapper(stateWrapper)
         }
         return super.updateState(view, props, stateWrapper)


### PR DESCRIPTION
## Description

This PR removes a comment related to `FabricViewStateManager` that is unnecessary since it was replaced with `StateWrapper` by https://github.com/software-mansion/react-native-screens/pull/2218/commits/536b096bc3254a85cee9ff765034f5a0953fa3cc.

## Changes

- removed comment
