### PR TITLE
Fixing Android keyboard adjustResize not working with status bar tran…

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.swmansion.rnscreens.Screen.WindowTraits
+import kotlin.math.max
 
 object ScreenWindowTraits {
     // Methods concerning statusBar management were taken from `react-native`'s status bar module:
@@ -39,6 +40,7 @@ object ScreenWindowTraits {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     val windowInsets =
                         defaultInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+                    val imeInsets = defaultInsets.getInsets(WindowInsetsCompat.Type.ime())
 
                     return WindowInsetsCompat
                         .Builder()
@@ -48,7 +50,7 @@ object ScreenWindowTraits {
                                 windowInsets.left,
                                 0,
                                 windowInsets.right,
-                                windowInsets.bottom,
+                                max(windowInsets.bottom, imeInsets.bottom),
                             ),
                         ).build()
                 } else {


### PR DESCRIPTION
…slucent

## Description

In android, the adjustResize soft input mode is not working as expected when status bar is set as translucent.
react-native version: 0.74.3
react-native-screens version: 3.34.0

Fixes #2308

## Changes

- Fixed an issue with window insets where the keyboard (IME) height was not being accurately calculated.
- Replaced the old handling of WindowInsetsCompat.Type.statusBars() with a new implementation that includes the keyboard inset (WindowInsetsCompat.Type.ime()).
- This ensures correct bottom insets handling when the keyboard is open by taking the maximum of the system bars and IME insets.

Example where issue is reproducible - https://github.com/1880akshay/RN_NewArch_TextInput/tree/android-keyboard