### PR TITLE
fix(Android): getChildDrawingOrder when using refreshcontrol

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -9,9 +9,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
+import android.widget.ImageView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
@@ -363,7 +365,7 @@ class Screen(
         parent?.let {
             for (i in 0 until it.childCount) {
                 val child = it.getChildAt(i)
-                if (child.javaClass.simpleName.equals("CircleImageView")) {
+                if (parent is SwipeRefreshLayout && child is ImageView) {
                     // SwipeRefreshLayout class which has CircleImageView as a child,
                     // does not handle `startViewTransition` properly.
                     // It has a custom `getChildDrawingOrder` method which returns


### PR DESCRIPTION
## Description
Fixes #2329

## Changes
- Changes how we check if the child is a CircleImageView to be minification safe


## Test code and steps to reproduce
Build `[this](https://github.com/BenIrving/refreshcontrolrepro/tree/main)` repro using this changeset, observe no crash when navigating between screens.

You can also check `Test640.tsx` test by going into the second screen (by button), then try to manually refresh list by swiping down (until the refresh control will show). During the refresh, try to go back to the first screen - application shouldn't crash.

## Checklist

- [x] Ensured that CI passes
