### PR TITLE
fix(iOS): modal not presenting when deep in stack

### DIFF
--- a/apps/src/tests/TestModalNavigation.tsx
+++ b/apps/src/tests/TestModalNavigation.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { NativeStackScreenProps, createNativeStackNavigator } from '@react-navigation/native-stack';
+
+type StackParamList = {
+  Home: undefined;
+  NestedStack: undefined;
+  MainStackScreen: undefined;
+  Screen1: undefined;
+  Screen2: undefined;
+  Screen3: undefined;
+};
+
+function HomeScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Home'>) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Home Screen</Text>
+      <Button
+        title="Navigate to Screen 1"
+        onPress={() => navigation.navigate('NestedStack')}
+      />
+    </View>
+  );
+}
+
+function MainStackScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Main stack screen</Text>
+    </View>
+  );
+}
+
+function Screen1({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Screen1'>) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Screen 1</Text>
+      <Button
+        title="Navigate to Screen 2"
+        onPress={() => navigation.navigate('Screen2')}
+      />
+    </View>
+  );
+};
+
+function Screen2({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Screen2'>) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Screen 2</Text>
+      <Button
+        title="Navigate to MainStackScreen - WORKS fine"
+        onPress={() => navigation.navigate('MainStackScreen')}
+      />
+      <Button
+        title="Navigate to Screen 3"
+        onPress={() => navigation.navigate('Screen3')}
+      />
+    </View>
+  );
+};
+
+function Screen3({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Screen3'>) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Screen 3</Text>
+      <Button
+        title="Navigate to MainStackScreen - NOT working"
+        onPress={() => navigation.navigate('MainStackScreen')}
+      />
+      <Button
+        title="Navigate to Screen 2"
+        onPress={() => navigation.navigate('Screen2')}
+      />
+    </View>
+  );
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+const NestedStack = createNativeStackNavigator<StackParamList>();
+
+function RootStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="NestedStack" component={NestedStackScreen} options={{ headerShown: true, presentation: 'modal' }} />
+      <Stack.Screen name="MainStackScreen" component={MainStackScreen} options={{ headerShown: true, presentation: 'modal' }} />
+    </Stack.Navigator>
+  );
+}
+
+function NestedStackScreen() {
+  return (
+    <NestedStack.Navigator screenOptions={{ presentation: 'modal' }}>
+      <NestedStack.Screen name="Screen1" component={Screen1} />
+      <NestedStack.Screen name="Screen2" component={Screen2} />
+      <NestedStack.Screen name="Screen3" component={Screen3} />
+    </NestedStack.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <RootStack />
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -113,4 +113,4 @@ export { default as Test2271 } from './Test2271';
 export { default as Test2282 } from './Test2282';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestHeader } from './TestHeader';
-
+export { default as TestModalNavigation } from './TestModalNavigation';

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -513,13 +513,6 @@ namespace react = facebook::react;
       [changeRootController dismissViewControllerAnimated:shouldAnimate completion:finish];
       return;
     }
-
-    UIViewController *lastModalVc = [self lastFromPresentedViewControllerChainStartingFrom:firstModalToBeDismissed];
-
-    if (lastModalVc != firstModalToBeDismissed) {
-      [lastModalVc dismissViewControllerAnimated:shouldAnimate completion:finish];
-      return;
-    }
   }
 
   // changeRootController does not have presentedViewController but it does not mean that no modals are in presentation;


### PR DESCRIPTION
## Description

When 3 screens with a ‘modal’ presentation mode are stacked, navigating to a screen outside of the current stack is not functioning correctly.

## Changes

Removed dismissing logic for `lastModalVc`.

## Screenshots / GIFs

### Before
https://github.com/user-attachments/assets/d4991253-52f1-4f35-8698-242d98b218d1

### After
https://github.com/user-attachments/assets/571ebd45-7319-4225-ab5b-4f68027f4f09

## Test code and steps to reproduce

`TestModalNavigation` was added to tests.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
