### PR TITLE
Monorepo Support: Use node resolver for react native location

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -150,13 +150,13 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
 
         // Use node resolver to locate react-native package
-        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, projectDir).text.trim())
+        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
         if (reactNativePackage.exists()) {
             url "$reactNativePackage.parentFile/android"
         }
         // Fallback to react-native package colocated in node_modules
         else {
-            url "$projectDir/../node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -148,10 +148,18 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
-        url "$projectDir/../node_modules/react-native/android"
+
+        // Use node resolver to locate react-native package
+        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, projectDir).text.trim())
+        if (reactNativePackage.exists()) {
+            url "$reactNativePackage.parentFile/android"
+        }
+        // Fallback to react-native package colocated in node_modules
+        else {
+            url "$projectDir/../node_modules/react-native/android"
+        }
     }
+
     mavenCentral()
     mavenLocal()
     google()

--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -91,7 +91,7 @@ To begin with, let install all dependencies:
 
 1. `yarn`
 2. `yarn submodules`
-3. `(cd react-navigation && yarn prepare)`
+3. `yarn prepare`
 4. `cd Example`
 5. `yarn`
 6. `yarn start` &ndash; make sure to start metro bundler before building the app in Android Studio
@@ -108,7 +108,7 @@ To begin with, let install all dependencies:
 
 1. `yarn`
 2. `yarn submodules`
-3. `(cd react-navigation && yarn prepare)`
+3. `yarn prepare`
 4. `cd Example`
 5. `yarn`
 6. `(cd ios && pod install)`


### PR DESCRIPTION
## Description

Monorepos are configured and structured on what works best for the project. Since this can vary from project to project, having a dynamic way to find dependencies will make this work for more projects. Currently, the repo only supports certain configurations of Monorepo structures. This PR adopts a similar approach as Expo to locate the react native package within the project. [Expo usage for reference]( https://github.com/expo/expo/blob/9821f2f8c8927d930a15041f22cd55e28f443274/packages/expo-modules-core/README.md?plain=1#L65)

## Changes

- Updates `build.gradle` to have node resolve the react native package directory
- Updates `CONTRIBUTING.md` to correct setup step as `yarn prepare` does not exist inside of `react-navigation` submodule.

## Test code and steps to reproduce

1. Put a `println` statement in the `build.gradle` file to examine the output of `reactNativePackage.parentFile`
2. Build Example app for android
3. Build FabricExample app for android
4. Both apps build successfully.

## Checklist

- [ ] ~Included code example that can be used to test this change~
- [ ] ~Updated TS types~
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/CONTRIBUTING.md
- [ ] Ensured that CI passes
