### PR TITLE
add workaround to fix webView fullScreen black screen

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -471,6 +471,14 @@ namespace react = facebook::react;
   UINavigationItem *navitem = vc.navigationItem;
   UINavigationController *navctr = (UINavigationController *)vc.parentViewController;
 
+  // When modal is shown the underlying RNSScreen isn't attached to any navigation controller.
+  // During the modal dismissal transition this update method is called on this RNSScreen resulting in nil navctr.
+  // After the transition is completed it will be called again and will configure the navigation controller correctly.
+  // Also see: https://github.com/software-mansion/react-native-screens/pull/2336
+  if (navctr == nil) {
+    return;
+  }
+
   NSUInteger currentIndex = [navctr.viewControllers indexOfObject:vc];
   UINavigationItem *prevItem =
       currentIndex > 0 ? [navctr.viewControllers objectAtIndex:currentIndex - 1].navigationItem : nil;


### PR DESCRIPTION
Description
Full screen modal was crashing sometimes on WebView.
Fixes https://github.com/software-mansion/react-native-screens/issues/2317.

Test code and steps to reproduce
-none

Checklist
 Included code example that can be used to test this change
 Ensured that CI passes