### PR TITLE
feat: remove not necessary workaround for ScrollView from RN 76

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1387,10 +1387,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
   _isSwiping = NO;
   _shouldNotify = YES;
-#ifdef RCT_NEW_ARCH_ENABLED
-#else
-  [self traverseForScrollView:self.screenView];
-#endif
 }
 
 - (void)viewDidLayoutSubviews
@@ -1791,33 +1787,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     self.view = snapshot;
     [superView addSubview:snapshot];
   }
-}
-
-#else
-#pragma mark - Paper specific
-
-- (void)traverseForScrollView:(UIView *)view
-{
-  if (![[self.view valueForKey:@"_bridge"] valueForKey:@"_jsThread"]) {
-    // we don't want to send `scrollViewDidEndDecelerating` event to JS before the JS thread is ready
-    return;
-  }
-
-  if ([NSStringFromClass([view class]) isEqualToString:@"AVPlayerView"]) {
-    // Traversing through AVPlayerView is an uncommon edge case that causes the disappearing screen
-    // to an excessive traversal through all video player elements
-    // (e.g., for react-native-video, this includes all controls and additional video views).
-    // Thus, we want to avoid unnecessary traversals through these views.
-    return;
-  }
-
-  if ([view isKindOfClass:[UIScrollView class]] &&
-      ([[(UIScrollView *)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)])) {
-    [[(UIScrollView *)view delegate] scrollViewDidEndDecelerating:(id)view];
-  }
-  [view.subviews enumerateObjectsUsingBlock:^(__kindof UIView *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-    [self traverseForScrollView:obj];
-  }];
 }
 #endif
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Due to fixes in RN 0.76 (https://github.com/facebook/react-native/commit/b98b9f1fa7717283f368eb182a51d971b8776c80 and https://github.com/facebook/react-native/commit/c6f32828b9487381dab27f645aedcdbae9dcbc7e) our workaround seems to not be necessary anymore. Would be nice to check if it works in RN 0.76 on both archs before merging it 😄 Right now this PR does not contain check for RN 0.76 since we have no such flag in `iOS` code so it is WIP.

