### PR TITLE
fix!: always set Zindex to undefined for InnerScreen

### DIFF
--- a/apps/src/tests/Test2232.tsx
+++ b/apps/src/tests/Test2232.tsx
@@ -35,7 +35,7 @@ const App = () => (
         component={SettingsScreen}
         options={{
           headerTintColor: 'hotpink',
-          headerBackTitleVisible: false,
+          headerBackButtonDisplayMode: 'minimal',
           headerTitle: () => (
             <View style={{ gap: 16, flexDirection: 'row' }}>
               <Square color="green" size={20} />

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -95,6 +95,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         isNativeStack,
         gestureResponseDistance,
         onGestureCancel,
+        style,
         ...props
       } = rest;
 
@@ -125,6 +126,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         <DelayedFreeze freeze={freezeOnBlur && activityState === 0}>
           <AnimatedScreen
             {...props}
+            style={[style, { zIndex: undefined }]}
             activityState={activityState}
             sheetAllowedDetents={sheetAllowedDetents}
             sheetLargestUndimmedDetent={sheetLargestUndimmedDetent}

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -126,6 +126,10 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         <DelayedFreeze freeze={freezeOnBlur && activityState === 0}>
           <AnimatedScreen
             {...props}
+            // Hierarchy of screens is handled on the native side and setting zIndex value causes this issue:
+            // https://github.com/software-mansion/react-native-screens/issues/2345
+            // With below change of zIndex, we force RN diffing mechanism to NOT include detaching and attaching mutation in one transaction.
+            // Detailed information can be found here https://github.com/software-mansion/react-native-screens/pull/2351
             style={[style, { zIndex: undefined }]}
             activityState={activityState}
             sheetAllowedDetents={sheetAllowedDetents}


### PR DESCRIPTION
## Description
Together with @kkafar we noticed that when switching back between BottomTabsView (A -> B -> A) , React is calling removeScreenAt and addScreen for tab we are leaving - in the same transaction! Because of that and asynchronous nature of react-native-screens, error described in #2345 exist. We also noticed that this weir behaviour is related to setting ZIndex in InnerScreen.

Fixes #2345

Test 2232 was failing due to change in headerBackTitleVisible property.

> [!Caution]
@kkafar:
Note that this change might be potentially breaking since we're effectively removing possibility of managing `Screen` components through "z indices", breaking public API. 

@kkafar:
The error mechanism is as follows:

1. `zIndex` being set causes RN diffing mechanism to include two mutations on the same view in the same transaction - effectively detaching and attaching it,
2. Thus when we navigate from tab B to A, react first detaches B from screen container and in the same transaction it attaches it again - however at the moment of reattach react expects B to be detached. This is not case due to the fact, that we don't execute updates synchronously, but rather we just schedule them in another block on UI thread;
3. React asserts the invariant from point 2., and when we violate it, its internal state gets corrupted later leading to crash. 

We detected that getting rid of setting `zIndex` on screens prevents the two consecutive operations on the same screen to appear, thus effectively solving the problem. 

Note, however, that we still won't support such cases with multiple mount/unmount mutations related to the same component in single transaction. 

## Changes


- For every InnerScreen created we set/override ZIndex style to undefined.
- Use headerBackButtonDisplayMode instead of headerBackTitleVisible.


## Test code and steps to reproduce


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
