### PR TITLE
feat: add monorepo support for Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,25 +152,23 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        def rnPackage = "$projectDir/../node_modules/react-native/android"
-        url "$projectDir/../node_modules/react-native/android"
-        println("old solution")
-        println(rnPackage)
 
-//        // Use node resolver to locate react-native package
-        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
-        if (reactNativePackage.exists()) {
-            def newRnPackage = "$reactNativePackage.parentFile/android"
-            println("eagerly found")
-            println(newRnPackage)
-            url "$reactNativePackage.parentFile/android"
-        }
-        // Fallback to react-native package colocated in node_modules
-        {
-            def newRnPackage = "$rootDir/../node_modules/react-native/android"
-            println("modified old solution")
-            println(newRnPackage)
-//            url "$rootDir/../node_modules/react-native/android"
+        // First look for the standard location of react-native, as in RN Hello World template
+        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
+        // TODO(kkafar): Note, that in latest template app https://github.com/react-native-community/template/blob/0f4745b7a9d84232aeedec2def8d75ab9b050d11/template/android/build.gradle
+        // this is not specified at all.
+        File standardRnAndroidDirLocation = file("$rootDir/../node_modules/react-native/android")
+        if (standardRnAndroidDirLocation.exists()) {
+            url standardRnAndroidDirLocation
+        } else {
+            // We're in non standard setup - try to use node resolver to locate the react-native package.
+            File reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+            def rnAndroidDirLocation = "$reactNativePackage.parentFile/android"
+            if (reactNativePackage.exists()) {
+                url rnAndroidDirLocation
+            } else {
+                println "[RNScreens] Failed to resolve react-native directory. Attempted locations: ${standardRnAndroidDirLocation}, ${rnAndroidDirLocation}"
+            }
         }
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,15 +152,25 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        def rnPackage = "$projectDir/../node_modules/react-native/android"
+        url "$projectDir/../node_modules/react-native/android"
+        println("old solution")
+        println(rnPackage)
 
-        // Use node resolver to locate react-native package
+//        // Use node resolver to locate react-native package
         def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
         if (reactNativePackage.exists()) {
+            def newRnPackage = "$reactNativePackage.parentFile/android"
+            println("eagerly found")
+            println(newRnPackage)
             url "$reactNativePackage.parentFile/android"
         }
         // Fallback to react-native package colocated in node_modules
-        else {
-            url "$rootDir/../node_modules/react-native/android"
+        {
+            def newRnPackage = "$rootDir/../node_modules/react-native/android"
+            println("modified old solution")
+            println(newRnPackage)
+//            url "$rootDir/../node_modules/react-native/android"
         }
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,10 +152,18 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
-        url "$projectDir/../node_modules/react-native/android"
+
+        // Use node resolver to locate react-native package
+        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, projectDir).text.trim())
+        if (reactNativePackage.exists()) {
+            url "$reactNativePackage.parentFile/android"
+        }
+        // Fallback to react-native package colocated in node_modules
+        else {
+            url "$projectDir/../node_modules/react-native/android"
+        }
     }
+
     mavenCentral()
     mavenLocal()
     google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -154,13 +154,13 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
 
         // Use node resolver to locate react-native package
-        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, projectDir).text.trim())
+        def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
         if (reactNativePackage.exists()) {
             url "$reactNativePackage.parentFile/android"
         }
         // Fallback to react-native package colocated in node_modules
         else {
-            url "$projectDir/../node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
 


### PR DESCRIPTION

## Description

Based on: https://github.com/software-mansion/react-native-screens/pull/2337 by @morganick.
Please see the original PR and its description for details.

See: https://github.com/software-mansion/react-native-screens/pull/2337#pullrequestreview-2328416182
for discussion why new PR has been created.

## Changes

- **Using node resolver to find react native package for better monorepo support**
- **Using rootDir instead of projectDir**
- **Change the order of path lookup**

## Test code and steps to reproduce

I've tested it using our both example apps and additionally I've created fresh RN app
and tested the Android build there.


## Checklist

- [x] Ensured that CI passes

