### PR TITLE
feat: expose `none` & `largest` values for `sheetLargestUndimmedDetent` prop

### DIFF
--- a/apps/src/tests/Test1649/state.tsx
+++ b/apps/src/tests/Test1649/state.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import * as jotai from 'jotai';
 import { AllowedDetentsType, SheetOptions } from './types';
+import { SHEET_DIMMED_ALWAYS } from 'react-native-screens';
 
 export const sheetInitialOptions: SheetOptions = {
   sheetAllowedDetents: [0.4, 0.6, 0.9],
   // sheetAllowedDetents: [0.6],
   // sheetAllowedDetents: 'fitToContents',
-  sheetLargestUndimmedDetent: 2,
+  sheetLargestUndimmedDetent: SHEET_DIMMED_ALWAYS,
   sheetGrabberVisible: false,
   sheetCornerRadius: 24,
   sheetExpandsWhenScrolledToEdge: true,

--- a/apps/src/tests/Test1649/state.tsx
+++ b/apps/src/tests/Test1649/state.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import * as jotai from 'jotai';
 import { AllowedDetentsType, SheetOptions } from './types';
-import { SHEET_DIMMED_ALWAYS } from 'react-native-screens';
 
 export const sheetInitialOptions: SheetOptions = {
   sheetAllowedDetents: [0.4, 0.6, 0.9],
   // sheetAllowedDetents: [0.6],
   // sheetAllowedDetents: 'fitToContents',
-  sheetLargestUndimmedDetent: SHEET_DIMMED_ALWAYS,
+  sheetLargestUndimmedDetent: 'none',
   sheetGrabberVisible: false,
   sheetCornerRadius: 24,
   sheetExpandsWhenScrolledToEdge: true,

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -191,7 +191,7 @@ Boolean indicating whether the sheet shows a grabber at the top.
 Works only when `stackPresentation` is set to `formSheet`.
 Defaults to `false`.
 
-### `sheetLargestUndimmedDetent` (iOS only)
+### `sheetLargestUndimmedDetent`
 
 The largest sheet detent for which a view underneath won't be dimmed.
 Works only when `presentation` is set to `formSheet`.
@@ -202,7 +202,7 @@ there won't be a dimming view beneath the sheet.
 There also legacy & **deprecated** prop values available, which work in tandem with
 corresponding legacy proop values for `sheetAllowedDetents` prop.
 
-Defaults to `-1`, indicating that the dimming view should be always present.
+Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
 
 ### `stackAnimation`
 

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -194,15 +194,20 @@ Defaults to `false`.
 ### `sheetLargestUndimmedDetent`
 
 The largest sheet detent for which a view underneath won't be dimmed.
-Works only when `presentation` is set to `formSheet`.
+Works only when `stackPresentation` is set to `formSheet`.
 
 This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
 there won't be a dimming view beneath the sheet.
 
-There also legacy & **deprecated** prop values available, which work in tandem with
-corresponding legacy proop values for `sheetAllowedDetents` prop.
+Additionaly there are following options available:
 
-Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
+* `none` - there will be dimming view for all detents levels,
+* `largest` - there won't be a dimming view for any detent level.
+
+There also legacy & **deprecated** prop values available: `medium`, `large` (don't confuse with `largest`), `all`, which work in tandem with
+corresponding legacy prop values for `sheetAllowedDetents` prop.
+
+Defaults to `none`, indicating that the dimming view should be always present.
 
 ### `stackAnimation`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -304,10 +304,15 @@ Works only when `stackPresentation` is set to `formSheet`.
 This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
 there won't be a dimming view beneath the sheet.
 
-There also legacy & **deprecated** prop values available, which work in tandem with
+Additionaly there are following options available:
+
+* `none` - there will be dimming view for all detents levels,
+* `largest` - there won't be a dimming view for any detent level.
+
+There also legacy & **deprecated** prop values available: `medium`, `large` (don't confuse with `largest`), `all`, which work in tandem with
 corresponding legacy prop values for `sheetAllowedDetents` prop.
 
-Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
+Defaults to `none`, indicating that the dimming view should be always present.
 
 #### `stackAnimation`
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -307,7 +307,7 @@ there won't be a dimming view beneath the sheet.
 There also legacy & **deprecated** prop values available, which work in tandem with
 corresponding legacy prop values for `sheetAllowedDetents` prop.
 
-Defaults to `-1`, indicating that the dimming view should be always present.
+Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
 
 #### `stackAnimation`
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -49,6 +49,9 @@ const SHEET_COMPAT_LARGE = [1.0];
 const SHEET_COMPAT_MEDIUM = [0.5];
 const SHEET_COMPAT_ALL = [0.5, 1.0];
 
+export const SHEET_DIMMED_ALWAYS = -1;
+// const SHEET_DIMMED_NEVER = 9999;
+
 // These exist to transform old 'legacy' values used by the formsheet API to the new API shape.
 // We can get rid of it, once we get rid of support for legacy values: 'large', 'medium', 'all'.
 function resolveSheetAllowedDetents(
@@ -80,10 +83,10 @@ function resolveSheetLargestUndimmedDetent(
   } else if (lud === 'medium') {
     return 0;
   } else if (lud === 'all') {
-    return -1;
+    return SHEET_DIMMED_ALWAYS;
   } else {
     // Safe default, every detent is dimmed
-    return -1;
+    return SHEET_DIMMED_ALWAYS;
   }
 }
 
@@ -112,7 +115,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
     const {
       // formSheet presentation related props
       sheetAllowedDetents = [1.0],
-      sheetLargestUndimmedDetent = -1,
+      sheetLargestUndimmedDetent = SHEET_DIMMED_ALWAYS,
       sheetGrabberVisible = false,
       sheetCornerRadius = -1.0,
       sheetExpandsWhenScrolledToEdge = true,

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -49,7 +49,7 @@ const SHEET_COMPAT_LARGE = [1.0];
 const SHEET_COMPAT_MEDIUM = [0.5];
 const SHEET_COMPAT_ALL = [0.5, 1.0];
 
-export const SHEET_DIMMED_ALWAYS = -1;
+const SHEET_DIMMED_ALWAYS = -1;
 // const SHEET_DIMMED_NEVER = 9999;
 
 // These exist to transform old 'legacy' values used by the formsheet API to the new API shape.
@@ -75,15 +75,18 @@ function resolveSheetAllowedDetents(
 
 function resolveSheetLargestUndimmedDetent(
   lud: ScreenProps['sheetLargestUndimmedDetent'],
+  largestDetentIndex: number,
 ): number {
   if (typeof lud === 'number') {
     return lud;
+  } else if (lud === 'largest') {
+    return largestDetentIndex;
+  } else if (lud === 'none' || lud === 'all') {
+    return SHEET_DIMMED_ALWAYS;
   } else if (lud === 'large') {
     return 1;
   } else if (lud === 'medium') {
     return 0;
-  } else if (lud === 'all') {
-    return SHEET_DIMMED_ALWAYS;
   } else {
     // Safe default, every detent is dimmed
     return SHEET_DIMMED_ALWAYS;
@@ -130,7 +133,10 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       const resolvedSheetAllowedDetents =
         resolveSheetAllowedDetents(sheetAllowedDetents);
       const resolvedSheetLargestUndimmedDetent =
-        resolveSheetLargestUndimmedDetent(sheetLargestUndimmedDetent);
+        resolveSheetLargestUndimmedDetent(
+          sheetLargestUndimmedDetent,
+          resolvedSheetAllowedDetents.length - 1,
+        );
       // Due to how Yoga resolves layout, we need to have different components for modal nad non-modal screens
       const AnimatedScreen =
         Platform.OS === 'android' ||

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,11 +77,6 @@ export {
 } from './utils';
 
 /**
- * Constants
- */
-export { SHEET_DIMMED_ALWAYS } from './components/Screen';
-
-/**
  * Hooks
  */
 export { default as useTransitionProgress } from './useTransitionProgress';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 export * from './types';
 
-/*
+/**
  * Core
  */
 export {
@@ -11,7 +11,7 @@ export {
   shouldUseActivityState,
 } from './core';
 
-/*
+/**
  * RNS Components
  */
 export {
@@ -57,17 +57,17 @@ export {
   NativeScreenContentWrapper,
 } from './components/ScreenContentWrapper';
 
-/*
+/**
  * Modules
  */
 export { default as NativeScreensModule } from './fabric/NativeScreensModule';
 
-/*
+/**
  * Contexts
  */
 export { GHContext } from './native-stack/contexts/GHContext';
 
-/*
+/**
  * Utils
  */
 export {
@@ -76,7 +76,12 @@ export {
   executeNativeBackPress,
 } from './utils';
 
-/*
+/**
+ * Constants
+ */
+export { SHEET_DIMMED_ALWAYS } from './components/Screen';
+
+/**
  * Hooks
  */
 export { default as useTransitionProgress } from './useTransitionProgress';

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -426,7 +426,15 @@ export type NativeStackNavigationOptions = {
    * This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
    * there won't be a dimming view beneath the sheet.
    *
-   * Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
+   * Additionaly there are following options available:
+   *
+   * * `none` - there will be dimming view for all detents levels,
+   * * `largest` - there won't be a dimming view for any detent level.
+   *
+   * There also legacy & **deprecated** prop values available: `medium`, `large` (don't confuse with `largest`), `all`, which work in tandem with
+   * corresponding legacy prop values for `sheetAllowedDetents` prop.
+   *
+   * Defaults to `none`, indicating that the dimming view should be always present.
    */
   sheetLargestUndimmedDetent?: ScreenProps['sheetLargestUndimmedDetent'];
   /**

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -426,7 +426,7 @@ export type NativeStackNavigationOptions = {
    * This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
    * there won't be a dimming view beneath the sheet.
    *
-   * Defaults to `-1`, indicating that the dimming view should be always present.
+   * Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
    */
   sheetLargestUndimmedDetent?: ScreenProps['sheetLargestUndimmedDetent'];
   /**

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -195,7 +195,7 @@ const RouteView = ({
     headerShown,
     hideKeyboardOnSwipe,
     homeIndicatorHidden,
-    sheetLargestUndimmedDetent = -1,
+    sheetLargestUndimmedDetent = 'none',
     sheetGrabberVisible = false,
     sheetCornerRadius = -1.0,
     sheetElevation = 24,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -351,12 +351,23 @@ export interface ScreenProps extends ViewProps {
    * This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
    * there won't be a dimming view beneath the sheet.
    *
-   * There also legacy & **deprecated** prop values available, which work in tandem with
+   * Additionaly there are following options available:
+   *
+   * * `none` - there will be dimming view for all detents levels,
+   * * `largest` - there won't be a dimming view for any detent level.
+   *
+   * There also legacy & **deprecated** prop values available: `medium`, `large` (don't confuse with `largest`), `all`, which work in tandem with
    * corresponding legacy prop values for `sheetAllowedDetents` prop.
    *
-   * Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
+   * Defaults to `none`, indicating that the dimming view should be always present.
    */
-  sheetLargestUndimmedDetent?: number | 'medium' | 'large' | 'all';
+  sheetLargestUndimmedDetent?:
+    | number
+    | 'none'
+    | 'largest'
+    | 'medium'
+    | 'large'
+    | 'all';
   /**
    * Index of the detent the sheet should expand to after being opened.
    * Works only when `stackPresentation` is set to `formSheet`.

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -354,7 +354,7 @@ export interface ScreenProps extends ViewProps {
    * There also legacy & **deprecated** prop values available, which work in tandem with
    * corresponding legacy prop values for `sheetAllowedDetents` prop.
    *
-   * Defaults to `-1`, indicating that the dimming view should be always present.
+   * Defaults to `SHEET_DIMMED_ALWAYS`, indicating that the dimming view should be always present.
    */
   sheetLargestUndimmedDetent?: number | 'medium' | 'large' | 'all';
   /**


### PR DESCRIPTION
## Description

I'm exposing two new options for `sheetLargestUndimmedDetent` prop:

* `none` - denoting that dimming view will be always present,
* `largest` - denoting that dimming view will never be present.

Previously to achieve the effect of `none` you had to either rely on default or pass `-1` raw value.

Similarly achieving the effect of `largest` required user to set a numeric value and update it everytime new detent was added / removed. 

> [!note]
~~As I wrote this description, new idea popped out - instead of exposing numeric constant just add some string options, as with  `sheetAllowedDetents` (it is an array or some predefined string constants).
> What would be the API though? `sheetLargestUndimmedDetent: 'none'`? What's the wording here?~~
>
> *Done! ^^^*

`react-navigation` PR:

* https://github.com/react-navigation/react-navigation/pull/12032


## Changes

Replaced raw `-1` with constants `none` and `largest`.


## Test code and steps to reproduce

`Test1649`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
