### PR TITLE
feat(iOS): sheetInitialDetent support

### DIFF
--- a/apps/src/tests/Test2002.tsx
+++ b/apps/src/tests/Test2002.tsx
@@ -5,9 +5,22 @@ import {
   DefaultTheme,
   NavigationContainer,
 } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
 
-function HomeScreen({ navigation }: any) {
+type StackParamList = {
+  Home: undefined;
+  formSheet: undefined;
+  fullScreenModal: undefined;
+};
+
+function HomeScreen({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
   return (
     <View style={styles.container}>
       <Button
@@ -22,7 +35,11 @@ function HomeScreen({ navigation }: any) {
   );
 }
 
-function ModalScreen({ navigation }: any) {
+function ModalScreen({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
   return (
     <View style={styles.container}>
       <Button onPress={() => navigation.goBack()} title="Dismiss" />
@@ -30,7 +47,7 @@ function ModalScreen({ navigation }: any) {
   );
 }
 
-const RootStack = createNativeStackNavigator();
+const RootStack = createNativeStackNavigator<StackParamList>();
 
 export default function App() {
   const scheme = useColorScheme();
@@ -45,6 +62,7 @@ export default function App() {
           options={{
             presentation: 'formSheet',
             sheetAllowedDetents: [0.3, 0.5, 0.8],
+            sheetInitialDetent: 1,
           }}
         />
         <RootStack.Screen

--- a/apps/src/tests/Test2002.tsx
+++ b/apps/src/tests/Test2002.tsx
@@ -7,7 +7,7 @@ import {
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-function HomeScreen({ navigation }) {
+function HomeScreen({ navigation }: any) {
   return (
     <View style={styles.container}>
       <Button
@@ -22,7 +22,7 @@ function HomeScreen({ navigation }) {
   );
 }
 
-function ModalScreen({ navigation }) {
+function ModalScreen({ navigation }: any) {
   return (
     <View style={styles.container}>
       <Button onPress={() => navigation.goBack()} title="Dismiss" />
@@ -42,7 +42,10 @@ export default function App() {
         <RootStack.Screen
           name="formSheet"
           component={ModalScreen}
-          options={{ presentation: 'formSheet' }}
+          options={{
+            presentation: 'formSheet',
+            sheetAllowedDetents: [0.3, 0.5, 0.8],
+          }}
         />
         <RootStack.Screen
           name="fullScreenModal"

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -90,6 +90,7 @@ namespace react = facebook::react;
 @property (nonatomic) NSNumber *sheetLargestUndimmedDetent;
 @property (nonatomic) BOOL sheetGrabberVisible;
 @property (nonatomic) CGFloat sheetCornerRadius;
+@property (nonatomic) NSInteger sheetInitialDetent;
 @property (nonatomic) BOOL sheetExpandsWhenScrolledToEdge;
 #endif // !TARGET_OS_TV
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1158,6 +1158,10 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
     [self setSheetAllowedDetents:[RNSConvert detentFractionsArrayFromVector:newScreenProps.sheetAllowedDetents]];
   }
 
+  if (newScreenProps.sheetInitialDetent != oldScreenProps.sheetInitialDetent) {
+    [self setSheetInitialDetent:newScreenProps.sheetInitialDetent];
+  }
+
   if (newScreenProps.sheetLargestUndimmedDetent != oldScreenProps.sheetLargestUndimmedDetent) {
     [self setSheetLargestUndimmedDetent:[NSNumber numberWithInt:newScreenProps.sheetLargestUndimmedDetent]];
   }

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -902,13 +902,6 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
           [self setAllowedDetentsForSheet:sheet
                                        to:[self detentsFromMaxHeightFractions:_sheetAllowedDetents]
                                   animate:NO];
-
-          if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
-            UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
-            [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
-          } else if (_sheetInitialDetent != 0) {
-            RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
-          }
         }
       }
     } else
@@ -934,12 +927,6 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
                                          UISheetPresentationControllerDetent.largeDetent
                                        ]
                                   animate:YES];
-          if (_sheetInitialDetent == 1) {
-            [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
-          } else if (_sheetInitialDetent != 0) {
-            RCTLogError(
-                @"[RNScreens] sheetInitialDetent out of bounds, on iOS versions below 16 sheetAllowedDetents array defaults to two items");
-          }
         } else {
           RCTLogError(@"[RNScreens] The values in sheetAllowedDetents array must be sorted");
         }
@@ -955,6 +942,26 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
           [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
         }
       }
+    }
+
+    if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
+      if (@available(iOS 16.0, *)) {
+        UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
+        [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
+      } else
+#endif // Check for iOS >= 16
+      {
+        if (_sheetInitialDetent < 2) {
+          [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+        } else {
+          RCTLogError(
+              @"[RNScreens] sheetInitialDetent out of bounds, on iOS versions below 16 sheetAllowedDetents is ignored in favor of an array of two system-defined detents");
+        }
+      }
+    } else if (_sheetInitialDetent != 0) {
+      RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
     }
 
     sheet.prefersScrollingExpandsWhenScrolledToEdge = _sheetExpandsWhenScrolledToEdge;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -889,8 +889,8 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
     sheet.delegate = self;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
-    if (_sheetAllowedDetents.count > 0) {
-      if (@available(iOS 16.0, *)) {
+    if (@available(iOS 16.0, *)) {
+      if (_sheetAllowedDetents.count > 0) {
         if (_sheetAllowedDetents.count == 1 && [_sheetAllowedDetents[0] integerValue] == SHEET_FIT_TO_CONTENTS) {
           // This is `fitToContents` case, where sheet should be just high to display its contents.
           // Paper: we do not set anything here, we will set once React computed layout of our React's children, namely

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -934,6 +934,12 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
                                          UISheetPresentationControllerDetent.largeDetent
                                        ]
                                   animate:YES];
+          if (_sheetInitialDetent == 1) {
+            [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+          } else if (_sheetInitialDetent != 0) {
+            RCTLogError(
+                @"[RNScreens] sheetInitialDetent out of bounds, on iOS versions below 16 sheetAllowedDetents array defaults to two items");
+          }
         } else {
           RCTLogError(@"[RNScreens] The values in sheetAllowedDetents array must be sorted");
         }

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -902,6 +902,13 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
           [self setAllowedDetentsForSheet:sheet
                                        to:[self detentsFromMaxHeightFractions:_sheetAllowedDetents]
                                   animate:NO];
+
+          if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
+            UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
+            [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
+          } else {
+            RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
+          }
         }
       }
     } else
@@ -1864,6 +1871,7 @@ RCT_EXPORT_VIEW_PROPERTY(sheetAllowedDetents, NSArray<NSNumber *> *);
 RCT_EXPORT_VIEW_PROPERTY(sheetLargestUndimmedDetent, NSNumber *);
 RCT_EXPORT_VIEW_PROPERTY(sheetGrabberVisible, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(sheetCornerRadius, CGFloat);
+RCT_EXPORT_VIEW_PROPERTY(sheetInitialDetent, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
 #endif
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -906,7 +906,7 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
           if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
             UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
             [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
-          } else {
+          } else if (_sheetInitialDetent != 0) {
             RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
           }
         }

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -287,10 +287,10 @@ Defaults to system default.
 
 #### `sheetInitialDetent`
 
-Index of the initial detent for the sheet.
+Index of the detent the sheet should expand to after being opened.
 Works only when `presentation` is set to `formSheet`.
 
-The detents must be defined in `sheetAllowedDetents` array.
+Defaults to `0` - which represents first detent in the detents array.
 
 #### `sheetGrabberVisible` (iOS only)
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -287,8 +287,10 @@ Defaults to system default.
 
 #### `sheetInitialDetent`
 
-Initial detent for the sheet.
+Index of the initial detent for the sheet.
 Works only when `presentation` is set to `formSheet`.
+
+The detents must be defined in `sheetAllowedDetents` array.
 
 #### `sheetGrabberVisible` (iOS only)
 

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -75,6 +75,7 @@ export interface NativeProps extends ViewProps {
   sheetGrabberVisible?: WithDefault<boolean, false>;
   sheetCornerRadius?: WithDefault<Float, -1.0>;
   sheetExpandsWhenScrolledToEdge?: WithDefault<boolean, false>;
+  sheetInitialDetent?: WithDefault<Int32, 0>;
   customAnimationOnSwipe?: boolean;
   fullScreenSwipeEnabled?: boolean;
   fullScreenSwipeShadowEnabled?: boolean;


### PR DESCRIPTION
## Description

This PR adds `sheetInitialDetent` support to iOS and fixes detents logic on iOS < 16.

This functionality depends on changes made in this PR: https://github.com/react-navigation/react-navigation/pull/12032

## Changes

- supporting `sheetInitialDetent` on iOS
- modified `Test2002.tsx` repro
- updated README definition to match types
- fixed `sheetAllowedDetents` on iOS < 16

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

- Use `Test2002.tsx` repro

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
- [x] Ensured that CI passes
