### PR TITLE
feat!: clamp `sheetInitialDetent` value

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -93,6 +93,15 @@ function resolveSheetLargestUndimmedDetent(
   }
 }
 
+function clamp(value: number, lowerBound: number, upperBound: number): number {
+  if (value > upperBound) {
+    return upperBound;
+  } else if (value < lowerBound) {
+    return lowerBound;
+  }
+  return value;
+}
+
 export const InnerScreen = React.forwardRef<View, ScreenProps>(
   function InnerScreen(props, ref) {
     const innerRef = React.useRef<ViewConfig | null>(null);
@@ -200,7 +209,11 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             sheetGrabberVisible={sheetGrabberVisible}
             sheetCornerRadius={sheetCornerRadius}
             sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
-            sheetInitialDetent={sheetInitialDetent}
+            sheetInitialDetent={clamp(
+              sheetInitialDetent,
+              0,
+              resolvedSheetAllowedDetents.length - 1,
+            )}
             gestureResponseDistance={{
               start: gestureResponseDistance?.start ?? -1,
               end: gestureResponseDistance?.end ?? -1,


### PR DESCRIPTION
## Description

In case `sheetInitialDetent` value is not in range `[0, sheetAllowedDetents.length - 1]` I decided to clamp it. 

Alternatives:

* throw an error,
* clamp it and print warning in dev mode that value has been clamped.

Open for discussion.

## Test code and steps to reproduce

`Test1649`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
