### PR TITLE
fix: bring back headers when using "modal" presentation on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -142,7 +142,11 @@ class ScreenStackFragment :
     // once it is hidden by user gesture.
     private val bottomSheetStateCallback =
         object : BottomSheetCallback() {
-            private var lastStableState: Int = SheetUtils.sheetStateFromDetentIndex(screen.sheetInitialDetentIndex, screen.sheetDetents.count())
+            private var lastStableState: Int =
+                SheetUtils.sheetStateFromDetentIndex(
+                    screen.sheetInitialDetentIndex,
+                    screen.sheetDetents.count(),
+                )
 
             override fun onStateChanged(
                 bottomSheet: View,
@@ -152,7 +156,10 @@ class ScreenStackFragment :
                     lastStableState = newState
                     screen.notifySheetDetentChange(SheetUtils.detentIndexFromSheetState(lastStableState, screen.sheetDetents.count()), true)
                 } else if (newState == BottomSheetBehavior.STATE_DRAGGING) {
-                    screen.notifySheetDetentChange(SheetUtils.detentIndexFromSheetState(lastStableState, screen.sheetDetents.count()), false)
+                    screen.notifySheetDetentChange(
+                        SheetUtils.detentIndexFromSheetState(lastStableState, screen.sheetDetents.count()),
+                        false,
+                    )
                 }
 
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
@@ -232,9 +239,7 @@ class ScreenStackFragment :
 
         coordinatorLayout.addView(screen.recycle())
 
-        if (screen.stackPresentation != Screen.StackPresentation.MODAL &&
-            screen.stackPresentation != Screen.StackPresentation.FORM_SHEET
-        ) {
+        if (screen.stackPresentation != Screen.StackPresentation.FORM_SHEET) {
             appBarLayout =
                 context?.let { AppBarLayout(it) }?.apply {
                     // By default AppBarLayout will have a background color set but since we cover the whole layout


### PR DESCRIPTION
## Description

Recently, when adding formSheets I've also merged some code for future modals implementation.
When detaching the yet-unused code for modals from being used I've forgotten about one code place,
causing the header to not be created.

`modal` presentation is rather not widely used on Android, because it has no real differences from `push`,
however I'm restoring the old behavior for the sake of backward compatibility.

Kudos to @alduzy for noticing the issue.

## Changes

* Fixed the condition that prevents the header from being created on Android, right now header 
    is not created only for `formSheet` stack presentation.


## Test code and steps to reproduce

`Test1649` - set 'modal' stack presentation to any screen and do not disable the header. See that it now works. 

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes


