### PR TITLE
chore: fix crash in example app due to typo in export

### DIFF
--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -111,7 +111,7 @@ export { default as Test2235 } from './Test2235';
 export { default as Test2252 } from './Test2252';
 export { default as Test2271 } from './Test2271';
 export { default as Test2282 } from './Test2282';
-export { default as Test2232 } from './Test2332';
+export { default as Test2332 } from './Test2332';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestHeader } from './TestHeader';
 export { default as TestModalNavigation } from './TestModalNavigation';


### PR DESCRIPTION
## Description

The `Test2332` was wrongly exported as `Test2232` from `index`, resulting in two exports with the same name => leading to crash.

## Changes

Renamed the export appropriately.

## Test code and steps to reproduce

Run any example app.

## Checklist

- [ ] Ensured that CI passes
