### PR TITLE
fix: prevent crash when there is no appearance model built

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -59,7 +59,7 @@ class Screen(
     var isSheetGrabberVisible: Boolean = false
 
     // corner radius must be updated after all props prop updates from a single transaction
-    // have been applied, because it depends of the presentation type.
+    // have been applied, because it depends on the presentation type.
     private var shouldUpdateSheetCornerRadius = false
     var sheetCornerRadius: Float = 0F
         set(value) {

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -21,6 +21,9 @@ import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.scroll.ReactScrollView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.shape.CornerFamily
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 
@@ -56,9 +59,9 @@ class Screen(
     var isSheetGrabberVisible: Boolean = false
     var sheetCornerRadius: Float = 0F
         set(value) {
-            field = value
-            if (container is ScreenStack || (container == null && fragment is ScreenStackFragment)) {
-                (fragment as ScreenStackFragment).onSheetCornerRadiusChange()
+            if (field != value && isNativeStackScreen()) {
+                field = value
+                onSheetCornerRadiusChange()
             }
         }
     var sheetExpandsWhenScrolledToEdge: Boolean = true
@@ -421,6 +424,21 @@ class Screen(
             ),
         )
     }
+
+    internal fun onSheetCornerRadiusChange() {
+        if (stackPresentation !== StackPresentation.FORM_SHEET || background == null) {
+            return
+        }
+        (background as MaterialShapeDrawable?)?.shapeAppearanceModel =
+            ShapeAppearanceModel
+                .Builder()
+                .apply {
+                    setTopLeftCorner(CornerFamily.ROUNDED, sheetCornerRadius)
+                    setTopRightCorner(CornerFamily.ROUNDED, sheetCornerRadius)
+                }.build()
+    }
+
+    private fun isNativeStackScreen(): Boolean = container is ScreenStack || fragmentWrapper is ScreenStackFragmentWrapper
 
     enum class StackPresentation {
         PUSH,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -57,7 +57,9 @@ class Screen(
     var sheetCornerRadius: Float = 0F
         set(value) {
             field = value
-            (fragment as? ScreenStackFragment)?.onSheetCornerRadiusChange()
+            if (container is ScreenStack || (container == null && fragment is ScreenStackFragment)) {
+                (fragment as ScreenStackFragment).onSheetCornerRadiusChange()
+            }
         }
     var sheetExpandsWhenScrolledToEdge: Boolean = true
 

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -440,7 +440,7 @@ class Screen(
         if (stackPresentation !== StackPresentation.FORM_SHEET || background == null) {
             return
         }
-        (background as? MaterialShapeDrawable?)?.let {
+        (background as MaterialShapeDrawable?)?.let {
             it.shapeAppearanceModel =
                 ShapeAppearanceModel
                     .Builder()

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -451,8 +451,6 @@ class Screen(
         }
     }
 
-    private fun isNativeStackScreen(): Boolean = container is ScreenStack || fragmentWrapper is ScreenStackFragmentWrapper
-
     enum class StackPresentation {
         PUSH,
         MODAL,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -191,16 +191,7 @@ class ScreenStackFragment :
     }
 
     internal fun onSheetCornerRadiusChange() {
-        if (screen.stackPresentation !== Screen.StackPresentation.FORM_SHEET || screen.background == null) {
-            return
-        }
-        (screen.background as MaterialShapeDrawable?)?.shapeAppearanceModel =
-            ShapeAppearanceModel
-                .Builder()
-                .apply {
-                    setTopLeftCorner(CornerFamily.ROUNDED, screen.sheetCornerRadius)
-                    setTopRightCorner(CornerFamily.ROUNDED, screen.sheetCornerRadius)
-                }.build()
+        screen.onSheetCornerRadiusChange()
     }
 
     override fun onCreateView(

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -191,7 +191,10 @@ class ScreenStackFragment :
     }
 
     internal fun onSheetCornerRadiusChange() {
-        (screen.background as MaterialShapeDrawable).shapeAppearanceModel =
+        if (screen.stackPresentation !== Screen.StackPresentation.FORM_SHEET || screen.background == null) {
+            return
+        }
+        (screen.background as MaterialShapeDrawable?)?.shapeAppearanceModel =
             ShapeAppearanceModel
                 .Builder()
                 .apply {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -92,6 +92,12 @@ open class ScreenViewManager :
         return super.updateState(view, props, stateWrapper)
     }
 
+    // Called after all props are updated for given view
+    override fun onAfterUpdateTransaction(view: Screen) {
+        super.onAfterUpdateTransaction(view)
+        view.onFinalizePropsUpdate()
+    }
+
     @ReactProp(name = "activityState")
     fun setActivityState(
         view: Screen,


### PR DESCRIPTION
## Description

I haven't investigated it carefully, but there were case when updating `sheetCornerRadius` the appearance
model has not been built yet leading to a crash when casting to a non-null type.

Additionally, this PR prevents calls to `onSheetCornerRadiusUpdate` when not in `formSheet` presentation
or not in native stack.

## Changes

* Prevent calls to `onSheetCornerRadiusUpdate` when not in `formSheet` presentation.
* Check for nullish view background before attempt to set the corner radius.
* Update the corner radius after all updates are applied, so that the `stackPresentation` has change of being updated.

## Test code and steps to reproduce

`Test1649`. Try setting the corner radius now, should work properly.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
