### PR TITLE
fix: align units of sheet corner radius in different callsites

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -441,12 +442,13 @@ class Screen(
             return
         }
         (background as? MaterialShapeDrawable?)?.let {
+            val resolvedCornerRadius = PixelUtil.toDIPFromPixel(sheetCornerRadius)
             it.shapeAppearanceModel =
                 ShapeAppearanceModel
                     .Builder()
                     .apply {
-                        setTopLeftCorner(CornerFamily.ROUNDED, sheetCornerRadius)
-                        setTopRightCorner(CornerFamily.ROUNDED, sheetCornerRadius)
+                        setTopLeftCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
+                        setTopRightCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
                     }.build()
         }
     }


### PR DESCRIPTION
## Description

Before this PR, when updating corner size after initial render different unit (pixel) has been used opposed to
`dp` used during initial render. This PR align this behaviour so that `dp` is always used.


## Changes

* Calculate appropriate value in `Screen.onSheetDetentChange` function

## Test code and steps to reproduce

`Test1649`

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
