### PR TITLE
refactor!: add "index" suffix to selected sheet props & add better error handling

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -86,7 +86,7 @@ function resolveSheetLargestUndimmedDetent(
   lastDetentIndex: number,
 ): number {
   if (typeof lud === 'number') {
-    if (!isNumberInClosedRange(lud, SHEET_DIMMED_ALWAYS, lastDetentIndex)) {
+    if (!isIndexInClosedRange(lud, SHEET_DIMMED_ALWAYS, lastDetentIndex)) {
       if (__DEV__) {
         throw new Error(
           "[RNScreens] Provided value of 'sheetLargestUndimmedDetentIndex' prop is out of bounds of 'sheetAllowedDetents' array.",
@@ -119,7 +119,7 @@ function resolveSheetInitialDetentIndex(
   } else if (index == null) {
     index = 0;
   }
-  if (!isNumberInClosedRange(index, 0, lastDetentIndex)) {
+  if (!isIndexInClosedRange(index, 0, lastDetentIndex)) {
     if (__DEV__) {
       throw new Error(
         "[RNScreens] Provided value of 'sheetInitialDetentIndex' prop is out of bounds of 'sheetAllowedDetents' array.",
@@ -131,12 +131,12 @@ function resolveSheetInitialDetentIndex(
   return index;
 }
 
-function isNumberInClosedRange(
+function isIndexInClosedRange(
   value: number,
   lowerBound: number,
   upperBound: number,
 ): boolean {
-  return value >= lowerBound && value <= upperBound;
+  return Number.isInteger(value) && value >= lowerBound && value <= upperBound;
 }
 
 export const InnerScreen = React.forwardRef<View, ScreenProps>(

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -86,6 +86,15 @@ function resolveSheetLargestUndimmedDetent(
   lastDetentIndex: number,
 ): number {
   if (typeof lud === 'number') {
+    if (!isNumberInClosedRange(lud, SHEET_DIMMED_ALWAYS, lastDetentIndex)) {
+      if (__DEV__) {
+        throw new Error(
+          "[RNScreens] Provided value of 'sheetLargestUndimmedDetentIndex' prop is out of bounds of 'sheetAllowedDetents' array.",
+        );
+      }
+      // Return default in production
+      return SHEET_DIMMED_ALWAYS;
+    }
     return lud;
   } else if (lud === 'last') {
     return lastDetentIndex;

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -93,6 +93,15 @@ function resolveSheetLargestUndimmedDetent(
   }
 }
 
+function clamp(value: number, lowerBound: number, upperBound: number): number {
+  if (value > upperBound) {
+    return upperBound;
+  } else if (value < lowerBound) {
+    return lowerBound;
+  }
+  return value;
+}
+
 export const InnerScreen = React.forwardRef<View, ScreenProps>(
   function InnerScreen(props, ref) {
     const innerRef = React.useRef<ViewConfig | null>(null);
@@ -200,7 +209,11 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             sheetGrabberVisible={sheetGrabberVisible}
             sheetCornerRadius={sheetCornerRadius}
             sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
-            sheetInitialDetent={sheetInitialDetent}
+            sheetInitialDetent={clamp(
+              sheetInitialDetent,
+              0,
+              resolvedSheetAllowedDetents.length - 1,
+            )}
             gestureResponseDistance={{
               start: gestureResponseDistance?.start ?? -1,
               end: gestureResponseDistance?.end ?? -1,

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -117,6 +117,7 @@ function resolveSheetInitialDetentIndex(
   if (index === 'last') {
     index = lastDetentIndex;
   } else if (index == null) {
+    // Intentional check for undefined & null ^
     index = 0;
   }
   if (!isIndexInClosedRange(index, 0, lastDetentIndex)) {

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -418,7 +418,7 @@ export type NativeStackNavigationOptions = {
    *
    * Defaults to `0` - which represents first detent in the detents array.
    */
-  sheetInitialDetent?: ScreenProps['sheetInitialDetent'];
+  sheetInitialDetentIndex?: ScreenProps['sheetInitialDetentIndex'];
   /**
    * The largest sheet detent for which a view underneath won't be dimmed.
    * Works only when `stackPresentation` is set to `formSheet`.
@@ -436,7 +436,7 @@ export type NativeStackNavigationOptions = {
    *
    * Defaults to `none`, indicating that the dimming view should be always present.
    */
-  sheetLargestUndimmedDetent?: ScreenProps['sheetLargestUndimmedDetent'];
+  sheetLargestUndimmedDetentIndex?: ScreenProps['sheetLargestUndimmedDetentIndex'];
   /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -195,12 +195,12 @@ const RouteView = ({
     headerShown,
     hideKeyboardOnSwipe,
     homeIndicatorHidden,
-    sheetLargestUndimmedDetent = 'none',
+    sheetLargestUndimmedDetentIndex = 'none',
     sheetGrabberVisible = false,
     sheetCornerRadius = -1.0,
     sheetElevation = 24,
     sheetExpandsWhenScrolledToEdge = true,
-    sheetInitialDetent = 0,
+    sheetInitialDetentIndex = 0,
     nativeBackButtonDismissalEnabled = false,
     navigationBarColor,
     navigationBarTranslucent,
@@ -318,9 +318,9 @@ const RouteView = ({
       hasLargeHeader={hasLargeHeader}
       style={[StyleSheet.absoluteFill, unstable_screenStyle]}
       sheetAllowedDetents={sheetAllowedDetents}
-      sheetLargestUndimmedDetent={sheetLargestUndimmedDetent}
+      sheetLargestUndimmedDetentIndex={sheetLargestUndimmedDetentIndex}
       sheetGrabberVisible={sheetGrabberVisible}
-      sheetInitialDetent={sheetInitialDetent}
+      sheetInitialDetentIndex={sheetInitialDetentIndex}
       sheetCornerRadius={sheetCornerRadius}
       sheetElevation={sheetElevation}
       sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -356,8 +356,8 @@ export interface ScreenProps extends ViewProps {
    * This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
    * there won't be a dimming view beneath the sheet.
    *
-   * If the specified index is out of bounds of `sheetAllowedDetents` array in dev mode error will be thrown,
-   * in production the value will be clamped.
+   * If the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment mode error will be thrown,
+   * in production the value will be reset to default value.
    *
    * Additionaly there are following options available:
    *
@@ -381,6 +381,11 @@ export interface ScreenProps extends ViewProps {
   /**
    * Index of the detent the sheet should expand to after being opened.
    * Works only when `stackPresentation` is set to `formSheet`.
+   *
+   * If the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment more error will be thrown,
+   * in production the value will be reset to default value.
+   *
+   * Additionaly there is `last` value available, when set the sheet will expand initially to last (largest) detent.
    *
    * Defaults to `0` - which represents first detent in the detents array.
    */

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -289,13 +289,17 @@ export interface ScreenProps extends ViewProps {
   unstable_screenStyle?: Pick<ViewStyle, 'backgroundColor'>;
   /**
    * Describes heights where a sheet can rest.
-   * Works only when `stackPresentation` is set to `formSheet`.
+   * Works only when `presentation` is set to `formSheet`.
    *
    * Heights should be described as fraction (a number from `[0, 1]` interval) of screen height / maximum detent height.
-   * There is also possibility to specify `[-1]` literal array with single element, which intets to set the sheet height
+   * You can pass an array of ascending values each defining allowed sheet detent. iOS accepts any number of detents,
+   * while **Android is limited to three**.
+   *
+   * There is also possibility to specify `fitToContents` literal, which intents to set the sheet height
    * to the height of its contents.
    *
    * Please note that the array **must** be sorted in ascending order.
+   * **Android is limited to up 3 values in the array** -- any surplus values, beside first three are ignored.
    *
    * There are also legacy & **deprecated** options available:
    *
@@ -303,7 +307,9 @@ export interface ScreenProps extends ViewProps {
    * * 'large' - corresponds to `[1.0]` detent value, maximum height,
    * * 'all' - corresponds to `[0.5, 1.0]` value, the name is deceiving due to compatibility reasons.
    *
-   * Defaults to `[1.0]` literal.
+   * These are provided solely for **temporary** backward compatibility and are destined for removal in future versions.
+   *
+   * Defaults to `[1.0]`.
    */
   sheetAllowedDetents?: number[] | 'fitToContents' | 'medium' | 'large' | 'all';
   /**
@@ -350,30 +356,35 @@ export interface ScreenProps extends ViewProps {
    * This prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which
    * there won't be a dimming view beneath the sheet.
    *
+   * If the specified index is out of bounds of `sheetAllowedDetents` array in dev mode error will be thrown,
+   * in production the value will be clamped.
+   *
    * Additionaly there are following options available:
    *
    * * `none` - there will be dimming view for all detents levels,
-   * * `largest` - there won't be a dimming view for any detent level.
+   * * `last` - there won't be a dimming view for any detent level.
    *
    * There also legacy & **deprecated** prop values available: `medium`, `large` (don't confuse with `largest`), `all`, which work in tandem with
    * corresponding legacy prop values for `sheetAllowedDetents` prop.
    *
+   * These are provided solely for **temporary** backward compatibility and are destined for removal in future versions.
+   *
    * Defaults to `none`, indicating that the dimming view should be always present.
    */
-  sheetLargestUndimmedDetent?:
+  sheetLargestUndimmedDetentIndex?:
     | number
     | 'none'
-    | 'largest'
-    | 'medium'
-    | 'large'
-    | 'all';
+    | 'last'
+    | 'medium' // deprecated
+    | 'large' // deprecated
+    | 'all'; // deprecated
   /**
    * Index of the detent the sheet should expand to after being opened.
    * Works only when `stackPresentation` is set to `formSheet`.
    *
    * Defaults to `0` - which represents first detent in the detents array.
    */
-  sheetInitialDetent?: number;
+  sheetInitialDetentIndex?: number | 'last';
   /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:


### PR DESCRIPTION
## Description

This PR aims to improve prop naming by following renames:

* `sheetInitialDetent` -> `sheetInitialDetentIndex`,
* `sheetLargestUndimmedDetent` -> `sheetLargestUndimmedDetentIndex`

In case of `sheetInitialDetentIndex` prop additional value is handled: `last`, which indicates that the
sheet should be opened initially at largest detent.

In case of `sheetLargestUndimmedDetent` the `largest` variant has been changed to `last`, so there is no discrepancy between these two props.

Additionally, error handling has been improved for both of these props. Now if they are out of bounds, in production environment default value is used,
in developement mode an descriptive error is thrown.

## Changes

^^^

## Test code and steps to reproduce

Test1649

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
