### PR TITLE
fix: check for surplus values in sheet detents array not only in dev mode

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -76,14 +76,16 @@ function resolveSheetAllowedDetents(
   allowedDetentsCompat: ScreenProps['sheetAllowedDetents'],
 ): number[] {
   if (Array.isArray(allowedDetentsCompat)) {
-    if (__DEV__) {
-      assertDetentsArrayIsSorted(allowedDetentsCompat);
-      if (Platform.OS === 'android' && allowedDetentsCompat.length > 3) {
+    if (Platform.OS === 'android' && allowedDetentsCompat.length > 3) {
+      if (__DEV__) {
         console.warn(
           '[RNScreens] Sheets API on Android do accept only up to 3 values. Any surplus value are ignored.',
         );
-        allowedDetentsCompat = allowedDetentsCompat.slice(0, 3);
       }
+      allowedDetentsCompat = allowedDetentsCompat.slice(0, 3);
+    }
+    if (__DEV__) {
+      assertDetentsArrayIsSorted(allowedDetentsCompat);
     }
     return allowedDetentsCompat;
   } else if (allowedDetentsCompat === 'fitToContents') {


### PR DESCRIPTION
## Description

Previous code reduced detent array to three values on Android only in dev mode - this is undesired.
We want to always do it.

## Changes

Moved the slicing operation out of check for dev mode.

## Test code and steps to reproduce

`Test1649`, pass more than 3 values on Android, see that it works.

## Checklist

- [ ] Ensured that CI passes
