### PR TITLE
fix(Android): do not crash in case background can not be casted to MaterialShapeDrawable

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -441,7 +441,7 @@ class Screen(
         if (stackPresentation !== StackPresentation.FORM_SHEET || background == null) {
             return
         }
-        (background as MaterialShapeDrawable?)?.let {
+        (background as? MaterialShapeDrawable?)?.let {
             val resolvedCornerRadius = PixelUtil.toDIPFromPixel(sheetCornerRadius)
             it.shapeAppearanceModel =
                 ShapeAppearanceModel


### PR DESCRIPTION
## Description

It turns out, that this check: https://github.com/software-mansion/react-native-screens/pull/2375/commits/b2dab7859c32a5848b40369c79c95b1e5f2bd77e was necessary,
and I forgot about it while applying the code review.

Current code will crash if `background != null && !(background is MaterialShapeDrawable)`, so e.g. when `background is ColorDrawable`.
We don't wanna fail in this case.

## Changes

Allowed the cast to fail instead of throwing exception, when casting background to `MaterialShapeDrawable`.
One thing that concerns me 

## Test code and steps to reproduce

`Test1649`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
