### PR TITLE
fix(Android,Fabric): invalid behaviour of `fitToContents` sheet detent

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -27,6 +27,7 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 import com.swmansion.rnscreens.ext.isInsideScrollViewWithRemoveClippedSubviews
+import java.lang.ref.WeakReference
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
 class Screen(
@@ -35,6 +36,8 @@ class Screen(
     ScreenContentWrapper.OnLayoutCallback {
     val fragment: Fragment?
         get() = fragmentWrapper?.fragment
+
+    var contentWrapper = WeakReference<ScreenContentWrapper>(null)
 
     val sheetBehavior: BottomSheetBehavior<Screen>?
         get() = (layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<Screen>
@@ -128,6 +131,7 @@ class Screen(
 
     fun registerLayoutCallbackForWrapper(wrapper: ScreenContentWrapper) {
         wrapper.delegate = this
+        this.contentWrapper = WeakReference(wrapper)
     }
 
     override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -154,10 +154,18 @@ class ScreenStackFragment :
             ) {
                 if (SheetUtils.isStateStable(newState)) {
                     lastStableState = newState
-                    screen.notifySheetDetentChange(SheetUtils.detentIndexFromSheetState(lastStableState, screen.sheetDetents.count()), true)
+                    screen.notifySheetDetentChange(
+                        SheetUtils.detentIndexFromSheetState(
+                            lastStableState,
+                            screen.sheetDetents.count()
+                        ), true
+                    )
                 } else if (newState == BottomSheetBehavior.STATE_DRAGGING) {
                     screen.notifySheetDetentChange(
-                        SheetUtils.detentIndexFromSheetState(lastStableState, screen.sheetDetents.count()),
+                        SheetUtils.detentIndexFromSheetState(
+                            lastStableState,
+                            screen.sheetDetents.count()
+                        ),
                         false,
                     )
                 }
@@ -340,13 +348,23 @@ class ScreenStackFragment :
         return when (keyboardState) {
             is KeyboardNotVisible -> {
                 when (screen.sheetDetents.count()) {
-                    1 ->
+                    1 -> if (screen.sheetDetents.first() == Screen.SHEET_FIT_TO_CONTENTS) {
+                        behavior.apply {
+                            state = BottomSheetBehavior.STATE_EXPANDED
+                            screen.contentWrapper.get()?.let {
+                                maxHeight = it.height
+                            }
+                            skipCollapsed = true
+                            isFitToContents = true
+                        }
+                    } else {
                         behavior.apply {
                             state = BottomSheetBehavior.STATE_EXPANDED
                             skipCollapsed = true
                             isFitToContents = true
                             maxHeight = (screen.sheetDetents.first() * containerHeight).toInt()
                         }
+                    }
 
                     2 ->
                         behavior.apply {
@@ -371,7 +389,8 @@ class ScreenStackFragment :
                             skipCollapsed = false
                             isFitToContents = false
                             peekHeight = (screen.sheetDetents[0] * containerHeight).toInt()
-                            expandedOffset = ((1 - screen.sheetDetents[2]) * containerHeight).toInt()
+                            expandedOffset =
+                                ((1 - screen.sheetDetents[2]) * containerHeight).toInt()
                             halfExpandedRatio =
                                 (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat()
                         }
@@ -450,7 +469,8 @@ class ScreenStackFragment :
                             skipCollapsed = false
                             isFitToContents = false
                             peekHeight = (screen.sheetDetents[0] * containerHeight).toInt()
-                            expandedOffset = ((1 - screen.sheetDetents[2]) * containerHeight).toInt()
+                            expandedOffset =
+                                ((1 - screen.sheetDetents[2]) * containerHeight).toInt()
                             halfExpandedRatio =
                                 (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat()
                         }
@@ -575,7 +595,8 @@ class ScreenStackFragment :
 //    ) : CoordinatorLayout(context), ReactCompoundViewGroup, ReactHitSlopView {
     ) : CoordinatorLayout(context),
         ReactPointerEventsView {
-        override fun onApplyWindowInsets(insets: WindowInsets?): WindowInsets = super.onApplyWindowInsets(insets)
+        override fun onApplyWindowInsets(insets: WindowInsets?): WindowInsets =
+            super.onApplyWindowInsets(insets)
 
         private val animationListener: Animation.AnimationListener =
             object : Animation.AnimationListener {


### PR DESCRIPTION
## Description

Fixes invalid behaviour of `fitToContents` sheet detent on Fabric. 

The erroneous behaviour has been caused by different order of updates on Fabric relative to Paper.
On Fabric `onCreateView` (the place where bottom sheet behaviour is created) is called much later,
Because of this the layoutCallback from `ScreenContentWrapper` fails to set proper sheet height,
as the `sheetBehaviour` is still `null`.

## Changes

`Screen` now keeps weak reference to `ScreenContentWrapper` and queries it when needed during behaviour configuration.


## Test code and steps to reproduce

`Test1649`, chante `sheetInitialDetents` to `fitToContents` and see that it now works on Fabric.

## Checklist

- [x] Included code example that can be used to test this change
- [-] Ensured that CI passes
