### PR TITLE
fix(Android): going back on fabric with horizontal list crash

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
@@ -40,6 +40,9 @@ internal fun View.isInsideScrollViewWithRemoveClippedSubviews(): Boolean {
     }
     var parentView = this.parent
     while (parentView is ViewGroup && parentView !is ScreenStack) {
+        if (parentView is ReactHorizontalScrollView) {
+            return parentView.removeClippedSubviews
+        }
         if (parentView is ReactScrollView) {
             return parentView.removeClippedSubviews
         }

--- a/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
@@ -40,11 +40,13 @@ internal fun View.isInsideScrollViewWithRemoveClippedSubviews(): Boolean {
     }
     var parentView = this.parent
     while (parentView is ViewGroup && parentView !is ScreenStack) {
-        if (parentView is ReactHorizontalScrollView) {
-            return parentView.removeClippedSubviews
-        }
-        if (parentView is ReactScrollView) {
-            return parentView.removeClippedSubviews
+        when (parentView) {
+            is ReactHorizontalScrollView -> {
+                return parentView.removeClippedSubviews
+            }
+            is ReactScrollView -> {
+                return parentView.removeClippedSubviews
+            }
         }
         parentView = parentView.parent
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
@@ -47,8 +47,10 @@ internal fun View.isInsideScrollViewWithRemoveClippedSubviews(): Boolean {
             is ReactScrollView -> {
                 return parentView.removeClippedSubviews
             }
+            else -> {
+                parentView = parentView.parent
+            }
         }
-        parentView = parentView.parent
     }
     return false
 }

--- a/apps/src/tests/Test2282.tsx
+++ b/apps/src/tests/Test2282.tsx
@@ -34,21 +34,31 @@ function Home({ navigation }: any) {
 
 function ListScreen() {
   return (
+    <>
+      <ParentFlatlist />
+      <ParentFlatlist horizontal />
+    </>
+  );
+}
+
+function ParentFlatlist(props: Partial<FlatListProps<number>>) {
+  return (
     <FlatList
-      data={Array.from({ length: 30 }).fill(0)}
+      data={Array.from({ length: 30 }).fill(0) as number[]}
       renderItem={({ index }) => {
-        if (index === 15) {
+        if (index === 10) {
           return <NestedFlatlist key={index} />;
-        } else if (index === 18) {
+        } else if (index === 15) {
           return <ExtraNestedFlatlist key={index} />;
-        } else if (index === 26) {
+        } else if (index === 20) {
           return <NestedFlatlist key={index} horizontal />;
-        } else if (index === 28) {
+        } else if (index === 25) {
           return <ExtraNestedFlatlist key={index} horizontal />;
         } else {
           return <Item key={index}>List item {index + 1}</Item>;
         }
       }}
+      {...props}
     />
   );
 }


### PR DESCRIPTION
## Description

This PR handles yet another case for going back on fabric. In the previous one (https://github.com/software-mansion/react-native-screens/pull/2383) I omitted a case where a horizontal list is simply rendered w/o being nested in any other list!

Fixes #2341 

## Changes

- updated `Test2292.tsx` repro
- handle `parentView is ReactHorizontalScrollView`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

- use `Test2282.tsx` repro

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
