### PR TITLE
fix(iOS): do not force API user to set `activityState`

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSInteger, RNSScreenSwipeDirection) {
 };
 
 typedef NS_ENUM(NSInteger, RNSActivityState) {
+  RNSActivityStateUndefined = -1,
   RNSActivityStateInactive = 0,
   RNSActivityStateTransitioningOrBelowTop = 1,
   RNSActivityStateOnTop = 2

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -118,6 +118,7 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
   _hasStatusBarHiddenSet = NO;
   _hasOrientationSet = NO;
   _hasHomeIndicatorHiddenSet = NO;
+  _activityState = RNSActivityStateUndefined;
 #if !TARGET_OS_TV
   _sheetExpandsWhenScrolledToEdge = YES;
 #endif // !TARGET_OS_TV


### PR DESCRIPTION
## Description

We did not set default value of `activityState` on iOS. It was set to `0` by default `int` initializer.

In `Screen` component native spec we set it to `-1`, however this had no impact, because the value setter
`setActivityStateOrNil:` filtered out the `-1` value.

TODO:

1. [x] Verify that change in default value do not break any other navigator!

^ Looks like this will work, because navigators such as bottom tabs always set the activity state explicitly. 


This is a problem, because now, after adding preload support #2389 we filter out screens with `activityState == 0` in native stack.
Therefore, we now unintentionally force our API user to always set desired `activityState`.

## Changes

Set `activityState` to `-1` by default on native side.

## Test code and steps to reproduce

Just render screen inside native-stack w/o `activityState` set. It won't be shown.
 
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
