### PR TITLE
feat!: expose library `compatibilityFlags` with new flag regarding header implementation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,7 +72,7 @@ export { GHContext } from './native-stack/contexts/GHContext';
  */
 export {
   isSearchBarAvailableForCurrentPlatform,
-  isNewBackTitleImplementation,
+  compatibilityFlags,
   executeNativeBackPress,
 } from './utils';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,23 @@ export function executeNativeBackPress() {
   return true;
 }
 
-// Because of a bug introduced in https://github.com/software-mansion/react-native-screens/pull/1646
-// react-native-screens v3.21 changed how header's backTitle handles whitespace strings in https://github.com/software-mansion/react-native-screens/pull/1726
-// To allow for backwards compatibility in @react-navigation/native-stack we need a way to check if this version or newer is used.
-// See https://github.com/react-navigation/react-navigation/pull/11423 for more context.
-export const isNewBackTitleImplementation = true;
+export const compatibilityFlags = {
+  /**
+   * Because of a bug introduced in https://github.com/software-mansion/react-native-screens/pull/1646
+   * react-native-screens v3.21 changed how header's backTitle handles whitespace strings in https://github.com/software-mansion/react-native-screens/pull/1726
+   * To allow for backwards compatibility in @react-navigation/native-stack we need a way to check if this version or newer is used.
+   * See https://github.com/react-navigation/react-navigation/pull/11423 for more context.
+   */
+  isNewBackTitleImplementation: true,
+
+  /**
+   * With version 4.0.0 the header implementation has been changed. To allow for backward compat
+   * with native-stack@v6 we want to expose a way to check whether the new implementation
+   * is in use or not.
+   *
+   * See:
+   * * https://github.com/software-mansion/react-native-screens/pull/2325
+   * * https://github.com/react-navigation/react-navigation/pull/12125
+   */
+  usesHeaderFlexboxImplementation: true,
+};


### PR DESCRIPTION
## Description

This PR introduces new `compatiblityFlags` object to the library public API. 
It is meant as a source of truth for the library consumers (especially `react-navigation`) to allow them to adjust to breaking changes
done in this library.

I've decided to go with single object with fields instead of individual constants, because it makes it easier for handling,
we don't have to change public exports every time we add something, it makes it easier to add/remove a flag.

## Changes

1. Created & exposed `compatiblityFlags` object,
2. added `usesHeaderFlexboxImplementation`,
2. moved old flags into the object.

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
