### PR TITLE
feat!: remove `shouldUseActivityState` flag

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -2,9 +2,6 @@
 
 import { Platform, UIManager } from 'react-native';
 
-// const that tells if the library should use new implementation, will be undefined for older versions
-export const shouldUseActivityState = true;
-
 export const isNativePlatformSupported =
   Platform.OS === 'ios' ||
   Platform.OS === 'android' ||

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,6 @@ export {
   enableFreeze,
   screensEnabled,
   freezeEnabled,
-  shouldUseActivityState,
 } from './core';
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,13 @@ export function executeNativeBackPress() {
   return true;
 }
 
+/**
+ * Exposes information useful for downstream navigation library implementers,
+ * so they can keep reasonable backward compatibility, if desired.
+ *
+ * We don't mean for this object to only grow in number of fields, however at the same time
+ * we won't be very hasty to reduce it. Expect gradual changes.
+ */
 export const compatibilityFlags = {
   /**
    * Because of a bug introduced in https://github.com/software-mansion/react-native-screens/pull/1646


### PR DESCRIPTION
## Description

This PR removes `shouldUseActivityState` flag from public API (and in general).

The flag was initially introduced in #624, as a mean for downstream library developers
to differentiate between different screen versions. This was introduced over 4 years ago 
and currently does not serve any role in `react-navigation` implementation. 

## Changes

* Removed `shouldUseActivityState` flag from public API,
* added comment for `compatibilityFlags` object.

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
