### PR TITLE
fix: CMake changes needed for RN 0.76.0

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -38,7 +38,16 @@ target_compile_definitions(
 
 find_package(ReactAndroid REQUIRED CONFIG)
 
-if(${RNS_NEW_ARCH_ENABLED})
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+   find_package(fbjni REQUIRED CONFIG)
+   
+   target_link_libraries(rnscreens
+     ReactAndroid::reactnative
+     ReactAndroid::jsi
+     fbjni::fbjni
+     android
+   )
+elseif(${RNS_NEW_ARCH_ENABLED})
     find_package(fbjni REQUIRED CONFIG)
     
     target_link_libraries(

--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -38,25 +38,34 @@ target_include_directories(
   ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
 )
 
-target_link_libraries(
-  ${LIB_TARGET_NAME}
-  fbjni
-  folly_runtime
-  glog
-  jsi
-  react_codegen_rncore
-  react_debug
-  react_nativemodule_core
-  react_render_core
-  react_render_debug
-  react_render_graphics
-  react_render_mapbuffer
-  react_render_componentregistry
-  react_utils
-  rrc_view
-  turbomodulejsijni
-  yoga
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    ReactAndroid::reactnative
+    ReactAndroid::jsi
+    fbjni::fbjni
+  )
+else()
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    fbjni
+    folly_runtime
+    glog
+    jsi
+    react_codegen_rncore
+    react_debug
+    react_nativemodule_core
+    react_render_core
+    react_render_debug
+    react_render_graphics
+    react_render_mapbuffer
+    react_render_componentregistry
+    react_utils
+    rrc_view
+    turbomodulejsijni
+    yoga
+  )
+endif()
 
 target_compile_options(
   ${LIB_TARGET_NAME}


### PR DESCRIPTION
## Description
CMake changes required for RN 0.76.0

See below discussion for change background
https://github.com/react-native-community/discussions-and-proposals/discussions/816#

Note that the RN provided flag is still not populating in 0.76.0-rc.5 and that the flag used in this PR is one being used by a number of other libraries.
<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
Fixes Android build errors on RN 0.76.0
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce
- Run an app with RN 0.76.0 without the changes and note the android build failures
- Run the same app again with the changes applied and note the build succeeds
<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
