### PR TITLE
chore: Remove legacy version check in `react-native.config.js`

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,34 +1,22 @@
-let supportsCodegenConfig = false;
-try {
-  const rnCliAndroidVersion =
-    require('@react-native-community/cli-platform-android/package.json').version;
-  const [major] = rnCliAndroidVersion.split('.');
-  supportsCodegenConfig = major >= 9;
-} catch (e) {
-  // ignore
-}
-
 module.exports = {
   dependency: {
     platforms: {
-      android: supportsCodegenConfig 
-      ? {
-          componentDescriptors: [
-            "RNSFullWindowOverlayComponentDescriptor",
-            "RNSScreenContainerComponentDescriptor",
-            "RNSScreenNavigationContainerComponentDescriptor",
-            "RNSScreenStackHeaderConfigComponentDescriptor",
-            "RNSScreenStackHeaderSubviewComponentDescriptor",
-            "RNSScreenStackComponentDescriptor",
-            "RNSSearchBarComponentDescriptor",
-            'RNSScreenComponentDescriptor',
-            "RNSScreenFooterComponentDescriptor",
-            "RNSScreenContentWrapperComponentDescriptor",
-            'RNSModalScreenComponentDescriptor'
-          ],
-          cmakeListsPath: "../android/src/main/jni/CMakeLists.txt"
-        } 
-      : {},
+      android: {
+        componentDescriptors: [
+          "RNSFullWindowOverlayComponentDescriptor",
+          "RNSScreenContainerComponentDescriptor",
+          "RNSScreenNavigationContainerComponentDescriptor",
+          "RNSScreenStackHeaderConfigComponentDescriptor",
+          "RNSScreenStackHeaderSubviewComponentDescriptor",
+          "RNSScreenStackComponentDescriptor",
+          "RNSSearchBarComponentDescriptor",
+          'RNSScreenComponentDescriptor',
+          "RNSScreenFooterComponentDescriptor",
+          "RNSScreenContentWrapperComponentDescriptor",
+          'RNSModalScreenComponentDescriptor'
+        ],
+        cmakeListsPath: "../android/src/main/jni/CMakeLists.txt"
+      },
     },
   },
 };


### PR DESCRIPTION
## Description

Removes legacy version check from `react-native.config.js`. 

## Changes

The community CLI is no longer a dependency for React Native, meaning it may not be installed in every project. For example, projects that use Expo won't include the `@react-native-community/cli-*` packages. Consequently, this check will fail, leading to issues with autolinking components.

This version check can be removed safely, as the 9th version of the CLI was released two years ago. 

## Test code and steps to reproduce

This change was tested using `expo` project on react native `0.76`.