### PR TITLE
fix: header config missing ref

### DIFF
--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -1,18 +1,12 @@
 'use client';
 
-import React, { Component, LegacyRef } from 'react';
+import React from 'react';
 import {
   HeaderSubviewTypes,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
 } from '../types';
-import {
-  Image,
-  ImageProps,
-  NativeMethods,
-  StyleSheet,
-  ViewProps,
-} from 'react-native';
+import { Image, ImageProps, StyleSheet, View, ViewProps } from 'react-native';
 
 // Native components
 import ScreenStackHeaderConfigNativeComponent from '../fabric/ScreenStackHeaderConfigNativeComponent';
@@ -22,21 +16,19 @@ export const ScreenStackHeaderSubview: React.ComponentType<
   React.PropsWithChildren<ViewProps & { type?: HeaderSubviewTypes }>
 > = ScreenStackHeaderSubviewNativeComponent as any;
 
-export function ScreenStackHeaderConfig(
-  props: ScreenStackHeaderConfigProps,
-  ref?: LegacyRef<
-    Component<ScreenStackHeaderConfigProps, any, any> & Readonly<NativeMethods>
-  >,
-): React.JSX.Element {
-  return (
-    <ScreenStackHeaderConfigNativeComponent
-      {...props}
-      ref={ref}
-      style={styles.headerConfig}
-      pointerEvents="box-none"
-    />
-  );
-}
+export const ScreenStackHeaderConfig = React.forwardRef<
+  View,
+  ScreenStackHeaderConfigProps
+>((props, ref) => (
+  <ScreenStackHeaderConfigNativeComponent
+    {...props}
+    ref={ref}
+    style={styles.headerConfig}
+    pointerEvents="box-none"
+  />
+));
+
+ScreenStackHeaderConfig.displayName = 'ScreenStackHeaderConfig';
 
 export const ScreenStackHeaderBackButtonImage = (
   props: ImageProps,

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import React from 'react';
+import React, { Component, LegacyRef } from 'react';
 import {
   HeaderSubviewTypes,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
 } from '../types';
-import { Image, ImageProps, StyleSheet, ViewProps } from 'react-native';
+import {
+  Image,
+  ImageProps,
+  NativeMethods,
+  StyleSheet,
+  ViewProps,
+} from 'react-native';
 
 // Native components
 import ScreenStackHeaderConfigNativeComponent from '../fabric/ScreenStackHeaderConfigNativeComponent';
@@ -18,10 +24,14 @@ export const ScreenStackHeaderSubview: React.ComponentType<
 
 export function ScreenStackHeaderConfig(
   props: ScreenStackHeaderConfigProps,
+  ref?: LegacyRef<
+    Component<ScreenStackHeaderConfigProps, any, any> & Readonly<NativeMethods>
+  >,
 ): React.JSX.Element {
   return (
     <ScreenStackHeaderConfigNativeComponent
       {...props}
+      ref={ref}
       style={styles.headerConfig}
       pointerEvents="box-none"
     />


### PR DESCRIPTION
## Description

This PR changes  `ScreenStackHeaderConfig` into a [forwardRef](@alduzy/reanimated-patch).

This is needed if you want to attach `ref` to it, which **react-native-reanimated** needs to do [here](https://github.com/software-mansion/react-native-reanimated/blob/1d417a5c711d60822d25bd8b823f1f5968214bde/apps/common-app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx#L24) in order to migrate to v4, since the header config is now a function component and cannot be used directly anymore.

Without this change the app crashes with `Cannot read property 'getScrollableNode' of null`.

Related PR: https://github.com/software-mansion/react-native-reanimated/pull/6622

<!--
## Changes

Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
<!--
## Test code and steps to reproduce

Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Ensured that CI passes
