### PR TITLE
fix(iOS): remove leftover _sheetsScrollView reference after cherry-picking from main

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -620,7 +620,6 @@ namespace react = facebook::react;
 - (void)invalidate
 {
   _controller = nil;
-  [_sheetsScrollView removeObserver:self forKeyPath:@"bounds" context:nil];
 }
 
 #if !TARGET_OS_TV && !TARGET_OS_VISION


### PR DESCRIPTION
## Description

This PR fixes iOS build after recent cherry-picks. It removes the _sheetsScrollView leftover reference.

## Checklist

- [ ] Ensured that CI passes
