### PR TITLE
refactor: Separate API props and NativeProps for ScreenStack 

### DIFF
--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -6,9 +6,9 @@ import { freezeEnabled } from '../core';
 import DelayedFreeze from './helpers/DelayedFreeze';
 
 // Native components
-import ScreenStackNativeComponent from '../fabric/ScreenStackNativeComponent';
-const NativeScreenStack: React.ComponentType<ScreenStackProps> =
-  ScreenStackNativeComponent as any;
+import ScreenStackNativeComponent, {
+  NativeProps,
+} from '../fabric/ScreenStackNativeComponent';
 
 function isFabric() {
   return 'nativeFabricUIManager' in global;
@@ -45,9 +45,19 @@ function ScreenStack(props: ScreenStackProps) {
     }
   });
   return (
-    <NativeScreenStack {...rest} ref={ref}>
+    <ScreenStackNativeComponent
+      {...rest}
+      /**
+       * This messy override is to conform NativeProps used by codegen and
+       * our Public API. To see reasoning go to this PR:
+       * https://github.com/software-mansion/react-native-screens/pull/2423#discussion_r1810616995
+       */
+      onFinishTransitioning={
+        props.onFinishTransitioning as NativeProps['onFinishTransitioning']
+      }
+      ref={ref}>
       {childrenWithFreeze}
-    </NativeScreenStack>
+    </ScreenStackNativeComponent>
   );
 }
 

--- a/src/fabric/ScreenStackNativeComponent.ts
+++ b/src/fabric/ScreenStackNativeComponent.ts
@@ -7,7 +7,7 @@ import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTyp
 // eslint-disable-next-line @typescript-eslint/ban-types
 type FinishTransitioningEvent = Readonly<{}>;
 
-interface NativeProps extends ViewProps {
+export interface NativeProps extends ViewProps {
   onFinishTransitioning?: DirectEventHandler<FinishTransitioningEvent>;
 }
 


### PR DESCRIPTION
## Description

Continuation of https://github.com/software-mansion/react-native-screens/pull/2423. Separate public `ScreenStackProps` and `NativeProps` by not casting NativeComponent as `React.ComponentType<ScreenStackProps> `. 

## Checklist

- [ ] Ensured that CI passes
