### PR TITLE
docs: Add hero support for 4k monitors

### DIFF
--- a/docs/src/components/Hero/ScreenSequence/styles.module.css
+++ b/docs/src/components/Hero/ScreenSequence/styles.module.css
@@ -23,8 +23,8 @@
 
 @media (min-width: 3000px) and (min-height: 2000px) {
   .screens {
-    top: -3vh;
-    min-height: 50%;
+    top: 3vh;
+    min-height: 35%;
   }
 }
 


### PR DESCRIPTION
## Description

Before on 4k monitors it was impossible to click on navbar due to hero svg overlapping with it. In this PR we adjusted styles for this to work.

<img width="642" alt="image" src="https://github.com/user-attachments/assets/cfe6e978-202e-41bc-9d9b-591f88ec7bea">

