### PR TITLE
fix(Android): formSheet flex 1 support

### DIFF
--- a/apps/src/tests/Test2462.tsx
+++ b/apps/src/tests/Test2462.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { View, Button, Text, StyleSheet, ScrollView } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationOptions,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+
+type StackParamList = {
+  Home: undefined;
+  'Sheet One': undefined;
+  'Sheet Two': undefined;
+  'Sheet Three': undefined;
+};
+
+function HomeScreen({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
+  return (
+    <View style={styles.container}>
+      <Button
+        onPress={() => navigation.navigate('Sheet One')}
+        title="Open First Sheet"
+      />
+      <Button
+        onPress={() => navigation.navigate('Sheet Two')}
+        title="Open Second Sheet"
+      />
+      <Button
+        onPress={() => navigation.navigate('Sheet Three')}
+        title="Open Third Sheet"
+      />
+    </View>
+  );
+}
+
+function Screen({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
+  return (
+    <View style={styles.sheetContainer}>
+      <Text style={styles.text}>I'm inside a view</Text>
+      <Button onPress={navigation.goBack} title="Dismiss" />
+    </View>
+  );
+}
+
+function Screen2({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
+  return (
+    <View style={{ ...styles.sheetContainer, flex: 1 }}>
+      <Text style={styles.text}>I'm inside a view with "flex: 1"</Text>
+      <Button onPress={navigation.goBack} title="Dismiss" />
+    </View>
+  );
+}
+
+function Screen3({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}) {
+  return (
+    <ScrollView
+      contentContainerStyle={styles.sheetContainer}
+      nestedScrollEnabled>
+      {Array(30)
+        .fill(0)
+        .map((_, index) => (
+          <Text style={styles.text} key={index}>
+            I'm inside a scrollview
+          </Text>
+        ))}
+      <Button onPress={navigation.goBack} title="Dismiss" />
+      <ScrollView>
+        {Array(30)
+          .fill(0)
+          .map((_, index) => (
+            <Text style={styles.text} key={'nested' + index}>
+              I'm inside a nested scrollview
+            </Text>
+          ))}
+      </ScrollView>
+    </ScrollView>
+  );
+}
+
+const RootStack = createNativeStackNavigator<StackParamList>();
+
+const commonSheetOptions = {
+  presentation: 'formSheet',
+  sheetAllowedDetents: [0.5, 1],
+  unstable_screenStyle: { backgroundColor: 'linen' },
+  sheetCornerRadius: 25,
+} as NativeStackNavigationOptions;
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <RootStack.Navigator>
+        <RootStack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ headerShown: false }}
+        />
+        <RootStack.Screen
+          name="Sheet One"
+          component={Screen}
+          options={commonSheetOptions}
+        />
+        <RootStack.Screen
+          name="Sheet Two"
+          component={Screen2}
+          options={commonSheetOptions}
+        />
+        <RootStack.Screen
+          name="Sheet Three"
+          component={Screen3}
+          options={commonSheetOptions}
+        />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontWeight: 'bold',
+    fontSize: 20,
+    padding: 5,
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  sheetContainer: {
+    backgroundColor: 'antiquewhite',
+    padding: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -116,6 +116,7 @@ export { default as Test2320 } from './Test2320';
 export { default as Test2332 } from './Test2332';
 export { default as Test2379 } from './Test2379';
 export { default as Test2395 } from './Test2395';
+export { default as Test2462 } from './Test2462';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestHeader } from './TestHeader';
 export { default as TestPreload } from './TestPreload';

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -77,7 +77,13 @@ function ScreenStackItem(
        * See https://github.com/software-mansion/react-native-screens/pull/1825
        * for detailed explanation.
        */}
-      <ScreenStackHeaderConfig {...headerConfig} />
+      <ScreenStackHeaderConfig
+        {...headerConfig}
+        hidden={
+          headerConfig?.hidden ||
+          (stackPresentation === 'formSheet' && Platform.OS === 'android')
+        }
+      />
     </>
   );
 

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -22,14 +22,17 @@ type Props = Omit<
   contentStyle?: StyleProp<ViewStyle>;
 };
 
-function ScreenStackItem({
-  children,
-  headerConfig,
-  activityState,
-  stackPresentation,
-  contentStyle,
-  ...rest
-}: Props, ref: React.ForwardedRef<View>) {
+function ScreenStackItem(
+  {
+    children,
+    headerConfig,
+    activityState,
+    stackPresentation,
+    contentStyle,
+    ...rest
+  }: Props,
+  ref: React.ForwardedRef<View>,
+) {
   const isHeaderInModal =
     Platform.OS === 'android'
       ? false
@@ -42,7 +45,7 @@ function ScreenStackItem({
       Platform.OS !== 'android' &&
         stackPresentation !== 'push' &&
         headerHiddenPreviousRef.current !== headerConfig?.hidden,
-      `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`
+      `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`,
     );
 
     headerHiddenPreviousRef.current = headerConfig?.hidden;
@@ -53,14 +56,14 @@ function ScreenStackItem({
       <DebugContainer
         style={[
           stackPresentation === 'formSheet'
-            ? Platform.OS === 'ios'
-              ? styles.absolute
-              : null
+            ? {
+                ...styles.sheet,
+                maxHeight: Platform.OS === 'android' ? '100%' : undefined,
+              }
             : styles.container,
           contentStyle,
         ]}
-        stackPresentation={stackPresentation ?? 'push'}
-      >
+        stackPresentation={stackPresentation ?? 'push'}>
         {children}
       </DebugContainer>
       {/**
@@ -86,8 +89,7 @@ function ScreenStackItem({
       activityState={activityState}
       stackPresentation={stackPresentation}
       hasLargeHeader={headerConfig?.largeTitle ?? false}
-      {...rest}
-    >
+      {...rest}>
       {isHeaderInModal ? (
         <ScreenStack style={styles.container}>
           <Screen
@@ -95,8 +97,7 @@ function ScreenStackItem({
             isNativeStack
             activityState={activityState}
             hasLargeHeader={headerConfig?.largeTitle ?? false}
-            style={StyleSheet.absoluteFill}
-          >
+            style={StyleSheet.absoluteFill}>
             {content}
           </Screen>
         </ScreenStack>
@@ -113,7 +114,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  absolute: {
+  sheet: {
     position: 'absolute',
     top: 0,
     start: 0,

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -79,6 +79,9 @@ function ScreenStackItem(
        */}
       <ScreenStackHeaderConfig
         {...headerConfig}
+        // We want to ensure the header is hidden for the `formSheet` presentation on Android as it doesn't have one.
+        // Otherwise it's height may influence sheet contents layout in an unwanted way.
+        // See https://github.com/software-mansion/react-native-screens/pull/2462
         hidden={
           headerConfig?.hidden ||
           (stackPresentation === 'formSheet' && Platform.OS === 'android')


### PR DESCRIPTION
This PR was originally posted in react-navigation: https://github.com/react-navigation/react-navigation/pull/12196
Since https://github.com/software-mansion/react-native-screens/pull/2433 the changes should be applied here.

This change relies on replacing `ScreenStackContent` in react-navigation with this `ScreenStackItem` component imported from react-native-screens. ~Until it's done this PR is a draft.~ Keep that in mind if you want to test this change.

## Description

This PR intents to add `flex: 1` support to android formSheets. Currently when you set `flex: 1` style to a wrapper component (quite usual thing to do) inside a screen with `presentation: 'formSheet'` it doesn't show up on android. On iOS it works fine.

This adjustment prevents the android sheet from breaking when given the `flex: 1` style and ensures that its behaviour aligns better with iOS.

While iOS is given sheet specific styles, Android receives `null`. Passing same styles to both platforms makes the `flex: 1` work as expected. To ensure that the scrollview on Android knows it's height and scrolls properly, a `maxHeight: '100%'` style is added.

Additionally, on Android there's no header in `formSheet` presentation. Thus we want to explicitly set it to hidden, as it may influence the content's  layout.

## Changes

- adjusted layout styles for `formSheet` presentation.
- ensured header is hidden on android sheet
- added `Test2462.tsx` repro

## Screenshots / GIFs

### Before

| without backgroundColor | with backgroundColor |
|---|---|
|  ![Screenshot 2024-10-29 at 11 44 38](https://github.com/user-attachments/assets/da334a8b-7080-43c5-9963-5615a49a704a) | ![Screenshot 2024-10-29 at 11 44 47](https://github.com/user-attachments/assets/547de8b8-dd93-4ea1-a90c-a38af1110b13) |

### After

| without backgroundColor | with backgroundColor |
|---|---|
|  ![Screenshot 2024-10-29 at 11 47 03](https://github.com/user-attachments/assets/d0d1a22a-203d-4545-bc8c-20ba855b421c) | ![Screenshot 2024-10-29 at 11 43 57](https://github.com/user-attachments/assets/1c873587-1668-4195-8a2c-55c723f6d05e) |

## Test code and steps to reproduce

- use `Test2462.tsx` repro

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
