### PR TITLE
fix(Android): screen goes blank when going back on fabric

### DIFF
--- a/apps/src/tests/Test2282.tsx
+++ b/apps/src/tests/Test2282.tsx
@@ -34,10 +34,10 @@ function Home({ navigation }: any) {
 
 function ListScreen() {
   return (
-    <>
+    <View style={{ flex: 1, backgroundColor: 'slateblue' }}>
       <ParentFlatlist />
       <ParentFlatlist horizontal />
-    </>
+    </View>
   );
 }
 
@@ -98,7 +98,7 @@ const Stack = createNativeStackNavigator();
 export default function App(): React.JSX.Element {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
+      <Stack.Navigator screenOptions={{ animation: 'slide_from_right' }}>
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="List" component={ListScreen} />
       </Stack.Navigator>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,11 @@ export { default as ScreenFooter } from './components/ScreenFooter';
 export { default as ScreenContentWrapper } from './components/ScreenContentWrapper';
 
 /**
+ * Modules
+ */
+export { default as NativeScreensModule } from './fabric/NativeScreensModule';
+
+/**
  * Contexts
  */
 export { GHContext } from './native-stack/contexts/GHContext';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ export { default as ScreenContentWrapper } from './components/ScreenContentWrapp
 /**
  * Modules
  */
+/* eslint-disable camelcase */
 export { default as NativeScreensModule_INTERNAL_DO_NOT_USE } from './fabric/NativeScreensModule';
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,7 @@ export { default as ScreenContentWrapper } from './components/ScreenContentWrapp
 /**
  * Modules
  */
-export { default as NativeScreensModule } from './fabric/NativeScreensModule';
+export { default as NativeScreensModule_INTERNAL_DO_NOT_USE } from './fabric/NativeScreensModule';
 
 /**
  * Contexts


### PR DESCRIPTION
## Description

This PR intents to fix current screen going blank on Android when returning to the previous one. The issue has been already fixed by https://github.com/software-mansion/react-native-screens/pull/2134, but re-appeared recently. After a quick bisect it turned out that https://github.com/software-mansion/react-native-screens/pull/2412 caused the regression. Bringing back the removed `NativeScreensModule` export fixes the issue.

Fixes #1685 

## Changes

- added missing export
- modified `Test2282.tsx` repro

## Screenshots / GIFs

### Before

https://github.com/user-attachments/assets/39bf6c66-39d2-4dfd-abc8-ee1c690417a4

### After

https://github.com/user-attachments/assets/003446b2-c976-4cdb-8ab4-348dd619ba79

## Test code and steps to reproduce

- use `Test2282.tsx` repro

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
