### PR TITLE
fix: clicking on Pressable located in screen header

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -1,4 +1,5 @@
 #include "RNSScreenShadowNode.h"
+#include "RNSScreenStackHeaderConfigShadowNode.h"
 
 namespace facebook {
 namespace react {
@@ -118,7 +119,16 @@ void RNSScreenShadowNode::appendChild(const ShadowNode::Shared &child) {
 
 void RNSScreenShadowNode::layout(facebook::react::LayoutContext layoutContext) {
   YogaLayoutableShadowNode::layout(layoutContext);
-
+    
+    auto headerConfigChildOpt = findHeaderConfigChild(*this);
+    if (headerConfigChildOpt) {
+      auto headerConfigChildConst = std::dynamic_pointer_cast<const RNSScreenStackHeaderConfigShadowNode>(headerConfigChildOpt->get());
+      auto headerConfigChild = std::const_pointer_cast<RNSScreenStackHeaderConfigShadowNode>(headerConfigChildConst);
+      auto stateData = getStateData();
+      auto contentOffset = stateData.contentOffset;
+      headerConfigChild->layoutMetrics_.frame.origin.y = -contentOffset.y;
+    }
+    
 #ifdef ANDROID
   applyFrameCorrections();
 #endif // ANDROID

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
@@ -4,5 +4,15 @@ namespace facebook::react {
 
 extern const char RNSScreenStackHeaderConfigComponentName[] =
     "RNSScreenStackHeaderConfig";
+}
 
+namespace facebook {
+    namespace  react {
+        Point RNSScreenStackHeaderConfigShadowNode::getContentOriginOffset(
+                bool /*includeTransform*/) const {
+            auto stateData = getStateData();
+            auto topInsetOffset = stateData.getPaddingTop();
+            return {0, topInsetOffset};
+        }
+    }
 }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
@@ -11,8 +11,8 @@ namespace facebook {
         Point RNSScreenStackHeaderConfigShadowNode::getContentOriginOffset(
                 bool /*includeTransform*/) const {
             auto stateData = getStateData();
-            auto topInsetOffset = stateData.getPaddingTop();
-            return {0, topInsetOffset};
+            auto paddingTop = stateData.getPaddingTop();
+            return {0, paddingTop};
         }
     }
 }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h
@@ -26,6 +26,8 @@ class JSI_EXPORT RNSScreenStackHeaderConfigShadowNode final
 
 #pragma mark - ShadowNode overrides
 
+  Point getContentOriginOffset(bool includeTransform) const override;
+
 #pragma mark - Custom interface
 };
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp
@@ -1,3 +1,4 @@
+
 #include "RNSScreenStackHeaderConfigState.h"
 
 namespace facebook {
@@ -17,6 +18,10 @@ Float RNSScreenStackHeaderConfigState::getPaddingStart() const noexcept {
 
 Float RNSScreenStackHeaderConfigState::getPaddingEnd() const noexcept {
   return paddingEnd_;
+}
+
+Float RNSScreenStackHeaderConfigState::getPaddingTop() const noexcept {
+  return paddingTop_;
 }
 
 } // namespace react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -17,8 +17,8 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
 
   RNSScreenStackHeaderConfigState() = default;
 
-  RNSScreenStackHeaderConfigState(Float paddingStart, Float paddingEnd)
-      : paddingStart_{paddingStart}, paddingEnd_{paddingEnd} {}
+  RNSScreenStackHeaderConfigState(Float paddingStart, Float paddingEnd, Float paddingTop)
+    : paddingStart_{paddingStart}, paddingEnd_{paddingEnd}, paddingTop_{paddingTop} {}
 
 #ifdef ANDROID
   RNSScreenStackHeaderConfigState(
@@ -41,10 +41,13 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
   [[nodiscard]] Float getPaddingStart() const noexcept;
 
   [[nodiscard]] Float getPaddingEnd() const noexcept;
+    
+  [[nodiscard]] Float getPaddingTop() const noexcept;
 
  private:
   Float paddingStart_{0.f};
   Float paddingEnd_{0.f};
+  Float paddingTop_{0.f};
 };
 
 } // namespace facebook::react

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -124,6 +124,7 @@ namespace react = facebook::react;
                                                      .leading = navBarMargins.leading + navBarContentMargins.leading +
                                                          (isDisplayingBackButton ? platformBackButtonWidth : 0),
                                                      .trailing = navBarMargins.trailing + navBarContentMargins.trailing,
+                                                     .top = self.navigationBar.frame.origin.y
                                                  }];
 }
 #endif

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -187,9 +187,9 @@ namespace react = facebook::react;
 
 - (void)updateHeaderInsetsInShadowTreeTo:(NSDirectionalEdgeInsets)insets
 {
-  if (_lastHeaderInsets.leading != insets.leading || _lastHeaderInsets.trailing != insets.trailing) {
+    if (_lastHeaderInsets.leading != insets.leading || _lastHeaderInsets.trailing != insets.trailing || _lastHeaderInsets.top != insets.top) {
 #ifdef RCT_NEW_ARCH_ENABLED
-    auto newState = react::RNSScreenStackHeaderConfigState{insets.leading, insets.trailing};
+    auto newState = react::RNSScreenStackHeaderConfigState{insets.leading, insets.trailing, insets.top};
     _state->updateState(std::move(newState));
     _lastHeaderInsets = std::move(insets);
 #else

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -102,7 +102,6 @@ const styles = StyleSheet.create({
   },
   headerConfig: {
     position: 'absolute',
-    top: '-100%',
     width: '100%',
     flexDirection: 'row',
     justifyContent: 'space-between',


### PR DESCRIPTION
## Description

This PR fixes clicking on Pressables that are added to the native header. Previously, Yoga had incorrect information about the location of the content in the header. 

The first step was to remove `top: "-100%"` style from the `ScreenStackHeaderConfig` which made Yoga think, that the content is pushed up by the size of its parent (Screen size). 

The second step involved updating `layoutMetrics` of the `RNSScreenStackHeaderConfigShadowNode`. The entire app content is pushed down by the size of the header, so it also has an impact on the header config in Yoga metrics. To mitigate this, the origin of `RNSScreenStackHeaderConfigShadowNode` is decreased by the size of the header which will zero out eventually leaving the header content in the desired position. On iOS this position is actually moved by the top inset size, so we also have to take it into account when setting header config layout metrics.

## Changes

Updated `ScreenShadowNode` to decrease `origin.y` of the `HeaderConfigShadowNode` by the size of the header. Added `paddingTop` to `HeaderConfigState` and set it as origin offset on iOS.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--


-->

## Screenshots / GIFs

### Before

| iOS       | Android        |
|--------------|--------------|
| <video src="https://github.com/user-attachments/assets/aa054d20-58e5-4153-924b-a1b74879ae6b">  | <video src="https://github.com/user-attachments/assets/dd9d2732-10c5-40ca-b384-1570c08410cf">  |

### After

| iOs       | Android        |
|--------------|--------------|
| <video src="https://github.com/user-attachments/assets/6953c9e5-b418-41b1-8b99-27f70c5df688">  | <video src="https://github.com/user-attachments/assets/f5762f46-36b2-423a-93da-9f61032b54bf">  |



## Test code and steps to reproduce

Tested on this example:

<details>
 <summary>code</summary>

```ts
import { NavigationContainer } from "@react-navigation/native";
import { createNativeStackNavigator, NativeStackNavigationProp } from "@react-navigation/native-stack";
import React, { ForwardedRef, forwardRef } from "react";
import { findNodeHandle, Pressable, PressableProps, StyleSheet, Text, View, } from "react-native";

type StackParamList = {
  Home: undefined,
}

type RouteProps = {
  navigation: NativeStackNavigationProp<StackParamList>;
}

type PressableState = 'pressed-in' | 'pressed' | 'pressed-out'


const Stack = createNativeStackNavigator<StackParamList>();


const PressableWithFeedback = forwardRef((props: PressableProps, ref: ForwardedRef<View>): React.JSX.Element => {
  const [pressedState, setPressedState] = React.useState<PressableState>('pressed-out');

  const onPressInCallback = React.useCallback((e) => {
    console.log('Pressable onPressIn', {
      locationX: e.nativeEvent.locationX,
      locationY: e.nativeEvent.locationY,
      pageX: e.nativeEvent.pageX,
      pageY: e.nativeEvent.pageY,
    });
    setPressedState('pressed-in');
    props.onPressIn?.();
  }, []);

  const onPressCallback = React.useCallback(() => {
    console.log('Pressable onPress');
    setPressedState('pressed');
  }, []);

  const onPressOutCallback = React.useCallback(() => {
    console.log('Pressable onPressOut');
    setPressedState('pressed-out');
  }, []);

  const onResponderMoveCallback = React.useCallback(() => {
    console.log('Pressable onResponderMove');
  }, []);

  const contentsStyle = pressedState === 'pressed-out'
    ? styles.pressablePressedOut
    : (pressedState === 'pressed'
      ? styles.pressablePressed
      : styles.pressablePressedIn);

  return (
    <View ref={ref} style={[contentsStyle, { width: "100%"}]}>
      <Pressable
        onPressIn={onPressInCallback}
        onPress={onPressCallback}
        onPressOut={onPressOutCallback}
        onResponderMove={onResponderMoveCallback}
      >
        {props.children}
      </Pressable>
    </View>

  );
})

function HeaderTitle(): React.JSX.Element {

  return (
    <PressableWithFeedback
      onPressIn={() => {
        console.log('Pressable onPressIn')
      }}
      onPress={() => console.log('Pressable onPress')}
      onPressOut={() => console.log('Pressable onPressOut')}
      onResponderMove={() => console.log('Pressable onResponderMove')}
      ref={ref => {
        console.log(findNodeHandle(ref));
        ref?.measure((x, y, width, height, pageX, pageY) => {
          console.log('header component measure', { x, y, width, height, pageX, pageY });
        })
      }}
    >
      <View style={{ height: 40, justifyContent: 'center', alignItems: 'center' }}>
        <Text style={{ alignItems: 'center' }}>Regular Pressable</Text>
      </View>
    </PressableWithFeedback>
  )
}

function Home(_: RouteProps): React.JSX.Element {
  return (
    <View style={{ flex: 1, backgroundColor: 'rgba(0, 0, 0, .8)' }}
    >
      <View style={{ flex: 1, alignItems: 'center', marginTop: 48 }}>
        <PressableWithFeedback
          onPressIn={() => console.log('Pressable onPressIn')}
          onPress={() => console.log('Pressable onPress')}
          onPressOut={() => console.log('Pressable onPressOut')}
        >
          <View style={{ height: 40, width: 200, justifyContent: 'center', alignItems: 'center' }}>
            <Text style={{ alignItems: 'center' }}>Regular Pressable</Text>
          </View>
        </PressableWithFeedback>
      </View>
    </View>
  );
}

function App(): React.JSX.Element {
  return (
    <NavigationContainer>
      <Stack.Navigator>
        <Stack.Screen
          name="Home"
          component={Home}
          options={{
            headerTitle: HeaderTitle,
          }}
        />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

const styles = StyleSheet.create({
  pressablePressedIn: {
    backgroundColor: 'lightsalmon',
  },
  pressablePressed: {
    backgroundColor: 'crimson',
  },
  pressablePressedOut: {
    backgroundColor: 'lightseagreen',
  }
});


export default App;


```

</details>


<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
