### PR TITLE
refactor: use side-effect import declaration to ensure TurboModule gets loaded

### DIFF
--- a/src/components/DebugContainer.tsx
+++ b/src/components/DebugContainer.tsx
@@ -16,9 +16,9 @@ type ContainerProps = ViewProps & {
  * See https://github.com/software-mansion/react-native-screens/pull/1825
  * for detailed explanation.
  */
-let DebugContainer: React.ComponentType<ContainerProps> = (props) => {
+let DebugContainer: React.ComponentType<ContainerProps> = props => {
   return <ScreenContentWrapper {...props} />;
-}
+};
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line react/display-name

--- a/src/components/DebugContainer.web.tsx
+++ b/src/components/DebugContainer.web.tsx
@@ -2,6 +2,6 @@ import * as React from 'react';
 import { type ViewProps } from 'react-native';
 import ScreenContentWrapper from './ScreenContentWrapper';
 
-export default function DebugContainer(props: ViewProps)  {
+export default function DebugContainer(props: ViewProps) {
   return <ScreenContentWrapper {...props} />;
 }

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -22,14 +22,17 @@ type Props = Omit<
   contentStyle?: StyleProp<ViewStyle>;
 };
 
-function ScreenStackItem({
-  children,
-  headerConfig,
-  activityState,
-  stackPresentation,
-  contentStyle,
-  ...rest
-}: Props, ref: React.ForwardedRef<View>) {
+function ScreenStackItem(
+  {
+    children,
+    headerConfig,
+    activityState,
+    stackPresentation,
+    contentStyle,
+    ...rest
+  }: Props,
+  ref: React.ForwardedRef<View>,
+) {
   const isHeaderInModal =
     Platform.OS === 'android'
       ? false
@@ -42,7 +45,7 @@ function ScreenStackItem({
       Platform.OS !== 'android' &&
         stackPresentation !== 'push' &&
         headerHiddenPreviousRef.current !== headerConfig?.hidden,
-      `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`
+      `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`,
     );
 
     headerHiddenPreviousRef.current = headerConfig?.hidden;
@@ -59,8 +62,7 @@ function ScreenStackItem({
             : styles.container,
           contentStyle,
         ]}
-        stackPresentation={stackPresentation ?? 'push'}
-      >
+        stackPresentation={stackPresentation ?? 'push'}>
         {children}
       </DebugContainer>
       {/**
@@ -86,8 +88,7 @@ function ScreenStackItem({
       activityState={activityState}
       stackPresentation={stackPresentation}
       hasLargeHeader={headerConfig?.largeTitle ?? false}
-      {...rest}
-    >
+      {...rest}>
       {isHeaderInModal ? (
         <ScreenStack style={styles.container}>
           <Screen
@@ -95,8 +96,7 @@ function ScreenStackItem({
             isNativeStack
             activityState={activityState}
             hasLargeHeader={headerConfig?.largeTitle ?? false}
-            style={StyleSheet.absoluteFill}
-          >
+            style={StyleSheet.absoluteFill}>
             {content}
           </Screen>
         </ScreenStack>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
+// Side effects import declaration to ensure our TurboModule
+// is loaded.
+import './fabric/NativeScreensModule';
+
 export * from './types';
 
 /**
@@ -36,12 +40,6 @@ export { default as ScreenStackItem } from './components/ScreenStackItem';
 export { default as FullWindowOverlay } from './components/FullWindowOverlay';
 export { default as ScreenFooter } from './components/ScreenFooter';
 export { default as ScreenContentWrapper } from './components/ScreenContentWrapper';
-
-/**
- * Modules
- */
-/* eslint-disable camelcase */
-export { default as NativeScreensModule_INTERNAL_DO_NOT_USE } from './fabric/NativeScreensModule';
 
 /**
  * Contexts


### PR DESCRIPTION
## Description

We want to ensure that the tubomodule spec gets loaded & executed
and at the same time we don't want it exported. 

This syntax should ensure it! [MDN docs link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only)

## Changes

Change export to side effect import!

## Test code and steps to reproduce

Run FabricExample on Android & see that the underneath screen does not disappear when popping a screen.

## Checklist

- [ ] Ensured that CI passes

