### PR TITLE
fix(iOS): change default sheet detent to large

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -60,8 +60,8 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
 };
 
 typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
-  RNSScreenDetentTypeMedium,
   RNSScreenDetentTypeLarge,
+  RNSScreenDetentTypeMedium,
   RNSScreenDetentTypeAll,
 };
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1619,7 +1619,7 @@ RCT_ENUM_CONVERTER(
       @"medium" : @(RNSScreenDetentTypeMedium),
       @"all" : @(RNSScreenDetentTypeAll),
     }),
-    RNSScreenDetentTypeAll,
+    RNSScreenDetentTypeLarge,
     integerValue)
 
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json


### PR DESCRIPTION
## Description

This PR ensures the default sheet detent is 'large' as stated in types.

The value is not being updated in `updateProps` since it's always 'large' and `setSheetAllowedDetents` is not triggered until we intentionally use a different value. Changing the order in the typedef ensures `RNSScreenDetentTypeLarge` gets picked up as the default value.

Fixes #2347

## Test code and steps to reproduce

- Use `StackPresentation` screen in the Example app

## Checklist

- [ ] Ensured that CI passes
