### PR TITLE
fix(iOS): RCTAssert.h file not found for case sensitive file system (#2472)

### DIFF
--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -1,7 +1,7 @@
 #import "RNSConvert.h"
 
 #ifndef RCT_NEW_ARCH_ENABLED
-#import <react/RCTAssert.h>
+#import <React/RCTAssert.h>
 #endif // !RCT_NEW_ARCH_ENABLED
 
 @implementation RNSConvert


### PR DESCRIPTION
## Description
Fix react-native-screens module build failure for case sensitive file systems.

Fixes #2472.