### PR TITLE
fix: prevent Require cycles warning cherry-pick from main

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -5,7 +5,7 @@ import { Animated, View, Platform } from 'react-native';
 
 import TransitionProgressContext from '../TransitionProgressContext';
 import DelayedFreeze from './helpers/DelayedFreeze';
-import { ScreenProps } from 'react-native-screens';
+import { ScreenProps } from '../types';
 
 import {
   freezeEnabled,

--- a/src/components/Screen.web.tsx
+++ b/src/components/Screen.web.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ScreenProps } from 'react-native-screens';
+import { ScreenProps } from '../types';
 import { Animated, View } from 'react-native';
 import React from 'react';
 

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -2,7 +2,7 @@
 
 import { Platform, View } from 'react-native';
 import React from 'react';
-import { ScreenContainerProps } from 'react-native-screens';
+import { ScreenContainerProps } from '../types';
 import { isNativePlatformSupported, screensEnabled } from '../core';
 
 // Native components

--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { ScreenStackProps, freezeEnabled } from 'react-native-screens';
+import { ScreenStackProps } from '../types';
+import { freezeEnabled } from '../core';
 import DelayedFreeze from './helpers/DelayedFreeze';
 
 // Native components

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -5,7 +5,7 @@ import {
   HeaderSubviewTypes,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
-} from 'react-native-screens';
+} from '../types';
 import { Image, ImageProps, StyleSheet, ViewProps } from 'react-native';
 
 // Native components

--- a/src/components/ScreenStackHeaderConfig.web.tsx
+++ b/src/components/ScreenStackHeaderConfig.web.tsx
@@ -4,7 +4,7 @@ import {
   HeaderSubviewTypes,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
-} from 'react-native-screens';
+} from '../types';
 
 export const ScreenStackHeaderBackButtonImage = (
   props: ImageProps,

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import React from 'react';
-import {
-  isSearchBarAvailableForCurrentPlatform,
-  SearchBarCommands,
-  SearchBarProps,
-} from 'react-native-screens';
+import { SearchBarCommands, SearchBarProps } from '../types';
+import { isSearchBarAvailableForCurrentPlatform } from '../utils';
 import { View } from 'react-native';
 
 // Native components

--- a/src/gesture-handler/GestureDetectorProvider.tsx
+++ b/src/gesture-handler/GestureDetectorProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GHContext } from 'react-native-screens';
+import { GHContext } from '../native-stack/contexts/GHContext';
 import ScreenGestureDetector from './ScreenGestureDetector';
 import type { GestureProviderProps } from '../native-stack/types';
 

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -23,7 +23,7 @@ import {
   ScreenStackHeaderConfigProps,
   SearchBarProps,
   SheetDetentTypes,
-} from 'react-native-screens';
+} from '../types';
 
 export type NativeStackNavigationEventMap = {
   /**

--- a/src/native-stack/utils/getDefaultHeaderHeight.tsx
+++ b/src/native-stack/utils/getDefaultHeaderHeight.tsx
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { StackPresentationTypes } from 'react-native-screens';
+import { StackPresentationTypes } from '../../types';
 type Layout = { width: number; height: number };
 
 const formSheetModalHeight = 56;

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -1,6 +1,11 @@
 import { Route, useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import { Platform } from 'react-native';
+import { SearchBarProps } from '../../types';
+import {
+  isSearchBarAvailableForCurrentPlatform,
+  executeNativeBackPress,
+} from '../../utils';
 import {
   ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderCenterView,
@@ -8,11 +13,8 @@ import {
   ScreenStackHeaderLeftView,
   ScreenStackHeaderRightView,
   ScreenStackHeaderSearchBarView,
-  SearchBar,
-  SearchBarProps,
-  isSearchBarAvailableForCurrentPlatform,
-  executeNativeBackPress,
-} from 'react-native-screens';
+} from '../../components/ScreenStackHeaderConfig';
+import SearchBar from '../../components/SearchBar';
 import { NativeStackNavigationOptions } from '../types';
 import { useBackPressSubscription } from '../utils/useBackPressSubscription';
 import { processFonts } from './FontProcessor';

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -4,13 +4,10 @@ import { Animated, Platform, StyleSheet, View, ViewProps } from 'react-native';
 // eslint-disable-next-line import/no-named-as-default, import/default, import/no-named-as-default-member, import/namespace
 import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
 import warnOnce from 'warn-once';
-import {
-  ScreenStack,
-  StackPresentationTypes,
-  ScreenContext,
-  GHContext,
-  GestureDetectorBridge,
-} from 'react-native-screens';
+import { StackPresentationTypes, GestureDetectorBridge } from '../../types';
+import ScreenStack from '../../components/ScreenStack';
+import { GHContext } from '../contexts/GHContext';
+import { ScreenContext } from '../../components/Screen';
 import {
   ParamListBase,
   StackActions,

--- a/src/reanimated/ReanimatedNativeStackScreen.tsx
+++ b/src/reanimated/ReanimatedNativeStackScreen.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Platform } from 'react-native';
+import { InnerScreen } from '../components/Screen';
 import {
   HeaderHeightChangeEventType,
-  InnerScreen,
   ScreenProps,
   TransitionProgressEventType,
-} from 'react-native-screens';
+} from '../types';
 
 // @ts-ignore file to be used only if `react-native-reanimated` available in the project
 import Animated, { useEvent, useSharedValue } from 'react-native-reanimated';

--- a/src/reanimated/ReanimatedScreen.tsx
+++ b/src/reanimated/ReanimatedScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { InnerScreen, ScreenProps } from 'react-native-screens';
+import { InnerScreen } from '../components/Screen';
+import { ScreenProps } from '../types';
 
 // @ts-ignore file to be used only if `react-native-reanimated` available in the project
 import Animated from 'react-native-reanimated';

--- a/src/reanimated/ReanimatedScreenProvider.tsx
+++ b/src/reanimated/ReanimatedScreenProvider.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { View } from 'react-native';
-import { ScreenProps, ScreenContext } from 'react-native-screens';
+import { ScreenContext } from '../components/Screen';
+import { ScreenProps } from '../types';
 import ReanimatedNativeStackScreen from './ReanimatedNativeStackScreen';
 import AnimatedScreen from './ReanimatedScreen';
 


### PR DESCRIPTION
This is a #2410 cherry-pick from main. This PR aims to bring the fix to v3 as well.

## Description

This PR fixes `require cycles` warning caused by importing from `react-native-screens` in a `react-native-screens` module by changing the imports to relative. Additionally it fixes an [issue](https://github.com/software-mansion/react-native-screens/issues/2302) with react-compiler in expo projects.

Fixes #2408  #2302.

## Checklist

- [x] Ensured that CI passes
