### PR TITLE
feat(iOS)!: change default animation curve & duration

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -91,7 +91,7 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setStackAnimation(view, (String) value);
         break;
       case "transitionDuration":
-        mViewManager.setTransitionDuration(view, value == null ? 350 : ((Double) value).intValue());
+        mViewManager.setTransitionDuration(view, value == null ? 500 : ((Double) value).intValue());
         break;
       case "replaceAnimation":
         mViewManager.setReplaceAnimation(view, (String) value);

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -297,7 +297,7 @@ When using `vertical` option, options `fullScreenSwipeEnabled: true`, `customAni
 
 ### `transitionDuration` (iOS only)
 
-Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `500`.
 
 The duration of `default` and `flip` transitions isn't customizable.
 

--- a/ios/RNSPercentDrivenInteractiveTransition.h
+++ b/ios/RNSPercentDrivenInteractiveTransition.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+#import "RNSScreenStackAnimator.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSPercentDrivenInteractiveTransition : UIPercentDrivenInteractiveTransition
+
+@property (nonatomic, nullable) RNSScreenStackAnimator *animationController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNSPercentDrivenInteractiveTransition.mm
+++ b/ios/RNSPercentDrivenInteractiveTransition.mm
@@ -1,0 +1,69 @@
+#import "RNSPercentDrivenInteractiveTransition.h"
+
+@implementation RNSPercentDrivenInteractiveTransition {
+  RNSScreenStackAnimator *_animationController;
+}
+
+#pragma mark - UIViewControllerInteractiveTransitioning
+
+- (void)startInteractiveTransition:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+  [super startInteractiveTransition:transitionContext];
+}
+
+#pragma mark - UIPercentDrivenInteractiveTransition
+
+// `updateInteractiveTransition`, `finishInteractiveTransition`,
+// `cancelInteractiveTransition` are forwared by superclass to
+// corresponding methods in transition context. In case
+// of "classical CA driven animaitons", such as UIView animation blocks
+// or direct utilization of CoreAnimation API, context drives the animation,
+// however in case of UIViewPropertyAnimator it does not. We need
+// to drive animation manually and this is exactly what happens below.
+
+- (void)updateInteractiveTransition:(CGFloat)percentComplete
+{
+  if (_animationController != nil) {
+    [self.animationController.inFlightAnimator setFractionComplete:percentComplete];
+  }
+  [super updateInteractiveTransition:percentComplete];
+}
+
+- (void)finishInteractiveTransition
+{
+  [self finalizeInteractiveTransitionWithAnimationWasCancelled:NO];
+  [super finishInteractiveTransition];
+}
+
+- (void)cancelInteractiveTransition
+{
+  [self finalizeInteractiveTransitionWithAnimationWasCancelled:YES];
+  [super cancelInteractiveTransition];
+}
+
+#pragma mark - Helpers
+
+- (void)finalizeInteractiveTransitionWithAnimationWasCancelled:(BOOL)cancelled
+{
+  if (_animationController == nil) {
+    return;
+  }
+
+  UIViewPropertyAnimator *_Nullable animator = self.animationController.inFlightAnimator;
+  if (animator == nil) {
+    return;
+  }
+
+  BOOL shouldReverseAnimation = cancelled;
+
+  id<UITimingCurveProvider> timingParams = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
+
+  [animator pauseAnimation];
+  [animator setReversed:shouldReverseAnimation];
+  [animator continueAnimationWithTimingParameters:timingParams durationFactor:(1 - animator.fractionComplete)];
+
+  // System retains it & we don't need it anymore.
+  _animationController = nil;
+}
+
+@end

--- a/ios/RNSPercentDrivenInteractiveTransition.mm
+++ b/ios/RNSPercentDrivenInteractiveTransition.mm
@@ -56,7 +56,7 @@
 
   BOOL shouldReverseAnimation = cancelled;
 
-  id<UITimingCurveProvider> timingParams = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
+  id<UITimingCurveProvider> timingParams = [_animationController timingParamsForAnimationCompletion];
 
   [animator pauseAnimation];
   [animator setReversed:shouldReverseAnimation];

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -20,6 +20,7 @@
 #import "RCTTouchHandler+RNSUtility.h"
 #endif // RCT_NEW_ARCH_ENABLED
 
+#import "RNSPercentDrivenInteractiveTransition.h"
 #import "RNSScreen.h"
 #import "RNSScreenStack.h"
 #import "RNSScreenStackAnimator.h"
@@ -149,7 +150,7 @@ namespace react = facebook::react;
   NSMutableArray<RNSScreenView *> *_reactSubviews;
   BOOL _invalidated;
   BOOL _isFullWidthSwiping;
-  UIPercentDrivenInteractiveTransition *_interactionController;
+  RNSPercentDrivenInteractiveTransition *_interactionController;
   __weak RNSScreenStackManager *_manager;
   BOOL _updateScheduled;
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -869,7 +870,7 @@ namespace react = facebook::react;
 
   switch (gestureRecognizer.state) {
     case UIGestureRecognizerStateBegan: {
-      _interactionController = [UIPercentDrivenInteractiveTransition new];
+      _interactionController = [RNSPercentDrivenInteractiveTransition new];
       [_controller popViewControllerAnimated:YES];
       break;
     }
@@ -916,7 +917,7 @@ namespace react = facebook::react;
   if (_interactionController == nil && fromView.reactSuperview) {
     BOOL shouldCancelDismiss = [self shouldCancelDismissFromView:fromView toView:toView];
     if (shouldCancelDismiss) {
-      _interactionController = [UIPercentDrivenInteractiveTransition new];
+      _interactionController = [RNSPercentDrivenInteractiveTransition new];
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self->_interactionController cancelInteractiveTransition];
         self->_interactionController = nil;
@@ -928,6 +929,10 @@ namespace react = facebook::react;
         [fromView notifyDismissCancelledWithDismissCount:dismissCount];
       });
     }
+  }
+
+  if (_interactionController != nil) {
+    [_interactionController setAnimationController:animationController];
   }
   return _interactionController;
 }
@@ -1111,7 +1116,7 @@ namespace react = facebook::react;
 {
   if (_interactionController == nil) {
     _customAnimation = YES;
-    _interactionController = [UIPercentDrivenInteractiveTransition new];
+    _interactionController = [RNSPercentDrivenInteractiveTransition new];
     [_controller popViewControllerAnimated:YES];
   }
 }

--- a/ios/RNSScreenStackAnimator.h
+++ b/ios/RNSScreenStackAnimator.h
@@ -2,6 +2,10 @@
 
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
 
+/// This property is filled only when there is an property aniamator associated with an ongoing interactive transition.
+/// In our case this is when we're handling full swipe or edge back gesture.
+@property (nonatomic, strong, nullable, readonly) UIViewPropertyAnimator *inFlightAnimator;
+
 - (nonnull instancetype)initWithOperation:(UINavigationControllerOperation)operation;
 + (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation;
 

--- a/ios/RNSScreenStackAnimator.h
+++ b/ios/RNSScreenStackAnimator.h
@@ -7,6 +7,15 @@
 @property (nonatomic, strong, nullable, readonly) UIViewPropertyAnimator *inFlightAnimator;
 
 - (nonnull instancetype)initWithOperation:(UINavigationControllerOperation)operation;
+
+/// In case of interactive / interruptible transition (e.g. swipe back gesture) this method should return
+/// timing parameters expected by animator to be used for animation completion (e.g. when user's
+/// gesture had ended).
+///
+/// @return timing curve provider expected to be used for animation completion or nil,
+/// when there is no interactive transition running.
+- (nullable id<UITimingCurveProvider>)timingParamsForAnimationCompletion;
+
 + (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation;
 
 @end

--- a/ios/RNSScreenStackAnimator.h
+++ b/ios/RNSScreenStackAnimator.h
@@ -2,7 +2,7 @@
 
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
 
-- (instancetype)initWithOperation:(UINavigationControllerOperation)operation;
+- (nonnull instancetype)initWithOperation:(UINavigationControllerOperation)operation;
 + (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation;
 
 @end

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -164,10 +164,9 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     // Damping of 1.0 seems close enough and we keep `animationDuration` functional.
     // id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] init];
 
-    id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
     UIViewPropertyAnimator *animator =
         [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
-                                        timingParameters:timingCurveProvider];
+                                        timingParameters:[RNSScreenStackAnimator defaultSpringTimingParametersApprox]];
 
     [animator addAnimations:^{
       fromViewController.view.transform = leftTransform;
@@ -213,11 +212,9 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     };
 
     if (!transitionContext.isInteractive) {
-      id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
-
-      UIViewPropertyAnimator *animator =
-          [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
-                                          timingParameters:timingCurveProvider];
+      UIViewPropertyAnimator *animator = [[UIViewPropertyAnimator alloc]
+          initWithDuration:[self transitionDuration:transitionContext]
+          timingParameters:[RNSScreenStackAnimator defaultSpringTimingParametersApprox]];
 
       [animator addAnimations:animationBlock];
       [animator addCompletion:completionBlock];
@@ -464,6 +461,18 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   }
 }
 
+#pragma mark - Public API
+
+- (nullable id<UITimingCurveProvider>)timingParamsForAnimationCompletion
+{
+  return [RNSScreenStackAnimator defaultSpringTimingParametersApprox];
+}
+
++ (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation
+{
+  return (animation != RNSScreenStackAnimationFlip && animation != RNSScreenStackAnimationDefault);
+}
+
 #pragma mark - Helpers
 
 - (void)animateTransitionWithStackAnimation:(RNSScreenStackAnimation)animation
@@ -492,9 +501,9 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   [self animateSimplePushWithShadowEnabled:shadowEnabled transitionContext:transitionContext toVC:toVC fromVC:fromVC];
 }
 
-+ (BOOL)isCustomAnimation:(RNSScreenStackAnimation)animation
++ (UISpringTimingParameters *)defaultSpringTimingParametersApprox
 {
-  return (animation != RNSScreenStackAnimationFlip && animation != RNSScreenStackAnimationDefault);
+  return [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
 }
 
 @end

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -179,13 +179,22 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
         shadowView.alpha = 0.0;
       }
     };
-    void (^completionBlock)(UIViewAnimatingPosition) = ^(UIViewAnimatingPosition finalPosition) {
+
+    void (^completionBlockImpl)(void) = ^{
       if (shadowView) {
         [shadowView removeFromSuperview];
       }
       fromViewController.view.transform = CGAffineTransformIdentity;
       toViewController.view.transform = CGAffineTransformIdentity;
       [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+    };
+
+    void (^completionBlock)(UIViewAnimatingPosition) = ^(UIViewAnimatingPosition finalPosition) {
+      completionBlockImpl();
+    };
+
+    void (^completionBlock2)(BOOL) = ^(BOOL finalPosition) {
+      completionBlockImpl();
     };
 
     if (!transitionContext.isInteractive) {
@@ -200,13 +209,11 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
       [animator startAnimation];
     } else {
       // we don't want the EaseInOut option when swiping to dismiss the view, it is the same in default animation option
-      UIViewPropertyAnimator *animator =
-          [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
-                                                     curve:UIViewAnimationCurveLinear
-                                                animations:animationBlock];
-
-      [animator addCompletion:completionBlock];
-      [animator startAnimation];
+      [UIView animateWithDuration:[self transitionDuration:transitionContext]
+                            delay:0.0
+                          options:UIViewAnimationOptionCurveLinear
+                       animations:animationBlock
+                       completion:completionBlock2];
     }
   }
 }

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -179,7 +179,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
         shadowView.alpha = 0.0;
       }
     };
-    void (^completionBlock)(BOOL) = ^(BOOL finished) {
+    void (^completionBlock)(UIViewAnimatingPosition) = ^(UIViewAnimatingPosition finalPosition) {
       if (shadowView) {
         [shadowView removeFromSuperview];
       }
@@ -189,16 +189,24 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     };
 
     if (!transitionContext.isInteractive) {
-      [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                       animations:animationBlock
-                       completion:completionBlock];
+      id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
+
+      UIViewPropertyAnimator *animator =
+          [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
+                                          timingParameters:timingCurveProvider];
+
+      [animator addAnimations:animationBlock];
+      [animator addCompletion:completionBlock];
+      [animator startAnimation];
     } else {
       // we don't want the EaseInOut option when swiping to dismiss the view, it is the same in default animation option
-      [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                            delay:0.0
-                          options:UIViewAnimationOptionCurveLinear
-                       animations:animationBlock
-                       completion:completionBlock];
+      UIViewPropertyAnimator *animator =
+          [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
+                                                     curve:UIViewAnimationCurveLinear
+                                                animations:animationBlock];
+
+      [animator addCompletion:completionBlock];
+      [animator startAnimation];
     }
   }
 }

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -4,11 +4,19 @@
 #import "RNSScreen.h"
 
 // proportions to default transition duration
-static const float RNSSlideOpenTransitionDurationProportion = 1;
-static const float RNSFadeOpenTransitionDurationProportion = 0.2 / 0.35;
-static const float RNSSlideCloseTransitionDurationProportion = 0.25 / 0.35;
-static const float RNSFadeCloseTransitionDurationProportion = 0.15 / 0.35;
-static const float RNSFadeCloseDelayTransitionDurationProportion = 0.1 / 0.35;
+static constexpr NSTimeInterval RNSReferenceTransitionDurationForProportionInSeconds = 0.35;
+static constexpr NSTimeInterval RNSDefaultTransitionDuration = 0.5;
+
+static constexpr float RNSSlideOpenTransitionDurationProportion = 1;
+static constexpr float RNSFadeOpenTransitionDurationProportion =
+    0.2 / RNSReferenceTransitionDurationForProportionInSeconds;
+static constexpr float RNSSlideCloseTransitionDurationProportion =
+    0.25 / RNSReferenceTransitionDurationForProportionInSeconds;
+static constexpr float RNSFadeCloseTransitionDurationProportion =
+    0.15 / RNSReferenceTransitionDurationForProportionInSeconds;
+static constexpr float RNSFadeCloseDelayTransitionDurationProportion =
+    0.1 / RNSReferenceTransitionDurationForProportionInSeconds;
+
 // same value is used in other projects using similar approach for transistions
 // and it looks the most similar to the value used by Apple
 static constexpr float RNSShadowViewMaxAlpha = 0.1;
@@ -22,7 +30,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
 {
   if (self = [super init]) {
     _operation = operation;
-    _transitionDuration = 0.35; // default duration in seconds
+    _transitionDuration = RNSDefaultTransitionDuration; // default duration in seconds
   }
   return self;
 }

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -135,15 +135,17 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
       [[transitionContext containerView] insertSubview:shadowView belowSubview:toViewController.view];
       shadowView.alpha = 0.0;
     }
-    
+
     // Default curve provider is as defined below, however spring timing defined this way
     // ignores the requested duration of the animation, effectively impairing our `animationDuration` prop.
     // Damping of 1.0 seems close enough and we keep `animationDuration` functional.
     // id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] init];
-    
+
     id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
-    UIViewPropertyAnimator *animator = [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext] timingParameters:timingCurveProvider];
-    
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
+                                        timingParameters:timingCurveProvider];
+
     [animator addAnimations:^{
       fromViewController.view.transform = leftTransform;
       toViewController.view.transform = CGAffineTransformIdentity;
@@ -151,7 +153,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
         shadowView.alpha = RNSShadowViewMaxAlpha;
       }
     }];
-    
+
     [animator addCompletion:^(UIViewAnimatingPosition finalPosition) {
       if (shadowView) {
         [shadowView removeFromSuperview];
@@ -160,7 +162,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
       toViewController.view.transform = CGAffineTransformIdentity;
       [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
     }];
-    
+
     [animator startAnimation];
   } else if (_operation == UINavigationControllerOperationPop) {
     toViewController.view.transform = leftTransform;

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -159,11 +159,6 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
       shadowView.alpha = 0.0;
     }
 
-    // Default curve provider is as defined below, however spring timing defined this way
-    // ignores the requested duration of the animation, effectively impairing our `animationDuration` prop.
-    // Damping of 1.0 seems close enough and we keep `animationDuration` functional.
-    // id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] init];
-
     UIViewPropertyAnimator *animator =
         [[UIViewPropertyAnimator alloc] initWithDuration:[self transitionDuration:transitionContext]
                                         timingParameters:[RNSScreenStackAnimator defaultSpringTimingParametersApprox]];
@@ -515,6 +510,11 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
 
 + (UISpringTimingParameters *)defaultSpringTimingParametersApprox
 {
+  // Default curve provider is as defined below, however spring timing defined this way
+  // ignores the requested duration of the animation, effectively impairing our `animationDuration` prop.
+  // Damping of 1.0 seems close enough and we keep `animationDuration` functional.
+  // id<UITimingCurveProvider> timingCurveProvider = [[UISpringTimingParameters alloc] init];
+
   return [[UISpringTimingParameters alloc] initWithDampingRatio:1.0];
 }
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -366,7 +366,7 @@ A string that can be used as a fallback for `headerTitle`.
 
 #### `transitionDuration` (iOS only)
 
-Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `500`.
 
 The duration of `default` and `flip` transitions isn't customizable.
 

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -99,7 +99,7 @@ export interface NativeProps extends ViewProps {
   gestureResponseDistance?: GestureResponseDistanceType;
   stackPresentation?: WithDefault<StackPresentation, 'push'>;
   stackAnimation?: WithDefault<StackAnimation, 'default'>;
-  transitionDuration?: WithDefault<Int32, 350>;
+  transitionDuration?: WithDefault<Int32, 500>;
   replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>;
   swipeDirection?: WithDefault<SwipeDirection, 'horizontal'>;
   hideKeyboardOnSwipe?: boolean;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -99,7 +99,7 @@ export interface NativeProps extends ViewProps {
   gestureResponseDistance?: GestureResponseDistanceType;
   stackPresentation?: WithDefault<StackPresentation, 'push'>;
   stackAnimation?: WithDefault<StackAnimation, 'default'>;
-  transitionDuration?: WithDefault<Int32, 350>;
+  transitionDuration?: WithDefault<Int32, 500>;
   replaceAnimation?: WithDefault<ReplaceAnimation, 'pop'>;
   swipeDirection?: WithDefault<SwipeDirection, 'horizontal'>;
   hideKeyboardOnSwipe?: boolean;

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -520,7 +520,7 @@ export type NativeStackNavigationOptions = {
    */
   title?: string;
   /**
-   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `500`.
    * The duration of `default` and `flip` transitions isn't customizable.
    *
    * @platform ios

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -456,7 +456,7 @@ export interface ScreenProps extends ViewProps {
    */
   swipeDirection?: SwipeDirectionTypes;
   /**
-   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `500`.
    * The duration of `default` and `flip` transitions isn't customizable.
    *
    * @platform ios


### PR DESCRIPTION
- **Use 0.5 for default transition duration value __but__ keep old animation proportions**
- **Write Push transition using property animator and spring timing curve**
- **Linter**
- **Write Pop transition using property animator and spring timing curve**
- **Implement non-interactive simple push using UIViewPropertyAnimator [PRB]**
- **Implement interactive simple-push using UIViewPropertyAnimator**
- **Make RNSScreenStackAnimator a source of truth on animation properties [PRB]**
- **Update documentation: default transition lasts 500ms**
- **Update default transition duration in Android spec**
- **Implement both interactive and not slide_from_left using UIViewPropertyAnimator**
- **Move comment on default spring animation to helper function**

## Description

WIP

## Changes

WIP

## Test code and steps to reproduce


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
