### PR TITLE
chore: compatibility table README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,13 @@ Screens are already integrated with the React Native's most popular navigation l
 
 ## Supported react-native version
 
+### Support for Paper
+
+Paper is the default rendering system for React Native versions prior to 0.76.
+
 | library version | react-native version |
 | --------------- | -------------------- |
-| 3.33.0+         | 0.72.0+
+| 3.33.0+         | 0.72.0+              |
 | 3.32.0+         | 0.71.0+              |
 | 3.30.0+         | 0.68.0+              |
 | 3.14.0+         | 0.64.0+              |
@@ -123,6 +127,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 3.35.0+         | 0.76.0+              |
 | 3.33.0+         | 0.75.0+              |
 | 3.32.0+         | 0.74.0+              |
 | 3.28.0+         | 0.73.0+              |


### PR DESCRIPTION
## Description

This PR updates the compatibility table in `README` with support for React Native 0.76.

I updated the table and added a brief description for Paper architecture since it's not the default for RN 0.76+.

## Tests

I ran the following tests in order to see if the compatibility changed since the last check.

### Paper

- RN `0.72` builds and run with screens `3.35.0` ✅
    - iOS ✅
    - Android ✅
- RN `0.76` builds and run with screens `3.33.0` ✅
    - iOS ✅
    - Android ✅

### Fabric

- RN `0.75` builds and run with screens `3.35.0` ✅
    - iOS ✅
    - Android ✅
- RN `0.76` builds and run with screens `3.33.0` ❌ 
    - iOS ✅
    - Android ❌

## Checklist

- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
