### PR TITLE
chore(README): Redact caution of migrating JS API of native stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation)
 
 > [!CAUTION]
-> NativeStack has been moved from react-native-screens/native-stack to @react-navigation/native-stack since version v6. With react-native-screens v4 native stack v5 (react-native-screens/native-stack) is deprecated and marked for removal in the upcoming minor release, react-native-screens v4 will support only @react-navigation/native-stack v7.
+> JS API of the native stack has been moved from react-native-screens/native-stack to @react-navigation/native-stack since version v6. Currently, native stack v5 (still held by react-native-screens) is deprecated and will be removed in the upcoming major release. From now on, only @react-navigation/native-stack v7 will be supported by react-native-screens.
 
 Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc).
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation)
 
 > [!CAUTION]
-> JS API of the native stack has been moved from react-native-screens/native-stack to @react-navigation/native-stack since version v6. Currently, native stack v5 (still held by react-native-screens) is deprecated and will be removed in the upcoming major release. From now on, only @react-navigation/native-stack v7 will be supported by react-native-screens.
+> JS API of the native stack has been moved from `react-native-screens/native-stack` to `@react-navigation/native-stack` since version v6. Currently, native stack v5 (imported from `react-native-screens/native-stack`) is deprecated and will be removed in the upcoming **minor** release. `react-native-screens` v4 will support only `@react-navigation/native-stack` v7.
 
 Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc).
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation)
 
 > [!CAUTION]
-> NativeStack has been moved from react-native-screens/native-stack to @react-navigation/native since version v6. With react-native-screens v4 native stack v5 (react-native-screens/native-stack) is deprecated and marked for removal in the upcoming minor release, react-native-screens v4 will support only @react-navigation/native-stack v7.
+> NativeStack has been moved from react-native-screens/native-stack to @react-navigation/native-stack since version v6. With react-native-screens v4 native stack v5 (react-native-screens/native-stack) is deprecated and marked for removal in the upcoming minor release, react-native-screens v4 will support only @react-navigation/native-stack v7.
 
 Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc).
 


### PR DESCRIPTION
## Description

Because `react-native-screens/native-stack` isn't moved to `@react-navigation/native` 😄 I've changed the caution about moving the dependency into the correct one. Also, I've redacted the sentence, so for me it looks better now.

## Changes

- Fixed `@react-navigation/native-stack` to `@react-navigation/native` in README.
- Redacted caution