### PR TITLE
feat(iOS)!: change default of `fullScreenSwipeShadowEnabled` to true

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -52,7 +52,7 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFullScreenSwipeEnabled(view, value == null ? false : (boolean) value);
         break;
       case "fullScreenSwipeShadowEnabled":
-        mViewManager.setFullScreenSwipeShadowEnabled(view, value == null ? false : (boolean) value);
+        mViewManager.setFullScreenSwipeShadowEnabled(view, value == null ? true : (boolean) value);
         break;
       case "homeIndicatorHidden":
         mViewManager.setHomeIndicatorHidden(view, value == null ? false : (boolean) value);

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -60,7 +60,7 @@ Boolean indicating whether the swipe gesture should work on whole screen. Swipin
 
 Boolean indicating whether the full screen dismiss gesture has shadow under view during transition. The gesture uses custom transition and thus
 doesn't have a shadow by default. When enabled, a custom shadow view is added during the transition which tries to mimic the
-default iOS shadow. Defaults to `false`.
+default iOS shadow. Defaults to `true`.
 
 ### `gestureEnabled` (iOS only)
 
@@ -223,7 +223,7 @@ Allows for the customization of how the given screen should appear/disappear whe
 - `"fade"` – fades screen in or out
 - `fade_from_bottom` – performs a fade from bottom animation
 - `"flip"` – flips the screen, requires `stackPresentation: "modal"` (iOS only)
-- `"simple_push"` – performs a default animation, but without shadow and native header transition (iOS only)
+- `"simple_push"` – performs a default animation, but without native header transition (iOS only)
 - `"slide_from_bottom"` - slide in the new screen from bottom to top
 - `"slide_from_right"` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `"slide_from_left"` - slide in the new screen from left to right

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -119,6 +119,7 @@ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
   _hasOrientationSet = NO;
   _hasHomeIndicatorHiddenSet = NO;
   _activityState = RNSActivityStateUndefined;
+  _fullScreenSwipeShadowEnabled = YES;
 #if !TARGET_OS_TV
   _sheetExpandsWhenScrolledToEdge = YES;
 #endif // !TARGET_OS_TV

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -96,7 +96,7 @@ Boolean indicating whether the swipe gesture should work on whole screen. Swipin
 
 Boolean indicating whether the full screen dismiss gesture has shadow under view during transition. The gesture uses custom transition and thus
 doesn't have a shadow by default. When enabled, a custom shadow view is added during the transition which tries to mimic the
-default iOS shadow. Defaults to `false`.
+default iOS shadow. Defaults to `true`.
 
 #### `gestureEnabled` (iOS only)
 
@@ -325,7 +325,7 @@ How the given screen should appear/disappear when pushed or popped at the top of
 - `fade` - fades screen in or out.
 - `fade_from_bottom` – performs a fade from bottom animation
 - `flip` – flips the screen, requires stackPresentation: `modal` (iOS only)
-- `simple_push` – performs a default animation, but without shadow and native header transition (iOS only)
+- `simple_push` – performs a default animation, but without native header transition (iOS only)
 - `slide_from_bottom` – performs a slide from bottom animation
 - `slide_from_right` - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
 - `slide_from_left` - slide in the new screen from left to right

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -86,7 +86,7 @@ export interface NativeProps extends ViewProps {
   sheetElevation?: WithDefault<Int32, 24>;
   customAnimationOnSwipe?: boolean;
   fullScreenSwipeEnabled?: boolean;
-  fullScreenSwipeShadowEnabled?: boolean;
+  fullScreenSwipeShadowEnabled?: WithDefault<boolean, true>;
   homeIndicatorHidden?: boolean;
   preventNativeDismiss?: boolean;
   gestureEnabled?: WithDefault<boolean, true>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -86,7 +86,7 @@ export interface NativeProps extends ViewProps {
   sheetElevation?: WithDefault<Int32, 24>;
   customAnimationOnSwipe?: boolean;
   fullScreenSwipeEnabled?: boolean;
-  fullScreenSwipeShadowEnabled?: boolean;
+  fullScreenSwipeShadowEnabled?: WithDefault<boolean, true>;
   homeIndicatorHidden?: boolean;
   preventNativeDismiss?: boolean;
   gestureEnabled?: WithDefault<boolean, true>;

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -164,7 +164,7 @@ export type NativeStackNavigationOptions = {
   /**
    * Whether the full screen dismiss gesture has shadow under view during transition. The gesture uses custom transition and thus
    * doesn't have a shadow by default. When enabled, a custom shadow view is added during the transition which tries to mimic the
-   * default iOS shadow. Defaults to `false`.
+   * default iOS shadow. Defaults to `true`.
    *
    * This does not affect the behavior of transitions that don't use gestures, enabled by `fullScreenGestureEnabled` prop.
    *
@@ -456,7 +456,7 @@ export type NativeStackNavigationOptions = {
    * - "fade" – fades screen in or out
    * - "fade_from_bottom" – performs a fade from bottom animation
    * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
-   * - "simple_push" – performs a default animation, but without shadow and native header transition (iOS only)
+   * - "simple_push" – performs a default animation, but without native header transition (iOS only)
    * - "slide_from_bottom" – performs a slide from bottom animation
    * - "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
    * - "slide_from_left" - slide in the new screen from left to right

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -188,7 +188,7 @@ const RouteView = ({
   const { options, render: renderScene } = descriptors[route.key];
 
   const {
-    fullScreenSwipeShadowEnabled = false,
+    fullScreenSwipeShadowEnabled = true,
     gestureEnabled,
     headerShown,
     hideKeyboardOnSwipe,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -135,9 +135,9 @@ export interface ScreenProps extends ViewProps {
    */
   fullScreenSwipeEnabled?: boolean;
   /**
-   * Whether the full screen dismiss gesture has shadow under view during transition. The gesture uses custom transition and thus
-   * doesn't have a shadow by default. When enabled, a custom shadow view is added during the transition which tries to mimic the
-   * default iOS shadow. Defaults to `false`.
+   * Whether the full screen dismiss gesture has shadow under view during transition.
+   * When enabled, a custom shadow view is added during the transition which tries to mimic the
+   * default iOS shadow. Defaults to `true`.
    *
    * This does not affect the behavior of transitions that don't use gestures, enabled by `fullScreenGestureEnabled` prop.
    *
@@ -392,7 +392,7 @@ export interface ScreenProps extends ViewProps {
    * - "fade" – fades screen in or out
    * - "fade_from_bottom" – performs a fade from bottom animation
    * - "flip" – flips the screen, requires stackPresentation: "modal" (iOS only)
-   * - "simple_push" – performs a default animation, but without shadow and native header transition (iOS only)
+   * - "simple_push" – performs a default animation, but without native header transition (iOS only)
    * - `slide_from_bottom` – performs a slide from bottom animation
    * - "slide_from_right" - slide in the new screen from right to left (Android only, resolves to default transition on iOS)
    * - "slide_from_left" - slide in the new screen from left to right


### PR DESCRIPTION
## Description

This PR changes default value for `fullScreenSwipeShadowEnabled` prop to `true` - meaning that the shadow will be present by default
in `simple_push` animation on iOS (this is the platform default).

> [!important]
> When changing this value I've noticed that the `fullScreenSwipeShadowEnabled` does something different
> than it suggests in type documentation & our GUIDE_FOR_LIBRARY_AUTHORS. Namely, it does effect `simple_push` animation
> in every scenario, not only in full screen swipe gesture interactive transition. I think we should change the name
> of the prop eventually. 

## Changes

Updated all the docs & code.

## Test code and steps to reproduce

I've played around with `Test1072`. Just set stack animation to simple push.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
