### PR TITLE
fix: get imageLoader from contextContainer

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1685,7 +1685,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.0.0-beta.14):
+  - RNScreens (4.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1706,9 +1706,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.0.0-beta.14)
+    - RNScreens/common (= 4.0.0)
     - Yoga
-  - RNScreens/common (4.0.0-beta.14):
+  - RNScreens/common (4.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2020,10 +2020,10 @@ SPEC CHECKSUMS:
   ReactCommon: 429ca28cd813c31359c73ffac6dc24f93347d522
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
   RNReanimated: 19ed24de2d15be31c25737f25a065d12d6920b02
-  RNScreens: c1e151cab51643c0cf42b88d275592a4aee220f1
+  RNScreens: 2fe13c8d610ef2d9d5ace2e7d85b716ec0f5217c
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 1d66db49f38fd9e576a1d7c3b081e46ab4c28b9e
+  Yoga: f8ec45ce98bba1bc93dd28f2ee37215180e6d2b6
 
 PODFILE CHECKSUM: 3c417461d16a55a55286761c6625260781e6da78
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenComponentDescriptor.h
@@ -2,7 +2,7 @@
 
 #ifdef ANDROID
 #include <fbjni/fbjni.h>
-#endif
+#endif // ANDROID
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/components/rnscreens/Props.h>
 #include <react/renderer/components/rnscreens/utils/RectUtil.h>

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -2,7 +2,7 @@
 
 #ifdef ANDROID
 #include <fbjni/fbjni.h>
-#endif
+#endif // ANDROID
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/components/rnscreens/Props.h>
 #include <react/renderer/components/rnscreens/utils/RectUtil.h>
@@ -21,6 +21,15 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
 
   void adopt(ShadowNode &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
+#ifndef NDEBUG
+    std::weak_ptr<void> imageLoader =
+        contextContainer_->at<std::shared_ptr<void>>("RCTImageLoader");
+    react_native_assert(
+        dynamic_cast<RNSScreenStackHeaderSubviewShadowNode *>(&shadowNode));
+    auto &subviewShadowNode =
+        static_cast<RNSScreenStackHeaderSubviewShadowNode &>(shadowNode);
+    subviewShadowNode.setImageLoader(imageLoader);
+#endif // NDEBUG
   }
 };
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
@@ -5,4 +5,21 @@ namespace facebook::react {
 extern const char RNSScreenStackHeaderSubviewComponentName[] =
     "RNSScreenStackHeaderSubview";
 
+#ifdef ANDROID
+#else // ANDROID
+#ifndef NDEBUG
+void RNSScreenStackHeaderSubviewShadowNode::setImageLoader(
+    std::weak_ptr<void> imageLoader) {
+  getStateDataMutable().setImageLoader(imageLoader);
 }
+RNSScreenStackHeaderSubviewShadowNode::StateData &
+RNSScreenStackHeaderSubviewShadowNode::getStateDataMutable() {
+  // We assume that this method is called to mutate the data, so we ensure
+  // we're unsealed.
+  ensureUnsealed();
+  return const_cast<RNSScreenStackHeaderSubviewShadowNode::StateData &>(
+      getStateData());
+}
+#endif // NDEBUG
+#endif // ANDROID
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.h
@@ -23,7 +23,20 @@ class JSI_EXPORT RNSScreenStackHeaderSubviewShadowNode final
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
   using StateData = ConcreteViewShadowNode::ConcreteStateData;
+#ifdef ANDROID
+#else // ANDROID
+#ifndef NDEBUG
+  void setImageLoader(std::weak_ptr<void> imageLoader);
+#endif // NDEBUG
+#endif // ANDROID
 
+ private:
+#ifdef ANDROID
+#else // ANDROID
+#ifndef NDEBUG
+  StateData &getStateDataMutable();
+#endif // NDEBUG
+#endif // ANDROID
 #pragma mark - ShadowNode overrides
 
 #pragma mark - Custom interface

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.cpp
@@ -9,7 +9,19 @@ using namespace rnscreens;
 folly::dynamic RNSScreenStackHeaderSubviewState::getDynamic() const {
   return folly::dynamic::object();
 }
-#endif
+#else // ANDROID
+#ifndef NDEBUG
+void RNSScreenStackHeaderSubviewState::setImageLoader(
+    std::weak_ptr<void> imageLoader) {
+  imageLoader_ = imageLoader;
+}
+
+std::weak_ptr<void> RNSScreenStackHeaderSubviewState::getImageLoader()
+    const noexcept {
+  return imageLoader_;
+}
+#endif // NDEBUG
+#endif // ANDROID
 
 } // namespace react
 } // namespace facebook

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h
@@ -32,8 +32,20 @@ class JSI_EXPORT RNSScreenStackHeaderSubviewState final {
   MapBuffer getMapBuffer() const {
     return MapBufferBuilder::EMPTY();
   };
-#endif
+#else // ANDROID
+#ifndef NDEBUG
+  void setImageLoader(std::weak_ptr<void> imageLoader);
+  std::weak_ptr<void> getImageLoader() const noexcept;
+#endif // NDEBUG
+#endif // ANDROID
 
+ private:
+#ifdef ANDROID
+#else // ANDROID
+#ifndef NDEBUG
+  std::weak_ptr<void> imageLoader_;
+#endif // NDEBUG
+#endif // ANDROID
 #pragma mark - Getters
 };
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenState.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenState.cpp
@@ -29,7 +29,7 @@ const FrameCorrectionModes &RNSScreenState::getHeaderCorrectionModes()
   return headerCorrectionModes_;
 }
 
-#endif
+#endif // ANDROID
 
 } // namespace react
 } // namespace facebook

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
@@ -7,7 +7,7 @@
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
-#endif
+#endif // ANDROID
 
 #include "FrameCorrectionModes.h"
 
@@ -53,7 +53,7 @@ class JSI_EXPORT RNSScreenState final {
 
   const FrameCorrectionModes &getHeaderCorrectionModes() const noexcept;
 
-#endif
+#endif // ANDROID
 
  private:
 #ifdef ANDROID

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -378,8 +378,12 @@ namespace react = facebook::react;
         // in DEV MODE we try to load from cache (we use private API for that as it is not exposed
         // publically in headers).
         RCTImageSource *imageSource = [RNSScreenStackHeaderConfig imageSourceFromImageView:imageView];
-        RCTImageLoader *imageLoader = [subview.bridge moduleForClass:[RCTImageLoader class]];
-
+        RCTImageLoader *imageLoader =
+#ifdef RCT_NEW_ARCH_ENABLED
+            [subview imageLoader];
+#else
+            [subview.bridge moduleForClass:[RCTImageLoader class]];
+#endif
         image = [imageLoader.imageCache
             imageForUrl:imageSource.request.URL.absoluteString
                    size:imageSource.size

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -4,6 +4,7 @@
 #endif
 
 #import <React/RCTConvert.h>
+#import <React/RCTImageLoader.h>
 #import <React/RCTViewManager.h>
 #import "RNSEnums.h"
 
@@ -20,10 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) UIView *reactSuperview;
 
-@property (nonatomic, weak) RCTBridge *bridge;
-
 #ifdef RCT_NEW_ARCH_ENABLED
+- (RCTImageLoader *)imageLoader;
 #else
+@property (nonatomic, weak) RCTBridge *bridge;
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 #endif // RCT_NEW_ARCH_ENABLED
 


### PR DESCRIPTION
## Description

PR getting rid of the last occurrence of `currentBridge`. As suggested by Meta team, we get the needed `RCTImageLoader` from `contextContainer`, which is available in `componentDescriptor`.