### PR TITLE
fix(iOS): fix navigation item animation

### DIFF
--- a/ios/RNSPercentDrivenInteractiveTransition.mm
+++ b/ios/RNSPercentDrivenInteractiveTransition.mm
@@ -49,14 +49,15 @@
     return;
   }
 
-  UIViewPropertyAnimator *_Nullable animator = _animationController.inFlightAnimator;
+  id<UIViewImplicitlyAnimating> _Nullable animator = _animationController.inFlightAnimator;
   if (animator == nil) {
     return;
   }
 
   BOOL shouldReverseAnimation = cancelled;
 
-  id<UITimingCurveProvider> timingParams = [_animationController timingParamsForAnimationCompletion];
+  // Nil params mean that the transition should be completed using originally set timing params.
+  id<UITimingCurveProvider> _Nullable timingParams = [_animationController timingParamsForAnimationCompletion];
 
   [animator pauseAnimation];
   [animator setReversed:shouldReverseAnimation];

--- a/ios/RNSScreenStackAnimator.h
+++ b/ios/RNSScreenStackAnimator.h
@@ -3,7 +3,7 @@
 @interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
 
 /// This property is filled whenever there is an ongoing animation and cleared on animation end.
-@property (nonatomic, strong, nullable, readonly) UIViewPropertyAnimator *inFlightAnimator;
+@property (nonatomic, strong, nullable, readonly) id<UIViewImplicitlyAnimating> inFlightAnimator;
 
 - (nonnull instancetype)initWithOperation:(UINavigationControllerOperation)operation;
 

--- a/ios/RNSViewPropertyAnimatorCompositor.h
+++ b/ios/RNSViewPropertyAnimatorCompositor.h
@@ -1,0 +1,30 @@
+#import <React/RCTAssert.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Retains collection of animators and itself implements `UIViewImplicitlyAnimating`. Object of this class
+/// fans out all call to methods of `UIViewAnimating` and `continueAnimationWithTimingParameters:durationFactor` to all
+/// the animators. The remaining methods of `UIViewImplicitlyAnimating`, are forwareded to the
+/// `animatorForImplicitAnimations`.
+///
+/// This allows to pass instance of this class as the interruptible animator and have the `animators` be interruptible
+/// with timing curve of the implicit animator. This is useful for navigation item animation.
+/// We also get possibility to drive all the animators simultaneously with gesture (interactive animation).
+@interface RNSViewPropertyAnimatorCompositor : NSObject <UIViewImplicitlyAnimating>
+
+@property (nonnull, strong, nonatomic, readonly) NSArray<id<UIViewImplicitlyAnimating>> *animators;
+@property (nullable, strong, nonatomic) id<UIViewImplicitlyAnimating> implicitAnimator;
+
+/// @param animators - nonnull, nonempty animator list
+/// @param implicitAnimator - designated aniamator to return from `- animatorForImplicitAnimations`
+/// @return nonnull instance only in case above invariants are not violated
+- (nullable instancetype)initWithAnimators:(nonnull NSArray<id<UIViewImplicitlyAnimating>> *)animators
+                          implicitAnimator:(nullable id<UIViewImplicitlyAnimating>)implicitAnimator
+    NS_DESIGNATED_INITIALIZER;
+
+- (nonnull id<UIViewImplicitlyAnimating>)animatorForImplicitAnimations;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNSViewPropertyAnimatorCompositor.mm
+++ b/ios/RNSViewPropertyAnimatorCompositor.mm
@@ -1,0 +1,136 @@
+#import "RNSViewPropertyAnimatorCompositor.h"
+#import <React/RCTAssert.h>
+
+@implementation RNSViewPropertyAnimatorCompositor
+
+RCT_NOT_IMPLEMENTED(-(instancetype)init)
+
+- (instancetype)initWithAnimators:(nonnull NSArray<id<UIViewImplicitlyAnimating>> *)animators
+                 implicitAnimator:(nullable id<UIViewImplicitlyAnimating>)implicitAnimator
+{
+  if (animators == nil || animators.count == 0) {
+    assert((false) && "[RNScreens] Expected non-empty animator list");
+    return nil;
+  }
+
+  if (self = [super init]) {
+    _animators = animators ?: @[];
+    _implicitAnimator = implicitAnimator;
+  }
+  return self;
+}
+
+- (id<UIViewImplicitlyAnimating>)animatorForImplicitAnimations
+{
+  if (_implicitAnimator != nil) {
+    return _implicitAnimator;
+  }
+  assert(_animators.count > 0 && "[RNScreens] Animator list must not be empty");
+  return _animators.firstObject;
+}
+
+#pragma mark - UIViewImplicityAnimating optional methods
+
+- (void)addAnimations:(void (^)())animation
+{
+  [self.animatorForImplicitAnimations addAnimations:animation];
+}
+
+- (void)addAnimations:(void (^)())animation delayFactor:(CGFloat)delayFactor
+{
+  [self.animatorForImplicitAnimations addAnimations:animation delayFactor:delayFactor];
+}
+
+- (void)addCompletion:(void (^)(UIViewAnimatingPosition))completion
+{
+  [self.animatorForImplicitAnimations addCompletion:completion];
+}
+
+- (void)continueAnimationWithTimingParameters:(id<UITimingCurveProvider>)parameters
+                               durationFactor:(CGFloat)durationFactor
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator continueAnimationWithTimingParameters:parameters durationFactor:durationFactor];
+  }
+  [self.implicitAnimator continueAnimationWithTimingParameters:parameters durationFactor:durationFactor];
+}
+
+#pragma mark - UIViewAnimating
+
+- (UIViewAnimatingState)state
+{
+  return self.animatorForImplicitAnimations.state;
+}
+
+- (BOOL)isRunning
+{
+  return self.animatorForImplicitAnimations.isRunning;
+}
+
+- (BOOL)isReversed
+{
+  return self.animatorForImplicitAnimations.isReversed;
+}
+
+- (void)setReversed:(BOOL)reversed
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    animator.reversed = reversed;
+  }
+  [self.implicitAnimator setReversed:reversed];
+}
+
+- (void)setFractionComplete:(CGFloat)fractionComplete
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    animator.fractionComplete = fractionComplete;
+  }
+  [self.implicitAnimator setFractionComplete:fractionComplete];
+}
+
+- (CGFloat)fractionComplete
+{
+  return self.animatorForImplicitAnimations.fractionComplete;
+}
+
+- (void)startAnimation
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator startAnimation];
+  }
+  [self.implicitAnimator startAnimation];
+}
+
+- (void)startAnimationAfterDelay:(NSTimeInterval)delay
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator startAnimationAfterDelay:delay];
+  }
+  [self.implicitAnimator startAnimationAfterDelay:delay];
+}
+
+- (void)pauseAnimation
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator pauseAnimation];
+  }
+  [self.implicitAnimator pauseAnimation];
+}
+
+- (void)stopAnimation:(BOOL)withoutFinishing
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator stopAnimation:withoutFinishing];
+  }
+  [self.implicitAnimator stopAnimation:withoutFinishing];
+}
+
+- (void)finishAnimationAtPosition:(UIViewAnimatingPosition)finalPosition
+{
+  for (id<UIViewImplicitlyAnimating> animator in _animators) {
+    [animator finishAnimationAtPosition:finalPosition];
+  }
+  [self.implicitAnimator finishAnimationAtPosition:finalPosition];
+}
+
+@end


### PR DESCRIPTION
## Description

Fixing navigation item animation on iOS. It will use default `EaseInOut` curve, instead of spring. 

(WIP paste a video)

> [!note]
> **Possible improvements**
> * Expose opportunity to customize header transition curve
> * Expose opportunity to customize animation completion curve (after gesture cancel)


> [!caution]
> [It was noted by @hirbod that the back button flashes when clicked and go-back-animation starts](https://github.com/software-mansion/react-native-screens/pull/2477#issuecomment-2465860226).
> Below you can see video of this bug. 
> This happens because:
> 1. Back button, when clicked, fades out a bit to give haptic feedback,
> 2. Back button, when clicked, triggers go-back-transition.
> 3. Both animations add-up, resulting in this 'flickering effect'. 

I wonder what should be the solution to above problem ^ (WIP tag people here). I see three paths:

1. Throw away these changes and restore old header behaviour: B's navigation item fades out completely and just then A's navigation item starts fading in - this prevents this "bug",
2. Go with this behaviour? (this is noticible though :/)
3. Override the animation of the back button. Should be doable with obj-c: I could find playing animation on the `layer`, remove it & add custom one; this will require some debugging time though & I see couple 
of technical issues to pull this off. 


## Changes

Added `RNSViewPropertyAnimatorCompositor` which proxies and fans out system callbacks to series of animators
and exposes implicit animator (returned as interruptible animator from stack animator) (the system animates navigation items with curve of interruptible animator).


## Test code and steps to reproduce

`Test1072`.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
