### PR TITLE
fix: Remove dangling global reference to `ScreenModule`

### DIFF
--- a/android/src/main/cpp/jni-adapter.cpp
+++ b/android/src/main/cpp/jni-adapter.cpp
@@ -18,6 +18,9 @@ Java_com_swmansion_rnscreens_ScreensModule_nativeInstall(
     return;
   }
   jsi::Runtime &rt = *runtime;
+  if (globalThis) {
+    env->DeleteGlobalRef(globalThis);
+  }
   globalThis = env->NewGlobalRef(thiz);
   JavaVM *jvm;
   env->GetJavaVM(&jvm);


### PR DESCRIPTION
## Description

Removes a dangling global reference to the `ScreenModule`.

## Changes

When the application reloads, `nativeInstall` is called, which overwrites the reference to `globalThis` without deleting it. This PR deletes the reference before creating a new one.

## Test code and steps to reproduce

I've tested it in a new project created using expo (SDK 52) and with fabric turn on. 