### PR TITLE
fix(iOS,Paper): fix broken modal go-back animation

### DIFF
--- a/apps/src/tests/TestModalNavigation.tsx
+++ b/apps/src/tests/TestModalNavigation.tsx
@@ -22,14 +22,22 @@ function HomeScreen({
         title="Navigate to Screen 1"
         onPress={() => navigation.navigate('NestedStack')}
       />
+      <Button
+        title="Navigate to Screen (same stack)"
+        onPress={() => navigation.navigate('MainStackScreen')}
+      />
     </View>
   );
 }
 
-function MainStackScreen() {
+function MainStackScreen({ navigation }: NativeStackScreenProps<StackParamList, 'MainStackScreen'>) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Main stack screen</Text>
+      <Button
+        title="goBack"
+        onPress={() => navigation.goBack()}
+      />
     </View>
   );
 }

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1288,7 +1288,7 @@ namespace react = facebook::react;
 // with modal presentation or foreign modal presented from inside a Screen.
 - (void)dismissAllRelatedModals
 {
-  [_controller dismissViewControllerAnimated:NO completion:nil];
+  [_controller dismissViewControllerAnimated:YES completion:nil];
 
   // This loop seems to be excessive. Above message send to `_controller` should
   // be enough, because system dismisses the controllers recursively,


### PR DESCRIPTION
## Description

We recently fixed left-out modals dismissal when reloading react-native. For some reason 
calling in `dismissViewControllerAnimated:completion:` on **nested** UINavigationController
(the one responsible for displaying the navigation bar in modal, not the one reponsible for presentation)
during invalidation messes up with the animation. 

I'm not really sure why this is the case. Earlier we were calling dismiss on all presented modals,
but not on UINavigationController itself and it worked like a charm. 

I've found out that simply animating the change solves the situation - we fix the animation and keep nice
modal dismissal on reload.

Fixes #2488

## Changes

:point_up:

## Test code and steps to reproduce

`TestModalNavigation`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
