### PR TITLE
chore(CI): fix iOS e2e tests

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Xcode version
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils
-        run: brew tap wix/brew && brew install applesimutils
+        run: brew tap wix/brew && brew install applesimutils && applesimutils --list
       - name: Install root node dependencies
         run: yarn install && yarn submodules
       - name: Install node dependencies

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Xcode version
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils
-        run: brew tap wix/brew && brew install applesimutils && applesimutils --list
+        run: brew tap wix/brew && brew install applesimutils
       - name: Install root node dependencies
         run: yarn install && yarn submodules
       - name: Install node dependencies

--- a/Example/.detoxrc.js
+++ b/Example/.detoxrc.js
@@ -42,7 +42,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14',
+        type: 'iPhone 16',
       },
     },
     attached: {

--- a/Example/.detoxrc.js
+++ b/Example/.detoxrc.js
@@ -42,7 +42,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 16',
+        type: 'iPhone 15 Pro',
       },
     },
     attached: {


### PR DESCRIPTION
## Description

CI started failing literally for no reason with error (when launching individual tests):

`DetoxRuntimeError: Failed to find a device by type = "iPhone 14"`

Sometimes restarting it makes it pass (no changes to code, just restarting CI).
I've also listed available devices on CI with `applesimutils --list` and iPhone 14 is obviously there.

I've changed the testing device to 'iPhone 15 Pro` (available on list ☝🏻) and it seems to be passing consistently, but 🤷🏻‍♂️ 


## Test code and steps to reproduce

CI should pass...

## Checklist

- [ ] Ensured that CI passes
