### PR TITLE
fix: make unstable_sheetFooter usable with react-navigation v7

### DIFF
--- a/src/components/ScreenFooter.tsx
+++ b/src/components/ScreenFooter.tsx
@@ -9,4 +9,12 @@ function ScreenFooter(props: ViewProps) {
   return <ScreenFooterNativeComponent {...props} />;
 }
 
+type FooterProps = {
+  children?: React.ReactNode;
+};
+
+export function FooterComponent({ children }: FooterProps) {
+  return <ScreenFooter collapsable={false}>{children}</ScreenFooter>;
+}
+
 export default ScreenFooter;

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -14,6 +14,7 @@ import { ScreenStackHeaderConfig } from './ScreenStackHeaderConfig';
 import Screen from './Screen';
 import ScreenStack from './ScreenStack';
 import { RNSScreensRefContext } from '../contexts';
+import { FooterComponent } from './ScreenFooter';
 
 type Props = Omit<
   ScreenProps,
@@ -33,6 +34,8 @@ function ScreenStackItem(
     contentStyle,
     style,
     screenId,
+    // eslint-disable-next-line camelcase
+    unstable_sheetFooter,
     ...rest
   }: Props,
   ref: React.ForwardedRef<View>,
@@ -86,6 +89,10 @@ function ScreenStackItem(
        * for detailed explanation.
        */}
       <ScreenStackHeaderConfig {...headerConfig} />
+      {/* eslint-disable-next-line camelcase */}
+      {stackPresentation === 'formSheet' && unstable_sheetFooter && (
+        <FooterComponent>{unstable_sheetFooter()}</FooterComponent>
+      )}
     </>
   );
 


### PR DESCRIPTION
## Description

Associated PR:

* https://github.com/react-navigation/react-navigation/pull/12258

The footer is currently broken, as in the effect of recent refactors it erroneously ended up being rendered as child as `ScreenStackItem`, thus due to internal implementation it is rendered under `ScreenContentWrapper`. However, it has to be rendered as direct child of `Screen` component (the same as `HeaderConfig`). 
 
Under usual circumstances this would be a breaking change, however the prop is marked as `unstable`, therefore I'm proceeding.

## Changes

`unstable_sheetFooter` is now rendered by `ScreenStackItem`.

## Test code and steps to reproduce

`Test1649`

## Checklist

- [ ] Ensured that CI passes
