### PR TITLE
fix(Android): prevent sheet footer from flickering on sheet sliding

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-import Example from './Example';
-// import * as Test from './src/tests';
+// import Example from './Example';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  return <Example />;
-  // return <Test.Test42 />;
+  // return <Example />;
+  return <Test.TestFormSheet />;
 }

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -5,10 +5,7 @@ import { Button, Text, TextInput, View } from "react-native";
 
 type RouteParamList = {
   Home: undefined;
-  FormSheet: {
-    footerEnabled?: boolean,
-    destinations?: Array<keyof RouteParamList>,
-  };
+  FormSheet: undefined;
 }
 
 type RouteProps<RouteName extends keyof RouteParamList> = {
@@ -21,23 +18,12 @@ const Stack = createNativeStackNavigator<RouteParamList>();
 function Home({ navigation }: RouteProps<'Home'>) {
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
-      <Button title="Open FormSheet" onPress={() => navigation.navigate('FormSheet', { footerEnabled: true })} />
+      <Button title="Open FormSheet" onPress={() => navigation.navigate('FormSheet')} />
     </View>
   );
 }
 
-function FormSheet({ navigation, route }: RouteProps<'FormSheet'>) {
-  // const { footerEnabled = false } = route.params;
-  //
-  // useLayoutEffect(() => {
-  //   console.log('Running useLayoutEffect in FormSheet');
-  //   if (footerEnabled) {
-  //     navigation.setOptions({
-  //     })
-  //   }
-  // }, [footerEnabled])
-
-
+function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
   return (
     <View style={{ backgroundColor: 'lightgreen' }}>
       <View style={{ paddingTop: 20 }}>
@@ -65,8 +51,9 @@ export default function App() {
           },
           unstable_sheetFooter: () => {
             return (
-              <View style={{ height: 48, backgroundColor: 'red' }}>
+              <View style={{ height: 64, backgroundColor: 'red' }}>
                 <Text>Footer</Text>
+                <Button title="Just click me" onPress={() => console.log('Footer button clicked')} />
               </View>
             );
           }

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,0 +1,77 @@
+import { NavigationContainer, RouteProp } from "@react-navigation/native";
+import { NativeStackNavigationProp, createNativeStackNavigator } from "@react-navigation/native-stack";
+import React, { useLayoutEffect } from "react";
+import { Button, Text, TextInput, View } from "react-native";
+
+type RouteParamList = {
+  Home: undefined;
+  FormSheet: {
+    footerEnabled?: boolean,
+    destinations?: Array<keyof RouteParamList>,
+  };
+}
+
+type RouteProps<RouteName extends keyof RouteParamList> = {
+  navigation: NativeStackNavigationProp<RouteParamList, RouteName>;
+  route: RouteProp<RouteParamList, RouteName>;
+}
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function Home({ navigation }: RouteProps<'Home'>) {
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
+      <Button title="Open FormSheet" onPress={() => navigation.navigate('FormSheet', { footerEnabled: true })} />
+    </View>
+  );
+}
+
+function FormSheet({ navigation, route }: RouteProps<'FormSheet'>) {
+  // const { footerEnabled = false } = route.params;
+  //
+  // useLayoutEffect(() => {
+  //   console.log('Running useLayoutEffect in FormSheet');
+  //   if (footerEnabled) {
+  //     navigation.setOptions({
+  //     })
+  //   }
+  // }, [footerEnabled])
+
+
+  return (
+    <View style={{ backgroundColor: 'lightgreen' }}>
+      <View style={{ paddingTop: 20 }}>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+      <View style={{ alignItems: 'center' }}>
+        <TextInput style={{ marginVertical: 12, paddingVertical: 8, backgroundColor: 'lavender', borderRadius: 24, width: '80%' }} placeholder="Trigger keyboard..."></TextInput>
+      </View>
+    </View>
+  )
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="FormSheet" component={FormSheet} options={{
+          presentation: 'formSheet',
+          sheetAllowedDetents: [0.5, 1.0],
+          sheetCornerRadius: 8,
+          sheetLargestUndimmedDetentIndex: 'last',
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+          unstable_sheetFooter: () => {
+            return (
+              <View style={{ height: 48, backgroundColor: 'red' }}>
+                <Text>Footer</Text>
+              </View>
+            );
+          }
+        }}/>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -124,3 +124,4 @@ export { default as TestActivityStateProgression } from './TestActivityStateProg
 export { default as TestHeaderTitle } from './TestHeaderTitle';
 export { default as TestModalNavigation } from './TestModalNavigation';
 export { default as TestMemoryLeak } from './TestMemoryLeak';
+export { default as TestFormSheet } from './TestFormSheet';


### PR DESCRIPTION

## Description

Previous implementation of `sheetTopWhileDragging` relied on linear interpolation.
Due to numeric errors in floating point division sometimes the footer was +- 1 pixel up/down 
from the accurate position, resulting in 1px flickering / "dancing".

This PR changes the way sheet top is computed to making use of the parent screen `top` property,
whenever possible.

## Changes

- **Add test dedicated to formsheet**
- **"Stabilize" footer**

## Test code and steps to reproduce

Added dedicated test `TestFormSheet`.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
