### PR TITLE
fix(Android): prevent crash with InsetsObserverProxy already registered

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
@@ -29,6 +29,10 @@ class RNScreensPackage : TurboReactPackage() {
             screenDummyLayoutHelper = ScreenDummyLayoutHelper(reactContext)
         }
 
+        // Proxy needs to register for lifecycle events in order to unregister itself
+        // on activity restarts.
+        InsetsObserverProxy.registerWithContext(reactContext)
+
         return listOf<ViewManager<*, *>>(
             ScreenContainerViewManager(),
             ScreenViewManager(),

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingFragment.kt
@@ -208,7 +208,7 @@ class DimmingFragment(
     override fun onStart() {
         // This is the earliest we can access child fragment manager & present another fragment
         super.onStart()
-        insetsProxy.registerOnView(requireRootView())
+        insetsProxy.registerOnView(requireDecorView())
         presentNestedFragment()
     }
 
@@ -307,7 +307,7 @@ class DimmingFragment(
             }
     }
 
-    private fun requireRootView(): View =
+    private fun requireDecorView(): View =
         checkNotNull(screen.reactContext.currentActivity) { "[RNScreens] Attempt to access activity on detached context" }
             .window.decorView
 


### PR DESCRIPTION
## Description

Activity restarts do not invalidate JVM state entirely (at least it seems so), therefore InsetsObserverProxy
kept being registered on some decorview between activity restarts (context recreations) leading to crash
(we guard against multiple registrations).

Fixes #2519
Possibly fixes #2507

## Changes

`InsetsOberverProxy` row registers for context lifecycle, when it's destroyed it cleans its state.

## Test code and steps to reproduce

Haven't managed to reproduce this myself, but got confirmation in #2507 that this patch works. 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
