### PR TITLE
fix: do not add views on transition to ViewPager2

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -405,7 +405,7 @@ class Screen(
                     // Unless the child is a ScrollView it's safe to assume that it's true
                     // and add a simple view for each possibly clipped item to make it work as expected.
                     // See https://github.com/software-mansion/react-native-screens/pull/2495
-                    if (child !is ReactScrollView && child !is ReactHorizontalScrollView) {
+                    if (child !is ReactScrollView && child !is ReactHorizontalScrollView && child !is ViewPager2) {
                         for (j in 0 until child.childCount) {
                             child.addView(View(context))
                         }

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -14,6 +14,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.viewpager2.widget.ViewPager2
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PixelUtil

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.scroll.ReactHorizontalScrollView
 import com.facebook.react.views.scroll.ReactScrollView
+import android.widget.HorizontalScrollView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
@@ -406,7 +407,7 @@ class Screen(
                     // Unless the child is a ScrollView it's safe to assume that it's true
                     // and add a simple view for each possibly clipped item to make it work as expected.
                     // See https://github.com/software-mansion/react-native-screens/pull/2495
-                    if (child !is ReactScrollView && child !is ReactHorizontalScrollView && child !is ViewPager2) {
+                    if (child !is ReactScrollView && child !is ReactHorizontalScrollView && child !is ViewPager2 && child !is HorizontalScrollView) {
                         for (j in 0 until child.childCount) {
                             child.addView(View(context))
                         }


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.


-->
There is an issue in `react-native-pager-view` that happens when you unmount a screen with ViewPager2 in it. As you cannot add views to `ViewPager2` directly. This change omits it. I can reproduce it on paper but Fabric seems also to be affected.

Fixes https://github.com/callstack/react-native-pager-view/issues/906.
## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->
- Fixes crash when transitioning with ViewPager2 mounted
<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
The repro is linked in the original issue.
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
