### PR TITLE
fix(web): reexport missing component

### DIFF
--- a/src/components/ScreenFooter.web.tsx
+++ b/src/components/ScreenFooter.web.tsx
@@ -1,5 +1,7 @@
 import { View } from 'react-native';
 
 const ScreenFooter = View;
+const FooterComponent = View;
 
 export default ScreenFooter;
+export { FooterComponent };


### PR DESCRIPTION
## Description

Recently `FooterComponent` was introduced for internal reasons, however it hasn't been exported on web
leading to issues.

> [!caution]
> We need to set up CI for web...

Fixes #2534

## Changes

`FooterComponent` is now exported from `ScreenFooter.web.tsx`

## Test code and steps to reproduce

??? We do not have a web example - we need to add it.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
