### PR TITLE
feat: Use `BaseReactPackage` instead of `TurboReactPackage`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
@@ -1,6 +1,6 @@
 package com.swmansion.rnscreens
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModuleList
@@ -14,7 +14,7 @@ import com.swmansion.rnscreens.utils.ScreenDummyLayoutHelper
         ScreensModule::class,
     ],
 )
-class RNScreensPackage : TurboReactPackage() {
+class RNScreensPackage : BaseReactPackage() {
     // We just retain it here. This object helps us tackle jumping content when using native header.
     // See: https://github.com/software-mansion/react-native-screens/pull/2169
     private var screenDummyLayoutHelper: ScreenDummyLayoutHelper? = null


### PR DESCRIPTION

## Description
This is required for RN 0.77 apparently. TurboReactPackage is deprecated on new arch. No idea why.

I am not sure about backwards compatibility either, sorry.

Feel free to close this PR if this isn't backwards compatible.

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
