### PR TITLE
refactor(iOS, Paper): do not add subviews to header config in HostTree

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -456,7 +456,7 @@ RNS_IGNORE_SUPER_CALL_END
     UIImage *shadowImage = appearance.shadowImage;
     // transparent background color
     [appearance configureWithTransparentBackground];
-      
+
     if (!config.hideShadow) {
       appearance.shadowColor = shadowColor;
       appearance.shadowImage = shadowImage;
@@ -688,11 +688,13 @@ RNS_IGNORE_SUPER_CALL_END
     UINavigationBarAppearance *scrollEdgeAppearance =
         [[UINavigationBarAppearance alloc] initWithBarAppearance:appearance];
     if (config.largeTitleBackgroundColor != nil) {
-      // Add support for using a fully transparent bar when the backgroundColor is set to transparent. 
+      // Add support for using a fully transparent bar when the backgroundColor is set to transparent.
       if (CGColorGetAlpha(config.largeTitleBackgroundColor.CGColor) == 0.) {
-      // This will also remove the background blur effect in the large title which is otherwise inherited from the standard appearance.
+        // This will also remove the background blur effect in the large title which is otherwise inherited from the
+        // standard appearance.
         [scrollEdgeAppearance configureWithTransparentBackground];
-        // This must be set to nil otherwise a default view will be added to the navigation bar background with an opaque background.
+        // This must be set to nil otherwise a default view will be added to the navigation bar background with an
+        // opaque background.
         scrollEdgeAppearance.backgroundColor = nil;
       } else {
         scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
@@ -825,12 +827,6 @@ RNS_IGNORE_SUPER_CALL_BEGIN
   [_reactSubviews removeObject:subview];
 }
 RNS_IGNORE_SUPER_CALL_BEGIN
-
-- (void)didUpdateReactSubviews
-{
-  [super didUpdateReactSubviews];
-  [self updateViewControllerIfNeeded];
-}
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - Fabric specific
@@ -1045,6 +1041,11 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 
 #else
 #pragma mark - Paper specific
+
+- (void)didUpdateReactSubviews
+{
+  [self updateViewControllerIfNeeded];
+}
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {


### PR DESCRIPTION
## Description

I was just writing #2552 and got confused that the header config subviews are added as subviews to the header config view
in host tree, before they are attached to the navigation bar view hierarchy. This transient state does not make any sense,
and we do not do similar thing on Fabric.

## Changes

`self.superview` returns now `nil` until the subview is mounted in navigation bar view hierarchy.

Also moved the function to Paper specific section of file, because it is not called on Fabric on any codepath. 

## Test code and steps to reproduce

We haven't used this behaviour. There should be no regression in text examples.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
