### PR TITLE
feat: Add `defaultValue` prop to search bar

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
@@ -138,6 +138,11 @@ class SearchBarManager :
         view.shouldShowHintSearchIcon = shouldShowHintSearchIcon ?: true
     }
 
+    @ReactProp(name = "defaultValue")
+    override fun setDefaultValue(view: SearchBarView, defaultValue: String?) {
+        view.setDefaultValue(defaultValue)
+    }
+
     override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? =
         MapBuilder.of(
             SearchBarBlurEvent.EVENT_NAME,

--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt
@@ -29,6 +29,9 @@ class SearchBarView(
     var shouldOverrideBackButton: Boolean = true
     var autoFocus: Boolean = false
     var shouldShowHintSearchIcon: Boolean = true
+    var defaultValue: String? = null
+        private set
+    private var defaultValueApplied = false
 
     private var searchViewFormatter: SearchViewFormatter? = null
 
@@ -81,6 +84,7 @@ class SearchBarView(
             if (autoFocus) {
                 screenStackFragment?.searchView?.focus()
             }
+            applyDefaultValueIfNeeded()
         }
     }
 
@@ -199,5 +203,23 @@ class SearchBarView(
         }, ;
 
         abstract fun toAndroidInputType(capitalize: SearchBarAutoCapitalize): Int
+    }
+
+    fun setDefaultValue(value: String?) {
+        if (defaultValue == null && value != null) {
+            defaultValue = value
+            applyDefaultValueIfNeeded()
+        }
+    }
+
+    private fun applyDefaultValueIfNeeded() {
+        if (!defaultValueApplied && defaultValue != null) {
+            screenStackFragment?.searchView?.let { searchView ->
+                if (searchView.query.isEmpty()) {
+                    searchView.setQuery(defaultValue, false)
+                    defaultValueApplied = true
+                }
+            }
+        }
     }
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
@@ -44,6 +44,9 @@ public class RNSSearchBarManagerDelegate<T extends View, U extends BaseViewManag
       case "cancelButtonText":
         mViewManager.setCancelButtonText(view, value == null ? null : (String) value);
         break;
+      case "defaultValue":
+        mViewManager.setDefaultValue(view, value == null ? null : (String) value);
+        break;
       case "barTintColor":
         mViewManager.setBarTintColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
@@ -20,6 +20,7 @@ public interface RNSSearchBarManagerInterface<T extends View> {
   void setObscureBackground(T view, boolean value);
   void setHideNavigationBar(T view, boolean value);
   void setCancelButtonText(T view, @Nullable String value);
+  void setDefaultValue(T view, @Nullable String value);
   void setBarTintColor(T view, @Nullable Integer value);
   void setTintColor(T view, @Nullable Integer value);
   void setTextColor(T view, @Nullable Integer value);

--- a/apps/src/tests/Test758.tsx
+++ b/apps/src/tests/Test758.tsx
@@ -42,6 +42,7 @@ function First({ navigation }: NativeStackScreenProps<ParamListBase>) {
     barTintColor: 'powderblue',
     tintColor: 'red',
     textColor: 'red',
+    defaultValue: 'Some default',
     hideWhenScrolling: true,
     obscureBackground: false,
     hideNavigationBar: false,

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -444,6 +444,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `barTintColor` - The search field background color. By default bar tint color is translucent.
 - `tintColor` - The color for the cursor caret and cancel button text. (iOS only)
 - `cancelButtonText` - The text to be used instead of default `Cancel` button text. (iOS only)
+- `defaultValue` - The initial text value of the search bar. Unlike `setText` which can be called via ref to update the value, this prop only affects the initial value when the search bar is mounted.
 - `disableBackButtonOverride` - Default behavior is to prevent screen from going back when search bar is open (`disableBackButtonOverride: false`). If you don't want this to happen set `disableBackButtonOverride` to `true`. (Android only)
 - `hideNavigationBar` - Boolean indicating whether to hide the navigation bar during searching. Defaults to `true`. (iOS only)
 - `hideWhenScrolling` - Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`. (iOS only)

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -763,6 +763,9 @@ RNS_IGNORE_SUPER_CALL_END
             RNSSearchBar *searchBar = subview.subviews[0];
             navitem.searchController = searchBar.controller;
             navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
+            if (searchBar.controller.searchBar && searchBar.defaultValue) {
+              searchBar.controller.searchBar.text = searchBar.defaultValue;
+            }
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
             if (@available(iOS 16.0, *)) {

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -20,6 +20,7 @@
 @property (nonatomic) BOOL hideWhenScrolling;
 @property (nonatomic) RNSSearchBarPlacement placement;
 @property (nonatomic, retain) UISearchController *controller;
+@property (nonatomic, copy) NSString *defaultValue;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0 && !TARGET_OS_TV

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -325,6 +325,13 @@ namespace react = facebook::react;
 #endif
 }
 
+- (void)setDefaultValue:(NSString *)defaultValue
+{
+  if (defaultValue != nil && _controller.searchBar.text.length == 0) {
+    [_controller.searchBar setText:defaultValue];
+  }
+}
+
 #pragma mark-- Fabric specific
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -371,6 +378,10 @@ namespace react = facebook::react;
 
   if (oldScreenProps.placement != newScreenProps.placement) {
     self.placement = [RNSConvert RNSScreenSearchBarPlacementFromCppEquivalent:newScreenProps.placement];
+  }
+
+  if (oldScreenProps.defaultValue != newScreenProps.defaultValue) {
+    [self setDefaultValue:RCTNSStringFromStringNilIfEmpty(newScreenProps.defaultValue)];
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -420,6 +431,7 @@ RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placement, RNSSearchBarPlacement)
+RCT_EXPORT_VIEW_PROPERTY(defaultValue, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTDirectEventBlock)

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -676,6 +676,22 @@ A React ref to imperatively modify search bar. Supported actions:
 - `cancelSearch` - cancel search in search bar.
 - `toggleCancelButton` (iOS only) - toggle cancel button display near search bar.
 
+#### `defaultValue`
+
+The initial text value of the search bar. Unlike using `ref.current.setText()`, this prop only affects the initial value when the search bar is mounted.
+
+Example:
+
+```js
+React.useLayoutEffect(() => {
+  navigation.setOptions({
+    searchBar: {
+      defaultValue: 'Initial search text',
+    },
+  });
+}, [navigation]);
+```
+
 ### Events
 
 The navigator can [emit events](https://reactnavigation.org/docs/navigation-events) on certain actions. Supported events are:

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -36,6 +36,7 @@ export interface NativeProps extends ViewProps {
   obscureBackground?: boolean;
   hideNavigationBar?: boolean;
   cancelButtonText?: string;
+  defaultValue?: string;
   // TODO: implement these on iOS
   barTintColor?: ColorValue;
   tintColor?: ColorValue;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -797,6 +797,12 @@ export interface SearchBarProps {
    * @default true
    */
   shouldShowHintSearchIcon?: boolean;
+  /**
+   * The initial text value of the search bar. Unlike `setText` which can be called
+   * via ref to update the value, this prop only affects the initial value when
+   * the search bar is mounted.
+   */
+  defaultValue?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

Add `defaultValue` prop to search bar, enabling initial text value configuration. 

```tsx
useLayoutEffect(() => {
  navigation.setOptions({
    headerSearchBarOptions: {
      defaultValue: 'Some default value',
    },
  });
}, [navigation]);
```

A common use-case for a default value is deep linking to a search screen that makes use of the search bar.

It's possible to imperatively set the value via ref using `setText`, however there's no the suitable callback to do it reliably without seeing the initial empty value / flickering.

Named the prop `defaultValue` to be consistent with RN TextInput where it's also used for the initial value for uncontrolled TextInput component.

- Resolves https://github.com/software-mansion/react-native-screens/discussions/1617
- Resolves https://github.com/software-mansion/react-native-screens/issues/2392

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

Tested in my app with a patch with these changes on:
- iOS (paper)
- Android (paper)

_I tried to run the react-native-screens example app, but got 'No component found for view with name "RNScreenStackHeaderConfig" on iOS after following the [Working on iOS](https://github.com/software-mansion/react-native-screens/blob/main/guides/CONTRIBUTING.md#working-on-ios) steps and didn't have time to debug it atm. Also the steps mention yarn prepare in react-navigation, but there's no such script._ 

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
