### PR TITLE
chore: fix misleading contributing guide

### DIFF
--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -91,8 +91,7 @@ To begin with, let install all dependencies:
 
 1. `yarn`
 2. `yarn submodules`
-3. `(cd react-navigation && yarn prepare)`
-4. `cd Example`
+4. `cd Example` or `cd FabricExample` (depending on architecture you want to work on)
 5. `yarn`
 6. `yarn start` &ndash; make sure to start metro bundler before building the app in Android Studio
 
@@ -108,10 +107,9 @@ To begin with, let install all dependencies:
 
 1. `yarn`
 2. `yarn submodules`
-3. `(cd react-navigation && yarn prepare)`
-4. `cd Example`
+4. `cd Example` or `cd FabricExample`
 5. `yarn`
-6. `(cd ios && pod install)`
+6. `(cd ios && pod install && cd ../)`
 7. `yarn start` &ndash; make sure to start metro bundler before building the app in XCode.
 
 and open `react-native-screens/Example/ios/ScreensExample.xcworkspace` with XCode.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.4.0-rc.0",
   "description": "Native navigation primitives for your React Native app.",
   "scripts": {
-    "submodules": "git submodule update --init --recursive && (cd react-navigation && yarn)",
+    "submodules": "git submodule update --init --recursive && (cd react-navigation && yarn && yarn build && cd ../)",
     "check-types": "tsc --noEmit",
     "start": "react-native start",
     "test:unit": "jest --passWithNoTests",


### PR DESCRIPTION
## Description

We recommended to run `yarn prepare` in `react-navigation` submodule, which is not existend (for some time now I believe).

## Changes

Updated the `yarn submodules` script & fixed the contributing guide.


## Test code and steps to reproduce

Clone fresh repo & follow contributing guide - it should work now. 

## Checklist

- [ ] Ensured that CI passes
