### PR TITLE
fix(iOS): restore behaviour of RNSScreenStackAnimationNone

### DIFF
--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -59,7 +59,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   }
 
   if (screen != nil && screen.stackAnimation == RNSScreenStackAnimationNone) {
-    return 0;
+    return 0.0;
   }
 
   if (screen != nil && screen.transitionDuration != nil && [screen.transitionDuration floatValue] >= 0) {
@@ -489,6 +489,34 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   }
 }
 
+- (void)animateNoneWithTransitionContext:(id<UIViewControllerContextTransitioning>)transitionContext
+                                    toVC:(UIViewController *)toViewController
+                                  fromVC:(UIViewController *)fromViewController
+{
+  if (_operation == UINavigationControllerOperationPush) {
+    [[transitionContext containerView] addSubview:toViewController.view];
+    [UIView animateWithDuration:[self transitionDuration:transitionContext]
+        animations:^{
+          toViewController.view.alpha = 1.0;
+        }
+        completion:^(BOOL finished) {
+          toViewController.view.alpha = 1.0;
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
+  } else if (_operation == UINavigationControllerOperationPop) {
+    [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
+
+    [UIView animateWithDuration:[self transitionDuration:transitionContext]
+        animations:^{
+          fromViewController.view.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          fromViewController.view.alpha = 1.0;
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
+  }
+}
+
 #pragma mark - Public API
 
 - (nullable id<UITimingCurveProvider>)timingParamsForAnimationCompletion
@@ -509,24 +537,34 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
                                        toVC:(UIViewController *)toVC
                                      fromVC:(UIViewController *)fromVC
 {
-  if (animation == RNSScreenStackAnimationSimplePush) {
-    [self animateSimplePushWithShadowEnabled:shadowEnabled transitionContext:transitionContext toVC:toVC fromVC:fromVC];
-    return;
-  } else if (animation == RNSScreenStackAnimationSlideFromLeft) {
-    [self animateSlideFromLeftWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
-    return;
-  } else if (animation == RNSScreenStackAnimationFade || animation == RNSScreenStackAnimationNone) {
-    [self animateFadeWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
-    return;
-  } else if (animation == RNSScreenStackAnimationSlideFromBottom) {
-    [self animateSlideFromBottomWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
-    return;
-  } else if (animation == RNSScreenStackAnimationFadeFromBottom) {
-    [self animateFadeFromBottomWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
-    return;
+  switch (animation) {
+    case RNSScreenStackAnimationSimplePush:
+      [self animateSimplePushWithShadowEnabled:shadowEnabled
+                             transitionContext:transitionContext
+                                          toVC:toVC
+                                        fromVC:fromVC];
+      return;
+    case RNSScreenStackAnimationSlideFromLeft:
+      [self animateSlideFromLeftWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
+      return;
+    case RNSScreenStackAnimationFade:
+      [self animateFadeWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
+      return;
+    case RNSScreenStackAnimationSlideFromBottom:
+      [self animateSlideFromBottomWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
+      return;
+    case RNSScreenStackAnimationFadeFromBottom:
+      [self animateFadeFromBottomWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
+      return;
+    case RNSScreenStackAnimationNone:
+      [self animateNoneWithTransitionContext:transitionContext toVC:toVC fromVC:fromVC];
+    default:
+      // simple_push is the default custom animation
+      [self animateSimplePushWithShadowEnabled:shadowEnabled
+                             transitionContext:transitionContext
+                                          toVC:toVC
+                                        fromVC:fromVC];
   }
-  // simple_push is the default custom animation
-  [self animateSimplePushWithShadowEnabled:shadowEnabled transitionContext:transitionContext toVC:toVC fromVC:fromVC];
 }
 
 + (UISpringTimingParameters *)defaultSpringTimingParametersApprox


### PR DESCRIPTION
## Description

WIP WIP

There is still some header animation noticable for some reason.


Note: Must be implemented with old animation API, because `UIViewPropertyAnimator` does not allow for 0 duration (it uses default if the specified animation duration is below some undocumented treshold).

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
