### PR TITLE
fix: take preload into account when freezing children

### DIFF
--- a/apps/src/tests/TestFreeze.tsx
+++ b/apps/src/tests/TestFreeze.tsx
@@ -38,6 +38,14 @@ function HomeScreen({
         title="Go to Details"
         onPress={() => navigation.navigate('Details')}
       />
+      <Button
+        title="Preload Details"
+        onPress={() => navigation.preload('Details')}
+      />
+      <Button
+        title="Preload Details2"
+        onPress={() => navigation.preload('Details2')}
+      />
     </View>
   );
 }
@@ -84,6 +92,7 @@ function App() {
         }}>
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Details" component={DetailsScreen} />
+        <Stack.Screen name="Details2" component={DetailsScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -177,6 +177,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
     const {
       enabled = screensEnabled(),
       freezeOnBlur = freezeEnabled(),
+      shouldFreeze,
       ...rest
     } = props;
 
@@ -271,8 +272,12 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         }
       };
 
+      const freeze =
+        freezeOnBlur &&
+        (isNativeStack ? Boolean(shouldFreeze) : activityState === 0);
+
       return (
-        <DelayedFreeze freeze={freezeOnBlur && activityState === 0}>
+        <DelayedFreeze freeze={freeze}>
           <AnimatedScreen
             {...props}
             /**

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -274,7 +274,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
 
       const freeze =
         freezeOnBlur &&
-        (isNativeStack ? Boolean(shouldFreeze) : activityState === 0);
+        (shouldFreeze !== undefined ? shouldFreeze : activityState === 0);
 
       return (
         <DelayedFreeze freeze={freeze}>

--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -77,6 +77,12 @@ function ScreenStack(props: ScreenStackProps) {
     },
   });
 
+  const preloadedScreensCount = React.Children.toArray(children).filter(
+    // @ts-expect-error it's either SceneView in v6 or RouteView in v5
+    child => child.props.isPreloaded,
+  ).length;
+
+  const renderedScreensSize = size - preloadedScreensCount;
   // freezes all screens except the top one
   const childrenWithFreeze = React.Children.map(children, (child, index) => {
     // @ts-expect-error it's either SceneView in v6 or RouteView in v5
@@ -88,8 +94,8 @@ function ScreenStack(props: ScreenStackProps) {
     // On Fabric, when screen is frozen, animated and reanimated values are not updated
     // due to component being unmounted. To avoid this, we don't freeze the previous screen there
     const freezePreviousScreen = isFabric()
-      ? size - index > 2
-      : size - index > 1;
+      ? renderedScreensSize - index > 2
+      : renderedScreensSize - index > 1;
 
     return (
       <DelayedFreeze freeze={isFreezeEnabled && freezePreviousScreen}>

--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -9,18 +9,12 @@ import {
   ScreenStackProps,
 } from '../types';
 import { GHContext, RNSScreensRefContext } from '../contexts';
-import { freezeEnabled } from '../core';
-import DelayedFreeze from './helpers/DelayedFreeze';
 import warnOnce from 'warn-once';
 
 // Native components
 import ScreenStackNativeComponent, {
   NativeProps,
 } from '../fabric/ScreenStackNativeComponent';
-
-function isFabric() {
-  return 'nativeFabricUIManager' in global;
-}
 
 const assertGHProvider = (
   ScreenGestureDetector: (
@@ -69,39 +63,11 @@ function ScreenStack(props: ScreenStackProps) {
     passedScreenRefs?.current ?? {},
   );
   const ref = React.useRef(null);
-  const size = React.Children.count(children);
   const ScreenGestureDetector = React.useContext(GHContext);
   const gestureDetectorBridge = React.useRef<GestureDetectorBridge>({
     stackUseEffectCallback: _stackRef => {
       // this method will be overriden in GestureDetector
     },
-  });
-
-  const preloadedScreensCount = React.Children.toArray(children).filter(
-    // @ts-expect-error it's either SceneView in v6 or RouteView in v5
-    child => child.props.isPreloaded,
-  ).length;
-
-  const renderedScreensSize = size - preloadedScreensCount;
-  // freezes all screens except the top one
-  const childrenWithFreeze = React.Children.map(children, (child, index) => {
-    // @ts-expect-error it's either SceneView in v6 or RouteView in v5
-    const { props, key } = child;
-    const descriptor = props?.descriptor ?? props?.descriptors?.[key];
-    const isFreezeEnabled =
-      descriptor?.options?.freezeOnBlur ?? freezeEnabled();
-
-    // On Fabric, when screen is frozen, animated and reanimated values are not updated
-    // due to component being unmounted. To avoid this, we don't freeze the previous screen there
-    const freezePreviousScreen = isFabric()
-      ? renderedScreensSize - index > 2
-      : renderedScreensSize - index > 1;
-
-    return (
-      <DelayedFreeze freeze={isFreezeEnabled && freezePreviousScreen}>
-        {child}
-      </DelayedFreeze>
-    );
   });
 
   React.useEffect(() => {
@@ -136,7 +102,7 @@ function ScreenStack(props: ScreenStackProps) {
             onFinishTransitioning as NativeProps['onFinishTransitioning']
           }
           ref={ref}>
-          {childrenWithFreeze}
+          {children}
         </ScreenStackNativeComponent>
       </ScreenGestureDetector>
     </RNSScreensRefContext.Provider>

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -30,6 +30,7 @@ function ScreenStackItem(
     children,
     headerConfig,
     activityState,
+    shouldFreeze,
     stackPresentation,
     contentStyle,
     style,
@@ -132,6 +133,7 @@ function ScreenStackItem(
       enabled
       isNativeStack
       activityState={activityState}
+      shouldFreeze={shouldFreeze}
       stackPresentation={stackPresentation}
       hasLargeHeader={headerConfig?.largeTitle ?? false}
       style={[style, internalScreenStyle]}
@@ -142,6 +144,7 @@ function ScreenStackItem(
             enabled
             isNativeStack
             activityState={activityState}
+            shouldFreeze={shouldFreeze}
             hasLargeHeader={headerConfig?.largeTitle ?? false}
             style={StyleSheet.absoluteFill}>
             {content}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -102,6 +102,10 @@ export type SearchBarPlacement = 'automatic' | 'inline' | 'stacked';
 export interface ScreenProps extends ViewProps {
   active?: 0 | 1 | Animated.AnimatedInterpolation<number>;
   activityState?: 0 | 1 | 2 | Animated.AnimatedInterpolation<number>;
+  /**
+   * Boolean indicating that the screen should be frozen with `react-freeze`.
+   */
+  shouldFreeze?: boolean;
   children?: React.ReactNode;
   /**
    * Boolean indicating that swipe dismissal should trigger animation provided by `stackAnimation`. Defaults to `false`.


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->
Fixed https://github.com/software-mansion/react-native-screens/issues/2557. We have to take preloaded screens into account when freezing screens. Till now, the assumption was that the newest screens are the ones rendered, right now top children can be the preloaded ones, so we have to filter them from calculating the size of frozen screens. We could also think of freezing the preloaded screens, wdyt about it @satya164 ?


## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

TestFreeze now includes preloading of screens, even more than 1 to see that the current one still gets the updates.

## Checklist

- [x] Included code example that can be used to test this change