### PR TITLE
feat: add codegen `ios.componentProvider` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,21 @@
     "jsSrcsDir": "./src/fabric",
     "android": {
       "javaPackageName": "com.swmansion.rnscreens"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNSFullWindowOverlay": "RNSFullWindowOverlay",
+        "RNSModalScreen": "RNSModalScreen",
+        "RNSScreenContainer": "RNSScreenContainer",
+        "RNSScreenContentWrapper": "RNSScreenContentWrapper",
+        "RNSScreenFooter": "RNSScreenFooter",
+        "RNSScreen": "RNSScreen",
+        "RNSScreenNavigationContainer": "RNSScreenNavigationContainer",
+        "RNSScreenStackHeaderConfig": "RNSScreenStackHeaderConfig",
+        "RNSScreenStackHeaderSubview": "RNSScreenStackHeaderSubview",
+        "RNSScreenStack": "RNSScreenStack",
+        "RNSSearchBar": "RNSSearchBar"
+      }
     }
   },
   "packageManager": "yarn@4.1.1"


### PR DESCRIPTION
## Description

Add a newly introduced field `ios.componentProvider` to the `codegen` configuration to create an association map between JS components and their native implementations. 

See more information here: https://github.com/software-mansion/react-native-svg/pull/2572

## Changes

- added `codegenConfig.ios.componentProvider` field to package.json

### Before

```objc

Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name) {
  static std::unordered_map<std::string, Class (*)(void)> sFabricComponentsClassMap = {
    // ...
    {"RNSFullWindowOverlay", RNSFullWindowOverlayCls}, // 3
    {"RNSModalScreen", RNSModalScreenCls}, // 3
    {"RNSScreenContainer", RNSScreenContainerCls}, // 3
    {"RNSScreenContentWrapper", RNSScreenContentWrapperCls}, // 3
    {"RNSScreenFooter", RNSScreenFooterCls}, // 3
    {"RNSScreen", RNSScreenCls}, // 3
    {"RNSScreenNavigationContainer", RNSScreenNavigationContainerCls}, // 3
    {"RNSScreenStackHeaderConfig", RNSScreenStackHeaderConfigCls}, // 3
    {"RNSScreenStackHeaderSubview", RNSScreenStackHeaderSubviewCls}, // 3
    {"RNSScreenStack", RNSScreenStackCls}, // 3
    {"RNSSearchBar", RNSSearchBarCls}, // 3
    // ...
```
### After

```objc
@implementation RCTThirdPartyComponentsProvider

+ (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
{
  return @{
		@"RNSFullWindowOverlay": NSClassFromString(@"RNSFullWindowOverlay"), // react-native-screens
		@"RNSModalScreen": NSClassFromString(@"RNSModalScreen"), // react-native-screens
		@"RNSScreenContainer": NSClassFromString(@"RNSScreenContainer"), // react-native-screens
		@"RNSScreenContentWrapper": NSClassFromString(@"RNSScreenContentWrapper"), // react-native-screens
		@"RNSScreenFooter": NSClassFromString(@"RNSScreenFooter"), // react-native-screens
		@"RNSScreen": NSClassFromString(@"RNSScreen"), // react-native-screens
		@"RNSScreenNavigationContainer": NSClassFromString(@"RNSScreenNavigationContainer"), // react-native-screens
		@"RNSScreenStackHeaderConfig": NSClassFromString(@"RNSScreenStackHeaderConfig"), // react-native-screens
		@"RNSScreenStackHeaderSubview": NSClassFromString(@"RNSScreenStackHeaderSubview"), // react-native-screens
		@"RNSScreenStack": NSClassFromString(@"RNSScreenStack"), // react-native-screens
		@"RNSSearchBar": NSClassFromString(@"RNSSearchBar"), // react-native-screens
  };
}
```

## Test code and steps to reproduce

Run `pod install` in React Native 0.77 app and see `RCTThirdPartyFabricComponentsProvider` to check the content
 