### PR TITLE
fix: point to existing symbol names in `ios.componentProvider`

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,14 +158,14 @@
       "componentProvider": {
         "RNSFullWindowOverlay": "RNSFullWindowOverlay",
         "RNSModalScreen": "RNSModalScreen",
-        "RNSScreenContainer": "RNSScreenContainer",
+        "RNSScreenContainer": "RNSScreenContainerView",
         "RNSScreenContentWrapper": "RNSScreenContentWrapper",
         "RNSScreenFooter": "RNSScreenFooter",
-        "RNSScreen": "RNSScreen",
-        "RNSScreenNavigationContainer": "RNSScreenNavigationContainer",
+        "RNSScreen": "RNSScreenView",
+        "RNSScreenNavigationContainer": "RNSScreenNavigationContainerView",
         "RNSScreenStackHeaderConfig": "RNSScreenStackHeaderConfig",
         "RNSScreenStackHeaderSubview": "RNSScreenStackHeaderSubview",
-        "RNSScreenStack": "RNSScreenStack",
+        "RNSScreenStack": "RNSScreenStackView",
         "RNSSearchBar": "RNSSearchBar"
       }
     }


### PR DESCRIPTION
## Description

#2567 introduced `ios.componentProvider` field to package definition - and that's fine, but we're pointing to wrong names there. 

## Changes

Updated the names to existing symbol names. 


## Test code and steps to reproduce

This caused runtime errors when running the app on 0.77. I need this commit for the #2581 (0.77 support)

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
