### PR TITLE
fix: Use `ImageResizeMode::None`

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -909,6 +909,8 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
       return RCTResizeModeCenter;
     case react::ImageResizeMode::Repeat:
       return RCTResizeModeRepeat;
+    case react::ImageResizeMode::None:
+      return RCTResizeModeNone;
     default:
       // Both RCTConvert and ImageProps use this as a default as of RN 0.76
       return RCTResizeModeStretch;


### PR DESCRIPTION
## Description

Technically the `::none` resize mode was missing - not sure if this is necessary since y'all added the `default` branch anyways.

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
