### PR TITLE
fix(Android): patch potential issues with Android build since RN lib-merge in 0.76

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -159,7 +159,13 @@ android {
                 "**/libc++_shared.so",
                 "**/libreact_render*.so",
                 "**/libreactnativejni.so",
-                "**/libreact_performance_timeline.so"
+                "**/libreact_performance_timeline.so",
+                // In 0.76 multiple react-native's libraries were merged and these are the main new artifacts we're using.
+                // Some of above lib* names could be removed after we remove support for 0.76.
+                // https://github.com/facebook/react-native/pull/43909
+                // https://github.com/facebook/react-native/pull/46059
+                "**/libfbjni.so", 
+                "**/libreactnative.so"
         ]
     }
     sourceSets.main {


### PR DESCRIPTION
## Description

Fixes #2463 

I haven't been able to reproduce the issue, however multiple people reported & confirmed it

Thanks @vadzimk for [pointing these out](https://github.com/software-mansion/react-native-screens/issues/2463#issuecomment-2573632504).

When adding support for 0.76.0 we overlooked that we relied on RN library structure (and naming) not only in CMake build but also in Gradle configuration.

I've looked up whether reanimated team did this - and [they did](https://github.com/software-mansion/react-native-reanimated/pull/6499/files#diff-1c0b83a843e69ff75029daed5b4befe9f46d71042a974e7defe9ded23456e0fd) & we will follow their lead here.

## Changes

Added `libfbjni` & `libreactnative` to exclude list so that these are subject of `duplicated dependency` error.

## Test code and steps to reproduce

WIP

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
