### PR TITLE
fix(Android): fix warning by removing package declaration from AndroidManifest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,9 +99,10 @@ def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
+    namespace "com.swmansion.rnscreens"
+
     def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.swmansion.rnscreens"
         buildFeatures {
             buildConfig true
         }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.swmansion.rnscreens">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
## Description

See the discussion:

https://github.com/software-mansion/react-native-screens/discussions/2597#discussioncomment-11759520

## Changes

Removed the package declaration from Android Manifest.

## Test code and steps to reproduce

Passing build should be enough.

## Checklist

- [x] Ensured that CI passes
