### PR TITLE
feat(ios): add searchBar bookmark button and handler

### DIFF
--- a/apps/src/screens/SearchBar.tsx
+++ b/apps/src/screens/SearchBar.tsx
@@ -43,6 +43,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
     useState(true);
   const [hideWhenScrolling, setHideWhenScrolling] = useState(false);
   const [obscureBackground, setObscureBackground] = useState(false);
+  const [showBookmarkButton, setShowBookmarkButton] = useState(false);
   const [hideNavigationBar, setHideNavigationBar] = useState(false);
   const [autoCapitalize, setAutoCapitalize] =
     useState<AutoCapitalize>('sentences');
@@ -59,6 +60,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         shouldShowHintSearchIcon,
         hideWhenScrolling,
         obscureBackground,
+        showBookmarkButton,
         hideNavigationBar,
         autoCapitalize,
         placeholder,
@@ -67,6 +69,11 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         onCancelButtonPress: () =>
           toast.push({
             message: '[iOS] Cancel button pressed',
+            backgroundColor: 'orange',
+          }),
+        onBookmarkButtonPress: () =>
+          toast.push({
+            message: '[iOS] Bookmark button pressed',
             backgroundColor: 'orange',
           }),
         onClose: () =>
@@ -106,6 +113,7 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
     shouldShowHintSearchIcon,
     hideWhenScrolling,
     obscureBackground,
+    showBookmarkButton,
     hideNavigationBar,
     autoCapitalize,
     inputType,
@@ -148,6 +156,11 @@ const MainScreen = ({ navigation }: MainScreenProps): React.JSX.Element => {
         label="Hide when scrolling"
         value={hideWhenScrolling}
         onValueChange={setHideWhenScrolling}
+      />
+      <SettingsSwitch
+        label="Show Bookmark Button"
+        value={showBookmarkButton}
+        onValueChange={setShowBookmarkButton}
       />
       <ThemedText style={styles.heading}>Android only</ThemedText>
       <SettingsPicker<InputType>

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -449,9 +449,11 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `hideWhenScrolling` - Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`. (iOS only)
 - `inputType` - Specifies type of input and keyboard for search bar. Can be one of `'text'`, `'phone'`, `'number'`, `'email'`. Defaults to `'text'`. (Android only)
 - `obscureBackground` - Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`. (iOS only)
+- `showBookmarkButton` - Boolean indicating whether the search bar should display a bookmark button. Defaults to `false`. (iOS only)
 - `onBlur` - A callback that gets called when search bar has lost focus.
 - `onChangeText` - A callback that gets called when the text changes. It receives the current text value of the search bar.
 - `onCancelButtonPress` - A callback that gets called when the cancel button is pressed.
+- `onBookmarkButtonPress` - A callback that gets called when the bookmark button is pressed.
 - `onClose` - A callback that gets called when search bar is closing. (Android only)
 - `onFocus` - A callback that gets called when search bar has received focus.
 - `onOpen` - A callback that gets called when search bar is expanding. (Android only)

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -31,6 +31,7 @@
 #else
 @property (nonatomic, copy) RCTDirectEventBlock onChangeText;
 @property (nonatomic, copy) RCTDirectEventBlock onCancelButtonPress;
+@property (nonatomic, copy) RCTDirectEventBlock onBookmarkButtonPress;
 @property (nonatomic, copy) RCTDirectEventBlock onSearchButtonPress;
 @property (nonatomic, copy) RCTDirectEventBlock onSearchFocus;
 @property (nonatomic, copy) RCTDirectEventBlock onSearchBlur;

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -127,6 +127,20 @@ namespace react = facebook::react;
   }
 #endif
 }
+- (void)emitOnBookmarkButtonPressEvent
+{
+#ifdef RCT_NEW_ARCH_ENABLED
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<const react::RNSSearchBarEventEmitter>(_eventEmitter)
+        ->onBookmarkButtonPress(react::RNSSearchBarEventEmitter::onBookmarkButtonPress{});
+  }
+#else
+  if (self.onBookmarkButtonPress) {
+    self.onBookmarkButtonPress(@{});
+  }
+#endif
+}
+
 
 - (void)emitOnChangeTextEventWithText:(NSString *)text
 {
@@ -150,6 +164,12 @@ namespace react = facebook::react;
     [_controller setObscuresBackgroundDuringPresentation:obscureBackground];
   }
 }
+
+- (void)setShowBookmarkButton:(BOOL)showBookmarkButton
+{
+  [_controller.searchBar setShowsBookmarkButton:showBookmarkButton];
+}
+
 
 - (void)setHideNavigationBar:(BOOL)hideNavigationBar
 {
@@ -290,6 +310,13 @@ namespace react = facebook::react;
 }
 #endif // !TARGET_OS_TV
 
+#if !TARGET_OS_TV
+- (void)searchBarBookmarkButtonClicked:(UISearchBar *)searchBar
+{
+  [self emitOnBookmarkButtonPressEvent];
+}
+#endif // !TARGET_OS_TV
+
 - (void)blur
 {
   [_controller.searchBar resignFirstResponder];
@@ -334,6 +361,8 @@ namespace react = facebook::react;
   const auto &newScreenProps = *std::static_pointer_cast<const react::RNSSearchBarProps>(props);
 
   [self setHideWhenScrolling:newScreenProps.hideWhenScrolling];
+  
+  [self setShowBookmarkButton:newScreenProps.showBookmarkButton];
 
   if (oldScreenProps.cancelButtonText != newScreenProps.cancelButtonText) {
     [self setCancelButtonText:RCTNSStringFromStringNilIfEmpty(newScreenProps.cancelButtonText)];
@@ -411,6 +440,7 @@ RCT_EXPORT_MODULE()
 #endif
 
 RCT_EXPORT_VIEW_PROPERTY(obscureBackground, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(showBookmarkButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideWhenScrolling, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoCapitalize, UITextAutocapitalizationType)
@@ -423,6 +453,7 @@ RCT_EXPORT_VIEW_PROPERTY(placement, RNSSearchBarPlacement)
 
 RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onBookmarkButtonPress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSearchButtonPress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSearchFocus, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSearchBlur, RCTDirectEventBlock)

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -589,6 +589,12 @@ Boolean indicating whether to obscure the underlying content with semi-transpare
 
 Defaults to `true`.
 
+#### `showBookmarkButton` (iOS only)
+
+Boolean indicates whether the search bar should display a bookmark button.
+
+Defaults to `false`.
+
 #### `onBlur`
 
 A callback that gets called when search bar has lost focus.
@@ -596,6 +602,10 @@ A callback that gets called when search bar has lost focus.
 #### `onCancelButtonPress`
 
 A callback that gets called when the cancel button is pressed.
+
+#### `onBookmarkButtonPress`
+
+A callback that gets called when the bookmark button is pressed.
 
 #### `onChangeText`
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -94,6 +94,9 @@ function SearchBar(props: SearchBarProps, ref: React.Ref<SearchBarCommands>) {
       onCancelButtonPress={
         props.onCancelButtonPress as DirectEventHandler<SearchBarEvent>
       }
+      onBookmarkButtonPress={
+        props.onBookmarkButtonPress as DirectEventHandler<SearchBarEvent>
+      }
       onChangeText={props.onChangeText as DirectEventHandler<ChangeTextEvent>}
     />
   );

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -28,12 +28,14 @@ export interface NativeProps extends ViewProps {
   onSearchBlur?: DirectEventHandler<SearchBarEvent> | null;
   onSearchButtonPress?: DirectEventHandler<SearchButtonPressedEvent> | null;
   onCancelButtonPress?: DirectEventHandler<SearchBarEvent> | null;
+  onBookmarkButtonPress?: DirectEventHandler<SearchBarEvent> | null;
   onChangeText?: DirectEventHandler<ChangeTextEvent> | null;
   hideWhenScrolling?: boolean;
   autoCapitalize?: WithDefault<AutoCapitalizeType, 'none'>;
   placeholder?: string;
   placement?: WithDefault<SearchBarPlacement, 'stacked'>;
   obscureBackground?: boolean;
+  showBookmarkButton?: boolean;
   hideNavigationBar?: boolean;
   cancelButtonText?: string;
   // TODO: implement these on iOS

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -723,6 +723,12 @@ export interface SearchBarProps {
    */
   obscureBackground?: boolean;
   /**
+   * Indicates whether the search bar should display a bookmark button.
+   *
+   * @platform iOS
+   */
+  showBookmarkButton?: boolean;
+  /**
    * A callback that gets called when search bar has lost focus
    */
   onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
@@ -732,6 +738,13 @@ export interface SearchBarProps {
    * @platform ios
    */
   onCancelButtonPress?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
+
+  /**
+   * A callback that gets called when the bookmark button is pressed.
+   *
+   * @platform iOS
+   */
+  onBookmarkButtonPress?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
 
   /**
    * A callback that gets called when the text changes. It receives the current text value of the search bar.


### PR DESCRIPTION
## Description

This PR adds support for a bookmark button in the SearchBar component on iOS.


## Changes

The addition of the showBookmarkButton prop allows developers to toggle the display of a bookmark button in the search bar, enabling a more customized and interactive user experience. The onBookmarkButtonPress callback provides a way to handle user interactions with the bookmark button, making it easy to implement bookmarking functionality within an app.


https://github.com/user-attachments/assets/be13e6e2-ecde-4f19-92cd-c8ab4bac0cae



## Checklist

- [ x] Included code example that can be used to test this change
- [ x] Updated TS types
- [ x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ x] Ensured that CI passes
