### PR TITLE
fix(Android): should not set cmake path in gradle when new architectu…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,9 +130,11 @@ android {
         prefab true
         buildConfig true
     }
-    externalNativeBuild {
-        cmake {
-            path "CMakeLists.txt"
+    if (isNewArchitectureEnabled()) {
+        externalNativeBuild {
+            cmake {
+                path "CMakeLists.txt"
+            }
         }
     }
     lintOptions {
@@ -159,7 +161,7 @@ android {
                 // Some of above lib* names could be removed after we remove support for 0.76.
                 // https://github.com/facebook/react-native/pull/43909
                 // https://github.com/facebook/react-native/pull/46059
-                "**/libfbjni.so", 
+                "**/libfbjni.so",
                 "**/libreactnative.so"
         ]
     }


### PR DESCRIPTION
# Summary:
Android build will fail when newArchEnabled=false, and trhow below exception:

```
Caused by: com.android.builder.errors.EvalIssueException: [CXX1210] /Users/sleepym09/code/project_test/node_modules/react-native-screens/android/CMakeLists.txt debug|arm64-v8a : No compatible library found
	at com.android.builder.errors.IssueReporter.reportError(IssueReporter.kt:116)
	at com.android.builder.errors.IssueReporter.reportError$default(IssueReporter.kt:112)
```

Actually we needn't to set cmake path if newArchEnabled is false.

Maybe related issues:
- [#48399](https://github.com/facebook/react-native/issues/48399)
- [#47729](https://github.com/facebook/react-native/issues/47729)

## Test Plan:
React Native Android builds with this change without newArchEnabled and no more build error.