### PR TITLE
chore(CI): fix part 2 - set xcode-version to 16.1

### DIFF
--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.1'
       - name: Install node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.1'
       - name: Install node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.1'
       - name: Get Xcode version
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils


### PR DESCRIPTION
## Description

Apparently there are some issues with newer xcode versions on GitHub CI

Following [gesture-handler lead](https://github.com/software-mansion/react-native-gesture-handler/pull/3319/) here.

## Changes

Set `xcode-version` to `16.1` temporarily in our CI workflow definitions.

## Test code and steps to reproduce

hopefully iOS-related workflows pass

## Checklist

- [ ] Ensured that CI passes

