### PR TITLE
refactor(iOS): update view controller once per transaction when adding header subviews

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -883,9 +883,6 @@ RNS_IGNORE_SUPER_CALL_BEGIN
   [self insertReactSubview:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
 
   _addedReactSubviewsInCurrentTransaction = true;
-
-  // TODO: This could be called only once per transaction.
-  [self updateViewControllerIfNeeded];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
@@ -909,7 +906,9 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
-  if (_addedReactSubviewsInCurrentTransaction && self.shouldHeaderBeVisible) {
+  if (_addedReactSubviewsInCurrentTransaction) {
+    [self updateViewControllerIfNeeded];
+
     // This call is made for the sake of https://github.com/software-mansion/react-native-screens/pull/2466.
     // In case header subview is added **after initial screen render** the system positions it correctly,
     // however `viewDidLayoutSubviews` is not called on `RNSNavigationController` and updated frame sizes of the
@@ -917,7 +916,9 @@ RNS_IGNORE_SUPER_CALL_BEGIN
     // Sending state update to ShadowTree from here is not enough, because native layout has not yet
     // happened after the child had been added. Requesting layout on navigation bar does not trigger layout callbacks
     // either, however doing so on main view of navigation controller does the trick.
-    [self layoutNavigationControllerView];
+    if (self.shouldHeaderBeVisible) {
+      [self layoutNavigationControllerView];
+    }
   }
   _addedReactSubviewsInCurrentTransaction = false;
 }


### PR DESCRIPTION
## Description

In #2466 I've introduced `RCTMountingTransactionObserving` for `RNSScreenStackHeaderConfig` component.
Now we can use this to reduce amount of calls to `updateViewControllerIfNeeded` (causing layout passes) when adding subviews.

I'm not changing the `unmount` path of the code as we have some more additional logic there which requires some more 
careful consideration. 

This also aligns us with Paper implementation. Note that it has been only implemented this way, because at the implementation time there was no way
to run this code on transaction completion.

## Changes

`- [RNSScreenStackHeaderConfig updateViewControllerIfNeeded]` is now called only once per transaction when adding subviews to header config.

## Test code and steps to reproduce

Test432, TestHeaderTitle, Test2552 - see that there are no regressions. 

> [!note]
During testing I've found that there is a bug with subview layout when modifying subviews after first render. This is not a regression however. Notice the wrong position of header right on video below 👇🏻 (Test432)


https://github.com/user-attachments/assets/7f8653e8-a7d9-4fb8-a875-182e7deb0495



## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
