### PR TITLE
fix(iOS): make `RCTMountingTransactionObserving` implementation new-arch only

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -59,8 +59,10 @@ namespace react = facebook::react;
 
 @end
 
+#ifdef RCT_NEW_ARCH_ENABLED
 @interface RNSScreenStackHeaderConfig () <RCTMountingTransactionObserving>
 @end
+#endif // RCT_NEW_ARCH_ENABLED
 
 @implementation RNSScreenStackHeaderConfig {
   NSMutableArray<RNSScreenStackHeaderSubview *> *_reactSubviews;


### PR DESCRIPTION
## Description

I've made mistake in #2466 - the aforementioned protocol does not exist on Paper.

## Changes

Use ifdef directive to prevent build errors.


## Test code and steps to reproduce

iOS + old-arch should just build.

## Checklist

- [ ] Ensured that CI passes
