### PR TITLE
feat(Android): deprecate series of status/navigation bar related props

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -224,6 +224,7 @@ open class ScreenViewManager :
         view.isStatusBarHidden = statusBarHidden
     }
 
+    @Deprecated("For apps targeting SDK 35 or above this prop has no effect")
     @ReactProp(name = "navigationBarColor", customType = "Color")
     override fun setNavigationBarColor(
         view: Screen,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -233,6 +233,7 @@ open class ScreenViewManager :
         view.navigationBarColor = navigationBarColor
     }
 
+    @Deprecated("For apps targeting SDK 35 or above edge-to-edge is enabled by default")
     @ReactProp(name = "navigationBarTranslucent")
     override fun setNavigationBarTranslucent(
         view: Screen,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -184,6 +184,10 @@ export interface ScreenProps extends ViewProps {
    * Sets the navigation bar color. Defaults to initial status bar color.
    *
    * @platform android
+   *
+   * @deprecated For all apps targeting Android SDK 35 or above this prop has no effect.
+   *  For SDK below 35 this works only with specific app setup.
+   *  See: https://developer.android.com/reference/android/view/Window#setNavigationBarColor(int)
    */
   navigationBarColor?: ColorValue;
   /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -194,6 +194,10 @@ export interface ScreenProps extends ViewProps {
    * Boolean indicating whether the content should be visible behind the navigation bar. Defaults to `false`.
    *
    * @platform android
+   *
+   * @deprecated For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default.
+   *  We expect that in future SDKs this option will be enforced.
+   *  See: https://developer.android.com/about/versions/15/behavior-changes-15#window-insets
    */
   navigationBarTranslucent?: boolean;
   /**


### PR DESCRIPTION

## Description

WIP WIP

## Changes

- **Deprecate navigationBarColor**
- **Deprecate navigationBarTranslucent**

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
