### PR TITLE
fix(Android): Restore focus on page transitions

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -478,6 +478,11 @@ class ScreenStackFragment :
         screen.background = shape
     }
 
+    override fun onStart() {
+        lastFocusedChild?.requestFocus()
+        super.onStart()
+    }
+
     override fun onStop() {
         if (DeviceUtils.isPlatformAndroidTV(context)) {
             lastFocusedChild = findLastFocusedChild()


### PR DESCRIPTION
## Description

After #1894 was merged, a refactoring of the native source happened, and the call to `lastFocusedChild.requestFocus()` that happened on the overridden `onStart()` method in `ScreenStackFragment` got lost along the way, making focus disappear when popping a screen from the stack.

Fixes #1706 

## Changes

- Updated `ScreenStackFragment.kt`, resurrecting the old `onStart()` override (`lastFocusedChild` is only set on Android TV, so this change only affects that platform)

