### PR TITLE
fix(iOS,Fabric): fix invalid position of FullWindowOverlay in certain scenarios

### DIFF
--- a/android/src/main/jni/rnscreens.h
+++ b/android/src/main/jni/rnscreens.h
@@ -20,6 +20,7 @@
 #include <react/renderer/components/rnscreens/RNSModalScreenComponentDescriptor.h>
 #include <react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h>
 #include <react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h>
+#include <react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h>
 
 namespace facebook {
 namespace react {

--- a/apps/src/shared/PressableWithFeedback.tsx
+++ b/apps/src/shared/PressableWithFeedback.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { ForwardedRef } from 'react';
+import { GestureResponderEvent, Pressable, PressableProps, StyleSheet, View } from 'react-native';
+
+export type PressableState = 'pressed-in' | 'pressed' | 'pressed-out'
+
+const PressableWithFeedback = React.forwardRef((props: PressableProps, ref: ForwardedRef<View>): React.JSX.Element => {
+  const [pressedState, setPressedState] = React.useState<PressableState>('pressed-out');
+
+  const onPressInCallback = React.useCallback((e: GestureResponderEvent) => {
+    console.log('Pressable onPressIn', {
+      locationX: e.nativeEvent.locationX,
+      locationY: e.nativeEvent.locationY,
+      pageX: e.nativeEvent.pageX,
+      pageY: e.nativeEvent.pageY,
+    });
+    setPressedState('pressed-in');
+    props.onPressIn?.(e);
+  }, [props]);
+
+  const onPressCallback = React.useCallback((e: GestureResponderEvent) => {
+    console.log('Pressable onPress');
+    setPressedState('pressed');
+    props.onPress?.(e);
+  }, [props]);
+
+  const onPressOutCallback = React.useCallback((e: GestureResponderEvent) => {
+    console.log('Pressable onPressOut');
+    setPressedState('pressed-out');
+    props.onPressOut?.(e);
+  }, [props]);
+
+  const onResponderMoveCallback = React.useCallback((e: GestureResponderEvent) => {
+    console.log('Pressable onResponderMove');
+    props.onResponderMove?.(e);
+  }, [props]);
+
+  const contentsStyle = pressedState === 'pressed-out'
+    ? styles.pressablePressedOut
+    : (pressedState === 'pressed'
+      ? styles.pressablePressed
+      : styles.pressablePressedIn);
+
+  return (
+    <View ref={ref} style={[contentsStyle]}>
+      <Pressable
+        onPressIn={onPressInCallback}
+        onPress={onPressCallback}
+        onPressOut={onPressOutCallback}
+        onResponderMove={onResponderMoveCallback}
+      >
+        {props.children}
+      </Pressable>
+    </View>
+
+  );
+});
+
+const styles = StyleSheet.create({
+  pressablePressedIn: {
+    backgroundColor: 'lightsalmon',
+  },
+  pressablePressed: {
+    backgroundColor: 'crimson',
+  },
+  pressablePressedOut: {
+    backgroundColor: 'lightseagreen',
+  },
+});
+
+export default PressableWithFeedback;
+

--- a/apps/src/tests/Test2466.tsx
+++ b/apps/src/tests/Test2466.tsx
@@ -1,8 +1,8 @@
-import { Header } from '@react-navigation/elements';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { ForwardedRef } from 'react';
-import { findNodeHandle, GestureResponderEvent, Pressable, PressableProps, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { findNodeHandle, Text, View } from 'react-native';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
 
 type StackParamList = {
   Home: undefined,
@@ -12,62 +12,7 @@ type RouteProps = {
   navigation: NativeStackNavigationProp<StackParamList>;
 }
 
-type PressableState = 'pressed-in' | 'pressed' | 'pressed-out'
-
-
 const Stack = createNativeStackNavigator<StackParamList>();
-
-const PressableWithFeedback = React.forwardRef((props: PressableProps, ref: ForwardedRef<View>): React.JSX.Element => {
-  const [pressedState, setPressedState] = React.useState<PressableState>('pressed-out');
-
-  const onPressInCallback = React.useCallback((e: GestureResponderEvent) => {
-    console.log('Pressable onPressIn', {
-      locationX: e.nativeEvent.locationX,
-      locationY: e.nativeEvent.locationY,
-      pageX: e.nativeEvent.pageX,
-      pageY: e.nativeEvent.pageY,
-    });
-    setPressedState('pressed-in');
-    props.onPressIn?.(e);
-  }, [props]);
-
-  const onPressCallback = React.useCallback((e: GestureResponderEvent) => {
-    console.log('Pressable onPress');
-    setPressedState('pressed');
-    props.onPress?.(e);
-  }, [props]);
-
-  const onPressOutCallback = React.useCallback((e: GestureResponderEvent) => {
-    console.log('Pressable onPressOut');
-    setPressedState('pressed-out');
-    props.onPressOut?.(e);
-  }, [props]);
-
-  const onResponderMoveCallback = React.useCallback((e: GestureResponderEvent) => {
-    console.log('Pressable onResponderMove');
-    props.onResponderMove?.(e);
-  }, [props]);
-
-  const contentsStyle = pressedState === 'pressed-out'
-    ? styles.pressablePressedOut
-    : (pressedState === 'pressed'
-      ? styles.pressablePressed
-      : styles.pressablePressedIn);
-
-  return (
-    <View ref={ref} style={[contentsStyle]}>
-      <Pressable
-        onPressIn={onPressInCallback}
-        onPress={onPressCallback}
-        onPressOut={onPressOutCallback}
-        onResponderMove={onResponderMoveCallback}
-      >
-        {props.children}
-      </Pressable>
-    </View>
-
-  );
-});
 
 function HeaderTitle(): React.JSX.Element {
   return (
@@ -138,18 +83,5 @@ function App(): React.JSX.Element {
     </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  pressablePressedIn: {
-    backgroundColor: 'lightsalmon',
-  },
-  pressablePressed: {
-    backgroundColor: 'crimson',
-  },
-  pressablePressedOut: {
-    backgroundColor: 'lightseagreen',
-  },
-});
-
 
 export default App;

--- a/apps/src/tests/Test2631.tsx
+++ b/apps/src/tests/Test2631.tsx
@@ -2,6 +2,17 @@ import * as React from 'react';
 
 import {Button, Pressable, StyleSheet, Text, View} from 'react-native';
 import {FullWindowOverlay} from 'react-native-screens';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
+
+function SharedPressable() {
+  return (
+    <PressableWithFeedback>
+      <View style={{ width: '100%', height: 32 }}>
+        <Text>Pressable</Text>
+      </View>
+    </PressableWithFeedback>
+  );
+}
 
 function HomeScreen() {
   const [overlayShown, setOverlayShown] = React.useState(false);
@@ -9,6 +20,7 @@ function HomeScreen() {
     <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}} collapsable={true}>
       <Text>Home Screen</Text>
       <Button title="Show Overlay" onPress={() => setOverlayShown(true)} />
+      <SharedPressable />
       {overlayShown && (
         <FullWindowOverlay>
           <View style={{flex: 1}}>
@@ -21,7 +33,7 @@ function HomeScreen() {
               }}
               onPress={() => setOverlayShown(false)}>
               <Text>Overlay</Text>
-              <View style={{ width: '100%', height: 32, backgroundColor: 'darksalmon' }} />
+              <SharedPressable />
             </Pressable>
           </View>
         </FullWindowOverlay>

--- a/apps/src/tests/Test2631.tsx
+++ b/apps/src/tests/Test2631.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+import {Button, Pressable, StyleSheet, Text, View} from 'react-native';
+import {FullWindowOverlay} from 'react-native-screens';
+
+function HomeScreen() {
+  const [overlayShown, setOverlayShown] = React.useState(false);
+  return (
+    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}} collapsable={true}>
+      <Text>Home Screen</Text>
+      <Button title="Show Overlay" onPress={() => setOverlayShown(true)} />
+      {overlayShown && (
+        <FullWindowOverlay>
+          <View style={{flex: 1}}>
+            <Pressable
+              style={{
+                flex: 1,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'rgba(130, 200, 120, 0.8)',
+              }}
+              onPress={() => setOverlayShown(false)}>
+              <Text>Overlay</Text>
+            </Pressable>
+          </View>
+        </FullWindowOverlay>
+      )}
+    </View>
+  );
+}
+
+function Header() {
+  return (
+    <View pointerEvents='box-none' style={{ height: 100.6666 }}>
+      <View style={[StyleSheet.absoluteFill, { }]}>
+        <View style={{ flex: 1, backgroundColor: 'white', opacity: 0.6}} />
+      </View>
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <View style={{flex: 1, backgroundColor: 'lightsalmon' }}>
+      <Header />
+      <HomeScreen />
+    </View>
+  );
+}
+

--- a/apps/src/tests/Test2631.tsx
+++ b/apps/src/tests/Test2631.tsx
@@ -21,6 +21,7 @@ function HomeScreen() {
               }}
               onPress={() => setOverlayShown(false)}>
               <Text>Overlay</Text>
+              <View style={{ width: '100%', height: 32, backgroundColor: 'darksalmon' }} />
             </Pressable>
           </View>
         </FullWindowOverlay>

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -118,6 +118,7 @@ export { default as Test2379 } from './Test2379';
 export { default as Test2395 } from './Test2395';
 export { default as Test2466 } from './Test2466';
 export { default as Test2552 } from './Test2552';
+export { default as Test2631 } from './Test2631';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
@@ -3,15 +3,10 @@
 #ifdef ANDROID
 #include <fbjni/fbjni.h>
 #endif // ANDROID
-#include <react/debug/react_native_assert.h>
-#include <react/renderer/components/rnscreens/Props.h>
-#include <react/renderer/components/rnscreens/utils/RectUtil.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include "RNSFullWindowOverlayShadowNode.h"
 
 namespace facebook::react {
-
-using namespace rnscreens;
 
 class RNSFullWindowOverlayComponentDescriptor final
     : public ConcreteComponentDescriptor<RNSFullWindowOverlayShadowNode> {

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
@@ -17,30 +17,6 @@ class RNSFullWindowOverlayComponentDescriptor final
     : public ConcreteComponentDescriptor<RNSFullWindowOverlayShadowNode> {
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
-
-  void adopt(ShadowNode &shadowNode) const override {
-    react_native_assert(
-        dynamic_cast<RNSFullWindowOverlayShadowNode *>(&shadowNode));
-    auto &subviewShadowNode =
-        static_cast<RNSFullWindowOverlayShadowNode &>(shadowNode);
-
-    react_native_assert(
-        dynamic_cast<YogaLayoutableShadowNode *>(&subviewShadowNode));
-    auto &layoutableShadowNode =
-        dynamic_cast<YogaLayoutableShadowNode &>(subviewShadowNode);
-
-    auto state = std::static_pointer_cast<
-        const RNSFullWindowOverlayShadowNode::ConcreteState>(
-        shadowNode.getState());
-    auto stateData = state->getData();
-
-    /*if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {*/
-    /*  layoutableShadowNode.setSize(*/
-    /*      Size{stateData.frameSize.width, stateData.frameSize.height});*/
-    /*}*/
-
-    ConcreteComponentDescriptor::adopt(shadowNode);
-  }
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayComponentDescriptor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef ANDROID
+#include <fbjni/fbjni.h>
+#endif // ANDROID
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/components/rnscreens/Props.h>
+#include <react/renderer/components/rnscreens/utils/RectUtil.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include "RNSFullWindowOverlayShadowNode.h"
+
+namespace facebook::react {
+
+using namespace rnscreens;
+
+class RNSFullWindowOverlayComponentDescriptor final
+    : public ConcreteComponentDescriptor<RNSFullWindowOverlayShadowNode> {
+ public:
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode &shadowNode) const override {
+    react_native_assert(
+        dynamic_cast<RNSFullWindowOverlayShadowNode *>(&shadowNode));
+    auto &subviewShadowNode =
+        static_cast<RNSFullWindowOverlayShadowNode &>(shadowNode);
+
+    react_native_assert(
+        dynamic_cast<YogaLayoutableShadowNode *>(&subviewShadowNode));
+    auto &layoutableShadowNode =
+        dynamic_cast<YogaLayoutableShadowNode &>(subviewShadowNode);
+
+    auto state = std::static_pointer_cast<
+        const RNSFullWindowOverlayShadowNode::ConcreteState>(
+        shadowNode.getState());
+    auto stateData = state->getData();
+
+    /*if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {*/
+    /*  layoutableShadowNode.setSize(*/
+    /*      Size{stateData.frameSize.width, stateData.frameSize.height});*/
+    /*}*/
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
@@ -16,6 +16,12 @@ void RNSFullWindowOverlayShadowNode::applyFrameCorrections() {
   ensureUnsealed();
 
   const auto &stateData = getStateData();
+
+  // During mounting phase due to view flattening the frame origin can be
+  // offsetted by non-zero point value, while we require FullWindowOverlay view
+  // to be always positioned at (0, 0). By adding this correction, the view will
+  // be positioned at (0, 0) after mounting stage finishes. See:
+  // https://github.com/software-mansion/react-native-screens/pull/2641
   layoutMetrics_.frame.origin -= stateData.contentOffset;
 }
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
@@ -4,25 +4,4 @@ namespace facebook::react {
 
 extern const char RNSFullWindowOverlayComponentName[] = "RNSFullWindowOverlay";
 
-#if !defined(ANDROID)
-void RNSFullWindowOverlayShadowNode::layout(LayoutContext layoutContext) {
-  YogaLayoutableShadowNode::layout(layoutContext);
-
-  applyFrameCorrections();
-}
-
-void RNSFullWindowOverlayShadowNode::applyFrameCorrections() {
-  ensureUnsealed();
-
-  const auto &stateData = getStateData();
-
-  // During mounting phase due to view flattening the frame origin can be
-  // offsetted by non-zero point value, while we require FullWindowOverlay view
-  // to be always positioned at (0, 0). By adding this correction, the view will
-  // be positioned at (0, 0) after mounting stage finishes. See:
-  // https://github.com/software-mansion/react-native-screens/pull/2641
-  layoutMetrics_.frame.origin -= stateData.contentOffset;
-}
-#endif // !ANDROID
-
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
@@ -1,0 +1,7 @@
+#include "RNSFullWindowOverlayShadowNode.h"
+
+namespace facebook::react {
+
+extern const char RNSFullWindowOverlayComponentName[] = "RNSFullWindowOverlay";
+
+}

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
@@ -4,12 +4,11 @@ namespace facebook::react {
 
 extern const char RNSFullWindowOverlayComponentName[] = "RNSFullWindowOverlay";
 
+#if !defined(ANDROID)
 void RNSFullWindowOverlayShadowNode::layout(LayoutContext layoutContext) {
   YogaLayoutableShadowNode::layout(layoutContext);
 
-#if !defined(ANDROID)
   applyFrameCorrections();
-#endif
 }
 
 void RNSFullWindowOverlayShadowNode::applyFrameCorrections() {
@@ -24,5 +23,6 @@ void RNSFullWindowOverlayShadowNode::applyFrameCorrections() {
   // https://github.com/software-mansion/react-native-screens/pull/2641
   layoutMetrics_.frame.origin -= stateData.contentOffset;
 }
+#endif // !ANDROID
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.cpp
@@ -4,4 +4,19 @@ namespace facebook::react {
 
 extern const char RNSFullWindowOverlayComponentName[] = "RNSFullWindowOverlay";
 
+void RNSFullWindowOverlayShadowNode::layout(LayoutContext layoutContext) {
+  YogaLayoutableShadowNode::layout(layoutContext);
+
+#if !defined(ANDROID)
+  applyFrameCorrections();
+#endif
 }
+
+void RNSFullWindowOverlayShadowNode::applyFrameCorrections() {
+  ensureUnsealed();
+
+  const auto &stateData = getStateData();
+  layoutMetrics_.frame.origin -= stateData.contentOffset;
+}
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
@@ -20,6 +20,10 @@ class JSI_EXPORT RNSFullWindowOverlayShadowNode final
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
   using StateData = ConcreteViewShadowNode::ConcreteStateData;
+
+  void layout(LayoutContext layoutContext) override;
+
+  void applyFrameCorrections();
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/rnscreens/EventEmitters.h>
+#include <react/renderer/components/rnscreens/Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/core/LayoutContext.h>
+#include "RNSFullWindowOverlayState.h"
+
+namespace facebook::react {
+
+JSI_EXPORT extern const char RNSFullWindowOverlayComponentName[];
+
+class JSI_EXPORT RNSFullWindowOverlayShadowNode final
+    : public ConcreteViewShadowNode<
+          RNSFullWindowOverlayComponentName,
+          RNSFullWindowOverlayProps,
+          RNSFullWindowOverlayEventEmitter,
+          RNSFullWindowOverlayState> {
+ public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+  using StateData = ConcreteViewShadowNode::ConcreteStateData;
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
@@ -21,9 +21,11 @@ class JSI_EXPORT RNSFullWindowOverlayShadowNode final
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
   using StateData = ConcreteViewShadowNode::ConcreteStateData;
 
+#if !defined(ANDROID)
   void layout(LayoutContext layoutContext) override;
 
   void applyFrameCorrections();
+#endif
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayShadowNode.h
@@ -11,20 +11,24 @@ namespace facebook::react {
 
 JSI_EXPORT extern const char RNSFullWindowOverlayComponentName[];
 
+using ConcreteViewShadowNodeSuperType = ConcreteViewShadowNode<
+    RNSFullWindowOverlayComponentName,
+    RNSFullWindowOverlayProps,
+    RNSFullWindowOverlayEventEmitter,
+    RNSFullWindowOverlayState>;
+
 class JSI_EXPORT RNSFullWindowOverlayShadowNode final
-    : public ConcreteViewShadowNode<
-          RNSFullWindowOverlayComponentName,
-          RNSFullWindowOverlayProps,
-          RNSFullWindowOverlayEventEmitter,
-          RNSFullWindowOverlayState> {
+    : public ConcreteViewShadowNodeSuperType {
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
   using StateData = ConcreteViewShadowNode::ConcreteStateData;
 
 #if !defined(ANDROID)
-  void layout(LayoutContext layoutContext) override;
-
-  void applyFrameCorrections();
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNodeSuperType::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
 #endif
 };
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
@@ -25,16 +25,6 @@ class JSI_EXPORT RNSFullWindowOverlayState final {
     return {};
   }
 #endif
-
-#if !defined(ANDROID)
-  RNSFullWindowOverlayState(Point contentOffset_)
-      : contentOffset{contentOffset_} {}
-#endif
-
-#if !defined(ANDROID)
-  /// Content offset caused by view flattening. iOS only.
-  Point contentOffset{};
-#endif
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/graphics/Float.h>
+
+namespace facebook::react {
+
+class JSI_EXPORT RNSFullWindowOverlayState final {
+ public:
+  using Shared = std::shared_ptr<const RNSFullWindowOverlayState>;
+
+  RNSFullWindowOverlayState() = default;
+
+  RNSFullWindowOverlayState(Point contentOffset_)
+      : contentOffset{contentOffset_} {}
+
+  /// Content offset caused by view flattening
+  Point contentOffset{};
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFullWindowOverlayState.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#if defined(ANDROID)
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif // ANDROID
+
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 
@@ -11,11 +17,24 @@ class JSI_EXPORT RNSFullWindowOverlayState final {
 
   RNSFullWindowOverlayState() = default;
 
+#if defined(ANDROID)
+  RNSFullWindowOverlayState(
+      const RNSFullWindowOverlayState &previousState,
+      folly::dynamic data) {}
+  folly::dynamic getDynamic() const {
+    return {};
+  }
+#endif
+
+#if !defined(ANDROID)
   RNSFullWindowOverlayState(Point contentOffset_)
       : contentOffset{contentOffset_} {}
+#endif
 
-  /// Content offset caused by view flattening
+#if !defined(ANDROID)
+  /// Content offset caused by view flattening. iOS only.
   Point contentOffset{};
+#endif
 };
 
 } // namespace facebook::react

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -81,8 +81,6 @@
   CGRect _reactFrame;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
-  react::Point _lastContentOffset;
-  react::RNSFullWindowOverlayShadowNode::ConcreteState::Shared _state;
 #else
   RCTTouchHandler *_touchHandler;
 #endif // RCT_NEW_ARCH_ENABLED
@@ -94,7 +92,6 @@
   if (self = [super init]) {
     static const auto defaultProps = std::make_shared<const react::RNSFullWindowOverlayProps>();
     _props = defaultProps;
-    _lastContentOffset = {0.f, 0.f};
     [self _initCommon];
   }
   return self;
@@ -212,22 +209,15 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 
   // Due to view flattening on new architecture there are situations
   // when we receive frames with origin different from (0, 0).
+  // We account for this frame manipulation in shadow node by setting
+  // RootNodeKind trait for the shadow node making state consistent
+  // between Host & Shadow Tree
   frame.origin = CGPointZero;
 
   _reactFrame = frame;
   [_container setFrame:frame];
-
-  if (_lastContentOffset != layoutMetrics.frame.origin && _state) {
-    _lastContentOffset = layoutMetrics.frame.origin;
-    _state->updateState(react::RNSFullWindowOverlayState(_lastContentOffset));
-  }
 }
 
-- (void)updateState:(const facebook::react::State::Shared &)state
-           oldState:(const facebook::react::State::Shared &)oldState
-{
-  _state = std::static_pointer_cast<const react::RNSFullWindowOverlayShadowNode::ConcreteState>(state);
-}
 RNS_IGNORE_SUPER_CALL_END
 
 #else

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -10,6 +10,7 @@
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+#import <rnscreens/RNSFullWindowOverlayComponentDescriptor.h>
 #else
 #import <React/RCTTouchHandler.h>
 #endif // RCT_NEW_ARCH_ENABLED

--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -5,4 +5,6 @@ import type { ViewProps } from 'react-native';
 
 interface NativeProps extends ViewProps {}
 
-export default codegenNativeComponent<NativeProps>('RNSFullWindowOverlay', {});
+export default codegenNativeComponent<NativeProps>('RNSFullWindowOverlay', {
+  interfaceOnly: true,
+});


### PR DESCRIPTION
## Description

Fixes #2631

I've given extensive description of both the issue ~and potential solution~ in #2631 issue discussion

* https://github.com/software-mansion/react-native-screens/issues/2631

In particular important parts are:

* https://github.com/software-mansion/react-native-screens/issues/2631#issuecomment-2606993563
* https://github.com/software-mansion/react-native-screens/issues/2631#issuecomment-2607054015

I settled down on zeroing origin of the `FullWindowOverlay` frame in HostTree & setting `ShadowNodeTraits::RootNodeKind` for the custom shadow node of `FullWindowOverlay` component in the ShadowTree. This is much cleaner than managing the state & content offset manually. 

## Changes

`FullWindowOverlay` has now custom component descriptor, shadow node & shadow node state (its empty). The shadow node has `ShadowNodeTraits::RootNodeKind` set allowing it to be the reference point when computing position of any descendant view in shadow tree - this is fine, because we always expect `FullWindowOverlay` to have origin at `(0, 0)` in window coordinate space.

In the HostTree we now ensure that `FWO` origin is at `(0, 0)` by overriding frame received during mounting stage. 

## Test code and steps to reproduce

Test2631 should now work not as in recording from issue description but correctly. 

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes

