### PR TITLE
fix: add missing files to whitelist in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "android/src/main/res",
     "android/src/fabric/",
     "android/src/paper/",
+    "android/src/versioned/",
     "android/build.gradle",
     "android/CMakeLists.txt",
     "ios/",


### PR DESCRIPTION
## Description

Recently I've added new directory `android/src/versioned` with several source code files in #2660, however I've 
forgotten to include this directory in npm whitelist files, so they didn't get included in latest release (4.7.0-beta.2).

Fixing this in this PR.


## Test code and steps to reproduce

Verified with `npm pack --dry-run` that these files are now included.

## Checklist

- [ ] Ensured that CI passes
