### PR TITLE
[Question] Is crash on RNSNavigationController when pushing non-RNSScreen ViewController intended?

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -751,6 +751,9 @@ RNS_IGNORE_SUPER_CALL_END
                                                fromViewController:(UIViewController *)fromVC
                                                  toViewController:(UIViewController *)toVC
 {
+  if (![toVC.view isKindOfClass:[RNSScreenView class]]) {
+    return nil;
+  }
   RNSScreenView *screen;
   if (operation == UINavigationControllerOperationPush) {
     screen = ((RNSScreen *)toVC).screenView;


### PR DESCRIPTION
## Description

This is basically a question PR. 

Given that RNSNavigationController is just another UINavigationController, I thought that I could push my ViewController to it.

But when I did, the app crashed on file, where this is PR is addressing.

RNSScreenStack tried to call a method `screen` on my ViewController, and because my ViewController had nothing to do with RNSScreen, the app crashed.

But, as I changed the code as this PR, the crash didn't happen, and navigation happend smoothly without any side-effects.

So, here's the question.
Is crash on RNSNavigationController when pushing non-RNSScreen ViewController expected, or intended?

If not, I think it'd be great to allow it...!

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
