### PR TITLE
chore(repo): exclude kotlin compiler log files from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ jsconfig.json
 .project
 .vscode
 
+# Kotlin (since 2.0 compiler)
+.kotlin/
+
 # BUCK
 buck-out/
 bin/


### PR DESCRIPTION
## Description

Since Kotlin compiler 2.0 it seems that error logs are saved in `android/.kotlin` directory.

## Checklist

- [ ] Ensured that CI passes

