### PR TITLE
fix(iOS): look through whole ancestor chain when looking for screenview from content wrapper

### DIFF
--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -87,7 +87,9 @@ namespace react = facebook::react;
   UIView *currentView = self;
 
   // In standard scenario this should do only a single iteration.
-  // Haven't got repro, but we got
+  // Haven't got repro, but we got reports that there are scenarios
+  // when there are intermediate views between screen view & the content wrapper.
+  // https://github.com/software-mansion/react-native-screens/pull/2683
   do {
     currentView = currentView.reactSuperview;
   } while (currentView != nil && ![currentView isKindOfClass:RNSScreenView.class]);

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -73,13 +73,26 @@ namespace react = facebook::react;
 
 - (void)attachToAncestorScreenView
 {
-  if (![self.reactSuperview isKindOfClass:RNSScreenView.class]) {
-    RCTLogError(@"Expected reactSuperview to be a RNSScreenView. Found %@", self.reactSuperview);
+  RNSScreen *_Nullable screen =
+      static_cast<RNSScreen *_Nullable>([[self findFirstScreenViewAncestor] reactViewController]);
+  if (screen == nil) {
+    RCTLogError(@"Failed to find parent screen controller from %@.", self);
     return;
   }
-
-  RNSScreen *screen = (RNSScreen *)[self.reactSuperview reactViewController];
   [self attachToAncestorScreenViewStartingFrom:screen];
+}
+
+- (nullable RNSScreenView *)findFirstScreenViewAncestor
+{
+  UIView *currentView = self;
+
+  // In standard scenario this should do only a single iteration.
+  // Haven't got repro, but we got
+  do {
+    currentView = currentView.reactSuperview;
+  } while (currentView != nil && ![currentView isKindOfClass:RNSScreenView.class]);
+
+  return static_cast<RNSScreenView *_Nullable>(currentView);
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Description

In #2670 I've added a check that logged RN error in case `contentWrapper.reactSuperview` is not a `RNSScreenView`. 
Now I got reports (but no reproduction :/) from two independent sources that this error is triggered pretty often,
which is unexpected from my perspective. I blindly blame view flattening / usage of legacy navigators but can not be sure.

This PR is an attempt to patch this behaviour.

## Changes

contentWrapper now searches whole view ancestor chain before logging an error.

## Test code and steps to reproduce

No reproducer :/ 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
