### PR TITLE
fix(Android,Fabric): inifinite state update loop in header subview

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
@@ -14,8 +14,8 @@ abstract class FabricEnabledHeaderSubviewViewGroup(
 ) : ViewGroup(context) {
     private var mStateWrapper: StateWrapper? = null
 
-    private var lastWidth = -1f
-    private var lastHeight = -1f
+    private var lastWidth = 0f
+    private var lastHeight = 0f
 
     fun setStateWrapper(wrapper: StateWrapper?) {
         mStateWrapper = wrapper

--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
@@ -7,11 +7,15 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import kotlin.math.abs
 
 abstract class FabricEnabledHeaderSubviewViewGroup(
     context: Context?,
 ) : ViewGroup(context) {
     private var mStateWrapper: StateWrapper? = null
+
+    private var lastWidth = -1f
+    private var lastHeight = -1f
 
     fun setStateWrapper(wrapper: StateWrapper?) {
         mStateWrapper = wrapper
@@ -38,6 +42,17 @@ abstract class FabricEnabledHeaderSubviewViewGroup(
         val offsetXDip: Float = PixelUtil.toDIPFromPixel(offsetX.toFloat())
         val offsetYDip: Float = PixelUtil.toDIPFromPixel(offsetY.toFloat())
 
+        // Check incoming state values. If they're already the correct value, return early to prevent
+        // infinite UpdateState/SetState loop.
+        if (abs(lastWidth - realWidth) < DELTA &&
+            abs(lastHeight - realHeight) < DELTA
+        ) {
+            return
+        }
+
+        lastWidth = realWidth
+        lastHeight = realHeight
+
         val map: WritableMap =
             WritableNativeMap().apply {
                 putDouble("frameWidth", realWidth.toDouble())
@@ -47,5 +62,9 @@ abstract class FabricEnabledHeaderSubviewViewGroup(
             }
 
         mStateWrapper?.updateState(map)
+    }
+
+    companion object {
+        private const val DELTA = 0.9f
     }
 }


### PR DESCRIPTION
## Description

Small oversight (:sweat-smile:) but we have infinite state update loop in header subview caused by not comparing 
current value to previous one (check out code changes, it will be obvious).

We have similar checks in `FabricEnabledViewGroup` & `FabricEnabledHeaderConfigViewGroup`.

## Changes

Added a check that prevents the loop.

## Checklist

- [ ] Ensured that CI passes

