### PR TITLE
chore(docs): add note that `fitToContents` includes small bottom padding on iOS

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -303,7 +303,7 @@ export interface ScreenProps extends ViewProps {
    * while **Android is limited to three**.
    *
    * There is also possibility to specify `fitToContents` literal, which intents to set the sheet height
-   * to the height of its contents.
+   * to the height of its contents. On iOS `fitToContents` currently also includes small padding accounting for bottom inset.
    *
    * Please note that the array **must** be sorted in ascending order. This invariant is verified only in developement mode,
    * where violation results in error.


### PR DESCRIPTION
## Description

This is a small discrepancy between platforms, which might be patched in next major if needed (created ticket on internal board)

Closes #2697 (see discussion)

## Changes

Updated types of `sheetAllowedDetents`.

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
