### PR TITLE
[Android] Add support for 16KB page size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,8 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_STL=c++_shared",
-                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}"
+                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }


### PR DESCRIPTION
## Description

Starting from Android 15 devices can use 16KB page size instead of 4KB. Apps that take advantage of this require additional linker flag.

This PR adds aforementioned flag so that apps that use Screens don't crash.

>[!NOTE]
> More info can be found [here](https://developer.android.com/guide/practices/page-sizes)

## Test plan

I've tested it while working on the same change in [Reanimated](https://github.com/software-mansion/react-native-reanimated/pull/7037). After adding this flag into screens app stopped crashing.


I've also tested it on `FabricExample` in Screens on AVD with 16KB page size. I've had some problems with this example app, but after adding this flag it stopped crashing on start (it still show some errors about undefined function though, but I believe the problem lies in my setup).