### PR TITLE
Add flag to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,8 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_STL=c++_shared",
-                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}"
+                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
+                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }


### PR DESCRIPTION
## Description

Starting from Android 15 devices can use 16KB page size instead of 4KB. Apps that take advantage of this require an additional linker flag.

This PR adds the flag above so that apps that use react-native-screens don't crash.



## Changes

Updated build.gradle file with below
```
     externalNativeBuild {
            cmake {
                arguments "-DANDROID_STL=c++_shared",
                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                        ++  "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
            }
        }
```

## Test Plan

Tested on AVD with 16KB page size.
