### PR TITLE
Remove incorrect import

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -8,7 +8,6 @@
 #include <react/renderer/components/rnscreens/utils/RectUtil.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include "RNSScreenStackHeaderSubviewShadowNode.h"
-#include "utils/RectUtil.h"
 
 namespace facebook::react {
 


### PR DESCRIPTION
4.7.0 comes with an incorrect import:
```
#include "utils/RectUtil.h"
``` 
which duplicates import of the same file in line 8:
```
#include <react/renderer/components/rnscreens/utils/RectUtil.h>
```