### PR TITLE
chore: suppress `-Wdollar-in-identifier-extension` compile time warning

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -17,6 +17,7 @@ add_compile_options(
   -Wall
   -Wpedantic
   -Wno-gnu-zero-variadic-macro-arguments
+  -Wno-dollar-in-identifier-extension
 )
 
 file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_COMPONENTS_DIR}/*.cpp ${LIB_COMMON_COMPONENTS_DIR}/utils/*.cpp)


### PR DESCRIPTION
## Description

Variable names prefixed with `$` are heavily utilised in codegened code. This leads to a wall of warnings popping up during every Android build. This PR aims to suppress these warnings.

## Changes

Added `-Wno-dollar-in-identifier-extension` compile time flag to `react_codegen_rnscreens` target.

## Test code and steps to reproduce

Clean caches & build fresh Android project with react-native screens.

## Checklist

- [ ] Ensured that CI passes
