### PR TITLE
fix(Android,Paper): regenerate codegened files for old architecture

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContainerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContainerManagerInterface.java
@@ -10,7 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenContainerManagerInterface<T extends View> {
+public interface RNSScreenContainerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContentWrapperManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContentWrapperManagerInterface.java
@@ -10,7 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenContentWrapperManagerInterface<T extends View> {
+public interface RNSScreenContentWrapperManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenFooterManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenFooterManagerInterface.java
@@ -10,7 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenFooterManagerInterface<T extends View> {
+public interface RNSScreenFooterManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -13,8 +13,9 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenManagerInterface<T extends View> {
+public interface RNSScreenManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setSheetAllowedDetents(T view, @Nullable ReadableArray value);
   void setSheetLargestUndimmedDetent(T view, int value);
   void setSheetGrabberVisible(T view, boolean value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -11,8 +11,9 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> {
+public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setBackgroundColor(T view, @Nullable Integer value);
   void setBackTitle(T view, @Nullable String value);
   void setBackTitleFontFamily(T view, @Nullable String value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderSubviewManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderSubviewManagerInterface.java
@@ -11,7 +11,8 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenStackHeaderSubviewManagerInterface<T extends View> {
+public interface RNSScreenStackHeaderSubviewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setType(T view, @Nullable String value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackManagerInterface.java
@@ -10,7 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSScreenStackManagerInterface<T extends View> {
+public interface RNSScreenStackManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
@@ -11,8 +11,9 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface RNSSearchBarManagerInterface<T extends View> {
+public interface RNSSearchBarManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setHideWhenScrolling(T view, boolean value);
   void setAutoCapitalize(T view, @Nullable String value);
   void setPlaceholder(T view, @Nullable String value);


### PR DESCRIPTION
## Description

Seems that these have changed. 

## Changes

Updated codegened files for old architecture by running `yarn sync-architectures`.

> [!caution]
I think that these changes also break compatibility on old architecture.

## Test code and steps to reproduce

Let's see whether Paper build works now on CI...

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
