### PR TITLE
fix(iOS,Paper): fix false-negative lookup result for parent view from content wrapper

### DIFF
--- a/apps/src/tests/TestXXX.tsx
+++ b/apps/src/tests/TestXXX.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+const Stack = createNativeStackNavigator();
+const NestedStack = createNativeStackNavigator();
+
+function Home({ navigation }) {
+  return (
+    <View style={[{ backgroundColor: 'goldenrod', flex: 1 }, styles.container]}>
+      <Button title="Go NestedStack" onPress={() => navigation.navigate('NestedStackHost')} />
+    </View>
+  );
+}
+
+function NestedHome({ navigation }) {
+  return (
+    <View style={[{ backgroundColor: 'goldenrod', flex: 1 }, styles.container]}>
+      <Text>NestedHome</Text>
+      <Button title="Go NestedSecond" onPress={() => navigation.navigate('NestedSecond')} />
+    </View>
+  );
+}
+
+function NestedSecond({ navigation }) {
+  return (
+    <View style={[{ backgroundColor: 'lightsalmon' }, styles.container]}>
+      <Text>NestedSecond</Text>
+      <Button title="Go back to NestedHome" onPress={() => navigation.popTo('NestedHome')} />
+      <Button title="REPLACE with NestedThird" onPress={() => navigation.replace('NestedThird')} />
+    </View>
+  );
+}
+
+function NestedThird({ navigation }) {
+  return (
+    <View style={[{ backgroundColor: 'lightblue', flex: 1 }, styles.container]}>
+      <Text>NestedSecond</Text>
+      <Button title="Go back to NestedHome" onPress={() => navigation.popTo('NestedHome')} />
+    </View>
+  );
+}
+
+function NestedStackHost() {
+  return (
+    <NestedStack.Navigator>
+      <NestedStack.Screen name="NestedHome" component={NestedHome} />
+      <NestedStack.Screen name="NestedSecond" component={NestedSecond} />
+      <NestedStack.Screen name="NestedThird" component={NestedThird} />
+    </NestedStack.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="NestedStackHost" component={NestedStackHost} options={{
+          headerShown: false,
+        }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 24,
+    flex: 1,
+    alignItems: 'center',
+  },
+});
+

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -122,6 +122,7 @@ export { default as Test2552 } from './Test2552';
 export { default as Test2631 } from './Test2631';
 export { default as Test2668 } from './Test2668';
 export { default as Test2675 } from './Test2675';
+export { default as TestXXX } from './TestXXX';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -75,8 +75,13 @@ namespace react = facebook::react;
 {
   RNSScreen *_Nullable screen =
       static_cast<RNSScreen *_Nullable>([[self findFirstScreenViewAncestor] reactViewController]);
+
   if (screen == nil) {
-    RCTLogError(@"Failed to find parent screen controller from %@.", self);
+    // On old architecture, especially when executing `replace` action it can happen that **replaced** (old one) screen
+    // receives willMoveToWindow: with not nil argument. On new architecture it seems to work as expected.
+#ifdef RCT_NEW_ARCH_ENABLED
+    RCTLogWarn(@"Failed to find parent screen controller from %@.", self);
+#endif
     return;
   }
   [self attachToAncestorScreenViewStartingFrom:screen];


### PR DESCRIPTION
## Description

Closes #2717

For some reason on old architecture, when calling `navigation.replace()` the replaced screen receives `willMoveToWindow:` message from UIKit with 
non-nil argument, defying my previous expectations. 

On new architecture this works as expected: removed screen receives `nil` window & we do not run the content-wrapper-attachment logic.

## Changes

Error is logged only on new architecture now.

## Test code and steps to reproduce

WIP

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
