### PR TITLE
refactor: detect fabric with RN$Bridgeless

### DIFF
--- a/src/gesture-handler/fabricUtils.ts
+++ b/src/gesture-handler/fabricUtils.ts
@@ -7,7 +7,7 @@ import { View } from 'react-native';
 type LocalGlobal = typeof global & Record<string, unknown>;
 
 export function isFabric() {
-  return !!(global as LocalGlobal)._IS_FABRIC;
+  return !!(global as LocalGlobal).RN$Bridgeless;
 }
 
 export type ShadowNodeWrapper = {

--- a/src/reanimated/ReanimatedNativeStackScreen.tsx
+++ b/src/reanimated/ReanimatedNativeStackScreen.tsx
@@ -25,7 +25,7 @@ const AnimatedScreen = Animated.createAnimatedComponent(
 // We use prop added to global by reanimated since it seems safer than the one from RN. See:
 // https://github.com/software-mansion/react-native-reanimated/blob/3fe8b35b05e82b2f2aefda1fb97799cf81e4b7bb/src/reanimated2/UpdateProps.ts#L46
 // @ts-expect-error nativeFabricUIManager is not yet included in the RN types
-const ENABLE_FABRIC = !!global?._IS_FABRIC;
+const ENABLE_FABRIC = !!global?.RN$Bridgeless;
 
 const ReanimatedNativeStackScreen = React.forwardRef<
   typeof AnimatedScreen,


### PR DESCRIPTION
## Description

Since 0.74 `RN$Bridgeless` is always defined in the global object and bridgeless mode isn't supported anymore. Therefore checking `RN$Bridgeless` for Fabric is safer than depending on `_IS_FABRIC` variable which we intend to remove in the future. `RN$Bridgeless` is added to `global` much faster than `_IS_FABRIC`.

See https://github.com/software-mansion/react-native-reanimated/pull/7043

## Changes

👍 

## Screenshots / GIFs

:shipit: 

## Test code and steps to reproduce

🚀 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
