### PR TITLE
fix(Android): fix sheet transition when there is no dimming applied

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -331,13 +331,14 @@ class ScreenStackFragment :
         }
 
         val animatorSet = AnimatorSet()
+        val dimmingDelegate = dimmingDelegate.value
 
         if (enter) {
             val alphaAnimator =
-                ValueAnimator.ofFloat(0f, dimmingDelegate.value.maxAlpha).apply {
+                ValueAnimator.ofFloat(0f, dimmingDelegate.maxAlpha).apply {
                     addUpdateListener { anim ->
                         val animatedValue = anim.animatedValue as? Float
-                        animatedValue?.let { dimmingDelegate.value.dimmingView.alpha = it }
+                        animatedValue?.let { dimmingDelegate.dimmingView.alpha = it }
                     }
                 }
             val startValueCallback = { initialStartValue: Number? -> screen.height.toFloat() }
@@ -349,13 +350,21 @@ class ScreenStackFragment :
                         animatedValue?.let { screen.translationY = it }
                     }
                 }
-            animatorSet.play(alphaAnimator).with(slideAnimator)
+
+            animatorSet
+                .play(slideAnimator)
+                .takeIf {
+                    dimmingDelegate.willDimForDetentIndex(
+                        screen,
+                        screen.sheetInitialDetentIndex,
+                    )
+                }?.with(alphaAnimator)
         } else {
             val alphaAnimator =
-                ValueAnimator.ofFloat(dimmingDelegate.value.dimmingView.alpha, 0f).apply {
+                ValueAnimator.ofFloat(dimmingDelegate.dimmingView.alpha, 0f).apply {
                     addUpdateListener { anim ->
                         val animatedValue = anim.animatedValue as? Float
-                        animatedValue?.let { dimmingDelegate.value.dimmingView.alpha = it }
+                        animatedValue?.let { dimmingDelegate.dimmingView.alpha = it }
                     }
                 }
             val slideAnimator =

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
@@ -28,7 +28,7 @@ class DimmingViewManager(
         root: ViewGroup,
     ) {
         root.addView(dimmingView, 0)
-        if (screen.sheetInitialDetentIndex <= screen.sheetLargestUndimmedDetentIndex) {
+        if (!willDimForDetentIndex(screen, screen.sheetInitialDetentIndex)) {
             dimmingView.alpha = 0.0f
         } else {
             dimmingView.alpha = maxAlpha
@@ -44,6 +44,11 @@ class DimmingViewManager(
     ) {
         behavior.addBottomSheetCallback(requireBottomSheetCallback(screen))
     }
+
+    /**
+     * Ask the manager whether it will apply non-zero alpha for sheet at given detent index.
+     */
+    fun willDimForDetentIndex(screen: Screen, index: Int) = index > screen.sheetLargestUndimmedDetentIndex
 
     /**
      * This bottom sheet callback is responsible for animating alpha of the dimming view.

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -52,8 +52,9 @@ export default function App() {
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="FormSheet" component={FormSheet} options={{
           presentation: 'formSheet',
-          //sheetAllowedDetents: [0.4, 0.75, 1.0],
-          sheetAllowedDetents: 'fitToContents',
+          sheetAllowedDetents: [0.4, 0.75, 0.9],
+          //sheetAllowedDetents: 'fitToContents',
+          sheetLargestUndimmedDetentIndex: 1,
           sheetCornerRadius: 8,
           headerShown: false,
           contentStyle: {


### PR DESCRIPTION
## Description

Shout out to @kligarski for spotting this out!

I've introduced a regression in 4.7.0 when refactoring sheet animation - basically it always animated to the resolved `maxAlpha`
for given sheet dimming view & did not take into account `sheetLargestUndimmedDetentIndex` prop, effectively disabling this prop.

This affects both architectures.

## Changes

When configuring enter animation we now take the prop into account.

## Test code and steps to reproduce

`TestFormSheet`

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
