### PR TITLE
fix: Allow undefined ref for SearchBarCommands in SearchBarProps

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -16,7 +16,9 @@ import SearchBarNativeComponent, {
 import { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 const NativeSearchBar: React.ComponentType<
-  SearchBarNativeProps & { ref?: React.RefObject<SearchBarCommands> }
+  SearchBarNativeProps & {
+    ref?: React.RefObject<SearchBarCommands | undefined>;
+  }
 > &
   typeof NativeSearchBarCommands =
   SearchBarNativeComponent as unknown as React.ComponentType<SearchBarNativeProps> &
@@ -36,7 +38,7 @@ type SearchBarCommandsType = {
 };
 
 function SearchBar(props: SearchBarProps, ref: React.Ref<SearchBarCommands>) {
-  const searchBarRef = React.useRef<SearchBarCommands | null>(null);
+  const searchBarRef = React.useRef<SearchBarCommands>(undefined);
 
   React.useImperativeHandle(ref, () => ({
     blur: () => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -687,7 +687,7 @@ export interface SearchBarProps {
    * * `cancelSearch` - cancel search in search bar.
    * * `toggleCancelButton` - depending on passed boolean value, hides or shows cancel button (iOS only)
    */
-  ref?: React.RefObject<SearchBarCommands>;
+  ref?: React.RefObject<SearchBarCommands | undefined>;
 
   /**
    * The auto-capitalization behavior


### PR DESCRIPTION
## Description

This change updates the type definition for SearchBarProps to accept a ref that can be undefined. Previously, the ref was forced to be non-nullable, which required developers to use workarounds (like non-null assertions) even though React handles null/undefined refs gracefully. With React 19, the framework ensures that refs are managed correctly regardless of their empty initial state. 

By allowing n undefined ref, we align the type definitions with React's natural behavior and improve the developer experience by eliminating unnecessary TypeScript errors. This change has no runtime impact, as the component lifecycle guarantees that the ref will be properly set before it is used.

Example that trigger the Typescript Error below:

  ```
useLayoutEffect(() => {
    navigation.setOptions({
      headerSearchBarOptions: {
        tintColor: colors.text,
        ref: searchBarRef,
      } satisfies SearchBarProps,
    });
  }, [navigation, colors.text]);
```
  
  Type 'RefObject<SearchBarCommands | undefined>' is not assignable to type 'RefObject<SearchBarCommands>'.
  Type 'SearchBarCommands | undefined' is not assignable to type 'SearchBarCommands'.
    Type 'undefined' is not assignable to type 'SearchBarCommands'.ts(2322)
