### PR TITLE
chore(readme): update supported react-native versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Screens are already integrated with the React Native's most popular navigation l
 ## Supported react-native version
 
 Below we present tables with mapping of the library version to the last supported react-native version. These tables are for the `4.x` line of the library. For compat tables 
-of `3.x` line please see consult [readme on the `3.x` branch](https://github.com/software-mansion/react-native-screens/tree/3.x?tab=readme-ov-file#supported-react-native-version).
+of `3.x` line please see [readme on the `3.x` branch](https://github.com/software-mansion/react-native-screens/tree/3.x?tab=readme-ov-file#supported-react-native-version).
 
 ### Support for Paper
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Paper is the default rendering system for React Native versions prior to 0.76.
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 4.9.0+          | 0.76.0+              |
 | 4.5.0+          | 0.74.0+              |
 | 4.0.0+          | 0.72.0+              |
 
@@ -126,6 +127,7 @@ Here's a table with summary of supported `react-native` versions when Fabric is 
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 4.9.0+          | 0.78.0+              |
 | 4.5.0+          | 0.77.0+              |
 | 4.0.0+          | 0.76.0+              |
 


### PR DESCRIPTION
## Description

Updated the "supported version table" for 4.9.0 release.

## Changes

Paper is supported for RN >= 0.76
Fabric is supported for RN == 78.

## Test code and steps to reproduce


## Checklist

- [ ] Ensured that CI passes
