### PR TITLE
Fix MUTATION_PARENT_TAG to Handle Parent Tag Across React Native Versions

### DIFF
--- a/ios/utils/RNSDefines.h
+++ b/ios/utils/RNSDefines.h
@@ -6,20 +6,28 @@
 
 #define RNS_IGNORE_SUPER_CALL_END _Pragma("clang diagnostic pop")
 
-#if defined __has_include
-#if __has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) ||\
-    __has_include(<React_RCTAppDelegate/RCTReactNativeFactory.h>) // added in 78; underscore is used in dynamic frameworks
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 0
-#else
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 1
-#endif
-#else
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 \
-  1 // Wild guess, close eyes and hope for the best.
-#endif
+// Check if the mutation has parentTag
+template <typename T>
+using has_parentTag_t = decltype(std::declval<T>().parentTag);
+template <typename T>
+inline constexpr bool has_parentTag = !std::is_void_v<has_parentTag_t<T>>;
 
-#if RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78
-#define MUTATION_PARENT_TAG(mutation) mutation.parentShadowView.tag
-#else
-#define MUTATION_PARENT_TAG(mutation) mutation.parentTag
-#endif
+// Check if the mutation has parentShadowView
+template <typename T>
+using has_parentShadowView_t = decltype(std::declval<T>().parentShadowView);
+template <typename T>
+inline constexpr bool has_parentShadowView = !std::is_void_v<has_parentShadowView_t<T>>;
+
+// Function to get the parent tag, choosing based on what's available
+template <typename T>
+auto get_parent_tag(T& mutation) {
+    if constexpr (has_parentTag<T>) {
+        return mutation.parentTag;
+    } else if constexpr (has_parentShadowView<T>) {
+        return mutation.parentShadowView.tag;
+    } else {
+        static_assert(sizeof(T) == 0, "Unknown mutation type");
+    }
+}
+
+#define MUTATION_PARENT_TAG(mutation) get_parent_tag(mutation)


### PR DESCRIPTION
## Description

The old `MUTATION_PARENT_TAG` code couldn’t always find the right property (`parentTag` or `parentShadowView.tag`) because its version check wasn’t reliable across setups. This PR fixes that by switching to a smarter way to pick the correct property without needing version checks, making it work for all React Native versions (before and after 78).

## Changes

- Replaced the version-based `#if` check with a new `get_parent_tag` function that automatically uses `parentTag` or `parentShadowView.tag` based on what’s available.

## Screenshots / GIFs
![1](https://github.com/user-attachments/assets/2995d521-6d22-472a-95ba-543ab30fc49f)
This is the previous state of the code in React Native 78.

## Related Issue
https://github.com/software-mansion/react-native-screens/issues/2726
https://github.com/software-mansion/react-native-screens/issues/2716
https://github.com/software-mansion/react-native-screens/issues/2594

@kkafar 