### PR TITLE
fix(iOS,Fabric): fix MUTATION_PARENT_TAG definition when using dynamic frameworks

### DIFF
--- a/ios/utils/RNSDefines.h
+++ b/ios/utils/RNSDefines.h
@@ -7,12 +7,15 @@
 #define RNS_IGNORE_SUPER_CALL_END _Pragma("clang diagnostic pop")
 
 #if defined __has_include
-#if __has_include( \
-    <React-RCTAppDelegate/RCTReactNativeFactory.h>) // added in 78
+#if __has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) ||\
+    __has_include(<React_RCTAppDelegate/RCTReactNativeFactory.h>) // added in 78; underscore is used in dynamic frameworks
 #define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 0
 #else
 #define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 1
 #endif
+#else
+#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 \
+  1 // Wild guess, close eyes and hope for the best.
 #endif
 
 #if RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78


### PR DESCRIPTION
## Description

It seems that '-' characters in import names are swapped for '_' when using dynamic frameworks,
therefore we need to check not only for `React-RCTAppDelegate` but also for `React_RCTAppDelegate`.

## Test code and steps to reproduce

Build with `USE_FRAMEWORKS=dynamic` now passes.

## Checklist

- [ ] Ensured that CI passes

