### PR TITLE
fix(Android): pressables under sheets dimming view intercept gesture events

### DIFF
--- a/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/bottomsheet/DimmingViewPointerEvents.kt
+++ b/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/bottomsheet/DimmingViewPointerEvents.kt
@@ -3,14 +3,16 @@ package com.swmansion.rnscreens.bottomsheet
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-
-internal class DimmingViewPointerEventsImpl(val dimmingView: DimmingView) : ReactPointerEventsView {
+internal class DimmingViewPointerEventsImpl(
+    val dimmingView: DimmingView,
+) : ReactPointerEventsView {
     override val pointerEvents: PointerEvents
-        get() = if (dimmingView.blockGestures == false) PointerEvents.AUTO else PointerEvents.NONE
+        get() = if (dimmingView.blockGestures) PointerEvents.AUTO else PointerEvents.NONE
 }
 
-internal class DimmingViewPointerEventsProxy(var pointerEventsImpl: DimmingViewPointerEventsImpl?) :
-    ReactPointerEventsView {
+internal class DimmingViewPointerEventsProxy(
+    var pointerEventsImpl: DimmingViewPointerEventsImpl?,
+) : ReactPointerEventsView {
     override val pointerEvents: PointerEvents
         get() = pointerEventsImpl?.pointerEvents ?: PointerEvents.NONE
 }

--- a/apps/src/shared/Spacer.tsx
+++ b/apps/src/shared/Spacer.tsx
@@ -2,9 +2,10 @@ import React, { ReactNode } from 'react';
 import { View } from 'react-native';
 
 interface Props {
-  children: ReactNode;
+  children?: ReactNode;
+  space?: number
 }
 
-export const Spacer = ({ children }: Props): React.JSX.Element => (
-  <View style={{ margin: 10 }}>{children}</View>
+export const Spacer = ({ children, space }: Props): React.JSX.Element => (
+  <View style={{ margin: space ?? 10 }}>{children}</View>
 );

--- a/apps/src/tests/Test1096.tsx
+++ b/apps/src/tests/Test1096.tsx
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: `rgba(0,0,0,0.5)`,
+    backgroundColor: 'rgba(0,0,0,0.5)',
   },
   box: {
     width: 40,

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,7 +1,9 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import { Button, Text, TextInput, View } from 'react-native';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
+import { Spacer } from '../shared';
 
 type RouteParamList = {
   Home: undefined;
@@ -19,6 +21,10 @@ function Home({ navigation }: RouteProps<'Home'>) {
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
       <Button title="Open FormSheet" onPress={() => navigation.navigate('FormSheet')} />
+      <Spacer space={12} />
+      <PressableWithFeedback>
+        <View style={{ width: '100%', height: 50 }} />
+      </PressableWithFeedback>
     </View>
   );
 }
@@ -52,9 +58,9 @@ export default function App() {
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="FormSheet" component={FormSheet} options={{
           presentation: 'formSheet',
-          sheetAllowedDetents: [0.4, 0.75, 0.9],
+          sheetAllowedDetents: [0.4, 0.6, 0.9],
           //sheetAllowedDetents: 'fitToContents',
-          sheetLargestUndimmedDetentIndex: 1,
+          sheetLargestUndimmedDetentIndex: 0,
           sheetCornerRadius: 8,
           headerShown: false,
           contentStyle: {


### PR DESCRIPTION
## Description

Regression introduced in 4.9.0, when adding backward compatibility in #2730. I've inverted the logical condition checking whether
dimming view blocks gestures and returned `PointerEvents.AUTO` when it wasn't supposed do block.

This PR fixes the condition.

Fixes #2738

## Test code and steps to reproduce

Enhanced `TestFormSheet` so that it allows to verify that it works correctly now. 

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
