### PR TITLE
fix(Android): apply fixes for RN 0.77.1 before release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,7 +119,13 @@ android {
                 "**/libc++_shared.so",
                 "**/libreact_render*.so",
                 "**/libreactnativejni.so",
-                "**/libreact_performance_timeline.so"
+                "**/libreact_performance_timeline.so",
+                // In 0.76 multiple react-native's libraries were merged and these are the main new artifacts we're using.
+                // Some of above lib* names could be removed after we remove support for 0.76.
+                // https://github.com/facebook/react-native/pull/43909
+                // https://github.com/facebook/react-native/pull/46059
+                "**/libfbjni.so", 
+                "**/libreactnative.so"
         ]
     }
     sourceSets.main {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,9 +59,10 @@ def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
+    namespace "com.swmansion.rnscreens"
+
     def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.swmansion.rnscreens"
         buildFeatures {
             buildConfig true
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,13 +61,6 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
     namespace "com.swmansion.rnscreens"
 
-    def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
-    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        buildFeatures {
-            buildConfig true
-        }
-    }
-
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {
@@ -95,6 +88,7 @@ android {
     }
     buildFeatures {
         prefab true
+        buildConfig true
     }
     externalNativeBuild {
         cmake {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.swmansion.rnscreens">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
## Description

Add fixes connected with changing RN to `react-native@0.77.1` before release.

## Changes

- https://github.com/software-mansion/react-native-screens/pull/2602
- https://github.com/software-mansion/react-native-screens/pull/2603
- https://github.com/software-mansion/react-native-screens/pull/2608

## Test code and steps to reproduce
Run example apps from the repo, run new app that uses RN 0.77.1 and this version of RNS.

## Checklist

- [ ] Ensured that CI passes
