### PR TITLE
feat(iOS): add experimental support for scrollview header when using formsheet

### DIFF
--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -71,9 +71,9 @@ function FormSheetWithFlatList({ }: RouteProps<'FormSheetWithFlatList'>) {
   );
 }
 
-const StickyHeader = React.forwardRef<View, { children?: React.ReactNode }>((props, ref: React.LegacyRef<View>) => {
+const StickyHeader = React.forwardRef<View, { children?: React.ReactNode, collapsable?: boolean }>((props, ref: React.LegacyRef<View>) => {
   return (
-    <View ref={ref} style={{ width: '100%', height: 150, backgroundColor: 'red' }}>
+    <View ref={ref} style={{ width: '100%', height: 150, backgroundColor: 'red' }} collapsable={props.collapsable ?? true}>
       {props.children}
     </View>
   );
@@ -94,10 +94,10 @@ function FormSheetWithScrollView() {
 
   return (
     <>
-      <StickyHeader ref={headerRef}>
+      <StickyHeader ref={headerRef} collapsable={false} >
         <Button title="Toggle extra content" onPress={() => setExtraContentVisible(old => !old)} />
       </StickyHeader>
-      <ScrollView nestedScrollEnabled contentInsetAdjustmentBehavior="automatic" style={{}}>
+      <ScrollView nestedScrollEnabled contentInsetAdjustmentBehavior="automatic">
         {data.map(renderItem)}
         {isExtraContentVisible && (
           data.slice(0, 40).map(renderItem)

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,7 +1,7 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
+import { Button, FlatList, ScrollView, Text, TextInput, View, Platform } from 'react-native';
 
 type ItemData = {
   id: number,
@@ -38,6 +38,8 @@ function Home({ navigation }: RouteProps<'Home'>) {
 
 function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
   return (
+    // When using `fitToContents` you can't use flex: 1. It is you who must provide
+    // the content size - you can't rely on parent size here.
     <View style={{ backgroundColor: 'lightgreen', flex: 1 }}>
       <View style={{ paddingTop: 20 }}>
         <Button title="Go back" onPress={() => navigation.goBack()} />
@@ -69,9 +71,9 @@ function FormSheetWithFlatList({ }: RouteProps<'FormSheetWithFlatList'>) {
   );
 }
 
-const StickyHeader = React.forwardRef((props, ref: React.LegacyRef<View>) => {
+const StickyHeader = React.forwardRef<View, { children?: React.ReactNode }>((props, ref: React.LegacyRef<View>) => {
   return (
-    <View ref={ref} style={{ width: '100%', height: 100, backgroundColor: 'red', zIndex: 1 }}>
+    <View ref={ref} style={{ width: '100%', height: 150, backgroundColor: 'red' }}>
       {props.children}
     </View>
   );
@@ -79,7 +81,6 @@ const StickyHeader = React.forwardRef((props, ref: React.LegacyRef<View>) => {
 
 function FormSheetWithScrollView() {
   const headerRef = React.useRef<View>(null);
-  const [stickyHeaderHeight, setStickyHeaderHeight] = React.useState(0);
   const [isExtraContentVisible, setExtraContentVisible] = React.useState(false);
 
   const data: ItemData[] = React.useMemo(() => generateData(150), []);
@@ -90,25 +91,6 @@ function FormSheetWithScrollView() {
       </Text>
     </View>
   ), []);
-
-  const headerMeasureCallback = React.useCallback((
-    x: number,
-    y: number,
-    width: number,
-    height: number,
-  ) => {
-    setStickyHeaderHeight(height);
-    console.log(`Setting headerheight to ${height}`);
-  }, []);
-
-  React.useLayoutEffect(() => {
-    if (headerRef.current == null) {
-      console.log('NO REF PRESENT');
-      return;
-    }
-
-    headerRef.current.measure(headerMeasureCallback);
-  }, [headerMeasureCallback]);
 
   return (
     <>
@@ -142,9 +124,9 @@ export default function App() {
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="FormSheet" component={FormSheet} options={{
           presentation: 'formSheet',
-          sheetAllowedDetents: [0.4, 0.75, 0.9],
+          sheetAllowedDetents: [0.4, 0.75],
           //sheetAllowedDetents: 'fitToContents',
-          sheetLargestUndimmedDetentIndex: 1,
+          sheetLargestUndimmedDetentIndex: 'none',
           sheetCornerRadius: 8,
           headerShown: false,
           contentStyle: {
@@ -163,7 +145,7 @@ export default function App() {
         }} />
         <Stack.Screen name="FormSheetWithScrollView" component={FormSheetWithScrollView} options={{
           presentation: 'formSheet',
-          sheetAllowedDetents: [0.6, 0.9],
+          sheetAllowedDetents: [0.6],
           sheetExpandsWhenScrolledToEdge: false,
           sheetGrabberVisible: true,
           sheetCornerRadius: 8,

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -71,15 +71,18 @@ function FormSheetWithFlatList({ }: RouteProps<'FormSheetWithFlatList'>) {
 
 const StickyHeader = React.forwardRef((props, ref: React.LegacyRef<View>) => {
   return (
-    <View ref={ref} style={{ width: '100%', height: 200, backgroundColor: 'red', zIndex: 1 }} />
+    <View ref={ref} style={{ width: '100%', height: 100, backgroundColor: 'red', zIndex: 1 }}>
+      {props.children}
+    </View>
   );
 });
 
 function FormSheetWithScrollView() {
   const headerRef = React.useRef<View>(null);
   const [stickyHeaderHeight, setStickyHeaderHeight] = React.useState(0);
+  const [isExtraContentVisible, setExtraContentVisible] = React.useState(false);
 
-  const data: ItemData[] = React.useMemo(() => generateData(100), []);
+  const data: ItemData[] = React.useMemo(() => generateData(150), []);
   const renderItem = React.useCallback((item: ItemData) => (
     <View key={item.id.toString()}>
       <Text>
@@ -109,9 +112,14 @@ function FormSheetWithScrollView() {
 
   return (
     <>
-      <StickyHeader ref={headerRef} />
-      <ScrollView nestedScrollEnabled contentInsetAdjustmentBehavior="automatic" style={{ paddingTop: stickyHeaderHeight }}>
+      <StickyHeader ref={headerRef}>
+        <Button title="Toggle extra content" onPress={() => setExtraContentVisible(old => !old)} />
+      </StickyHeader>
+      <ScrollView nestedScrollEnabled contentInsetAdjustmentBehavior="automatic" style={{}}>
         {data.map(renderItem)}
+        {isExtraContentVisible && (
+          data.slice(0, 40).map(renderItem)
+        )}
       </ScrollView>
     </>
   );

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -202,8 +202,6 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)correctScrollViewFrame:(nonnull RNS_REACT_SCROLL_VIEW_COMPONENT *)scrollViewComponent
                     withHeader:(nullable UIView *)headerView
 {
-  //  NSLog(@"[2] Setting SV %@ frame from %@ to %@", scrollView, NSStringFromCGRect(scrollView.frame),
-  //  NSStringFromCGRect(newScrollViewFrame));
   RNSScreenContentWrapper *_Nullable contentWrapper = _contentWrapperBox.contentWrapper;
   if (contentWrapper != nil && [contentWrapper coerceChildScrollViewComponentSizeToSize:self.frame.size]) {
     return;

--- a/ios/RNSScreenContentWrapper.h
+++ b/ios/RNSScreenContentWrapper.h
@@ -1,5 +1,6 @@
 #import <React/RCTViewManager.h>
 #import <UIKit/UIKit.h>
+#import "RNSDefines.h"
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTFabricComponentsPlugins.h>
@@ -11,6 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RNSScreenContentWrapper;
+@class RNS_REACT_SCROLL_VIEW_COMPONENT;
 
 @protocol RNSScreenContentWrapperDelegate <NSObject>
 
@@ -28,12 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
     RCTView
 #endif
 
+@property (nonatomic, nullable, weak) id<RNSScreenContentWrapperDelegate> delegate;
+
 /**
  * Call this method to notify delegate with most recent frame set by React.
  */
 - (void)triggerDelegateUpdate;
 
-@property (nonatomic, nullable, weak) id<RNSScreenContentWrapperDelegate> delegate;
+- (nullable RNS_REACT_SCROLL_VIEW_COMPONENT *)childRCTScrollViewComponent;
 
 @end
 

--- a/ios/RNSScreenContentWrapper.h
+++ b/ios/RNSScreenContentWrapper.h
@@ -39,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable RNS_REACT_SCROLL_VIEW_COMPONENT *)childRCTScrollViewComponent;
 
+- (BOOL)coerceChildScrollViewComponentSizeToSize:(CGSize)size;
+
 @end
 
 @interface RNSScreenContentWrapperManager : RCTViewManager

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -125,9 +125,9 @@ namespace react = facebook::react;
   }
 
   if (self.subviews.count > 2) {
-    // TODO: Log some warning here
     RCTLogWarn(
-        @"[RNScreens] FormSheet with ScrollView expects at most 2 subviews. Got %ld. This might result in incorrect layout.",
+        @"[RNScreens] FormSheet with ScrollView expects at most 2 subviews. Got %ld. This might result in incorrect layout. \
+          If you want to display header alongside the scrollView, make sure to apply `collapsable: false` on your header component view.",
         self.subviews.count);
   }
 
@@ -139,12 +139,23 @@ namespace react = facebook::react;
     newFrame.size = size;
     scrollViewComponent.frame = newFrame;
     return YES;
-  } else if (scrollViewComponentIndex == 1) {
-    UIView *headerView = self.subviews[0];
+  }
 
+  // Case 2: There is a header - we adjust scrollview size by the header height.
+  if (scrollViewComponentIndex == 1) {
+    UIView *headerView = self.subviews[0];
     CGRect newFrame = scrollViewComponent.frame;
     newFrame.size = size;
     newFrame.size.height -= headerView.frame.size.height;
+#ifdef RCT_NEW_ARCH_ENABLED
+    // For some unknown yet reason on new architecture the scroll view
+    // is placed at (0, 0), which makes no sense given there
+    // is another child at lower index in flex layout.
+    // TODO: Research why this happens and solve this properly.
+    if (newFrame.origin.y == 0) {
+      newFrame.origin.y = headerView.frame.size.height;
+    }
+#endif // RCT_NEW_ARCH_ENABLED
     scrollViewComponent.frame = newFrame;
     return YES;
   }

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -1,16 +1,20 @@
 #import "RNSScreenContentWrapper.h"
+#import "RNSDefines.h"
 #import "RNSScreen.h"
 #import "RNSScreenStack.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTConversions.h>
 #import <React/RCTLog.h>
+#import <React/RCTScrollViewComponentView.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
 namespace react = facebook::react;
+#else
+#import <React/RCTScrollView.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
 @implementation RNSScreenContentWrapper
@@ -100,6 +104,16 @@ namespace react = facebook::react;
   } while (currentView != nil && ![currentView isKindOfClass:RNSScreenView.class]);
 
   return static_cast<RNSScreenView *_Nullable>(currentView);
+}
+
+- (nullable RNS_REACT_SCROLL_VIEW_COMPONENT *)childRCTScrollViewComponent
+{
+  for (UIView *subview in self.subviews) {
+    if ([subview isKindOfClass:RNS_REACT_SCROLL_VIEW_COMPONENT.class]) {
+      return static_cast<RNS_REACT_SCROLL_VIEW_COMPONENT *>(subview);
+    }
+  }
+  return nil;
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -116,6 +116,42 @@ namespace react = facebook::react;
   return nil;
 }
 
+- (BOOL)coerceChildScrollViewComponentSizeToSize:(CGSize)size
+{
+  RNS_REACT_SCROLL_VIEW_COMPONENT *_Nullable scrollViewComponent = [self childRCTScrollViewComponent];
+
+  if (scrollViewComponent == nil) {
+    return NO;
+  }
+
+  if (self.subviews.count > 2) {
+    // TODO: Log some warning here
+    RCTLogWarn(
+        @"[RNScreens] FormSheet with ScrollView expects at most 2 subviews. Got %ld. This might result in incorrect layout.",
+        self.subviews.count);
+  }
+
+  NSUInteger scrollViewComponentIndex = [[self subviews] indexOfObject:scrollViewComponent];
+
+  // Case 1: ScrollView first child - takes whole size.
+  if (scrollViewComponentIndex == 0) {
+    CGRect newFrame = scrollViewComponent.frame;
+    newFrame.size = size;
+    scrollViewComponent.frame = newFrame;
+    return YES;
+  } else if (scrollViewComponentIndex == 1) {
+    UIView *headerView = self.subviews[0];
+
+    CGRect newFrame = scrollViewComponent.frame;
+    newFrame.size = size;
+    newFrame.size.height -= headerView.frame.size.height;
+    scrollViewComponent.frame = newFrame;
+    return YES;
+  }
+
+  return NO;
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/utils/RNSDefines.h
+++ b/ios/utils/RNSDefines.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#pragma mark - Compiler utility
+
 #define RNS_IGNORE_SUPER_CALL_BEGIN \
   _Pragma("clang diagnostic push")  \
       _Pragma("clang diagnostic ignored \"-Wobjc-missing-super-calls\"")
 
 #define RNS_IGNORE_SUPER_CALL_END _Pragma("clang diagnostic pop")
+
+#pragma mark - React Native version dependent code
 
 #if defined __has_include
 #if __has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) ||\
@@ -22,4 +26,16 @@
 #define MUTATION_PARENT_TAG(mutation) mutation.parentShadowView.tag
 #else
 #define MUTATION_PARENT_TAG(mutation) mutation.parentTag
+#endif
+
+#pragma mark - React Native architecture dependent code
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#define RNS_REACT_SCROLL_VIEW_COMPONENT RCTScrollViewComponentView
+
+#else
+
+#define RNS_REACT_SCROLL_VIEW_COMPONENT RCTScrollView
+
 #endif


### PR DESCRIPTION
## Description

Given numerous feature requests & the frequent need to have header above the scrollview in sheet this PR adds this possibility. 

Please see [`TestFormSheet`](https://github.com/software-mansion/react-native-screens/blob/main/apps/src/tests/TestFormSheet.tsx) for example implementation.

Note that this PR enables header by handling special case when there is **exactly one** view rendered directly under sheet at index 0 (and scroll view on index 1). Again - see example ☝🏻 

## Changes

We're now detecting special case inside content wrapper: scroll view at index 0 or header at 0 & scrollview at 1. We then adjust the layout manually. If these cases are not detected we fallback to previous behaviour.

## Test code and steps to reproduce

Enhanced `TestFormSheet` to allow for testing this.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
