### PR TITLE
fix(Android): missing content when using flex for formsheet contents

### DIFF
--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -32,6 +32,7 @@ function ScreenStackItem(
     activityState,
     shouldFreeze,
     stackPresentation,
+    sheetAllowedDetents,
     contentStyle,
     style,
     screenId,
@@ -71,7 +72,9 @@ function ScreenStackItem(
           stackPresentation === 'formSheet'
             ? Platform.OS === 'ios'
               ? styles.absolute
-              : null
+              : sheetAllowedDetents === 'fitToContents'
+              ? null
+              : styles.container
             : styles.container,
           contentStyle,
         ]}
@@ -136,6 +139,7 @@ function ScreenStackItem(
       shouldFreeze={shouldFreeze}
       stackPresentation={stackPresentation}
       hasLargeHeader={headerConfig?.largeTitle ?? false}
+      sheetAllowedDetents={sheetAllowedDetents}
       style={[style, internalScreenStyle]}
       {...rest}>
       {isHeaderInModal ? (

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -108,7 +108,9 @@ const MaybeNestedStack = ({
         stackPresentation === 'formSheet'
           ? Platform.OS === 'ios'
             ? styles.absoluteFillNoBottom
-            : null
+            : options.sheetAllowedDetents === 'fitToContents'
+            ? null
+            : styles.container
           : styles.container,
         stackPresentation !== 'transparentModal' &&
           stackPresentation !== 'containedTransparentModal' && {

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -71,12 +71,14 @@ const MaybeNestedStack = ({
   options,
   route,
   stackPresentation,
+  sheetAllowedDetents,
   children,
   internalScreenStyle,
 }: {
   options: NativeStackNavigationOptions;
   route: Route<string>;
   stackPresentation: StackPresentationTypes;
+  sheetAllowedDetents: NativeStackNavigationOptions['sheetAllowedDetents'];
   children: React.ReactNode;
   internalScreenStyle?: Pick<ViewStyle, 'backgroundColor'>;
 }) => {
@@ -108,7 +110,7 @@ const MaybeNestedStack = ({
         stackPresentation === 'formSheet'
           ? Platform.OS === 'ios'
             ? styles.absoluteFillNoBottom
-            : options.sheetAllowedDetents === 'fitToContents'
+            : sheetAllowedDetents === 'fitToContents'
             ? null
             : styles.container
           : styles.container,
@@ -152,6 +154,7 @@ const MaybeNestedStack = ({
         <Screen
           enabled
           isNativeStack
+          sheetAllowedDetents={sheetAllowedDetents}
           hasLargeHeader={hasLargeHeader}
           style={[StyleSheet.absoluteFill, internalScreenStyle]}>
           <HeaderHeightContext.Provider value={headerHeight}>
@@ -440,6 +443,7 @@ const RouteView = ({
           <MaybeNestedStack
             options={options}
             route={route}
+            sheetAllowedDetents={sheetAllowedDetents}
             stackPresentation={stackPresentation}
             internalScreenStyle={internalScreenStyle}>
             {renderScene()}


### PR DESCRIPTION
## Description

Fixing the styles applied to the content in screens with `formSheet` presentation.
Currently when using `flex: 1` on the content of the sheet it might cause the content to disappear. This PR mitigates that. 


## Changes

When not in `fitToContents` mode we apply `flex: 1` to content wrapper. 


## Test code and steps to reproduce

`TestFormSheet` - notice that the contents has `flex: 1` and it displays correctly.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
