### PR TITLE
fix(Android): findTitleTextViewInToolbar couldn't find the correct view in certain cases

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -419,7 +419,7 @@ class ScreenStackHeaderConfig(
             for (i in 0 until toolbar.childCount) {
                 val view = toolbar.getChildAt(i)
                 if (view is TextView) {
-                    if (view.text == toolbar.title) {
+                    if (TextUtils.equals(view.text, toolbar.title)) {
                         return view
                     }
                 }


### PR DESCRIPTION
## Description

Fixes #2745 

## Changes

Use `TextUtils` to compare the value of `view.text` and `toolbar.title`. `text` and `title` are `CharSequence`, there are no guarantee that they will be the same type, therefore the `==` comparison could fail.

For example, `Toolbar` could be styled natively in the project, therefore the value of its `TextView` child could be `SpannableString`, while title could be still just a `String`.

## Test code and steps to reproduce

## Checklist

- [ ] Ensured that CI passes
