### PR TITLE
fix(CI): update Example, bump reanimated

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1550,7 +1550,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.17.0):
+  - RNReanimated (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1572,10 +1572,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.17.0)
-    - RNReanimated/worklets (= 3.17.0)
+    - RNReanimated/reanimated (= 3.17.2)
+    - RNReanimated/worklets (= 3.17.2)
     - Yoga
-  - RNReanimated/reanimated (3.17.0):
+  - RNReanimated/reanimated (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1597,9 +1597,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.17.0)
+    - RNReanimated/reanimated/apple (= 3.17.2)
     - Yoga
-  - RNReanimated/reanimated/apple (3.17.0):
+  - RNReanimated/reanimated/apple (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1622,7 +1622,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.17.0):
+  - RNReanimated/worklets (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1644,9 +1644,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.17.0)
+    - RNReanimated/worklets/apple (= 3.17.2)
     - Yoga
-  - RNReanimated/worklets/apple (3.17.0):
+  - RNReanimated/worklets/apple (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1931,7 +1931,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
@@ -1992,7 +1992,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
   ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
   RNGestureHandler: 9f3109e11ed88fe5bed280bf7762b25e4c52f396
-  RNReanimated: c34bdc579a880e39f6f5588d12cf0c3204eb5aa8
+  RNReanimated: 4d99256f5258ea8b4fbd635c660d4983b1743d3b
   RNScreens: 3c7a1921b619b7b8d6f59f34a2b53cbf72dd5668
   RNVectorIcons: 1f688883f7dfb5b346a03689800a88c5e3376029
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/Example/package.json
+++ b/Example/package.json
@@ -28,7 +28,7 @@
     "react": "19.0.0",
     "react-native": "0.78.0",
     "react-native-gesture-handler": "^2.24.0",
-    "react-native-reanimated": "^3.17.1",
+    "react-native-reanimated": "^3.17.2",
     "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "5.2.0",
     "react-native-screens": "link:../",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -4459,7 +4459,7 @@ __metadata:
     react-native: "npm:0.78.0"
     react-native-codegen: "npm:^0.71.3"
     react-native-gesture-handler: "npm:^2.24.0"
-    react-native-reanimated: "npm:^3.17.1"
+    react-native-reanimated: "npm:^3.17.2"
     react-native-restart: "npm:^0.0.27"
     react-native-safe-area-context: "npm:5.2.0"
     react-native-screens: "link:../"
@@ -11010,9 +11010,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:^3.17.1":
-  version: 3.17.1
-  resolution: "react-native-reanimated@npm:3.17.1"
+"react-native-reanimated@npm:^3.17.2":
+  version: 3.17.2
+  resolution: "react-native-reanimated@npm:3.17.2"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -11030,7 +11030,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10c0/da4f653a675816eb0b3502aa5029c21ec4ec8889bcbbbbc174d567db1c05d9529d638a22c2e4085bf5a97ad2e184988d64cfa9b77774cb32322f29ab4e6c2585
+  checksum: 10c0/f4c4a6c092f9fd5da258ee8373b5450e5775b99a8ff87c9c9af2fe801403ee06d2ba4dedac38d08d8f6de95ea881863b2a47217bc29a5aa3522b16a5b050f667
   languageName: node
   linkType: hard
 

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1614,7 +1614,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.17.0):
+  - RNReanimated (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1636,10 +1636,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.17.0)
-    - RNReanimated/worklets (= 3.17.0)
+    - RNReanimated/reanimated (= 3.17.2)
+    - RNReanimated/worklets (= 3.17.2)
     - Yoga
-  - RNReanimated/reanimated (3.17.0):
+  - RNReanimated/reanimated (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1661,9 +1661,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.17.0)
+    - RNReanimated/reanimated/apple (= 3.17.2)
     - Yoga
-  - RNReanimated/reanimated/apple (3.17.0):
+  - RNReanimated/reanimated/apple (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1686,7 +1686,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.17.0):
+  - RNReanimated/worklets (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1708,9 +1708,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.17.0)
+    - RNReanimated/worklets/apple (= 3.17.2)
     - Yoga
-  - RNReanimated/worklets/apple (3.17.0):
+  - RNReanimated/worklets/apple (3.17.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2079,7 +2079,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
   ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
   RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNReanimated: cf6008a0102a21a275d90bacafc4f433c2efa926
+  RNReanimated: df8afe0155d72ee0856673d5478becd8661c31ae
   RNScreens: f64d247b892b2948d08f4a3600bd3d48700fd0f3
   RNVectorIcons: 1f688883f7dfb5b346a03689800a88c5e3376029
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -23,7 +23,7 @@
     "react": "19.0.0",
     "react-native": "0.78.0",
     "react-native-gesture-handler": "^2.24.0",
-    "react-native-reanimated": "^3.17.0",
+    "react-native-reanimated": "^3.17.2",
     "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "5.2.0",
     "react-native-screens": "link:../",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -3665,7 +3665,7 @@ __metadata:
     react: "npm:19.0.0"
     react-native: "npm:0.78.0"
     react-native-gesture-handler: "npm:^2.24.0"
-    react-native-reanimated: "npm:^3.17.0"
+    react-native-reanimated: "npm:^3.17.2"
     react-native-restart: "npm:^0.0.27"
     react-native-safe-area-context: "npm:5.2.0"
     react-native-screens: "link:../"
@@ -8869,9 +8869,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:^3.17.0":
-  version: 3.17.0
-  resolution: "react-native-reanimated@npm:3.17.0"
+"react-native-reanimated@npm:^3.17.2":
+  version: 3.17.2
+  resolution: "react-native-reanimated@npm:3.17.2"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -8889,7 +8889,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10c0/a3a89b790f04e344ba16ad4efc2176a33769713f979d84c1c3c486814de93748e61ac1a85c0970c3ef5f52c100641dc7e00d3296b387bbbc38c4fdaf6dca7108
+  checksum: 10c0/f4c4a6c092f9fd5da258ee8373b5450e5775b99a8ff87c9c9af2fe801403ee06d2ba4dedac38d08d8f6de95ea881863b2a47217bc29a5aa3522b16a5b050f667
   languageName: node
   linkType: hard
 

--- a/apps/src/screens/BottomTabsAndStack.tsx
+++ b/apps/src/screens/BottomTabsAndStack.tsx
@@ -101,12 +101,12 @@ const NavigationTabsAndStack = (): React.JSX.Element => (
     <Tab.Screen
       name="A"
       component={AStack}
-      options={{ tabBarButtonTestID: 'bottom-tabs-A-tab' }}
+      options={{ tabBarTestID: 'bottom-tabs-A-tab' }}
     />
     <Tab.Screen
       name="B"
       component={BStack}
-      options={{ tabBarButtonTestID: 'bottom-tabs-B-tab' }}
+      options={{ tabBarTestID: 'bottom-tabs-B-tab' }}
     />
     <Tab.Screen name="C" component={CStack} />
     <Tab.Screen name="D" component={DStack} />

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-native": "0.78.0",
     "react-native-builder-bob": "^0.23.2",
     "react-native-gesture-handler": "^2.24.0",
-    "react-native-reanimated": "^3.17.0",
+    "react-native-reanimated": "^3.17.2",
     "react-native-safe-area-context": "5.2.0",
     "react-native-windows": "^0.64.8",
     "react-test-renderer": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14472,9 +14472,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:^3.17.0":
-  version: 3.17.0
-  resolution: "react-native-reanimated@npm:3.17.0"
+"react-native-reanimated@npm:^3.17.2":
+  version: 3.17.2
+  resolution: "react-native-reanimated@npm:3.17.2"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -14492,7 +14492,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10c0/a3a89b790f04e344ba16ad4efc2176a33769713f979d84c1c3c486814de93748e61ac1a85c0970c3ef5f52c100641dc7e00d3296b387bbbc38c4fdaf6dca7108
+  checksum: 10c0/f4c4a6c092f9fd5da258ee8373b5450e5775b99a8ff87c9c9af2fe801403ee06d2ba4dedac38d08d8f6de95ea881863b2a47217bc29a5aa3522b16a5b050f667
   languageName: node
   linkType: hard
 
@@ -14545,7 +14545,7 @@ __metadata:
     react-native: "npm:0.78.0"
     react-native-builder-bob: "npm:^0.23.2"
     react-native-gesture-handler: "npm:^2.24.0"
-    react-native-reanimated: "npm:^3.17.0"
+    react-native-reanimated: "npm:^3.17.2"
     react-native-safe-area-context: "npm:5.2.0"
     react-native-windows: "npm:^0.64.8"
     react-test-renderer: "npm:^19.0.0"


### PR DESCRIPTION
## Description

Fixes CI on both platforms.

## Changes

- change Example to use tab bar button test ID option available in react-navigation 6 (previous one was correct for react-navigation 7 but example apps use version 6)
- bump to `react-native-reanimated@3.17.2` in order to fix the issue with Android CI (https://github.com/software-mansion/react-native-reanimated/pull/7196)

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes