### PR TITLE
fix(Android,native-stack): fix check for `sheetAllowedDetents` value & apply appropriate styles

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -96,7 +96,7 @@ function resolveSheetAllowedDetents(
     return SHEET_COMPAT_ALL;
   } else {
     // Safe default, only large detent is allowed.
-    return [1.0];
+    return SHEET_COMPAT_LARGE;
   }
 }
 

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -57,8 +57,8 @@ function ScreenStackItem(
   React.useEffect(() => {
     warnOnce(
       Platform.OS !== 'android' &&
-        stackPresentation !== 'push' &&
-        headerHiddenPreviousRef.current !== headerConfig?.hidden,
+      stackPresentation !== 'push' &&
+      headerHiddenPreviousRef.current !== headerConfig?.hidden,
       `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`,
     );
 
@@ -73,8 +73,8 @@ function ScreenStackItem(
             ? Platform.OS === 'ios'
               ? styles.absolute
               : sheetAllowedDetents === 'fitToContents'
-              ? null
-              : styles.container
+                ? null
+                : styles.container
             : styles.container,
           contentStyle,
         ]}

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -57,8 +57,8 @@ function ScreenStackItem(
   React.useEffect(() => {
     warnOnce(
       Platform.OS !== 'android' &&
-      stackPresentation !== 'push' &&
-      headerHiddenPreviousRef.current !== headerConfig?.hidden,
+        stackPresentation !== 'push' &&
+        headerHiddenPreviousRef.current !== headerConfig?.hidden,
       `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`,
     );
 
@@ -73,8 +73,8 @@ function ScreenStackItem(
             ? Platform.OS === 'ios'
               ? styles.absolute
               : sheetAllowedDetents === 'fitToContents'
-                ? null
-                : styles.container
+              ? null
+              : styles.container
             : styles.container,
           contentStyle,
         ]}

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -104,16 +104,19 @@ const MaybeNestedStack = ({
     headerShownPreviousRef.current = headerShown;
   }, [headerShown, stackPresentation, route.name]);
 
+  const formSheetAdjustedContentStyle =
+    stackPresentation === 'formSheet'
+      ? Platform.OS === 'ios'
+        ? styles.absoluteFillNoBottom
+        : sheetAllowedDetents === 'fitToContents'
+        ? null
+        : styles.container
+      : styles.container;
+
   const content = (
     <Container
       style={[
-        stackPresentation === 'formSheet'
-          ? Platform.OS === 'ios'
-            ? styles.absoluteFillNoBottom
-            : sheetAllowedDetents === 'fitToContents'
-            ? null
-            : styles.container
-          : styles.container,
+        formSheetAdjustedContentStyle,
         stackPresentation !== 'transparentModal' &&
           stackPresentation !== 'containedTransparentModal' && {
             backgroundColor: colors.background,
@@ -198,6 +201,7 @@ const RouteView = ({
     headerShown,
     hideKeyboardOnSwipe,
     homeIndicatorHidden,
+    sheetAllowedDetents = [1.0],
     sheetLargestUndimmedDetentIndex = 'none',
     sheetGrabberVisible = false,
     sheetCornerRadius = -1.0,
@@ -223,7 +227,6 @@ const RouteView = ({
   } = options;
 
   let {
-    sheetAllowedDetents = [1.0],
     customAnimationOnSwipe,
     fullScreenSwipeEnabled,
     gestureResponseDistance,
@@ -241,10 +244,6 @@ const RouteView = ({
     internalScreenStyle = {
       backgroundColor: flattenContentStyles?.backgroundColor,
     };
-  }
-
-  if (sheetAllowedDetents === 'fitToContents') {
-    sheetAllowedDetents = [-1];
   }
 
   if (swipeDirection === 'vertical') {


### PR DESCRIPTION
## Description

I've made a small change in v5 code in #2748, however due to my overlook it introduced a regression in native-stack v5.
Since it is a quick fix I'm patching it. 

Basically I've parsed & transformed `sheetAllowedDetents` value in `RouteView`, **before** passing it to `MaybeNestedStack`, where
I've checked for `sheetAllowedDetents === 'fitToContents'`, which could not be true, because in such case it has been transformed to `[-1]`
literal in `RouteView`.

Only the latest 4.10.0-beta.0 & beta.1 versions are affected.

## Changes

Removed `sheetAllowedDetents` prop value transformation in `RouteView` since `Screen` component handles it nicely internally.

## Test code and steps to reproduce

`TestFormSheet`, but you need to run it using `createNativeStackNavigator` from `react-native-screens/native-stack`.
Don't forget to change the `presentation` prop to `stackPresentation`, when changing to v5.

## Checklist

- [ ] Ensured that CI passes

