### PR TITLE
chore(examples): adjust metro config to allow for easier modify-test loop with react-navigation submodule

### DIFF
--- a/Example/metro.config.js
+++ b/Example/metro.config.js
@@ -55,6 +55,9 @@ const modules = [
   ...Object.keys(libPackage.peerDependencies),
 ];
 
+// Currently each `@react-navigation` package has `src/index.tsx`.
+const reactNavigationIndexExts = ['tsx', 'ts', 'js', 'jsx'];
+
 // We want to enforce that these modules are **not** imported from node modules
 // of the react navigation git submodule.
 const reactNavigationDuplicatedModules = [
@@ -82,6 +85,8 @@ const config = {
   // We need to make sure that only one version is loaded for peerDependencies
   // So we exclude them at the root, and alias them to the versions in example's node_modules
   resolver: {
+    resolverMainFields: ['react-native', 'browser', 'main'],
+
     blockList: exclusionList(
       blockListProvider(modules, libNodeModules).concat(
         blockListProvider(
@@ -101,14 +106,14 @@ const config = {
     // are consulted first, resulting in double-loaded packages (so doubled react, react-native and other package instances) leading
     // to various errors. To mitigate this we define this custom request resolver. It does following:
     //
-    // 1. blocks all conflicting modules by using `blockList` (this includes both our lib & react navigation)
-    // 2. keeps module resolution algorithm - while it would be handy for the implementation simplicity to use this option,
-    //    it causes some surprising quality-of-life issues described below,
-    // 3. looks only inside these node modules directories which are explicitly specified in `nodeModulesPaths`.
+    // 1. blocks all conflicting modules by using `blockList` (this includes both our lib & react navigation),
+    // 2. disables module resolution algorithm - we do not look for different node_modules beside those specified explicitely,
+    // 3. looks only inside these node modules directories which are explicitly specified in `nodeModulesPaths`,
+    // 4. hijacks requests for `react-navigation` packages & resolves them to the `@react-navigation/xxx/src/*` files
+    // so that they are transformed & included in bundle. Otherwise the pretransformed files are included causing
+    // quality-of-life degradation, since local changes to source code are not immediately visible.
 
-    // Setting this to `true` leads to situtaion where code from `lib` directory (transformed) of `@react-navigation/xxx` is imported,
-    // making it inconvenient to modify & test `react-navigation` code. We want the `src` to be imported.
-    disableHierarchicalLookup: false,
+    disableHierarchicalLookup: true,
 
     // Project node modules + directory where `react-native-screens` repo lives in + react navigation node modules.
     // These are consulted in order of definition.
@@ -119,6 +124,35 @@ const config = {
       libNodeModules,
       reactNavigationNodeModules,
     ],
+
+    resolveRequest: (context, moduleName, platform) => {
+      // We want to enforce that in case of react navigation the `src` files
+      // are transformed & bundled instead of the pretransformed ones in `@react-navigation/xxx/lib` directory.
+      if (moduleName.startsWith('@react-navigation/')) {
+        for (const fileExt of reactNavigationIndexExts) {
+          // App node modules contain symlink to react-navigation submodule.
+          const moduleEntryPoint = path.join(
+            appNodeModules,
+            moduleName,
+            'src',
+            `index.${fileExt}`,
+          );
+          if (fs.existsSync(moduleEntryPoint)) {
+            return {
+              filePath: moduleEntryPoint,
+              type: 'sourceFile',
+            };
+          }
+        }
+
+        console.warn(`
+          Failed to find entry point of module: ${moduleName}.
+          Please note that this **might** mean that local changes to that module code won't be visible in bundle.
+        `);
+      }
+
+      return context.resolveRequest(context, moduleName, platform);
+    },
   },
 
   transformer: {


### PR DESCRIPTION
## Description

> [!caution]
> ~TODO:  Needs to be rebased on top of main, dropping changes from #2736~ done

I've explained the issue in code comments: metro by default picks up source files from 
`@react-navigation/xxx/lib` instead of ones from `@react-navigation/xxx/src`. 
This makes playing with `@react-navigation` & testing it harder (even when one just need to add some logs)...

## Changes

This PR adds a resolver, which explicitly resolves `@react-navigation/xxx` packages imports to the `@react-navigation/xxx/src/*` implementation. 

This PR also makes sure the metro block-list works correctly.

## Test code and steps to reproduce

No extra tests needed - just example apps should build & load.
You can now add a `console.log` into react-navigation submodule code & it will work!

## Checklist

- [ ] Ensured that CI passes

