### PR TITLE
fix(iOS) pushing a removing screen to controller

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -40,6 +40,7 @@ namespace react = facebook::react;
 - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal;
 - (void)notifyFinishTransitioning;
 - (RNSScreenView *)screenView;
+@property (nonatomic, readonly) BOOL disappeared;
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)setViewToSnapshot;
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1383,6 +1383,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     self.view = view;
     _fakeView = [UIView new];
     _shouldNotify = YES;
+    _disappeared = NO;
 #ifdef RCT_NEW_ARCH_ENABLED
     _initialView = (RNSScreenView *)view;
 #endif
@@ -1394,6 +1395,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+  _disappeared = NO;
   if (!_isSwiping) {
     [self.screenView notifyWillAppear];
     if (self.transitionCoordinator.isInteractive) {
@@ -1421,6 +1423,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewWillDisappear:(BOOL)animated
 {
   [super viewWillDisappear:animated];
+  _disappeared = NO;
   // self.navigationController might be null when we are dismissing a modal
   if (!self.transitionCoordinator.isInteractive && self.navigationController != nil) {
     // user might have long pressed ios 14 back button item,
@@ -1458,6 +1461,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
+  _disappeared = NO;
   if (!_isSwiping || _shouldNotify) {
     // we are going forward or dismissing without swipe
     // or successfully swiped back
@@ -1474,6 +1478,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
+  _disappeared = YES;
   if (self.parentViewController == nil && self.presentingViewController == nil) {
     if (self.screenView.preventNativeDismiss) {
       // if we want to prevent the native dismiss, we do not send dismissal event,

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -677,7 +677,16 @@ RNS_IGNORE_SUPER_CALL_END
       [newControllers removeLastObject];
 
       [_controller setViewControllers:newControllers animated:NO];
-      [_controller pushViewController:top animated:YES];
+
+      // If entered waiting transition complete logic
+      // the `updateContainer` is async calling
+      // top controller may not a new one
+      // but old one between disappeared and unmounted
+      // which not in _controllers, but _reactSubviews not remove it yet
+      // should not push it
+      if(!((RNSScreen *)top).disappeared) {
+        [_controller pushViewController:top animated:YES];
+      }
     } else {
       // don't really know what this case could be, but may need to handle it
       // somehow


### PR DESCRIPTION
## Description

Fixes #2559 

Bug track:
The logic waiting for the transition complete and then call `updateContainer` has problem. 
An old screen may be about to be removed but has not yet been removed.
which not in _controllers, but _reactSubviews not remove it yet.
`updateContainer` iterates _reactSubviews and call `setPushViewControllers`.
The old screen will push again.


This change add a property **`disappeared`** to RNSScreen, defaults to `NO`.
- on `viewWillAppear`/`viewDidAppear`/`viewWillDisappear` set `NO`
- on `viewDidDisappear` set `YES`

In `RNSScreenStack`'s `setPushViewControllers`,  check if it's not an new screen.

``` typescript
if(!((RNSScreen *)top).disappeared) {
  [_controller pushViewController:top animated:YES];
}
```
