### PR TITLE
fix: FullWindowOverlay not working with dynamic frameworks

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -17,12 +17,6 @@
 
 @implementation RNSFullWindowOverlayContainer
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-+ (void)load
-{
-  [super load];
-}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -84,6 +78,12 @@
 #else
   RCTTouchHandler *_touchHandler;
 #endif // RCT_NEW_ARCH_ENABLED
+}
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
++ (void)load
+{
+  [super load];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

-->

Fixes #2652

The `RNSFullWindowOverlay` component was not used with dynamic frameworks, leading to the use of a legacy component.

As highlighted in [this React Native PR](https://github.com/facebook/react-native/pull/37274), all Fabric components must implement the load method to be correctly resolved.

Although `RNSFullWindowOverlay.mm` already included this method, it was mistakenly placed in `RNSFullWindowOverlayContainer` instead of `RNSFullWindowOverlay`, where it should have been implemented.

After correcting this placement, the reported issue is no longer reproducible 🎉.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

-->

- moved `load` method from `RNSFullWindowOverlayContainer` to `RNSFullWindowOverlay` class

## Screenshots / GIFs

### Before
![before](https://github.com/user-attachments/assets/62af4ba7-6d77-492c-a44d-444fa944b070)

### After
![after](https://github.com/user-attachments/assets/54272109-ea97-4363-a453-d945e5b1b39c)

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
