### PR TITLE
fix(Android): fix drawing order when dismissing multiple stacked sheets

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -571,3 +571,5 @@ class Screen(
         const val SHEET_FIT_TO_CONTENTS = -1.0
     }
 }
+
+internal fun View.asScreen() = this as Screen

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.kt
@@ -30,7 +30,7 @@ class ScreenStackViewManager :
         child: View,
         index: Int,
     ) {
-        require(child is Screen) { "Attempt attach child that is not of type RNScreen" }
+        require(child is Screen) { "Attempt attach child that is not of type Screen" }
         NativeProxy.addScreenToMap(child.id, child)
         parent.addScreen(child, index)
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/ViewExt.kt
@@ -35,3 +35,5 @@ internal fun View.maybeBgColor(): Int? {
     }
     return null
 }
+
+internal fun View.asViewGroupOrNull(): ViewGroup? = this as? ViewGroup

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,7 +1,11 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, FlatList, ScrollView, Text, TextInput, View, Platform } from 'react-native';
+import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
+import { enableFreeze } from 'react-native-screens';
+
+enableFreeze(false);
+enableFreeze(false);
 
 type ItemData = {
   id: number,
@@ -12,6 +16,7 @@ type RouteParamList = {
   Home: undefined;
   Second: undefined;
   FormSheet: undefined;
+  SecondFormSheet: undefined;
   FormSheetWithFlatList: undefined;
   FormSheetWithScrollView: undefined;
 };
@@ -54,9 +59,30 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
       <View style={{ paddingTop: 20 }}>
         <Button title="Go back" onPress={() => navigation.goBack()} />
         <Button title="Open Second" onPress={() => navigation.navigate('Second')} />
+        <Button title="Open SecondFormSheet" onPress={() => navigation.navigate('SecondFormSheet')} />
       </View>
       <View style={{ alignItems: 'center' }}>
         <TextInput style={{ marginVertical: 12, paddingVertical: 8, backgroundColor: 'lavender', borderRadius: 24, width: '80%' }} placeholder="Trigger keyboard..." />
+      </View>
+    </View>
+  );
+}
+
+function SecondFormSheet({ navigation }: RouteProps<'SecondFormSheet'>) {
+  return (
+    // When using `fitToContents` you can't use flex: 1. It is you who must provide
+    // the content size - you can't rely on parent size here.
+    <View style={{ backgroundColor: 'lightgreen', flex: undefined }}>
+      <View style={{ paddingTop: 20 }}>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+        <Button title="Open Second" onPress={() => navigation.navigate('Second')} />
+        <Button title="Pop to top" onPress={() => navigation.popToTop()} />
+      </View>
+      <View style={{ alignItems: 'center' }}>
+        <TextInput style={{ marginVertical: 12, paddingVertical: 8, backgroundColor: 'lavender', borderRadius: 24, width: '80%' }} placeholder="Trigger keyboard..." />
+      </View>
+      <View style={{ backgroundColor: 'green', height: 500 }}>
+        <Text>Additional content</Text>
       </View>
     </View>
   );
@@ -138,6 +164,18 @@ export default function App() {
           presentation: 'formSheet',
           sheetAllowedDetents: [0.4, 0.75],
           //sheetAllowedDetents: 'fitToContents',
+          sheetLargestUndimmedDetentIndex: 'none',
+          sheetCornerRadius: 8,
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+          //unstable_sheetFooter: FormSheetFooter,
+        }} />
+        <Stack.Screen name="SecondFormSheet" component={SecondFormSheet} options={{
+          presentation: 'formSheet',
+          //sheetAllowedDetents: [0.4, 0.75],
+          sheetAllowedDetents: 'fitToContents',
           sheetLargestUndimmedDetentIndex: 'none',
           sheetCornerRadius: 8,
           headerShown: false,

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -2,10 +2,6 @@ import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
-import { enableFreeze } from 'react-native-screens';
-
-enableFreeze(false);
-enableFreeze(false);
 
 type ItemData = {
   id: number,


### PR DESCRIPTION
## Description

Closes #2773

Android, for some reason, draws exiting views first. If there are multiple exiting views it also reverses their drawing order. 

In case of non-transparent screens we already have a workaround for that - we change the order or drawing last two screens when needed.

`formSheet` presentation introduced whole new layer of complexity - due to transparency there are cases where multiple **visible** screens are dismissed at once, resulting in jarring visual effects (see recording titled "before" below 👇🏻 ) 

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/01290c1f-d1dc-4668-ada3-70b2fe10e17c" alt="before" /> | <video src="https://github.com/user-attachments/assets/9b8566c0-91fd-41d5-8af8-50e01611a702" alt="before" /> |

## Changes

We now handle case of multiple transparent screens being dismissed simultaneously by applying  appropriate children drawing strategy. 

> [!caution]
> This PR removes `isDetachingCurrentScreen` & `reverseLastTwoChildren` state & introduces replacement: `childDrawingOrderStrategy` - which modifies the order of children drawing when not null & the container is in transition (`startViewTransition` has been called, but `endViewTransition` not). 

## Test code and steps to reproduce

`TestFormSheet` - see recording.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
