### PR TITLE
fix: update workaround preventing React Native from hiding frozen screens to work with RN 0.78

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -257,16 +257,20 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       }
 
       const handleRef = (ref: ViewConfig) => {
+        // Workaround is necessary to prevent React Native from hiding frozen screens.
+        // See this PR: https://github.com/grahammendick/navigation/pull/860
         if (ref?.viewConfig?.validAttributes?.style) {
           ref.viewConfig.validAttributes.style = {
             ...ref.viewConfig.validAttributes.style,
-            display: false,
+            // @ts-ignore: Please see the comment above.
+            display: null,
           };
           setRef(ref);
         } else if (ref?._viewConfig?.validAttributes?.style) {
           ref._viewConfig.validAttributes.style = {
             ...ref._viewConfig.validAttributes.style,
-            display: false,
+            // @ts-ignore: Please see the comment above.
+            display: null,
           };
           setRef(ref);
         }

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -36,14 +36,14 @@ interface ViewConfig extends View {
   viewConfig: {
     validAttributes: {
       style: {
-        display: boolean;
+        display: boolean | null;
       };
     };
   };
   _viewConfig: {
     validAttributes: {
       style: {
-        display: boolean;
+        display: boolean | null;
       };
     };
   };
@@ -262,14 +262,12 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         if (ref?.viewConfig?.validAttributes?.style) {
           ref.viewConfig.validAttributes.style = {
             ...ref.viewConfig.validAttributes.style,
-            // @ts-ignore: Please see the comment above.
             display: null,
           };
           setRef(ref);
         } else if (ref?._viewConfig?.validAttributes?.style) {
           ref._viewConfig.validAttributes.style = {
             ...ref._viewConfig.validAttributes.style,
-            // @ts-ignore: Please see the comment above.
             display: null,
           };
           setRef(ref);


### PR DESCRIPTION
## Description

React Native sets `display: 'none'` for frozen screens - this behavior can become an issue, if you for example press back button twice very fast on iOS -  frozen screen might still be invisible. The problem and its workaround suggested by @grahammendick can be seen in issue https://github.com/software-mansion/react-native-screens/issues/1207. The workaround was introduced in PR https://github.com/software-mansion/react-native-screens/pull/1208.

Recently, React Native 0.78 has changed the way of diffing props and the workaround stopped working. The details and a new workaround has been suggested by @grahammendick once again in issue https://github.com/software-mansion/react-native-screens/issues/2753 and PR https://github.com/grahammendick/navigation/pull/860.

This PR introduces the suggested workaround.

A big thank you to @grahammendick for figuring it out and suggesting the solution once again, appreciate it! 

Fixes https://github.com/software-mansion/react-native-screens/issues/2753.

## Changes

- change `display: false` to `display: null`,
- change `ViewConfig` interface to allow `null` value.

## Screenshots / GIFs

WIP


## Test code and steps to reproduce

WIP

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Ensured that CI passes
