### PR TITLE
chore: remove unnecessary enableFreeze from Example.tsx

### DIFF
--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -34,13 +34,10 @@ import SearchBar from './src/screens/SearchBar';
 import Events from './src/screens/Events';
 import Gestures from './src/screens/Gestures';
 
-import { enableFreeze } from 'react-native-screens';
 import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import * as Tests from './src/tests';
-
-enableFreeze();
 
 function isPlatformReady(name: keyof typeof SCREENS) {
   if (Platform.isTV) {


### PR DESCRIPTION
## Description

In `Example.tsx`, we run `enableFreeze()` but it will be overwritten by `enableFreeze(true)` in `App.tsx` as the call from `App.tsx` is run after `Example.tsx`.

In case changing this setting is necessary for testing, it should be changed in top-level file of the app, in our case it is the `App.tsx`.

I left out `enableFreeze` wrapped in `useEffect` in `Test2229.tsx` as it will be called when running the test.

## Changes

- remove `enableFreeze()` from `Example.tsx`

## Checklist

- [ ] Ensured that CI passes
