### PR TITLE
fix(Android,Paper): header config blocks gestures close to the top of the screen

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
@@ -23,24 +23,20 @@ abstract class FabricEnabledHeaderConfigViewGroup(
         mStateWrapper = wrapper
     }
 
-    fun updatePaddings(
-        paddingStart: Int,
-        paddingEnd: Int,
-    ) {
-        // Do nothing on Fabric. This method is used only on Paper.
-    }
-
     fun updateHeaderConfigState(
         width: Int,
         height: Int,
         paddingStart: Int,
         paddingEnd: Int,
     ) {
+        // Implementation of this method differs between Fabric & Paper!
+        Log.i("ConfigShadowNode", "FABRIC updateHeaderConfigState")
         updateState(width, height, paddingStart, paddingEnd)
     }
 
+    // Implementation of this method differs between Fabric & Paper!
     @UiThread
-    fun updateState(
+    private fun updateState(
         width: Int,
         height: Int,
         paddingStart: Int,

--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
@@ -30,7 +30,6 @@ abstract class FabricEnabledHeaderConfigViewGroup(
         paddingEnd: Int,
     ) {
         // Implementation of this method differs between Fabric & Paper!
-        Log.i("ConfigShadowNode", "FABRIC updateHeaderConfigState")
         updateState(width, height, paddingStart, paddingEnd)
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -124,16 +124,13 @@ class ScreenStackHeaderConfig(
 
         val contentInsetEnd = toolbar.currentContentInsetEnd + toolbar.paddingEnd
 
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            updateHeaderConfigState(
-                toolbar.width,
-                toolbar.height,
-                contentInsetStart,
-                contentInsetEnd,
-            )
-        } else {
-            updatePaddings(contentInsetStart, contentInsetEnd)
-        }
+        // Note that implementation of the callee differs between architectures.
+        updateHeaderConfigState(
+            toolbar.width,
+            toolbar.height,
+            contentInsetStart,
+            contentInsetEnd,
+        )
     }
 
     override fun onLayout(

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigShadowNode.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigShadowNode.kt
@@ -10,14 +10,17 @@ internal class ScreenStackHeaderConfigShadowNode(
 ) : LayoutShadowNode() {
     var paddingStart: Float = 0f
     var paddingEnd: Float = 0f
+    var height: Float = 0f
 
     override fun setLocalData(data: Any?) {
         if (data is PaddingBundle) {
             paddingStart = data.paddingStart
             paddingEnd = data.paddingEnd
+            height = data.height
 
             setPadding(Spacing.START, paddingStart)
             setPadding(Spacing.END, paddingEnd)
+            setPosition(Spacing.TOP, -height)
         } else {
             super.setLocalData(data)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/utils/PaddingBundle.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/PaddingBundle.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens.utils
 // Used only on Paper together with `setLocalData` mechanism to pass
 // the information on header paddings to shadow node.
 data class PaddingBundle(
+    val height: Float,
     val paddingStart: Float,
     val paddingEnd: Float,
 )

--- a/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens
 
 import android.content.Context
 import android.view.ViewGroup
+import androidx.annotation.UiThread
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.UIManagerModule
@@ -13,32 +14,40 @@ abstract class FabricEnabledHeaderConfigViewGroup(
 ) : ViewGroup(context) {
     private var lastPaddingStart = 0
     private var lastPaddingEnd = 0
+    private var lastHeight = 0
 
     fun setStateWrapper(wrapper: StateWrapper?) = Unit
 
-    // Do nothing on Paper. This method is used only on Fabric.
     fun updateHeaderConfigState(
         width: Int,
         height: Int,
         paddingStart: Int,
         paddingEnd: Int,
-    ) = Unit
+    ) {
+      // Implementation of this method differs between Fabric & Paper!
+      updateState(width, height, paddingStart, paddingEnd)
+    }
 
-    fun updatePaddings(
+    // Implementation of this method differs between Fabric & Paper!
+    @UiThread
+    private fun updateState(
+        width: Int,
+        height: Int,
         paddingStart: Int,
         paddingEnd: Int,
     ) {
         // Note that on Paper we do not convert these props from px to dip. This is done internally by RN.
-        if (abs(lastPaddingStart - paddingStart) < DELTA && abs(lastPaddingEnd - paddingEnd) < DELTA) {
+        if (abs(lastPaddingStart - paddingStart) < DELTA && abs(lastPaddingEnd - paddingEnd) < DELTA && abs(lastHeight - height) < DELTA) {
             return
         }
 
         lastPaddingStart = paddingStart
         lastPaddingEnd = paddingEnd
+        lastHeight = height
 
         val reactContext = context as? ReactContext
         val uiManagerModule = reactContext?.getNativeModule(UIManagerModule::class.java)
-        uiManagerModule?.setViewLocalData(this.id, PaddingBundle(paddingStart.toFloat(), paddingEnd.toFloat()))
+        uiManagerModule?.setViewLocalData(this.id, PaddingBundle(height.toFloat(), paddingStart.toFloat(), paddingEnd.toFloat()))
     }
 
     companion object {


### PR DESCRIPTION
## Description

Fixes #2758

#2466 removed old workaround for header config blocking gestures - we just set top: `-100%` 
to place the headerconfig in the top of the screen effectively preventing blocking. 

#2466 removed these styles & frame correction is now applied directly in shadow node. This is done fine
on Fabric, however the solution was not replicated on Paper.

## Changes

Beside padding information we now send native toolbar height to header config shadow node on Paper.
This information is used there to offset the header config position by this value.

Should solve the problem.

### Screenshots

| before | after |
| - | - |
| <img src="https://github.com/user-attachments/assets/640cad09-584d-4983-af92-11ae68d49f9f" alt="before" /> | <img src="https://github.com/user-attachments/assets/de15190e-e999-495f-8a6d-abf7f375d468" alt="after" /> |


## Test code and steps to reproduce

`Example` -> `Header options` -> click on the very top button (very top of it). Previously the button was not effectively 
clicked. Now it works.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
