### PR TITLE
fix(Android): keep `formSheet` selected detent index after fragment reattachment

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -482,7 +482,14 @@ class Screen(
             ?.dispatchEvent(HeaderHeightChangeEvent(surfaceId, id, headerHeight))
     }
 
-    internal fun notifySheetDetentChange(
+    internal fun onSheetDetentChanged(
+        detentIndex: Int,
+        isStable: Boolean,
+    ) {
+        dispatchSheetDetentChanged(detentIndex, isStable)
+    }
+
+    private fun dispatchSheetDetentChanged(
         detentIndex: Int,
         isStable: Boolean,
     ) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -466,7 +465,6 @@ class ScreenStackFragment :
 
     private fun requireSheetDelegate(): SheetDelegate {
         if (sheetDelegate == null) {
-            Log.i(TAG, "create sheet delegate")
             sheetDelegate = SheetDelegate(screen)
         }
         return sheetDelegate!!

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -7,8 +7,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -16,33 +16,23 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
-import android.view.WindowManager
 import android.view.animation.Animation
 import android.view.animation.AnimationSet
 import android.view.animation.Transformation
-import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
-import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ReactPointerEventsView
 import com.facebook.react.uimanager.UIManagerHelper
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import com.swmansion.rnscreens.bottomsheet.DimmingViewManager
 import com.swmansion.rnscreens.bottomsheet.SheetDelegate
-import com.swmansion.rnscreens.bottomsheet.SheetUtils
-import com.swmansion.rnscreens.bottomsheet.isSheetFitToContents
-import com.swmansion.rnscreens.bottomsheet.useSingleDetent
-import com.swmansion.rnscreens.bottomsheet.useThreeDetents
-import com.swmansion.rnscreens.bottomsheet.useTwoDetents
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
 import com.swmansion.rnscreens.events.ScreenAnimationDelegate
 import com.swmansion.rnscreens.events.ScreenDismissedEvent
@@ -198,7 +188,7 @@ class ScreenStackFragment :
                 ).apply {
                     behavior =
                         if (screen.usesFormSheetPresentation()) {
-                            createAndConfigureBottomSheetBehaviour()
+                            createBottomSheetBehaviour()
                         } else if (isToolbarTranslucent) {
                             null
                         } else {
@@ -237,22 +227,16 @@ class ScreenStackFragment :
             toolbar?.let { appBarLayout?.addView(it.recycle()) }
             setHasOptionsMenu(true)
         }
-        return coordinatorLayout
-    }
-
-    override fun onViewCreated(
-        view: View,
-        savedInstanceState: Bundle?,
-    ) {
-        super.onViewCreated(view, savedInstanceState)
 
         if (!screen.usesFormSheetPresentation()) {
-            return
+            return coordinatorLayout
         }
 
-        sheetDelegate = SheetDelegate(screen)
+        // Lifecycle of sheet delegate is tied to fragment.
+        val sheetDelegate = requireSheetDelegate()
 
-        assert(view == coordinatorLayout)
+        sheetDelegate.configureBottomSheetBehaviour(screen.sheetBehavior!!)
+
         val dimmingDelegate = requireDimmingDelegate(forceCreation = true)
         dimmingDelegate.onViewHierarchyCreated(screen, coordinatorLayout)
         dimmingDelegate.onBehaviourAttached(screen, screen.sheetBehavior!!)
@@ -263,6 +247,15 @@ class ScreenStackFragment :
             View.MeasureSpec.makeMeasureSpec(container.height, View.MeasureSpec.EXACTLY),
         )
         coordinatorLayout.layout(0, 0, container.width, container.height)
+
+        return coordinatorLayout
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
     }
 
     override fun onCreateAnimation(
@@ -344,205 +337,7 @@ class ScreenStackFragment :
         return animatorSet
     }
 
-    /**
-     * This method might return slightly different values depending on code path,
-     * but during testing I've found this effect negligible. For practical purposes
-     * this is acceptable.
-     */
-    private fun tryResolveContainerHeight(): Int? {
-        if (screen.container != null) {
-            return screenStack.height
-        }
-
-        context
-            ?.resources
-            ?.displayMetrics
-            ?.heightPixels
-            ?.let { return it }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            (context?.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)
-                ?.currentWindowMetrics
-                ?.bounds
-                ?.height()
-                ?.let { return it }
-        }
-        return null
-    }
-
-    private val keyboardSheetCallback =
-        object : BottomSheetCallback() {
-            @RequiresApi(Build.VERSION_CODES.M)
-            override fun onStateChanged(
-                bottomSheet: View,
-                newState: Int,
-            ) {
-                if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
-                    val isImeVisible =
-                        WindowInsetsCompat
-                            .toWindowInsetsCompat(bottomSheet.rootWindowInsets)
-                            .isVisible(WindowInsetsCompat.Type.ime())
-                    if (isImeVisible) {
-                        // Does it not interfere with React Native focus mechanism? In any case I'm not aware
-                        // of different way of hiding the keyboard.
-                        // https://stackoverflow.com/questions/1109022/how-can-i-close-hide-the-android-soft-keyboard-programmatically
-                        // https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/visibility
-
-                        // I want to be polite here and request focus before dismissing the keyboard,
-                        // however even if it fails I want to try to hide the keyboard. This sometimes works...
-                        bottomSheet.requestFocus()
-                        val imm = requireContext().getSystemService(InputMethodManager::class.java)
-                        imm.hideSoftInputFromWindow(bottomSheet.windowToken, 0)
-                    }
-                }
-            }
-
-            override fun onSlide(
-                bottomSheet: View,
-                slideOffset: Float,
-            ) = Unit
-        }
-
-    internal fun configureBottomSheetBehaviour(
-        behavior: BottomSheetBehavior<Screen>,
-        keyboardState: KeyboardState = KeyboardNotVisible,
-    ): BottomSheetBehavior<Screen> {
-        val containerHeight = tryResolveContainerHeight()
-        check(containerHeight != null) {
-            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
-        }
-
-        behavior.apply {
-            isHideable = true
-            isDraggable = true
-        }
-
-        screen.footer?.registerWithSheetBehavior(behavior)
-
-        return when (keyboardState) {
-            is KeyboardNotVisible -> {
-                when (screen.sheetDetents.count()) {
-                    1 ->
-                        behavior.apply {
-                            val height =
-                                if (screen.isSheetFitToContents()) {
-                                    screen.contentWrapper
-                                        .get()
-                                        ?.height
-                                        .takeIf { screen.contentWrapper.get()?.isLaidOut == true }
-                                } else {
-                                    (screen.sheetDetents.first() * containerHeight).toInt()
-                                }
-                            useSingleDetent(height = height)
-                        }
-
-                    2 ->
-                        behavior.useTwoDetents(
-                            state =
-                                SheetUtils.sheetStateFromDetentIndex(
-                                    screen.sheetInitialDetentIndex,
-                                    screen.sheetDetents.count(),
-                                ),
-                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
-                            secondHeight = (screen.sheetDetents[1] * containerHeight).toInt(),
-                        )
-
-                    3 ->
-                        behavior.useThreeDetents(
-                            state =
-                                SheetUtils.sheetStateFromDetentIndex(
-                                    screen.sheetInitialDetentIndex,
-                                    screen.sheetDetents.count(),
-                                ),
-                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
-                            halfExpandedRatio = (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat(),
-                            expandedOffsetFromTop = ((1 - screen.sheetDetents[2]) * containerHeight).toInt(),
-                        )
-
-                    else -> throw IllegalStateException(
-                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
-                    )
-                }
-            }
-
-            is KeyboardVisible -> {
-                val newMaxHeight =
-                    if (behavior.maxHeight - keyboardState.height > 1) {
-                        behavior.maxHeight - keyboardState.height
-                    } else {
-                        behavior.maxHeight
-                    }
-                when (screen.sheetDetents.count()) {
-                    1 ->
-                        behavior.apply {
-                            useSingleDetent(height = newMaxHeight)
-                            addBottomSheetCallback(keyboardSheetCallback)
-                        }
-
-                    2 ->
-                        behavior.apply {
-                            useTwoDetents(
-                                state = BottomSheetBehavior.STATE_EXPANDED,
-                                secondHeight = newMaxHeight,
-                            )
-                            addBottomSheetCallback(keyboardSheetCallback)
-                        }
-
-                    3 ->
-                        behavior.apply {
-                            useThreeDetents(
-                                state = BottomSheetBehavior.STATE_EXPANDED,
-                            )
-                            maxHeight = newMaxHeight
-                            addBottomSheetCallback(keyboardSheetCallback)
-                        }
-
-                    else -> throw IllegalStateException(
-                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
-                    )
-                }
-            }
-
-            is KeyboardDidHide -> {
-                // Here we assume that the keyboard was either closed explicitly by user,
-                // or the user dragged the sheet down. In any case the state should
-                // stay unchanged.
-
-                behavior.removeBottomSheetCallback(keyboardSheetCallback)
-                when (screen.sheetDetents.count()) {
-                    1 ->
-                        behavior.useSingleDetent(
-                            height = (screen.sheetDetents.first() * containerHeight).toInt(),
-                            forceExpandedState = false,
-                        )
-
-                    2 ->
-                        behavior.useTwoDetents(
-                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
-                            secondHeight = (screen.sheetDetents[1] * containerHeight).toInt(),
-                        )
-
-                    3 ->
-                        behavior.useThreeDetents(
-                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
-                            halfExpandedRatio = (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat(),
-                            expandedOffsetFromTop = ((1 - screen.sheetDetents[2]) * containerHeight).toInt(),
-                        )
-
-                    else -> throw IllegalStateException(
-                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
-                    )
-                }
-            }
-        }
-    }
-
     private fun createBottomSheetBehaviour(): BottomSheetBehavior<Screen> = BottomSheetBehavior<Screen>()
-
-    // In general it would be great to create BottomSheetBehaviour only via this method as it runs some
-    // side effects.
-    private fun createAndConfigureBottomSheetBehaviour(): BottomSheetBehavior<Screen> =
-        configureBottomSheetBehaviour(createBottomSheetBehaviour())
 
     private fun resolveBackgroundColor(screen: Screen): Int? {
         val screenColor =
@@ -675,6 +470,14 @@ class ScreenStackFragment :
             dimmingDelegate = DimmingViewManager(screen.reactContext, screen)
         }
         return dimmingDelegate!!
+    }
+
+    private fun requireSheetDelegate(): SheetDelegate {
+        if (sheetDelegate == null) {
+            Log.i(TAG, "create sheet delegate")
+            sheetDelegate = SheetDelegate(screen)
+        }
+        return sheetDelegate!!
     }
 
     private class ScreensCoordinatorLayout(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -109,11 +109,6 @@ class SheetDelegate(
         }
     }
 
-    fun onSheetBehaviorAttached(behavior: BottomSheetBehavior<Screen>) {
-        // There is a guard internally that does not allow the callback to be duplicated.
-        behavior.addBottomSheetCallback(sheetStateObserver)
-    }
-
     internal fun configureBottomSheetBehaviour(
         behavior: BottomSheetBehavior<Screen>,
         keyboardState: KeyboardState = KeyboardNotVisible,
@@ -129,6 +124,7 @@ class SheetDelegate(
             isDraggable = true
         }
 
+        // There is a guard internally that does not allow the callback to be duplicated.
         behavior.addBottomSheetCallback(sheetStateObserver)
 
         Log.i(TAG, "Configure with selectedDetentIndex: $selectedDetentIndex")

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -1,6 +1,12 @@
 package com.swmansion.rnscreens.bottomsheet
 
+import android.content.Context
+import android.os.Build
+import android.util.Log
 import android.view.View
+import android.view.WindowManager
+import android.view.inputmethod.InputMethodManager
+import androidx.annotation.RequiresApi
 import androidx.core.graphics.Insets
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.WindowInsetsCompat
@@ -8,6 +14,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.swmansion.rnscreens.InsetsObserverProxy
 import com.swmansion.rnscreens.KeyboardDidHide
 import com.swmansion.rnscreens.KeyboardNotVisible
@@ -23,13 +30,16 @@ class SheetDelegate(
 
     private var isKeyboardVisible: Boolean = false
     private var keyboardState: KeyboardState = KeyboardNotVisible
-    private var lastStableDetentIndex: Int = screen.sheetInitialDetentIndex
+
+    var lastStableDetentIndex: Int = screen.sheetInitialDetentIndex
+        private set
 
     @BottomSheetBehavior.State
-    private var lastStableState: Int = SheetUtils.sheetStateFromDetentIndex(
+    var lastStableState: Int = SheetUtils.sheetStateFromDetentIndex(
         screen.sheetInitialDetentIndex,
         screen.sheetDetents.count()
     )
+        private set
 
     private val sheetStateObserver = SheetStateObserver()
 
@@ -85,12 +95,160 @@ class SheetDelegate(
                 newState,
                 screen.sheetDetents.count()
             )
+
+            Log.i(
+                TAG,
+                "lastStableState: $lastStableState, lastStableDetentIndex: $lastStableDetentIndex"
+            )
         }
 
         screen.onSheetDetentChanged(lastStableDetentIndex, isStable)
 
         if (shouldDismissSheetInState(newState)) {
             stackFragment.dismissSelf()
+        }
+    }
+
+    fun onSheetBehaviorAttached(behavior: BottomSheetBehavior<Screen>) {
+        // There is a guard internally that does not allow the callback to be duplicated.
+        behavior.addBottomSheetCallback(sheetStateObserver)
+    }
+
+    internal fun configureBottomSheetBehaviour(
+        behavior: BottomSheetBehavior<Screen>,
+        keyboardState: KeyboardState = KeyboardNotVisible,
+        selectedDetentIndex: Int = lastStableDetentIndex,
+    ): BottomSheetBehavior<Screen> {
+
+        val containerHeight = tryResolveContainerHeight()
+        check(containerHeight != null) {
+            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
+        }
+
+        behavior.apply {
+            isHideable = true
+            isDraggable = true
+        }
+
+        Log.i(TAG, "Configure with selectedDetentIndex: $selectedDetentIndex")
+
+        screen.footer?.registerWithSheetBehavior(behavior)
+
+        return when (keyboardState) {
+            is KeyboardNotVisible -> {
+                when (screen.sheetDetents.count()) {
+                    1 ->
+                        behavior.apply {
+                            val height =
+                                if (screen.isSheetFitToContents()) {
+                                    screen.contentWrapper
+                                        .get()
+                                        ?.height
+                                        .takeIf { screen.contentWrapper.get()?.isLaidOut == true }
+                                } else {
+                                    (screen.sheetDetents.first() * containerHeight).toInt()
+                                }
+                            useSingleDetent(height = height)
+                        }
+
+                    2 ->
+                        behavior.useTwoDetents(
+                            state =
+                            SheetUtils.sheetStateFromDetentIndex(
+                                selectedDetentIndex,
+                                screen.sheetDetents.count(),
+                            ),
+                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
+                            secondHeight = (screen.sheetDetents[1] * containerHeight).toInt(),
+                        )
+
+                    3 ->
+                        behavior.useThreeDetents(
+                            state =
+                            SheetUtils.sheetStateFromDetentIndex(
+                                selectedDetentIndex,
+                                screen.sheetDetents.count(),
+                            ),
+                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
+                            halfExpandedRatio = (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat(),
+                            expandedOffsetFromTop = ((1 - screen.sheetDetents[2]) * containerHeight).toInt(),
+                        )
+
+                    else -> throw IllegalStateException(
+                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
+                    )
+                }
+            }
+
+            is KeyboardVisible -> {
+                val newMaxHeight =
+                    if (behavior.maxHeight - keyboardState.height > 1) {
+                        behavior.maxHeight - keyboardState.height
+                    } else {
+                        behavior.maxHeight
+                    }
+                when (screen.sheetDetents.count()) {
+                    1 ->
+                        behavior.apply {
+                            useSingleDetent(height = newMaxHeight)
+                            addBottomSheetCallback(keyboardSheetCallback)
+                        }
+
+                    2 ->
+                        behavior.apply {
+                            useTwoDetents(
+                                state = BottomSheetBehavior.STATE_EXPANDED,
+                                secondHeight = newMaxHeight,
+                            )
+                            addBottomSheetCallback(keyboardSheetCallback)
+                        }
+
+                    3 ->
+                        behavior.apply {
+                            useThreeDetents(
+                                state = BottomSheetBehavior.STATE_EXPANDED,
+                            )
+                            maxHeight = newMaxHeight
+                            addBottomSheetCallback(keyboardSheetCallback)
+                        }
+
+                    else -> throw IllegalStateException(
+                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
+                    )
+                }
+            }
+
+            is KeyboardDidHide -> {
+                // Here we assume that the keyboard was either closed explicitly by user,
+                // or the user dragged the sheet down. In any case the state should
+                // stay unchanged.
+
+                behavior.removeBottomSheetCallback(keyboardSheetCallback)
+                when (screen.sheetDetents.count()) {
+                    1 ->
+                        behavior.useSingleDetent(
+                            height = (screen.sheetDetents.first() * containerHeight).toInt(),
+                            forceExpandedState = false,
+                        )
+
+                    2 ->
+                        behavior.useTwoDetents(
+                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
+                            secondHeight = (screen.sheetDetents[1] * containerHeight).toInt(),
+                        )
+
+                    3 ->
+                        behavior.useThreeDetents(
+                            firstHeight = (screen.sheetDetents[0] * containerHeight).toInt(),
+                            halfExpandedRatio = (screen.sheetDetents[1] / screen.sheetDetents[2]).toFloat(),
+                            expandedOffsetFromTop = ((1 - screen.sheetDetents[2]) * containerHeight).toInt(),
+                        )
+
+                    else -> throw IllegalStateException(
+                        "[RNScreens] Invalid detent count ${screen.sheetDetents.count()}. Expected at most 3.",
+                    )
+                }
+            }
         }
     }
 
@@ -106,7 +264,7 @@ class SheetDelegate(
             isKeyboardVisible = true
             keyboardState = KeyboardVisible(imeInset.bottom)
             sheetBehavior?.let {
-                stackFragment.configureBottomSheetBehaviour(it, keyboardState)
+                this.configureBottomSheetBehaviour(it, keyboardState)
             }
 
             val prevInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
@@ -124,9 +282,9 @@ class SheetDelegate(
         } else {
             sheetBehavior?.let {
                 if (isKeyboardVisible) {
-                    stackFragment.configureBottomSheetBehaviour(it, KeyboardDidHide)
+                    this.configureBottomSheetBehaviour(it, KeyboardDidHide)
                 } else if (keyboardState != KeyboardNotVisible) {
-                    stackFragment.configureBottomSheetBehaviour(it, KeyboardNotVisible)
+                    this.configureBottomSheetBehaviour(it, KeyboardNotVisible)
                 } else {
                 }
             }
@@ -146,6 +304,67 @@ class SheetDelegate(
 
     private fun shouldDismissSheetInState(@BottomSheetBehavior.State state: Int) =
         state == BottomSheetBehavior.STATE_HIDDEN
+
+    /**
+     * This method might return slightly different values depending on code path,
+     * but during testing I've found this effect negligible. For practical purposes
+     * this is acceptable.
+     */
+    private fun tryResolveContainerHeight(): Int? {
+        screen.container?.let { return it.height }
+
+        val context = screen.reactContext
+
+        context
+            .resources
+            ?.displayMetrics
+            ?.heightPixels
+            ?.let { return it }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            (context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)
+                ?.currentWindowMetrics
+                ?.bounds
+                ?.height()
+                ?.let { return it }
+        }
+        return null
+    }
+
+    private val keyboardSheetCallback =
+        object : BottomSheetCallback() {
+            @RequiresApi(Build.VERSION_CODES.M)
+            override fun onStateChanged(
+                bottomSheet: View,
+                newState: Int,
+            ) {
+                if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+                    val isImeVisible =
+                        WindowInsetsCompat
+                            .toWindowInsetsCompat(bottomSheet.rootWindowInsets)
+                            .isVisible(WindowInsetsCompat.Type.ime())
+                    if (isImeVisible) {
+                        // Does it not interfere with React Native focus mechanism? In any case I'm not aware
+                        // of different way of hiding the keyboard.
+                        // https://stackoverflow.com/questions/1109022/how-can-i-close-hide-the-android-soft-keyboard-programmatically
+                        // https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/visibility
+
+                        // I want to be polite here and request focus before dismissing the keyboard,
+                        // however even if it fails I want to try to hide the keyboard. This sometimes works...
+                        bottomSheet.requestFocus()
+                        val imm =
+                            screen.reactContext.getSystemService(InputMethodManager::class.java)
+                        imm.hideSoftInputFromWindow(bottomSheet.windowToken, 0)
+                    }
+                }
+            }
+
+            override fun onSlide(
+                bottomSheet: View,
+                slideOffset: Float,
+            ) = Unit
+        }
+
 
     private inner class SheetStateObserver : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(bottomSheet: View, newState: Int) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -2,7 +2,6 @@ package com.swmansion.rnscreens.bottomsheet
 
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
@@ -95,11 +94,6 @@ class SheetDelegate(
                     newState,
                     screen.sheetDetents.count(),
                 )
-
-            Log.i(
-                TAG,
-                "lastStableState: $lastStableState, lastStableDetentIndex: $lastStableDetentIndex",
-            )
         }
 
         screen.onSheetDetentChanged(lastStableDetentIndex, isStable)
@@ -126,8 +120,6 @@ class SheetDelegate(
 
         // There is a guard internally that does not allow the callback to be duplicated.
         behavior.addBottomSheetCallback(sheetStateObserver)
-
-        Log.i(TAG, "Configure with selectedDetentIndex: $selectedDetentIndex")
 
         screen.footer?.registerWithSheetBehavior(behavior)
 


### PR DESCRIPTION
## Description

On each fragment reattachment we reconfigure the behaviour, but we do not keep the state.
Each time we use `sheetInitialDetentIndex` instead of the last stable detent index. 

## Changes

This PR moves sheet configuration to `SheetDelegate` to declutter `ScreenStackFragment` & uses appropriate value during configuration.

Lifecycle of the `SheetDelegate` is tied to the fragment, therefore on fragment **recreation** (not *reattachment*) the state still will be lost.

### Recordings

> [!note]
There still is no animation when navigating from `formSheet` to `push` in the same stack, but it is separate issue (already WIP to handle this).


| before | after |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/e42b00db-bd72-4265-8f5e-9c5bbf0425dd" alt="before" /> | <video src="https://github.com/user-attachments/assets/c2e6aae4-e168-4662-8e28-32ddbfeae0aa" alt="after" /> |


## Test code and steps to reproduce

`TestFormSheet`

1. navigate to sheet
2. expand it
3. navigate to "second"
4. go back
5. observe that sheet stays in expanded state

## Checklist

- [ ] Ensured that CI passes
