### PR TITLE
fix(CI): change order of events in Fabric iOS events e2e test

### DIFF
--- a/FabricExample/e2e/examplesTests/events.e2e.ts
+++ b/FabricExample/e2e/examplesTests/events.e2e.ts
@@ -13,14 +13,7 @@ const pressBack = async () => {
 const awaitClassicalEventBehavior = async () => {
   if (device.getPlatform() === 'ios') {
     // The order of events in this test differs from the Paper version of the same test.
-    // When screen is removed after using iOS native back button, native side notifies JS via:
-    // 1. onDismissed => in reaction to this event, a navigation action is dispatched,
-    //    which causes emission of beforeRemove event;
-    // 2. onDisappear => in reaction to this event, transitionEnd with closing=true is emitted.
-    // On Fabric, these events are handled in the same order as the order of notifications from the native side.
-    // On Paper, this is not the case - onDismissed is executed after two transitionEnd events are already handled.
-    // onDismissed is dispatched asynchronously from the native side and this probably delays handling it on JS side
-    // but I am not sure of the details why it is dispatched asynchronously.
+    // Please see https://github.com/software-mansion/react-native-screens/pull/2785 for details.
     await expect(
       element(by.text('9. Chats | transitionStart | closing')),
     ).toExist();

--- a/FabricExample/e2e/examplesTests/events.e2e.ts
+++ b/FabricExample/e2e/examplesTests/events.e2e.ts
@@ -12,6 +12,15 @@ const pressBack = async () => {
 
 const awaitClassicalEventBehavior = async () => {
   if (device.getPlatform() === 'ios') {
+    // The order of events in this test differs from the Paper version of the same test.
+    // When screen is removed after using iOS native back button, native side notifies JS via:
+    // 1. onDismissed => in reaction to this event, a navigation action is dispatched,
+    //    which causes emission of beforeRemove event;
+    // 2. onDisappear => in reaction to this event, transitionEnd with closing=true is emitted.
+    // On Fabric, these events are handled in the same order as the order of notifications from the native side.
+    // On Paper, this is not the case - onDismissed is executed after two transitionEnd events are already handled.
+    // onDismissed is dispatched asynchronously from the native side and this probably delays handling it on JS side
+    // but I am not sure of the details why it is dispatched asynchronously.
     await expect(
       element(by.text('9. Chats | transitionStart | closing')),
     ).toExist();

--- a/FabricExample/e2e/examplesTests/events.e2e.ts
+++ b/FabricExample/e2e/examplesTests/events.e2e.ts
@@ -21,14 +21,14 @@ const awaitClassicalEventBehavior = async () => {
     await expect(
       element(by.text('11. Main | transitionStart | opening')),
     ).toExist();
+    await expect(element(by.text('12. Privacy | beforeRemove'))).toExist();
+    await expect(element(by.text('13. Chats | beforeRemove'))).toExist();
     await expect(
-      element(by.text('12. Chats | transitionEnd | closing')),
+      element(by.text('14. Chats | transitionEnd | closing')),
     ).toExist();
     await expect(
-      element(by.text('13. Privacy | transitionEnd | closing')),
+      element(by.text('15. Privacy | transitionEnd | closing')),
     ).toExist();
-    await expect(element(by.text('14. Privacy | beforeRemove'))).toExist();
-    await expect(element(by.text('15. Chats | beforeRemove'))).toExist();
     await expect(
       element(by.text('16. Main | transitionEnd | opening')),
     ).toExist();


### PR DESCRIPTION
## Description

Changed order of events in Fabric iOS events e2e test.

The order of events in this test differs from the Paper version of the same test. When screen is removed after using iOS native back button, native side notifies JS via:

1. onDismissed => in reaction to this event, a navigation action is dispatched, which causes emission of beforeRemove event;
2. onDisappear => in reaction to this event, transitionEnd with closing=true is emitted.

On Fabric, these events are handled in the same order as the order of notifications from the native side. On Paper, this is not the case - onDismissed is executed after two transitionEnd events are already handled. onDismissed is dispatched asynchronously from the native side (it is wrapped in `dispatch_async`!) and this probably delays handling it on JS side but I am not sure of the details why it is dispatched asynchronously.

Currently this divergence between architectures seems to not lead to any issues. Just let it be noted & not forgotten. 

## Changes

- change order of assertions
- add comment with explanation

## Test code and steps to reproduce

Run Fabric iOS CI.

## Checklist

- [x] Ensured that CI for Fabric iOS passes
