### PR TITLE
fix(CI): add missing AVD dependency to Paper Android e2e workflow

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -60,9 +60,11 @@ jobs:
         run: yarn
 
       - name: Install AVD dependencies
+        # libxkbfile1 is removed by "Free Disk Space (Ubuntu)" step first. Here we install it again
+        # as it seems to be needed by the emulator.
         run: |
           sudo apt update
-          sudo apt-get install -y libpulse0 libgl1
+          sudo apt-get install -y libpulse0 libgl1 libxkbfile1
 
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}


### PR DESCRIPTION
## Description

Add missing AVD dependency.

## Changes

- add missing AVD dependency to android-e2e-test (Paper) workflow.


## Test code and steps to reproduce

Run CI for Paper Android.

## Checklist

- [ ] Ensured that CI passes for Paper Android
