### PR TITLE
test(e2e,Fabric): add e2e tests for issue/PR examples 42..528

### DIFF
--- a/FabricExample/Gemfile.lock
+++ b/FabricExample/Gemfile.lock
@@ -95,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  xcodeproj (< 1.26.0)
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -1,7 +1,7 @@
 import { device } from 'detox';
 
-describe('E2E', () => {
-  beforeAll(async () => {
+describe('Tests from PRs and issues', () => {
+  beforeEach(async () => {
     await device.reloadReactNative();
   });
 

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -9,19 +9,66 @@ describe('Test432', () => {
     await waitFor(element(by.id('root-screen-tests-Test432')))
     .toBeVisible()
     .whileElement(by.id('root-screen-examples-scrollview'))
-    .scroll(100, 'down', NaN, 0.85);
+    .scroll(600, 'down', NaN, 0.85);
 
     await expect(element(by.id('root-screen-tests-Test432'))).toBeVisible();
     await element(by.id('root-screen-tests-Test432')).tap();
   });
 
+  it('home-square should be fully visible', async () => {
+    await expect(element(by.id('home-square'))).toBeVisible(100);
+  });
 
-  // home home-square
-  // details details-red-square | click | details-green-square | click | details-red-square | back
-  // info info-green-square-1 | click | info-red-square info-green-square-1 info-green-square-2 | click | info-green-square-1 | back
-  // settings settings-square
-  // za kazdym powrotem do home sprawdzic czarny square
+  it('squares from details screen should be fully visible', async () => {
+    await element(by.id('go-to-details')).tap();
+    await expect(element(by.id('details-red-square'))).toBeVisible(100);
 
+    await element(by.id('details-toggle-subviews')).tap();
+    // On Android, we need to wait for some elements (e.g. at first, this square is only 25% visible)
+    waitFor(element(by.id('details-green-square'))).toBeVisible(100);
 
+    await element(by.id('details-toggle-subviews')).tap();
+    await expect(element(by.id('details-red-square'))).toBeVisible(100);
 
+    if (device.getPlatform() === 'ios') {
+      await element(by.id('BackButton')).tap();
+    } else {
+      await device.pressBack();
+    }
+
+    await expect(element(by.id('home-square'))).toBeVisible(100);
+  });
+
+  it('squares from info screen should be fully visible', async () => {
+    await element(by.id('go-to-info')).tap();
+    await expect(element(by.id('info-green-square-1'))).toBeVisible(100);
+
+    await element(by.id('info-toggle-subviews')).tap();
+    waitFor(element(by.id('info-green-square-1'))).toBeVisible(100);
+    waitFor(element(by.id('info-green-square-2'))).toBeVisible(100);
+    waitFor(element(by.id('info-red-square'))).toBeVisible(100);
+
+    await element(by.id('info-toggle-subviews')).tap();
+    waitFor(element(by.id('info-green-square-1'))).toBeVisible(100);
+
+    if (device.getPlatform() === 'ios') {
+      await element(by.id('BackButton')).tap();
+    } else {
+      await device.pressBack();
+    }
+
+    await expect(element(by.id('home-square'))).toBeVisible(100);
+  });
+
+  it('squares from settings screen should be fully visible', async () => {
+    await element(by.id('show-settings')).tap();
+    await expect(element(by.id('settings-square'))).toBeVisible(100);
+
+    if (device.getPlatform() === 'ios') {
+      await element(by.id('settings-text')).swipe('down', 'fast');
+    } else {
+      await device.pressBack();
+    }
+    await expect(element(by.id('home-square'))).toBeVisible(100);
+  });
 });

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -16,19 +16,19 @@ describe('Test432', () => {
   });
 
   it('headerRight element should be fully visible', async () => {
-    await expect(element(by.id('home-square'))).toBeVisible(100);
+    await expect(element(by.id('home-headerRight'))).toBeVisible(100);
   });
 
   it('headerRight elements should toggle and stay fully visible', async () => {
-    await element(by.id('go-to-details')).tap();
-    await expect(element(by.id('details-red-square'))).toBeVisible(100);
+    await element(by.id('home-button-go-to-details')).tap();
+    await expect(element(by.id('details-headerRight-red'))).toBeVisible(100);
 
-    await element(by.id('details-toggle-subviews')).tap();
+    await element(by.id('details-button-toggle-subviews')).tap();
     // On Android, we need to wait for some elements (e.g. at first, this square is only 25% visible)
-    waitFor(element(by.id('details-green-square'))).toBeVisible(100);
+    waitFor(element(by.id('details-headerRight-green'))).toBeVisible(100);
 
-    await element(by.id('details-toggle-subviews')).tap();
-    await expect(element(by.id('details-red-square'))).toBeVisible(100);
+    await element(by.id('details-button-toggle-subviews')).tap();
+    await expect(element(by.id('details-headerRight-red'))).toBeVisible(100);
 
     if (device.getPlatform() === 'ios') {
       await element(by.id('BackButton')).tap();
@@ -36,20 +36,20 @@ describe('Test432', () => {
       await device.pressBack();
     }
 
-    await expect(element(by.id('home-square'))).toBeVisible(100);
+    await expect(element(by.id('home-headerRight'))).toBeVisible(100);
   });
 
   it('headerLeft and headerRight elements should toggle and stay fully visible', async () => {
-    await element(by.id('go-to-info')).tap();
-    await expect(element(by.id('info-green-square-1'))).toBeVisible(100);
+    await element(by.id('home-button-go-to-info')).tap();
+    await expect(element(by.id('info-headerRight-green-1'))).toBeVisible(100);
 
-    await element(by.id('info-toggle-subviews')).tap();
-    waitFor(element(by.id('info-green-square-1'))).toBeVisible(100);
-    waitFor(element(by.id('info-green-square-2'))).toBeVisible(100);
-    waitFor(element(by.id('info-red-square'))).toBeVisible(100);
+    await element(by.id('info-button-toggle-subviews')).tap();
+    waitFor(element(by.id('info-headerRight-green-1'))).toBeVisible(100);
+    waitFor(element(by.id('info-headerRight-green-2'))).toBeVisible(100);
+    waitFor(element(by.id('info-headerLeft-red'))).toBeVisible(100);
 
-    await element(by.id('info-toggle-subviews')).tap();
-    waitFor(element(by.id('info-green-square-1'))).toBeVisible(100);
+    await element(by.id('info-button-toggle-subviews')).tap();
+    waitFor(element(by.id('info-headerRight-green-1'))).toBeVisible(100);
 
     if (device.getPlatform() === 'ios') {
       await element(by.id('BackButton')).tap();
@@ -57,19 +57,19 @@ describe('Test432', () => {
       await device.pressBack();
     }
 
-    await expect(element(by.id('home-square'))).toBeVisible(100);
+    await expect(element(by.id('home-headerRight'))).toBeVisible(100);
   });
 
   it('headerRight element on modal should be fully visible', async () => {
-    await element(by.id('show-settings')).tap();
-    await expect(element(by.id('settings-square'))).toBeVisible(100);
+    await element(by.id('home-button-show-settings')).tap();
+    await expect(element(by.id('settings-headerRight'))).toBeVisible(100);
 
     if (device.getPlatform() === 'ios') {
       await element(by.id('settings-text')).swipe('down', 'fast');
     } else {
       await device.pressBack();
     }
-    await expect(element(by.id('home-square'))).toBeVisible(100);
+    await expect(element(by.id('home-headerRight'))).toBeVisible(100);
   });
 });
 

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -5,21 +5,21 @@ describe('Test432', () => {
     await device.reloadReactNative();
   });
 
-  it('should Test432 exist', async () => {
+  it('Test432 should exist', async () => {
     await waitFor(element(by.id('root-screen-tests-Test432')))
-    .toBeVisible()
-    .whileElement(by.id('root-screen-examples-scrollview'))
-    .scroll(600, 'down', NaN, 0.85);
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
 
     await expect(element(by.id('root-screen-tests-Test432'))).toBeVisible();
     await element(by.id('root-screen-tests-Test432')).tap();
   });
 
-  it('home-square should be fully visible', async () => {
+  it('headerRight element should be fully visible', async () => {
     await expect(element(by.id('home-square'))).toBeVisible(100);
   });
 
-  it('squares from details screen should be fully visible', async () => {
+  it('headerRight elements should toggle and stay fully visible', async () => {
     await element(by.id('go-to-details')).tap();
     await expect(element(by.id('details-red-square'))).toBeVisible(100);
 
@@ -39,7 +39,7 @@ describe('Test432', () => {
     await expect(element(by.id('home-square'))).toBeVisible(100);
   });
 
-  it('squares from info screen should be fully visible', async () => {
+  it('headerLeft and headerRight elements should toggle and stay fully visible', async () => {
     await element(by.id('go-to-info')).tap();
     await expect(element(by.id('info-green-square-1'))).toBeVisible(100);
 
@@ -60,7 +60,7 @@ describe('Test432', () => {
     await expect(element(by.id('home-square'))).toBeVisible(100);
   });
 
-  it('squares from settings screen should be fully visible', async () => {
+  it('headerRight element on modal should be fully visible', async () => {
     await element(by.id('show-settings')).tap();
     await expect(element(by.id('settings-square'))).toBeVisible(100);
 
@@ -80,17 +80,17 @@ if (device.getPlatform() === 'ios') {
       await device.reloadReactNative();
     });
 
-    it('should Test528 exist', async () => {
+    it('Test528 should exist', async () => {
       await waitFor(element(by.id('root-screen-tests-Test528')))
-      .toBeVisible()
-      .whileElement(by.id('root-screen-examples-scrollview'))
-      .scroll(600, 'down', NaN, 0.85);
+        .toBeVisible()
+        .whileElement(by.id('root-screen-examples-scrollview'))
+        .scroll(600, 'down', NaN, 0.85);
 
       await expect(element(by.id('root-screen-tests-Test528'))).toBeVisible();
       await element(by.id('root-screen-tests-Test528')).tap();
     });
 
-    it('displays headerRight button after orientation change on Screen1', async () => {
+    it('headerRight button should be visible after orientation change', async () => {
       await expect(element(by.text('Custom Button'))).toBeVisible(100);
       await device.setOrientation('landscape');
       await expect(element(by.text('Custom Button'))).toBeVisible(100);
@@ -98,7 +98,7 @@ if (device.getPlatform() === 'ios') {
       await expect(element(by.text('Custom Button'))).toBeVisible(100);
     });
 
-    it('displays headerRight button on Screen1 after orientation change on Screen2', async () => {
+    it('headerRight button should be visible after coming back from horizontal screen', async () => {
       await element(by.text('Go to Screen 2')).tap();
       await device.setOrientation('landscape');
       await element(by.id('BackButton')).tap();
@@ -108,4 +108,3 @@ if (device.getPlatform() === 'ios') {
     });
   });
 }
-

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -1,0 +1,8 @@
+import { device } from 'detox';
+
+describe('E2E', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+});

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -72,3 +72,40 @@ describe('Test432', () => {
     await expect(element(by.id('home-square'))).toBeVisible(100);
   });
 });
+
+// Detox currently supports orientation only on iOS
+if (device.getPlatform() === 'ios') {
+  describe('Test528', () => {
+    beforeAll(async () => {
+      await device.reloadReactNative();
+    });
+
+    it('should Test528 exist', async () => {
+      await waitFor(element(by.id('root-screen-tests-Test528')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+      await expect(element(by.id('root-screen-tests-Test528'))).toBeVisible();
+      await element(by.id('root-screen-tests-Test528')).tap();
+    });
+
+    it('displays headerRight button after orientation change on Screen1', async () => {
+      await expect(element(by.text('Custom Button'))).toBeVisible(100);
+      await device.setOrientation('landscape');
+      await expect(element(by.text('Custom Button'))).toBeVisible(100);
+      await device.setOrientation('portrait');
+      await expect(element(by.text('Custom Button'))).toBeVisible(100);
+    });
+
+    it('displays headerRight button on Screen1 after orientation change on Screen2', async () => {
+      await element(by.text('Go to Screen 2')).tap();
+      await device.setOrientation('landscape');
+      await element(by.id('BackButton')).tap();
+      await expect(element(by.text('Custom Button'))).toBeVisible(100);
+      await device.setOrientation('portrait');
+      await expect(element(by.text('Custom Button'))).toBeVisible(100);
+    });
+  });
+}
+

--- a/FabricExample/e2e/examplesTests/tests.e2e.ts
+++ b/FabricExample/e2e/examplesTests/tests.e2e.ts
@@ -1,8 +1,27 @@
-import { device } from 'detox';
+import { device, expect, element, by } from 'detox';
 
-describe('Tests from PRs and issues', () => {
-  beforeEach(async () => {
+describe('Test432', () => {
+  beforeAll(async () => {
     await device.reloadReactNative();
   });
+
+  it('should Test432 exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test432')))
+    .toBeVisible()
+    .whileElement(by.id('root-screen-examples-scrollview'))
+    .scroll(100, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test432'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test432')).tap();
+  });
+
+
+  // home home-square
+  // details details-red-square | click | details-green-square | click | details-red-square | back
+  // info info-green-square-1 | click | info-red-square info-green-square-1 info-green-square-2 | click | info-green-square-1 | back
+  // settings settings-square
+  // za kazdym powrotem do home sprawdzic czarny square
+
+
 
 });

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2013,61 +2013,61 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f185bc10472e612edc743be4355bf46bad800446
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 2c8856d4e9b0ba79f3e37079bd90aa0971353a1b
   RCTRequired: 48708ac722594441cf535d4815275c11149a1e75
   RCTTypeSafety: e0c05b269c20da6febb9c80ae50ac4a815cca00a
   React: c1773c9d8bc6451f1b00ee11d9bd0bdf7b54a7e2
   React-callinvoker: 245546c9de42c6f5fa7c9262289d8fb7ab2f735a
-  React-Core: 10fc423129324980e0c6949b1fc442f8a746496e
-  React-CoreModules: 922575c1b919ef68dbab2761db90afdd585257a5
-  React-cxxreact: 07ceb4a53f352d0836373fbe866cadeb95b67222
+  React-Core: 67ea7c88b0e73c2321cbf9cd6f76b26ee291d3f8
+  React-CoreModules: 8a8737a847fa832881cdb2e9d14b327ea8fa77f3
+  React-cxxreact: 42ff2a3e508d749689536ba39a7040b9cf965690
   React-debug: c6270aaf1c7220150ac7f02143ef1d728f818732
-  React-defaultsnativemodule: 6527d6c458e39142faed0615f9db44f3e28a1181
-  React-domnativemodule: 40e893d9c72c5380f57ad562fbf665bc3a237359
-  React-Fabric: 75d054645f8b82a3d883cb6e434361a8568f40c6
-  React-FabricComponents: 87b8467879ea160f58dbaee3bbd1d968cf53dd6d
-  React-FabricImage: 763ec9a65f6a0009fda55e9811e9c39d091e2f76
+  React-defaultsnativemodule: b87f958802b7813152ffa8c873e0c20ea55edc24
+  React-domnativemodule: d190ecf40907bc0377be3fc4b84d79eefcd7995b
+  React-Fabric: ecbdc9b5e5f3ac62103a5c9bd1430cdbbcd8edfd
+  React-FabricComponents: 713d885749f3ef8692ff134524477b7848b3c742
+  React-FabricImage: 5aad10fb4a821c7accd8ef249214bc7d1ae5746f
   React-featureflags: 403f925f7f8a43071d203eb1bd0b582ccd9b601d
-  React-featureflagsnativemodule: 9db6380bd1957a79b8d45d55e6acadf8ec065419
-  React-graphics: 483c5b5308fafd1510fcc4a4ddf989ffee9b58de
-  React-hermes: 4da67646484805735f254b674e24046e1f39781c
-  React-idlecallbacksnativemodule: fcc79b33619a72ea3293dcc90a36368c9ecd0a52
-  React-ImageManager: e6d7843c470838ed8a6f3b74f3a2111143010489
-  React-jserrorhandler: 687e6800ad2375e952ed54f5361552846ff882fa
-  React-jsi: f5a54adbaebcaefc8b26d73524340daf0c9ebe03
-  React-jsiexecutor: 4073f480ba56ca44b28e8e3c843c2ff874795514
-  React-jsinspector: 2a5b8161cb374e9d1196d81668baf0568b61377a
-  React-jsinspectortracing: e9108a890ec559a2673c58b21fbc0db080608c05
-  React-jsitracing: c783b4c25cb3f8c2790713ea2def82e5aa42820a
-  React-logger: b414e4fcd3be78ed0b78645f07a057c26ed18888
-  React-Mapbuffer: 2765656df475f7aaa0b5bf4856aa8201380dce16
-  React-microtasksnativemodule: e39619e9d06c31ca3a92628ee9b70491b9662e58
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
-  React-NativeModulesApple: 5b12971faa02f3ce82731c9c5deba659d83e1f4b
-  React-perflogger: 85ea5a47f97143ec3140c19c38eaa9168bbfe6c1
-  React-performancetimeline: 34e73c0da8e6ad855218cfec7db0a5c2834466b2
+  React-featureflagsnativemodule: a7ea02436d18ad0c0bf531d8f566194713ad5d69
+  React-graphics: 3547cdbb5c10d8610dad27579caad6c4c761fbea
+  React-hermes: d4d2490df576400ba44265bfb443dcc1b9b7c7c3
+  React-idlecallbacksnativemodule: 0f004e45424972c8313d8af962ce5b8732352e2f
+  React-ImageManager: 1abcacc5d4d1ba98231434b6eeaae543b6f7f075
+  React-jserrorhandler: 3d25cd7251c85515365628d878bc2a4f07444374
+  React-jsi: a7d7c45e28039a4817c1b80d1f8302f35c20e3ed
+  React-jsiexecutor: 0def615a82aa42001d03f7a95ea28d5ecc117726
+  React-jsinspector: 39628b5cc680b3cab3c631de0e3ad07a43556594
+  React-jsinspectortracing: db9800afd9cb0ee33c2253f234574b3d68d97d2a
+  React-jsitracing: 595ccbe6ac256aaa1fbc22efbf0fc2474244d575
+  React-logger: 417a59476b6d8f7c00ffc7d0fec4964a91c7617e
+  React-Mapbuffer: 7df58125cd83062b50f90fa3f656e9509f1fa21c
+  React-microtasksnativemodule: 00924a9b4b311aec4d9d8c38de9217f88a92f1de
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
+  React-NativeModulesApple: 814c1f7b25e0ce6343ffc6d0d9cf0a1c11f486c6
+  React-perflogger: e3e2eb3b206f1d6375ad673b2d10bf57836f436e
+  React-performancetimeline: eba3e7710a19759c7a1d6aced3abe23bdc196460
   React-RCTActionSheet: c32efd32f661f888acf55edf30d742d80386ab4f
-  React-RCTAnimation: e8ec262e00d3eb8f0bed786f720b01b035961cec
-  React-RCTAppDelegate: d9a2b2610a582fe7099087cd69ac455d837be9c5
-  React-RCTBlob: 846c0e2ec3da1cc5da03a1d94dde794e445ce8c1
-  React-RCTFabric: 05392addbc532b6f3410ba914d2252f9c629affb
-  React-RCTFBReactNativeSpec: db8ccb471152b3cee8c7abeaf6f524ba2bd75fc1
-  React-RCTImage: 6abbb45d7f6025cd1e5180928d24322fd1885a9f
-  React-RCTLinking: 5cca7087d943d24269bf232f63af9fa1746eeb09
-  React-RCTNetwork: 2fad4baf76e21afd4ddb2316ac5d1390f219efbe
-  React-RCTSettings: f472baca4e986546314ca4a867769eaf3089a6b9
-  React-RCTText: 5a5917ec9bcff3ded118b7fcd198cdde38bb8232
-  React-RCTVibration: ce0d94d094d67a7ee869041592fa194ff93eb585
+  React-RCTAnimation: b89a2d8cc791f0996203ea647878589de6efb451
+  React-RCTAppDelegate: 685b1a2a562cde000dc600fdda2130559eb73222
+  React-RCTBlob: f3726c35ecc2bba9eec112f8d52a5d0433a715e6
+  React-RCTFabric: ae366e8bf743818885b4a5e45b9b8887f78e3856
+  React-RCTFBReactNativeSpec: c92e9905558befec8e03c1f223de10430cb7b372
+  React-RCTImage: 15ca3faf7ec989826fbd62c89b85fb9fb5cdd10c
+  React-RCTLinking: 02c7ac32777cea3170c74bc8324184323b12d592
+  React-RCTNetwork: 78628d76c2ae2eb2b5cc1a6dfbec285ccdbdb9c8
+  React-RCTSettings: 2062ce9b6e69b3686c3591551ed4024c488cf96a
+  React-RCTText: cc059835349d468d8d93e82da6c9aa9c6032ad56
+  React-RCTVibration: a9219f8da44afc58f3b291bd6798b700153a8e10
   React-rendererconsistency: bb3a3c5730ab4e6a8a9ee0ffb3cb84d727c3bed5
-  React-rendererdebug: 0ce779179199216814ee1368951b9c3c0b183595
+  React-rendererdebug: d5a6fecae88c29fc336379489e00d0f3e60e98ef
   React-rncore: 03e107717ccd4ac9d5d79196681faa740ede0b9f
-  React-RuntimeApple: ec335c65a192e3b09ca322582a8cb311f74119d2
-  React-RuntimeCore: 8bb00314545f6c1173f7b4c6c0e0a6c74bcb5c8e
+  React-RuntimeApple: 876f41dc76bb6b6e738f6d3ad7ea3d89e535efa8
+  React-RuntimeCore: c491a1a2eb734765d6e02618f5f2a28e2872f751
   React-runtimeexecutor: a13bd44f6168899cdf60682f137a09516cd5ea35
-  React-RuntimeHermes: 3009df42da2b7015cc66fe4961b2ccca81160f1c
-  React-runtimescheduler: b79baa0ca5d8e8840ad49cbcdb44ab693d7fbdaa
+  React-RuntimeHermes: eff796dfd1df04f9f2cd8b37be37a47d90a4ab4c
+  React-runtimescheduler: 4bd885d85b7841b823c2164725c959c6dbc0fd4e
   React-timing: ddfc36f45351e851633b857cf75eb167e119d3b7
   React-utils: 9ea2e9d57dd01e5b9cf1270969e3179ac3b7f325
   ReactAppDependencyProvider: 19db96cb59117f0cf2e32993b7a2ba34b6397c57
@@ -2081,4 +2081,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 9368f39644a8576a848701c298cb4a4fd39a41bf
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1733,7 +1733,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.10.0-beta.3):
+  - RNScreens (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1754,9 +1754,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.10.0-beta.3)
+    - RNScreens/common (= 4.10.0)
     - Yoga
-  - RNScreens/common (4.10.0-beta.3):
+  - RNScreens/common (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2013,61 +2013,61 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f185bc10472e612edc743be4355bf46bad800446
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 2c8856d4e9b0ba79f3e37079bd90aa0971353a1b
   RCTRequired: 48708ac722594441cf535d4815275c11149a1e75
   RCTTypeSafety: e0c05b269c20da6febb9c80ae50ac4a815cca00a
   React: c1773c9d8bc6451f1b00ee11d9bd0bdf7b54a7e2
   React-callinvoker: 245546c9de42c6f5fa7c9262289d8fb7ab2f735a
-  React-Core: 67ea7c88b0e73c2321cbf9cd6f76b26ee291d3f8
-  React-CoreModules: 8a8737a847fa832881cdb2e9d14b327ea8fa77f3
-  React-cxxreact: 42ff2a3e508d749689536ba39a7040b9cf965690
+  React-Core: 10fc423129324980e0c6949b1fc442f8a746496e
+  React-CoreModules: 922575c1b919ef68dbab2761db90afdd585257a5
+  React-cxxreact: 07ceb4a53f352d0836373fbe866cadeb95b67222
   React-debug: c6270aaf1c7220150ac7f02143ef1d728f818732
-  React-defaultsnativemodule: b87f958802b7813152ffa8c873e0c20ea55edc24
-  React-domnativemodule: d190ecf40907bc0377be3fc4b84d79eefcd7995b
-  React-Fabric: ecbdc9b5e5f3ac62103a5c9bd1430cdbbcd8edfd
-  React-FabricComponents: 713d885749f3ef8692ff134524477b7848b3c742
-  React-FabricImage: 5aad10fb4a821c7accd8ef249214bc7d1ae5746f
+  React-defaultsnativemodule: 6527d6c458e39142faed0615f9db44f3e28a1181
+  React-domnativemodule: 40e893d9c72c5380f57ad562fbf665bc3a237359
+  React-Fabric: 75d054645f8b82a3d883cb6e434361a8568f40c6
+  React-FabricComponents: 87b8467879ea160f58dbaee3bbd1d968cf53dd6d
+  React-FabricImage: 763ec9a65f6a0009fda55e9811e9c39d091e2f76
   React-featureflags: 403f925f7f8a43071d203eb1bd0b582ccd9b601d
-  React-featureflagsnativemodule: a7ea02436d18ad0c0bf531d8f566194713ad5d69
-  React-graphics: 3547cdbb5c10d8610dad27579caad6c4c761fbea
-  React-hermes: d4d2490df576400ba44265bfb443dcc1b9b7c7c3
-  React-idlecallbacksnativemodule: 0f004e45424972c8313d8af962ce5b8732352e2f
-  React-ImageManager: 1abcacc5d4d1ba98231434b6eeaae543b6f7f075
-  React-jserrorhandler: 3d25cd7251c85515365628d878bc2a4f07444374
-  React-jsi: a7d7c45e28039a4817c1b80d1f8302f35c20e3ed
-  React-jsiexecutor: 0def615a82aa42001d03f7a95ea28d5ecc117726
-  React-jsinspector: 39628b5cc680b3cab3c631de0e3ad07a43556594
-  React-jsinspectortracing: db9800afd9cb0ee33c2253f234574b3d68d97d2a
-  React-jsitracing: 595ccbe6ac256aaa1fbc22efbf0fc2474244d575
-  React-logger: 417a59476b6d8f7c00ffc7d0fec4964a91c7617e
-  React-Mapbuffer: 7df58125cd83062b50f90fa3f656e9509f1fa21c
-  React-microtasksnativemodule: 00924a9b4b311aec4d9d8c38de9217f88a92f1de
-  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
-  React-NativeModulesApple: 814c1f7b25e0ce6343ffc6d0d9cf0a1c11f486c6
-  React-perflogger: e3e2eb3b206f1d6375ad673b2d10bf57836f436e
-  React-performancetimeline: eba3e7710a19759c7a1d6aced3abe23bdc196460
+  React-featureflagsnativemodule: 9db6380bd1957a79b8d45d55e6acadf8ec065419
+  React-graphics: 483c5b5308fafd1510fcc4a4ddf989ffee9b58de
+  React-hermes: 4da67646484805735f254b674e24046e1f39781c
+  React-idlecallbacksnativemodule: fcc79b33619a72ea3293dcc90a36368c9ecd0a52
+  React-ImageManager: e6d7843c470838ed8a6f3b74f3a2111143010489
+  React-jserrorhandler: 687e6800ad2375e952ed54f5361552846ff882fa
+  React-jsi: f5a54adbaebcaefc8b26d73524340daf0c9ebe03
+  React-jsiexecutor: 4073f480ba56ca44b28e8e3c843c2ff874795514
+  React-jsinspector: 2a5b8161cb374e9d1196d81668baf0568b61377a
+  React-jsinspectortracing: e9108a890ec559a2673c58b21fbc0db080608c05
+  React-jsitracing: c783b4c25cb3f8c2790713ea2def82e5aa42820a
+  React-logger: b414e4fcd3be78ed0b78645f07a057c26ed18888
+  React-Mapbuffer: 2765656df475f7aaa0b5bf4856aa8201380dce16
+  React-microtasksnativemodule: e39619e9d06c31ca3a92628ee9b70491b9662e58
+  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
+  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
+  React-NativeModulesApple: 5b12971faa02f3ce82731c9c5deba659d83e1f4b
+  React-perflogger: 85ea5a47f97143ec3140c19c38eaa9168bbfe6c1
+  React-performancetimeline: 34e73c0da8e6ad855218cfec7db0a5c2834466b2
   React-RCTActionSheet: c32efd32f661f888acf55edf30d742d80386ab4f
-  React-RCTAnimation: b89a2d8cc791f0996203ea647878589de6efb451
-  React-RCTAppDelegate: 685b1a2a562cde000dc600fdda2130559eb73222
-  React-RCTBlob: f3726c35ecc2bba9eec112f8d52a5d0433a715e6
-  React-RCTFabric: ae366e8bf743818885b4a5e45b9b8887f78e3856
-  React-RCTFBReactNativeSpec: c92e9905558befec8e03c1f223de10430cb7b372
-  React-RCTImage: 15ca3faf7ec989826fbd62c89b85fb9fb5cdd10c
-  React-RCTLinking: 02c7ac32777cea3170c74bc8324184323b12d592
-  React-RCTNetwork: 78628d76c2ae2eb2b5cc1a6dfbec285ccdbdb9c8
-  React-RCTSettings: 2062ce9b6e69b3686c3591551ed4024c488cf96a
-  React-RCTText: cc059835349d468d8d93e82da6c9aa9c6032ad56
-  React-RCTVibration: a9219f8da44afc58f3b291bd6798b700153a8e10
+  React-RCTAnimation: e8ec262e00d3eb8f0bed786f720b01b035961cec
+  React-RCTAppDelegate: d9a2b2610a582fe7099087cd69ac455d837be9c5
+  React-RCTBlob: 846c0e2ec3da1cc5da03a1d94dde794e445ce8c1
+  React-RCTFabric: 05392addbc532b6f3410ba914d2252f9c629affb
+  React-RCTFBReactNativeSpec: db8ccb471152b3cee8c7abeaf6f524ba2bd75fc1
+  React-RCTImage: 6abbb45d7f6025cd1e5180928d24322fd1885a9f
+  React-RCTLinking: 5cca7087d943d24269bf232f63af9fa1746eeb09
+  React-RCTNetwork: 2fad4baf76e21afd4ddb2316ac5d1390f219efbe
+  React-RCTSettings: f472baca4e986546314ca4a867769eaf3089a6b9
+  React-RCTText: 5a5917ec9bcff3ded118b7fcd198cdde38bb8232
+  React-RCTVibration: ce0d94d094d67a7ee869041592fa194ff93eb585
   React-rendererconsistency: bb3a3c5730ab4e6a8a9ee0ffb3cb84d727c3bed5
-  React-rendererdebug: d5a6fecae88c29fc336379489e00d0f3e60e98ef
+  React-rendererdebug: 0ce779179199216814ee1368951b9c3c0b183595
   React-rncore: 03e107717ccd4ac9d5d79196681faa740ede0b9f
-  React-RuntimeApple: 876f41dc76bb6b6e738f6d3ad7ea3d89e535efa8
-  React-RuntimeCore: c491a1a2eb734765d6e02618f5f2a28e2872f751
+  React-RuntimeApple: ec335c65a192e3b09ca322582a8cb311f74119d2
+  React-RuntimeCore: 8bb00314545f6c1173f7b4c6c0e0a6c74bcb5c8e
   React-runtimeexecutor: a13bd44f6168899cdf60682f137a09516cd5ea35
-  React-RuntimeHermes: eff796dfd1df04f9f2cd8b37be37a47d90a4ab4c
-  React-runtimescheduler: 4bd885d85b7841b823c2164725c959c6dbc0fd4e
+  React-RuntimeHermes: 3009df42da2b7015cc66fe4961b2ccca81160f1c
+  React-runtimescheduler: b79baa0ca5d8e8840ad49cbcdb44ab693d7fbdaa
   React-timing: ddfc36f45351e851633b857cf75eb167e119d3b7
   React-utils: 9ea2e9d57dd01e5b9cf1270969e3179ac3b7f325
   ReactAppDependencyProvider: 19db96cb59117f0cf2e32993b7a2ba34b6397c57
@@ -2075,10 +2075,10 @@ SPEC CHECKSUMS:
   ReactCommon: 179964ffc47fa62ad0e1eebac704e88c59b46667
   RNGestureHandler: 4e7defe5095e936424173fc75f0bf2af5bba8e23
   RNReanimated: 183ca222293bd622678e387100e54d03d952c73b
-  RNScreens: b40d97d6ad4b6f1f55552bed30b845ae01ff3d2c
+  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 330be28eee1242da875db9e851b19a4df496b999
 
 PODFILE CHECKSUM: 9368f39644a8576a848701c298cb4a4fd39a41bf
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/apps/src/shared/Square.tsx
+++ b/apps/src/shared/Square.tsx
@@ -4,11 +4,13 @@ import { View } from 'react-native';
 interface Props {
   color?: string;
   size?: number;
+  testID?: string;
 }
 
 export const Square = ({
   size = 100,
   color = 'red',
+  testID,
 }: Props): React.JSX.Element => (
-  <View style={{ width: size, height: size, backgroundColor: color }} />
+  <View style={{ width: size, height: size, backgroundColor: color }} testID={testID} />
 );

--- a/apps/src/tests/Test432.tsx
+++ b/apps/src/tests/Test432.tsx
@@ -26,14 +26,17 @@ const HomeScreen = ({ navigation }: StackScreenProps<'Home'>) => {
       <Button
         title={'Go to details'}
         onPress={() => navigation.navigate('Details')}
+        testID="go-to-details"
       />
       <Button
         title={'Go to info'}
         onPress={() => navigation.navigate('Info')}
+        testID="go-to-info"
       />
       <Button
         title={'Show settings'}
         onPress={() => navigation.navigate('Settings')}
+        testID="show-settings"
       />
     </View>
   );
@@ -45,15 +48,19 @@ const DetailsScreen = ({ navigation }: StackScreenProps<'Details'>) => {
     navigation.setOptions({
       headerBackVisible: !x,
       headerRight: () =>
-        x ? <Square size={20} color="green" testID="details-green-square" /> : <Square size={10} testID="details-red-square" />,
+        x ? (
+          <Square size={20} color="green" testID="details-green-square" />
+        ) : (
+          <Square size={10} testID="details-red-square" />
+        ),
     });
   }, [navigation, x]);
 
-  return <Button title="Toggle subviews" onPress={() => setX(prev => !prev)} />;
+  return <Button title="Toggle subviews" onPress={() => setX(prev => !prev)} testID='details-toggle-subviews' />;
 };
 
 const SettingsScreen = () => {
-  return <Text>Settings</Text>;
+  return <Text testID='settings-text'>Settings</Text>;
 };
 
 const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
@@ -61,7 +68,14 @@ const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
 
   const square1 = (props: { tintColor?: string }) => (
     <View style={{ gap: 8, flexDirection: 'row' }}>
-      {hasLeftItem && <Square {...props} color="green" size={20} testID="info-green-square-2" />}
+      {hasLeftItem && (
+        <Square
+          {...props}
+          color="green"
+          size={20}
+          testID="info-green-square-2"
+        />
+      )}
       <Square {...props} color="green" size={20} testID="info-green-square-1" />
     </View>
   );
@@ -82,6 +96,7 @@ const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
     <Button
       title="Toggle subviews"
       onPress={() => setHasLeftItem(prev => !prev)}
+      testID='info-toggle-subviews'
     />
   );
 };
@@ -95,7 +110,9 @@ const StackNavigator = () => {
         name="Home"
         component={HomeScreen}
         options={{
-          headerRight: () => <Square size={20} color="black" testID="home-square" />,
+          headerRight: () => (
+            <Square size={20} color="black" testID="home-square" />
+          ),
         }}
       />
       <Stack.Screen name="Details" component={DetailsScreen} />

--- a/apps/src/tests/Test432.tsx
+++ b/apps/src/tests/Test432.tsx
@@ -26,17 +26,17 @@ const HomeScreen = ({ navigation }: StackScreenProps<'Home'>) => {
       <Button
         title={'Go to details'}
         onPress={() => navigation.navigate('Details')}
-        testID="go-to-details"
+        testID="home-button-go-to-details"
       />
       <Button
         title={'Go to info'}
         onPress={() => navigation.navigate('Info')}
-        testID="go-to-info"
+        testID="home-button-go-to-info"
       />
       <Button
         title={'Show settings'}
         onPress={() => navigation.navigate('Settings')}
-        testID="show-settings"
+        testID="home-button-show-settings"
       />
     </View>
   );
@@ -49,18 +49,24 @@ const DetailsScreen = ({ navigation }: StackScreenProps<'Details'>) => {
       headerBackVisible: !x,
       headerRight: () =>
         x ? (
-          <Square size={20} color="green" testID="details-green-square" />
+          <Square size={20} color="green" testID="details-headerRight-green" />
         ) : (
-          <Square size={10} testID="details-red-square" />
+          <Square size={10} testID="details-headerRight-red" />
         ),
     });
   }, [navigation, x]);
 
-  return <Button title="Toggle subviews" onPress={() => setX(prev => !prev)} testID='details-toggle-subviews' />;
+  return (
+    <Button
+      title="Toggle subviews"
+      onPress={() => setX(prev => !prev)}
+      testID="details-button-toggle-subviews"
+    />
+  );
 };
 
 const SettingsScreen = () => {
-  return <Text testID='settings-text'>Settings</Text>;
+  return <Text testID="settings-text">Settings</Text>;
 };
 
 const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
@@ -73,15 +79,20 @@ const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
           {...props}
           color="green"
           size={20}
-          testID="info-green-square-2"
+          testID="info-headerRight-green-2"
         />
       )}
-      <Square {...props} color="green" size={20} testID="info-green-square-1" />
+      <Square
+        {...props}
+        color="green"
+        size={20}
+        testID="info-headerRight-green-1"
+      />
     </View>
   );
 
   const square2 = (props: { tintColor?: string }) => (
-    <Square {...props} color="red" size={20} testID="info-red-square" />
+    <Square {...props} color="red" size={20} testID="info-headerLeft-red" />
   );
 
   useLayoutEffect(() => {
@@ -96,7 +107,7 @@ const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
     <Button
       title="Toggle subviews"
       onPress={() => setHasLeftItem(prev => !prev)}
-      testID='info-toggle-subviews'
+      testID="info-button-toggle-subviews"
     />
   );
 };
@@ -111,7 +122,7 @@ const StackNavigator = () => {
         component={HomeScreen}
         options={{
           headerRight: () => (
-            <Square size={20} color="black" testID="home-square" />
+            <Square size={20} color="black" testID="home-headerRight" />
           ),
         }}
       />
@@ -129,7 +140,7 @@ const StackNavigator = () => {
         options={{
           presentation: 'modal',
           animation: 'slide_from_bottom',
-          headerRight: () => <Square size={30} testID="settings-square" />,
+          headerRight: () => <Square size={30} testID="settings-headerRight" />,
         }}
       />
     </Stack.Navigator>

--- a/apps/src/tests/Test432.tsx
+++ b/apps/src/tests/Test432.tsx
@@ -45,7 +45,7 @@ const DetailsScreen = ({ navigation }: StackScreenProps<'Details'>) => {
     navigation.setOptions({
       headerBackVisible: !x,
       headerRight: () =>
-        x ? <Square size={20} color="green" /> : <Square size={10} />,
+        x ? <Square size={20} color="green" testID="details-green-square" /> : <Square size={10} testID="details-red-square" />,
     });
   }, [navigation, x]);
 
@@ -61,13 +61,13 @@ const InfoScreen = ({ navigation }: StackScreenProps<'Info'>) => {
 
   const square1 = (props: { tintColor?: string }) => (
     <View style={{ gap: 8, flexDirection: 'row' }}>
-      {hasLeftItem && <Square {...props} color="green" size={20} />}
-      <Square {...props} color="green" size={20} />
+      {hasLeftItem && <Square {...props} color="green" size={20} testID="info-green-square-2" />}
+      <Square {...props} color="green" size={20} testID="info-green-square-1" />
     </View>
   );
 
   const square2 = (props: { tintColor?: string }) => (
-    <Square {...props} color="red" size={20} />
+    <Square {...props} color="red" size={20} testID="info-red-square" />
   );
 
   useLayoutEffect(() => {
@@ -95,7 +95,7 @@ const StackNavigator = () => {
         name="Home"
         component={HomeScreen}
         options={{
-          headerRight: () => <Square size={20} color="black" />,
+          headerRight: () => <Square size={20} color="black" testID="home-square" />,
         }}
       />
       <Stack.Screen name="Details" component={DetailsScreen} />
@@ -112,7 +112,7 @@ const StackNavigator = () => {
         options={{
           presentation: 'modal',
           animation: 'slide_from_bottom',
-          headerRight: () => <Square size={30} />,
+          headerRight: () => <Square size={30} testID="settings-square" />,
         }}
       />
     </Stack.Navigator>

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -5,7 +5,7 @@ export { default as Test111 } from './Test111';     // [E2E skipped]: can't chec
 export { default as Test263 } from './Test263';     // [E2E skipped]: example differs from PR, even if changed the problem still occurs
 export { default as Test349 } from './Test349';     // [E2E skipped]: can't check autofill easily, wrong prop name
 export { default as Test364 } from './Test364';     // [E2E skipped]: tabBarVisible prop doesn't exist anymore, suggested solution is to change navigator hierarchy (proposed in PR and in react-navigation docs)
-export { default as Test432 } from './Test432';
+export { default as Test432 } from './Test432';     // [E2E created]
 export { default as Test528 } from './Test528';
 export { default as Test550 } from './Test550';
 export { default as Test556 } from './Test556';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -6,7 +6,7 @@ export { default as Test263 } from './Test263';     // [E2E skipped]: example di
 export { default as Test349 } from './Test349';     // [E2E skipped]: can't check autofill easily, wrong prop name
 export { default as Test364 } from './Test364';     // [E2E skipped]: tabBarVisible prop doesn't exist anymore, suggested solution is to change navigator hierarchy (proposed in PR and in react-navigation docs)
 export { default as Test432 } from './Test432';     // [E2E created]
-export { default as Test528 } from './Test528';
+export { default as Test528 } from './Test528';     // [E2E created](iOS): Detox supports changing orientation only on iOS
 export { default as Test550 } from './Test550';
 export { default as Test556 } from './Test556';
 export { default as Test564 } from './Test564';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 
-export { default as Test42 } from './Test42';
-export { default as Test111 } from './Test111';
-export { default as Test263 } from './Test263';
+export { default as Test42 } from './Test42';       // [E2E skipped]: can't check orientation, unclear problem description
+export { default as Test111 } from './Test111';     // [E2E skipped]: can't check flickering
+export { default as Test263 } from './Test263';     // [E2E skipped]: example differs from PR, even if changed the problem still occurs
 export { default as Test349 } from './Test349';
 export { default as Test364 } from './Test364';
 export { default as Test432 } from './Test432';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -3,8 +3,8 @@
 export { default as Test42 } from './Test42';       // [E2E skipped]: can't check orientation, unclear problem description
 export { default as Test111 } from './Test111';     // [E2E skipped]: can't check flickering
 export { default as Test263 } from './Test263';     // [E2E skipped]: example differs from PR, even if changed the problem still occurs
-export { default as Test349 } from './Test349';
-export { default as Test364 } from './Test364';
+export { default as Test349 } from './Test349';     // [E2E skipped]: can't check autofill easily, wrong prop name
+export { default as Test364 } from './Test364';     // [E2E skipped]: tabBarVisible prop doesn't exist anymore, suggested solution is to change navigator hierarchy (proposed in PR and in react-navigation docs)
 export { default as Test432 } from './Test432';
 export { default as Test528 } from './Test528';
 export { default as Test550 } from './Test550';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test42, ..., Test528` and implement them if possible for Fabric. In the future, each non-skipped test will be in a seperate PR.

### Test42
Skipped because we can’t really check what is the orientation of the screen with Detox.

### Test111
Skipped because we can’t test flickering with Detox.

### Test263
Skipped because example differs from the problem mentioned in https://github.com/software-mansion/react-native-screens/issues/263. Even when I recreated the issue, it still occurs. [This comment from the PR](https://github.com/software-mansion/react-native-screens/issues/263#issuecomment-930127450) explains why it is the case. 

### Test349
Skipped because we can’t test autofill with Detox. The test also uses outdated prop name.

### Test364
Skipped because the test uses `tabBarVisible` prop that no longer exists. `react-navigation` documentation suggests other [solution](https://reactnavigation.org/docs/hiding-tabbar-in-screens/) to this problem.

### Test 432
Test created. It checks whether correct squares are fully visible. For some reason, on Android, these squares are not `100%` visible from the start (but I don’t see the problem in manual testing).  For the test, `waitingFor` the squares to become `100%` visible works.

### Test 528
Test created but only for iOS because Detox supports changing orientation of the device [only on iOS](https://wix.github.io/Detox/docs/api/device/#devicesetorientationorientation). Test checks if the headerRight button is visible after changing screens/orientation.

## Changes

- add `Test432` and `Test528`
- add comments for every test screen in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes