### PR TITLE
fix(Android): fix space assignment in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -214,7 +214,7 @@ android {
 
 repositories {
     maven {
-        url "${reactNativeRootDir}/android"
+        url = "${reactNativeRootDir}/android"
     }
 
     mavenCentral()


### PR DESCRIPTION
Space-assignment syntax in Groovy DSL has been deprecated This is scheduled to be removed in Gradle 10.0.
Use assignment ('url = <value>') instead.

## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
`npm run android` failed on `react-native-community/react-native:v15.0` docker container, complaining about deprecated syntax in build.gradle

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
