### PR TITLE
fix(Android): implement ReactPointerEventsView to prevent header config from intercepting touches

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -480,7 +480,7 @@ class ScreenStackFragment :
         constructor(context: Context, fragment: ScreenStackFragment) : this(
             context,
             fragment,
-            ScreensCoordinatorLayoutPointerEventsImpl(),
+            PointerEventsBoxNoneImpl(),
         )
 
         override fun onApplyWindowInsets(insets: WindowInsets?): WindowInsets = super.onApplyWindowInsets(insets)
@@ -543,7 +543,13 @@ class ScreenStackFragment :
             }
         }
 
-        override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        override fun onLayout(
+            changed: Boolean,
+            l: Int,
+            t: Int,
+            r: Int,
+            b: Int,
+        ) {
             super.onLayout(changed, l, t, r, b)
 
             if (fragment.screen.usesFormSheetPresentation()) {

--- a/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
+++ b/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
@@ -3,7 +3,7 @@ package com.swmansion.rnscreens
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-internal class PointerEventsBoxNoneImpl : ReactPointerEventsView {
+internal class PointerEventsBoxNoneImpl() : ReactPointerEventsView {
     // We set pointer events to BOX_NONE, because we don't want the ScreensCoordinatorLayout
     // to be target of react gestures and effectively prevent interaction with screens
     // underneath the current screen (useful in `modal` & `formSheet` presentation).

--- a/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
+++ b/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
@@ -3,7 +3,7 @@ package com.swmansion.rnscreens
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-internal class ScreensCoordinatorLayoutPointerEventsImpl : ReactPointerEventsView {
+internal class PointerEventsBoxNoneImpl : ReactPointerEventsView {
     // We set pointer events to BOX_NONE, because we don't want the ScreensCoordinatorLayout
     // to be target of react gestures and effectively prevent interaction with screens
     // underneath the current screen (useful in `modal` & `formSheet` presentation).

--- a/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
+++ b/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
@@ -3,7 +3,7 @@ package com.swmansion.rnscreens
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-internal class ScreensCoordinatorLayoutPointerEventsImpl() : ReactPointerEventsView {
+internal class PointerEventsBoxNoneImpl() : ReactPointerEventsView {
     // We set pointer events to BOX_NONE, because we don't want the ScreensCoordinatorLayout
     // to be target of react gestures and effectively prevent interaction with screens
     // underneath the current screen (useful in `modal` & `formSheet` presentation).


### PR DESCRIPTION
## Description

Closes #2794

We set `visibility = GONE` for the header config in HostTree (HT), however this only prevents the Android framework from setting header config frame,
and does not prevent `ReactNative` from setting non-zero frame. When it has non-zero frame, react recognizes it as a touch target.

## Changes

I've implemented `ReactPointerEventsView` (returning `box-none`) making sure that RN won't treat it as touch target.

I considered another approach - setting the frame to zero or not letting react native to set the frame on the view - it also works, 
however requires cumbersome implementation on Android API level < 29, since `suppressLayout` method is available since 29.
On lower API levels you can not really ignore the frame - you can call `layout` with 0 width in `onLayout` of the header config...

## Test code and steps to reproduce

`HeaderOptions` screen in `Example` app.

Tested it on both architectures & with `headerShown: false/true`.

## Checklist

- [ ] Ensured that CI passes
