### PR TITLE
fix(iOS): use prefersPageSizing for modal on iOS 18.0+

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -247,7 +247,10 @@ Using `containedModal` and `containedTransparentModal` with other types of modal
 
 For iOS:
 
-- `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier. For iOS 18 and later, additional prop `prefersPageSizing` will be set to `true` to ensure consistent behavior between iOS versions (`UIModalPresentationAutomatic` was mapped to `UIModalPresentationPageSheet` before iOS 18 but now it is mapped to `UIModalPresentationFormSheet`).
+- `modal` will use:
+   *  on iOS 18 and later [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc). However, since the iOS 18 changed the default behaviour from `UIModalPresentationPageSheet` to `UIModalPresentationFormSheet` (it looks vastly different on regular size classes devices, e.g. iPad), for the sake of backward compatibility, we keep the default behaviour from before iOS 18. *This might change in future major release of `react-native-screens`.
+   *  on iOS 13 and later [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc)
+   * on iOS 12 and earlier will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc). 
 - `fullScreenModal` will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc)
 - `formSheet` will use [`UIModalPresentationFormSheet`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationformsheet?language=objc)
 - `transparentModal` will use [`UIModalPresentationOverFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationoverfullscreen?language=objc)

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -247,7 +247,7 @@ Using `containedModal` and `containedTransparentModal` with other types of modal
 
 For iOS:
 
-- `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier.
+- `modal` will use [`UIModalPresentationAutomatic`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc) on iOS 13 and later, and will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) on iOS 12 and earlier. For iOS 18 and later, additional prop `prefersPageSizing` will be set to `true` to ensure consistent behavior between iOS versions (`UIModalPresentationAutomatic` was mapped to `UIModalPresentationPageSheet` before iOS 18 but now it is mapped to `UIModalPresentationFormSheet`).
 - `fullScreenModal` will use [`UIModalPresentationFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc)
 - `formSheet` will use [`UIModalPresentationFormSheet`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationformsheet?language=objc)
 - `transparentModal` will use [`UIModalPresentationOverFullScreen`](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationoverfullscreen?language=objc)

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -247,7 +247,8 @@ RNS_IGNORE_SUPER_CALL_END
 #else
       _controller.modalPresentationStyle = UIModalPresentationFullScreen;
 #endif
-#if !TARGET_OS_TV
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_17_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_17_0 && !TARGET_OS_TV
       if (@available(iOS 18.0, *)) {
         UISheetPresentationController *sheetController = _controller.sheetPresentationController;
         if (sheetController != nil) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -247,6 +247,17 @@ RNS_IGNORE_SUPER_CALL_END
 #else
       _controller.modalPresentationStyle = UIModalPresentationFullScreen;
 #endif
+#if !TARGET_OS_TV
+      if (@available(iOS 18.0, *)) {
+        UISheetPresentationController *sheetController = _controller.sheetPresentationController;
+        if (sheetController != nil) {
+          sheetController.prefersPageSizing = true;
+        } else {
+          RCTLogError(
+              @"[RNScreens] sheetPresentationController is null when attempting to set prefersPageSizing for modal");
+        }
+      }
+#endif
       break;
     case RNSScreenStackPresentationFullScreenModal:
       _controller.modalPresentationStyle = UIModalPresentationFullScreen;


### PR DESCRIPTION
## Description

Brings back `stackPresentation: 'modal'`'s size on iOS 18.0+.

Since the release of iOS 18, screens with `stackPresentation: 'modal'` changed size on devices with a bigger screen, such as an iPad - they became much smaller, which impacted applications of the library's users (see issue https://github.com/software-mansion/react-native-screens/issues/2549). This happens because `UIModalPresentationAutomatic`, which is used by `react-native-screens` for modal on iOS, has been changed with the release of iOS 18. `UIModalPresentationAutomatic` is now mapped to `UIModalPresentationFormSheet` for iOS >=18 and `UIModalPresentationPageSheet` for earlier versions (this was the default before).

For more context please see PR https://github.com/software-mansion/react-native-screens/pull/2793 but the TL;DR is that we consider this a breaking change for our users and therefore we decided to bring back the old behavior for `react-native-screens` v4 using [`prefersPageSizing`](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/preferspagesizing?language=objc) property of the `UISheetPresentationController` which has been available since iOS 17.0+.

Resolves https://github.com/software-mansion/react-native-screens/issues/2549.

## Changes

- use `prefersPageSizing` for modal on iOS 18.0+

## Screenshots / GIFs

### Before
![Modal without `prefersPageSizing` on iOS 18](https://github.com/user-attachments/assets/724bd109-b0c0-47e4-b897-43cd53ef3dd9)

### After
![Modal with `prefersPageSizing` on iOS 18](https://github.com/user-attachments/assets/b0925934-25dc-4103-8422-8fb07a18fd18)

## Test code and steps to reproduce

Open `Modals` example screen and use `Open modal` button.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
