### PR TITLE
refactor(iOS): cleanup no. 1 in `RNSScreenStackHeaderConfig.updateViewController:withConfig:animated:`

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -12,7 +12,7 @@
 
 @interface NSString (RNSStringUtil)
 
-+ (BOOL)rnscreens_isBlank:(nullable NSString *)string;
++ (BOOL)rnscreens_isBlankOrNull:(nullable NSString *)string;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -12,7 +12,7 @@
 
 @interface NSString (RNSStringUtil)
 
-+ (BOOL)RNSisBlank:(nullable NSString *)string;
++ (BOOL)rnscreens_isBlank:(nullable NSString *)string;
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -612,6 +612,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
+
   [config applySemanticContentAttributeIfNeededToNavCtrl:navctr];
 
   if (shouldHide) {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -612,23 +612,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
-
-  if ((config.direction == UISemanticContentAttributeForceLeftToRight ||
-       config.direction == UISemanticContentAttributeForceRightToLeft) &&
-      // iOS 12 cancels swipe gesture when direction is changed. See #1091
-      navctr.view.semanticContentAttribute != config.direction) {
-    // This is needed for swipe back gesture direction
-    navctr.view.semanticContentAttribute = config.direction;
-
-    // This is responsible for the direction of the navigationBar and its contents
-    navctr.navigationBar.semanticContentAttribute = config.direction;
-    [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ navctr.navigationBar.class ]]
-        setSemanticContentAttribute:config.direction];
-    [[UIView appearanceWhenContainedInInstancesOfClasses:@[ navctr.navigationBar.class ]]
-        setSemanticContentAttribute:config.direction];
-    [[UISearchBar appearanceWhenContainedInInstancesOfClasses:@[ navctr.navigationBar.class ]]
-        setSemanticContentAttribute:config.direction];
-  }
+  [config applySemanticContentAttributeIfNeededToNavCtrl:navctr];
 
   if (shouldHide) {
     navitem.title = config.title;
@@ -845,6 +829,26 @@ RNS_IGNORE_SUPER_CALL_END
         }];
   } else {
     [self setAnimatedConfig:vc withConfig:config];
+  }
+}
+
+- (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *)navCtrl
+{
+  if ((self.direction == UISemanticContentAttributeForceLeftToRight ||
+       self.direction == UISemanticContentAttributeForceRightToLeft) &&
+      // iOS 12 cancels swipe gesture when direction is changed. See #1091
+      navCtrl.view.semanticContentAttribute != self.direction) {
+    // This is needed for swipe back gesture direction
+    navCtrl.view.semanticContentAttribute = self.direction;
+
+    // This is responsible for the direction of the navigationBar and its contents
+    navCtrl.navigationBar.semanticContentAttribute = self.direction;
+    [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
+        setSemanticContentAttribute:self.direction];
+    [[UIView appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
+        setSemanticContentAttribute:self.direction];
+    [[UISearchBar appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
+        setSemanticContentAttribute:self.direction];
   }
 }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -49,7 +49,7 @@ namespace react = facebook::react;
 
 @implementation NSString (RNSStringUtil)
 
-+ (BOOL)RNSisBlank:(NSString *)string
++ (BOOL)rnscreens_isBlank:(NSString *)string
 {
   if (string == nil) {
     return YES;
@@ -621,7 +621,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
 #if !TARGET_OS_TV
-  const auto isBackTitleBlank = [NSString RNSisBlank:config.backTitle] == YES;
+  const auto isBackTitleBlank = [NSString rnscreens_isBlank:config.backTitle] == YES;
   NSString *resolvedBackTitle = isBackTitleBlank ? prevItem.title : config.backTitle;
   RNSUIBarButtonItem *backBarButtonItem = [[RNSUIBarButtonItem alloc] initWithTitle:resolvedBackTitle
                                                                               style:UIBarButtonItemStylePlain

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -49,7 +49,7 @@ namespace react = facebook::react;
 
 @implementation NSString (RNSStringUtil)
 
-+ (BOOL)rnscreens_isBlank:(NSString *)string
++ (BOOL)rnscreens_isBlankOrNull:(NSString *)string
 {
   if (string == nil) {
     return YES;
@@ -621,7 +621,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
 #if !TARGET_OS_TV
-  const auto isBackTitleBlank = [NSString rnscreens_isBlank:config.backTitle] == YES;
+  const auto isBackTitleBlank = [NSString rnscreens_isBlankOrNull:config.backTitle] == YES;
   NSString *resolvedBackTitle = isBackTitleBlank ? prevItem.title : config.backTitle;
   RNSUIBarButtonItem *backBarButtonItem = [[RNSUIBarButtonItem alloc] initWithTitle:resolvedBackTitle
                                                                               style:UIBarButtonItemStylePlain

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -629,7 +629,7 @@ RNS_IGNORE_SUPER_CALL_END
                                                                              action:nil];
   [backBarButtonItem setMenuHidden:config.disableBackButtonMenu];
 
-  auto isBackButtonCustomized = !isBackTitleBlank || config.disableBackButtonMenu;
+  auto shouldUseCustomBackBarButtonItem = !isBackTitleBlank || config.disableBackButtonMenu;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_14_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
@@ -646,7 +646,7 @@ RNS_IGNORE_SUPER_CALL_END
          // See: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
          ![config.backTitleFontFamily isEqual:@"System"]) ||
         config.backTitleFontSize) {
-      isBackButtonCustomized = YES;
+      shouldUseCustomBackBarButtonItem = YES;
       NSMutableDictionary *attrs = [NSMutableDictionary new];
       NSNumber *size = config.backTitleFontSize ?: @17;
       if (config.backTitleFontFamily) {
@@ -669,7 +669,7 @@ RNS_IGNORE_SUPER_CALL_END
     // When backBarButtonItem's title is null, back menu will use value
     // of backButtonTitle
     [backBarButtonItem setTitle:nil];
-    isBackButtonCustomized = YES;
+    shouldUseCustomBackBarButtonItem = YES;
     prevItem.backButtonTitle = resolvedBackTitle;
   }
 
@@ -677,7 +677,7 @@ RNS_IGNORE_SUPER_CALL_END
   // as assigning one will override the native behavior of automatically shortening
   // the title to "Back" or hide the back title if there's not enough space.
   // See: https://github.com/software-mansion/react-native-screens/issues/1589
-  if (isBackButtonCustomized) {
+  if (shouldUseCustomBackBarButtonItem) {
     prevItem.backBarButtonItem = backBarButtonItem;
   }
 


### PR DESCRIPTION
## Description

This method is very hard to read & it is very scary to refactor
since as far as I remember, sometimes even call order matters here.

Therefore, I've decided to split the refactoring process into many small PRs.
This PR improves local variable naming & extracts LTR handling to separate method.

## Test code and steps to reproduce

Nothing should change. LTR works as earlier. Can be tested in Example by toggling RTL mode (there is a button for it).

## Checklist

- [ ] Ensured that CI passes
