### PR TITLE
chore: update iOS min supported version to 15.1

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1733,7 +1733,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.10.0-beta.2):
+  - RNScreens (4.10.0-beta.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1754,9 +1754,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.10.0-beta.2)
+    - RNScreens/common (= 4.10.0-beta.3)
     - Yoga
-  - RNScreens/common (4.10.0-beta.2):
+  - RNScreens/common (4.10.0-beta.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2075,7 +2075,7 @@ SPEC CHECKSUMS:
   ReactCommon: 179964ffc47fa62ad0e1eebac704e88c59b46667
   RNGestureHandler: 4e7defe5095e936424173fc75f0bf2af5bba8e23
   RNReanimated: 183ca222293bd622678e387100e54d03d952c73b
-  RNScreens: 2aa993d221ba928ee75682f3c0940620a8d46865
+  RNScreens: b40d97d6ad4b6f1f55552bed30b845ae01ff3d2c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 330be28eee1242da875db9e851b19a4df496b999
 

--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
-platform = new_arch_enabled ? "11.0" : "9.0"
+min_supported_ios_version = new_arch_enabled ? "15.1" : "15.1"
 source_files = new_arch_enabled ? 'ios/**/*.{h,m,mm,cpp}' : ["ios/**/*.{h,m,mm}", "cpp/RNScreensTurboModule.cpp", "cpp/RNScreensTurboModule.h"]
 
 Pod::Spec.new do |s|
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/software-mansion/react-native-screens"
   s.license      = "MIT"
   s.author       = { "author" => "author@domain.cn" }
-  s.platforms    = { :ios => platform, :tvos => "11.0", :visionos => "1.0" }
+  s.platforms    = { :ios => min_supported_ios_version, :tvos => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/software-mansion/react-native-screens.git", :tag => "#{s.version}" }
   s.source_files = source_files
   s.project_header_files = "cpp/**/*.h" # Don't expose C++ headers publicly to allow importing framework into Swift files


### PR DESCRIPTION
## Description

This is not a breaking change, because we support `react-native` 0.76+ anyway, and it has iOS min 
deployment target [set to 15.1](https://github.com/react-native-community/discussions-and-proposals/discussions/812)

This is needed because I work with @maciejstosio on an issue with `backButtonDisplayMode` & it has been introduced 
in iOS 14.0. The workaround I've found works only on iOS >= 14.0, therefore it would be nice to not have to 
add any ifdefs in source code. 

## Changes

Bumped the min. supported iOS version to 15.1 from 11.0.

I've left the new-arch-condition in the podspec code, despite the fact that it is not needed, 
so that it is clear where do we change things when it becomes needed.

tvOS version is left unchanged for now (most likely it should also be updated!).

## Test code and steps to reproduce

The app should build and run on any device with 15.1 or newer iOS version.

## Checklist

- [ ] Ensured that CI passes
