### PR TITLE
fix(Android,Fabric): prevent header subview disappearance when using `setOptions`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
@@ -58,7 +58,7 @@ class ScreenStackHeaderSubview(
             // frame received might be computed by native layout & completely invalid (zero height).
             // RN layout is the source of subview **size** (not origin) & we need to avoid sending
             // this native size to ST. Doing otherwise might lead to problems.
-            // See: TODO: PR LINK
+            // See: https://github.com/software-mansion/react-native-screens/pull/2812
             if (isReactSizeSet) {
                 updateSubviewFrameState(width, height, l, t)
             }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.kt
@@ -10,6 +10,14 @@ class ScreenStackHeaderSubview(
 ) : FabricEnabledHeaderSubviewViewGroup(context) {
     private var reactWidth = 0
     private var reactHeight = 0
+
+    /**
+     * Semantics: true iff we **believe** that SurfaceMountingManager has measured this view during mount item
+     * execution. We recognize this case by checking measure mode in `onMeasure`. If Androidx
+     * happens to use `EXACTLY` for both dimensions this property might convey invalid information.
+     */
+    private var isReactSizeSet = false
+
     var type = Type.RIGHT
 
     val config: ScreenStackHeaderConfig?
@@ -22,9 +30,10 @@ class ScreenStackHeaderSubview(
         if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
             MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
         ) {
-            // dimensions provided by react
+            // dimensions provided by react (with high probability)
             reactWidth = MeasureSpec.getSize(widthMeasureSpec)
             reactHeight = MeasureSpec.getSize(heightMeasureSpec)
+            isReactSizeSet = true
             val parent = parent
             if (parent != null) {
                 forceLayout()
@@ -44,7 +53,15 @@ class ScreenStackHeaderSubview(
         if (changed && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             val width = r - l
             val height = b - t
-            updateSubviewFrameState(width, height, l, t)
+
+            // When setting subviews via `setOptions` from `useEffect` hook in a component, the first
+            // frame received might be computed by native layout & completely invalid (zero height).
+            // RN layout is the source of subview **size** (not origin) & we need to avoid sending
+            // this native size to ST. Doing otherwise might lead to problems.
+            // See: TODO: PR LINK
+            if (isReactSizeSet) {
+                updateSubviewFrameState(width, height, l, t)
+            }
         }
     }
 


### PR DESCRIPTION
## Description

* [x] Should be merged after #2811 & rebased.

When setting subviews via `setOptions` from `useEffect` hook in a
component, the first frame received might be computed by native
layout & completely invalid (zero height). RN layout is the source of a
subview **size** (not origin). When we send such update with zero height
Yoga might (or might not, depending on exact update timing in relation
to other ongoing commits / layouts) set the subview height to 0!
This causes the subview to become invisible & we want to avoid that.

This had not been a problem before https://github.com/software-mansion/react-native-screens/pull/2696, because we would filter out
this kind of frame in the `setSize` guard in the
`ComponentDescriptor.adopt` method of the `HeaderSubview`. https://github.com/software-mansion/react-native-screens/pull/2696 allowed
for zero-sized frames for other, unrelated reason & we must allow these
  as long as they come from React Native layout & not native one.



## Changes

We now filter these invalid frames on the side of HostTree, by detecting whether React has measured the subview or not. 

## Test code and steps to reproduce

I've tested the problem on slightly modified `Test2466`:

<details>

<summary>Code snippet</summary>

```tsx
        import { NavigationContainer } from '@react-navigation/native';
        import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-navigation/native-stack';
        import React from 'react';
        import { findNodeHandle, Text, View } from 'react-native';
        import PressableWithFeedback from '../shared/PressableWithFeedback';

        type StackParamList = {
          Home: undefined,
        }

        type RouteProps = {
          navigation: NativeStackNavigationProp<StackParamList>;
        }

        const Stack = createNativeStackNavigator<StackParamList>();

        function HeaderTitle(): React.JSX.Element {
          return (
            <PressableWithFeedback
              onLayout={event => {
                const { x, y, width, height } = event.nativeEvent.layout;
                console.log('Title onLayout', { x, y, width, height });
              }}
              onPressIn={() => {
                console.log('Pressable onPressIn');
              }}
              onPress={() => console.log('Pressable onPress')}
              onPressOut={() => console.log('Pressable onPressOut')}
              onResponderMove={() => console.log('Pressable onResponderMove')}
              ref={node => {
                console.log(findNodeHandle(node));
                node?.measure((x, y, width, height, pageX, pageY) => {
                  console.log('header component measure', { x, y, width, height, pageX, pageY });
                });
              }}
            >
              <View style={{ height: 40, justifyContent: 'center', alignItems: 'center' }}>
                <Text style={{ alignItems: 'center' }}>Regular Pressable</Text>
              </View>
            </PressableWithFeedback>
          );
        }

        function HeaderLeft(): React.JSX.Element {
          return (
            <HeaderTitle />
          );
        }

        function Home({ navigation }: RouteProps): React.JSX.Element {
          React.useEffect(() => {
            console.log('calling setOptions in useEffect');
            navigation.setOptions({
              //headerTitle: HeaderTitle,
              headerLeft: HeaderLeft,
              //headerRight: HeaderLeft,
            });
          }, [navigation]);
          return (
            <View style={{ flex: 1, backgroundColor: 'rgba(0, 0, 0, .8)' }}
            >
              <View style={{ flex: 1, alignItems: 'center', marginTop: 48 }}>
                <PressableWithFeedback
                  onPressIn={() => console.log('Pressable onPressIn')}
                  onPress={() => console.log('Pressable onPress')}
                  onPressOut={() => console.log('Pressable onPressOut')}
                >
                  <View style={{ height: 40, width: 200, justifyContent: 'center', alignItems: 'center' }}>
                    <Text style={{ alignItems: 'center' }}>Regular Pressable</Text>
                  </View>
                </PressableWithFeedback>
              </View>
            </View>
          );
        }

        function App(): React.JSX.Element {
          return (
            <NavigationContainer>
              <Stack.Navigator>
                <Stack.Screen
                  name="Home"
                  component={Home}
                  options={{
                    //headerTitle: HeaderTitle,
                    //headerLeft: HeaderLeft,
                    //headerRight: HeaderLeft,
                  }}
                />
              </Stack.Navigator>
            </NavigationContainer>
          );
        }

        export default App;
```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes (https://github.com/software-mansion/react-native-screens/pull/2812/commits/7d3205eddfc02b09f7dc7d88a52208b7d8e6ca58)
