### PR TITLE
fix useHeaderHeight hook

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -77,7 +77,8 @@ namespace react = facebook::react;
     RNSScreen *screenController = (RNSScreen *)self.topViewController;
     BOOL isNotDismissingModal = screenController.presentedViewController == nil ||
         (screenController.presentedViewController != nil &&
-         ![screenController.presentedViewController isBeingDismissed]);
+         ![screenController.presentedViewController isBeingDismissed]) ||
+        ([screenController.presentedViewController isKindOfClass:[UISearchController class]]);
 
     // Calculate header height during simple transition from one screen to another.
     // If RNSScreen includes a navigation controller of type RNSNavigationController, it should not calculate


### PR DESCRIPTION
## Description

This PR fixes https://github.com/software-mansion/react-native-screens/issues/2611.

After this changes the hook will provide header height values after focusing search bar. 

## Changes

It seems that we have a logic, that disables `useHeaderHeight` updates when the modal is being closed. The condition assumes that only if there is a [presentedViewController](https://developer.apple.com/documentation/uikit/uiviewcontroller/presentedviewcontroller?language=objc), this is a modal. But it looks like it can also be a `UISearchController`, so we exclude that from the condition. 

## Screenshots / GIFs

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/928fdd00-a27e-4ff4-82d3-adf9f9e69cba" />|<video src="https://github.com/user-attachments/assets/b5c9dd7b-570c-4a78-b244-ffcff26a7032"/>| 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
