### PR TITLE
refactor(Android): add `isTranslucent` to `ScreenFragmentWrapper` & align method naming on `Screen`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -260,6 +260,9 @@ class Screen(
         )
     }
 
+    /**
+     * Whether this screen allows to see the content underneath it.
+     */
     fun isTranslucent(): Boolean =
         when (stackPresentation) {
             StackPresentation.TRANSPARENT_MODAL,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -260,7 +260,7 @@ class Screen(
         )
     }
 
-    fun isTransparent(): Boolean =
+    fun isTranslucent(): Boolean =
         when (stackPresentation) {
             StackPresentation.TRANSPARENT_MODAL,
             StackPresentation.FORM_SHEET,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -128,6 +128,7 @@ open class ScreenFragment :
         ScreenWindowTraits.trySetWindowTraits(screen, activity, tryGetContext())
     }
 
+    // Plain ScreenFragments can not be translucent
     override fun isTranslucent() = false
 
     override fun tryGetActivity(): Activity? {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.kt
@@ -128,6 +128,8 @@ open class ScreenFragment :
         ScreenWindowTraits.trySetWindowTraits(screen, activity, tryGetContext())
     }
 
+    override fun isTranslucent() = false
+
     override fun tryGetActivity(): Activity? {
         activity?.let { return it }
         val context = screen.context

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt
@@ -26,6 +26,15 @@ interface ScreenFragmentWrapper :
 
     fun onViewAnimationEnd()
 
+    // Fragment information
+
+    /**
+     * Whether this screen fragment makes it possible to see content underneath it
+     * (not fully opaque or does not fill full screen).
+     */
+    fun isTranslucent(): Boolean
+
+
     // Helpers
     fun tryGetActivity(): Activity?
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenModalFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenModalFragment.kt
@@ -92,6 +92,8 @@ class ScreenModalFragment :
         savedInstanceState: Bundle?,
     ): View? = null
 
+    override fun isTranslucent(): Boolean = true
+
     override fun dismissFromContainer() {
         check(container is ScreenStack)
         val container = container as ScreenStack

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -184,7 +184,7 @@ class ScreenStack(
         newTop = notDismissedWrappers.firstOrNull()
         visibleBottom =
             notDismissedWrappers
-                .dropWhile { it.screen.isTranslucent() }
+                .dropWhile { it.isTranslucent() }
                 .firstOrNull()
                 ?.takeUnless { it === newTop }
 
@@ -238,8 +238,8 @@ class ScreenStack(
             childDrawingOrderStrategy = SwapLastTwo()
         } else if (newTop != null &&
             newTopAlreadyInStack &&
-            topScreenWrapper?.screen?.isTranslucent() == true &&
-            newTop.screen.isTranslucent() == false
+            topScreenWrapper?.isTranslucent() == true &&
+            newTop.isTranslucent() == false
         ) {
             // In case where we dismiss multiple transparent views we want to ensure
             // that they are drawn in correct order - Android swaps them by default,
@@ -250,7 +250,7 @@ class ScreenStack(
                     .asSequence()
                     .takeWhile {
                         it !== newTop &&
-                            it.screen.isTranslucent()
+                            it.isTranslucent()
                     }.count()
             if (dismissedTransparentScreenApproxCount > 1) {
                 childDrawingOrderStrategy =
@@ -311,7 +311,7 @@ class ScreenStack(
     private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenFragmentWrapper?) {
         if (screenWrappers.size > 1 && visibleBottom != null) {
             topScreenWrapper?.let {
-                if (it.screen.isTranslucent()) {
+                if (it.isTranslucent()) {
                     val screenFragmentsBeneathTop = screenWrappers.slice(0 until screenWrappers.size - 1).asReversed()
                     // go from the top of the stack excluding the top screen
                     for (fragmentWrapper in screenFragmentsBeneathTop) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -184,7 +184,7 @@ class ScreenStack(
         newTop = notDismissedWrappers.firstOrNull()
         visibleBottom =
             notDismissedWrappers
-                .dropWhile { it.screen.isTransparent() }
+                .dropWhile { it.screen.isTranslucent() }
                 .firstOrNull()
                 ?.takeUnless { it === newTop }
 
@@ -238,8 +238,8 @@ class ScreenStack(
             childDrawingOrderStrategy = SwapLastTwo()
         } else if (newTop != null &&
             newTopAlreadyInStack &&
-            topScreenWrapper?.screen?.isTransparent() == true &&
-            newTop.screen.isTransparent() == false
+            topScreenWrapper?.screen?.isTranslucent() == true &&
+            newTop.screen.isTranslucent() == false
         ) {
             // In case where we dismiss multiple transparent views we want to ensure
             // that they are drawn in correct order - Android swaps them by default,
@@ -250,7 +250,7 @@ class ScreenStack(
                     .asSequence()
                     .takeWhile {
                         it !== newTop &&
-                            it.screen.isTransparent()
+                            it.screen.isTranslucent()
                     }.count()
             if (dismissedTransparentScreenApproxCount > 1) {
                 childDrawingOrderStrategy =
@@ -311,7 +311,7 @@ class ScreenStack(
     private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenFragmentWrapper?) {
         if (screenWrappers.size > 1 && visibleBottom != null) {
             topScreenWrapper?.let {
-                if (it.screen.isTransparent()) {
+                if (it.screen.isTranslucent()) {
                     val screenFragmentsBeneathTop = screenWrappers.slice(0 until screenWrappers.size - 1).asReversed()
                     // go from the top of the stack excluding the top screen
                     for (fragmentWrapper in screenFragmentsBeneathTop) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -86,6 +86,8 @@ class ScreenStackFragment :
         )
     }
 
+    override fun isTranslucent(): Boolean = screen.isTranslucent()
+
     override fun removeToolbar() {
         appBarLayout?.let {
             toolbar?.let { toolbar ->
@@ -380,7 +382,7 @@ class ScreenStackFragment :
         // If the screen is a transparent modal with hidden header we don't want to update the toolbar
         // menu because it may erase the menu of the previous screen (which is still visible in these
         // circumstances). See here: https://github.com/software-mansion/react-native-screens/issues/2271
-        if (!screen.isTransparent() || screen.headerConfig?.isHeaderHidden == false) {
+        if (!screen.isTranslucent() || screen.headerConfig?.isHeaderHidden == false) {
             updateToolbarMenu(menu)
         }
         return super.onPrepareOptionsMenu(menu)


### PR DESCRIPTION

## Description

Makes it more straightforward to get translucency information from fragment.

## Changes

- **Expose `isTranslucent` on `ScreenFragmentWrapper` & rename `Screen.isTransparent`**
- **Add comments**
- **Add comments 2**
- **Use newly exposed method**
- **Update ScreenModalFragment**

## Test code and steps to reproduce

Nothing changes in behaviour.

## Checklist

- [ ] Ensured that CI passes
