### PR TITLE
fix(Windows): fix building and crashing issues

### DIFF
--- a/src/components/ScreenContentWrapper.windows.tsx
+++ b/src/components/ScreenContentWrapper.windows.tsx
@@ -1,0 +1,5 @@
+import { View } from 'react-native';
+
+const ScreenContentWrapper = View;
+
+export default ScreenContentWrapper;

--- a/src/components/ScreenFooter.windows.tsx
+++ b/src/components/ScreenFooter.windows.tsx
@@ -1,0 +1,7 @@
+import { View } from 'react-native';
+
+const ScreenFooter = View;
+const FooterComponent = View;
+
+export default ScreenFooter;
+export { FooterComponent };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { BackHandler, Platform } from 'react-native';
 export const isSearchBarAvailableForCurrentPlatform = [
   'ios',
   'android',
-  'windows'
+  'windows',
 ].includes(Platform.OS);
 
 export function executeNativeBackPress() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { BackHandler, Platform } from 'react-native';
 export const isSearchBarAvailableForCurrentPlatform = [
   'ios',
   'android',
+  'windows'
 ].includes(Platform.OS);
 
 export function executeNativeBackPress() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import { BackHandler, Platform } from 'react-native';
 export const isSearchBarAvailableForCurrentPlatform = [
   'ios',
   'android',
-  'windows',
 ].includes(Platform.OS);
 
 export function executeNativeBackPress() {

--- a/windows/RNScreens/ModalScreenViewManager.cpp
+++ b/windows/RNScreens/ModalScreenViewManager.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+#include "ModalScreenViewManager.h"
+#include "JSValueXaml.h"
+#include "NativeModules.h"
+#include "ModalScreen.h"
+
+namespace winrt {
+using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+} // namespace winrt
+
+namespace winrt::RNScreens::implementation {
+// IViewManager
+winrt::hstring ModalScreenViewManager::Name() noexcept {
+  return L"RNSModalScreen";
+}
+
+
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ModalScreenViewManager.h
+++ b/windows/RNScreens/ModalScreenViewManager.h
@@ -8,6 +8,6 @@ namespace winrt::RNScreens::implementation {
 class ModalScreenViewManager : public ScreenViewManager {
  public:
   ModalScreenViewManager() = default;
-  virtual winrt::hstring Name() noexcept;
+  winrt::hstring Name() noexcept;
 };
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ModalScreenViewManager.h
+++ b/windows/RNScreens/ModalScreenViewManager.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "NativeModules.h"
+#include "winrt/Microsoft.ReactNative.h"
+#include "ScreenViewManager.h"
+
+namespace winrt::RNScreens::implementation {
+
+class ModalScreenViewManager : public ScreenViewManager {
+ public:
+  ModalScreenViewManager() = default;
+  virtual winrt::hstring Name() noexcept;
+};
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/RNScreens.vcxproj
+++ b/windows/RNScreens/RNScreens.vcxproj
@@ -20,7 +20,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
   <PropertyGroup Label="Fallback Windows SDK Versions">
    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
-   <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.16299.0</WindowsTargetPlatformMinVersion>
+   <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/windows/RNScreens/RNScreens.vcxproj
+++ b/windows/RNScreens/RNScreens.vcxproj
@@ -123,6 +123,7 @@
     <ClInclude Include="ScreenStack.h" />
     <ClInclude Include="ScreenStackHeaderConfigViewManager.h" />
     <ClInclude Include="ScreenStackHeaderSubviewViewManager.h" />
+    <ClInclude Include="SearchBarViewManager.h" />
     <ClInclude Include="ModalScreenViewManager.h" />
     <ClInclude Include="ScreenViewManager.h" />
     <ClInclude Include="RNScreens.h">
@@ -136,6 +137,7 @@
     </ClCompile>
     <ClInclude Include="ScreenStackHeaderConfig.h" />
     <ClInclude Include="ScreenStackHeaderSubview.h" />
+    <ClInclude Include="SearchBar.h" />
     <ClInclude Include="ScreenStackViewManager.h" />
   </ItemGroup>
   <ItemGroup>
@@ -148,6 +150,7 @@
     <ClCompile Include="ScreenStack.cpp" />
     <ClCompile Include="ScreenStackHeaderConfigViewManager.cpp" />
     <ClCompile Include="ScreenStackHeaderSubviewViewManager.cpp" />
+    <ClCompile Include="SearchBarViewManager.cpp" />
     <ClCompile Include="ModalScreenViewManager.cpp" />
     <ClCompile Include="ScreenViewManager.cpp" />
     <ClCompile Include="ReactPackageProvider.cpp">
@@ -156,6 +159,7 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="ScreenStackHeaderConfig.cpp" />
     <ClCompile Include="ScreenStackHeaderSubview.cpp" />
+    <ClCompile Include="SearchBar.cpp" />
     <ClCompile Include="ScreenStackViewManager.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/windows/RNScreens/RNScreens.vcxproj
+++ b/windows/RNScreens/RNScreens.vcxproj
@@ -122,6 +122,8 @@
     <ClInclude Include="ScreenContainerViewManager.h" />
     <ClInclude Include="ScreenStack.h" />
     <ClInclude Include="ScreenStackHeaderConfigViewManager.h" />
+    <ClInclude Include="ScreenStackHeaderSubviewViewManager.h" />
+    <ClInclude Include="ModalScreenViewManager.h" />
     <ClInclude Include="ScreenViewManager.h" />
     <ClInclude Include="RNScreens.h">
       <DependentUpon>RNScreens.idl</DependentUpon>
@@ -133,6 +135,7 @@
       <DependentUpon>RNScreens.idl</DependentUpon>
     </ClCompile>
     <ClInclude Include="ScreenStackHeaderConfig.h" />
+    <ClInclude Include="ScreenStackHeaderSubview.h" />
     <ClInclude Include="ScreenStackViewManager.h" />
   </ItemGroup>
   <ItemGroup>
@@ -144,12 +147,15 @@
     <ClCompile Include="ScreenContainerViewManager.cpp" />
     <ClCompile Include="ScreenStack.cpp" />
     <ClCompile Include="ScreenStackHeaderConfigViewManager.cpp" />
+    <ClCompile Include="ScreenStackHeaderSubviewViewManager.cpp" />
+    <ClCompile Include="ModalScreenViewManager.cpp" />
     <ClCompile Include="ScreenViewManager.cpp" />
     <ClCompile Include="ReactPackageProvider.cpp">
       <DependentUpon>ReactPackageProvider.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="ScreenStackHeaderConfig.cpp" />
+    <ClCompile Include="ScreenStackHeaderSubview.cpp" />
     <ClCompile Include="ScreenStackViewManager.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/windows/RNScreens/RNScreens.vcxproj.filters
+++ b/windows/RNScreens/RNScreens.vcxproj.filters
@@ -17,8 +17,11 @@
     <ClCompile Include="RNScreens.cpp" />
     <ClCompile Include="Screen.cpp" />
     <ClCompile Include="ScreenStackHeaderConfigViewManager.cpp" />
+    <ClCompile Include="ScreenStackHeaderSubviewViewManager.cpp" />
+    <ClCompile Include="ModalScreenViewManager.cpp" />
     <ClCompile Include="ScreenViewManager.cpp" />
     <ClCompile Include="ScreenStackHeaderConfig.cpp" />
+    <ClCompile Include="ScreenStackHeaderSubview.cpp" />
     <ClCompile Include="ScreenStackViewManager.cpp" />
     <ClCompile Include="ScreenStack.cpp" />
     <ClCompile Include="ScreenContainerViewManager.cpp" />
@@ -31,8 +34,11 @@
     <ClInclude Include="RNScreens.h" />
     <ClInclude Include="Screen.h" />
     <ClInclude Include="ScreenStackHeaderConfigViewManager.h" />
+    <ClInclude Include="ScreenStackHeaderSubviewViewManager.h" />
+    <ClInclude Include="ModalScreenViewManager.h" />
     <ClInclude Include="ScreenViewManager.h" />
     <ClInclude Include="ScreenStackHeaderConfig.h" />
+    <ClInclude Include="ScreenStackHeaderSubview.h" />
     <ClInclude Include="ScreenStackViewManager.h" />
     <ClInclude Include="ScreenStack.h" />
     <ClInclude Include="ScreenContainer.h" />

--- a/windows/RNScreens/RNScreens.vcxproj.filters
+++ b/windows/RNScreens/RNScreens.vcxproj.filters
@@ -18,10 +18,12 @@
     <ClCompile Include="Screen.cpp" />
     <ClCompile Include="ScreenStackHeaderConfigViewManager.cpp" />
     <ClCompile Include="ScreenStackHeaderSubviewViewManager.cpp" />
+    <ClCompile Include="SearchBarViewManager.cpp" />
     <ClCompile Include="ModalScreenViewManager.cpp" />
     <ClCompile Include="ScreenViewManager.cpp" />
     <ClCompile Include="ScreenStackHeaderConfig.cpp" />
     <ClCompile Include="ScreenStackHeaderSubview.cpp" />
+    <ClCompile Include="SearchBar.cpp" />
     <ClCompile Include="ScreenStackViewManager.cpp" />
     <ClCompile Include="ScreenStack.cpp" />
     <ClCompile Include="ScreenContainerViewManager.cpp" />
@@ -35,10 +37,12 @@
     <ClInclude Include="Screen.h" />
     <ClInclude Include="ScreenStackHeaderConfigViewManager.h" />
     <ClInclude Include="ScreenStackHeaderSubviewViewManager.h" />
+    <ClInclude Include="SearchBarViewManager.h" />
     <ClInclude Include="ModalScreenViewManager.h" />
     <ClInclude Include="ScreenViewManager.h" />
     <ClInclude Include="ScreenStackHeaderConfig.h" />
     <ClInclude Include="ScreenStackHeaderSubview.h" />
+    <ClInclude Include="SearchBar.h" />
     <ClInclude Include="ScreenStackViewManager.h" />
     <ClInclude Include="ScreenStack.h" />
     <ClInclude Include="ScreenContainer.h" />

--- a/windows/RNScreens/ReactPackageProvider.cpp
+++ b/windows/RNScreens/ReactPackageProvider.cpp
@@ -8,6 +8,8 @@
 #include "ScreenStackHeaderConfigViewManager.h"
 #include "ScreenStackViewManager.h"
 #include "ScreenViewManager.h"
+#include "ScreenStackHeaderSubviewViewManager.h"
+#include "ModalScreenViewManager.h"
 
 using namespace winrt::Microsoft::ReactNative;
 
@@ -17,14 +19,25 @@ void ReactPackageProvider::CreatePackage(
   packageBuilder.AddViewManager(L"RNScreensViewManager", []() {
     return winrt::make<ScreenViewManager>();
   });
+
   packageBuilder.AddViewManager(L"RNScreensStackHeaderConfigViewManager", []() {
     return winrt::make<ScreenStackHeaderConfigViewManager>();
   });
+
   packageBuilder.AddViewManager(L"RNSScreenStackViewManager", []() {
     return winrt::make<ScreenStackViewManager>();
   });
+
   packageBuilder.AddViewManager(L"RNSScreenContainerViewManager", []() {
     return winrt::make<ScreenContainerViewManager>();
+  });
+
+  packageBuilder.AddViewManager(L"RNSScreenStackHeaderSubviewViewManager", [] () {
+    return winrt::make<ScreenStackHeaderSubviewViewManager>();
+  });
+
+  packageBuilder.AddViewManager(L"RNSModalScreenViewManager", [] () {
+    return winrt::make<ModalScreenViewManager>();
   });
 }
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ReactPackageProvider.cpp
+++ b/windows/RNScreens/ReactPackageProvider.cpp
@@ -10,6 +10,7 @@
 #include "ScreenViewManager.h"
 #include "ScreenStackHeaderSubviewViewManager.h"
 #include "ModalScreenViewManager.h"
+#include "SearchBarViewManager.h"
 
 using namespace winrt::Microsoft::ReactNative;
 
@@ -38,6 +39,10 @@ void ReactPackageProvider::CreatePackage(
 
   packageBuilder.AddViewManager(L"RNSModalScreenViewManager", [] () {
     return winrt::make<ModalScreenViewManager>();
+  });
+
+  packageBuilder.AddViewManager(L"RNSSearchBar", [] () {
+    return winrt::make<SearchBarViewManager>();
   });
 }
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/Screen.cpp
+++ b/windows/RNScreens/Screen.cpp
@@ -119,4 +119,10 @@ void Screen::dispatchOnDisappear() {
         eventDataWriter.WriteObjectEnd();
       });
 }
+StackAnimation Screen::GetStackAnimation() const {
+  return stackAnimation;
+}
+void Screen::SetStackAnimation(StackAnimation const& animation) {
+  stackAnimation = animation;
+}
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/Screen.h
+++ b/windows/RNScreens/Screen.h
@@ -8,9 +8,10 @@ enum class StackAnimation {
   DEFAULT,
   NONE,
   FADE,
-  SIMPLE_FROM_BOTTOM,
+  SLIDE_FROM_BOTTOM,
   SLIDE_FROM_RIGHT,
   SLIDE_FROM_LEFT,
+  FADE_FROM_BOTTOM,
   IOS_FROM_RIGHT,
   IOS_FROM_LEFT
 };
@@ -59,8 +60,11 @@ class Screen : public winrt::Windows::UI::Xaml::Controls::StackPanelT<Screen> {
   void dispatchOnDisappear();
   void dispatchOnWillAppear();
   void dispatchOnWillDisappear();
+  StackAnimation GetStackAnimation() const;
+  void SetStackAnimation(StackAnimation const& animation);
 
  private:
   winrt::Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
+  StackAnimation stackAnimation;
 };
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/Screen.h
+++ b/windows/RNScreens/Screen.h
@@ -2,7 +2,7 @@
 
 namespace winrt::RNScreens::implementation {
 
-enum class StackPresentation { PUSH, MODAL, TRANSPARENT_MODAL };
+enum class StackPresentation { PUSH, MODAL, TRANSPARENT_MODAL, FORM_SHEET };
 
 enum class StackAnimation {
   DEFAULT,

--- a/windows/RNScreens/ScreenStackHeaderConfig.cpp
+++ b/windows/RNScreens/ScreenStackHeaderConfig.cpp
@@ -15,5 +15,29 @@ using namespace Windows::UI::Xaml::Controls;
 namespace winrt::RNScreens::implementation {
 ScreenStackHeaderConfig::ScreenStackHeaderConfig(
     winrt::Microsoft::ReactNative::IReactContext reactContext)
-    : m_reactContext(reactContext) {}
+    : m_reactContext(reactContext),
+     m_children(
+                    {winrt::single_threaded_vector<Windows::UI::Xaml::UIElement>()}) {}
+
+void ScreenStackHeaderConfig::addView(winrt::Windows::UI::Xaml::UIElement element) {
+  Children().Append(element);
+}
+
+void ScreenStackHeaderConfig::removeAllChildren() {
+  Children().Clear();
+}
+
+void ScreenStackHeaderConfig::removeChildAt(int64_t index) {
+  Children().RemoveAt(static_cast<uint32_t>(index));
+}
+
+void ScreenStackHeaderConfig::replaceChild(
+    winrt::Windows::UI::Xaml::UIElement oldChild,
+    winrt::Windows::UI::Xaml::UIElement newChild) {
+  uint32_t index;
+  if (!Children().IndexOf(oldChild, index))
+    return;
+
+  Children().SetAt(index, newChild);
+}
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderConfig.h
+++ b/windows/RNScreens/ScreenStackHeaderConfig.h
@@ -6,8 +6,17 @@ class ScreenStackHeaderConfig
           ScreenStackHeaderConfig> {
  public:
   ScreenStackHeaderConfig(
-      winrt::Microsoft::ReactNative::IReactContext m_reactContext);
+      winrt::Microsoft::ReactNative::IReactContext reactContext);
 
+  void addView(winrt::Windows::UI::Xaml::UIElement element);
+  void removeAllChildren();
+  void removeChildAt(int64_t index);
+  void replaceChild(
+      winrt::Windows::UI::Xaml::UIElement oldChild,
+      winrt::Windows::UI::Xaml::UIElement newChild);
+
+  winrt::Windows::Foundation::Collections::IVector<Windows::UI::Xaml::UIElement>
+      m_children;
  private:
   winrt::Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
 };

--- a/windows/RNScreens/ScreenStackHeaderConfigViewManager.cpp
+++ b/windows/RNScreens/ScreenStackHeaderConfigViewManager.cpp
@@ -26,7 +26,48 @@ ScreenStackHeaderConfigViewManager::CreateView() noexcept {
 
 // IViewManagerRequiresNativeLayout
 bool ScreenStackHeaderConfigViewManager::RequiresNativeLayout() {
-  return true;
+  return false;
+}
+
+// IViewManagerWithChildren
+void ScreenStackHeaderConfigViewManager::AddView(
+    FrameworkElement parent,
+    UIElement child,
+    int64_t index) {
+  auto screenStackHeaderConfig = parent.as<ScreenStackHeaderConfig>();
+  if (!screenStackHeaderConfig)
+    return;
+
+  screenStackHeaderConfig->addView(child);
+}
+
+void ScreenStackHeaderConfigViewManager::RemoveAllChildren(FrameworkElement parent) {
+  auto screenStackHeaderConfig = parent.as<ScreenStackHeaderConfig>();
+  if (!screenStackHeaderConfig)
+    return;
+
+  screenStackHeaderConfig->removeAllChildren();
+}
+
+void ScreenStackHeaderConfigViewManager::RemoveChildAt(
+    FrameworkElement parent,
+    int64_t index) {
+  auto screenStackHeaderConfig = parent.as<ScreenStackHeaderConfig>();
+  if (!screenStackHeaderConfig)
+    return;
+
+  screenStackHeaderConfig->removeChildAt(index);
+}
+
+void ScreenStackHeaderConfigViewManager::ReplaceChild(
+    FrameworkElement parent,
+    UIElement oldChild,
+    UIElement newChild) {
+  auto screenStackHeaderConfig = parent.as<ScreenStackHeaderConfig>();
+  if (!screenStackHeaderConfig)
+    return;
+
+  screenStackHeaderConfig->replaceChild(oldChild, newChild);
 }
 
 // IViewManagerWithReactContext

--- a/windows/RNScreens/ScreenStackHeaderConfigViewManager.h
+++ b/windows/RNScreens/ScreenStackHeaderConfigViewManager.h
@@ -10,6 +10,7 @@ class ScreenStackHeaderConfigViewManager
           winrt::Microsoft::ReactNative::IViewManager,
           winrt::Microsoft::ReactNative::IViewManagerRequiresNativeLayout,
           winrt::Microsoft::ReactNative::IViewManagerWithReactContext,
+          winrt::Microsoft::ReactNative::IViewManagerWithChildren,
           winrt::Microsoft::ReactNative::IViewManagerWithNativeProperties,
           winrt::Microsoft::ReactNative::
               IViewManagerWithExportedEventTypeConstants,
@@ -23,6 +24,20 @@ class ScreenStackHeaderConfigViewManager
 
   // IViewManagerRequiresNativeLayout
   bool RequiresNativeLayout();
+
+  // IViewManagerWithChildren
+  void AddView(
+      winrt::Windows::UI::Xaml::FrameworkElement parent,
+      winrt::Windows::UI::Xaml::UIElement child,
+      int64_t index);
+  void RemoveAllChildren(winrt::Windows::UI::Xaml::FrameworkElement parent);
+  void RemoveChildAt(
+      winrt::Windows::UI::Xaml::FrameworkElement parent,
+      int64_t index);
+  void ReplaceChild(
+      winrt::Windows::UI::Xaml::FrameworkElement parent,
+      winrt::Windows::UI::Xaml::UIElement oldChild,
+      winrt::Windows::UI::Xaml::UIElement newChild);
 
   // IViewManagerWithReactContext
   winrt::Microsoft::ReactNative::IReactContext ReactContext() noexcept;

--- a/windows/RNScreens/ScreenStackHeaderSubview.cpp
+++ b/windows/RNScreens/ScreenStackHeaderSubview.cpp
@@ -15,5 +15,29 @@ using namespace Windows::UI::Xaml::Controls;
 namespace winrt::RNScreens::implementation {
 ScreenStackHeaderSubview::ScreenStackHeaderSubview(
     winrt::Microsoft::ReactNative::IReactContext reactContext)
-    : m_reactContext(reactContext) {}
+    : m_reactContext(reactContext),
+      m_children(
+               {winrt::single_threaded_vector<Windows::UI::Xaml::UIElement>()}) {}
+
+void ScreenStackHeaderSubview::addView(winrt::Windows::UI::Xaml::UIElement element) {
+  Children().Append(element);
+}
+
+void ScreenStackHeaderSubview::removeAllChildren() {
+//   Children().Clear();
+}
+
+void ScreenStackHeaderSubview::removeChildAt(int64_t index) {
+//   Children().RemoveAt(static_cast<uint32_t>(index));
+}
+
+void ScreenStackHeaderSubview::replaceChild(
+    winrt::Windows::UI::Xaml::UIElement oldChild,
+    winrt::Windows::UI::Xaml::UIElement newChild) {
+  uint32_t index;
+  if (!Children().IndexOf(oldChild, index))
+    return;
+
+  Children().SetAt(index, newChild);
+}
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderSubview.cpp
+++ b/windows/RNScreens/ScreenStackHeaderSubview.cpp
@@ -24,11 +24,11 @@ void ScreenStackHeaderSubview::addView(winrt::Windows::UI::Xaml::UIElement eleme
 }
 
 void ScreenStackHeaderSubview::removeAllChildren() {
-//   Children().Clear();
+  Children().Clear();
 }
 
 void ScreenStackHeaderSubview::removeChildAt(int64_t index) {
-//   Children().RemoveAt(static_cast<uint32_t>(index));
+  Children().RemoveAt(static_cast<uint32_t>(index));
 }
 
 void ScreenStackHeaderSubview::replaceChild(

--- a/windows/RNScreens/ScreenStackHeaderSubview.cpp
+++ b/windows/RNScreens/ScreenStackHeaderSubview.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+#include "ScreenStackHeaderSubview.h"
+#include "JSValueXaml.h"
+#include "NativeModules.h"
+
+namespace winrt {
+using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+} // namespace winrt
+
+namespace winrt::RNScreens::implementation {
+ScreenStackHeaderSubview::ScreenStackHeaderSubview(
+    winrt::Microsoft::ReactNative::IReactContext reactContext)
+    : m_reactContext(reactContext) {}
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderSubview.h
+++ b/windows/RNScreens/ScreenStackHeaderSubview.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace winrt::RNScreens::implementation {
+class ScreenStackHeaderSubview
+    : public winrt::Windows::UI::Xaml::Controls::StackPanelT<
+          ScreenStackHeaderSubview> {
+ public:
+  ScreenStackHeaderSubview(
+      winrt::Microsoft::ReactNative::IReactContext m_reactContext);
+
+ private:
+  winrt::Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
+};
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderSubview.h
+++ b/windows/RNScreens/ScreenStackHeaderSubview.h
@@ -6,7 +6,17 @@ class ScreenStackHeaderSubview
           ScreenStackHeaderSubview> {
  public:
   ScreenStackHeaderSubview(
-      winrt::Microsoft::ReactNative::IReactContext m_reactContext);
+      winrt::Microsoft::ReactNative::IReactContext reactContext);
+
+  void addView(winrt::Windows::UI::Xaml::UIElement element);
+  void removeAllChildren();
+  void removeChildAt(int64_t index);
+  void replaceChild(
+      winrt::Windows::UI::Xaml::UIElement oldChild,
+      winrt::Windows::UI::Xaml::UIElement newChild);
+
+  winrt::Windows::Foundation::Collections::IVector<Windows::UI::Xaml::UIElement>
+      m_children;
 
  private:
   winrt::Microsoft::ReactNative::IReactContext m_reactContext{nullptr};

--- a/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp
+++ b/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp
@@ -1,8 +1,8 @@
 #include "pch.h"
 #include "ScreenStackHeaderSubviewViewManager.h"
+#include "ScreenStackHeaderSubview.h"
 #include "JSValueXaml.h"
 #include "NativeModules.h"
-#include "ScreenStackHeaderSubview.h"
 
 namespace winrt {
 using namespace Microsoft::ReactNative;
@@ -19,25 +19,54 @@ winrt::hstring ScreenStackHeaderSubviewViewManager::Name() noexcept {
   return L"RNSScreenStackHeaderSubview";
 }
 
-winrt::FrameworkElement
-ScreenStackHeaderSubviewViewManager::CreateView() noexcept {
-  return winrt::make<ScreenStackHeaderSubview>(m_reactContext);
+winrt::FrameworkElement ScreenStackHeaderSubviewViewManager::CreateView() noexcept {
+  return winrt::make<winrt::RNScreens::implementation::ScreenStackHeaderSubview>(m_reactContext);
 }
 
 // IViewManagerRequiresNativeLayout
 bool ScreenStackHeaderSubviewViewManager::RequiresNativeLayout() {
-  return true;
+  return false;
 }
 
-// IViewManagerWithReactContext
-winrt::IReactContext
-ScreenStackHeaderSubviewViewManager::ReactContext() noexcept {
-  return m_reactContext;
+// IViewManagerWithChildren
+void ScreenStackHeaderSubviewViewManager::AddView(
+    FrameworkElement parent,
+    UIElement child,
+    int64_t index) {
+  auto screenStackHeaderSubview = parent.as<ScreenStackHeaderSubview>();
+  if (!screenStackHeaderSubview)
+    return;
+
+  screenStackHeaderSubview->addView(child);
 }
 
-void ScreenStackHeaderSubviewViewManager::ReactContext(
-    IReactContext reactContext) noexcept {
-  m_reactContext = reactContext;
+void ScreenStackHeaderSubviewViewManager::RemoveAllChildren(FrameworkElement parent) {
+  auto screenStackHeaderSubview = parent.as<ScreenStackHeaderSubview>();
+  if (!screenStackHeaderSubview)
+    return;
+
+  screenStackHeaderSubview->removeAllChildren();
+}
+
+void ScreenStackHeaderSubviewViewManager::RemoveChildAt(
+    FrameworkElement parent,
+    int64_t index) {
+  auto screenStackHeaderSubview = parent.as<ScreenStackHeaderSubview>();
+  if (!screenStackHeaderSubview)
+    return;
+
+  screenStackHeaderSubview->removeChildAt(index);
+}
+
+void ScreenStackHeaderSubviewViewManager::ReplaceChild(
+    FrameworkElement parent,
+    UIElement oldChild,
+    UIElement newChild) {
+  auto screenStackHeaderSubview = parent.as<ScreenStackHeaderSubview>();
+  if (!screenStackHeaderSubview)
+    return;
+
+  screenStackHeaderSubview->replaceChild(oldChild, newChild);
 }
 
 // IViewManagerWithNativeProperties
@@ -61,17 +90,6 @@ void ScreenStackHeaderSubviewViewManager::UpdateProperties(
   }
 }
 
-// IViewManagerWithExportedEventTypeConstants
-ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
-    ExportedCustomBubblingEventTypeConstants() noexcept {
-  return nullptr;
-}
-
-ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
-    ExportedCustomDirectEventTypeConstants() noexcept {
-  return nullptr;
-}
-
 // IViewManagerWithCommands
 IVectorView<hstring> ScreenStackHeaderSubviewViewManager::Commands() noexcept {
   auto commands = winrt::single_threaded_vector<hstring>();
@@ -86,4 +104,26 @@ void ScreenStackHeaderSubviewViewManager::DispatchCommand(
   (void)commandId;
   (void)commandArgsReader;
 }
+
+
+// IViewManagerWithExportedEventTypeConstants
+ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
+    ExportedCustomBubblingEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
+    ExportedCustomDirectEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+// IViewManagerWithReactContext
+winrt::IReactContext ScreenStackHeaderSubviewViewManager::ReactContext() noexcept {
+  return m_reactContext;
+}
+
+void ScreenStackHeaderSubviewViewManager::ReactContext(IReactContext reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp
+++ b/windows/RNScreens/ScreenStackHeaderSubviewViewManager.cpp
@@ -1,0 +1,89 @@
+#include "pch.h"
+#include "ScreenStackHeaderSubviewViewManager.h"
+#include "JSValueXaml.h"
+#include "NativeModules.h"
+#include "ScreenStackHeaderSubview.h"
+
+namespace winrt {
+using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+} // namespace winrt
+
+namespace winrt::RNScreens::implementation {
+// IViewManager
+winrt::hstring ScreenStackHeaderSubviewViewManager::Name() noexcept {
+  return L"RNSScreenStackHeaderSubview";
+}
+
+winrt::FrameworkElement
+ScreenStackHeaderSubviewViewManager::CreateView() noexcept {
+  return winrt::make<ScreenStackHeaderSubview>(m_reactContext);
+}
+
+// IViewManagerRequiresNativeLayout
+bool ScreenStackHeaderSubviewViewManager::RequiresNativeLayout() {
+  return true;
+}
+
+// IViewManagerWithReactContext
+winrt::IReactContext
+ScreenStackHeaderSubviewViewManager::ReactContext() noexcept {
+  return m_reactContext;
+}
+
+void ScreenStackHeaderSubviewViewManager::ReactContext(
+    IReactContext reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
+// IViewManagerWithNativeProperties
+IMapView<hstring, ViewManagerPropertyType>
+ScreenStackHeaderSubviewViewManager::NativeProps() noexcept {
+  auto nativeProps =
+      winrt::single_threaded_map<hstring, ViewManagerPropertyType>();
+  return nativeProps.GetView();
+}
+
+void ScreenStackHeaderSubviewViewManager::UpdateProperties(
+    FrameworkElement const &view,
+    IJSValueReader const &propertyMapReader) noexcept {
+  (void)view;
+  const JSValueObject &propertyMap = JSValue::ReadObjectFrom(propertyMapReader);
+  for (auto const &pair : propertyMap) {
+    auto const &propertyName = pair.first;
+    auto const &propertyValue = pair.second;
+    (void)propertyName;
+    (void)propertyValue;
+  }
+}
+
+// IViewManagerWithExportedEventTypeConstants
+ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
+    ExportedCustomBubblingEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+ConstantProviderDelegate ScreenStackHeaderSubviewViewManager::
+    ExportedCustomDirectEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+// IViewManagerWithCommands
+IVectorView<hstring> ScreenStackHeaderSubviewViewManager::Commands() noexcept {
+  auto commands = winrt::single_threaded_vector<hstring>();
+  return commands.GetView();
+}
+
+void ScreenStackHeaderSubviewViewManager::DispatchCommand(
+    FrameworkElement const &view,
+    winrt::hstring const &commandId,
+    winrt::IJSValueReader const &commandArgsReader) noexcept {
+  (void)view;
+  (void)commandId;
+  (void)commandArgsReader;
+}
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/ScreenStackHeaderSubviewViewManager.h
+++ b/windows/RNScreens/ScreenStackHeaderSubviewViewManager.h
@@ -1,44 +1,28 @@
 #pragma once
-
 #include "NativeModules.h"
 #include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::RNScreens::implementation {
 
-class ScreenViewManager
+class ScreenStackHeaderSubviewViewManager
     : public winrt::implements<
-          ScreenViewManager,
+          ScreenStackHeaderSubviewViewManager,
           winrt::Microsoft::ReactNative::IViewManager,
           winrt::Microsoft::ReactNative::IViewManagerRequiresNativeLayout,
-          winrt::Microsoft::ReactNative::IViewManagerWithChildren,
           winrt::Microsoft::ReactNative::IViewManagerWithReactContext,
           winrt::Microsoft::ReactNative::IViewManagerWithNativeProperties,
           winrt::Microsoft::ReactNative::
               IViewManagerWithExportedEventTypeConstants,
           winrt::Microsoft::ReactNative::IViewManagerWithCommands> {
  public:
-  ScreenViewManager() = default;
+  ScreenStackHeaderSubviewViewManager() = default;
 
   // IViewManager
-  virtual winrt::hstring Name() noexcept;
+  winrt::hstring Name() noexcept;
   winrt::Windows::UI::Xaml::FrameworkElement CreateView() noexcept;
 
   // IViewManagerRequiresNativeLayout
   bool RequiresNativeLayout();
-
-  // IViewManagerWithChildren
-  void AddView(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      winrt::Windows::UI::Xaml::UIElement child,
-      int64_t index);
-  void RemoveAllChildren(winrt::Windows::UI::Xaml::FrameworkElement parent);
-  void RemoveChildAt(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      int64_t index);
-  void ReplaceChild(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      winrt::Windows::UI::Xaml::UIElement oldChild,
-      winrt::Windows::UI::Xaml::UIElement newChild);
 
   // IViewManagerWithReactContext
   winrt::Microsoft::ReactNative::IReactContext ReactContext() noexcept;

--- a/windows/RNScreens/ScreenViewManager.cpp
+++ b/windows/RNScreens/ScreenViewManager.cpp
@@ -121,8 +121,10 @@ void ScreenViewManager::UpdateProperties(
           screen->SetStackAnimation(StackAnimation::SLIDE_FROM_BOTTOM);
         } else if (propertyValue.AsString() == "fade_from_bottom") {
           screen->SetStackAnimation(StackAnimation::FADE_FROM_BOTTOM);
-        } else if (propertyValue.AsString() == "ios") {
-          screen->SetStackAnimation(StackAnimation::IOS);
+        } else if (propertyValue.AsString() == "ios_from_right") {
+          screen->SetStackAnimation(StackAnimation::IOS_FROM_RIGHT);
+        } else if (propertyValue.AsString() == "ios_from_left") {
+          screen->SetStackAnimation(StackAnimation::IOS_FROM_LEFT);
         } else {
             std::string error = "Unknown animation type: ";
             error += propertyValue.AsString();

--- a/windows/RNScreens/ScreenViewManager.cpp
+++ b/windows/RNScreens/ScreenViewManager.cpp
@@ -98,22 +98,49 @@ ScreenViewManager::NativeProps() noexcept {
 void ScreenViewManager::UpdateProperties(
     FrameworkElement const &view,
     IJSValueReader const &propertyMapReader) noexcept {
-  (void)view;
-  const JSValueObject &propertyMap = JSValue::ReadObjectFrom(propertyMapReader);
-  for (auto const &pair : propertyMap) {
-    auto const &propertyName = pair.first;
-    auto const &propertyValue = pair.second;
-    if (propertyValue != nullptr) {
-      if (propertyName == "replaceAnimation") {
-        auto const &value = propertyValue.AsString();
-        // TODO: Implement this for Windows
-        (void)value;
-      } else if (propertyName == "stackPresentation") {
-        auto const &value = propertyValue.AsString();
-        // TODO: Implement this for Windows
-        (void)value;
-      } else {
-        OutputDebugStringA("Unknown property in ScreenViewManager\n");
+  if (auto screen = view.try_as<Screen>()) {
+    const JSValueObject &propertyMap = JSValue::ReadObjectFrom(propertyMapReader);
+    for (auto const &pair : propertyMap) {
+      auto const &propertyName = pair.first;
+      auto const &propertyValue = pair.second;
+      if (propertyName == "stackAnimation") {
+        if (propertyValue.IsNull() ||
+            propertyValue.AsString() == "default" ||
+            propertyValue.AsString() == "flip" ||
+            propertyValue.AsString() == "simple_push") {
+          screen->SetStackAnimation(winrt::RNScreens::implementation::StackAnimation::DEFAULT);
+        } else if (propertyValue.AsString() == "none") {
+          screen->SetStackAnimation(StackAnimation::NONE);
+        } else if (propertyValue.AsString() == "fade") {
+          screen->SetStackAnimation(StackAnimation::FADE);
+        } else if (propertyValue.AsString() == "slide_from_right") {
+          screen->SetStackAnimation(StackAnimation::SLIDE_FROM_RIGHT);
+        } else if (propertyValue.AsString() == "slide_from_left") {
+          screen->SetStackAnimation(StackAnimation::SLIDE_FROM_LEFT);
+        } else if (propertyValue.AsString() == "slide_from_bottom") {
+          screen->SetStackAnimation(StackAnimation::SLIDE_FROM_BOTTOM);
+        } else if (propertyValue.AsString() == "fade_from_bottom") {
+          screen->SetStackAnimation(StackAnimation::FADE_FROM_BOTTOM);
+        } else if (propertyValue.AsString() == "ios") {
+          screen->SetStackAnimation(StackAnimation::IOS);
+        } else {
+            std::string error = "Unknown animation type: ";
+            error += propertyValue.AsString();
+            throw std::runtime_error(error);
+        }
+      }
+      if (propertyValue != nullptr) {
+        if (propertyName == "replaceAnimation") {
+          auto const &value = propertyValue.AsString();
+          // TODO: Implement this for Windows
+          (void)value;
+        } else if (propertyName == "stackPresentation") {
+          auto const &value = propertyValue.AsString();
+          // TODO: Implement this for Windows
+          (void)value;
+        } else {
+          OutputDebugStringA("Unknown property in ScreenViewManager\n");
+        }
       }
     }
   }

--- a/windows/RNScreens/SearchBar.cpp
+++ b/windows/RNScreens/SearchBar.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include "ModalScreenViewManager.h"
+#include "SearchBar.h"
 #include "JSValueXaml.h"
 #include "NativeModules.h"
 
@@ -13,10 +13,7 @@ using namespace Windows::UI::Xaml::Controls;
 } // namespace winrt
 
 namespace winrt::RNScreens::implementation {
-// IViewManager
-winrt::hstring ModalScreenViewManager::Name() noexcept {
-  return L"RNSModalScreen";
-}
-
-
+SearchBar::SearchBar(
+    winrt::Microsoft::ReactNative::IReactContext reactContext)
+    : m_reactContext(reactContext) {}
 } // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/SearchBar.h
+++ b/windows/RNScreens/SearchBar.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace winrt::RNScreens::implementation {
+class SearchBar
+    : public winrt::Windows::UI::Xaml::Controls::StackPanelT<
+          SearchBar> {
+ public:
+  SearchBar(
+      winrt::Microsoft::ReactNative::IReactContext reactContext);
+
+ private:
+  winrt::Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
+};
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/SearchBarViewManager.cpp
+++ b/windows/RNScreens/SearchBarViewManager.cpp
@@ -1,0 +1,88 @@
+#include "pch.h"
+#include "SearchBarViewManager.h"
+#include "SearchBar.h"
+#include "JSValueXaml.h"
+#include "NativeModules.h"
+
+namespace winrt {
+using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+} // namespace winrt
+
+namespace winrt::RNScreens::implementation {
+// IViewManager
+winrt::hstring SearchBarViewManager::Name() noexcept {
+  return L"RNSSearchBar";
+}
+
+winrt::FrameworkElement SearchBarViewManager::CreateView() noexcept {
+  return winrt::make<winrt::RNScreens::implementation::SearchBar>(m_reactContext);
+}
+
+// IViewManagerRequiresNativeLayout
+bool SearchBarViewManager::RequiresNativeLayout() {
+  return false;
+}
+
+// IViewManagerWithNativeProperties
+IMapView<hstring, ViewManagerPropertyType>
+SearchBarViewManager::NativeProps() noexcept {
+  auto nativeProps =
+      winrt::single_threaded_map<hstring, ViewManagerPropertyType>();
+  return nativeProps.GetView();
+}
+
+void SearchBarViewManager::UpdateProperties(
+    FrameworkElement const &view,
+    IJSValueReader const &propertyMapReader) noexcept {
+  (void)view;
+  const JSValueObject &propertyMap = JSValue::ReadObjectFrom(propertyMapReader);
+  for (auto const &pair : propertyMap) {
+    auto const &propertyName = pair.first;
+    auto const &propertyValue = pair.second;
+    (void)propertyName;
+    (void)propertyValue;
+  }
+}
+
+// IViewManagerWithCommands
+IVectorView<hstring> SearchBarViewManager::Commands() noexcept {
+  auto commands = winrt::single_threaded_vector<hstring>();
+  return commands.GetView();
+}
+
+void SearchBarViewManager::DispatchCommand(
+    FrameworkElement const &view,
+    winrt::hstring const &commandId,
+    winrt::IJSValueReader const &commandArgsReader) noexcept {
+  (void)view;
+  (void)commandId;
+  (void)commandArgsReader;
+}
+
+
+// IViewManagerWithExportedEventTypeConstants
+ConstantProviderDelegate SearchBarViewManager::
+    ExportedCustomBubblingEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+ConstantProviderDelegate SearchBarViewManager::
+    ExportedCustomDirectEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+// IViewManagerWithReactContext
+winrt::IReactContext SearchBarViewManager::ReactContext() noexcept {
+  return m_reactContext;
+}
+
+void SearchBarViewManager::ReactContext(IReactContext reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
+} // namespace winrt::RNScreens::implementation

--- a/windows/RNScreens/SearchBarViewManager.h
+++ b/windows/RNScreens/SearchBarViewManager.h
@@ -4,18 +4,17 @@
 #include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::RNScreens::implementation {
-class ScreenStackHeaderSubviewViewManager
+class SearchBarViewManager
     : public winrt::implements<
-        ScreenStackHeaderSubviewViewManager,
+        SearchBarViewManager,
         winrt::Microsoft::ReactNative::IViewManager,
         winrt::Microsoft::ReactNative::IViewManagerWithNativeProperties,
         winrt::Microsoft::ReactNative::IViewManagerWithCommands,
-        winrt::Microsoft::ReactNative::IViewManagerWithChildren,
         winrt::Microsoft::ReactNative::IViewManagerWithExportedEventTypeConstants,
         winrt::Microsoft::ReactNative::IViewManagerRequiresNativeLayout,
         winrt::Microsoft::ReactNative::IViewManagerWithReactContext> {
  public:
-  ScreenStackHeaderSubviewViewManager() = default;
+  SearchBarViewManager() = default;
 
   // IViewManager
   winrt::hstring Name() noexcept;
@@ -23,20 +22,6 @@ class ScreenStackHeaderSubviewViewManager
 
   // IViewManagerRequiresNativeLayout
   bool RequiresNativeLayout();
-
-  // IViewManagerWithChildren
-  void AddView(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      winrt::Windows::UI::Xaml::UIElement child,
-      int64_t index);
-  void RemoveAllChildren(winrt::Windows::UI::Xaml::FrameworkElement parent);
-  void RemoveChildAt(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      int64_t index);
-  void ReplaceChild(
-      winrt::Windows::UI::Xaml::FrameworkElement parent,
-      winrt::Windows::UI::Xaml::UIElement oldChild,
-      winrt::Windows::UI::Xaml::UIElement newChild);
 
   // IViewManagerWithNativeProperties
   winrt::Windows::Foundation::Collections::IMapView<


### PR DESCRIPTION
## Description

Fixes problems with building and crashes in Windows apps. Some components are still WIP and we'll finish work on them in the future.

Resolves https://github.com/software-mansion/react-native-screens/issues/2541.

## Changes

- add Windows-specific implementations of `ScreenContentWrapper` and `ScreenFooter`,
- start work on stack header and subviews, searchbar,  stack animations - these components are not implemented yet
- change minimum version of `WindowsTargetPlatform` to match `WinUI` requirements,

## Test code and steps to reproduce

Create new `react-native-windows` app with components from `react-native-screens`, build and run (it might be necessary to run `npx react-native run-windows` twice in order to install all required packages).

