### PR TITLE
fix(iOS,Fabric): fix sporadic exiting screen content jump on goBack action

### DIFF
--- a/apps/src/tests/Test2538.tsx
+++ b/apps/src/tests/Test2538.tsx
@@ -1,0 +1,41 @@
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+import { Button, Text, View } from 'react-native';
+
+const Stack = createNativeStackNavigator();
+
+type RouteNavProps = {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}
+
+function Home({ navigation }: RouteNavProps) {
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightgreen' }}>
+      <Text>Home screen</Text>
+      <Button title="Go second" onPress={() => navigation.navigate('Second')} />
+    </View>
+  );
+}
+
+function Second({ navigation }: RouteNavProps) {
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightblue' }}>
+      <Text>Second screen</Text>
+      <Button title="Go back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="Second" component={Second} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default App;

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -118,6 +118,7 @@ export { default as Test2332 } from './Test2332';
 export { default as Test2379 } from './Test2379';
 export { default as Test2395 } from './Test2395';
 export { default as Test2466 } from './Test2466';
+export { default as Test2538 } from './Test2538';
 export { default as Test2552 } from './Test2552';
 export { default as Test2611 } from './Test2611';
 export { default as Test2631 } from './Test2631';

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1914,6 +1914,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // if we dismissed the view natively, it will already be detached from view hierarchy
   if (self.view.window != nil) {
     UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:NO];
+    snapshot.frame = self.view.frame;
     [self.view removeFromSuperview];
     self.view = snapshot;
     [superView addSubview:snapshot];


### PR DESCRIPTION
## Description

Fixes #2538

From time to time the **snapshot** of exiting screen would receive bad frame from the OS during the transition
resulting in the visual bug depicted in #2538 and on video down below :point_down:.

Basically what happens is described by logs present on the recording below.
In JS initiated back transition we exchange the `screenView` with its snapshot &
the snapshot **sometimes** receives UIKit-originated frame with origin at `(0, 0)`.

I guess it happens only sporadically, because there is some race condition, between
animation & layout depending on whether the navigation bar is still attached in the model
tree or not.

There is no issue in natively initiated back transition.

https://github.com/user-attachments/assets/d9d90cac-4507-44ff-bda1-619b71b5da56


## Changes

I've decided to go with setting the snapshot frame directly on creation. 
Given that the `screenView` has correct frame set (with header height taken into account),
the snapshot will have correct frame.


## Test code and steps to reproduce

I've added simple `Test2538`, which you can test by going back and forth between screens.
With the patch applied I haven't seen the issue even once.


## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
