### PR TITLE
fix(Fabric,iOS): header subviews do not support dynamic content changes

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-// import Example from './Example';
-import * as Test from './src/tests';
+import Example from './Example';
+// import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  // return <Example />;
-  return <Test.Test2714 />;
+  return <Example />;
+  // return <Test.Test42 />;
 }

--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-import Example from './Example';
-//import * as Test from './src/tests';
+// import Example from './Example';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  return <Example />;
-  //return <Test.Test42 />;
+  // return <Example />;
+  return <Test.Test2714 />;
 }

--- a/apps/src/shared/PressableWithFeedback.tsx
+++ b/apps/src/shared/PressableWithFeedback.tsx
@@ -48,6 +48,7 @@ const PressableWithFeedback = React.forwardRef((props: PressableProps, ref: Forw
         onPress={onPressCallback}
         onPressOut={onPressOutCallback}
         onResponderMove={onResponderMoveCallback}
+        style={props.style}
       >
         {props.children}
       </Pressable>

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -99,6 +99,7 @@ function SimpleHome() {
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
       <Button title="Toggle subview size" onPress={() => setExpanded(val => !val)} />
+      <Button title="Go to HomeScreen" onPress={() => navigation.navigate('HomeScreen')} />
     </View>
   );
 }
@@ -106,7 +107,8 @@ function SimpleHome() {
 function SimpleStack() {
   return (
     <Stack.Navigator>
-      <Stack.Screen name="Home" component={SimpleHome} />
+      <Stack.Screen name="SimpleHome" component={SimpleHome} />
+      <Stack.Screen name="HomeScreen" component={HomeScreen} />
     </Stack.Navigator>
   );
 }

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -47,6 +47,16 @@ const HomeScreen = ({ navigation }: any) => {
         <PressableWithFeedback style={styles.button} onPress={() => console.log(1)}>
           <Text>1</Text>
         </PressableWithFeedback>
+        {secondButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(2)}>
+            <Text>2</Text>
+          </PressableWithFeedback>
+        )}
+        {thirdButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(3)}>
+            <Text>3</Text>
+          </PressableWithFeedback>
+        )}
         <PressableWithFeedback style={styles.button} onPress={() => console.log('D')}>
           <Text>[D]</Text>
         </PressableWithFeedback>

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -114,14 +114,25 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { useEffect } from 'react';
+
+function HeaderItemSmall() {
+  return (
+    <Text style={styles.headerRight}>Hi</Text>
+  );
+}
+
+function HeaderItemLarge() {
+  return (
+    <Text style={styles.headerRight}>Longer Header Right</Text>
+  );
+}
 
 const RootStack = createNativeStackNavigator({
   screens: {
     Home: {
       screen: HomeScreen,
       options: {
-        headerRight: () => <Text style={styles.headerRight}>Hi</Text>,
+        headerRight: HeaderItemSmall,
         headerTitle: 'Longer Screen Title',
       },
     },
@@ -140,17 +151,23 @@ export default function App() {
 
 function HomeScreen() {
   const navigation = useNavigation();
+  const [isLargeHeaderItem, setLargeHeaderItem] = React.useState(false);
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Button
         title={'Update Header'}
         onPress={() => {
-          navigation.setOptions({
-            headerRight: () => (
-              <Text style={[styles.headerRight]}>Longer Header Right</Text>
-            ),
-          });
+          if (isLargeHeaderItem) {
+            navigation.setOptions({
+              headerRight: HeaderItemSmall,
+            });
+          } else {
+            navigation.setOptions({
+              headerRight: HeaderItemLarge,
+            });
+          }
+          setLargeHeaderItem(old => !old);
         }}
       />
     </View>

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+// import { NavigationContainer } from '@react-navigation/native';
+// import { Pressable, Text, View, StyleSheet, Button } from 'react-native';
+// import { createNativeStackNavigator } from '@react-navigation/native-stack';
+// import { GestureHandlerRootView } from 'react-native-gesture-handler';
+//
+// const styles = StyleSheet.create({
+//   button: {
+//     width: 42,
+//     height: 42,
+//     marginHorizontal: 5,
+//     padding: 5,
+//     borderRadius: 20,
+//     justifyContent: 'center',
+//     alignItems: 'center',
+//     backgroundColor: 'blue',
+//   },
+//   buttonsView: {
+//     flexDirection: 'row',
+//     borderWidth: 1,
+//   },
+// });
+//
+// const Stack = createNativeStackNavigator();
+//
+// function MyStack() {
+//   return (
+//     <Stack.Navigator
+//       screenOptions={{
+//         headerShown: true,
+//         headerBackButtonDisplayMode: 'minimal',
+//       }}>
+//       <Stack.Screen name="Home" component={HomeScreen} />
+//       <Stack.Screen name="Profile" component={HomeScreen} />
+//     </Stack.Navigator>
+//   );
+// }
+//
+// const HomeScreen = ({ navigation }: any) => {
+//   const [secondButtonShown, setSecondButtonShown] = React.useState(true);
+//   const [thirdButtonShown, setThirdButtonShown] = React.useState(true);
+//   const [showAllButtons, setShowAllButtons] = React.useState(true);
+//
+//   const headerRight = React.useCallback(() => {
+//     return (
+//       <>
+//         <Pressable style={styles.button} onPress={() => console.log(1)}>
+//           <Text>1</Text>
+//         </Pressable>
+//         {secondButtonShown && (
+//           <Pressable style={styles.button} onPress={() => console.log(2)}>
+//             <Text>2</Text>
+//           </Pressable>
+//         )}
+//         {thirdButtonShown && (
+//           <Pressable style={styles.button} onPress={() => console.log(3)}>
+//             <Text>3</Text>
+//           </Pressable>
+//         )}
+//       </>
+//     );
+//   }, [secondButtonShown, thirdButtonShown]);
+//
+//   React.useLayoutEffect(() => {
+//     navigation.setOptions({
+//       headerStyle: { backgroundColor: 'pink' },
+//       headerRight: () => (
+//         <View
+//           style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
+//           {headerRight()}
+//           <Pressable style={styles.button} onPress={() => console.log('D')}>
+//             <Text>[D]</Text>
+//           </Pressable>
+//         </View>
+//       ),
+//     });
+//   }, [navigation, headerRight, showAllButtons]);
+//
+//   return (
+//     <View>
+//       <Text>Home Screen</Text>
+//       <Button
+//         title="Toggle 2nd button"
+//         onPress={() => setSecondButtonShown(p => !p)}
+//       />
+//       <Button
+//         title="Toggle 3rd button"
+//         onPress={() => setThirdButtonShown(p => !p)}
+//       />
+//       <Button
+//         title="Toggle All Right Buttons"
+//         onPress={() => setShowAllButtons(p => !p)}
+//       />
+//     </View>
+//   );
+// };
+//
+// function App() {
+//   return (
+//     <GestureHandlerRootView>
+//       <NavigationContainer>
+//         <MyStack />
+//       </NavigationContainer>
+//     </GestureHandlerRootView>
+//   );
+// }
+//
+// export default App;
+
+import {
+  createStaticNavigation,
+  useNavigation,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useEffect } from 'react';
+
+const RootStack = createNativeStackNavigator({
+  screens: {
+    Home: {
+      screen: HomeScreen,
+      options: {
+        headerRight: () => <Text style={styles.headerRight}>Hi</Text>,
+        headerTitle: 'Longer Screen Title',
+      },
+    },
+  },
+});
+
+const RootNavigation = createStaticNavigation(RootStack);
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <RootNavigation />
+    </SafeAreaProvider>
+  );
+}
+
+function HomeScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Button
+        title={'Update Header'}
+        onPress={() => {
+          navigation.setOptions({
+            headerRight: () => (
+              <Text style={[styles.headerRight]}>Longer Header Right</Text>
+            ),
+          });
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerRight: {
+    paddingHorizontal: 10,
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { Pressable, Text, View, StyleSheet, Button } from 'react-native';
+import { Text, View, StyleSheet, Button } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
 
 const styles = StyleSheet.create({
@@ -24,7 +23,7 @@ const styles = StyleSheet.create({
 
 const Stack = createNativeStackNavigator();
 
-function MyStack() {
+function RootStack() {
   return (
     <Stack.Navigator
       screenOptions={{
@@ -44,36 +43,21 @@ const HomeScreen = ({ navigation }: any) => {
 
   const headerRight = React.useCallback(() => {
     return (
-      <>
+      <View style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
         <PressableWithFeedback style={styles.button} onPress={() => console.log(1)}>
           <Text>1</Text>
         </PressableWithFeedback>
-        {secondButtonShown && (
-          <PressableWithFeedback style={styles.button} onPress={() => console.log(2)}>
-            <Text>2</Text>
-          </PressableWithFeedback>
-        )}
-        {thirdButtonShown && (
-          <PressableWithFeedback style={styles.button} onPress={() => console.log(3)}>
-            <Text>3</Text>
-          </PressableWithFeedback>
-        )}
-      </>
+        <PressableWithFeedback style={styles.button} onPress={() => console.log('D')}>
+          <Text>[D]</Text>
+        </PressableWithFeedback>
+      </View>
     );
-  }, [secondButtonShown, thirdButtonShown]);
+  }, [secondButtonShown, thirdButtonShown, showAllButtons]);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
       headerStyle: { backgroundColor: 'pink' },
-      headerRight: () => (
-        <View
-          style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
-          {headerRight()}
-          <PressableWithFeedback style={styles.button} onPress={() => console.log('D')}>
-            <Text>[D]</Text>
-          </PressableWithFeedback>
-        </View>
-      ),
+      headerRight: headerRight,
     });
   }, [navigation, headerRight, showAllButtons]);
 
@@ -98,11 +82,9 @@ const HomeScreen = ({ navigation }: any) => {
 
 function App() {
   return (
-    <GestureHandlerRootView>
-      <NavigationContainer>
-        <MyStack />
-      </NavigationContainer>
-    </GestureHandlerRootView>
+    <NavigationContainer>
+      <RootStack />
+    </NavigationContainer>
   );
 }
 

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -15,6 +15,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: 'blue',
   },
+  largeButton: {
+    width: 64,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
   buttonsView: {
     flexDirection: 'row',
     borderWidth: 1,
@@ -40,11 +50,12 @@ const HomeScreen = ({ navigation }: any) => {
   const [secondButtonShown, setSecondButtonShown] = React.useState(true);
   const [thirdButtonShown, setThirdButtonShown] = React.useState(true);
   const [showAllButtons, setShowAllButtons] = React.useState(true);
+  const [isLargeSize, setLargeSize] = React.useState(true);
 
   const headerRight = React.useCallback(() => {
     return (
       <View style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
-        <PressableWithFeedback style={styles.button} onPress={() => console.log(1)}>
+        <PressableWithFeedback style={isLargeSize ? styles.largeButton : styles.button} onPress={() => console.log(1)}>
           <Text>1</Text>
         </PressableWithFeedback>
         {secondButtonShown && (
@@ -62,7 +73,7 @@ const HomeScreen = ({ navigation }: any) => {
         </PressableWithFeedback>
       </View>
     );
-  }, [secondButtonShown, thirdButtonShown, showAllButtons]);
+  }, [secondButtonShown, thirdButtonShown, showAllButtons, isLargeSize]);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -74,6 +85,10 @@ const HomeScreen = ({ navigation }: any) => {
   return (
     <View>
       <Text>Home Screen</Text>
+      <Button
+        title="Toggle size"
+        onPress={() => setLargeSize(p => !p)}
+      />
       <Button
         title="Toggle 2nd button"
         onPress={() => setSecondButtonShown(p => !p)}

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -1,183 +1,110 @@
 import React from 'react';
-// import { NavigationContainer } from '@react-navigation/native';
-// import { Pressable, Text, View, StyleSheet, Button } from 'react-native';
-// import { createNativeStackNavigator } from '@react-navigation/native-stack';
-// import { GestureHandlerRootView } from 'react-native-gesture-handler';
-//
-// const styles = StyleSheet.create({
-//   button: {
-//     width: 42,
-//     height: 42,
-//     marginHorizontal: 5,
-//     padding: 5,
-//     borderRadius: 20,
-//     justifyContent: 'center',
-//     alignItems: 'center',
-//     backgroundColor: 'blue',
-//   },
-//   buttonsView: {
-//     flexDirection: 'row',
-//     borderWidth: 1,
-//   },
-// });
-//
-// const Stack = createNativeStackNavigator();
-//
-// function MyStack() {
-//   return (
-//     <Stack.Navigator
-//       screenOptions={{
-//         headerShown: true,
-//         headerBackButtonDisplayMode: 'minimal',
-//       }}>
-//       <Stack.Screen name="Home" component={HomeScreen} />
-//       <Stack.Screen name="Profile" component={HomeScreen} />
-//     </Stack.Navigator>
-//   );
-// }
-//
-// const HomeScreen = ({ navigation }: any) => {
-//   const [secondButtonShown, setSecondButtonShown] = React.useState(true);
-//   const [thirdButtonShown, setThirdButtonShown] = React.useState(true);
-//   const [showAllButtons, setShowAllButtons] = React.useState(true);
-//
-//   const headerRight = React.useCallback(() => {
-//     return (
-//       <>
-//         <Pressable style={styles.button} onPress={() => console.log(1)}>
-//           <Text>1</Text>
-//         </Pressable>
-//         {secondButtonShown && (
-//           <Pressable style={styles.button} onPress={() => console.log(2)}>
-//             <Text>2</Text>
-//           </Pressable>
-//         )}
-//         {thirdButtonShown && (
-//           <Pressable style={styles.button} onPress={() => console.log(3)}>
-//             <Text>3</Text>
-//           </Pressable>
-//         )}
-//       </>
-//     );
-//   }, [secondButtonShown, thirdButtonShown]);
-//
-//   React.useLayoutEffect(() => {
-//     navigation.setOptions({
-//       headerStyle: { backgroundColor: 'pink' },
-//       headerRight: () => (
-//         <View
-//           style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
-//           {headerRight()}
-//           <Pressable style={styles.button} onPress={() => console.log('D')}>
-//             <Text>[D]</Text>
-//           </Pressable>
-//         </View>
-//       ),
-//     });
-//   }, [navigation, headerRight, showAllButtons]);
-//
-//   return (
-//     <View>
-//       <Text>Home Screen</Text>
-//       <Button
-//         title="Toggle 2nd button"
-//         onPress={() => setSecondButtonShown(p => !p)}
-//       />
-//       <Button
-//         title="Toggle 3rd button"
-//         onPress={() => setThirdButtonShown(p => !p)}
-//       />
-//       <Button
-//         title="Toggle All Right Buttons"
-//         onPress={() => setShowAllButtons(p => !p)}
-//       />
-//     </View>
-//   );
-// };
-//
-// function App() {
-//   return (
-//     <GestureHandlerRootView>
-//       <NavigationContainer>
-//         <MyStack />
-//       </NavigationContainer>
-//     </GestureHandlerRootView>
-//   );
-// }
-//
-// export default App;
-
-import {
-  createStaticNavigation,
-  useNavigation,
-} from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
+import { Pressable, Text, View, StyleSheet, Button } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Button, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
 
-function HeaderItemSmall() {
-  return (
-    <Text style={styles.headerRight}>Hi</Text>
-  );
-}
-
-function HeaderItemLarge() {
-  return (
-    <Text style={styles.headerRight}>Longer Header Right</Text>
-  );
-}
-
-const RootStack = createNativeStackNavigator({
-  screens: {
-    Home: {
-      screen: HomeScreen,
-      options: {
-        headerRight: HeaderItemSmall,
-        headerTitle: 'Longer Screen Title',
-      },
-    },
+const styles = StyleSheet.create({
+  button: {
+    width: 42,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
+  buttonsView: {
+    flexDirection: 'row',
+    borderWidth: 1,
   },
 });
 
-const RootNavigation = createStaticNavigation(RootStack);
+const Stack = createNativeStackNavigator();
 
-export default function App() {
+function MyStack() {
   return (
-    <SafeAreaProvider>
-      <RootNavigation />
-    </SafeAreaProvider>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerBackButtonDisplayMode: 'minimal',
+      }}>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Profile" component={HomeScreen} />
+    </Stack.Navigator>
   );
 }
 
-function HomeScreen() {
-  const navigation = useNavigation();
-  const [isLargeHeaderItem, setLargeHeaderItem] = React.useState(false);
+const HomeScreen = ({ navigation }: any) => {
+  const [secondButtonShown, setSecondButtonShown] = React.useState(true);
+  const [thirdButtonShown, setThirdButtonShown] = React.useState(true);
+  const [showAllButtons, setShowAllButtons] = React.useState(true);
+
+  const headerRight = React.useCallback(() => {
+    return (
+      <>
+        <PressableWithFeedback style={styles.button} onPress={() => console.log(1)}>
+          <Text>1</Text>
+        </PressableWithFeedback>
+        {secondButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(2)}>
+            <Text>2</Text>
+          </PressableWithFeedback>
+        )}
+        {thirdButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(3)}>
+            <Text>3</Text>
+          </PressableWithFeedback>
+        )}
+      </>
+    );
+  }, [secondButtonShown, thirdButtonShown]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: 'pink' },
+      headerRight: () => (
+        <View
+          style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
+          {headerRight()}
+          <PressableWithFeedback style={styles.button} onPress={() => console.log('D')}>
+            <Text>[D]</Text>
+          </PressableWithFeedback>
+        </View>
+      ),
+    });
+  }, [navigation, headerRight, showAllButtons]);
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <View>
+      <Text>Home Screen</Text>
       <Button
-        title={'Update Header'}
-        onPress={() => {
-          if (isLargeHeaderItem) {
-            navigation.setOptions({
-              headerRight: HeaderItemSmall,
-            });
-          } else {
-            navigation.setOptions({
-              headerRight: HeaderItemLarge,
-            });
-          }
-          setLargeHeaderItem(old => !old);
-        }}
+        title="Toggle 2nd button"
+        onPress={() => setSecondButtonShown(p => !p)}
+      />
+      <Button
+        title="Toggle 3rd button"
+        onPress={() => setThirdButtonShown(p => !p)}
+      />
+      <Button
+        title="Toggle All Right Buttons"
+        onPress={() => setShowAllButtons(p => !p)}
       />
     </View>
   );
+};
+
+function App() {
+  return (
+    <GestureHandlerRootView>
+      <NavigationContainer>
+        <MyStack />
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  );
 }
 
-const styles = StyleSheet.create({
-  headerRight: {
-    paddingHorizontal: 10,
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-});
+export default App;
+

--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -1,35 +1,8 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { Text, View, StyleSheet, Button } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
-
-const styles = StyleSheet.create({
-  button: {
-    width: 42,
-    height: 42,
-    marginHorizontal: 5,
-    padding: 5,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'blue',
-  },
-  largeButton: {
-    width: 64,
-    height: 42,
-    marginHorizontal: 5,
-    padding: 5,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'blue',
-  },
-  buttonsView: {
-    flexDirection: 'row',
-    borderWidth: 1,
-  },
-});
 
 const Stack = createNativeStackNavigator();
 
@@ -105,13 +78,82 @@ const HomeScreen = ({ navigation }: any) => {
   );
 };
 
-function App() {
+function SimpleHome() {
+  const navigation = useNavigation();
+  const [isExpanded, setExpanded] = React.useState(false);
+
+  const headerRight = React.useCallback(() => {
+    return (
+      <PressableWithFeedback>
+        <View style={[{ width: 128, height: 42 }, isExpanded ? { width: 192 } : null]} />
+      </PressableWithFeedback>
+    );
+  }, [isExpanded]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight,
+    });
+  }, [headerRight, navigation]);
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
+      <Button title="Toggle subview size" onPress={() => setExpanded(val => !val)} />
+    </View>
+  );
+}
+
+function SimpleStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={SimpleHome} />
+    </Stack.Navigator>
+  );
+}
+
+// function App() {
+//   return (
+//     <NavigationContainer>
+//       <RootStack />
+//     </NavigationContainer>
+//   );
+// }
+
+function AppSimplified() {
   return (
     <NavigationContainer>
-      <RootStack />
+      <SimpleStack />
     </NavigationContainer>
   );
 }
 
-export default App;
+// export default App;
+export default AppSimplified;
 
+
+const styles = StyleSheet.create({
+  button: {
+    width: 42,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
+  largeButton: {
+    width: 64,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
+  buttonsView: {
+    flexDirection: 'row',
+    borderWidth: 1,
+  },
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -124,6 +124,7 @@ export { default as Test2611 } from './Test2611';
 export { default as Test2631 } from './Test2631';
 export { default as Test2668 } from './Test2668';
 export { default as Test2675 } from './Test2675';
+export { default as Test2714 } from './Test2714';
 export { default as Test2717 } from './Test2717';
 export { default as Test2767 } from './Test2767';
 export { default as Test2789 } from './Test2789';

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -35,48 +35,53 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
-#if defined(ANDROID)
     if (!isSizeEmpty(stateData.frameSize)) {
       layoutableShadowNode.setSize(stateData.frameSize);
     }
-#else
-    auto mostRecentState = std::static_pointer_cast<
-        const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
-        shadowNode.getMostRecentState());
-
-    auto mostRecentStateData = mostRecentState->getData();
-
-    std::printf(
-        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}, mostRecent {%.2lf, %.2lf}\n",
-        shadowNode.getTag(),
-        stateData.frameSize.width,
-        stateData.frameSize.height,
-        mostRecentStateData.frameSize.width,
-        mostRecentStateData.frameSize.height);
-
-    if (!isSizeEmpty(stateData.frameSize)) {
-      // This is a ugly hack to workaround issue with dynamic content change.
-      // When the size of this shadow node contents (children) change due to JS
-      // update, e.g. new icon is added, if the size is set for the yogaNode
-      // corresponding to this shadow node, the enforced size will be used
-      // and the size won't be updated by Yoga to reflect the contents size
-      // change ->
-      // -> host tree won't get layout metrics update -> we won't trigger native
-      // layout -> the views in header will be positioned incorrectly. Here we
-      // try to detect, whether this shadow node is cloned as a result of state
-      // update (we assume that only source if the state updates is HostTree) or
-      // other change.
-      if (stateData.frameSize != mostRecentStateData.frameSize) {
-        std::printf("SubviewCD [%d] adopt APPLY\n", shadowNode.getTag());
-        layoutableShadowNode.setSize(stateData.frameSize);
-      } else {
-        // If the state has not changed we assign undefined size, to allow Yoga
-        // to recompute the shadow node layout.
-        std::printf("SubviewCD [%d] adopt ZERO\n", shadowNode.getTag());
-        layoutableShadowNode.setSize({YGUndefined, YGUndefined});
-      }
-    }
-#endif // Android
+    //    auto mostRecentState = std::static_pointer_cast<
+    //        const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
+    //        shadowNode.getMostRecentState());
+    //
+    //    auto mostRecentStateData = mostRecentState->getData();
+    //
+    //    std::printf(
+    //        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}, mostRecent {%.2lf,
+    //        %.2lf}\n", shadowNode.getTag(), stateData.frameSize.width,
+    //        stateData.frameSize.height,
+    //        mostRecentStateData.frameSize.width,
+    //        mostRecentStateData.frameSize.height);
+    //
+    //    if (!isSizeEmpty(stateData.frameSize)) {
+    //      // This is a ugly hack to workaround issue with dynamic content
+    //      change.
+    //      // When the size of this shadow node contents (children) change due
+    //      to JS
+    //      // update, e.g. new icon is added, if the size is set for the
+    //      yogaNode
+    //      // corresponding to this shadow node, the enforced size will be used
+    //      // and the size won't be updated by Yoga to reflect the contents
+    //      size
+    //      // change ->
+    //      // -> host tree won't get layout metrics update -> we won't trigger
+    //      native
+    //      // layout -> the views in header will be positioned incorrectly.
+    //      Here we
+    //      // try to detect, whether this shadow node is cloned as a result of
+    //      state
+    //      // update (we assume that only source if the state updates is
+    //      HostTree) or
+    //      // other change.
+    //      if (stateData.frameSize != mostRecentStateData.frameSize) {
+    //        std::printf("SubviewCD [%d] adopt APPLY\n", shadowNode.getTag());
+    //        layoutableShadowNode.setSize(stateData.frameSize);
+    //      } else {
+    //        // If the state has not changed we assign undefined size, to allow
+    //        Yoga
+    //        // to recompute the shadow node layout.
+    //        std::printf("SubviewCD [%d] adopt ZERO\n", shadowNode.getTag());
+    //        layoutableShadowNode.setSize({YGUndefined, YGUndefined});
+    //      }
+    //    }
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -35,6 +35,12 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
+    auto mostRecentState = std::static_pointer_cast<
+        const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
+        shadowNode.getMostRecentState());
+
+    auto mostRecentStateData = mostRecentState->getData();
+
     std::printf(
         "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}\n",
         shadowNode.getTag(),
@@ -51,7 +57,11 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
     // rozmiar SN, to nie będziemy wstanie zareagować na zmiany rozmiaru
     // zrobione nie ze strony natywnej, a z JSa...
     if (!isSizeEmpty(stateData.frameSize)) {
-      //      layoutableShadowNode.setSize(stateData.frameSize);
+      if (stateData.frameSize != mostRecentStateData.frameSize) {
+        layoutableShadowNode.setSize(stateData.frameSize);
+      } else {
+        layoutableShadowNode.setSize({YGUndefined, YGUndefined});
+      }
     }
 
     ConcreteComponentDescriptor::adopt(shadowNode);

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -42,10 +42,12 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
     auto mostRecentStateData = mostRecentState->getData();
 
     std::printf(
-        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}\n",
+        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}, mostRecent {%.2lf, %.2lf}\n",
         shadowNode.getTag(),
         stateData.frameSize.width,
-        stateData.frameSize.height);
+        stateData.frameSize.height,
+        mostRecentStateData.frameSize.width,
+        mostRecentStateData.frameSize.height);
 
     // Po zmianie rozmiaru kontentu, shadow node jest klonowany i ustawiany jest
     // tutaj stan z poprzedniego shadow node'a (możliwe, że też ostatni
@@ -57,12 +59,21 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
     // rozmiar SN, to nie będziemy wstanie zareagować na zmiany rozmiaru
     // zrobione nie ze strony natywnej, a z JSa...
     if (!isSizeEmpty(stateData.frameSize)) {
+      // This is a ugly hack to workaround issue with dynamic content change.
+      // When the size of this shadow node contents (children) change due to JS
+      // update, e.g. new icon is added,
       if (stateData.frameSize != mostRecentStateData.frameSize) {
+        std::printf("SubviewCD [%d] adopt APPLY\n", shadowNode.getTag());
         layoutableShadowNode.setSize(stateData.frameSize);
       } else {
+        std::printf("SubviewCD [%d] adopt ZERO\n", shadowNode.getTag());
         layoutableShadowNode.setSize({YGUndefined, YGUndefined});
       }
     }
+
+    //    if (!isSizeEmpty(stateData.frameSize)) {
+    //      layoutableShadowNode.setSize(stateData.frameSize);
+    //    }
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -35,6 +35,11 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
+#if defined(ANDROID)
+    if (!isSizeEmpty(stateData.frameSize)) {
+      layoutableShadowNode.setSize(stateData.frameSize);
+    }
+#else
     auto mostRecentState = std::static_pointer_cast<
         const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
         shadowNode.getMostRecentState());
@@ -71,6 +76,7 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         layoutableShadowNode.setSize({YGUndefined, YGUndefined});
       }
     }
+#endif // Android
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -35,6 +35,21 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
+    std::printf(
+        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}\n",
+        shadowNode.getTag(),
+        stateData.frameSize.width,
+        stateData.frameSize.height);
+
+    // Po zmianie rozmiaru kontentu, shadow node jest klonowany i ustawiany jest
+    // tutaj stan z poprzedniego shadow node'a (możliwe, że też ostatni
+    // zamontowany), który był obliczony dla poprzedniego rozmiaru kontentu.
+    // Strona natywna, nic nie zmieni, bo Yoga wylayoutuje ten subview tak, żeby
+    // się zmieścił w tej ograniczonej przestrzeni. Bądź tu mądry. Jak to teraz
+    // naprawić? Wydaje się, że potrzebujemy w ST znać zarówno rozmiar jak i
+    // content offset, żeby działały pressable. Natomiast jeżeli wymusimy
+    // rozmiar SN, to nie będziemy wstanie zareagować na zmiany rozmiaru
+    // zrobione nie ze strony natywnej, a z JSa...
     if (!isSizeEmpty(stateData.frameSize)) {
       layoutableShadowNode.setSize(stateData.frameSize);
     }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -51,7 +51,7 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
     // rozmiar SN, to nie będziemy wstanie zareagować na zmiany rozmiaru
     // zrobione nie ze strony natywnej, a z JSa...
     if (!isSizeEmpty(stateData.frameSize)) {
-      layoutableShadowNode.setSize(stateData.frameSize);
+      //      layoutableShadowNode.setSize(stateData.frameSize);
     }
 
     ConcreteComponentDescriptor::adopt(shadowNode);

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -38,50 +38,6 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
     if (!isSizeEmpty(stateData.frameSize)) {
       layoutableShadowNode.setSize(stateData.frameSize);
     }
-    //    auto mostRecentState = std::static_pointer_cast<
-    //        const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
-    //        shadowNode.getMostRecentState());
-    //
-    //    auto mostRecentStateData = mostRecentState->getData();
-    //
-    //    std::printf(
-    //        "SubviewCD [%d] adopt frameSize {%.2lf, %.2lf}, mostRecent {%.2lf,
-    //        %.2lf}\n", shadowNode.getTag(), stateData.frameSize.width,
-    //        stateData.frameSize.height,
-    //        mostRecentStateData.frameSize.width,
-    //        mostRecentStateData.frameSize.height);
-    //
-    //    if (!isSizeEmpty(stateData.frameSize)) {
-    //      // This is a ugly hack to workaround issue with dynamic content
-    //      change.
-    //      // When the size of this shadow node contents (children) change due
-    //      to JS
-    //      // update, e.g. new icon is added, if the size is set for the
-    //      yogaNode
-    //      // corresponding to this shadow node, the enforced size will be used
-    //      // and the size won't be updated by Yoga to reflect the contents
-    //      size
-    //      // change ->
-    //      // -> host tree won't get layout metrics update -> we won't trigger
-    //      native
-    //      // layout -> the views in header will be positioned incorrectly.
-    //      Here we
-    //      // try to detect, whether this shadow node is cloned as a result of
-    //      state
-    //      // update (we assume that only source if the state updates is
-    //      HostTree) or
-    //      // other change.
-    //      if (stateData.frameSize != mostRecentStateData.frameSize) {
-    //        std::printf("SubviewCD [%d] adopt APPLY\n", shadowNode.getTag());
-    //        layoutableShadowNode.setSize(stateData.frameSize);
-    //      } else {
-    //        // If the state has not changed we assign undefined size, to allow
-    //        Yoga
-    //        // to recompute the shadow node layout.
-    //        std::printf("SubviewCD [%d] adopt ZERO\n", shadowNode.getTag());
-    //        layoutableShadowNode.setSize({YGUndefined, YGUndefined});
-    //      }
-    //    }
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
@@ -29,6 +29,7 @@ void RNSScreenStackHeaderSubviewShadowNode::applyFrameCorrections() {
   layoutMetrics_.frame.origin.x = stateData.contentOffset.x;
   layoutMetrics_.frame.origin.y = stateData.contentOffset.y;
 
+#if !defined(ANDROID)
   // Only a single child is expected
   react_native_assert(yogaNode_.getChildCount() == 1);
 
@@ -38,6 +39,7 @@ void RNSScreenStackHeaderSubviewShadowNode::applyFrameCorrections() {
 
   // We want to have exactly the same size as our child.
   layoutMetrics_.frame.size = childLayoutMetrics.frame.size;
+#endif
 }
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewShadowNode.cpp
@@ -1,5 +1,15 @@
 #include "RNSScreenStackHeaderSubviewShadowNode.h"
 
+namespace rnscreens {
+
+using namespace facebook::react;
+
+YogaLayoutableShadowNode &shadowNodeFromContext(YGNodeConstRef yogaNode) {
+  return dynamic_cast<YogaLayoutableShadowNode &>(
+      *static_cast<ShadowNode *>(YGNodeGetContext(yogaNode)));
+}
+} // namespace rnscreens
+
 namespace facebook::react {
 
 extern const char RNSScreenStackHeaderSubviewComponentName[] =
@@ -14,9 +24,20 @@ void RNSScreenStackHeaderSubviewShadowNode::layout(
 void RNSScreenStackHeaderSubviewShadowNode::applyFrameCorrections() {
   ensureUnsealed();
 
+  // State-based correction
   const auto &stateData = getStateData();
   layoutMetrics_.frame.origin.x = stateData.contentOffset.x;
   layoutMetrics_.frame.origin.y = stateData.contentOffset.y;
+
+  // Only a single child is expected
+  react_native_assert(yogaNode_.getChildCount() == 1);
+
+  auto childYogaNode = yogaNode_.getChild(0);
+  auto &childNode = rnscreens::shadowNodeFromContext(childYogaNode);
+  const auto &childLayoutMetrics = childNode.getLayoutMetrics();
+
+  // We want to have exactly the same size as our child.
+  layoutMetrics_.frame.size = childLayoutMetrics.frame.size;
 }
 
 } // namespace facebook::react

--- a/ios/RNSHeaderSubviewContentWrapper.h
+++ b/ios/RNSHeaderSubviewContentWrapper.h
@@ -11,7 +11,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RNSHeaderSubviewContentWrapper;
+
+@protocol RNSHeaderSubviewContentWrapperDelegate <NSObject>
+
+/**
+ * Called by the content wrapper on a delegate when React Native updates the layout.
+ */
+- (void)headerSubviewContentWrapper:(RNSHeaderSubviewContentWrapper *)contentWrapper
+                 receivedReactFrame:(CGRect)reactFrame
+                          didChange:(BOOL)frameChanged;
+
+@end
+
+/**
+ * Component view with layout managed by react-native. Notifies it's delegate on react-native driven layout changes.
+ * Does not send notifications when frame is set by native layout.
+ */
 @interface RNSHeaderSubviewContentWrapper : RCTViewComponentView
+
+/**
+ * Register delegate here, to get notifications when layout of this component changes.
+ */
+@property (nonatomic, nullable, weak) id<RNSHeaderSubviewContentWrapperDelegate> delegate;
 
 @end
 

--- a/ios/RNSHeaderSubviewContentWrapper.h
+++ b/ios/RNSHeaderSubviewContentWrapper.h
@@ -1,0 +1,22 @@
+#import <React/RCTViewManager.h>
+#import <UIKit/UIKit.h>
+#import "RCTViewComponentView.h"
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTViewComponentView.h>
+#else
+#import <React/RCTView.h>
+#endif // RCT_NEW_ARCH_ENABLED
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSHeaderSubviewContentWrapper : RCTViewComponentView
+
+@end
+
+@interface RNSHeaderSubviewContentWrapperManager : RCTViewManager
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNSHeaderSubviewContentWrapper.h
+++ b/ios/RNSHeaderSubviewContentWrapper.h
@@ -19,16 +19,19 @@ NS_ASSUME_NONNULL_BEGIN
  * Called by the content wrapper on a delegate when React Native updates the layout.
  */
 - (void)headerSubviewContentWrapper:(RNSHeaderSubviewContentWrapper *)contentWrapper
-                 receivedReactFrame:(CGRect)reactFrame
-                          didChange:(BOOL)frameChanged;
+                  receivedReactSize:(CGSize)reactSize;
 
 @end
 
 /**
  * Component view with layout managed by react-native. Notifies it's delegate on react-native driven layout changes.
  * Does not send notifications when frame is set by native layout.
+ *
+ * Note: this view assumes it is placed exactly at origin=(0, 0) relative to its parent in view hierarchy. It overrides
+ * the frame received from React enforcing this "partial invariant". "Partial" - because in case it is laid natively it
+ * just accepts given frame as is.
  */
-@interface RNSHeaderSubviewContentWrapper : RCTViewComponentView
+@interface RNSHeaderSubviewContentWrapper : UIView <RCTComponentViewProtocol>
 
 /**
  * Register delegate here, to get notifications when layout of this component changes.

--- a/ios/RNSHeaderSubviewContentWrapper.mm
+++ b/ios/RNSHeaderSubviewContentWrapper.mm
@@ -1,0 +1,45 @@
+#import "RNSHeaderSubviewContentWrapper.h"
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+namespace react = facebook::react;
+#else
+#import <React/RCTScrollView.h>
+#endif // RCT_NEW_ARCH_ENABLED
+
+@implementation RNSHeaderSubviewContentWrapper
+
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return react::concreteComponentDescriptorProvider<react::RNSHeaderSubviewContentWrapperComponentDescriptor>();
+}
+
+Class<RCTComponentViewProtocol> RNSHeaderSubviewContentWrapperCls(void)
+{
+  return RNSHeaderSubviewContentWrapper.class;
+}
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
++ (void)load
+{
+  [super load];
+}
+
+@end
+
+@implementation RNSHeaderSubviewContentWrapperManager
+
+RCT_EXPORT_MODULE()
+
+#if !defined(RCT_NEW_ARCH_ENABLED)
+- (UIView *)view
+{
+  return [RNSHeaderSubviewContentWrapper new];
+}
+#endif
+
+@end

--- a/ios/RNSHeaderSubviewContentWrapper.mm
+++ b/ios/RNSHeaderSubviewContentWrapper.mm
@@ -1,6 +1,7 @@
 #import "RNSHeaderSubviewContentWrapper.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
+#import <React/RCTConversions.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -11,7 +12,47 @@ namespace react = facebook::react;
 #import <React/RCTScrollView.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
-@implementation RNSHeaderSubviewContentWrapper
+@implementation RNSHeaderSubviewContentWrapper {
+  CGRect _lastReactFrame;
+}
+
+- (void)notifyDelegateWithFrame:(CGRect)reactFrame
+{
+  BOOL didChange = NO;
+  if (!CGRectEqualToRect(_lastReactFrame, reactFrame)) {
+    _lastReactFrame = reactFrame;
+    didChange = YES;
+  }
+  [self.delegate headerSubviewContentWrapper:self receivedReactFrame:reactFrame didChange:didChange];
+}
+
+#pragma mark - Fabric specific
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  self = [super initWithFrame:frame];
+  if (self) {
+    _lastReactFrame = CGRectNull;
+  }
+  return self;
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTComponentViewProtocol
+
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics
+{
+  NSLog(
+      @"HSContentWrapper [%ld] updateLayoutMetrics %@",
+      self.tag,
+      NSStringFromCGRect(RCTCGRectFromRect(layoutMetrics.frame)));
+  [self notifyDelegateWithFrame:RCTCGRectFromRect(layoutMetrics.frame)];
+
+  NSLog(@"HSContentWrapper [%ld] super call", self.tag);
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+}
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
@@ -28,6 +69,8 @@ Class<RCTComponentViewProtocol> RNSHeaderSubviewContentWrapperCls(void)
 {
   [super load];
 }
+
+#endif
 
 @end
 

--- a/ios/RNSModule.h
+++ b/ios/RNSModule.h
@@ -1,4 +1,3 @@
-
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <rnscreens/rnscreens.h>
 #else

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -90,9 +90,9 @@ namespace react = facebook::react;
   [self updateContainer];
 }
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 // We do not call super as we do not want to update UIKit model. It will
 // be updated after we receive all mutations.
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex
 {
   subview.reactSuperview = self;

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1097,9 +1097,9 @@ RNS_IGNORE_SUPER_CALL_END
 
 #endif // !TARGET_OS_TV
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 // We hijack the udpates as we don't want to update UIKit model yet.
 // This is done after all mutations are processed.
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex
 {
   if (![subview isKindOfClass:[RNSScreenView class]]) {
@@ -1215,6 +1215,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction
                 withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
+  NSLog(@"ScreenStack [%ld] transactionWILLMountWithNumber: %lld", self.tag, transaction.getNumber());
   for (const auto &mutation : transaction.getMutations()) {
     if (mutation.type == react::ShadowViewMutation::Delete) {
       RNSScreenView *_Nullable toBeRemovedChild = [self childScreenForTag:mutation.oldChildShadowView.tag];
@@ -1229,6 +1230,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
+  NSLog(@"ScreenStack [%ld] transactionDIDMountWithNumber: %lld", self.tag, transaction.getNumber());
   for (const auto &mutation : transaction.getMutations()) {
     // Note that self.tag might be invalid in cases this stack is removed.
     // This mostlikely does not cause any problems now, but it is something

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -73,6 +73,7 @@ namespace react = facebook::react;
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
+  NSLog(@"NavCtrl view=[%ld] didLayoutSubviews", static_cast<UIView *>(self.delegate).tag);
   if ([self.topViewController isKindOfClass:[RNSScreen class]]) {
     RNSScreen *screenController = (RNSScreen *)self.topViewController;
     BOOL isNotDismissingModal = screenController.presentedViewController == nil ||

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_END
  * Allows to send information with size to the corresponding node in shadow tree.
  * This method updates state of header config shadow node only.
  */
-- (void)updateHeaderConfigState:(CGSize)size;
+- (void)updateShadowStateWithSize:(CGSize)size;
 
 /**
  * Updates state of header config shadow node and all subview shadow nodes in context of given UINavigationBar.

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -217,6 +217,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)updateHeaderConfigState:(CGSize)size
 {
   if (!CGSizeEqualToSize(size, _lastSize)) {
+    NSLog(@"Config [%ld] updateShadowState %@", self.tag, NSStringFromCGSize(size));
     auto newState = react::RNSScreenStackHeaderConfigState(RCTSizeFromCGSize(size));
     _state->updateState(std::move(newState));
     _lastSize = size;
@@ -228,6 +229,7 @@ RNS_IGNORE_SUPER_CALL_END
   if (!navigationBar) {
     return;
   }
+  NSLog(@"Config [%ld] maybe update shadow state of navigation bar components", self.tag);
 
   [self updateHeaderConfigState:navigationBar.frame.size];
   for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -135,6 +135,18 @@ static constexpr auto DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   _blurEffect = RNSBlurEffectStyleNone;
 }
 
+- (void)setFrame:(CGRect)frame
+{
+  NSLog(@"HeaderConfig [%ld] setFrame:%@", self.tag, NSStringFromCGRect(frame));
+  [super setFrame:frame];
+}
+
+- (void)setBounds:(CGRect)bounds
+{
+  NSLog(@"HeaderConfig [%ld] setBounds:%@", self.tag, NSStringFromCGRect(bounds));
+  [super setBounds:bounds];
+}
+
 RNS_IGNORE_SUPER_CALL_BEGIN
 - (UIView *)reactSuperview
 {
@@ -762,9 +774,10 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 {
   [_reactSubviews removeObject:subview];
 }
-RNS_IGNORE_SUPER_CALL_BEGIN
+RNS_IGNORE_SUPER_CALL_END
 
 #ifdef RCT_NEW_ARCH_ENABLED
+
 #pragma mark - Fabric specific
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -233,8 +233,7 @@ RNS_IGNORE_SUPER_CALL_END
 
   [self updateShadowStateWithSize:navigationBar.frame.size];
   for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {
-    CGRect frameInNavBarCoordinates = [subview convertRect:subview.frame toView:navigationBar];
-    [subview updateShadowStateWithFrame:frameInNavBarCoordinates];
+    [subview updateShadowStateInContextOfAncestorView:navigationBar];
   }
 }
 #else

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -214,7 +214,7 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
-- (void)updateHeaderConfigState:(CGSize)size
+- (void)updateShadowStateWithSize:(CGSize)size
 {
   if (!CGSizeEqualToSize(size, _lastSize)) {
     NSLog(@"Config [%ld] updateShadowState %@", self.tag, NSStringFromCGSize(size));
@@ -231,10 +231,10 @@ RNS_IGNORE_SUPER_CALL_END
   }
   NSLog(@"Config [%ld] maybe update shadow state of navigation bar components", self.tag);
 
-  [self updateHeaderConfigState:navigationBar.frame.size];
+  [self updateShadowStateWithSize:navigationBar.frame.size];
   for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {
     CGRect frameInNavBarCoordinates = [subview convertRect:subview.frame toView:navigationBar];
-    [subview updateHeaderSubviewFrameInShadowTree:frameInNavBarCoordinates];
+    [subview updateShadowStateWithFrame:frameInNavBarCoordinates];
   }
 }
 #else

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -33,10 +33,20 @@ NS_ASSUME_NONNULL_BEGIN
  * Updates state of the header subview shadow node in shadow tree in context of given ancestor view.
  * This method updates state of header subview shadow node only.
  *
- *  @param ancestorView - ancestor view in relation to which, the frame send in state update is computed; if this is
+ * @param ancestorView - ancestor view in relation to which, the frame send in state update is computed; if this is
  * `nil` the method does nothing.
  */
 - (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView;
+
+/**
+ * Updates state of the header subview shadow node in shadow tree in context of given ancestor view.
+ * This method updates state of header subview shadow node only.
+ *
+ * @param ancestorView ancestor view in relation to which, the frame send in state update is computed; if this is
+ * `nil` the method does nothing.
+ * @param frame source frame, which will be transformed in relation to `ancestorView`.
+ */
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView withFrame:(CGRect)frame;
 #endif
 
 @end

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -21,7 +21,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) UIView *reactSuperview;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-- (void)updateHeaderSubviewFrameInShadowTree:(CGRect)frame;
+/**
+ * Updates state of the header subview shadow node in shadow tree.
+ * This method updates state of header subview shadow node only.
+ */
+- (void)updateShadowStateWithFrame:(CGRect)frame;
+
+/**
+ * Updates state of the header subview shadow node in shadow tree in context of given ancestor view.
+ * This method updates state of header subview shadow node only.
+ *
+ *  @param ancestorView - ancestor view in relation to which, the frame send in state update is computed; if this is
+ * `nil` the method does nothing.
+ */
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView;
 #endif
 
 @end

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -6,6 +6,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 #import "RNSEnums.h"
+#import "RNSHeaderSubviewContentWrapper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -15,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 #else
     UIView
 #endif
+    <RNSHeaderSubviewContentWrapperDelegate>
 
 @property (nonatomic) RNSScreenStackHeaderSubviewType type;
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -155,6 +155,26 @@ RNS_IGNORE_SUPER_CALL_BEGIN
   _state = std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(state);
 }
 
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  NSLog(
+      @"Subview [%ld] addsReactSubview [%ld] with frame %@",
+      self.tag,
+      childComponentView.tag,
+      NSStringFromCGRect(childComponentView.frame));
+  [super mountChildComponentView:childComponentView index:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  NSLog(
+      @"Subview [%ld] removesReactSubview [%ld] with frame %@",
+      self.tag,
+      childComponentView.tag,
+      NSStringFromCGRect(childComponentView.frame));
+  [super unmountChildComponentView:childComponentView index:index];
+}
+
 - (void)updateHeaderSubviewFrameInShadowTree:(CGRect)frame
 {
   if (_state == nullptr) {
@@ -164,6 +184,7 @@ RNS_IGNORE_SUPER_CALL_BEGIN
   if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
     auto newState =
         react::RNSScreenStackHeaderSubviewState(RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin));
+    NSLog(@"Subview [%ld] send state update %@", self.tag, NSStringFromCGRect(frame));
     _state->updateState(std::move(newState));
     _lastScheduledFrame = frame;
   }

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -58,6 +58,7 @@ namespace react = facebook::react;
   // TODO: It is possible, that this needs to be called only on old architecture.
   // Make sure that Test432 keeps working.
   [toLayoutView setNeedsLayout];
+  //  [self setNeedsLayout];
 
   // TODO: Determine why this must be called & deferring layout to next "update cycle"
   // is not sufficient. See Test2552 and Test432. (Talking Paper here).
@@ -106,6 +107,7 @@ namespace react = facebook::react;
 }
 
 RNS_IGNORE_SUPER_CALL_BEGIN
+
 // System layouts the subviews.
 - (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
@@ -122,11 +124,25 @@ RNS_IGNORE_SUPER_CALL_BEGIN
         NSStringFromCGRect(frame),
         self);
   } else {
+    NSLog(@"Subview [%ld] updateLayoutMetrics %@", self.tag, NSStringFromCGRect(CGRect{CGPointZero, frame.size}));
     self.bounds = CGRect{CGPointZero, frame.size};
     [self layoutNavigationBar];
   }
 }
+
 RNS_IGNORE_SUPER_CALL_BEGIN
+
+- (void)setFrame:(CGRect)frame
+{
+  NSLog(@"Subview [%ld] setFrame %@", self.tag, NSStringFromCGRect(frame));
+  [super setFrame:frame];
+}
+
+- (void)setBounds:(CGRect)bounds
+{
+  NSLog(@"Subview [%ld] setBounds %@", self.tag, NSStringFromCGRect(bounds));
+  [super setBounds:bounds];
+}
 
 + (BOOL)shouldBeRecycled
 {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
         "RNSScreenStackHeaderConfig": "RNSScreenStackHeaderConfig",
         "RNSScreenStackHeaderSubview": "RNSScreenStackHeaderSubview",
         "RNSScreenStack": "RNSScreenStackView",
-        "RNSSearchBar": "RNSSearchBar"
+        "RNSSearchBar": "RNSSearchBar",
+        "RNSHeaderSubviewContentWrapper": "RNSHeaderSubviewContentWrapper"
       }
     }
   },

--- a/src/components/HeaderSubviewContentWrapper.tsx
+++ b/src/components/HeaderSubviewContentWrapper.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { ViewProps } from 'react-native';
+import { Platform, View, ViewProps } from 'react-native';
 
 import HeaderSubviewContentWrapperNativeComponent from '../fabric/HeaderSubviewContentWrapperNativeComponent';
 
 function HeaderSubviewContentWrapper(props: ViewProps) {
+  if (Platform.OS === 'android') {
+    return (
+      <View collapsable={false} {...props}>
+        {props.children}
+      </View>
+    );
+  }
   return (
     <HeaderSubviewContentWrapperNativeComponent collapsable={false} {...props}>
       {props.children}

--- a/src/components/HeaderSubviewContentWrapper.tsx
+++ b/src/components/HeaderSubviewContentWrapper.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { ViewProps } from 'react-native';
+
+import HeaderSubviewContentWrapperNativeComponent from '../fabric/HeaderSubviewContentWrapperNativeComponent';
+
+function HeaderSubviewContentWrapper(props: ViewProps) {
+  return (
+    <HeaderSubviewContentWrapperNativeComponent collapsable={false} {...props}>
+      {props.children}
+    </HeaderSubviewContentWrapperNativeComponent>
+  );
+}
+
+export default HeaderSubviewContentWrapper;

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -17,6 +17,7 @@ import ScreenStackHeaderSubviewNativeComponent, {
   type NativeProps as ScreenStackHeaderSubviewNativeProps,
 } from '../fabric/ScreenStackHeaderSubviewNativeComponent';
 import { EDGE_TO_EDGE } from './helpers/edge-to-edge';
+import HeaderSubviewContentWrapper from './HeaderSubviewContentWrapper';
 
 export const ScreenStackHeaderSubview: React.ComponentType<ScreenStackHeaderSubviewNativeProps> =
   ScreenStackHeaderSubviewNativeComponent;
@@ -45,38 +46,41 @@ export const ScreenStackHeaderBackButtonImage = (
 );
 
 export const ScreenStackHeaderRightView = (props: ViewProps): JSX.Element => {
-  const { style, ...rest } = props;
+  const { style, children, ...rest } = props;
 
   return (
     <ScreenStackHeaderSubview
       {...rest}
       type="right"
-      style={[styles.headerSubview, style]}
-    />
+      style={[styles.headerSubview, style]}>
+      <HeaderSubviewContentWrapper>{children}</HeaderSubviewContentWrapper>
+    </ScreenStackHeaderSubview>
   );
 };
 
 export const ScreenStackHeaderLeftView = (props: ViewProps): JSX.Element => {
-  const { style, ...rest } = props;
+  const { style, children, ...rest } = props;
 
   return (
     <ScreenStackHeaderSubview
       {...rest}
       type="left"
-      style={[styles.headerSubview, style]}
-    />
+      style={[styles.headerSubview, style]}>
+      <HeaderSubviewContentWrapper>{children}</HeaderSubviewContentWrapper>
+    </ScreenStackHeaderSubview>
   );
 };
 
 export const ScreenStackHeaderCenterView = (props: ViewProps): JSX.Element => {
-  const { style, ...rest } = props;
+  const { style, children, ...rest } = props;
 
   return (
     <ScreenStackHeaderSubview
       {...rest}
       type="center"
-      style={[styles.headerSubviewCenter, style]}
-    />
+      style={[styles.headerSubviewCenter, style]}>
+      <HeaderSubviewContentWrapper>{children}</HeaderSubviewContentWrapper>
+    </ScreenStackHeaderSubview>
   );
 };
 
@@ -86,8 +90,9 @@ export const ScreenStackHeaderSearchBarView = (
   <ScreenStackHeaderSubview
     {...props}
     type="searchBar"
-    style={styles.headerSubview}
-  />
+    style={styles.headerSubview}>
+    <HeaderSubviewContentWrapper>{props.children}</HeaderSubviewContentWrapper>
+  </ScreenStackHeaderSubview>
 );
 
 const styles = StyleSheet.create({

--- a/src/fabric/HeaderSubviewContentWrapperNativeComponent.ts
+++ b/src/fabric/HeaderSubviewContentWrapperNativeComponent.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { ViewProps } from 'react-native';
+
+export interface NativeProps extends ViewProps {}
+
+export default codegenNativeComponent<NativeProps>(
+  'RNSHeaderSubviewContentWrapper',
+  {},
+);


### PR DESCRIPTION
## Description

Regression most likely introduced in 4.5.0 by #2466.
Fixes #2714
Fixes #2815


This is a ugly hack to workaround issue with dynamic content change.
When the size of this shadow node contents (children) change due to JS
update, e.g. new icon is added, if the size is set for the yogaNode
corresponding to this shadow node, the enforced size will be used
and the size won't be updated by Yoga to reflect the contents size
change -> host tree won't get layout metrics update -> we won't trigger native
layout -> the views in header will be positioned incorrectly.

> [!important]
> This PR handles iOS only, however there is **similar** issue on Android. The issue can be reproduced on the same test example. Android will be handled in separate PR.

## Changes

## Test code and steps to reproduce

Most of the fragile header interactions must be tested:

* [ ] Header title truncation - `TestHeaderTitle` ❌ This PR introduces regression here on iOS (Android not tested yet)
* [x] Pressables in header - `Test2466` (iOS works, Android code is unmodified here)
* [x] https://github.com/software-mansion/react-native-screens/pull/2807 (this PR does not touch Android)
* [x] https://github.com/software-mansion/react-native-screens/pull/2811 (this PR does not touch Android)
* [x] https://github.com/software-mansion/react-native-screens/pull/2812 (this PR does not touch Android)
* [x] Header behaviour on orientation changes - https://github.com/software-mansion/react-native-screens/pull/2756 (this PR does not touch Android)
* [x] New test `Test2714` handling header item resizing.
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
