### PR TITLE
test(e2e, Fabric): add e2e test for issue/PR example 593

### DIFF
--- a/FabricExample/e2e/issuesTests/Test593.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test593.e2e.ts
@@ -51,9 +51,9 @@ const awaitValidEventBehavior = async () => {
       element(by.text('18. Status | transitionEnd | opening')),
     ).toExist();
   } else {
-    await waitFor(element(by.text('13. Status | transitionStart | opening')))
-      .toExist()
-      .withTimeout(500);
+    await expect(
+      element(by.text('13. Status | transitionStart | opening')),
+    ).toExist();
     await expect(
       element(by.text('14. Status | transitionEnd | opening')),
     ).toExist();

--- a/FabricExample/e2e/issuesTests/Test593.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test593.e2e.ts
@@ -1,0 +1,125 @@
+import { device, expect, element, by } from 'detox';
+
+const awaitValidEventBehavior = async () => {
+  await expect(
+    element(by.text('3. Status | transitionStart | closing')),
+  ).toExist();
+  await expect(
+    element(by.text('4. Deeper | transitionStart | opening')),
+  ).toExist();
+  await expect(
+    element(by.text('5. Privacy | transitionStart | opening')),
+  ).toExist();
+  await expect(
+    element(by.text('6. Status | transitionEnd | closing')),
+  ).toExist();
+  await expect(
+    element(by.text('7. Deeper | transitionEnd | opening')),
+  ).toExist();
+  await expect(
+    element(by.text('8. Privacy | transitionEnd | opening')),
+  ).toExist();
+  await expect(
+    element(by.text('9. Privacy | transitionStart | closing')),
+  ).toExist();
+  await expect(
+    element(by.text('10. Another | transitionStart | opening')),
+  ).toExist();
+  await expect(
+    element(by.text('11. Privacy | transitionEnd | closing')),
+  ).toExist();
+  await expect(
+    element(by.text('12. Another | transitionEnd | opening')),
+  ).toExist();
+  if (device.getPlatform() === 'ios') {
+    await expect(
+      element(by.text('13. Deeper | transitionStart | closing')),
+    ).toExist();
+    await expect(
+      element(by.text('14. Another | transitionStart | closing')),
+    ).toExist();
+    await expect(
+      element(by.text('15. Status | transitionStart | opening')),
+    ).toExist();
+    await expect(
+      element(by.text('16. Deeper | transitionEnd | closing')),
+    ).toExist();
+    await expect(
+      element(by.text('17. Another | transitionEnd | closing')),
+    ).toExist();
+    await expect(
+      element(by.text('18. Status | transitionEnd | opening')),
+    ).toExist();
+  } else {
+    await waitFor(element(by.text('13. Status | transitionStart | opening')))
+      .toExist()
+      .withTimeout(500);
+    await expect(
+      element(by.text('14. Status | transitionEnd | opening')),
+    ).toExist();
+  }
+};
+
+describe('Test593', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+
+    await waitFor(element(by.id('root-screen-tests-Test593')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+  });
+
+  it('Test593 should exist', async () => {
+    await expect(element(by.id('root-screen-tests-Test593'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test593')).tap();
+  });
+
+  it('should run transitionStart & transitionEnd opening events', async () => {
+    await element(by.id('root-screen-tests-Test593')).tap();
+
+    await expect(
+      element(by.text('1. Status | transitionStart | opening')),
+    ).toExist();
+    await expect(
+      element(by.text('2. Status | transitionEnd | opening')),
+    ).toExist();
+  });
+
+  it('should go back from screen in nested stack and run opening & closing events in correct order', async () => {
+    await element(by.id('root-screen-tests-Test593')).tap();
+
+    await element(by.id('status-button-go-to-deeper')).tap();
+    await element(by.id('privacy-button-go-to-another')).tap();
+
+    if (device.getPlatform() === 'ios') {
+      await element(by.type('_UIButtonBarButton')).atIndex(0).tap();
+    } else {
+      await element(by.type('androidx.appcompat.widget.AppCompatImageButton'))
+        .atIndex(0)
+        .tap();
+    }
+
+    await awaitValidEventBehavior();
+  });
+
+  it('should use "none" animation, go back from screen in nested stack and run opening & closing events in correct order', async () => {
+    await element(by.id('root-screen-tests-Test593')).tap();
+
+    await element(by.id('Test593-stack-animation-picker')).tap();
+    await element(by.id('stack-animation-none')).tap();
+
+    await element(by.id('status-button-go-to-deeper')).tap();
+    await element(by.id('privacy-button-go-to-another')).tap();
+
+    if (device.getPlatform() === 'ios') {
+      await element(by.type('_UIButtonBarButton')).atIndex(0).tap();
+    } else {
+      await element(by.type('androidx.appcompat.widget.AppCompatImageButton'))
+        .atIndex(0)
+        .tap();
+    }
+
+    await awaitValidEventBehavior();
+  });
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -11,7 +11,7 @@ export { default as Test550 } from './Test550';     // [E2E skipped]: the prop d
 export { default as Test556 } from './Test556';     // [E2E skipped]: can't check flickering nor non-deterministic white screen bug
 export { default as Test564 } from './Test564';     // [E2E skipped]: issue still present
 export { default as Test577 } from './Test577';     // [E2E created](iOS): issue is related to iOS modal
-export { default as Test593 } from './Test593';
+export { default as Test593 } from './Test593';     // [E2E created]
 export { default as Test619 } from './Test619';
 export { default as Test624 } from './Test624';
 export { default as Test640 } from './Test640';


### PR DESCRIPTION
## Description

Create e2e test for `Test593`.

### Test 593
Test created. Test screen changed to allow using `default` and `none` stack animations. Events and their order is different than in related PRs (https://github.com/software-mansion/react-native-screens/pull/593, https://github.com/software-mansion/react-native-screens/pull/941) but it matches behavior from `Events` test screen.

## Changes

- add e2e test for `Test593`
- add comment in `apps/src/tests/index.ts`

## Test code and steps to reproduce
CI

## Checklist

- [x] Ensured that CI passes
