### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 619..640 

### DIFF
--- a/FabricExample/e2e/issuesTests/Test640.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test640.e2e.ts
@@ -1,0 +1,30 @@
+import { device, expect, element, by } from 'detox';
+
+describe('Test640', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test640 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test640')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test640'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test640')).tap();
+  });
+
+  it('scrolling down on modal should not close the modal but activate refresh', async () => {
+    await element(by.id('home-button-go-to-modal')).tap();
+    await element(by.text('Scroll to 4')).swipe('down', 'fast');
+
+    if (device.getPlatform() === 'android') {
+      await expect(element(by.id('modal-refresh-control'))).toBeVisible();
+    } else {
+      await expect(element(by.type('UIRefreshControl'))).toBeVisible();
+    }
+
+    await expect(element(by.id('home-button-go-to-modal'))).not.toBeVisible();
+  });
+});

--- a/apps/src/tests/Test640.js
+++ b/apps/src/tests/Test640.js
@@ -19,7 +19,11 @@ function wait(timeout) {
 
 function HomeScreen({ navigation }) {
   return (
-    <Button title="Navigate" onPress={() => navigation.navigate('Modal')} />
+    <Button
+      title="Navigate"
+      onPress={() => navigation.navigate('Modal')}
+      testID="home-button-go-to-modal"
+    />
   );
 }
 
@@ -35,7 +39,11 @@ function Modal({ navigation }) {
   return (
     <ScrollView
       refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          testID="modal-refresh-control"
+        />
       }
       contentInsetAdjustmentBehavior="automatic"
       scrollToOverflowEnabled

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -12,8 +12,8 @@ export { default as Test556 } from './Test556';     // [E2E skipped]: can't chec
 export { default as Test564 } from './Test564';     // [E2E skipped]: issue still present
 export { default as Test577 } from './Test577';     // [E2E created](iOS): issue is related to iOS modal
 export { default as Test593 } from './Test593';
-export { default as Test619 } from './Test619';
-export { default as Test624 } from './Test624';
+export { default as Test619 } from './Test619';     // [E2E skipped]: can't check components jumping
+export { default as Test624 } from './Test624';     // [E2E skipped]: PR changed library internals, test screen seems unrelated
 export { default as Test640 } from './Test640';
 export { default as Test642 } from './Test642';
 export { default as Test645 } from './Test645';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -14,7 +14,7 @@ export { default as Test577 } from './Test577';     // [E2E created](iOS): issue
 export { default as Test593 } from './Test593';
 export { default as Test619 } from './Test619';     // [E2E skipped]: can't check components jumping
 export { default as Test624 } from './Test624';     // [E2E skipped]: PR changed library internals, test screen seems unrelated
-export { default as Test640 } from './Test640';
+export { default as Test640 } from './Test640';     // [E2E created]
 export { default as Test642 } from './Test642';
 export { default as Test645 } from './Test645';
 export { default as Test648 } from './Test648';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test619, ..., Test640` and implement them if possible for Fabric. 

### Test619
Skipped because we can't check components "jumping".

### Test624
Skipped because the change in PR https://github.com/software-mansion/react-native-screens/pull/624 is connected to internal JS prop. The test screen seems to be repurposed.

### Test640
Test created. It checks if `RefreshControl` works correctly with `modal` (refresh instead of the modal closing).

## Changes

- add `Test640`
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes
