### PR TITLE
docs: update information in native-stack's README and guide for library authors

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -96,6 +96,8 @@ Defaults to `false`.
 
 ### `navigationBarColor` (Android only)
 
+This prop is **deprecated**. See [here](https://developer.android.com/about/versions/15/behavior-changes-15#ux).
+
 Sets the navigation bar color. Defaults to initial status bar color.
 
 ### `navigationBarHidden` (Android only)
@@ -273,6 +275,8 @@ Defaults to `fade` on iOS and `none` on Android.
 
 ### `statusBarColor` (Android only)
 
+This prop is **deprecated**. See [here](https://developer.android.com/about/versions/15/behavior-changes-15#ux).
+
 Sets the status bar color (similar to the `StatusBar` component). Defaults to initial status bar color.
 
 ### `statusBarHidden`
@@ -288,6 +292,8 @@ Sets the status bar color (similar to the `StatusBar` component). Requires enabl
 Defaults to `auto`.
 
 ### `statusBarTranslucent` (Android only)
+
+This prop is **deprecated**. See [here](https://developer.android.com/about/versions/15/behavior-changes-15#ux).
 
 Sets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.
 

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -263,7 +263,9 @@ For iOS:
 
 For Android:
 
-`modal`, `containedModal`, `fullScreenModal`, `formSheet`, `pageSheet` will use `Screen.StackPresentation.MODAL`.
+`modal`, `containedModal`, `fullScreenModal`, `pageSheet` will use `Screen.StackPresentation.MODAL`.
+
+`formSheet` will use `Screen.StackPresentation.FORM_SHEET`.
 
 `transparentModal`, `containedTransparentModal` will use `Screen.StackPresentation.TRANSPARENT_MODAL`.
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -349,7 +349,7 @@ How the screen should be presented. Possible values:
 - `containedModal` – will use "UIModalPresentationCurrentContext" modal style on iOS and will fallback to `"modal"` on Android.
 - `containedTransparentModal` – will use "UIModalPresentationOverCurrentContext" modal style on iOS and will fallback to `"transparentModal"` on Android.
 - `fullScreenModal` – will use "UIModalPresentationFullScreen" modal style on iOS and will fallback to `"modal"` on Android.
-- `formSheet` – will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to `"modal"` on Android.
+- `formSheet` – will use "UIModalPresentationFormSheet" modal style on iOS and "BottomSheetBehavior" on Android.
 - `pageSheet` – will use "UIModalPresentationPageSheet" modal style on iOS and will fallback to `"modal"` on Android.
 
 Defaults to `push`.

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -188,7 +188,7 @@ export interface ScreenProps extends ViewProps {
    *
    * @deprecated For all apps targeting Android SDK 35 or above this prop has no effect and is subject to removal in the future.
    *  For SDK below 35 this works only with specific app setup.
-   *  This props is subject to removal in the future.
+   *  This prop is subject to removal in the future.
    *  See: https://developer.android.com/reference/android/view/Window#setNavigationBarColor(int)
    */
   navigationBarColor?: ColorValue;


### PR DESCRIPTION
## Description

Small changes in docs.

## Changes

- add deprecation messages to navigation/status bar related props deprecated in https://github.com/software-mansion/react-native-screens/pull/2638 in `GUIDE_FOR_LIBRARY_AUTHORS.md`
- fix typo in `src/types.tsx`
- update information about `formSheet` in `GUIDE_FOR_LIBRARY_AUTHORS.md`

