### PR TITLE
feat(iOS): add `unstable_accessibilityContainerViewIsModal` prop for `FullWindowOverlay`

### DIFF
--- a/ios/RNSFullWindowOverlay.h
+++ b/ios/RNSFullWindowOverlay.h
@@ -26,7 +26,7 @@ namespace react = facebook::react;
     RCTView <RCTInvalidating>
 #endif // RCT_NEW_ARCH_ENABLED
 
-@property (nonatomic) BOOL containerAccessibilityViewIsModal;
+@property (nonatomic) BOOL accessibilityContainerViewIsModal;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 @property (nonatomic) react::LayoutMetrics oldLayoutMetrics;

--- a/ios/RNSFullWindowOverlay.h
+++ b/ios/RNSFullWindowOverlay.h
@@ -26,6 +26,8 @@ namespace react = facebook::react;
     RCTView <RCTInvalidating>
 #endif // RCT_NEW_ARCH_ENABLED
 
+@property (nonatomic) BOOL containerAccessibilityViewIsModal;
+
 #ifdef RCT_NEW_ARCH_ENABLED
 @property (nonatomic) react::LayoutMetrics oldLayoutMetrics;
 @property (nonatomic) react::LayoutMetrics newLayoutMetrics;

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -17,10 +17,10 @@
 
 @implementation RNSFullWindowOverlayContainer
 
-- (instancetype)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame accessibilityViewIsModal:(BOOL)accessibilityViewIsModal
 {
   if (self = [super initWithFrame:frame]) {
-    self.accessibilityViewIsModal = YES;
+    self.accessibilityViewIsModal = accessibilityViewIsModal;
   }
   return self;
 }
@@ -92,27 +92,35 @@
   if (self = [super init]) {
     static const auto defaultProps = std::make_shared<const react::RNSFullWindowOverlayProps>();
     _props = defaultProps;
-    [self _initCommon];
+    [self initCommonProps];
   }
   return self;
 }
-#endif // RCT_NEW_ARCH_ENABLED
-
+#else
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   if (self = [super init]) {
     _bridge = bridge;
-    [self _initCommon];
+    [self initCommonProps];
   }
 
   return self;
 }
+#endif // RCT_NEW_ARCH_ENABLED
 
-- (void)_initCommon
+- (void)initCommonProps
 {
+  // Default value used by container.
+  _containerAccessibilityViewIsModal = YES;
   _reactFrame = CGRectNull;
   _container = self.container;
   [self show];
+}
+
+- (void)setContainerAccessibilityViewIsModal:(BOOL)containerAccessibilityViewIsModal
+{
+  _containerAccessibilityViewIsModal = containerAccessibilityViewIsModal;
+  self.container.accessibilityViewIsModal = containerAccessibilityViewIsModal;
 }
 
 - (void)addSubview:(UIView *)view
@@ -123,7 +131,8 @@
 - (RNSFullWindowOverlayContainer *)container
 {
   if (_container == nil) {
-    _container = [[RNSFullWindowOverlayContainer alloc] initWithFrame:_reactFrame];
+    _container = [[RNSFullWindowOverlayContainer alloc] initWithFrame:_reactFrame
+                                             accessibilityViewIsModal:_containerAccessibilityViewIsModal];
   }
 
   return _container;
@@ -220,6 +229,19 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 
 RNS_IGNORE_SUPER_CALL_END
 
+- (void)updateProps:(const facebook::react::Props::Shared &)props
+           oldProps:(const facebook::react::Props::Shared &)oldProps
+{
+  const auto &oldComponentProps = *std::static_pointer_cast<react::RNSFullWindowOverlayProps>(_props);
+  const auto &newComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(props);
+
+  if (newComponentProps.containerAccessibilityViewIsModal != oldComponentProps.containerAccessibilityViewIsModal) {
+    [self setContainerAccessibilityViewIsModal:newComponentProps.containerAccessibilityViewIsModal];
+  }
+
+  [super updateProps:props oldProps:oldProps];
+}
+
 #else
 #pragma mark - Paper specific
 
@@ -249,6 +271,8 @@ Class<RCTComponentViewProtocol> RNSFullWindowOverlayCls(void)
 @implementation RNSFullWindowOverlayManager
 
 RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(containerAccessibilityViewIsModal, BOOL)
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #else

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -232,7 +232,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)updateProps:(const facebook::react::Props::Shared &)props
            oldProps:(const facebook::react::Props::Shared &)oldProps
 {
-  const auto &oldComponentProps = *std::static_pointer_cast<react::RNSFullWindowOverlayProps>(_props);
+  const auto &oldComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(_props);
   const auto &newComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(props);
 
   if (newComponentProps.containerAccessibilityViewIsModal != oldComponentProps.containerAccessibilityViewIsModal) {

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -111,16 +111,16 @@
 - (void)initCommonProps
 {
   // Default value used by container.
-  _containerAccessibilityViewIsModal = YES;
+  _accessibilityContainerViewIsModal = YES;
   _reactFrame = CGRectNull;
   _container = self.container;
   [self show];
 }
 
-- (void)setContainerAccessibilityViewIsModal:(BOOL)containerAccessibilityViewIsModal
+- (void)setAccessibilityContainerViewIsModal:(BOOL)accessibilityContainerViewIsModal
 {
-  _containerAccessibilityViewIsModal = containerAccessibilityViewIsModal;
-  self.container.accessibilityViewIsModal = containerAccessibilityViewIsModal;
+  _accessibilityContainerViewIsModal = accessibilityContainerViewIsModal;
+  self.container.accessibilityViewIsModal = accessibilityContainerViewIsModal;
 }
 
 - (void)addSubview:(UIView *)view
@@ -132,7 +132,7 @@
 {
   if (_container == nil) {
     _container = [[RNSFullWindowOverlayContainer alloc] initWithFrame:_reactFrame
-                                             accessibilityViewIsModal:_containerAccessibilityViewIsModal];
+                                             accessibilityViewIsModal:_accessibilityContainerViewIsModal];
   }
 
   return _container;
@@ -236,7 +236,7 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &newComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(props);
 
   if (newComponentProps.containerAccessibilityViewIsModal != oldComponentProps.containerAccessibilityViewIsModal) {
-    [self setContainerAccessibilityViewIsModal:newComponentProps.containerAccessibilityViewIsModal];
+    [self setAccessibilityContainerViewIsModal:newComponentProps.containerAccessibilityViewIsModal];
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -272,7 +272,7 @@ Class<RCTComponentViewProtocol> RNSFullWindowOverlayCls(void)
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_VIEW_PROPERTY(containerAccessibilityViewIsModal, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(accessibilityContainerViewIsModal, BOOL)
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #else

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -235,8 +235,8 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &oldComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(_props);
   const auto &newComponentProps = *std::static_pointer_cast<const react::RNSFullWindowOverlayProps>(props);
 
-  if (newComponentProps.containerAccessibilityViewIsModal != oldComponentProps.containerAccessibilityViewIsModal) {
-    [self setAccessibilityContainerViewIsModal:newComponentProps.containerAccessibilityViewIsModal];
+  if (newComponentProps.accessibilityContainerViewIsModal != oldComponentProps.accessibilityContainerViewIsModal) {
+    [self setAccessibilityContainerViewIsModal:newComponentProps.accessibilityContainerViewIsModal];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/src/components/FullWindowOverlay.tsx
+++ b/src/components/FullWindowOverlay.tsx
@@ -10,13 +10,21 @@ import {
 
 // Native components
 import FullWindowOverlayNativeComponent from '../fabric/FullWindowOverlayNativeComponent';
+import type { NativeProps } from '../fabric/FullWindowOverlayNativeComponent';
+
 const NativeFullWindowOverlay: React.ComponentType<
   PropsWithChildren<{
     style: StyleProp<ViewStyle>;
-  }>
+  }> &
+    NativeProps
 > = FullWindowOverlayNativeComponent as any;
 
-function FullWindowOverlay(props: { children: ReactNode }) {
+type FullWindowOverlayProps = {
+  children: ReactNode;
+  unstable_containerAccessibilityViewIsModal?: boolean;
+};
+
+function FullWindowOverlay(props: FullWindowOverlayProps) {
   const { width, height } = useWindowDimensions();
   if (Platform.OS !== 'ios') {
     console.warn('Using FullWindowOverlay is only valid on iOS devices.');
@@ -24,7 +32,10 @@ function FullWindowOverlay(props: { children: ReactNode }) {
   }
   return (
     <NativeFullWindowOverlay
-      style={[StyleSheet.absoluteFill, { width, height }]}>
+      style={[StyleSheet.absoluteFill, { width, height }]}
+      containerAccessibilityViewIsModal={
+        props.unstable_containerAccessibilityViewIsModal
+      }>
       {props.children}
     </NativeFullWindowOverlay>
   );

--- a/src/components/FullWindowOverlay.tsx
+++ b/src/components/FullWindowOverlay.tsx
@@ -21,7 +21,7 @@ const NativeFullWindowOverlay: React.ComponentType<
 
 type FullWindowOverlayProps = {
   children: ReactNode;
-  unstable_containerAccessibilityViewIsModal?: boolean;
+  unstable_accessibilityContainerViewIsModal?: boolean;
 };
 
 function FullWindowOverlay(props: FullWindowOverlayProps) {
@@ -33,8 +33,8 @@ function FullWindowOverlay(props: FullWindowOverlayProps) {
   return (
     <NativeFullWindowOverlay
       style={[StyleSheet.absoluteFill, { width, height }]}
-      containerAccessibilityViewIsModal={
-        props.unstable_containerAccessibilityViewIsModal
+      accessibilityContainerViewIsModal={
+        props.unstable_accessibilityContainerViewIsModal
       }>
       {props.children}
     </NativeFullWindowOverlay>

--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -6,7 +6,7 @@ import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
 // Internal export, not part of stable library API.
 export interface NativeProps extends ViewProps {
-  containerAccessibilityViewIsModal?: WithDefault<boolean, true>;
+  accessibilityContainerViewIsModal?: WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSFullWindowOverlay', {

--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -2,8 +2,12 @@
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
+import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
-interface NativeProps extends ViewProps {}
+// Internal export, not part of stable library API.
+export interface NativeProps extends ViewProps {
+  containerAccessibilityViewIsModal?: WithDefault<boolean, true>;
+}
 
 export default codegenNativeComponent<NativeProps>('RNSFullWindowOverlay', {
   interfaceOnly: true,


### PR DESCRIPTION
## Description


The prop defaults to `true` due to backward compatibility reasons.
I believe this should be changed with major version change.

There is no need to update Android interfaces, because we render plain `View` there in place of `FullWindowOverlay`.

The prop is `unstable` since I haven't decided yet on whether
I want to expose completely new prop or make
`RNSFullWindowOverlayContainer` use value of
`RNSFullWindowOverlay.accessibilityViewIsModal`.

This would be possible, because it is regular prop on `View`
component. See: https://reactnative.dev/docs/view#accessibilityviewismodal-ios

Currently I went with new prop and not repurposing `accessibilityViewIsModal` on `RNSFullWindowOverlay` since I'm not that familiar with the accessibility API & want to avoid focus request collisions etc. & in case the original prop becomes utilised in the future. 


## Changes

Added new prop.

## Test code and steps to reproduce

`Test1096` + VoiceOver, when `unstable_accessibilityContainerViewIsModal: false` you should be able to access content under the FWO with voice over. 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
