### PR TITLE
test(Windows): select react-native version for test project based on react-native-windows latest version

### DIFF
--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Determine latest react-native version supported by react-native-windows
         id: determine-rn-version
         run: |
-          rn=$(npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
+          $rn=$(npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
           echo "rn=$rn" >> $GITHUB_OUTPUT
 
       - name: Create Example app

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -66,10 +66,10 @@ jobs:
               $minor = $matches[2]
               $desiredVersion = "$major.$minor"
               echo "Installing $desiredVersion version."
-              echo "rn=$desiredVersion" >> $GITHUB_OUTPUT
+              echo "rn=$desiredVersion" >> $env:GITHUB_OUTPUT
           } else {
               echo "Failed to parse version from npm. Installing latest version."
-              echo "rn=latest" >> $GITHUB_OUTPUT
+              echo "rn=latest" >> $env:GITHUB_OUTPUT
           }
 
       - name: Create Example app

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -57,8 +57,14 @@ jobs:
       - name: Unpack library files
         run: tar -xzf (Get-ChildItem -Path .\*.tgz)
 
+      - name: Determine latest react-native version supported by react-native-windows
+        id: determine-rn-version
+        run: |
+          rn=$(npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
+          echo "rn=$rn" >> $GITHUB_OUTPUT
+
       - name: Create Example app
-        run: npx @react-native-community/cli@latest init WindowsExample --version (npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
+        run: npx @react-native-community/cli@latest init WindowsExample --version ${{ steps.determine-rn-version.outputs.rn }}
 
       - name: Install app dependencies
         working-directory: WindowsExample

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           $rn=$(npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
           echo "rn=$rn" >> $GITHUB_OUTPUT
+          echo "rn=$rn"
 
       - name: Create Example app
         run: npx @react-native-community/cli@latest init WindowsExample --version ${{ steps.determine-rn-version.outputs.rn }}

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -60,9 +60,17 @@ jobs:
       - name: Determine latest react-native version supported by react-native-windows
         id: determine-rn-version
         run: |
-          $rn=$(npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
-          echo "rn=$rn" >> $GITHUB_OUTPUT
-          echo "rn=$rn"
+          $rnwVersion = npm view react-native-windows version
+          if ($rnwVersion -match '(\d+)\.(\d+)\.') {
+              $major = $matches[1]
+              $minor = $matches[2]
+              $desiredVersion = "$major.$minor"
+              echo "Installing $desiredVersion version."
+              echo "rn=$desiredVersion" >> $GITHUB_OUTPUT
+          } else {
+              echo "Failed to parse version from npm. Installing latest version."
+              echo "rn=latest" >> $GITHUB_OUTPUT
+          }
 
       - name: Create Example app
         run: npx @react-native-community/cli@latest init WindowsExample --version ${{ steps.determine-rn-version.outputs.rn }}

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -58,7 +58,7 @@ jobs:
         run: tar -xzf (Get-ChildItem -Path .\*.tgz)
 
       - name: Create Example app
-        run: npx @react-native-community/cli@latest init WindowsExample
+        run: npx @react-native-community/cli@latest init WindowsExample --version (npm view react-native-windows version | sed -n 's/^\([0-9]*\.[0-9]*\)\..*/\1/p')
 
       - name: Install app dependencies
         working-directory: WindowsExample


### PR DESCRIPTION
## Description

Select `react-native version` for test project based on `react-native-windows` latest version.

Sometimes, when new `react-native` version is released but `react-native-windows` is not yet available for this version, CI might fail because of the version mismatch. Now we fetch latest version of `react-native-windows` from NPM in format `x.yy.zz` and we use `x.yy` to determine latest supported version of `react-native`. Then we use it to initialize new `react-native` project.

## Changes

- modify Windows CI

## Test code and steps to reproduce

Windows CI

## Checklist

- [x] Ensured that Windows CI passes
