### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 642..645

### DIFF
--- a/FabricExample/e2e/issuesTests/Test645.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test645.e2e.ts
@@ -1,0 +1,48 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS } from '../e2e-utils';
+
+// headerLargeTitle is supported only on iOS
+describeIfiOS('Test645', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test645 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test645')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test645'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test645')).tap();
+  });
+
+  it('header large title "Main" should be fully visible', async () => {
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
+  it('header large title "Details" should be fully visible', async () => {
+    await element(by.id('home-button-go-to-details')).tap();
+    await expect(element(by.text('Details').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
+  it('header large title "Settings" should be fully visible', async () => {
+    await element(by.id('details-button-go-to-settings')).tap();
+    await expect(element(by.text('Settings').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
+  it('header large title "Main" should be fully visible after coming back from Settings', async () => {
+    await element(by.id('settings-button-go-to-home')).tap();
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
+  it('header large title "Main" should be fully visible on Second tab screen', async () => {
+    await element(by.id('home-button-go-to-second')).tap();
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
+  it('header large title "Main" should be fully visible after coming back from Second tab screen', async () => {
+    await element(by.id('second-button-go-back')).tap();
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+});

--- a/FabricExample/e2e/issuesTests/Test645.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test645.e2e.ts
@@ -21,6 +21,16 @@ describeIfiOS('Test645', () => {
     await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
   });
 
+  it('large title should collapse after scrolling down', async () => {
+    await element(by.id('main-scrollview')).scroll(200, 'down', NaN, 0.85);
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).not.toBeVisible();
+  });
+
+  it('large title should reappear after scrolling to top', async () => {
+    await element(by.id('main-scrollview')).scroll(250, 'up', NaN, 0.85);
+    await expect(element(by.text('Main').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);
+  });
+
   it('header large title "Details" should be fully visible', async () => {
     await element(by.id('home-button-go-to-details')).tap();
     await expect(element(by.text('Details').withAncestor(by.type('_UINavigationBarLargeTitleView')))).toBeVisible(100);

--- a/apps/src/tests/Test645.js
+++ b/apps/src/tests/Test645.js
@@ -12,10 +12,12 @@ function HomeScreen({ navigation }) {
       <Button
         onPress={() => navigation.navigate('Details')}
         title="Go to Details"
+        testID="home-button-go-to-details"
       />
       <Button
         onPress={() => navigation.navigate('Second')}
         title="Go to Second"
+        testID="home-button-go-to-second"
       />
     </View>
   );
@@ -27,8 +29,9 @@ function DetailsScreen({ navigation }) {
       <Button
         onPress={() => navigation.navigate('Settings')}
         title="Go to Settings"
+        testID="details-button-go-to-settings"
       />
-      <Text>Details</Text>
+      <Text>Some text.</Text>
     </View>
   );
 }
@@ -39,8 +42,9 @@ function SettingsScreen({ navigation }) {
       <Button
         onPress={() => navigation.popTo('Main', { screen: 'Home' })}
         title="Go to Home"
+        testID="settings-button-go-to-home"
       />
-      <Text>Details</Text>
+      <Text>Some text.</Text>
     </View>
   );
 }
@@ -49,7 +53,7 @@ function SecondScreen({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text style={{ fontSize: 30 }}>This is a second screen!</Text>
-      <Button onPress={() => navigation.goBack()} title="go back" />
+      <Button onPress={() => navigation.goBack()} title="go back" testID="second-button-go-back" />
     </View>
   );
 }

--- a/apps/src/tests/Test645.js
+++ b/apps/src/tests/Test645.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Text, View } from 'react-native';
+import { Button, Text, ScrollView } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { NavigationContainer } from '@react-navigation/native';
@@ -7,7 +7,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 function HomeScreen({ navigation }) {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <ScrollView contentContainerStyle={{padding: 10, paddingTop: 160, height: 1500}} testID="main-scrollview">
       <Text style={{ fontSize: 30 }}>This is the home screen!</Text>
       <Button
         onPress={() => navigation.navigate('Details')}
@@ -19,42 +19,42 @@ function HomeScreen({ navigation }) {
         title="Go to Second"
         testID="home-button-go-to-second"
       />
-    </View>
+    </ScrollView>
   );
 }
 
 function DetailsScreen({ navigation }) {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <ScrollView contentContainerStyle={{padding: 10, paddingTop: 160, height: 1500}}>
       <Button
         onPress={() => navigation.navigate('Settings')}
         title="Go to Settings"
         testID="details-button-go-to-settings"
       />
       <Text>Some text.</Text>
-    </View>
+    </ScrollView>
   );
 }
 
 function SettingsScreen({ navigation }) {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <ScrollView contentContainerStyle={{padding: 10, paddingTop: 160, height: 1500}}>
       <Button
         onPress={() => navigation.popTo('Main', { screen: 'Home' })}
         title="Go to Home"
         testID="settings-button-go-to-home"
       />
       <Text>Some text.</Text>
-    </View>
+    </ScrollView>
   );
 }
 
 function SecondScreen({ navigation }) {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <ScrollView contentContainerStyle={{padding: 10, paddingTop: 160, height: 1500}}>
       <Text style={{ fontSize: 30 }}>This is a second screen!</Text>
       <Button onPress={() => navigation.goBack()} title="go back" testID="second-button-go-back" />
-    </View>
+    </ScrollView>
   );
 }
 
@@ -73,7 +73,7 @@ function MainStackScreen() {
 
 function TabsScreen() {
   return (
-    <Tabs.Navigator detachInactiveScreens={true}>
+    <Tabs.Navigator detachInactiveScreens={true} screenOptions={{ headerShown: false }}>
       <Tabs.Screen name="Home" component={HomeScreen} />
       <Tabs.Screen name="Second" component={SecondScreen} />
     </Tabs.Navigator>

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -15,7 +15,7 @@ export { default as Test593 } from './Test593';     // [E2E created]
 export { default as Test619 } from './Test619';     // [E2E skipped]: can't check components jumping
 export { default as Test624 } from './Test624';     // [E2E skipped]: PR changed library internals, test screen seems unrelated
 export { default as Test640 } from './Test640';     // [E2E created]
-export { default as Test642 } from './Test642';
+export { default as Test642 } from './Test642';     // [E2E skipped]: can't check status bar visibility/style
 export { default as Test645 } from './Test645';
 export { default as Test648 } from './Test648';
 export { default as Test649 } from './Test649';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -16,7 +16,7 @@ export { default as Test619 } from './Test619';     // [E2E skipped]: can't chec
 export { default as Test624 } from './Test624';     // [E2E skipped]: PR changed library internals, test screen seems unrelated
 export { default as Test640 } from './Test640';     // [E2E created]
 export { default as Test642 } from './Test642';     // [E2E skipped]: can't check status bar visibility/style
-export { default as Test645 } from './Test645';
+export { default as Test645 } from './Test645';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
 export { default as Test648 } from './Test648';
 export { default as Test649 } from './Test649';
 export { default as Test654 } from './Test654';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test642, Test645` and implement them if possible for Fabric. 

### Test642
Skipped because we can't check status bar visibility/style.

### Test645
Test created, only on iOS (`headerLargeTitle` is supported only on iOS). It checks if `headerLargeTitle` isn't collapsed when changing screens. I changed `Test645` screen to use `ScrollView` because it was used in original issue.

## Changes

- add `Test645`
- change regular `View` to `ScrollView` in test screen `Test645`
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes
