### PR TITLE
feat(iOS): make `fitToContents` sheet height react to dynamic content 

### DIFF
--- a/FabricExample/e2e/issuesTests/Test2877.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test2877.e2e.ts
@@ -1,0 +1,37 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS } from '../e2e-utils';
+
+// issue fixed only on iOS at the moment
+describeIfiOS('Test2877', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test2877 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test2877')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test2877'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test2877')).tap();
+  });
+
+  it('formSheet should open without hidden content', async () => {
+    await element(by.id('home-button-open-formsheet')).tap();
+
+    await expect(element(by.text('Like this.'))).not.toBeVisible();
+  });
+
+  it('formSheet should adapt height to appearing content, making it visible after 1 second', async () => {
+    await waitFor(element(by.text('Like this.')))
+      .toBeVisible(100)
+      .withTimeout(1200);
+  });
+
+  it('additional content in the formSheet should hide after 1 second', async () => {
+    await waitFor(element(by.text('Like this.')))
+      .not.toBeVisible(100)
+      .withTimeout(1200);
+  });
+});

--- a/apps/src/tests/Test2877.tsx
+++ b/apps/src/tests/Test2877.tsx
@@ -25,11 +25,9 @@ function Home({ navigation }: StackNavigationProp) {
       <Button
         title="Open FormSheet"
         onPress={() => navigation.navigate('FormSheet')}
+        testID="home-button-open-formsheet"
       />
-      <Button
-        title="Go back"
-        onPress={() => navigation.pop()}
-      />
+      <Button title="Go back" onPress={() => navigation.pop()} />
     </View>
   );
 }
@@ -57,16 +55,18 @@ function FormSheet({ navigation }: StackNavigationProp) {
         }}>
         <Text>Every second, sheet's height should change.</Text>
       </View>
-      {extended && <View
-        style={{
-          height: 200,
-          flex: 1,
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: 'lightgreen',
-        }}>
-        <Text>Like this.</Text>
-      </View>}
+      {extended && (
+        <View
+          style={{
+            height: 200,
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'lightgreen',
+          }}>
+          <Text>Like this.</Text>
+        </View>
+      )}
     </View>
   );
 }

--- a/apps/src/tests/Test2877.tsx
+++ b/apps/src/tests/Test2877.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, Text, View } from 'react-native';
+
+type RouteParamList = {
+  Home: undefined;
+  FormSheet: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function Home({ navigation }: StackNavigationProp) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Button
+        title="Open FormSheet"
+        onPress={() => navigation.navigate('FormSheet')}
+      />
+      <Button
+        title="Go back"
+        onPress={() => navigation.pop()}
+      />
+    </View>
+  );
+}
+
+function FormSheet({ navigation }: StackNavigationProp) {
+  const [extended, setExtended] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setExtended(!extended);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <View>
+      <Button title="Go back" onPress={() => navigation.goBack()} />
+      <View
+        style={{
+          height: 200,
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+        <Text>Every second, sheet's height should change.</Text>
+      </View>
+      {extended && <View
+        style={{
+          height: 200,
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'lightgreen',
+        }}>
+        <Text>Like this.</Text>
+      </View>}
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen
+          name="FormSheet"
+          component={FormSheet}
+          options={{
+            headerShown: false,
+            presentation: 'formSheet',
+            sheetAllowedDetents: 'fitToContents',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/Test2877.tsx
+++ b/apps/src/tests/Test2877.tsx
@@ -27,7 +27,6 @@ function Home({ navigation }: StackNavigationProp) {
         onPress={() => navigation.navigate('FormSheet')}
         testID="home-button-open-formsheet"
       />
-      <Button title="Go back" onPress={() => navigation.pop()} />
     </View>
   );
 }

--- a/apps/src/tests/Test2877.tsx
+++ b/apps/src/tests/Test2877.tsx
@@ -33,18 +33,24 @@ function Home({ navigation }: StackNavigationProp) {
 
 function FormSheet({ navigation }: StackNavigationProp) {
   const [extended, setExtended] = useState(false);
+  const [intervalEnabled, setIntervalEnabled] = useState(true);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    if (!intervalEnabled) {
+      return;
+    }
+
+    const intervalHandle = setInterval(() => {
       setExtended(!extended);
     }, 1000);
 
-    return () => clearInterval(interval);
-  });
+    return () => clearInterval(intervalHandle);
+  }, [extended, intervalEnabled]);
 
   return (
     <View>
       <Button title="Go back" onPress={() => navigation.goBack()} />
+      <Button title="Toggle automatic toggling" onPress={() => setIntervalEnabled(old => !old)} />
       <View
         style={{
           height: 200,

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -131,6 +131,7 @@ export { default as Test2809 } from './Test2809';
 export { default as Test2811 } from './Test2811';
 export { default as Test2819 } from './Test2819';
 export { default as Test2855 } from './Test2855';
+export { default as Test2877 } from './Test2877';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -131,7 +131,7 @@ export { default as Test2809 } from './Test2809';
 export { default as Test2811 } from './Test2811';
 export { default as Test2819 } from './Test2819';
 export { default as Test2855 } from './Test2855';
-export { default as Test2877 } from './Test2877';
+export { default as Test2877 } from './Test2877'; // [E2E created](iOS): issue is related to formSheet on iOS
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -126,7 +126,7 @@ struct ContentWrapperBox {
   _sheetExpandsWhenScrolledToEdge = YES;
 #endif // !TARGET_OS_TV
   _sheetsScrollView = nil;
-  _sheetFrameHeight = NO;
+  _sheetFrameHeight = 0.0;
 #ifdef RCT_NEW_ARCH_ENABLED
   _markedForUnmountInCurrentTransaction = NO;
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -444,7 +444,7 @@ RNS_IGNORE_SUPER_CALL_END
 {
   // We want to update and animate allowedDetents for FormSheet only if there was a change
   // in frame's height but sometimes we receive a frame with the same dimensions mutliple times.
-  // In order to prevent visual glitches, we comapre new value to the old one and update
+  // In order to prevent visual glitches, we compare new value to the old one and update
   // only if there was a change in height.
   if (self.stackPresentation != RNSScreenStackPresentationFormSheet || _sheetContentHeight == reactFrame.size.height) {
     return;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -166,8 +166,6 @@ RNS_IGNORE_SUPER_CALL_END
     auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
     _state->updateState(std::move(newState));
 
-    NSLog(@"ScreenView [%ld] state update send, size: %@", self.tag, NSStringFromCGSize(self.bounds.size));
-
     // TODO: Requesting layout on every layout is wrong. We should look for a way to get rid of this.
     UINavigationController *navctr = _controller.navigationController;
     [navctr.view setNeedsLayout];
@@ -448,18 +446,7 @@ RNS_IGNORE_SUPER_CALL_END
   // in frame's height but sometimes we receive a frame with the same dimensions mutliple times.
   // In order to prevent visual glitches, we comapre new value to the old one and update
   // only if there was a change in height.
-  NSLog(
-      @"ScreenView [%ld] contentWrapper:[%ld] receivedReactFrame:%@",
-      self.tag,
-      contentWrapper.tag,
-      NSStringFromCGRect(reactFrame));
   if (self.stackPresentation != RNSScreenStackPresentationFormSheet || _sheetContentHeight == reactFrame.size.height) {
-    NSLog(
-        @"ScreenView [%ld] contentWrapper:[%ld] receivedReactFrame:%@ sheetFrameHeight:%.2f - EARLY RETURN",
-        self.tag,
-        contentWrapper.tag,
-        NSStringFromCGRect(reactFrame),
-        _sheetContentHeight);
     return;
   }
 
@@ -1325,10 +1312,6 @@ RNS_IGNORE_SUPER_CALL_END
   _oldLayoutMetrics = oldLayoutMetrics;
   UIViewController *parentVC = self.reactViewController.parentViewController;
   if (parentVC == nil || ![parentVC isKindOfClass:[RNSNavigationController class]]) {
-    NSLog(
-        @"ScreenView [%ld] updateLayoutMetrics:%@",
-        self.tag,
-        NSStringFromCGRect(RCTCGRectFromRect(layoutMetrics.frame)));
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
   }
   // when screen is mounted under RNSNavigationController it's size is controller

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -62,7 +62,7 @@ struct ContentWrapperBox {
 
 @implementation RNSScreenView {
   __weak RNS_REACT_SCROLL_VIEW_COMPONENT *_sheetsScrollView;
-  BOOL _didSetSheetAllowedDetentsOnController;
+  CGFloat _sheetFrameHeight;
   ContentWrapperBox _contentWrapperBox;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
@@ -126,7 +126,7 @@ struct ContentWrapperBox {
   _sheetExpandsWhenScrolledToEdge = YES;
 #endif // !TARGET_OS_TV
   _sheetsScrollView = nil;
-  _didSetSheetAllowedDetentsOnController = NO;
+  _sheetFrameHeight = NO;
 #ifdef RCT_NEW_ARCH_ENABLED
   _markedForUnmountInCurrentTransaction = NO;
 #endif // RCT_NEW_ARCH_ENABLED
@@ -440,11 +440,13 @@ RNS_IGNORE_SUPER_CALL_END
 /// This is RNSScreenContentWrapperDelegate method, where we do get notified when React did update frame of our child.
 - (void)contentWrapper:(RNSScreenContentWrapper *)contentWrapper receivedReactFrame:(CGRect)reactFrame
 {
-  if (self.stackPresentation != RNSScreenStackPresentationFormSheet || _didSetSheetAllowedDetentsOnController == YES) {
+  // We want to update and animate allowedDetents for FormSheet only if there was a change
+  // in frame's height but sometimes we receive a frame with the same dimensions mutliple times.
+  // In order to prevent visual glitches, we comapre new value to the old one and update
+  // only if there was a change in height.
+  if (self.stackPresentation != RNSScreenStackPresentationFormSheet || _sheetFrameHeight == reactFrame.size.height) {
     return;
   }
-
-  _didSetSheetAllowedDetentsOnController = YES;
 
 #if !TARGET_OS_TV && !TARGET_OS_VISION && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
@@ -456,6 +458,7 @@ RNS_IGNORE_SUPER_CALL_END
     }
 
     if (_sheetAllowedDetents.count > 0 && _sheetAllowedDetents[0].intValue == SHEET_FIT_TO_CONTENTS) {
+      _sheetFrameHeight = reactFrame.size.height;
       auto detents = [self detentsFromMaxHeights:@[ [NSNumber numberWithFloat:reactFrame.size.height +
                                                               _contentWrapperBox.contentHeightErrata] ]];
       [self setAllowedDetentsForSheet:sheetController to:detents animate:YES];

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -137,14 +137,14 @@ struct ContentWrapperBox {
   return _controller;
 }
 
-#ifdef RCT_NEW_ARCH_ENABLED
 RNS_IGNORE_SUPER_CALL_BEGIN
+#ifdef RCT_NEW_ARCH_ENABLED
 - (NSArray<UIView *> *)reactSubviews
 {
   return _reactSubviews;
 }
-RNS_IGNORE_SUPER_CALL_END
 #endif
+RNS_IGNORE_SUPER_CALL_END
 
 - (void)updateBounds
 {


### PR DESCRIPTION
## Description

Allows `fitToContents` sheet's height to adapt to dynamic content on iOS.

`contentWrapper:(RNSScreenContentWrapper *)contentWrapper receivedReactFrame:(CGRect)reactFrame` receives many frames, some of them contain the same dimensions. Calling `[self setAllowedDetentsForSheet:sheetController to:detents animate:YES]` mutliple times, even with the same `detents`, causes visual glitches (dimming behing formSheet on iPhone/iPad and header on iPad have very odd-looking animations).

Before, we would set `_didSetSheetAllowedDetentsOnController` to `YES` after setting detents for the first time and then ignore all incoming frames - including those with new height after content changed its height. Now, we remember frame height we received, and when we receive a new frame, we compare new height to the previous value. If it is different, we update detents using `setAllowedDetentsForSheet`.

Supersedes https://github.com/software-mansion/react-native-screens/pull/2741.

Fixes https://github.com/software-mansion/react-native-screens/issues/2688.

## Changes

- replace boolean property `_didSetSheetAllowedDetentsOnController` with float `_sheetFrameHeight`
- add `Test2877` test screen

## Screenshots / GIFs

| Before | After |
| ------ | ------ |
| <video src="https://github.com/user-attachments/assets/52895e55-483d-4766-bca2-7550757f1868" alt="before" /> | <video src="https://github.com/user-attachments/assets/d3bf33c0-5186-40e5-9b41-77aa31936cec" alt="after" /> |

## Test code and steps to reproduce

Enter `Test2877` screen and open form sheet. Its height should adapt to displayed content every second.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
