### PR TITLE
[0.80] Do not use ChoreographerCompat

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -3,11 +3,11 @@ package com.swmansion.rnscreens
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
+import android.view.Choreographer
 import android.view.WindowInsets
 import android.view.WindowManager
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.WindowInsetsCompat
-import com.facebook.react.modules.core.ChoreographerCompat
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.utils.InsetsCompat
@@ -38,8 +38,8 @@ open class CustomToolbar(
     private var isForceShadowStateUpdateOnLayoutRequested = false
 
     private var isLayoutEnqueued = false
-    private val layoutCallback: ChoreographerCompat.FrameCallback =
-        object : ChoreographerCompat.FrameCallback() {
+    private val layoutCallback: Choreographer.FrameCallback =
+        object : Choreographer.FrameCallback() {
             override fun doFrame(frameTimeNanos: Long) {
                 isLayoutEnqueued = false
                 // The following measure specs are selected to work only with Android APIs <= 29.

--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -39,7 +39,7 @@ open class CustomToolbar(
 
     private var isLayoutEnqueued = false
     private val layoutCallback: Choreographer.FrameCallback =
-        object : Choreographer.FrameCallback() {
+        object : Choreographer.FrameCallback {
             override fun doFrame(frameTimeNanos: Long) {
                 isLayoutEnqueued = false
                 // The following measure specs are selected to work only with Android APIs <= 29.

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -31,7 +31,7 @@ open class ScreenContainer(
     private var needsUpdate = false
     private var isLayoutEnqueued = false
     private val layoutCallback: Choreographer.FrameCallback =
-        object : Choreographer.FrameCallback() {
+        object : Choreographer.FrameCallback {
             override fun doFrame(frameTimeNanos: Long) {
                 isLayoutEnqueued = false
                 measure(

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.view.Choreographer
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -12,7 +13,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.modules.core.ChoreographerCompat
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
@@ -30,8 +30,8 @@ open class ScreenContainer(
     private var isAttached = false
     private var needsUpdate = false
     private var isLayoutEnqueued = false
-    private val layoutCallback: ChoreographerCompat.FrameCallback =
-        object : ChoreographerCompat.FrameCallback() {
+    private val layoutCallback: Choreographer.FrameCallback =
+        object : Choreographer.FrameCallback() {
             override fun doFrame(frameTimeNanos: Long) {
                 isLayoutEnqueued = false
                 measure(


### PR DESCRIPTION
## Description

We noticed you folks were using `ChoreographerCompat` from ReactNative which has been removed in RN 0.80
(it was deprecated for a while).

You should instead use `android.view.Choreographer`

