### PR TITLE
fix: `ScreenStackHeaderSearchBarView` invalid props type

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -39,7 +39,7 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
     return MapBufferBuilder::EMPTY();
   };
 #else // ANDROID
-#ifndef NDEBUG
+#if !defined(NDEBUG)
   void setImageLoader(std::weak_ptr<void> imageLoader);
   std::weak_ptr<void> getImageLoader() const noexcept;
 #endif // !NDEBUG

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import React from 'react';
-import {
-  HeaderSubviewTypes,
-  ScreenStackHeaderConfigProps,
-  SearchBarProps,
-} from '../types';
+import { ScreenStackHeaderConfigProps, SearchBarProps } from '../types';
 import {
   Image,
   ImageProps,
@@ -17,12 +13,13 @@ import {
 
 // Native components
 import ScreenStackHeaderConfigNativeComponent from '../fabric/ScreenStackHeaderConfigNativeComponent';
-import ScreenStackHeaderSubviewNativeComponent from '../fabric/ScreenStackHeaderSubviewNativeComponent';
+import ScreenStackHeaderSubviewNativeComponent, {
+  type NativeProps as ScreenStackHeaderSubviewNativeProps,
+} from '../fabric/ScreenStackHeaderSubviewNativeComponent';
 import { EDGE_TO_EDGE } from './helpers/edge-to-edge';
 
-export const ScreenStackHeaderSubview: React.ComponentType<
-  React.PropsWithChildren<ViewProps & { type?: HeaderSubviewTypes }>
-> = ScreenStackHeaderSubviewNativeComponent as any;
+export const ScreenStackHeaderSubview: React.ComponentType<ScreenStackHeaderSubviewNativeProps> =
+  ScreenStackHeaderSubviewNativeComponent;
 
 export const ScreenStackHeaderConfig = React.forwardRef<
   View,

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { ScreenStackHeaderConfigProps, SearchBarProps } from '../types';
+import { ScreenStackHeaderConfigProps } from '../types';
 import {
   Image,
   ImageProps,
@@ -87,7 +87,7 @@ export const ScreenStackHeaderCenterView = (
 };
 
 export const ScreenStackHeaderSearchBarView = (
-  props: React.PropsWithChildren<SearchBarProps>,
+  props: React.PropsWithChildren<ViewProps>,
 ): JSX.Element => (
   <ScreenStackHeaderSubview
     {...props}

--- a/src/components/ScreenStackHeaderConfig.web.tsx
+++ b/src/components/ScreenStackHeaderConfig.web.tsx
@@ -1,10 +1,6 @@
 import { Image, ImageProps, View, ViewProps } from 'react-native';
 import React from 'react';
-import {
-  HeaderSubviewTypes,
-  ScreenStackHeaderConfigProps,
-  SearchBarProps,
-} from '../types';
+import { HeaderSubviewTypes, ScreenStackHeaderConfigProps } from '../types';
 
 export const ScreenStackHeaderBackButtonImage = (
   props: ImageProps,
@@ -27,7 +23,7 @@ export const ScreenStackHeaderCenterView = (
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderSearchBarView = (
-  props: React.PropsWithChildren<Omit<SearchBarProps, 'ref'>>,
+  props: React.PropsWithChildren<ViewProps>,
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderConfig = (


### PR DESCRIPTION

## Description

No idea why `ScreenStackHeaderSearchBarView` is typed this way, however it does not accept the 
props it declares on type level. This is plain `RCTView` / `RCTViewComponentView` (depending on architecture).

`SearchBar` does accept `SearchBarProps`.

## Changes

- **Style changes in headerconfig state**
- **Simplify typing on ScreenStackHeaderConfigSubview**
- **Fix typing for `ScreenStackHeaderSearchBarView`**

## Test code and steps to reproduce

N/A; Type fix. Hopefully we do not break anything, however if someone passed props to this component 
they did not have any effect anyway.

## Checklist

- [ ] Ensured that CI passes
