### PR TITLE
refactor(web): cleanup types in ScreenStackHeaderConfig

### DIFF
--- a/src/components/ScreenStackHeaderConfig.web.tsx
+++ b/src/components/ScreenStackHeaderConfig.web.tsx
@@ -27,9 +27,9 @@ export const ScreenStackHeaderSearchBarView = (
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderConfig = (
-  props: React.PropsWithChildren<ScreenStackHeaderConfigProps>,
+  props: ScreenStackHeaderConfigProps,
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderSubview: React.ComponentType<
-  React.PropsWithChildren<ViewProps & { type?: HeaderSubviewTypes }>
+  ViewProps & { type?: HeaderSubviewTypes }
 > = View;

--- a/src/components/ScreenStackHeaderConfig.web.tsx
+++ b/src/components/ScreenStackHeaderConfig.web.tsx
@@ -10,20 +10,20 @@ export const ScreenStackHeaderBackButtonImage = (
   </View>
 );
 
-export const ScreenStackHeaderRightView = (
-  props: React.PropsWithChildren<ViewProps>,
-): JSX.Element => <View {...props} />;
+export const ScreenStackHeaderRightView = (props: ViewProps): JSX.Element => (
+  <View {...props} />
+);
 
-export const ScreenStackHeaderLeftView = (
-  props: React.PropsWithChildren<ViewProps>,
-): JSX.Element => <View {...props} />;
+export const ScreenStackHeaderLeftView = (props: ViewProps): JSX.Element => (
+  <View {...props} />
+);
 
-export const ScreenStackHeaderCenterView = (
-  props: React.PropsWithChildren<ViewProps>,
-): JSX.Element => <View {...props} />;
+export const ScreenStackHeaderCenterView = (props: ViewProps): JSX.Element => (
+  <View {...props} />
+);
 
 export const ScreenStackHeaderSearchBarView = (
-  props: React.PropsWithChildren<ViewProps>,
+  props: ViewProps,
 ): JSX.Element => <View {...props} />;
 
 export const ScreenStackHeaderConfig = (


### PR DESCRIPTION
## Description

Follow up to #2833, review: https://github.com/software-mansion/react-native-screens/pull/2883#pullrequestreview-2786094325

## Changes

`ViewProps` already do have children, there is no need to specify it for the second time. 

## Test code and steps to reproduce

Web should work as before.

## Checklist

- [ ] Ensured that CI passes

