### PR TITLE
fix(CI): publish nightly - incorrect relative paths to scripts & missing build.log

### DIFF
--- a/.github/workflows/npm-screens-publish-nightly.yml
+++ b/.github/workflows/npm-screens-publish-nightly.yml
@@ -35,18 +35,6 @@ jobs:
         id: build
         run: ./scripts/create-npm-package.sh
 
-      - name: Check if any node_modules were packed
-        id: node_modules
-        run: ! grep --silent -E "node_modules/.+" build.log
-
-      - name: Show build log
-        if: failure() && steps.build.outcome == 'failure'
-        run: cat build.log
-
-      - name: Show packed node_modules
-        if: failure() && steps.node_modules.outcome == 'failure'
-        run: ! grep -E "node_modules/.+" build.log
-
       - name: Add package name to env
         run: echo "PACKAGE_NAME=$(ls -l | egrep -o "react-native-screens-(.*)(=?\.tgz)")" >> $GITHUB_ENV
 

--- a/scripts/create-npm-package.sh
+++ b/scripts/create-npm-package.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# This script assumes it is run from the top level repo directory.
+
 yarn install --immutable
 
-if ! CURRENT_VERSION=$(node ./set-version.js --nightly); then
+if ! CURRENT_VERSION=$(node ./scripts/set-version.js --nightly); then
   exit 1
 fi
 
@@ -10,6 +12,6 @@ yarn prepare
 
 npm pack
 
-node ./set-version.js "$CURRENT_VERSION" >/dev/null
+node ./scripts/set-version.js "$CURRENT_VERSION" >/dev/null
 
 echo "Done!"


### PR DESCRIPTION
## Description

Fixing issues making the CI not work!

## Changes

* fixed relative paths to `set-version` script from `create-npm-package` script
* removed job steps of `npm-screens-publish-nightly` workflow, since we do not generate `build.log` file at any point; we're also not including any `node_module` files into a release due to `whitelist` placed in `package.json`.

## Test code and steps to reproduce

Let's see whether CI passes

## Checklist

- [ ] Ensured that CI passes
