### PR TITLE
chore(CI): fix workflow commands

### DIFF
--- a/.github/workflows/npm-screens-publish-nightly.yml
+++ b/.github/workflows/npm-screens-publish-nightly.yml
@@ -35,18 +35,6 @@ jobs:
         id: build
         run: ./scripts/create-npm-package.sh
 
-      - name: Check if any node_modules were packed
-        id: node_modules
-        run: ! grep --silent -E "node_modules/.+" build.log
-
-      - name: Show build log
-        if: failure() && steps.build.outcome == 'failure'
-        run: cat build.log
-
-      - name: Show packed node_modules
-        if: failure() && steps.node_modules.outcome == 'failure'
-        run: ! grep -E "node_modules/.+" build.log
-
       - name: Add package name to env
         run: echo "PACKAGE_NAME=$(ls -l | egrep -o "react-native-screens-(.*)(=?\.tgz)")" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Description

This fixes `Build nightly and publish on npm` workflow.

## Changes

Removes obsolete workflow steps. They were checking against the file that no longer exists.

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
