### PR TITLE
fix: Disable view controller methods swizzling when Xcode is running for previews

### DIFF
--- a/ios/UIViewController+RNScreens.mm
+++ b/ios/UIViewController+RNScreens.mm
@@ -52,6 +52,10 @@
   dispatch_once(&once_token, ^{
     Class uiVCClass = [UIViewController class];
 
+    if([[[NSProcessInfo processInfo] environment][@"XCODE_RUNNING_FOR_PREVIEWS"] isEqual:@"1"]) {
+      return;
+    }
+
     method_exchangeImplementations(
         class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
         class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));


### PR DESCRIPTION
## Description

SwiftUI previews the normal setup for UIKit doesn't happen, so the Objective-C method swizzling in RNScreens causes an infinite loop because `findChildRNSScreensViewController` , which is called by `reactNativeScreensChildViewControllerForStatusBarHidden` (and other swizzled methods), always returns `nil`.

This fix disables swizzling when Xcode is running for previews.

This may bring some issues if RN screens are within SwiftUI navigation stack but at least for basic SwiftUI previews that fix works.

Fixes #1602

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
