### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 648..649

### DIFF
--- a/FabricExample/e2e/issuesTests/Test649.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test649.e2e.ts
@@ -1,0 +1,51 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS } from '../e2e-utils';
+
+// headerLargeTitle is supported only on iOS
+describeIfiOS('Test649', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test649 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test649')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test649'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test649')).tap();
+  });
+
+  it('header large title "First" should be fully visible', async () => {
+    await expect(
+      element(
+        by
+          .text('First')
+          .withAncestor(by.type('_UINavigationBarLargeTitleView')),
+      ),
+    ).toBeVisible(100);
+  });
+
+  it('header title "Second" should not be a large title', async () => {
+    await element(by.id('first-button-go-to-second')).tap();
+    await expect(
+      element(
+        by
+          .text('Second')
+          .withAncestor(by.type('_UINavigationBarLargeTitleView')),
+      ),
+    ).not.toBeVisible(100);
+  });
+
+  it('header large title "First" should be fully visible after coming back from Second', async () => {
+    await element(by.id('second-button-go-to-first')).tap();
+    await expect(
+      element(
+        by
+          .text('First')
+          .withAncestor(by.type('_UINavigationBarLargeTitleView')),
+      ),
+    ).toBeVisible(100);
+  });
+});

--- a/apps/src/tests/Test649.js
+++ b/apps/src/tests/Test649.js
@@ -8,11 +8,10 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator
-        screenOptions={{
+      <Stack.Navigator>
+        <Stack.Screen name="First" component={First} options={{
           headerLargeTitle: true,
-        }}>
-        <Stack.Screen name="First" component={First} />
+        }}/>
         <Stack.Screen name="Second" component={Second} />
       </Stack.Navigator>
     </NavigationContainer>
@@ -21,10 +20,11 @@ export default function App() {
 
 function First({ navigation }) {
   return (
-    <ScrollView>
+    <ScrollView contentContainerStyle={{ marginTop: 160, height: 1500 }}>
       <Button
         title="Tap me for second screen"
         onPress={() => navigation.navigate('Second')}
+        testID="first-button-go-to-second"
       />
     </ScrollView>
   );
@@ -36,6 +36,7 @@ function Second({ navigation }) {
       <Button
         title="Tap me for first screen"
         onPress={() => navigation.popTo('First')}
+        testID="second-button-go-to-first"
       />
     </ScrollView>
   );

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -17,7 +17,7 @@ export { default as Test624 } from './Test624';     // [E2E skipped]: PR changed
 export { default as Test640 } from './Test640';     // [E2E created]
 export { default as Test642 } from './Test642';     // [E2E skipped]: can't check status bar visibility/style
 export { default as Test645 } from './Test645';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
-export { default as Test648 } from './Test648';
+export { default as Test648 } from './Test648';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test649 } from './Test649';
 export { default as Test654 } from './Test654';
 export { default as Test658 } from './Test658';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -18,7 +18,7 @@ export { default as Test640 } from './Test640';     // [E2E created]
 export { default as Test642 } from './Test642';     // [E2E skipped]: can't check status bar visibility/style
 export { default as Test645 } from './Test645';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
 export { default as Test648 } from './Test648';     // [E2E skipped]: can't check animation in a meaningful way
-export { default as Test649 } from './Test649';
+export { default as Test649 } from './Test649';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
 export { default as Test654 } from './Test654';
 export { default as Test658 } from './Test658';
 export { default as Test662 } from './Test662';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test648, Test649` and implement them if possible for Fabric. 

### Test648
Skipped because we can't check new animation in any meaningful way.

### Test649
Test created, only on iOS (`headerLargeTitle` is supported only on iOS). It checks if `headerLargeTitle` isn't collapsed when coming back from a screen without `headerLargeTitle`. I changed `Test649` screen to match original issue.

## Changes

- add `Test649`
- change header to normal size on Second screen in `Test649` to match original issue
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes
