### PR TITLE
test(e2e, Fabric): add e2e test for issue/PR example 658

### DIFF
--- a/FabricExample/e2e/issuesTests/Test658.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test658.e2e.ts
@@ -1,0 +1,197 @@
+import { device, expect, element, by } from 'detox';
+
+const checkScreenVisibility = async function (visible: boolean[]) {
+  for (const [index, shouldBeVisible] of visible.entries()) {
+    const assertionElement = expect(
+      element(
+        by.id('screen-text-added-routes-number').and(by.text(`${index}`)),
+      ),
+    );
+
+    if (shouldBeVisible) {
+      await assertionElement.toBeVisible();
+    } else {
+      await assertionElement.not.toBeVisible();
+    }
+  }
+};
+
+describe('Test658', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test658 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test658')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test658'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test658')).tap();
+  });
+
+  it('modals should hide content behind', async () => {
+    await checkScreenVisibility([true]);
+
+    await element(by.id('screen-0-button-open-modal')).tap();
+    await checkScreenVisibility([false, true]);
+
+    await element(by.id('screen-1-button-open-modal')).tap();
+    await checkScreenVisibility([false, false, true]);
+
+    await element(by.id('screen-2-button-open-modal')).tap();
+    await checkScreenVisibility([false, false, false, true]);
+
+    await element(by.id('screen-3-button-go-back')).tap();
+    await checkScreenVisibility([false, false, true, false]);
+
+    await element(by.id('screen-2-button-go-back')).tap();
+    await checkScreenVisibility([false, true, false, false]);
+
+    await element(by.id('screen-1-button-go-back')).tap();
+    await checkScreenVisibility([true, false, false, false]);
+  });
+
+  it('transparent modals should not hide content behind', async () => {
+    await checkScreenVisibility([true]);
+
+    await element(by.id('screen-0-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([true, true]);
+
+    await element(by.id('screen-1-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([true, true, true]);
+
+    await element(by.id('screen-2-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([true, true, true, true]);
+
+    await element(by.id('screen-3-button-go-back')).tap();
+    await checkScreenVisibility([true, true, true, false]);
+
+    await element(by.id('screen-2-button-go-back')).tap();
+    await checkScreenVisibility([true, true, false, false]);
+
+    await element(by.id('screen-1-button-go-back')).tap();
+    await checkScreenVisibility([true, false, false, false]);
+  });
+
+  it('opening modals and transparent modals should show correct screens', async () => {
+    await checkScreenVisibility([true]);
+
+    await element(by.id('screen-0-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([true, true]);
+
+    await element(by.id('screen-1-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([true, true, true]);
+
+    await element(by.id('screen-2-button-open-modal')).tap();
+    await checkScreenVisibility([false, false, false, true]);
+
+    await element(by.id('screen-3-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([false, false, false, true, true]);
+
+    await element(by.id('screen-4-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([false, false, false, true, true, true]);
+
+    await element(by.id('screen-5-button-open-transparent-modal')).tap();
+    await checkScreenVisibility([false, false, false, true, true, true, true]);
+
+    await element(by.id('screen-6-button-open-modal')).tap();
+    await checkScreenVisibility([
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it('closing modals and transparent modals should show correct screens', async () => {
+    await element(by.id('screen-7-button-go-back')).tap();
+    await checkScreenVisibility([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+    ]);
+
+    await element(by.id('screen-6-button-go-back')).tap();
+    await checkScreenVisibility([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
+
+    await element(by.id('screen-5-button-go-back')).tap();
+    await checkScreenVisibility([
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+    ]);
+
+    await element(by.id('screen-4-button-go-back')).tap();
+    await checkScreenVisibility([
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+    ]);
+
+    await element(by.id('screen-3-button-go-back')).tap();
+    await checkScreenVisibility([
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+
+    await element(by.id('screen-2-button-go-back')).tap();
+    await checkScreenVisibility([
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+
+    await element(by.id('screen-1-button-go-back')).tap();
+    await checkScreenVisibility([
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+});

--- a/FabricExample/e2e/issuesTests/Test658.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test658.e2e.ts
@@ -1,6 +1,6 @@
 import { device, expect, element, by } from 'detox';
 
-const checkScreenVisibility = async function (visible: boolean[]) {
+async function checkScreenVisibility(visible: boolean[]) {
   for (const [index, shouldBeVisible] of visible.entries()) {
     const assertionElement = expect(
       element(
@@ -14,7 +14,7 @@ const checkScreenVisibility = async function (visible: boolean[]) {
       await assertionElement.not.toBeVisible();
     }
   }
-};
+}
 
 describe('Test658', () => {
   beforeAll(async () => {

--- a/apps/src/tests/Test658.js
+++ b/apps/src/tests/Test658.js
@@ -32,22 +32,40 @@ export default function App() {
 }
 
 function Screen({ navigation }) {
-  const addedRoutes = navigation.dangerouslyGetState().routes.length - 1;
+  const addedRoutes = navigation.getState().routes.length - 1;
   const margin = addedRoutes * 20;
   const width = Dimensions.get('screen').width - addedRoutes * 40;
   const backgroundColor = colors[addedRoutes % colors.length];
   return (
     <View
       style={[
-        { width, margin, backgroundColor, height: '100%', borderWidth: 2 },
+        {
+          width,
+          margin,
+          backgroundColor,
+          height: '100%',
+          borderWidth: 2,
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
       ]}>
       <Button
         title="Open transparent modal"
         onPress={() => navigation.push('TransparentModal')}
+        testID={'screen-' + addedRoutes + '-button-open-transparent-modal'}
       />
-      <Button title="Open modal" onPress={() => navigation.push('Modal')} />
+      <Button
+        title="Open modal"
+        onPress={() => navigation.push('Modal')}
+        testID={'screen-' + addedRoutes + '-button-open-modal'}
+      />
       {addedRoutes > 0 && (
-        <Button title="Back" onPress={() => navigation.goBack()} />
+        <Button
+          title="Back"
+          onPress={() => navigation.goBack()}
+          testID={'screen-' + addedRoutes + '-button-go-back'}
+        />
       )}
       <Text style={{ padding: 10 }}>
         For each transparent modal you open, all previously visible screens
@@ -57,6 +75,11 @@ function Screen({ navigation }) {
         For each new (non-transparent) modal you open, all previously visible
         screens should be hidden.
       </Text>
+      <View style={{ width: '100%' }}>
+        <Text testID="screen-text-added-routes-number" style={{ width: 20 }}>
+          {addedRoutes}
+        </Text>
+      </View>
     </View>
   );
 }

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -20,7 +20,7 @@ export { default as Test645 } from './Test645';     // [E2E created](iOS): heade
 export { default as Test648 } from './Test648';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test649 } from './Test649';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
 export { default as Test654 } from './Test654';     // [E2E created](iOS): issue related to iOS native back button
-export { default as Test658 } from './Test658';
+export { default as Test658 } from './Test658';     // [E2E created]
 export { default as Test662 } from './Test662';
 export { default as Test691 } from './Test691';
 export { default as Test702 } from './Test702';


### PR DESCRIPTION
## Description

Create e2e test for `Test658`.

### Test658
Test created. It checks that opening multiple modals/transparent modals works correctly.

## Changes

- modify `Test658` screen to allow testing:
  - change `dangerouslyGetState()` to `getState()` ([details](https://reactnavigation.org/docs/6.x/upgrading-from-5.x/#dropped-dangerously-from-dangerouslygetparent-and-dangerouslygetstate))
  - move buttons from under status bar
  - add `Text` with screen number
  - add testIDs
- add e2e test for `Test658`
- add comment in `apps/src/tests/index.ts`

## Test code and steps to reproduce
CI

## Checklist

- [ ] Ensured that CI passes
