### PR TITLE
WIP feat: Add sheet translation Y (position) that with Reanimated hook

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1926,72 +1926,72 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f185bc10472e612edc743be4355bf46bad800446
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 2c8856d4e9b0ba79f3e37079bd90aa0971353a1b
   RCTRequired: 48708ac722594441cf535d4815275c11149a1e75
   RCTTypeSafety: e0c05b269c20da6febb9c80ae50ac4a815cca00a
   React: c1773c9d8bc6451f1b00ee11d9bd0bdf7b54a7e2
   React-callinvoker: 245546c9de42c6f5fa7c9262289d8fb7ab2f735a
-  React-Core: 10fc423129324980e0c6949b1fc442f8a746496e
-  React-CoreModules: 922575c1b919ef68dbab2761db90afdd585257a5
-  React-cxxreact: 07ceb4a53f352d0836373fbe866cadeb95b67222
+  React-Core: 67ea7c88b0e73c2321cbf9cd6f76b26ee291d3f8
+  React-CoreModules: 8a8737a847fa832881cdb2e9d14b327ea8fa77f3
+  React-cxxreact: 42ff2a3e508d749689536ba39a7040b9cf965690
   React-debug: c6270aaf1c7220150ac7f02143ef1d728f818732
-  React-defaultsnativemodule: 6527d6c458e39142faed0615f9db44f3e28a1181
-  React-domnativemodule: 40e893d9c72c5380f57ad562fbf665bc3a237359
-  React-Fabric: 75d054645f8b82a3d883cb6e434361a8568f40c6
-  React-FabricComponents: 87b8467879ea160f58dbaee3bbd1d968cf53dd6d
-  React-FabricImage: 763ec9a65f6a0009fda55e9811e9c39d091e2f76
+  React-defaultsnativemodule: b87f958802b7813152ffa8c873e0c20ea55edc24
+  React-domnativemodule: d190ecf40907bc0377be3fc4b84d79eefcd7995b
+  React-Fabric: ecbdc9b5e5f3ac62103a5c9bd1430cdbbcd8edfd
+  React-FabricComponents: 713d885749f3ef8692ff134524477b7848b3c742
+  React-FabricImage: 5aad10fb4a821c7accd8ef249214bc7d1ae5746f
   React-featureflags: 403f925f7f8a43071d203eb1bd0b582ccd9b601d
-  React-featureflagsnativemodule: 9db6380bd1957a79b8d45d55e6acadf8ec065419
-  React-graphics: 483c5b5308fafd1510fcc4a4ddf989ffee9b58de
-  React-hermes: 4da67646484805735f254b674e24046e1f39781c
-  React-idlecallbacksnativemodule: fcc79b33619a72ea3293dcc90a36368c9ecd0a52
-  React-ImageManager: e6d7843c470838ed8a6f3b74f3a2111143010489
-  React-jserrorhandler: 687e6800ad2375e952ed54f5361552846ff882fa
-  React-jsi: f5a54adbaebcaefc8b26d73524340daf0c9ebe03
-  React-jsiexecutor: 4073f480ba56ca44b28e8e3c843c2ff874795514
-  React-jsinspector: 2a5b8161cb374e9d1196d81668baf0568b61377a
-  React-jsinspectortracing: e9108a890ec559a2673c58b21fbc0db080608c05
-  React-jsitracing: c783b4c25cb3f8c2790713ea2def82e5aa42820a
-  React-logger: b414e4fcd3be78ed0b78645f07a057c26ed18888
-  React-Mapbuffer: 2765656df475f7aaa0b5bf4856aa8201380dce16
-  React-microtasksnativemodule: e39619e9d06c31ca3a92628ee9b70491b9662e58
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: 04803a01f39f31cc6605a5531280b477b48f8a88
-  React-NativeModulesApple: 5b12971faa02f3ce82731c9c5deba659d83e1f4b
-  React-perflogger: 85ea5a47f97143ec3140c19c38eaa9168bbfe6c1
-  React-performancetimeline: 34e73c0da8e6ad855218cfec7db0a5c2834466b2
+  React-featureflagsnativemodule: a7ea02436d18ad0c0bf531d8f566194713ad5d69
+  React-graphics: 3547cdbb5c10d8610dad27579caad6c4c761fbea
+  React-hermes: d4d2490df576400ba44265bfb443dcc1b9b7c7c3
+  React-idlecallbacksnativemodule: 0f004e45424972c8313d8af962ce5b8732352e2f
+  React-ImageManager: 1abcacc5d4d1ba98231434b6eeaae543b6f7f075
+  React-jserrorhandler: 3d25cd7251c85515365628d878bc2a4f07444374
+  React-jsi: a7d7c45e28039a4817c1b80d1f8302f35c20e3ed
+  React-jsiexecutor: 0def615a82aa42001d03f7a95ea28d5ecc117726
+  React-jsinspector: 39628b5cc680b3cab3c631de0e3ad07a43556594
+  React-jsinspectortracing: db9800afd9cb0ee33c2253f234574b3d68d97d2a
+  React-jsitracing: 595ccbe6ac256aaa1fbc22efbf0fc2474244d575
+  React-logger: 417a59476b6d8f7c00ffc7d0fec4964a91c7617e
+  React-Mapbuffer: 7df58125cd83062b50f90fa3f656e9509f1fa21c
+  React-microtasksnativemodule: 00924a9b4b311aec4d9d8c38de9217f88a92f1de
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: e134b241010ebe2aacdcea013565963d13826faa
+  React-NativeModulesApple: 814c1f7b25e0ce6343ffc6d0d9cf0a1c11f486c6
+  React-perflogger: e3e2eb3b206f1d6375ad673b2d10bf57836f436e
+  React-performancetimeline: eba3e7710a19759c7a1d6aced3abe23bdc196460
   React-RCTActionSheet: c32efd32f661f888acf55edf30d742d80386ab4f
-  React-RCTAnimation: e8ec262e00d3eb8f0bed786f720b01b035961cec
-  React-RCTAppDelegate: eb5b35353d1f436fd6e29d085ce0fd4907702701
-  React-RCTBlob: 846c0e2ec3da1cc5da03a1d94dde794e445ce8c1
-  React-RCTFabric: a5a522ad41191cfc4be76168a9d2419cc98927dd
-  React-RCTFBReactNativeSpec: 94be872229e19e010579f05b8ef5c6a9e345101e
-  React-RCTImage: 6abbb45d7f6025cd1e5180928d24322fd1885a9f
-  React-RCTLinking: 5cca7087d943d24269bf232f63af9fa1746eeb09
-  React-RCTNetwork: 2fad4baf76e21afd4ddb2316ac5d1390f219efbe
-  React-RCTSettings: f472baca4e986546314ca4a867769eaf3089a6b9
-  React-RCTText: 5a5917ec9bcff3ded118b7fcd198cdde38bb8232
-  React-RCTVibration: ce0d94d094d67a7ee869041592fa194ff93eb585
+  React-RCTAnimation: b89a2d8cc791f0996203ea647878589de6efb451
+  React-RCTAppDelegate: 67feb265afff8fd06c044327912cd495fcf7d9fe
+  React-RCTBlob: f3726c35ecc2bba9eec112f8d52a5d0433a715e6
+  React-RCTFabric: 00646c6593724ec75235de5cd1c08d772ece021d
+  React-RCTFBReactNativeSpec: c6faa4d4334073047def631621692caa9f6db2ae
+  React-RCTImage: 15ca3faf7ec989826fbd62c89b85fb9fb5cdd10c
+  React-RCTLinking: 02c7ac32777cea3170c74bc8324184323b12d592
+  React-RCTNetwork: 78628d76c2ae2eb2b5cc1a6dfbec285ccdbdb9c8
+  React-RCTSettings: 2062ce9b6e69b3686c3591551ed4024c488cf96a
+  React-RCTText: cc059835349d468d8d93e82da6c9aa9c6032ad56
+  React-RCTVibration: a9219f8da44afc58f3b291bd6798b700153a8e10
   React-rendererconsistency: bb3a3c5730ab4e6a8a9ee0ffb3cb84d727c3bed5
-  React-rendererdebug: 0ce779179199216814ee1368951b9c3c0b183595
+  React-rendererdebug: d5a6fecae88c29fc336379489e00d0f3e60e98ef
   React-rncore: 03e107717ccd4ac9d5d79196681faa740ede0b9f
-  React-RuntimeApple: ec335c65a192e3b09ca322582a8cb311f74119d2
-  React-RuntimeCore: 8bb00314545f6c1173f7b4c6c0e0a6c74bcb5c8e
+  React-RuntimeApple: 876f41dc76bb6b6e738f6d3ad7ea3d89e535efa8
+  React-RuntimeCore: c491a1a2eb734765d6e02618f5f2a28e2872f751
   React-runtimeexecutor: a13bd44f6168899cdf60682f137a09516cd5ea35
-  React-RuntimeHermes: 3009df42da2b7015cc66fe4961b2ccca81160f1c
-  React-runtimescheduler: b79baa0ca5d8e8840ad49cbcdb44ab693d7fbdaa
+  React-RuntimeHermes: eff796dfd1df04f9f2cd8b37be37a47d90a4ab4c
+  React-runtimescheduler: 4bd885d85b7841b823c2164725c959c6dbc0fd4e
   React-timing: ddfc36f45351e851633b857cf75eb167e119d3b7
-  React-utils: 9ea2e9d57dd01e5b9cf1270969e3179ac3b7f325
-  ReactAppDependencyProvider: 19db96cb59117f0cf2e32993b7a2ba34b6397c57
-  ReactCodegen: d3c2ea01d0f9eb6c3e5de3ad94ad2fc309465861
-  ReactCommon: 179964ffc47fa62ad0e1eebac704e88c59b46667
-  RNGestureHandler: 8b33b2c5688a54fcce223d184753757da498235c
-  RNReanimated: f9bc911c24a63fc17e721302e1bca07fdedd9241
-  RNScreens: b99e3f7a66804be22fab7ee54ad91b55714b1fa6
+  React-utils: d1482eca4f773398cf0bdb0b99283e16dc710a96
+  ReactAppDependencyProvider: e7d2fe30cf4bb2090d5bea9b4ca29dd8e548ed71
+  ReactCodegen: 87717e46389a7c2f57866d8ee66c8955bb41d986
+  ReactCommon: bd1703fa1b6b6ccb2494bed17caf93f1861ce315
+  RNGestureHandler: ff5f6de814c8229df499e65918b5dce10a5d60b0
+  RNReanimated: cdbe5dfe73c9143df3f750ff547a758eb16d2ab8
+  RNScreens: 1001be117f0be9d44af67f71814ff01e6926495a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 330be28eee1242da875db9e851b19a4df496b999
 
 PODFILE CHECKSUM: e1c705abfb728b259283bd3b94a9aaac16e72096
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Example/ios/ScreensExample.xcodeproj/project.pbxproj
+++ b/Example/ios/ScreensExample.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = ZLTMSN9YWT;
 						LastSwiftMigration = 1620;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -534,6 +535,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ZLTMSN9YWT;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = ScreensExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
@@ -563,6 +565,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ZLTMSN9YWT;
 				INFOPLIST_FILE = ScreensExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -768,10 +771,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -834,10 +834,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2013,72 +2013,72 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: f185bc10472e612edc743be4355bf46bad800446
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 2c8856d4e9b0ba79f3e37079bd90aa0971353a1b
   RCTRequired: 48708ac722594441cf535d4815275c11149a1e75
   RCTTypeSafety: e0c05b269c20da6febb9c80ae50ac4a815cca00a
   React: c1773c9d8bc6451f1b00ee11d9bd0bdf7b54a7e2
   React-callinvoker: 245546c9de42c6f5fa7c9262289d8fb7ab2f735a
-  React-Core: 10fc423129324980e0c6949b1fc442f8a746496e
-  React-CoreModules: 922575c1b919ef68dbab2761db90afdd585257a5
-  React-cxxreact: 07ceb4a53f352d0836373fbe866cadeb95b67222
+  React-Core: 67ea7c88b0e73c2321cbf9cd6f76b26ee291d3f8
+  React-CoreModules: 8a8737a847fa832881cdb2e9d14b327ea8fa77f3
+  React-cxxreact: 42ff2a3e508d749689536ba39a7040b9cf965690
   React-debug: c6270aaf1c7220150ac7f02143ef1d728f818732
-  React-defaultsnativemodule: 6527d6c458e39142faed0615f9db44f3e28a1181
-  React-domnativemodule: 40e893d9c72c5380f57ad562fbf665bc3a237359
-  React-Fabric: 75d054645f8b82a3d883cb6e434361a8568f40c6
-  React-FabricComponents: 87b8467879ea160f58dbaee3bbd1d968cf53dd6d
-  React-FabricImage: 763ec9a65f6a0009fda55e9811e9c39d091e2f76
+  React-defaultsnativemodule: b87f958802b7813152ffa8c873e0c20ea55edc24
+  React-domnativemodule: d190ecf40907bc0377be3fc4b84d79eefcd7995b
+  React-Fabric: ecbdc9b5e5f3ac62103a5c9bd1430cdbbcd8edfd
+  React-FabricComponents: 713d885749f3ef8692ff134524477b7848b3c742
+  React-FabricImage: 5aad10fb4a821c7accd8ef249214bc7d1ae5746f
   React-featureflags: 403f925f7f8a43071d203eb1bd0b582ccd9b601d
-  React-featureflagsnativemodule: 9db6380bd1957a79b8d45d55e6acadf8ec065419
-  React-graphics: 483c5b5308fafd1510fcc4a4ddf989ffee9b58de
-  React-hermes: 4da67646484805735f254b674e24046e1f39781c
-  React-idlecallbacksnativemodule: fcc79b33619a72ea3293dcc90a36368c9ecd0a52
-  React-ImageManager: e6d7843c470838ed8a6f3b74f3a2111143010489
-  React-jserrorhandler: 687e6800ad2375e952ed54f5361552846ff882fa
-  React-jsi: f5a54adbaebcaefc8b26d73524340daf0c9ebe03
-  React-jsiexecutor: 4073f480ba56ca44b28e8e3c843c2ff874795514
-  React-jsinspector: 2a5b8161cb374e9d1196d81668baf0568b61377a
-  React-jsinspectortracing: e9108a890ec559a2673c58b21fbc0db080608c05
-  React-jsitracing: c783b4c25cb3f8c2790713ea2def82e5aa42820a
-  React-logger: b414e4fcd3be78ed0b78645f07a057c26ed18888
-  React-Mapbuffer: 2765656df475f7aaa0b5bf4856aa8201380dce16
-  React-microtasksnativemodule: e39619e9d06c31ca3a92628ee9b70491b9662e58
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
-  React-NativeModulesApple: 5b12971faa02f3ce82731c9c5deba659d83e1f4b
-  React-perflogger: 85ea5a47f97143ec3140c19c38eaa9168bbfe6c1
-  React-performancetimeline: 34e73c0da8e6ad855218cfec7db0a5c2834466b2
+  React-featureflagsnativemodule: a7ea02436d18ad0c0bf531d8f566194713ad5d69
+  React-graphics: 3547cdbb5c10d8610dad27579caad6c4c761fbea
+  React-hermes: d4d2490df576400ba44265bfb443dcc1b9b7c7c3
+  React-idlecallbacksnativemodule: 0f004e45424972c8313d8af962ce5b8732352e2f
+  React-ImageManager: 1abcacc5d4d1ba98231434b6eeaae543b6f7f075
+  React-jserrorhandler: 3d25cd7251c85515365628d878bc2a4f07444374
+  React-jsi: a7d7c45e28039a4817c1b80d1f8302f35c20e3ed
+  React-jsiexecutor: 0def615a82aa42001d03f7a95ea28d5ecc117726
+  React-jsinspector: 39628b5cc680b3cab3c631de0e3ad07a43556594
+  React-jsinspectortracing: db9800afd9cb0ee33c2253f234574b3d68d97d2a
+  React-jsitracing: 595ccbe6ac256aaa1fbc22efbf0fc2474244d575
+  React-logger: 417a59476b6d8f7c00ffc7d0fec4964a91c7617e
+  React-Mapbuffer: 7df58125cd83062b50f90fa3f656e9509f1fa21c
+  React-microtasksnativemodule: 00924a9b4b311aec4d9d8c38de9217f88a92f1de
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
+  React-NativeModulesApple: 814c1f7b25e0ce6343ffc6d0d9cf0a1c11f486c6
+  React-perflogger: e3e2eb3b206f1d6375ad673b2d10bf57836f436e
+  React-performancetimeline: eba3e7710a19759c7a1d6aced3abe23bdc196460
   React-RCTActionSheet: c32efd32f661f888acf55edf30d742d80386ab4f
-  React-RCTAnimation: e8ec262e00d3eb8f0bed786f720b01b035961cec
-  React-RCTAppDelegate: d9a2b2610a582fe7099087cd69ac455d837be9c5
-  React-RCTBlob: 846c0e2ec3da1cc5da03a1d94dde794e445ce8c1
-  React-RCTFabric: 05392addbc532b6f3410ba914d2252f9c629affb
-  React-RCTFBReactNativeSpec: db8ccb471152b3cee8c7abeaf6f524ba2bd75fc1
-  React-RCTImage: 6abbb45d7f6025cd1e5180928d24322fd1885a9f
-  React-RCTLinking: 5cca7087d943d24269bf232f63af9fa1746eeb09
-  React-RCTNetwork: 2fad4baf76e21afd4ddb2316ac5d1390f219efbe
-  React-RCTSettings: f472baca4e986546314ca4a867769eaf3089a6b9
-  React-RCTText: 5a5917ec9bcff3ded118b7fcd198cdde38bb8232
-  React-RCTVibration: ce0d94d094d67a7ee869041592fa194ff93eb585
+  React-RCTAnimation: b89a2d8cc791f0996203ea647878589de6efb451
+  React-RCTAppDelegate: 685b1a2a562cde000dc600fdda2130559eb73222
+  React-RCTBlob: f3726c35ecc2bba9eec112f8d52a5d0433a715e6
+  React-RCTFabric: ae366e8bf743818885b4a5e45b9b8887f78e3856
+  React-RCTFBReactNativeSpec: c92e9905558befec8e03c1f223de10430cb7b372
+  React-RCTImage: 15ca3faf7ec989826fbd62c89b85fb9fb5cdd10c
+  React-RCTLinking: 02c7ac32777cea3170c74bc8324184323b12d592
+  React-RCTNetwork: 78628d76c2ae2eb2b5cc1a6dfbec285ccdbdb9c8
+  React-RCTSettings: 2062ce9b6e69b3686c3591551ed4024c488cf96a
+  React-RCTText: cc059835349d468d8d93e82da6c9aa9c6032ad56
+  React-RCTVibration: a9219f8da44afc58f3b291bd6798b700153a8e10
   React-rendererconsistency: bb3a3c5730ab4e6a8a9ee0ffb3cb84d727c3bed5
-  React-rendererdebug: 0ce779179199216814ee1368951b9c3c0b183595
+  React-rendererdebug: d5a6fecae88c29fc336379489e00d0f3e60e98ef
   React-rncore: 03e107717ccd4ac9d5d79196681faa740ede0b9f
-  React-RuntimeApple: ec335c65a192e3b09ca322582a8cb311f74119d2
-  React-RuntimeCore: 8bb00314545f6c1173f7b4c6c0e0a6c74bcb5c8e
+  React-RuntimeApple: 876f41dc76bb6b6e738f6d3ad7ea3d89e535efa8
+  React-RuntimeCore: c491a1a2eb734765d6e02618f5f2a28e2872f751
   React-runtimeexecutor: a13bd44f6168899cdf60682f137a09516cd5ea35
-  React-RuntimeHermes: 3009df42da2b7015cc66fe4961b2ccca81160f1c
-  React-runtimescheduler: b79baa0ca5d8e8840ad49cbcdb44ab693d7fbdaa
+  React-RuntimeHermes: eff796dfd1df04f9f2cd8b37be37a47d90a4ab4c
+  React-runtimescheduler: 4bd885d85b7841b823c2164725c959c6dbc0fd4e
   React-timing: ddfc36f45351e851633b857cf75eb167e119d3b7
-  React-utils: 9ea2e9d57dd01e5b9cf1270969e3179ac3b7f325
-  ReactAppDependencyProvider: 19db96cb59117f0cf2e32993b7a2ba34b6397c57
-  ReactCodegen: d3c2ea01d0f9eb6c3e5de3ad94ad2fc309465861
-  ReactCommon: 179964ffc47fa62ad0e1eebac704e88c59b46667
-  RNGestureHandler: 4e7defe5095e936424173fc75f0bf2af5bba8e23
-  RNReanimated: 183ca222293bd622678e387100e54d03d952c73b
-  RNScreens: f61e0dee5a4a45c4df14d6afabe671745108bdf7
+  React-utils: d1482eca4f773398cf0bdb0b99283e16dc710a96
+  ReactAppDependencyProvider: e7d2fe30cf4bb2090d5bea9b4ca29dd8e548ed71
+  ReactCodegen: 87717e46389a7c2f57866d8ee66c8955bb41d986
+  ReactCommon: bd1703fa1b6b6ccb2494bed17caf93f1861ce315
+  RNGestureHandler: 70069ab3e0431b03f6e465b65745f87a1a02c6c0
+  RNReanimated: bc7be90dec8df273a2d14da13a64f9da4b694e59
+  RNScreens: 1f515d987def9c65664d2f30317bc6ea58a318c8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 330be28eee1242da875db9e851b19a4df496b999
 
 PODFILE CHECKSUM: 9368f39644a8576a848701c298cb4a4fd39a41bf
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -64,6 +64,7 @@ class Screen(
 
     // Props for controlling modal presentation
     var isSheetGrabberVisible: Boolean = false
+    var isSheetDismissible: Boolean = true
 
     // corner radius must be updated after all props prop updates from a single transaction
     // have been applied, because it depends on the presentation type.

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -515,9 +515,7 @@ class Screen(
             ?.dispatchEvent(HeaderHeightChangeEvent(surfaceId, id, headerHeight))
     }
 
-    internal fun onSheetTranslation(
-        top: Int
-    ) {
+    internal fun onSheetTranslation(top: Int) {
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
         val translationY = PixelUtil.toDIPFromPixel(top.toFloat())
         reactEventDispatcher?.dispatchEvent(

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -31,6 +31,7 @@ import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
+import com.swmansion.rnscreens.events.SheetTranslationEvent
 import com.swmansion.rnscreens.ext.parentAsViewGroup
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
@@ -512,6 +513,20 @@ class Screen(
         UIManagerHelper
             .getEventDispatcherForReactTag(screenContext, id)
             ?.dispatchEvent(HeaderHeightChangeEvent(surfaceId, id, headerHeight))
+    }
+
+    internal fun onSheetTranslation(
+        top: Int
+    ) {
+        val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+        val translationY = PixelUtil.toDIPFromPixel(top.toFloat())
+        reactEventDispatcher?.dispatchEvent(
+            SheetTranslationEvent(
+                surfaceId,
+                id,
+                translationY,
+            ),
+        )
     }
 
     internal fun onSheetDetentChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -26,6 +26,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.swmansion.rnscreens.bottomsheet.SheetUtils
 import com.swmansion.rnscreens.bottomsheet.isSheetFitToContents
 import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
@@ -82,7 +83,15 @@ class Screen(
     // TODO: Model this with custom data structure to guarantee that this invariant is not violated.
     var sheetDetents = mutableListOf(1.0)
     var sheetLargestUndimmedDetentIndex: Int = -1
+
+    private var shouldUpdateSheetState = false
     var sheetInitialDetentIndex: Int = 0
+        set(value) {
+            if (field != value) {
+                field = value
+                shouldUpdateSheetState = true
+            }
+        }
     var sheetClosesOnTouchOutside = true
     var sheetElevation: Float = 24F
 
@@ -560,10 +569,27 @@ class Screen(
             shouldUpdateSheetCornerRadius = false
             onSheetCornerRadiusChange()
         }
+
+        if (shouldUpdateSheetState) {
+            shouldUpdateSheetState = false
+            onSheetStateChange()
+        }
+    }
+
+    private fun onSheetStateChange() {
+        if (!usesFormSheetPresentation()) {
+            return
+        }
+
+        sheetBehavior?.state =
+            SheetUtils.sheetStateFromDetentIndex(
+                sheetInitialDetentIndex,
+                sheetDetents.count(),
+            )
     }
 
     internal fun onSheetCornerRadiusChange() {
-        if (stackPresentation !== StackPresentation.FORM_SHEET || background == null) {
+        if (!usesFormSheetPresentation() || background == null) {
             return
         }
         (background as? MaterialShapeDrawable?)?.let {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragmentWrapper.kt
@@ -34,7 +34,6 @@ interface ScreenFragmentWrapper :
      */
     fun isTranslucent(): Boolean
 
-
     // Helpers
     fun tryGetActivity(): Activity?
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -285,7 +285,10 @@ class ScreenStackFragment :
                 ValueAnimator.ofObject(evaluator, screen.height.toFloat(), 0f).apply {
                     addUpdateListener { anim ->
                         val animatedValue = anim.animatedValue as? Float
-                        animatedValue?.let { screen.translationY = it }
+                        animatedValue?.let {
+                            screen.translationY = it
+                            screen.onSheetTranslation(minOf((screen.top + it).toInt(), screen.height))
+                        }
                     }
                 }
 
@@ -309,7 +312,10 @@ class ScreenStackFragment :
                 ValueAnimator.ofFloat(0f, (coordinatorLayout.bottom - screen.top).toFloat()).apply {
                     addUpdateListener { anim ->
                         val animatedValue = anim.animatedValue as? Float
-                        animatedValue?.let { screen.translationY = it }
+                        animatedValue?.let {
+                            screen.translationY = it
+                            screen.onSheetTranslation(minOf((screen.top + it).toInt(), screen.height))
+                        }
                     }
                 }
             animatorSet.play(alphaAnimator).with(slideAnimator)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -24,10 +24,10 @@ import kotlin.math.max
 
 class ScreenStackHeaderConfig(
     context: Context,
-    private val pointerEventsImpl: ReactPointerEventsView
-) : FabricEnabledHeaderConfigViewGroup(context), ReactPointerEventsView by pointerEventsImpl {
-
-    constructor(context: Context): this(context, pointerEventsImpl = PointerEventsBoxNoneImpl())
+    private val pointerEventsImpl: ReactPointerEventsView,
+) : FabricEnabledHeaderConfigViewGroup(context),
+    ReactPointerEventsView by pointerEventsImpl {
+    constructor(context: Context) : this(context, pointerEventsImpl = PointerEventsBoxNoneImpl())
 
     private val configSubviews = ArrayList<ScreenStackHeaderSubview>(3)
     val toolbar: CustomToolbar

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -23,6 +23,7 @@ import com.swmansion.rnscreens.events.ScreenTransitionProgressEvent
 import com.swmansion.rnscreens.events.ScreenWillAppearEvent
 import com.swmansion.rnscreens.events.ScreenWillDisappearEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
+import com.swmansion.rnscreens.events.SheetTranslationEvent
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
 open class ScreenViewManager :
@@ -388,6 +389,7 @@ open class ScreenViewManager :
             HeaderBackButtonClickedEvent.EVENT_NAME to MapBuilder.of("registrationName", "onHeaderBackButtonClicked"),
             ScreenTransitionProgressEvent.EVENT_NAME to MapBuilder.of("registrationName", "onTransitionProgress"),
             SheetDetentChangedEvent.EVENT_NAME to MapBuilder.of("registrationName", "onSheetDetentChanged"),
+            SheetTranslationEvent.EVENT_NAME to MapBuilder.of("registrationName", "onSheetTranslation"),
         )
 
     protected override fun getDelegate(): ViewManagerDelegate<Screen> = delegate

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -163,6 +163,15 @@ open class ScreenViewManager :
         view.isGestureEnabled = gestureEnabled
     }
 
+    @ReactProp(name = "sheetDismissible", defaultBoolean = true)
+    override fun setSheetDismissible(
+        view: Screen,
+        sheetDismissible: Boolean,
+    ) {
+        view.isSheetDismissible = sheetDismissible
+        view.sheetClosesOnTouchOutside = sheetDismissible
+    }
+
     @ReactProp(name = "replaceAnimation")
     override fun setReplaceAnimation(
         view: Screen,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
@@ -19,14 +19,14 @@ import com.swmansion.rnscreens.ext.equalWithRespectToEps
 internal class DimmingView(
     context: Context,
     initialAlpha: Float = 0.6F,
-    private val pointerEventsProxy: DimmingViewPointerEventsProxy
+    private val pointerEventsProxy: DimmingViewPointerEventsProxy,
 ) : ViewGroup(context),
     ReactCompoundViewGroup,
     ReactPointerEventsView by pointerEventsProxy {
-
     constructor(context: Context, initialAlpha: Float = 0.6F) : this(
-        context, initialAlpha,
-        DimmingViewPointerEventsProxy(null)
+        context,
+        initialAlpha,
+        DimmingViewPointerEventsProxy(null),
     )
 
     init {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
@@ -48,7 +48,10 @@ class DimmingViewManager(
     /**
      * Ask the manager whether it will apply non-zero alpha for sheet at given detent index.
      */
-    fun willDimForDetentIndex(screen: Screen, index: Int) = index > screen.sheetLargestUndimmedDetentIndex
+    fun willDimForDetentIndex(
+        screen: Screen,
+        index: Int,
+    ) = index > screen.sheetLargestUndimmedDetentIndex
 
     fun invalidate(behavior: BottomSheetBehavior<Screen>?) {
         dimmingViewCallback?.let { callback -> behavior?.removeBottomSheetCallback(callback) }
@@ -165,7 +168,10 @@ class DimmingViewManager(
             }
         }
 
-    private fun requireBottomSheetCallback(screen: Screen, forceCreation: Boolean = false): BottomSheetCallback {
+    private fun requireBottomSheetCallback(
+        screen: Screen,
+        forceCreation: Boolean = false,
+    ): BottomSheetCallback {
         if (dimmingViewCallback == null || forceCreation) {
             dimmingViewCallback = AnimateDimmingViewCallback(screen, dimmingView, maxAlpha)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -2,7 +2,9 @@ package com.swmansion.rnscreens.bottomsheet
 
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import androidx.core.graphics.Insets
@@ -82,6 +84,11 @@ class SheetDelegate(
 
     private fun handleHostFragmentOnPause() {
         InsetsObserverProxy.removeOnApplyWindowInsetsListener(this)
+    }
+
+    private fun onSheetSlide(bottomSheet: View) {
+        Log.d(TAG, "${(screen.parent as ViewGroup).top}")
+        screen.onSheetTranslation(bottomSheet.top)
     }
 
     private fun onSheetStateChanged(newState: Int) {
@@ -369,7 +376,9 @@ class SheetDelegate(
         override fun onSlide(
             bottomSheet: View,
             slideOffset: Float,
-        ) = Unit
+        ) {
+            this@SheetDelegate.onSheetSlide(bottomSheet)
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -2,9 +2,7 @@ package com.swmansion.rnscreens.bottomsheet
 
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import android.view.View
-import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import androidx.core.graphics.Insets
@@ -87,7 +85,6 @@ class SheetDelegate(
     }
 
     private fun onSheetSlide(bottomSheet: View) {
-        Log.d(TAG, "${(screen.parent as ViewGroup).top}")
         screen.onSheetTranslation(bottomSheet.top)
     }
 
@@ -121,7 +118,7 @@ class SheetDelegate(
         }
 
         behavior.apply {
-            isHideable = true
+            isHideable = screen.isSheetDismissible
             isDraggable = true
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenAnimationDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenAnimationDelegate.kt
@@ -1,7 +1,6 @@
 package com.swmansion.rnscreens.events
 
 import android.animation.Animator
-import android.util.Log
 import com.swmansion.rnscreens.ScreenStackFragmentWrapper
 
 // The goal is to make this universal delegate for handling animation progress related logic.
@@ -13,7 +12,7 @@ class ScreenAnimationDelegate(
 ) : Animator.AnimatorListener {
     enum class AnimationType {
         ENTER,
-        EXIT
+        EXIT,
     }
 
     private var currentState: LifecycleState = LifecycleState.INITIALIZED

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt
@@ -6,31 +6,34 @@ import com.swmansion.rnscreens.ScreenFragment
 
 // TODO: Consider taking weak ref here or accepting screen as argument in every method
 // to avoid reference cycle.
-class ScreenEventEmitter(val screen: Screen) {
+class ScreenEventEmitter(
+    val screen: Screen,
+) {
     val reactEventDispatcher
         get() = screen.reactEventDispatcher
 
     val reactSurfaceId
         get() = UIManagerHelper.getSurfaceId(screen)
 
-    fun dispatchOnWillAppear() =
-        reactEventDispatcher?.dispatchEvent(ScreenWillAppearEvent(reactSurfaceId, screen.id))
+    fun dispatchOnWillAppear() = reactEventDispatcher?.dispatchEvent(ScreenWillAppearEvent(reactSurfaceId, screen.id))
 
-    fun dispatchOnAppear() =
-        reactEventDispatcher?.dispatchEvent(ScreenAppearEvent(reactSurfaceId, screen.id))
+    fun dispatchOnAppear() = reactEventDispatcher?.dispatchEvent(ScreenAppearEvent(reactSurfaceId, screen.id))
 
-    fun dispatchOnWillDisappear() =
-        reactEventDispatcher?.dispatchEvent(ScreenWillDisappearEvent(reactSurfaceId, screen.id))
+    fun dispatchOnWillDisappear() = reactEventDispatcher?.dispatchEvent(ScreenWillDisappearEvent(reactSurfaceId, screen.id))
 
-    fun dispatchOnDisappear() =
-        reactEventDispatcher?.dispatchEvent(ScreenDisappearEvent(reactSurfaceId, screen.id))
+    fun dispatchOnDisappear() = reactEventDispatcher?.dispatchEvent(ScreenDisappearEvent(reactSurfaceId, screen.id))
 
-    fun dispatchOnDismissed() =
-        reactEventDispatcher?.dispatchEvent(ScreenDismissedEvent(reactSurfaceId, screen.id))
+    fun dispatchOnDismissed() = reactEventDispatcher?.dispatchEvent(ScreenDismissedEvent(reactSurfaceId, screen.id))
 
-    fun dispatchTransitionProgress(progress: Float, isExitAnimation: Boolean, isGoingForward: Boolean) {
+    fun dispatchTransitionProgress(
+        progress: Float,
+        isExitAnimation: Boolean,
+        isGoingForward: Boolean,
+    ) {
         val sanitizedProgress = progress.coerceIn(0.0f, 1.0f)
         val coalescingKey = ScreenFragment.getCoalescingKey(sanitizedProgress)
-        reactEventDispatcher?.dispatchEvent(ScreenTransitionProgressEvent(reactSurfaceId, screen.id, sanitizedProgress, isExitAnimation, isGoingForward, coalescingKey))
+        reactEventDispatcher?.dispatchEvent(
+            ScreenTransitionProgressEvent(reactSurfaceId, screen.id, sanitizedProgress, isExitAnimation, isGoingForward, coalescingKey),
+        )
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/events/SheetTranslationEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SheetTranslationEvent.kt
@@ -5,21 +5,21 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
 class SheetTranslationEvent(
-  surfaceId: Int,
-  viewId: Int,
-  private val y: Float,
+    surfaceId: Int,
+    viewId: Int,
+    private val y: Float,
 ) : Event<SheetTranslationEvent>(surfaceId, viewId) {
-  override fun getEventName(): String = EVENT_NAME
+    override fun getEventName(): String = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun getEventData(): WritableMap? =
-    Arguments.createMap().apply {
-      putDouble("y", y.toDouble())
+    override fun getEventData(): WritableMap? =
+        Arguments.createMap().apply {
+            putDouble("y", y.toDouble())
+        }
+
+    companion object {
+        const val EVENT_NAME = "topSheetTranslation"
     }
-
-  companion object {
-    const val EVENT_NAME = "topSheetTranslation"
-  }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/events/SheetTranslationEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/SheetTranslationEvent.kt
@@ -1,0 +1,25 @@
+package com.swmansion.rnscreens.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class SheetTranslationEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val y: Float,
+) : Event<SheetTranslationEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  // All events for a given view can be coalesced.
+  override fun getCoalescingKey(): Short = 0
+
+  override fun getEventData(): WritableMap? =
+    Arguments.createMap().apply {
+      putDouble("y", y.toDouble())
+    }
+
+  companion object {
+    const val EVENT_NAME = "topSheetTranslation"
+  }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildDrawingOrderStrategyImpl.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/views/ChildDrawingOrderStrategyImpl.kt
@@ -17,7 +17,6 @@ internal abstract class ChildrenDrawingOrderStrategyBase(
     override fun isEnabled() = enabled
 }
 
-
 internal class ReverseFromIndex(
     val startIndex: Int,
 ) : ChildrenDrawingOrderStrategyBase() {

--- a/android/src/main/java/com/swmansion/rnscreens/transition/ExternalBoundaryValuesEvaluator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/transition/ExternalBoundaryValuesEvaluator.kt
@@ -9,7 +9,10 @@ typealias BoundaryValueProviderFn = (Number?) -> Float?
  * not use boundary values used during value animator construction. This allows to defer computation
  * of animator boundary values to the moment when animation starts.
  */
-class ExternalBoundaryValuesEvaluator(val startValueProvider: BoundaryValueProviderFn, val endValueProvider: BoundaryValueProviderFn) : FloatEvaluator() {
+class ExternalBoundaryValuesEvaluator(
+    val startValueProvider: BoundaryValueProviderFn,
+    val endValueProvider: BoundaryValueProviderFn,
+) : FloatEvaluator() {
     var startValueCache: Number? = null
     var endValueCache: Number? = null
 
@@ -27,7 +30,11 @@ class ExternalBoundaryValuesEvaluator(val startValueProvider: BoundaryValueProvi
         return endValueCache
     }
 
-    override fun evaluate(fraction: Float, startValue: Number?, endValue: Number?): Float? {
+    override fun evaluate(
+        fraction: Float,
+        startValue: Number?,
+        endValue: Number?,
+    ): Float? {
         val realStartValue = getStartValue(startValue)
         val realEndValue = getEndValue(endValue)
         if (realStartValue == null || realEndValue == null) {

--- a/android/src/main/java/com/swmansion/rnscreens/utils/FragmentTransactionKt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/FragmentTransactionKt.kt
@@ -4,7 +4,10 @@ import androidx.fragment.app.FragmentTransaction
 import com.swmansion.rnscreens.R
 import com.swmansion.rnscreens.Screen.StackAnimation
 
-internal fun FragmentTransaction.setTweenAnimations(stackAnimation: StackAnimation, shouldUseOpenAnimation: Boolean) {
+internal fun FragmentTransaction.setTweenAnimations(
+    stackAnimation: StackAnimation,
+    shouldUseOpenAnimation: Boolean,
+) {
     if (shouldUseOpenAnimation) {
         when (stackAnimation) {
             StackAnimation.DEFAULT ->

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -28,6 +28,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManager<
       case "sheetAllowedDetents":
         mViewManager.setSheetAllowedDetents(view, (ReadableArray) value);
         break;
+      case "sheetDismissible":
+        mViewManager.setSheetDismissible(view, value == null ? false : (boolean) value);
+        break;
       case "sheetLargestUndimmedDetent":
         mViewManager.setSheetLargestUndimmedDetent(view, value == null ? -1 : ((Double) value).intValue());
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSScreenManagerInterface<T extends View>  {
   void setSheetAllowedDetents(T view, @Nullable ReadableArray value);
+  void setSheetDismissible(T view, boolean value);
   void setSheetLargestUndimmedDetent(T view, int value);
   void setSheetGrabberVisible(T view, boolean value);
   void setSheetCornerRadius(T view, float value);

--- a/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/paper/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
@@ -24,8 +24,8 @@ abstract class FabricEnabledHeaderConfigViewGroup(
         paddingStart: Int,
         paddingEnd: Int,
     ) {
-      // Implementation of this method differs between Fabric & Paper!
-      updateState(width, height, paddingStart, paddingEnd)
+        // Implementation of this method differs between Fabric & Paper!
+        updateState(width, height, paddingStart, paddingEnd)
     }
 
     // Implementation of this method differs between Fabric & Paper!

--- a/android/src/versioned/backgroundcolor/76/ViewBackgroundUtils.kt
+++ b/android/src/versioned/backgroundcolor/76/ViewBackgroundUtils.kt
@@ -6,4 +6,3 @@ import com.facebook.react.views.view.ReactViewGroup
 
 @OptIn(UnstableReactNativeAPI::class)
 internal fun ReactViewGroup.resolveBackgroundColor(): Int? = (this.background as? CSSBackgroundDrawable)?.color
-

--- a/android/src/versioned/backgroundcolor/latest/ViewBackgroundUtils.kt
+++ b/android/src/versioned/backgroundcolor/latest/ViewBackgroundUtils.kt
@@ -1,9 +1,6 @@
 package com.swmansion.rnscreens.utils
 
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.BackgroundStyleApplicator
-import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
 import com.facebook.react.views.view.ReactViewGroup
 
 internal fun ReactViewGroup.resolveBackgroundColor(): Int? = BackgroundStyleApplicator.getBackgroundColor(this)
-

--- a/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
+++ b/android/src/versioned/pointerevents/77/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
@@ -3,7 +3,7 @@ package com.swmansion.rnscreens
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-internal class PointerEventsBoxNoneImpl() : ReactPointerEventsView {
+internal class PointerEventsBoxNoneImpl : ReactPointerEventsView {
     // We set pointer events to BOX_NONE, because we don't want the ScreensCoordinatorLayout
     // to be target of react gestures and effectively prevent interaction with screens
     // underneath the current screen (useful in `modal` & `formSheet` presentation).

--- a/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
+++ b/android/src/versioned/pointerevents/latest/com/swmansion/rnscreens/PointerEventsBoxNoneImpl.kt
@@ -3,7 +3,7 @@ package com.swmansion.rnscreens
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 
-internal class PointerEventsBoxNoneImpl() : ReactPointerEventsView {
+internal class PointerEventsBoxNoneImpl : ReactPointerEventsView {
     // We set pointer events to BOX_NONE, because we don't want the ScreensCoordinatorLayout
     // to be target of react gestures and effectively prevent interaction with screens
     // underneath the current screen (useful in `modal` & `formSheet` presentation).

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,7 +1,7 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
+import { Button, FlatList, ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
 
 import {
@@ -39,10 +39,11 @@ function generateData(count: number): ItemData[] {
 }
 
 function Home({ navigation }: RouteProps<'Home'>) {
+  const dimentions = useWindowDimensions()
   const context = React.useContext(TranslationContext)
 
   const translateY = useDerivedValue(() => {
-    return context?.y.value ?? 0
+    return dimentions.height - (context?.y.value ?? 0)
   })
 
   const circleStyle = useAnimatedStyle(() => ({

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -4,6 +4,12 @@ import React from 'react';
 import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
 
+import {
+  ReanimatedScreenProvider,
+  useReanimatedSheetTranslation,
+} from 'react-native-screens/reanimated';
+import Animated, { SharedValue, useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated';
+
 type ItemData = {
   id: number,
   text: string;
@@ -23,6 +29,9 @@ type RouteProps<RouteName extends keyof RouteParamList> = {
   route: RouteProp<RouteParamList, RouteName>;
 }
 
+const TranslationContext = React.createContext<{ y: SharedValue<number>, setY: (value: number) => void } | undefined>(undefined);
+
+
 const Stack = createNativeStackNavigator<RouteParamList>();
 
 function generateData(count: number): ItemData[] {
@@ -30,6 +39,18 @@ function generateData(count: number): ItemData[] {
 }
 
 function Home({ navigation }: RouteProps<'Home'>) {
+  const context = React.useContext(TranslationContext)
+
+  const translateY = useDerivedValue(() => {
+    return context?.y.value ?? 0
+  })
+
+  const circleStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateY: -translateY.value }
+    ]
+  }))
+
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
       <Button title="Open sheet" onPress={() => navigation.navigate('FormSheet')} />
@@ -41,6 +62,7 @@ function Home({ navigation }: RouteProps<'Home'>) {
           <Text>Pressable</Text>
         </View>
       </PressableWithFeedback>
+      <Animated.View style={[{ position: 'absolute', right: 16, bottom: 50, width: 64, height: 64, borderRadius: 32, backgroundColor: 'red' }, circleStyle]} />
     </View>
   );
 }
@@ -54,6 +76,13 @@ function Second({ navigation }: RouteProps<'Second'>) {
 }
 
 function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
+  const context = React.useContext(TranslationContext)
+  const translation = useReanimatedSheetTranslation()
+
+  useDerivedValue(() => {
+    context?.setY(translation.value)
+  })
+
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
@@ -163,57 +192,67 @@ function FormSheetFooter() {
 }
 
 export default function App() {
+  const translationY = useSharedValue(0)
+  const setY = (value: number) => {
+    'worklet'
+    translationY.value = value
+  }
+
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Home" component={Home} />
-        <Stack.Screen name="Second" component={Second} />
-        <Stack.Screen name="FormSheet" component={FormSheet} options={{
-          presentation: 'formSheet',
-          sheetAllowedDetents: [0.4, 0.75],
-          //sheetAllowedDetents: 'fitToContents',
-          sheetLargestUndimmedDetentIndex: 'none',
-          sheetCornerRadius: 8,
-          headerShown: false,
-          contentStyle: {
-            backgroundColor: 'lightblue',
-          },
-          //unstable_sheetFooter: FormSheetFooter,
-        }} />
-        <Stack.Screen name="SecondFormSheet" component={SecondFormSheet} options={{
-          presentation: 'formSheet',
-          //sheetAllowedDetents: [0.4, 0.75],
-          sheetAllowedDetents: 'fitToContents',
-          sheetLargestUndimmedDetentIndex: 'none',
-          sheetCornerRadius: 8,
-          headerShown: false,
-          contentStyle: {
-            backgroundColor: 'lightblue',
-          },
-          //unstable_sheetFooter: FormSheetFooter,
-        }} />
-        <Stack.Screen name="FormSheetWithFlatList" component={FormSheetWithFlatList} options={{
-          presentation: 'formSheet',
-          sheetAllowedDetents: [1.0],
-          sheetCornerRadius: 8,
-          headerShown: false,
-          contentStyle: {
-            backgroundColor: 'lightblue',
-          },
-        }} />
-        <Stack.Screen name="FormSheetWithScrollView" component={FormSheetWithScrollView} options={{
-          presentation: 'formSheet',
-          sheetAllowedDetents: [0.6],
-          sheetExpandsWhenScrolledToEdge: false,
-          sheetGrabberVisible: true,
-          sheetCornerRadius: 8,
-          headerShown: false,
-          contentStyle: {
-            backgroundColor: 'lightblue',
-          },
-        }} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <ReanimatedScreenProvider>
+      <TranslationContext.Provider value={{ y: translationY, setY }}>
+        <NavigationContainer>
+          <Stack.Navigator>
+            <Stack.Screen name="Home" component={Home} />
+            <Stack.Screen name="Second" component={Second} />
+            <Stack.Screen name="FormSheet" component={FormSheet} options={{
+              presentation: 'formSheet',
+              sheetAllowedDetents: [0.4, 0.75],
+              //sheetAllowedDetents: 'fitToContents',
+              sheetLargestUndimmedDetentIndex: 'none',
+              sheetCornerRadius: 8,
+              headerShown: false,
+              contentStyle: {
+                backgroundColor: 'lightblue',
+              },
+              //unstable_sheetFooter: FormSheetFooter,
+            }} />
+            <Stack.Screen name="SecondFormSheet" component={SecondFormSheet} options={{
+              presentation: 'formSheet',
+              //sheetAllowedDetents: [0.4, 0.75],
+              sheetAllowedDetents: 'fitToContents',
+              sheetLargestUndimmedDetentIndex: 'none',
+              sheetCornerRadius: 8,
+              headerShown: false,
+              contentStyle: {
+                backgroundColor: 'lightblue',
+              },
+              //unstable_sheetFooter: FormSheetFooter,
+            }} />
+            <Stack.Screen name="FormSheetWithFlatList" component={FormSheetWithFlatList} options={{
+              presentation: 'formSheet',
+              sheetAllowedDetents: [1.0],
+              sheetCornerRadius: 8,
+              headerShown: false,
+              contentStyle: {
+                backgroundColor: 'lightblue',
+              },
+            }} />
+            <Stack.Screen name="FormSheetWithScrollView" component={FormSheetWithScrollView} options={{
+              presentation: 'formSheet',
+              sheetAllowedDetents: [0.6],
+              sheetExpandsWhenScrolledToEdge: false,
+              sheetGrabberVisible: true,
+              sheetCornerRadius: 8,
+              headerShown: false,
+              contentStyle: {
+                backgroundColor: 'lightblue',
+              },
+            }} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </TranslationContext.Provider>
+    </ReanimatedScreenProvider>
   );
 }
 

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -1,14 +1,8 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, FlatList, ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
+import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
-
-import {
-  ReanimatedScreenProvider,
-  useReanimatedSheetTranslation,
-} from 'react-native-screens/reanimated';
-import Animated, { SharedValue, useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated';
 
 type ItemData = {
   id: number,
@@ -29,9 +23,6 @@ type RouteProps<RouteName extends keyof RouteParamList> = {
   route: RouteProp<RouteParamList, RouteName>;
 }
 
-const TranslationContext = React.createContext<{ y: SharedValue<number>, setY: (value: number) => void } | undefined>(undefined);
-
-
 const Stack = createNativeStackNavigator<RouteParamList>();
 
 function generateData(count: number): ItemData[] {
@@ -39,19 +30,6 @@ function generateData(count: number): ItemData[] {
 }
 
 function Home({ navigation }: RouteProps<'Home'>) {
-  const dimentions = useWindowDimensions()
-  const context = React.useContext(TranslationContext)
-
-  const translateY = useDerivedValue(() => {
-    return dimentions.height - (context?.y.value ?? 0)
-  })
-
-  const circleStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateY: -translateY.value }
-    ]
-  }))
-
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
       <Button title="Open sheet" onPress={() => navigation.navigate('FormSheet')} />
@@ -63,7 +41,6 @@ function Home({ navigation }: RouteProps<'Home'>) {
           <Text>Pressable</Text>
         </View>
       </PressableWithFeedback>
-      <Animated.View style={[{ position: 'absolute', right: 16, bottom: 50, width: 64, height: 64, borderRadius: 32, backgroundColor: 'red' }, circleStyle]} />
     </View>
   );
 }
@@ -77,13 +54,6 @@ function Second({ navigation }: RouteProps<'Second'>) {
 }
 
 function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
-  const context = React.useContext(TranslationContext)
-  const translation = useReanimatedSheetTranslation()
-
-  useDerivedValue(() => {
-    context?.setY(translation.value)
-  })
-
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
@@ -193,67 +163,56 @@ function FormSheetFooter() {
 }
 
 export default function App() {
-  const translationY = useSharedValue(0)
-  const setY = (value: number) => {
-    'worklet'
-    translationY.value = value
-  }
-
   return (
-    <ReanimatedScreenProvider>
-      <TranslationContext.Provider value={{ y: translationY, setY }}>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen name="Home" component={Home} />
-            <Stack.Screen name="Second" component={Second} />
-            <Stack.Screen name="FormSheet" component={FormSheet} options={{
-              presentation: 'formSheet',
-              sheetAllowedDetents: [0.4, 0.75],
-              //sheetAllowedDetents: 'fitToContents',
-              sheetLargestUndimmedDetentIndex: 'none',
-              sheetCornerRadius: 8,
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'lightblue',
-              },
-              //unstable_sheetFooter: FormSheetFooter,
-            }} />
-            <Stack.Screen name="SecondFormSheet" component={SecondFormSheet} options={{
-              presentation: 'formSheet',
-              //sheetAllowedDetents: [0.4, 0.75],
-              sheetAllowedDetents: 'fitToContents',
-              sheetLargestUndimmedDetentIndex: 'none',
-              sheetCornerRadius: 8,
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'lightblue',
-              },
-              //unstable_sheetFooter: FormSheetFooter,
-            }} />
-            <Stack.Screen name="FormSheetWithFlatList" component={FormSheetWithFlatList} options={{
-              presentation: 'formSheet',
-              sheetAllowedDetents: [1.0],
-              sheetCornerRadius: 8,
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'lightblue',
-              },
-            }} />
-            <Stack.Screen name="FormSheetWithScrollView" component={FormSheetWithScrollView} options={{
-              presentation: 'formSheet',
-              sheetAllowedDetents: [0.6],
-              sheetExpandsWhenScrolledToEdge: false,
-              sheetGrabberVisible: true,
-              sheetCornerRadius: 8,
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'lightblue',
-              },
-            }} />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </TranslationContext.Provider>
-    </ReanimatedScreenProvider>
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="Second" component={Second} />
+        <Stack.Screen name="FormSheet" component={FormSheet} options={{
+          presentation: 'formSheet',
+          sheetAllowedDetents: [0.4, 0.75],
+          //sheetAllowedDetents: 'fitToContents',
+          sheetLargestUndimmedDetentIndex: 'none',
+          sheetCornerRadius: 8,
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+          //unstable_sheetFooter: FormSheetFooter,
+        }} />
+        <Stack.Screen name="SecondFormSheet" component={SecondFormSheet} options={{
+          presentation: 'formSheet',
+          //sheetAllowedDetents: [0.4, 0.75],
+          sheetAllowedDetents: 'fitToContents',
+          sheetLargestUndimmedDetentIndex: 'none',
+          sheetCornerRadius: 8,
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+          //unstable_sheetFooter: FormSheetFooter,
+        }} />
+        <Stack.Screen name="FormSheetWithFlatList" component={FormSheetWithFlatList} options={{
+          presentation: 'formSheet',
+          sheetAllowedDetents: [1.0],
+          sheetCornerRadius: 8,
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+        }} />
+        <Stack.Screen name="FormSheetWithScrollView" component={FormSheetWithScrollView} options={{
+          presentation: 'formSheet',
+          sheetAllowedDetents: [0.6],
+          sheetExpandsWhenScrolledToEdge: false,
+          sheetGrabberVisible: true,
+          sheetCornerRadius: 8,
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: 'lightblue',
+          },
+        }} />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
-

--- a/apps/src/tests/TestSheetFeatures.tsx
+++ b/apps/src/tests/TestSheetFeatures.tsx
@@ -80,8 +80,10 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
   }, [currentDetentIndex])
 
   useEffect(() => {
-    const unsubscribe = navigation.addListener('sheetDetentChange', (e) => {
-      setCurrentDetentIndex(e.data.index);
+    const unsubscribe = navigation.addListener('sheetDetentChange', ({ data }) => {
+      if (data.stable) {
+        setCurrentDetentIndex(data.index);
+      }
     })
 
     return unsubscribe

--- a/apps/src/tests/TestSheetFeatures.tsx
+++ b/apps/src/tests/TestSheetFeatures.tsx
@@ -1,6 +1,6 @@
 import { NavigationContainer, RouteProp, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button, View, useWindowDimensions, StyleSheet, TextInput } from 'react-native';
 import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
 import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
@@ -54,6 +54,7 @@ function FormSheetFooter() {
 }
 
 function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
+  const [currentDetentIndex, setCurrentDetentIndex] = useState(0)
   const dimentions = useWindowDimensions();
   const contextY = React.useContext(TranslationContext)
   const translation = useReanimatedSheetTranslation()
@@ -72,6 +73,20 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
     }
   }, []))
 
+  useEffect(() => {
+    navigation.setOptions({
+      sheetInitialDetentIndex: currentDetentIndex,
+    })
+  }, [currentDetentIndex])
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('sheetDetentChange', (e) => {
+      setCurrentDetentIndex(e.data.index);
+    })
+
+    return unsubscribe
+  }, [])
+
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
@@ -80,8 +95,8 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
         <TextInput style={styles.input} placeholder="Trigger keyboard..."/>
       </View>
       <View style={{ marginTop: 20 }}>
-        <Button title="Expand" onPress={() => navigation.setOptions({ sheetInitialDetentIndex: 2 })} />
-        <Button title="Collapse" onPress={() => navigation.setOptions({ sheetInitialDetentIndex: 0 })} />
+        <Button title="Expand" onPress={() => setCurrentDetentIndex(1)} />
+        <Button title="Collapse" onPress={() => setCurrentDetentIndex(0)} />
         <Button title="Dismiss" onPress={() => navigation.goBack()} />
       </View>
     </View>
@@ -99,7 +114,7 @@ export default function App() {
             <Stack.Screen name="Home" component={Home} />
             <Stack.Screen name="FormSheet" component={FormSheet} options={{
               presentation: 'formSheet',
-              sheetAllowedDetents: [0.4, 0.6, 1],
+              sheetAllowedDetents: [0.3, 0.6, 1],
               sheetLargestUndimmedDetentIndex: 'none',
               sheetCornerRadius: 16,
               headerShown: false,

--- a/apps/src/tests/TestSheetFeatures.tsx
+++ b/apps/src/tests/TestSheetFeatures.tsx
@@ -120,7 +120,7 @@ export default function App() {
               sheetLargestUndimmedDetentIndex: 'none',
               sheetCornerRadius: 16,
               headerShown: false,
-              sheetDismissible: false,
+              // sheetDismissible: false,
               // gestureEnabled: false,
               unstable_sheetFooter: FormSheetFooter,
             }} />

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -76,12 +76,13 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
     <View style={{ flex: 1 }}>
-      <View style={{ paddingTop: 20 }}>
-        <Button title="Go back" onPress={() => navigation.goBack()} />
-      </View>
-
-      <View style={{ alignItems: 'center' }}>
+      <View style={styles.inputWrapper}>
         <TextInput style={styles.input} placeholder="Trigger keyboard..."/>
+      </View>
+      <View style={{ marginTop: 20 }}>
+        <Button title="Expand" onPress={() => navigation.setOptions({ sheetInitialDetentIndex: 2 })} />
+        <Button title="Collapse" onPress={() => navigation.setOptions({ sheetInitialDetentIndex: 0 })} />
+        <Button title="Dismiss" onPress={() => navigation.goBack()} />
       </View>
     </View>
   );
@@ -98,9 +99,9 @@ export default function App() {
             <Stack.Screen name="Home" component={Home} />
             <Stack.Screen name="FormSheet" component={FormSheet} options={{
               presentation: 'formSheet',
-              sheetAllowedDetents: [0.2, 0.5, 0.8],
+              sheetAllowedDetents: [0.4, 0.6, 1],
               sheetLargestUndimmedDetentIndex: 'none',
-              sheetCornerRadius: 8,
+              sheetCornerRadius: 16,
               headerShown: false,
               // gestureEnabled: false,
               unstable_sheetFooter: FormSheetFooter,
@@ -116,17 +117,20 @@ const styles = StyleSheet.create({
   circle: {
     position: 'absolute',
     right: 16,
-    bottom: 50,
-    width: 64,
-    height: 64,
-    borderRadius: 32,
+    bottom: 32,
+    width: 56,
+    height: 56,
+    borderRadius: 56 / 2,
     backgroundColor: 'white',
   },
+  inputWrapper: {
+    padding: 12,
+  },
   input: {
-    marginVertical: 12,
     paddingVertical: 8,
+    paddingHorizontal: 12,
+    height: 40,
     backgroundColor: 'lavender',
-    borderRadius: 24,
-    width: '80%',
+    borderRadius: 16,
   }
 })

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -1,0 +1,106 @@
+import { NavigationContainer, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+import { Button, TextInput, View, useWindowDimensions } from 'react-native';
+import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
+import Animated, { SharedValue, WithSpringConfig, useAnimatedStyle, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
+
+const SPRING_CONFIG: WithSpringConfig = {
+  damping: 500,
+  stiffness: 1000,
+  mass: 3,
+  overshootClamping: true,
+  restDisplacementThreshold: 10,
+  restSpeedThreshold: 10,
+}
+
+type RouteParamList = {
+  Home: undefined;
+  FormSheet: undefined;
+};
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+const TranslationContext = React.createContext<SharedValue<number> | undefined>(undefined);
+
+type RouteProps<RouteName extends keyof RouteParamList> = {
+  navigation: NativeStackNavigationProp<RouteParamList, RouteName>;
+  route: RouteProp<RouteParamList, RouteName>;
+}
+
+function Home({ navigation }: RouteProps<'Home'>) {
+  const translateY = React.useContext(TranslationContext);
+
+  const circleStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateY: translateY?.value ?? 0 }
+    ]
+  }));
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
+      <Button title="Open sheet" onPress={() => navigation.navigate('FormSheet')} />
+      <Animated.View style={[{ position: 'absolute', right: 16, bottom: 50, width: 64, height: 64, borderRadius: 32, backgroundColor: 'red' }, circleStyle]} />
+    </View>
+  );
+}
+
+function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
+  const dimentions = useWindowDimensions();
+  const contextY = React.useContext(TranslationContext)
+  const translation = useReanimatedSheetTranslation()
+
+  useDerivedValue(() => {
+    if (!contextY) return
+    contextY.value = -(dimentions.height - translation.value)
+  })
+
+  const goBack = () => {
+    navigation.goBack()
+    if (contextY) {
+      // Reanimated doesn't get fired when dismissed programmatically even if native is firing it.
+      // I guess due to the component being unmounted early?
+      contextY.value = withSpring(0, SPRING_CONFIG);
+    }
+  }
+
+  return (
+    // When using `fitToContents` you can't use flex: 1. It is you who must provide
+    // the content size - you can't rely on parent size here.
+    <View style={{ backgroundColor: 'lightgreen', flex: 1 }}>
+      <View style={{ paddingTop: 20 }}>
+        <Button title="Go back" onPress={goBack} />
+      </View>
+      <View style={{ alignItems: 'center' }}>
+        <TextInput style={{ marginVertical: 12, paddingVertical: 8, backgroundColor: 'lavender', borderRadius: 24, width: '80%' }} placeholder="Trigger keyboard..." />
+      </View>
+    </View>
+  );
+}
+
+export default function App() {
+  const translationY = useSharedValue(0)
+
+  return (
+    <ReanimatedScreenProvider>
+      <TranslationContext.Provider value={translationY}>
+        <NavigationContainer>
+          <Stack.Navigator>
+            <Stack.Screen name="Home" component={Home} />
+            <Stack.Screen name="FormSheet" component={FormSheet} options={{
+              presentation: 'formSheet',
+              sheetAllowedDetents: [0.4, 0.75],
+              sheetLargestUndimmedDetentIndex: 'none',
+              sheetCornerRadius: 8,
+              headerShown: false,
+              gestureEnabled: false,
+              contentStyle: {
+                backgroundColor: 'lightblue',
+              },
+            }} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </TranslationContext.Provider>
+    </ReanimatedScreenProvider>
+  );
+}

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -67,12 +67,9 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
-    <View style={{ backgroundColor: 'lightgreen', flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <View style={{ paddingTop: 20 }}>
         <Button title="Go back" onPress={goBack} />
-      </View>
-      <View style={{ alignItems: 'center' }}>
-        <TextInput style={{ marginVertical: 12, paddingVertical: 8, backgroundColor: 'lavender', borderRadius: 24, width: '80%' }} placeholder="Trigger keyboard..." />
       </View>
     </View>
   );
@@ -89,14 +86,11 @@ export default function App() {
             <Stack.Screen name="Home" component={Home} />
             <Stack.Screen name="FormSheet" component={FormSheet} options={{
               presentation: 'formSheet',
-              sheetAllowedDetents: [0.4, 0.75],
+              sheetAllowedDetents: [0.2, 0.5, 0.8],
               sheetLargestUndimmedDetentIndex: 'none',
               sheetCornerRadius: 8,
               headerShown: false,
-              gestureEnabled: false,
-              contentStyle: {
-                backgroundColor: 'lightblue',
-              },
+              // gestureEnabled: false,
             }} />
           </Stack.Navigator>
         </NavigationContainer>

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -3,7 +3,7 @@ import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-na
 import React from 'react';
 import { Button, View, useWindowDimensions } from 'react-native';
 import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
-import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
+import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 
 const SPRING_CONFIG: WithSpringConfig = {
   damping: 500,

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -1,9 +1,9 @@
 import { NavigationContainer, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, TextInput, View, useWindowDimensions } from 'react-native';
+import { Button, View, useWindowDimensions } from 'react-native';
 import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
-import Animated, { SharedValue, WithSpringConfig, useAnimatedStyle, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
+import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
 
 const SPRING_CONFIG: WithSpringConfig = {
   damping: 500,
@@ -50,7 +50,7 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
   const contextY = React.useContext(TranslationContext)
   const translation = useReanimatedSheetTranslation()
 
-  useDerivedValue(() => {
+  useAnimatedReaction(() => translation.value, () => {
     if (!contextY) return
     contextY.value = -(dimentions.height - translation.value)
   })

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -103,6 +103,7 @@ export default function App() {
               sheetLargestUndimmedDetentIndex: 'none',
               sheetCornerRadius: 16,
               headerShown: false,
+              // sheetDismissible: false,
               // gestureEnabled: false,
               unstable_sheetFooter: FormSheetFooter,
             }} />

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -1,6 +1,6 @@
-import { NavigationContainer, RouteProp } from '@react-navigation/native';
+import { NavigationContainer, RouteProp, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, View, useWindowDimensions } from 'react-native';
 import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
 import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
@@ -55,21 +55,21 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
     contextY.value = -(dimentions.height - translation.value)
   })
 
-  const goBack = () => {
-    navigation.goBack()
-    if (contextY) {
-      // Reanimated doesn't get fired when dismissed programmatically even if native is firing it.
-      // I guess due to the component being unmounted early?
+  // Reanimated doesn't get fired when dismissed even if native is firing it.
+  // I guess due to the component being unmounted early in react-navigation?
+  useFocusEffect(useCallback(() => {
+    return () => {
+      if (!contextY) return;
       contextY.value = withSpring(0, SPRING_CONFIG);
     }
-  }
+  }, []))
 
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
     <View style={{ flex: 1 }}>
       <View style={{ paddingTop: 20 }}>
-        <Button title="Go back" onPress={goBack} />
+        <Button title="Go back" onPress={() => navigation.goBack()} />
       </View>
     </View>
   );

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -1,7 +1,7 @@
 import { NavigationContainer, RouteProp, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
 import React, { useCallback } from 'react';
-import { Button, View, useWindowDimensions } from 'react-native';
+import { Button, View, useWindowDimensions, StyleSheet, TextInput } from 'react-native';
 import { ReanimatedScreenProvider, useReanimatedSheetTranslation } from 'react-native-screens/reanimated';
 import Animated, { useAnimatedReaction, SharedValue, WithSpringConfig, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 
@@ -40,7 +40,15 @@ function Home({ navigation }: RouteProps<'Home'>) {
   return (
     <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
       <Button title="Open sheet" onPress={() => navigation.navigate('FormSheet')} />
-      <Animated.View style={[{ position: 'absolute', right: 16, bottom: 50, width: 64, height: 64, borderRadius: 32, backgroundColor: 'red' }, circleStyle]} />
+      <Animated.View style={[styles.circle, circleStyle]} />
+    </View>
+  );
+}
+
+function FormSheetFooter() {
+  return (
+    <View style={{ height: 64, backgroundColor: 'lavender' }}>
+      <Button title="Just click me" onPress={() => console.log('Footer button clicked')} />
     </View>
   );
 }
@@ -71,6 +79,10 @@ function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
       <View style={{ paddingTop: 20 }}>
         <Button title="Go back" onPress={() => navigation.goBack()} />
       </View>
+
+      <View style={{ alignItems: 'center' }}>
+        <TextInput style={styles.input} placeholder="Trigger keyboard..."/>
+      </View>
     </View>
   );
 }
@@ -91,6 +103,7 @@ export default function App() {
               sheetCornerRadius: 8,
               headerShown: false,
               // gestureEnabled: false,
+              unstable_sheetFooter: FormSheetFooter,
             }} />
           </Stack.Navigator>
         </NavigationContainer>
@@ -98,3 +111,22 @@ export default function App() {
     </ReanimatedScreenProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  circle: {
+    position: 'absolute',
+    right: 16,
+    bottom: 50,
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'white',
+  },
+  input: {
+    marginVertical: 12,
+    paddingVertical: 8,
+    backgroundColor: 'lavender',
+    borderRadius: 24,
+    width: '80%',
+  }
+})

--- a/apps/src/tests/TestSheetTranslate.tsx
+++ b/apps/src/tests/TestSheetTranslate.tsx
@@ -103,7 +103,7 @@ export default function App() {
               sheetLargestUndimmedDetentIndex: 'none',
               sheetCornerRadius: 16,
               headerShown: false,
-              // sheetDismissible: false,
+              sheetDismissible: false,
               // gestureEnabled: false,
               unstable_sheetFooter: FormSheetFooter,
             }} />

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -142,5 +142,4 @@ export { default as TestMemoryLeak } from './TestMemoryLeak';
 export { default as TestFormSheet } from './TestFormSheet';
 export { default as TestAndroidTransitions } from './TestAndroidTransitions';
 export { default as TestAnimation } from './TestAnimation';
-
-
+export { default as TestSheetTranslate } from './TestSheetTranslate';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -142,4 +142,4 @@ export { default as TestMemoryLeak } from './TestMemoryLeak';
 export { default as TestFormSheet } from './TestFormSheet';
 export { default as TestAndroidTransitions } from './TestAndroidTransitions';
 export { default as TestAnimation } from './TestAnimation';
-export { default as TestSheetTranslate } from './TestSheetTranslate';
+export { default as TestSheetFeatures } from './TestSheetFeatures';

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -177,6 +177,13 @@ There are also legacy & **deprecated** options available:
 
 Defaults to `[1.0]` literal.
 
+### `sheetDismissible`
+
+Whether you can interactively dismiss a sheet.
+Works only when `stackPresentation` is set to `formSheet`.
+
+Defaults to `true`.
+
 ### `sheetExpandsWhenScrolledToEdge` (iOS only)
 
 Whether the sheet should expand to larger detent when scrolling.

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -113,6 +113,7 @@ namespace react = facebook::react;
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
+@property (nonatomic, copy) RCTDirectEventBlock onSheetTranslation;
 @property (nonatomic, copy) RCTDirectEventBlock onGestureCancel;
 @property (nonatomic, copy) RCTDirectEventBlock onSheetDetentChanged;
 #endif // RCT_NEW_ARCH_ENABLED
@@ -140,6 +141,7 @@ namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
+- (void)notifySheetTranslation:(double)y;
 - (void)notifyDismissCancelledWithDismissCount:(int)dismissCount;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -94,6 +94,7 @@ namespace react = facebook::react;
 @property (nonatomic) CGFloat sheetCornerRadius;
 @property (nonatomic) NSInteger sheetInitialDetent;
 @property (nonatomic) BOOL sheetExpandsWhenScrolledToEdge;
+@property (nonatomic) BOOL sheetDismissible;
 #endif // !TARGET_OS_TV
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -990,7 +990,7 @@ RNS_IGNORE_SUPER_CALL_END
  * Updates settings for sheet presentation controller.
  * Note that this method should not be called inside `stackPresentation` setter, because on Paper we don't have
  * guarantee that values of all related props had been updated earlier. It should be invoked from `didSetProps`.
- * On Fabric we have control over prop-setting process but it might be reasonable to run it from `finalizeUpdates`.
+ * On Fabric we should call this from `updateProps`.
  */
 - (void)updateFormSheetPresentationStyle
 {
@@ -1326,6 +1326,12 @@ RNS_IGNORE_SUPER_CALL_END
     [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
   }
 
+#if !TARGET_OS_TV && !TARGET_OS_VISION
+  if (self.stackPresentation == RNSScreenStackPresentationFormSheet) {
+    [self updateFormSheetPresentationStyle];
+  }
+#endif // !TARGET_OS_TV
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -1350,14 +1356,6 @@ RNS_IGNORE_SUPER_CALL_END
   // pass the dimensions to ui view manager to take into account when laying out
   // subviews
   // Explanation taken from `reactSetFrame`, which is old arch equivalent of this code.
-}
-
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
-{
-  [super finalizeUpdates:updateMask];
-#if !TARGET_OS_TV && !TARGET_OS_VISION
-  [self updateFormSheetPresentationStyle];
-#endif // !TARGET_OS_TV
 }
 
 #pragma mark - Paper specific

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -723,12 +723,11 @@ RNS_IGNORE_SUPER_CALL_END
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
     std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onSheetTranslation(react::RNSScreenEventEmitter::OnSheetTranslation{
-            .y = y});
+        ->onSheetTranslation(react::RNSScreenEventEmitter::OnSheetTranslation{.y = y});
   }
   RNSScreenViewEvent *event = [[RNSScreenViewEvent alloc] initWithEventName:@"onSheetTranslation"
                                                                    reactTag:[NSNumber numberWithInt:self.tag]
-                                                                   y:y];
+                                                                          y:y];
   [self postNotificationForEventDispatcherObserversWithEvent:event];
 #else
   if (self.onSheetTranslation) {
@@ -1434,9 +1433,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 - (void)viewWillLayoutSubviews
 {
   [super viewWillLayoutSubviews];
-  
-  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
   // We are tracking translation Y on layout.
   // Note that this doesn't trigger when user is about to close the sheet
   // so we are going to track it again during transition (see below).
@@ -1449,14 +1448,14 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
       [self notifySheetTranslation:sheetY];
     }
   }
-  #endif
+#endif
 }
 
 // TODO: Find out why this is executed when screen is going out
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  
+
   if (!_isSwiping) {
     [self.screenView notifyWillAppear];
     if (self.transitionCoordinator.isInteractive) {
@@ -1480,21 +1479,21 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self setupProgressNotification];
     [self setupGestureHandler];
   }
-  
-  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
   if (@available(iOS 15.0, *)) {
     if (self.presentedView != nil) {
       [self.presentedView addObserver:self forKeyPath:@"frame" options:0 context:NULL];
     }
   }
-  #endif
+#endif
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
   [super viewWillDisappear:animated];
-  
+
   // self.navigationController might be null when we are dismissing a modal
   if (!self.transitionCoordinator.isInteractive && self.navigationController != nil) {
     // user might have long pressed ios 14 back button item,
@@ -1527,17 +1526,17 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
     [self setupProgressNotification];
   }
-  
+
   _trackingYFromLayout = NO;
-  
-  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
   if (@available(iOS 15.0, *)) {
     if (self.presentedView != nil) {
       [self.presentedView removeObserver:self forKeyPath:@"frame"];
     }
   }
-  #endif
+#endif
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -1588,7 +1587,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 // KVO for the sheet Y only when gesture is disabled.
 // Transition does not trigger when dragging in this case.
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context
 {
   if ([keyPath isEqualToString:@"frame"]) {
     if (!_isTransitioning && self.modalInPresentation) {
@@ -1750,9 +1752,8 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (void)setupGestureHandler
 {
-  
-  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
   if (@available(iOS 15.0, *)) {
     if (self.presentedView == nil) {
       return;
@@ -1765,11 +1766,12 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
       }
     }
   }
-  #endif
+#endif
 }
 
 // Track sheet Y when dragging.
-- (void)handlePanGesture:(UIPanGestureRecognizer *)gesture {
+- (void)handlePanGesture:(UIPanGestureRecognizer *)gesture
+{
   switch (gesture.state) {
     case UIGestureRecognizerStateBegan: {
       _dragging = YES;
@@ -1832,16 +1834,16 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
       _currentAlpha = fmax(0.0, fmin(1.0, fakeViewAlpha));
       [self notifyTransitionProgress:_currentAlpha closing:_closing goingForward:_goingForward];
     }
-    
-    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
-        __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
     if (@available(iOS 15.0, *)) {
       if (!_dragging && self.presentedView != nil) {
         CGFloat sheetY = self.presentedView.layer.presentationLayer.frame.origin.y;
         [self notifySheetTranslation:sheetY];
       }
     }
-    #endif
+#endif
   }
 }
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -2150,6 +2150,7 @@ RCT_EXPORT_VIEW_PROPERTY(sheetGrabberVisible, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(sheetCornerRadius, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(sheetInitialDetent, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(sheetDismissible, BOOL);
 #endif
 
 #if !TARGET_OS_TV && !TARGET_OS_VISION

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1059,7 +1059,7 @@ RNS_IGNORE_SUPER_CALL_END
       }
     }
 
-    if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
+    if (_sheetInitialDetent >= 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
       if (@available(iOS 16.0, *)) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -18,6 +18,7 @@
 #import "RNSConvert.h"
 #import "RNSHeaderHeightChangeEvent.h"
 #import "RNSScreenViewEvent.h"
+#import "RNSSheetTranslationEvent.h"
 #else
 #import <React/RCTScrollView.h>
 #import <React/RCTTouchHandler.h>
@@ -731,9 +732,10 @@ RNS_IGNORE_SUPER_CALL_END
     std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
         ->onSheetTranslation(react::RNSScreenEventEmitter::OnSheetTranslation{.y = y});
   }
-  RNSScreenViewEvent *event = [[RNSScreenViewEvent alloc] initWithEventName:@"onSheetTranslation"
-                                                                   reactTag:[NSNumber numberWithInt:self.tag]
-                                                                          y:y];
+  RNSSheetTranslationEvent *event =
+      [[RNSSheetTranslationEvent alloc] initWithEventName:@"onSheetTranslation"
+                                                 reactTag:[NSNumber numberWithInt:self.tag]
+                                                        y:y];
   [self postNotificationForEventDispatcherObserversWithEvent:event];
 #else
   if (self.onSheetTranslation) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -113,6 +113,7 @@ struct ContentWrapperBox {
   _stackPresentation = RNSScreenStackPresentationPush;
   _stackAnimation = RNSScreenStackAnimationDefault;
   _gestureEnabled = YES;
+  _sheetDismissible = YES;
   _replaceAnimation = RNSScreenReplaceAnimationPop;
   _dismissed = NO;
   _hasStatusBarStyleSet = NO;
@@ -337,8 +338,13 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
   _controller.modalInPresentation = !gestureEnabled;
-
   _gestureEnabled = gestureEnabled;
+}
+
+- (void)setSheetDismissible:(BOOL)sheetDismissible
+{
+  _controller.modalInPresentation = !sheetDismissible;
+  _sheetDismissible = sheetDismissible;
 }
 
 - (void)setReplaceAnimation:(RNSScreenReplaceAnimation)replaceAnimation
@@ -764,6 +770,11 @@ RNS_IGNORE_SUPER_CALL_END
   if (_preventNativeDismiss) {
     return NO;
   }
+
+  if (self.stackPresentation == RNSScreenStackPresentationFormSheet) {
+    return _sheetDismissible;
+  }
+
   return _gestureEnabled;
 }
 
@@ -1285,6 +1296,7 @@ RNS_IGNORE_SUPER_CALL_END
   [self setSheetGrabberVisible:newScreenProps.sheetGrabberVisible];
   [self setSheetCornerRadius:newScreenProps.sheetCornerRadius];
   [self setSheetExpandsWhenScrolledToEdge:newScreenProps.sheetExpandsWhenScrolledToEdge];
+  [self setSheetDismissible:newScreenProps.sheetDismissible];
 
   if (newScreenProps.sheetAllowedDetents != oldScreenProps.sheetAllowedDetents) {
     [self setSheetAllowedDetents:[RNSConvert detentFractionsArrayFromVector:newScreenProps.sheetAllowedDetents]];

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1779,23 +1779,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     _isTransitioning = YES;
     _fakeView.alpha = 0.0;
 
-    if (@available(iOS 15.0, *)) {
-      _fakeView.frame = CGRectMake(0, _closing ?
-                                   self.sheetPresentationController.presentedView.frame.origin.y :
-                                   self.sheetPresentationController.containerView.frame.size.height, 0, 0);
-    }
-
     [self.transitionCoordinator
         animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
           [[context containerView] addSubview:self->_fakeView];
           self->_fakeView.alpha = 1.0;
-      
-          if (@available(iOS 15.0, *)) {
-            self->_fakeView.frame = CGRectMake(0, self->_closing ?
-                                               self.sheetPresentationController.containerView.frame.size.height :
-                                               self.sheetPresentationController.presentedView.frame.origin.y, 0, 0);
-          }
-      
           self->_transitionTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleTransition)];
           [self->_transitionTimer addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
         }
@@ -1818,7 +1805,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     }
     
     if (!_dragging) {
-      CGFloat sheetY = _fakeView.layer.presentationLayer.frame.origin.y;
+      CGFloat sheetY = self.sheetPresentationController.presentedView.layer.presentationLayer.frame.origin.y;
       [self notifySheetTranslation:sheetY from:@"transition"];
     }
   }

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -3,7 +3,7 @@
 #import "UIView+Pinning.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
-
+#import <React/RCTConversions.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -1,5 +1,6 @@
 #import "RNSScreenFooter.h"
 #import "RNSScreen.h"
+#import "UIView+Pinning.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
@@ -12,6 +13,7 @@
 
 @implementation RNSScreenFooter {
   RNSScreenView *_parent;
+  NSLayoutConstraint *_heightConstraint;
 }
 
 - (instancetype)init
@@ -26,73 +28,38 @@
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
   [super willMoveToSuperview:newSuperview];
-  //  if ([newSuperview isKindOfClass:RNSScreenView.class]) {
-  //    RNSScreenView *screen = (RNSScreenView *)newSuperview;
-  //    _parent = (RNSScreenView *)newSuperview;
-
-  //    [NSLayoutConstraint activateConstraints:@[
-  //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom
-  //      relatedBy:NSLayoutRelationEqual toItem:screen attribute:NSLayoutAttributeBottom multiplier:1.0
-  //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeLeft
-  //      relatedBy:NSLayoutRelationEqual toItem:screen attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0],
-  //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual
-  //      toItem:screen attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0], [NSLayoutConstraint
-  //      constraintWithItem:self attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:screen
-  //      attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0], [NSLayoutConstraint
-  //      constraintWithItem:screen attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop
-  //      multiplier:1.0 constant:0.0],
-  //    ]];
-  //    [self setNeedsLayout];
-  //  }
+  if ([newSuperview isKindOfClass:RNSScreenView.class]) {
+    _parent = (RNSScreenView *)newSuperview;
+  }
 }
 
 - (void)didMoveToSuperview
 {
   if (_parent != nil) {
-    //    [NSLayoutConstraint activateConstraints:@[
-    //      [NSLayoutConstraint constraintWithItem:self
-    //                                   attribute:NSLayoutAttributeBottom
-    //                                   relatedBy:NSLayoutRelationEqual
-    //                                      toItem:_parent
-    //                                   attribute:NSLayoutAttributeBottom
-    //                                  multiplier:1.0
-    //                                    constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeLeft
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeLeft multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeRight multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeTop
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeTop multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeBottom
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeLeft
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeRight
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeTop
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0],
-    //    ]];
-    //    [self setNeedsLayout];
+    [self pinToView:_parent.controller.view
+          fromEdges:UIRectEdgeLeft | UIRectEdgeRight | UIRectEdgeBottom
+         withHeight:@0
+        constraints:^(
+            NSLayoutConstraint *top,
+            NSLayoutConstraint *bottom,
+            NSLayoutConstraint *left,
+            NSLayoutConstraint *right,
+            NSLayoutConstraint *heightConstraint) {
+          self->_heightConstraint = heightConstraint;
+        }];
   }
 }
 
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+
+  UIView *firstView = self.subviews.firstObject;
+  _heightConstraint.constant = firstView.frame.size.height;
+
   if (self.onLayout != nil) {
     self.onLayout(self.frame);
   }
-  //
-  //  if (self.subviews.count > 0) {
-  //    CGSize childsSize = self.subviews[0].frame.size;
-  //
-  //  }
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/events/RNSSheetTranslationEvent.h
+++ b/ios/events/RNSSheetTranslationEvent.h
@@ -1,0 +1,7 @@
+#import <React/RCTEventDispatcherProtocol.h>
+
+@interface RNSSheetTranslationEvent : NSObject <RCTEvent>
+
+- (instancetype)initWithEventName:(NSString *)eventName reactTag:(NSNumber *)reactTag y:(double)y;
+
+@end

--- a/ios/events/RNSSheetTranslationEvent.mm
+++ b/ios/events/RNSSheetTranslationEvent.mm
@@ -1,0 +1,49 @@
+#import "RNSSheetTranslationEvent.h"
+#import <React/RCTAssert.h>
+
+@implementation RNSSheetTranslationEvent {
+  double _y;
+}
+
+@synthesize viewTag = _viewTag;
+@synthesize eventName = _eventName;
+
+- (instancetype)initWithEventName:(NSString *)eventName reactTag:(NSNumber *)reactTag y:(double)y
+{
+  RCTAssertParam(reactTag);
+
+  if ((self = [super init])) {
+    _eventName = [eventName copy];
+    _viewTag = reactTag;
+    _y = y;
+  }
+  return self;
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)init)
+
+- (NSDictionary *)body
+{
+  NSDictionary *body = @{
+    @"y" : @(_y),
+  };
+
+  return body;
+}
+
+- (BOOL)canCoalesce
+{
+  return NO;
+}
+
++ (NSString *)moduleDotMethod
+{
+  return @"RCTEventEmitter.receiveEvent";
+}
+
+- (NSArray *)arguments
+{
+  return @[ self.viewTag, RCTNormalizeInputEventName(self.eventName), [self body] ];
+}
+
+@end

--- a/ios/utils/UIView+Pinning.h
+++ b/ios/utils/UIView+Pinning.h
@@ -1,0 +1,17 @@
+#import <UIKit/UIKit.h>
+
+@interface UIView (Pinning)
+
+- (void)pinToView:(UIView *_Nullable)view
+        fromEdges:(UIRectEdge)edges
+       withHeight:(nullable NSNumber *)height
+      constraints:(void (^_Nullable)(
+                      NSLayoutConstraint *_Nullable top,
+                      NSLayoutConstraint *_Nullable bottom,
+                      NSLayoutConstraint *_Nullable left,
+                      NSLayoutConstraint *_Nullable right,
+                      NSLayoutConstraint *_Nullable heightConstraint))block;
+
+- (void)unpin;
+
+@end

--- a/ios/utils/UIView+Pinning.mm
+++ b/ios/utils/UIView+Pinning.mm
@@ -1,0 +1,59 @@
+#import "UIView+Pinning.h"
+
+@implementation UIView (Pinning)
+
+- (void)pinToView:(UIView *)view
+        fromEdges:(UIRectEdge)edges
+       withHeight:(NSNumber *)height
+      constraints:(void (^)(
+                      NSLayoutConstraint *top,
+                      NSLayoutConstraint *bottom,
+                      NSLayoutConstraint *left,
+                      NSLayoutConstraint *right,
+                      NSLayoutConstraint *heightConstraint))block
+{
+  self.translatesAutoresizingMaskIntoConstraints = NO;
+
+  NSLayoutConstraint *topConstraint = nil;
+  NSLayoutConstraint *bottomConstraint = nil;
+  NSLayoutConstraint *leftConstraint = nil;
+  NSLayoutConstraint *rightConstraint = nil;
+  NSLayoutConstraint *heightConstraint = nil;
+
+  if (edges & UIRectEdgeTop) {
+    topConstraint = [self.topAnchor constraintEqualToAnchor:view.topAnchor];
+    topConstraint.active = YES;
+  }
+
+  if (edges & UIRectEdgeBottom) {
+    bottomConstraint = [self.bottomAnchor constraintEqualToAnchor:view.bottomAnchor];
+    bottomConstraint.active = YES;
+  }
+
+  if (edges & UIRectEdgeLeft) {
+    leftConstraint = [self.leadingAnchor constraintEqualToAnchor:view.leadingAnchor];
+    leftConstraint.active = YES;
+  }
+
+  if (edges & UIRectEdgeRight) {
+    rightConstraint = [self.trailingAnchor constraintEqualToAnchor:view.trailingAnchor];
+    rightConstraint.active = YES;
+  }
+
+  if (height != nil) {
+    heightConstraint = [self.heightAnchor constraintEqualToConstant:height.floatValue];
+    heightConstraint.active = YES;
+  }
+
+  if (block) {
+    block(topConstraint, bottomConstraint, leftConstraint, rightConstraint, heightConstraint);
+  }
+}
+
+- (void)unpin
+{
+  self.translatesAutoresizingMaskIntoConstraints = YES;
+  [self removeConstraints:self.constraints];
+}
+
+@end

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -266,6 +266,13 @@ There are also legacy & **deprecated** options available:
 
 Defaults to `[1.0]` literal.
 
+### `sheetDismissible`
+
+Whether you can interactively dismiss a sheet.
+Works only when `stackPresentation` is set to `formSheet`.
+
+Defaults to `true`.
+
 #### `sheetElevation` (Android only)
 
 Integer value describing elevation of the sheet, impacting shadow on the top edge of the sheet.

--- a/src/SheetTranslationContext.tsx
+++ b/src/SheetTranslationContext.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import * as React from 'react';
+import { Animated } from 'react-native';
+
+export default React.createContext<Animated.Value | undefined>(
+  undefined,
+);

--- a/src/SheetTranslationContext.tsx
+++ b/src/SheetTranslationContext.tsx
@@ -3,6 +3,4 @@
 import * as React from 'react';
 import { Animated } from 'react-native';
 
-export default React.createContext<Animated.Value | undefined>(
-  undefined,
-);
+export default React.createContext<Animated.Value | undefined>(undefined);

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Animated, View, Platform } from 'react-native';
 
 import TransitionProgressContext from '../TransitionProgressContext';
+import SheetTranslationContext from '../SheetTranslationContext';
 import DelayedFreeze from './helpers/DelayedFreeze';
 import { ScreenProps } from '../types';
 
@@ -174,6 +175,8 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
     const progress = React.useRef(new Animated.Value(0)).current;
     const goingForward = React.useRef(new Animated.Value(0)).current;
 
+    const translationY = React.useRef(new Animated.Value(0)).current;
+
     const {
       enabled = screensEnabled(),
       freezeOnBlur = freezeEnabled(),
@@ -343,18 +346,34 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
                     ],
                     { useNativeDriver: true },
                   )
+            }
+            onSheetTranslation={
+              !isNativeStack
+                ? undefined
+                : Animated.event(
+                    [
+                      {
+                        nativeEvent: {
+                          y: translationY,
+                        },
+                      },
+                    ],
+                    { useNativeDriver: true },
+                  )
             }>
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
               children
             ) : (
-              <TransitionProgressContext.Provider
-                value={{
-                  progress,
-                  closing,
-                  goingForward,
-                }}>
-                {children}
-              </TransitionProgressContext.Provider>
+              <SheetTranslationContext.Provider value={translationY}>
+                <TransitionProgressContext.Provider
+                  value={{
+                    progress,
+                    closing,
+                    goingForward,
+                  }}>
+                  {children}
+                </TransitionProgressContext.Provider>
+              </SheetTranslationContext.Provider>
             )}
           </AnimatedScreen>
         </DelayedFreeze>

--- a/src/components/ScreenFooter.tsx
+++ b/src/components/ScreenFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, ViewProps } from 'react-native';
+import { ViewProps } from 'react-native';
 import ScreenFooterNativeComponent from '../fabric/ScreenFooterNativeComponent';
 
 /**
@@ -14,11 +14,7 @@ type FooterProps = {
 };
 
 export function FooterComponent({ children }: FooterProps) {
-  return (
-    <ScreenFooter collapsable={false}>
-      <View collapsable>{children}</View>
-    </ScreenFooter>
-  );
+  return <ScreenFooter collapsable={false}>{children}</ScreenFooter>;
 }
 
 export default ScreenFooter;

--- a/src/components/ScreenFooter.tsx
+++ b/src/components/ScreenFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewProps } from 'react-native';
+import { View, ViewProps } from 'react-native';
 import ScreenFooterNativeComponent from '../fabric/ScreenFooterNativeComponent';
 
 /**
@@ -14,7 +14,11 @@ type FooterProps = {
 };
 
 export function FooterComponent({ children }: FooterProps) {
-  return <ScreenFooter collapsable={false}>{children}</ScreenFooter>;
+  return (
+    <ScreenFooter collapsable={false}>
+      <View collapsable>{children}</View>
+    </ScreenFooter>
+  );
 }
 
 export default ScreenFooter;

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -84,6 +84,7 @@ export interface NativeProps extends ViewProps {
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;
   sheetAllowedDetents?: number[];
+  sheetDismissible?: boolean;
   sheetLargestUndimmedDetent?: WithDefault<Int32, -1>;
   sheetGrabberVisible?: WithDefault<boolean, false>;
   sheetCornerRadius?: WithDefault<Float, -1.0>;

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -23,6 +23,10 @@ type TransitionProgressEvent = Readonly<{
   goingForward: Int32;
 }>;
 
+type SheetTranslationEvent = Readonly<{
+  y: Double;
+}>;
+
 type HeaderHeightChangeEvent = Readonly<{
   headerHeight: Double;
 }>;
@@ -75,6 +79,7 @@ export interface NativeProps extends ViewProps {
   onWillDisappear?: DirectEventHandler<ScreenEvent>;
   onHeaderHeightChange?: DirectEventHandler<HeaderHeightChangeEvent>;
   onTransitionProgress?: DirectEventHandler<TransitionProgressEvent>;
+  onSheetTranslation?: DirectEventHandler<SheetTranslationEvent>;
   onGestureCancel?: DirectEventHandler<ScreenEvent>;
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -84,6 +84,7 @@ export interface NativeProps extends ViewProps {
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;
   sheetAllowedDetents?: number[];
+  sheetDismissible?: boolean;
   sheetLargestUndimmedDetent?: WithDefault<Int32, -1>;
   sheetGrabberVisible?: WithDefault<boolean, false>;
   sheetCornerRadius?: WithDefault<Float, -1.0>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -23,6 +23,10 @@ type TransitionProgressEvent = Readonly<{
   goingForward: Int32;
 }>;
 
+type SheetTranslationEvent = Readonly<{
+  y: Double;
+}>;
+
 type HeaderHeightChangeEvent = Readonly<{
   headerHeight: Double;
 }>;
@@ -75,6 +79,7 @@ export interface NativeProps extends ViewProps {
   onWillDisappear?: DirectEventHandler<ScreenEvent>;
   onHeaderHeightChange?: DirectEventHandler<HeaderHeightChangeEvent>;
   onTransitionProgress?: DirectEventHandler<TransitionProgressEvent>;
+  onSheetTranslation?: DirectEventHandler<SheetTranslationEvent>;
   onGestureCancel?: DirectEventHandler<ScreenEvent>;
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,3 +54,4 @@ export {
  * Hooks
  */
 export { default as useTransitionProgress } from './useTransitionProgress';
+export { default as useSheetTranslation } from './useSheetTranslation';

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -396,6 +396,13 @@ export type NativeStackNavigationOptions = {
    */
   sheetAllowedDetents?: ScreenProps['sheetAllowedDetents'] | 'fitToContents';
   /**
+   * Whether you can interactively dismiss a sheet.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   *
+   * Defaults to `true`.
+   */
+  sheetDismissible?: boolean;
+  /**
    * Integer value describing elevation of the sheet, impacting shadow on the top edge of the sheet.
    *
    * Not dynamic.

--- a/src/native-stack/views/NativeStackView.tsx
+++ b/src/native-stack/views/NativeStackView.tsx
@@ -208,6 +208,7 @@ const RouteView = ({
     sheetElevation = 24,
     sheetExpandsWhenScrolledToEdge = true,
     sheetInitialDetentIndex = 0,
+    sheetDismissible = true,
     nativeBackButtonDismissalEnabled = false,
     navigationBarColor,
     navigationBarTranslucent,
@@ -332,6 +333,7 @@ const RouteView = ({
       sheetCornerRadius={sheetCornerRadius}
       sheetElevation={sheetElevation}
       sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
+      sheetDismissible={sheetDismissible}
       customAnimationOnSwipe={customAnimationOnSwipe}
       freezeOnBlur={freezeOnBlur}
       fullScreenSwipeEnabled={fullScreenSwipeEnabled}

--- a/src/reanimated/ReanimatedNativeStackScreen.tsx
+++ b/src/reanimated/ReanimatedNativeStackScreen.tsx
@@ -61,7 +61,7 @@ const ReanimatedNativeStackScreen = React.forwardRef<
   const closing = useSharedValue(0);
   const goingForward = useSharedValue(0);
 
-  const translationY = useSharedValue(0);
+  const translationY = useSharedValue(dimensions.height);
 
   return (
     <AnimatedScreen
@@ -91,11 +91,10 @@ const ReanimatedNativeStackScreen = React.forwardRef<
           translationY.value = event.y;
         },
         [
-          // This should not be necessary, but is not properly managed by `react-native-reanimated`
           // @ts-ignore wrong type
           Platform.OS === 'android'
             ? 'onSheetTranslation'
-            : // for some reason there is a difference in required event name between architectures
+            :
             ENABLE_FABRIC
             ? 'onSheetTranslation'
             : 'topSheetTranslation',

--- a/src/reanimated/ReanimatedNativeStackScreen.tsx
+++ b/src/reanimated/ReanimatedNativeStackScreen.tsx
@@ -94,8 +94,7 @@ const ReanimatedNativeStackScreen = React.forwardRef<
           // @ts-ignore wrong type
           Platform.OS === 'android'
             ? 'onSheetTranslation'
-            :
-            ENABLE_FABRIC
+            : ENABLE_FABRIC
             ? 'onSheetTranslation'
             : 'topSheetTranslation',
         ],

--- a/src/reanimated/ReanimatedSheetTranslationContext.tsx
+++ b/src/reanimated/ReanimatedSheetTranslationContext.tsx
@@ -2,4 +2,6 @@ import * as React from 'react';
 // @ts-ignore file to be used only if `react-native-reanimated` available in the project
 import Animated from 'react-native-reanimated';
 
-export default React.createContext<Animated.SharedValue<number> | undefined>(undefined);
+export default React.createContext<Animated.SharedValue<number> | undefined>(
+  undefined,
+);

--- a/src/reanimated/ReanimatedSheetTranslationContext.tsx
+++ b/src/reanimated/ReanimatedSheetTranslationContext.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+// @ts-ignore file to be used only if `react-native-reanimated` available in the project
+import Animated from 'react-native-reanimated';
+
+export default React.createContext<Animated.SharedValue<number> | undefined>(undefined);

--- a/src/reanimated/index.tsx
+++ b/src/reanimated/index.tsx
@@ -1,3 +1,4 @@
 export { default as ReanimatedScreenProvider } from './ReanimatedScreenProvider';
 export { default as useReanimatedTransitionProgress } from './useReanimatedTransitionProgress';
+export { default as useReanimatedSheetTranslation } from './useReanimatedSheetTranslation';
 export { default as useReanimatedHeaderHeight } from './useReanimatedHeaderHeight';

--- a/src/reanimated/useReanimatedSheetTranslation.tsx
+++ b/src/reanimated/useReanimatedSheetTranslation.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import ReanimatedSheetTranslationContext from './ReanimatedSheetTranslationContext';
+
+export default function useReanimatedSheetTranslation() {
+  const translation = React.useContext(ReanimatedSheetTranslationContext);
+
+  if (translation === undefined) {
+    throw new Error(
+      "Couldn't find values for reanimated sheet translation. Are you inside a screen in Native Stack?",
+    );
+  }
+
+  return translation;
+}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -264,7 +264,7 @@ export interface ScreenProps extends ViewProps {
     e: NativeSyntheticEvent<TransitionProgressEventType>,
   ) => void;
   /**
-   * An internal callback called every frame during the transition of screens of `native-stack`, used to feed transition context.
+   * An internal callback called every frame during Y translation of the sheet. Use only with `formSheet` presentation.
    */
   onSheetTranslation?: (
     e: NativeSyntheticEvent<SheetTranslationEventType>,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -333,6 +333,13 @@ export interface ScreenProps extends ViewProps {
    */
   sheetAllowedDetents?: number[] | 'fitToContents' | 'medium' | 'large' | 'all';
   /**
+   * Whether you can interactively dismiss a sheet.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   *
+   * Defaults to `true`.
+   */
+  sheetDismissible?: boolean;
+  /**
    * Integer value describing elevation of the sheet, impacting shadow on the top edge of the sheet.
    *
    * Not dynamic - changing it after the component is rendered won't have an effect.

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -91,6 +91,10 @@ export type TransitionProgressEventType = {
   goingForward: number;
 };
 
+export type SheetTranslationEventType = {
+  y: number;
+};
+
 export type GestureResponseDistanceType = {
   start?: number;
   end?: number;
@@ -258,6 +262,12 @@ export interface ScreenProps extends ViewProps {
    */
   onTransitionProgress?: (
     e: NativeSyntheticEvent<TransitionProgressEventType>,
+  ) => void;
+  /**
+   * An internal callback called every frame during the transition of screens of `native-stack`, used to feed transition context.
+   */
+  onSheetTranslation?: (
+    e: NativeSyntheticEvent<SheetTranslationEventType>,
   ) => void;
   /**
    * A callback that gets called when the current screen will appear. This is called as soon as the transition begins.

--- a/src/useSheetTranslation.tsx
+++ b/src/useSheetTranslation.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import SheetTranslationContext from './SheetTranslationContext';
+
+export default function useSheetTranslation() {
+  const translation = React.useContext(SheetTranslationContext);
+
+  if (translation === undefined) {
+    throw new Error(
+      "Couldn't find values for sheet translation. Are you inside a screen in Native Stack?",
+    );
+  }
+
+  return translation;
+}


### PR DESCRIPTION
## Description

This PR introduces new Event for tracking the translation Y value of the sheet when being dragged or presented. This is particularly useful on some use-cases where we want to animate separate views based on the sheet's position e.g. Apple Maps app.

Also added support for Footer on IOS.

## Changes

- Added support for translation Y (position) value event. Includes Reanimated hook.
- Implement Footer on IOS

### TODO:

- [ ] New Arc (IOS): fix footer visual glitches :/
- [ ] New Arc (Android): fix correct translation Y value.

## Test code and steps to reproduce

WIP

| IOS | Android |
| - | - |
| https://github.com/user-attachments/assets/ff8e1cc8-662c-462e-8835-eb3e75b3842a | https://github.com/user-attachments/assets/2464f3db-61d6-4292-855a-3336cc15a645 |

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
