### PR TITLE
fix: use `providers.exec` to enable `configuration-cache`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,10 @@ def resolveReactNativeDirectory() {
     }
 
     // We're in non standard setup, e.g. monorepo - try to use node resolver to locate the react-native package.
-    String maybeRnPackagePath = ["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()
+    String maybeRnPackagePath = providers.exec {
+        workingDir(rootDir)
+        commandLine("node", "--print", "require.resolve('react-native/package.json')")
+    }.standardOutput.asText.get().trim()
 
     File nodeResolverRnDirFile = null
     // file() constructor fails in case string is null or blank


### PR DESCRIPTION
## Description

Fixes:
```
Starting an external process 'node --print require.resolve('react-native/package.json')' during configuration time is unsupported
``` 
when `configuration-cache` is enabled.

## Changes

Replace `execute` with `providers.exec`. You can read more about it here: https://docs.gradle.org/8.13/userguide/configuration_cache.html#config_cache:requirements:external_processes. 

## Test code and steps to reproduce

- build project with `configuration-cache` flag ✅ 