### PR TITLE
fix(Fabric,iOS): header subviews do not support dynamic content changes

### DIFF
--- a/apps/src/tests/Test2714.tsx
+++ b/apps/src/tests/Test2714.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
+import { Text, View, StyleSheet, Button } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
+
+const Stack = createNativeStackNavigator();
+
+function RootStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerBackButtonDisplayMode: 'minimal',
+      }}>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Profile" component={HomeScreen} />
+    </Stack.Navigator>
+  );
+}
+
+const HomeScreen = ({ navigation }: any) => {
+  const [secondButtonShown, setSecondButtonShown] = React.useState(true);
+  const [thirdButtonShown, setThirdButtonShown] = React.useState(true);
+  const [showAllButtons, setShowAllButtons] = React.useState(true);
+  const [isLargeSize, setLargeSize] = React.useState(true);
+
+  const headerRight = React.useCallback(() => {
+    return (
+      <View style={[styles.buttonsView, !showAllButtons && { display: 'none' }]}>
+        <PressableWithFeedback style={isLargeSize ? styles.largeButton : styles.button} onPress={() => console.log(1)}>
+          <Text>1</Text>
+        </PressableWithFeedback>
+        {secondButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(2)}>
+            <Text>2</Text>
+          </PressableWithFeedback>
+        )}
+        {thirdButtonShown && (
+          <PressableWithFeedback style={styles.button} onPress={() => console.log(3)}>
+            <Text>3</Text>
+          </PressableWithFeedback>
+        )}
+        <PressableWithFeedback style={styles.button} onPress={() => console.log('D')}>
+          <Text>[D]</Text>
+        </PressableWithFeedback>
+      </View>
+    );
+  }, [secondButtonShown, thirdButtonShown, showAllButtons, isLargeSize]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: 'pink' },
+      headerRight: headerRight,
+    });
+  }, [navigation, headerRight, showAllButtons]);
+
+  return (
+    <View>
+      <Text>Home Screen</Text>
+      <Button
+        title="Toggle size"
+        onPress={() => setLargeSize(p => !p)}
+      />
+      <Button
+        title="Toggle 2nd button"
+        onPress={() => setSecondButtonShown(p => !p)}
+      />
+      <Button
+        title="Toggle 3rd button"
+        onPress={() => setThirdButtonShown(p => !p)}
+      />
+      <Button
+        title="Toggle All Right Buttons"
+        onPress={() => setShowAllButtons(p => !p)}
+      />
+    </View>
+  );
+};
+
+function SimpleHome() {
+  const navigation = useNavigation();
+  const [isExpanded, setExpanded] = React.useState(false);
+
+  const headerRight = React.useCallback(() => {
+    return (
+      <PressableWithFeedback>
+        <View style={[{ width: 128, height: 42 }, isExpanded ? { width: 192 } : null]} />
+      </PressableWithFeedback>
+    );
+  }, [isExpanded]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight,
+    });
+  }, [headerRight, navigation]);
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'lightsalmon' }}>
+      <Button title="Toggle subview size" onPress={() => setExpanded(val => !val)} />
+      <Button title="Go to HomeScreen" onPress={() => navigation.navigate('HomeScreen')} />
+    </View>
+  );
+}
+
+function SimpleStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="SimpleHome" component={SimpleHome} />
+      <Stack.Screen name="HomeScreen" component={HomeScreen} />
+    </Stack.Navigator>
+  );
+}
+
+// function App() {
+//   return (
+//     <NavigationContainer>
+//       <RootStack />
+//     </NavigationContainer>
+//   );
+// }
+
+function AppSimplified() {
+  return (
+    <NavigationContainer>
+      <SimpleStack />
+    </NavigationContainer>
+  );
+}
+
+// export default App;
+export default AppSimplified;
+
+
+const styles = StyleSheet.create({
+  button: {
+    width: 42,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
+  largeButton: {
+    width: 64,
+    height: 42,
+    marginHorizontal: 5,
+    padding: 5,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'blue',
+  },
+  buttonsView: {
+    flexDirection: 'row',
+    borderWidth: 1,
+  },
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -124,6 +124,7 @@ export { default as Test2611 } from './Test2611';
 export { default as Test2631 } from './Test2631';
 export { default as Test2668 } from './Test2668';
 export { default as Test2675 } from './Test2675';
+export { default as Test2714 } from './Test2714';
 export { default as Test2717 } from './Test2717';
 export { default as Test2767 } from './Test2767';
 export { default as Test2789 } from './Test2789';

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h
@@ -47,6 +47,7 @@ class RNSScreenStackHeaderConfigComponentDescriptor final
 #else
     if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
       layoutableShadowNode.setSize(stateData.frameSize);
+      layoutableShadowNode.setPadding(stateData.edgeInsets);
     }
 #endif // ANDROID
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -17,8 +17,31 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
 
   RNSScreenStackHeaderConfigState() = default;
 
-  // Used in iOS code
-  RNSScreenStackHeaderConfigState(Size frameSize_) : frameSize{frameSize_} {}
+#if !defined(ANDROID)
+  RNSScreenStackHeaderConfigState(Size frameSize_, EdgeInsets edgeInsets_)
+      : frameSize{frameSize_}, edgeInsets{edgeInsets_} {}
+
+  // Make it copyable
+  RNSScreenStackHeaderConfigState(const RNSScreenStackHeaderConfigState &source)
+      : frameSize{source.frameSize}, edgeInsets{source.edgeInsets} {}
+  RNSScreenStackHeaderConfigState &operator=(
+      const RNSScreenStackHeaderConfigState &source) {
+    this->frameSize.width = source.frameSize.width;
+    this->frameSize.height = source.frameSize.height;
+    this->edgeInsets = source.edgeInsets;
+    return *this;
+  }
+
+  bool operator==(const RNSScreenStackHeaderConfigState &other) {
+    return this->frameSize == other.frameSize &&
+        this->edgeInsets == other.edgeInsets;
+  }
+
+  bool operator!=(const RNSScreenStackHeaderConfigState &other) {
+    return this->frameSize != other.frameSize ||
+        this->edgeInsets != other.edgeInsets;
+  }
+#endif
 
 #ifdef ANDROID
   RNSScreenStackHeaderConfigState(
@@ -45,7 +68,11 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
 #endif // !NDEBUG
 #endif // ANDROID
 
-  const Size frameSize{};
+  Size frameSize{};
+
+#if !defined(ANDROID)
+  EdgeInsets edgeInsets{}; // zero initialized
+#endif
 
 #ifdef ANDROID
   Float paddingStart{0.f};

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -35,9 +35,9 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
-    if (!isSizeEmpty(stateData.frameSize)) {
-      layoutableShadowNode.setSize(stateData.frameSize);
-    }
+    //    if (!isSizeEmpty(stateData.frameSize)) {
+    //      layoutableShadowNode.setSize(stateData.frameSize);
+    //    }
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -20,6 +20,7 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
   void adopt(ShadowNode &shadowNode) const override {
+#ifdef ANDROID
     react_native_assert(
         dynamic_cast<RNSScreenStackHeaderSubviewShadowNode *>(&shadowNode));
     auto &subviewShadowNode =
@@ -35,9 +36,10 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
         shadowNode.getState());
     auto stateData = state->getData();
 
-    //    if (!isSizeEmpty(stateData.frameSize)) {
-    //      layoutableShadowNode.setSize(stateData.frameSize);
-    //    }
+    if (!isSizeEmpty(stateData.frameSize)) {
+      layoutableShadowNode.setSize(stateData.frameSize);
+    }
+#endif
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_END
  * Allows to send information with size to the corresponding node in shadow tree.
  * This method updates state of header config shadow node only.
  */
-- (void)updateHeaderConfigState:(CGSize)size;
+- (void)updateShadowStateWithSize:(CGSize)size edgeInsets:(NSDirectionalEdgeInsets)edgeInsets;
 
 /**
  * Updates state of header config shadow node and all subview shadow nodes in context of given UINavigationBar.

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -231,8 +231,7 @@ RNS_IGNORE_SUPER_CALL_END
 
   [self updateHeaderConfigState:navigationBar.frame.size];
   for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {
-    CGRect frameInNavBarCoordinates = [subview convertRect:subview.frame toView:navigationBar];
-    [subview updateHeaderSubviewFrameInShadowTree:frameInNavBarCoordinates];
+    [subview updateShadowStateInContextOfAncestorView:navigationBar];
   }
 }
 #else

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -21,7 +21,30 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) UIView *reactSuperview;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-- (void)updateHeaderSubviewFrameInShadowTree:(CGRect)frame;
+/**
+ * Updates state of the header subview shadow node in shadow tree.
+ * This method updates state of header subview shadow node only.
+ */
+- (void)updateShadowStateWithFrame:(CGRect)frame;
+
+/**
+ * Updates state of the header subview shadow node in shadow tree in context of given ancestor view.
+ * This method updates state of header subview shadow node only.
+ *
+ * @param ancestorView - ancestor view in relation to which, the frame send in state update is computed; if this is
+ * `nil` the method does nothing.
+ */
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView;
+
+/**
+ * Updates state of the header subview shadow node in shadow tree in context of given ancestor view.
+ * This method updates state of header subview shadow node only.
+ *
+ * @param ancestorView ancestor view in relation to which, the frame send in state update is computed; if this is
+ * `nil` the method does nothing.
+ * @param frame source frame, which will be transformed in relation to `ancestorView`.
+ */
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView withFrame:(CGRect)frame;
 #endif
 
 @end

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -55,10 +55,7 @@ namespace react = facebook::react;
     return;
   }
 
-  RNSScreenStackHeaderConfig *headerConfig = [self getHeaderConfig];
-  UINavigationController *navctr = headerConfig.screenView.reactViewController.navigationController;
-
-  UIView *toLayoutView = navctr.navigationBar;
+  UIView *toLayoutView = [self findNavigationBar];
 
   // TODO: It is possible, that this needs to be called only on old architecture.
   // Make sure that Test432 keeps working.

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -39,6 +39,11 @@ namespace react = facebook::react;
   return headerConfig;
 }
 
+- (nullable UINavigationBar *)findNavigationBar
+{
+  return [[[[[self getHeaderConfig] screenView] reactViewController] navigationController] navigationBar];
+}
+
 // We're forcing the navigation controller's view to re-layout
 // see: https://github.com/software-mansion/react-native-screens/pull/2385
 - (void)layoutNavigationBar
@@ -67,6 +72,42 @@ namespace react = facebook::react;
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #pragma mark - Fabric specific
+
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView withFrame:(CGRect)frame
+{
+  if (ancestorView == nil) {
+    // We can not compute valid value
+    return;
+  }
+
+  CGRect convertedFrame = [self convertRect:frame toView:ancestorView];
+  [self updateShadowStateWithFrame:convertedFrame];
+}
+
+- (void)updateShadowStateInContextOfAncestorView:(nullable UIView *)ancestorView
+{
+  [self updateShadowStateInContextOfAncestorView:ancestorView withFrame:self.frame];
+}
+
+- (void)updateShadowStateWithFrame:(CGRect)frame
+{
+  if (_state == nullptr) {
+    return;
+  }
+
+  if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
+    auto newState =
+        react::RNSScreenStackHeaderSubviewState(RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin));
+    _state->updateState(std::move(newState));
+    _lastScheduledFrame = frame;
+  }
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self updateShadowStateInContextOfAncestorView:[self findNavigationBar]];
+}
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
 + (void)load
@@ -137,20 +178,6 @@ RNS_IGNORE_SUPER_CALL_BEGIN
            oldState:(const facebook::react::State::Shared &)oldState
 {
   _state = std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(state);
-}
-
-- (void)updateHeaderSubviewFrameInShadowTree:(CGRect)frame
-{
-  if (_state == nullptr) {
-    return;
-  }
-
-  if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
-    auto newState =
-        react::RNSScreenStackHeaderSubviewState(RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin));
-    _state->updateState(std::move(newState));
-    _lastScheduledFrame = frame;
-  }
 }
 #else // RCT_NEW_ARCH_ENABLED
 #pragma mark - Paper specific


### PR DESCRIPTION
## Description

Regression most likely introduced in 4.5.0 by #2466.
Fixes #2714
Fixes #2815
Supersedes #2845


This is a ugly hack to workaround issue with dynamic content change.
When the size of this shadow node contents (children) change due to JS
update, e.g. new icon is added, if the size is set for the yogaNode
corresponding to this shadow node, the enforced size will be used
and the size won't be updated by Yoga to reflect the contents size
change -> host tree won't get layout metrics update -> we won't trigger native
layout -> the views in header will be positioned incorrectly.

> [!important]
> This PR handles iOS only, however there is **similar** issue on Android. The issue can be reproduced on the same test example. Android will be handled in separate PR.

## Changes

## Test code and steps to reproduce

In this approach I've settled with:

1. not calling set size on iOS for `RNSScreenStackHeaderSubviewShadowNode`,
2. updating header config padding & sending it as state to shadow tree.

Added `Test2714`

Most of the fragile header interactions must be tested:

* [x] Header title truncation - `TestHeaderTitle` ~❌ This PR introduces regression here on iOS (Android not tested yet)~ ✅ Works
* [x] Pressables in header - `Test2466` (iOS works, Android code is unmodified here)
* [x] https://github.com/software-mansion/react-native-screens/pull/2807 (this PR does not touch Android)
* [x] https://github.com/software-mansion/react-native-screens/pull/2811 (this PR does not touch Android)
* [x] https://github.com/software-mansion/react-native-screens/pull/2812 (this PR does not touch Android)
* [x] Header behaviour on orientation changes - https://github.com/software-mansion/react-native-screens/pull/2756 (this PR does not touch Android)
* [x] New test `Test2714` handling header item resizing.
## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes


