### PR TITLE
chore(iOS): fix XCode symbol discovery for methods surrounded with `RNS_IGNORE_SUPER_CALL_BEGIN`

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -209,8 +209,8 @@
   [childComponentView removeFromSuperview];
 }
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 // We do not set frame for ouselves, but rather for the container.
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)updateLayoutMetrics:(react::LayoutMetrics const &)layoutMetrics
            oldLayoutMetrics:(react::LayoutMetrics const &)oldLayoutMetrics
 {
@@ -226,7 +226,6 @@ RNS_IGNORE_SUPER_CALL_BEGIN
   _reactFrame = frame;
   [_container setFrame:frame];
 }
-
 RNS_IGNORE_SUPER_CALL_END
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -139,14 +139,14 @@ struct ContentWrapperBox {
   return _controller;
 }
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 #ifdef RCT_NEW_ARCH_ENABLED
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (NSArray<UIView *> *)reactSubviews
 {
   return _reactSubviews;
 }
-#endif
 RNS_IGNORE_SUPER_CALL_END
+#endif
 
 - (void)updateBounds
 {

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -90,9 +90,9 @@ namespace react = facebook::react;
   [self updateContainer];
 }
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 // We do not call super as we do not want to update UIKit model. It will
 // be updated after we receive all mutations.
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex
 {
   subview.reactSuperview = self;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -761,7 +761,7 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 {
   [_reactSubviews removeObject:subview];
 }
-RNS_IGNORE_SUPER_CALL_BEGIN
+RNS_IGNORE_SUPER_CALL_END
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - Fabric specific

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -126,7 +126,7 @@ RNS_IGNORE_SUPER_CALL_BEGIN
     [self layoutNavigationBar];
   }
 }
-RNS_IGNORE_SUPER_CALL_BEGIN
+RNS_IGNORE_SUPER_CALL_END
 
 + (BOOL)shouldBeRecycled
 {

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -105,8 +105,8 @@ namespace react = facebook::react;
   return react::concreteComponentDescriptorProvider<react::RNSScreenStackHeaderSubviewComponentDescriptor>();
 }
 
-RNS_IGNORE_SUPER_CALL_BEGIN
 // System layouts the subviews.
+RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
 {


### PR DESCRIPTION

## Description

Some pragmas were paired incorrectly (BEGIN & BEGIN instead of BEGIN & END) & for some reason, if there is whitespace 
between `RNS_IGNORE_SUPER_CALL_BEGIN` and first method below it, XCode won't include that method in method list (triggered by Ctrl+6), similarly 
"goto definition" won't work...

## Changes

Fixed above :point_up:

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
