### PR TITLE
fix(Fabric,Android): header subviews do not support dynamic content changes

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewComponentDescriptor.h
@@ -20,26 +20,9 @@ class RNSScreenStackHeaderSubviewComponentDescriptor final
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
   void adopt(ShadowNode &shadowNode) const override {
-#ifdef ANDROID
-    react_native_assert(
-        dynamic_cast<RNSScreenStackHeaderSubviewShadowNode *>(&shadowNode));
-    auto &subviewShadowNode =
-        static_cast<RNSScreenStackHeaderSubviewShadowNode &>(shadowNode);
-
-    react_native_assert(
-        dynamic_cast<YogaLayoutableShadowNode *>(&subviewShadowNode));
-    auto &layoutableShadowNode =
-        dynamic_cast<YogaLayoutableShadowNode &>(subviewShadowNode);
-
-    auto state = std::static_pointer_cast<
-        const RNSScreenStackHeaderSubviewShadowNode::ConcreteState>(
-        shadowNode.getState());
-    auto stateData = state->getData();
-
-    if (!isSizeEmpty(stateData.frameSize)) {
-      layoutableShadowNode.setSize(stateData.frameSize);
-    }
-#endif
+    // Note: Be very careful with calling `shadowNode.setSize` here. By doing
+    // that, you are likely to introduce a regressions on both platforms. See:
+    // https://github.com/software-mansion/react-native-screens/pull/2905
 
     ConcreteComponentDescriptor::adopt(shadowNode);
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens/issues/2714 on Android
Fixes https://github.com/software-mansion/react-native-screens/issues/2815 on Android

See #2905 for detailed description.

## Changes

Removed call to `RNSScreenStaceaderSubviewShadowNode.setSize` in corresponding component descriptor.

It seems that we do not need to enforce node size from HostTree. Setting appropriate content offset is enough for pressables to function correctly (assuming that native layout **does not change size of any subview**). I currently can't come up with any scenario where this would happen. 

## Test code and steps to reproduce

I've tested:

* [x] `Test2714` introduced in PR with iOS fixes - https://github.com/software-mansion/react-native-screens/pull/2905
* [x] Pressables in header - https://github.com/software-mansion/react-native-screens/pull/2466,
* [x] Header title truncation - https://github.com/software-mansion/react-native-screens/pull/2325 (only few cases, as the list is long there) & noticed a regression (not related to this PR, described in comment below the PR description),
* [x] Insets with orientation change (Android) - https://github.com/software-mansion/react-native-screens/pull/2756
* [x] https://github.com/software-mansion/react-native-screens/pull/2807 (on `TestHeaderTitle` with call to `setOptions` in `useLayoutEffect`)
* [x] `Test2811` - https://github.com/software-mansion/react-native-screens/pull/2811
* [x] https://github.com/software-mansion/react-native-screens/pull/2812 (with snippet provided in that PR description)



## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
