### PR TITLE
fix(Android): fix formSheet not adjusting for keyboard when it contains input with autofocus

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
@@ -2,8 +2,6 @@ package com.swmansion.rnscreens
 
 import android.util.Log
 import android.view.View
-import androidx.collection.ArraySet
-import androidx.collection.arraySetOf
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -12,7 +10,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import java.lang.ref.WeakReference
 
 object InsetsObserverProxy : OnApplyWindowInsetsListener, LifecycleEventListener {
-    private val listeners: ArraySet<OnApplyWindowInsetsListener> = arraySetOf()
+    private val listeners: HashSet<OnApplyWindowInsetsListener> = hashSetOf()
     private var eventSourceView: WeakReference<View> = WeakReference(null)
 
     // Please note semantics of this property. This is not `isRegistered`, because somebody, could unregister

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
@@ -2,6 +2,8 @@ package com.swmansion.rnscreens
 
 import android.util.Log
 import android.view.View
+import androidx.collection.ArraySet
+import androidx.collection.arraySetOf
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -10,7 +12,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import java.lang.ref.WeakReference
 
 object InsetsObserverProxy : OnApplyWindowInsetsListener, LifecycleEventListener {
-    private val listeners: ArrayList<OnApplyWindowInsetsListener> = arrayListOf()
+    private val listeners: ArraySet<OnApplyWindowInsetsListener> = arraySetOf()
     private var eventSourceView: WeakReference<View> = WeakReference(null)
 
     // Please note semantics of this property. This is not `isRegistered`, because somebody, could unregister

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -527,6 +527,23 @@ class Screen(
         }
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        // Insets handler for formSheet is added onResume but it is often
+        // too late if we use input with autofocus. It happens because onResume is called after
+        // finishing animator animation. onAttachedToWindow is called before onApplyWindowInsets
+        // so we use it to set the handler earlier.
+        // More details: https://github.com/software-mansion/react-native-screens/pull/2911
+        if (usesFormSheetPresentation()) {
+            (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
+                InsetsObserverProxy.addOnApplyWindowInsetsListener(
+                    it,
+                )
+            }
+        }
+    }
+
     private fun dispatchSheetDetentChanged(
         detentIndex: Int,
         isStable: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -544,12 +544,11 @@ class Screen(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        // Insets handler for formSheet is added onResume but it is often
-        // too late if we use input with autofocus. It happens because onResume is called after
-        // finishing animator animation. onAttachedToWindow is called before onApplyWindowInsets
-        // so we use it to set the handler earlier.
-        // More details: https://github.com/software-mansion/react-native-screens/pull/2911
-        if (usesFormSheetPresentation()) {
+        // Insets handler for formSheet is added onResume but it is often too late if we use input
+        // with autofocus - onResume is called after finishing animator animation.
+        // onAttachedToWindow is called before onApplyWindowInsets so we use it to set the handler
+        // earlier. More details: https://github.com/software-mansion/react-native-screens/pull/2911
+        if (usesFormSheetPresentation() && isNativeStackScreen) {
             (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
                 InsetsObserverProxy.addOnApplyWindowInsetsListener(
                     it,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -31,6 +31,7 @@ import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
+import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.ext.parentAsViewGroup
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
@@ -548,8 +549,8 @@ class Screen(
         // with autofocus - onResume is called after finishing animator animation.
         // onAttachedToWindow is called before onApplyWindowInsets so we use it to set the handler
         // earlier. More details: https://github.com/software-mansion/react-native-screens/pull/2911
-        if (usesFormSheetPresentation() && isNativeStackScreen) {
-            (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
+        if (usesFormSheetPresentation()) {
+            fragment?.asScreenStackFragment()?.sheetDelegate?.let {
                 InsetsObserverProxy.addOnApplyWindowInsetsListener(
                     it,
                 )

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -249,18 +249,6 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     DISPATCH_MODE_STOP,
                 ) {
-                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
-                        // FormSheet's onResume is called after finishing animator animation but adding
-                        // insets handler then is often too late if we use input autofocus.
-                        // This callback's onPrepare is called before onApplyWindowInsets so we use it
-                        // to set the handler earlier.
-                        (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
-                            InsetsObserverProxy.addOnApplyWindowInsetsListener(
-                                it
-                            )
-                        }
-                    }
-
                     override fun onProgress(
                         insets: WindowInsetsCompat,
                         runningAnimations: MutableList<WindowInsetsAnimationCompat>,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -74,7 +74,7 @@ class ScreenStackFragment :
 
     private var dimmingDelegate: DimmingViewManager? = null
 
-    private var sheetDelegate: SheetDelegate? = null
+    internal var sheetDelegate: SheetDelegate? = null
 
     @SuppressLint("ValidFragment")
     constructor(screenView: Screen) : super(screenView)
@@ -249,6 +249,18 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     DISPATCH_MODE_STOP,
                 ) {
+                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                        // FormSheet's onResume is called after finishing animator animation but adding
+                        // insets handler then is often too late if we use input autofocus.
+                        // This callback's onPrepare is called before onApplyWindowInsets so we use it
+                        // to set the handler earlier.
+                        (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
+                            InsetsObserverProxy.addOnApplyWindowInsetsListener(
+                                it
+                            )
+                        }
+                    }
+
                     override fun onProgress(
                         insets: WindowInsetsCompat,
                         runningAnimations: MutableList<WindowInsetsAnimationCompat>,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -175,24 +175,9 @@ class SheetDelegate(
             }
 
             is KeyboardVisible -> {
-                // This code currently does not work (changing maxHeight requires relayout)
-                // but it creates visual glitch when closing formSheet with keyboard still open.
-                // Decided to temporarily comment it out.
-                // More details: https://github.com/software-mansion/react-native-screens/pull/2911
-
-                // val newMaxHeight =
-                //     if (behavior.maxHeight - keyboardState.height > 1) {
-                //         behavior.maxHeight - keyboardState.height
-                //     } else {
-                //         behavior.maxHeight
-                //     }
-
-                val newMaxHeight = behavior.maxHeight
-
                 when (screen.sheetDetents.count()) {
                     1 ->
                         behavior.apply {
-                            useSingleDetent(height = newMaxHeight)
                             addBottomSheetCallback(keyboardHandlerCallback)
                         }
 
@@ -200,7 +185,6 @@ class SheetDelegate(
                         behavior.apply {
                             useTwoDetents(
                                 state = BottomSheetBehavior.STATE_EXPANDED,
-                                secondHeight = newMaxHeight,
                             )
                             addBottomSheetCallback(keyboardHandlerCallback)
                         }
@@ -210,7 +194,6 @@ class SheetDelegate(
                             useThreeDetents(
                                 state = BottomSheetBehavior.STATE_EXPANDED,
                             )
-                            maxHeight = newMaxHeight
                             addBottomSheetCallback(keyboardHandlerCallback)
                         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -175,12 +175,20 @@ class SheetDelegate(
             }
 
             is KeyboardVisible -> {
-                val newMaxHeight =
-                    if (behavior.maxHeight - keyboardState.height > 1) {
-                        behavior.maxHeight - keyboardState.height
-                    } else {
-                        behavior.maxHeight
-                    }
+                // This code currently does not work (changing maxHeight requires relayout)
+                // but it creates visual glitch when closing formSheet with keyboard still open.
+                // Decided to temporarily comment it out.
+                // More details: https://github.com/software-mansion/react-native-screens/pull/2911
+
+                // val newMaxHeight =
+                //     if (behavior.maxHeight - keyboardState.height > 1) {
+                //         behavior.maxHeight - keyboardState.height
+                //     } else {
+                //         behavior.maxHeight
+                //     }
+
+                val newMaxHeight = behavior.maxHeight
+
                 when (screen.sheetDetents.count()) {
                     1 ->
                         behavior.apply {

--- a/android/src/main/java/com/swmansion/rnscreens/ext/FragmentExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/FragmentExt.kt
@@ -1,0 +1,6 @@
+package com.swmansion.rnscreens.ext
+
+import androidx.fragment.app.Fragment
+import com.swmansion.rnscreens.ScreenStackFragment
+
+internal fun Fragment.asScreenStackFragment() = this as ScreenStackFragment


### PR DESCRIPTION
## Description

Sometimes, formSheet that contains input with autoFocus would not account for the keyboard and would remain behind it. This is because `SheetDelegate` is set as a `OnApplyWindowInsetsListener` when fragment is resumed - this happens after finishing formSheet entering animations (animators impact fragment lifecycle). Sometimes, IME insets were applied before this handler was set. Now, we can use `WindowInsetsAnimationCallback` added in [this PR](https://github.com/software-mansion/react-native-screens/pull/2909). Its `onPrepare` method is called before `onApplyWindowInsets` therefore making it possible to set `OnApplyWindowInsetsListener` in time.

## Changes

- change `insetsObserverProxy`'s `listeners` to `HashSet` (we might try to add the same listener multiple times)
- override `onPrepare` method in `WindowInsetsAnimationCallback`
- change visibility of `SheetDelegate` to `internal`

## Test code and steps to reproduce

Open `Test2895` screen in the example app, open & close the formSheet (multiple times).

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
