### PR TITLE
feat(Android): deprecate status/navigation bar edge to edge related props in native code

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -362,6 +362,10 @@ class Screen(
             fragmentWrapper?.let { ScreenWindowTraits.setHidden(this, it.tryGetActivity()) }
         }
 
+    @Deprecated(
+        "For apps targeting SDK 35 or above this prop has no effect because " +
+            "edge-to-edge is enabled by default and the status bar is always translucent.",
+    )
     var isStatusBarTranslucent: Boolean? = null
         set(statusBarTranslucent) {
             if (statusBarTranslucent != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -381,6 +381,10 @@ class Screen(
             }
         }
 
+    @Deprecated(
+        "For apps targeting SDK 35 or above this prop has no effect because " +
+            "edge-to-edge is enabled by default and the status bar is always translucent.",
+    )
     var statusBarColor: Int? = null
         set(statusBarColor) {
             if (statusBarColor != null) {
@@ -396,6 +400,9 @@ class Screen(
             }
         }
 
+    @Deprecated(
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. ",
+    )
     var navigationBarColor: Int? = null
         set(navigationBarColor) {
             if (navigationBarColor != null) {
@@ -410,6 +417,9 @@ class Screen(
             }
         }
 
+    @Deprecated(
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. ",
+    )
     var isNavigationBarTranslucent: Boolean? = null
         set(navigationBarTranslucent) {
             if (navigationBarTranslucent != null) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -2,7 +2,6 @@ package com.swmansion.rnscreens
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
-import android.annotation.TargetApi
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.graphics.Color
@@ -89,7 +88,7 @@ object ScreenWindowTraits {
 
     @Deprecated(
         "For apps targeting SDK 35 or above this prop has no effect because " +
-                "edge-to-edge is enabled by default and the status bar is always translucent."
+            "edge-to-edge is enabled by default and the status bar is always translucent.",
     )
     internal fun setColor(
         screen: Screen,
@@ -149,7 +148,7 @@ object ScreenWindowTraits {
 
     @Deprecated(
         "For apps targeting SDK 35 or above this prop has no effect because " +
-                "edge-to-edge is enabled by default and the status bar is always translucent."
+            "edge-to-edge is enabled by default and the status bar is always translucent.",
     )
     internal fun setTranslucent(
         screen: Screen,
@@ -163,7 +162,6 @@ object ScreenWindowTraits {
         val translucent = screenForTranslucent?.isStatusBarTranslucent ?: false
         UiThreadUtil.runOnUiThread(
             object : GuardedRunnable(context.exceptionHandler) {
-                @TargetApi(Build.VERSION_CODES.LOLLIPOP)
                 override fun runGuarded() {
                     // If the status bar is translucent hook into the window insets calculations
                     // and consume all the top insets so no padding will be added under the status bar.
@@ -204,7 +202,7 @@ object ScreenWindowTraits {
     // Methods concerning navigationBar management were taken from `react-native-navigation`'s repo:
     // https://github.com/wix/react-native-navigation/blob/9bb70d81700692141a2c505c081c2d86c7f9c66e/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
     @Deprecated(
-        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. "
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. ",
     )
     internal fun setNavigationBarColor(
         screen: Screen,
@@ -227,7 +225,7 @@ object ScreenWindowTraits {
     }
 
     @Deprecated(
-        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. "
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. ",
     )
     internal fun setNavigationBarTranslucent(
         screen: Screen,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -231,7 +231,7 @@ object ScreenWindowTraits {
         screen: Screen,
         activity: Activity?,
     ) {
-        if (activity == null) {
+        if (activity == null || EdgeToEdgePackageDetector.ENABLED) {
             return
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -87,6 +87,10 @@ object ScreenWindowTraits {
         activity.requestedOrientation = orientation
     }
 
+    @Deprecated(
+        "For apps targeting SDK 35 or above this prop has no effect because " +
+                "edge-to-edge is enabled by default and the status bar is always translucent."
+    )
     internal fun setColor(
         screen: Screen,
         activity: Activity?,
@@ -199,6 +203,9 @@ object ScreenWindowTraits {
 
     // Methods concerning navigationBar management were taken from `react-native-navigation`'s repo:
     // https://github.com/wix/react-native-navigation/blob/9bb70d81700692141a2c505c081c2d86c7f9c66e/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+    @Deprecated(
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. "
+    )
     internal fun setNavigationBarColor(
         screen: Screen,
         activity: Activity?,
@@ -219,6 +226,9 @@ object ScreenWindowTraits {
         window.navigationBarColor = color
     }
 
+    @Deprecated(
+        "For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default. "
+    )
     internal fun setNavigationBarTranslucent(
         screen: Screen,
         activity: Activity?,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -18,7 +18,7 @@ import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.swmansion.rnscreens.Screen.WindowTraits
-import com.swmansion.rnscreens.utils.EdgeToEdge
+import com.swmansion.rnscreens.utils.EdgeToEdgePackageDetector
 
 object ScreenWindowTraits {
     // Methods concerning statusBar management were taken from `react-native`'s status bar module:
@@ -155,7 +155,7 @@ object ScreenWindowTraits {
         activity: Activity?,
         context: ReactContext?,
     ) {
-        if (activity == null || context == null || EdgeToEdge.ENABLED) {
+        if (activity == null || context == null || EdgeToEdgePackageDetector.ENABLED) {
             return
         }
         val screenForTranslucent = findScreenForTrait(screen, WindowTraits.TRANSLUCENT)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenWindowTraits.kt
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.swmansion.rnscreens.Screen.WindowTraits
+import com.swmansion.rnscreens.utils.EdgeToEdge
 
 object ScreenWindowTraits {
     // Methods concerning statusBar management were taken from `react-native`'s status bar module:
@@ -142,12 +143,16 @@ object ScreenWindowTraits {
         }
     }
 
+    @Deprecated(
+        "For apps targeting SDK 35 or above this prop has no effect because " +
+                "edge-to-edge is enabled by default and the status bar is always translucent."
+    )
     internal fun setTranslucent(
         screen: Screen,
         activity: Activity?,
         context: ReactContext?,
     ) {
-        if (activity == null || context == null) {
+        if (activity == null || context == null || EdgeToEdge.ENABLED) {
             return
         }
         val screenForTranslucent = findScreenForTrait(screen, WindowTraits.TRANSLUCENT)

--- a/android/src/main/java/com/swmansion/rnscreens/utils/EdgeToEdge.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/EdgeToEdge.kt
@@ -1,0 +1,13 @@
+package com.swmansion.rnscreens.utils
+
+// https://github.com/zoontek/react-native-edge-to-edge/blob/main/react-native-is-edge-to-edge/README.md
+object EdgeToEdge {
+    // we cannot detect edge-to-edge, but we can detect react-native-edge-to-edge install
+    val ENABLED: Boolean =
+        try {
+            Class.forName("com.zoontek.rnedgetoedge.EdgeToEdgePackage")
+            true
+        } catch (exception: ClassNotFoundException) {
+            false
+        }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/utils/EdgeToEdgePackageDetector.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/EdgeToEdgePackageDetector.kt
@@ -1,7 +1,7 @@
 package com.swmansion.rnscreens.utils
 
 // https://github.com/zoontek/react-native-edge-to-edge/blob/main/react-native-is-edge-to-edge/README.md
-object EdgeToEdge {
+object EdgeToEdgePackageDetector {
     // we cannot detect edge-to-edge, but we can detect react-native-edge-to-edge install
     val ENABLED: Boolean =
         try {


### PR DESCRIPTION
## Description

Deprecate native props and methods related to status/navigation bars that will be no longer relevant after edge-to-edge is enforced (they were deprecated already in this PR: https://github.com/software-mansion/react-native-screens/pull/2638).

## Changes

- deprecate deprecate status/navigation bar edge to edge related props in native code
- add EdgeToEdge detection utility
- prevent adding `ScreenWindowTraits`' `windowInsetsListener` to `InsetsObserverProxy` if edge-to-edge is enabled

## Checklist

- [ ] Ensured that CI passes
