### PR TITLE
fix: remove global ref when invalidating module

### DIFF
--- a/android/src/main/cpp/jni-adapter.cpp
+++ b/android/src/main/cpp/jni-adapter.cpp
@@ -94,6 +94,16 @@ Java_com_swmansion_rnscreens_ScreensModule_nativeInstall(
       std::move(rnScreensModuleHostObject));
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_swmansion_rnscreens_ScreensModule_nativeUninstall(
+        JNIEnv *env,
+        jobject thiz) {
+    if (globalThis != nullptr) {
+        env->DeleteGlobalRef(globalThis);
+        globalThis = nullptr;
+    }
+}
+
 void JNICALL JNI_OnUnload(JavaVM *jvm, void *) {
   JNIEnv *env;
   if (jvm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
@@ -35,6 +35,13 @@ class ScreensModule(
 
     private external fun nativeInstall(jsiPtr: Long)
 
+    private external fun nativeUninstall()
+
+    override fun invalidate() {
+        super.invalidate()
+        nativeUninstall()
+    }
+
     override fun initialize() {
         super.initialize()
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Right now, when removing React Native instance in brownfield apps, the `ScreensModule` cpp side is kept in memory until the whole app is killed. This code removes global ref when invalidating the module too. It fixes memleaks e.g. in Expensify App.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

You'd need brownfield app so no repro attached. Try remove and add RN instance to native android app a couple of times, then do a heap dump in AS and check for `ScreensModule` instances with 0 depth in its references.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
