### PR TITLE
fix(iOS): pressables in header not working when hosting screen has modal presentation

### DIFF
--- a/apps/src/tests/Test2842.tsx
+++ b/apps/src/tests/Test2842.tsx
@@ -1,0 +1,62 @@
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import { NativeStackNavigationProp, createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+import { styles } from '../shared/styles';
+import { Button, Text, View } from 'react-native';
+import { Rectangle } from '../shared/Rectangle';
+import PressableWithFeedback from '../shared/PressableWithFeedback';
+
+interface StackParamList extends ParamListBase {
+  Home: undefined;
+  Modal: undefined;
+}
+
+interface StackNavigationProps {
+  navigation: NativeStackNavigationProp<StackParamList>;
+}
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+function Home({ navigation }: StackNavigationProps) {
+  return (
+    <View style={[styles.flexContainer, { backgroundColor: 'darkorange' }]}>
+      <Text>Home</Text>
+      <Button title="Open modal" onPress={() => navigation.navigate('Modal')} />
+    </View>
+  );
+}
+
+function Modal({ navigation }: StackNavigationProps) {
+  return (
+    <View style={[styles.flexContainer, { backgroundColor: 'lightblue' }]}>
+      <Text>Modal</Text>
+      <Button title="Close modal" onPress={() => navigation.pop()} />
+    </View>
+  );
+}
+
+function HeaderRight() {
+  return (
+    <PressableWithFeedback>
+      <Rectangle width={128} height={36} color={'lightgreen'} style={{ borderRadius: 16 }} />
+    </PressableWithFeedback>
+  );
+}
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} options={{
+          headerRight: HeaderRight,
+        }} />
+        <Stack.Screen name="Modal" component={Modal} options={{
+          presentation: 'modal',
+          headerRight: HeaderRight,
+        }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default App;

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -131,6 +131,7 @@ export { default as Test2789 } from './Test2789';
 export { default as Test2809 } from './Test2809';
 export { default as Test2811 } from './Test2811';
 export { default as Test2819 } from './Test2819';
+export { default as Test2842 } from './Test2842';
 export { default as Test2855 } from './Test2855';
 export { default as Test2877 } from './Test2877'; // [E2E created](iOS): issue is related to formSheet on iOS
 export { default as Test2895 } from './Test2895';


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
