### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 662..691

### DIFF
--- a/FabricExample/e2e/issuesTests/Test691.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test691.e2e.ts
@@ -1,0 +1,45 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS } from '../e2e-utils';
+
+// issue related to iOS modal behavior
+describeIfiOS('Test691', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test691 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test691')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test691'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test691')).tap();
+  });
+
+  it('modal on tab1 should open', async () => {
+    await expect(element(by.text('This is a first screen!'))).toBeVisible();
+
+    await element(by.id('first-button-open-modal')).tap();
+
+    await expect(element(by.text('This is a first screen!'))).not.toBeVisible();
+    await expect(element(by.text('This is a modal screen!'))).toBeVisible();
+  });
+
+  it('switching tabs should not hide the modal', async () => {
+    await element(by.id('modal-button-go-to-tab2')).tap();
+
+    await expect(element(by.text('This is a modal screen!'))).toBeVisible();
+    await expect(element(by.text('This is a first screen!'))).not.toBeVisible();
+    await expect(
+      element(by.text('This is a second screen!')),
+    ).not.toBeVisible();
+  });
+
+  it('closing the modal should reveal changed tab', async () => {
+    await element(by.text('Modal')).swipe('down', 'fast');
+
+    await expect(element(by.text('This is a modal screen!'))).not.toBeVisible();
+    await expect(element(by.text('This is a second screen!'))).toBeVisible();
+  });
+});

--- a/apps/src/tests/Test691.js
+++ b/apps/src/tests/Test691.js
@@ -12,7 +12,11 @@ function First({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text style={{ fontSize: 30 }}>This is a first screen!</Text>
-      <Button onPress={() => navigation.navigate('Modal')} title="Modal" />
+      <Button
+        onPress={() => navigation.navigate('Modal')}
+        title="Modal"
+        testID="first-button-open-modal"
+      />
     </View>
   );
 }
@@ -21,7 +25,11 @@ function Modal({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text style={{ fontSize: 30 }}>This is a modal screen!</Text>
-      <Button onPress={() => navigation.navigate('Tab2')} title="Tab2" />
+      <Button
+        onPress={() => navigation.navigate('Tab2')}
+        title="Tab2"
+        testID="modal-button-go-to-tab2"
+      />
     </View>
   );
 }

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -22,7 +22,7 @@ export { default as Test649 } from './Test649';     // [E2E created](iOS): heade
 export { default as Test654 } from './Test654';     // [E2E created](iOS): issue related to iOS native back button
 export { default as Test658 } from './Test658';     // [E2E created]
 export { default as Test662 } from './Test662';     // [E2E skipped]: can't check animation in a meaningful way
-export { default as Test691 } from './Test691';
+export { default as Test691 } from './Test691';     // [E2E created](iOS): issue related to iOS modal behavior
 export { default as Test702 } from './Test702';
 export { default as Test706 } from './Test706';
 export { default as Test713 } from './Test713';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -21,7 +21,7 @@ export { default as Test648 } from './Test648';     // [E2E skipped]: can't chec
 export { default as Test649 } from './Test649';     // [E2E created](iOS): headerLargeTitle is supported only on iOS
 export { default as Test654 } from './Test654';     // [E2E created](iOS): issue related to iOS native back button
 export { default as Test658 } from './Test658';     // [E2E created]
-export { default as Test662 } from './Test662';
+export { default as Test662 } from './Test662';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test691 } from './Test691';
 export { default as Test702 } from './Test702';
 export { default as Test706 } from './Test706';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test662, Test691` and implement them if possible for Fabric. 

### Test662
Skipped because we can't check new animation in any meaningful way.

### Test691
Test created, only on iOS (original issue was related to iOS modal behavior - on Android `presentation: 'modal'` screens are regular screens so their behavior differs). It checks if modal remains open after changing the tab.

## Changes

- add `Test691` e2e test
- add testIDs to `Test691` test screen
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [ ] Ensured that CI passes
