### PR TITLE
chore(example): add shared, reusable color values

### DIFF
--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -38,6 +38,8 @@ import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import * as Tests from './src/tests';
+import { ScreensDarkTheme, ScreensLightTheme } from './src/shared/styling/adapter/react-navigation';
+import Colors from './src/shared/styling/Colors';
 
 function isPlatformReady(name: keyof typeof SCREENS) {
   if (Platform.isTV) {
@@ -153,29 +155,29 @@ const examples = screens.filter(name => SCREENS[name].type === 'example');
 const playgrounds = screens.filter(name => SCREENS[name].type === 'playground');
 const tests = isTestSectionEnabled()
   ? screens
-      .filter(name => SCREENS[name].type === 'test')
-      .sort((name1, name2) => {
-        const testNumber1 = Number(name1.substring(4));
-        const testNumber2 = Number(name2.substring(4));
+    .filter(name => SCREENS[name].type === 'test')
+    .sort((name1, name2) => {
+      const testNumber1 = Number(name1.substring(4));
+      const testNumber2 = Number(name2.substring(4));
 
-        if (Number.isNaN(testNumber1) && Number.isNaN(testNumber2)) {
-          return 0;
-        } else if (Number.isNaN(testNumber1)) {
-          return 1;
-        } else if (Number.isNaN(testNumber2)) {
-          return -1;
-        } else {
-          return testNumber1 - testNumber2;
-        }
-      })
+      if (Number.isNaN(testNumber1) && Number.isNaN(testNumber2)) {
+        return 0;
+      } else if (Number.isNaN(testNumber1)) {
+        return 1;
+      } else if (Number.isNaN(testNumber2)) {
+        return -1;
+      } else {
+        return testNumber1 - testNumber2;
+      }
+    })
   : [];
 
 type RootStackParamList = {
   Main: undefined;
   Tests: undefined;
 } & {
-  [P in keyof typeof SCREENS]: undefined;
-};
+    [P in keyof typeof SCREENS]: undefined;
+  };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -258,15 +260,14 @@ const ExampleApp = (): React.JSX.Element => {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <GestureDetectorProvider>
         <ThemeToggle.Provider value={{ toggleTheme }}>
-          <NavigationContainer theme={isDark ? DarkTheme : DefaultTheme}>
+          <NavigationContainer theme={isDark ? ScreensDarkTheme : ScreensLightTheme}>
             <Stack.Navigator
               screenOptions={{ statusBarStyle: isDark ? 'light' : 'dark' }}>
               <Stack.Screen
                 name="Main"
                 options={{
-                  title: `${
-                    Platform.isTV ? '📺' : '📱'
-                  } React Native Screens Examples`,
+                  title: `${Platform.isTV ? '📺' : '📱'
+                    } React Native Screens Examples`,
                 }}
                 component={MainScreen}
               />

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -5,11 +5,8 @@ import {
   I18nManager,
   Platform,
   useColorScheme,
-  View,
 } from 'react-native';
 import {
-  DarkTheme,
-  DefaultTheme,
   NavigationContainer,
   NavigationIndependentTree,
   useTheme,
@@ -39,7 +36,6 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import * as Tests from './src/tests';
 import { ScreensDarkTheme, ScreensLightTheme } from './src/shared/styling/adapter/react-navigation';
-import Colors from './src/shared/styling/Colors';
 
 function isPlatformReady(name: keyof typeof SCREENS) {
   if (Platform.isTV) {

--- a/apps/src/shared/Alert.tsx
+++ b/apps/src/shared/Alert.tsx
@@ -5,7 +5,7 @@ import useThemeColorPallette from './styling/adapter/react-navigation/useColorPa
 
 export const Alert = (): React.JSX.Element => {
   const navigation = useNavigation();
-  const colors = useThemeColorPallette();
+  const { colors } = useThemeColorPallette();
 
   const backgrounds = [
     colors.BlueLight80,

--- a/apps/src/shared/Alert.tsx
+++ b/apps/src/shared/Alert.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { Text, StyleSheet, Dimensions, View, Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import useThemeColorPallette from './styling/adapter/react-navigation/useColorPallette';
 
 export const Alert = (): React.JSX.Element => {
   const navigation = useNavigation();
+  const colors = useThemeColorPallette();
+
   const backgrounds = [
-    'darkviolet',
-    'slateblue',
-    'mediumseagreen',
-    'orange',
-    'indianred',
+    colors.BlueLight80,
+    colors.YellowDark80,
+    colors.PurpleLight80,
+    colors.BlueDark80,
+    colors.YellowLight80,
   ];
   const bgColor = backgrounds[Math.floor(Math.random() * backgrounds.length)];
 

--- a/apps/src/shared/Dialog.tsx
+++ b/apps/src/shared/Dialog.tsx
@@ -8,6 +8,7 @@ import {
   SafeAreaView,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import Colors from './styling/Colors';
 
 export const Dialog = (): React.JSX.Element => {
   const navigation = useNavigation();
@@ -35,7 +36,7 @@ const styles = StyleSheet.create({
   },
   wrapper: {
     width: Dimensions.get('screen').width - 40,
-    backgroundColor: 'white',
+    backgroundColor: Colors.background,
     shadowColor: 'black',
     shadowOffset: {
       width: 0,
@@ -57,7 +58,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   button: {
-    backgroundColor: 'dodgerblue',
+    backgroundColor: Colors.BlueLight80,
     height: 40,
     borderRadius: 8,
     justifyContent: 'center',

--- a/apps/src/shared/PressableWithFeedback.tsx
+++ b/apps/src/shared/PressableWithFeedback.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ForwardedRef } from 'react';
 import { GestureResponderEvent, Pressable, PressableProps, StyleSheet, View } from 'react-native';
+import Colors from './styling/Colors';
 
 export type PressableState = 'pressed-in' | 'pressed' | 'pressed-out'
 
@@ -59,13 +60,13 @@ const PressableWithFeedback = React.forwardRef((props: PressableProps, ref: Forw
 
 const styles = StyleSheet.create({
   pressablePressedIn: {
-    backgroundColor: 'lightsalmon',
+    backgroundColor: Colors.BlueLight100,
   },
   pressablePressed: {
-    backgroundColor: 'crimson',
+    backgroundColor: Colors.YellowLight100,
   },
   pressablePressedOut: {
-    backgroundColor: 'lightseagreen',
+    backgroundColor: Colors.PurpleLight100,
   },
 });
 

--- a/apps/src/shared/SettingsInput.tsx
+++ b/apps/src/shared/SettingsInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, StyleSheet } from 'react-native';
 import { ThemedText, ThemedView, ThemedTextInput } from '.';
+import Colors from './styling/Colors';
 
 type Props = {
   label: string;
@@ -40,7 +41,7 @@ const styles = StyleSheet.create({
     padding: 10,
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: '#039be5',
+    borderColor: Colors.cardBorder,
   },
   label: {
     fontSize: 15,

--- a/apps/src/shared/SettingsMultiInput.tsx
+++ b/apps/src/shared/SettingsMultiInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Text, View, Pressable, StyleSheet, TextInput } from 'react-native';
+import Colors from './styling/Colors';
 
 type Props = {
   label: string;
@@ -36,6 +37,7 @@ export function SettingsMultiInput({
   );
 }
 
+
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
@@ -44,8 +46,8 @@ const styles = StyleSheet.create({
     padding: 10,
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: '#039be5',
-    backgroundColor: 'white',
+    borderColor: Colors.cardBorder,
+    backgroundColor: Colors.background,
   },
   labelWrapper: {
     flexDirection: 'row',
@@ -59,7 +61,7 @@ const styles = StyleSheet.create({
     height: 40,
     flex: 1,
     borderWidth: 1,
-    borderColor: 'black',
+    borderColor: Colors.cardBorder,
   },
   inputLabel: {
     fontSize: 15,

--- a/apps/src/shared/SettingsPicker.tsx
+++ b/apps/src/shared/SettingsPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
 import { ThemedText, ThemedView } from '.';
+import Colors from './styling/Colors';
 
 type Props<T = string> = {
   testID?: string;
@@ -28,17 +29,17 @@ export function SettingsPicker<T extends string>({
           style={styles.label}>{`${label}: ${value}`}</ThemedText>
         {isOpen
           ? items.map(item => (
-              <TouchableOpacity key={item} onPress={() => onValueChange(item)}>
-                <ThemedText
-                  testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
-                  style={[
-                    styles.item,
-                    item === value && { fontWeight: 'bold' },
-                  ]}>
-                  {item}
-                </ThemedText>
-              </TouchableOpacity>
-            ))
+            <TouchableOpacity key={item} onPress={() => onValueChange(item)}>
+              <ThemedText
+                testID={`${label.split(' ').join('-')}-${item}`.toLowerCase()}
+                style={[
+                  styles.item,
+                  item === value && { fontWeight: 'bold' },
+                ]}>
+                {item}
+              </ThemedText>
+            </TouchableOpacity>
+          ))
           : null}
       </ThemedView>
     </TouchableOpacity>
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
     padding: 10,
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: '#039be5',
+    borderColor: Colors.cardBorder,
   },
   label: {
     fontSize: 15,

--- a/apps/src/shared/SettingsSwitch.tsx
+++ b/apps/src/shared/SettingsSwitch.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
 import { ThemedText, ThemedView } from '.';
+import Colors from './styling/Colors';
 
 type Props = {
   label: string;
@@ -34,7 +35,7 @@ const styles = StyleSheet.create({
     padding: 10,
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: '#039be5',
+    borderColor: Colors.cardBorder,
   },
   label: {
     fontSize: 15,

--- a/apps/src/shared/Snack.tsx
+++ b/apps/src/shared/Snack.tsx
@@ -23,7 +23,7 @@ export const Snack = ({ route, navigation }: Props): React.JSX.Element => {
       navigation.goBack();
     }, DISAPPEAR_AFTER);
     return () => clearTimeout(timer);
-  }, []);
+  }, [navigation]);
 
   return (
     <Pressable style={styles.container} onPress={() => navigation.goBack()}>

--- a/apps/src/shared/Square.tsx
+++ b/apps/src/shared/Square.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { View } from 'react-native';
+import { ColorValue, View } from 'react-native';
+import Colors from './styling/Colors';
 
 interface Props {
-  color?: string;
+  color?: ColorValue;
   size?: number;
   testID?: string;
 }
 
 export const Square = ({
   size = 100,
-  color = 'red',
+  color = Colors.primary,
   testID,
 }: Props): React.JSX.Element => (
   <View style={{ width: size, height: size, backgroundColor: color }} testID={testID} />

--- a/apps/src/shared/ThemedView.tsx
+++ b/apps/src/shared/ThemedView.tsx
@@ -1,11 +1,11 @@
-import { useTheme } from '@react-navigation/native';
 import React from 'react';
 import { View, ViewProps } from 'react-native';
+import useThemeColorPallette from './styling/adapter/react-navigation/useColorPallette';
 
 export const ThemedView = ({ children, style, ...props }: ViewProps) => {
-  const { colors } = useTheme();
+  const { colors } = useThemeColorPallette();
   return (
-    <View style={[{ backgroundColor: colors.card }, style]} {...props}>
+    <View style={[{ backgroundColor: colors.offBackground }, style]} {...props}>
       {children}
     </View>
   );

--- a/apps/src/shared/styling/Colors.ts
+++ b/apps/src/shared/styling/Colors.ts
@@ -93,7 +93,7 @@ export const Palette = {
 
   LightOffNavy: '#30354a',
   OffNavy: '#272b3c',
-  Navy: '#32736',
+  Navy: '#232736',
 } as const;
 
 export type ColorPallette = typeof Palette & {

--- a/apps/src/shared/styling/Colors.ts
+++ b/apps/src/shared/styling/Colors.ts
@@ -1,3 +1,5 @@
+import { ColorValue } from 'react-native';
+
 export const Palette = {
   NavyLight100: '#001a72',
   NavyLight80: '#33488e',
@@ -92,15 +94,36 @@ export const Palette = {
   LightOffNavy: '#30354a',
   OffNavy: '#272b3c',
   Navy: '#32736',
+} as const;
+
+export type ColorPallette = typeof Palette & {
+  background: ColorValue,
+  offBackground: ColorValue,
+  primary: ColorValue,
+  cardBackground: ColorValue,
+  cardBorder: ColorValue,
 };
 
-const Colors = {
+export const Colors: ColorPallette = {
   ...Palette,
   background: Palette.White,
   offBackground: Palette.OffWhite,
-  border: Palette.NavyLight40,
-  badge: Palette.NavyLight100,
+  primary: Palette.NavyLight100,
+  cardBackground: Palette.White,
+  cardBorder: Palette.NavyLight20,
+};
+
+export const LightColors: ColorPallette = Colors;
+
+export const DarkColors: ColorPallette = {
+  ...Palette,
+  background: Palette.Navy,
+  offBackground: Palette.OffNavy,
+  primary: Palette.NavyLight10,
+  cardBackground: Palette.Navy,
+  cardBorder: Palette.NavyDark60,
 };
 
 export default Colors;
+
 

--- a/apps/src/shared/styling/Colors.ts
+++ b/apps/src/shared/styling/Colors.ts
@@ -1,0 +1,106 @@
+export const Palette = {
+  NavyLight100: '#001a72',
+  NavyLight80: '#33488e',
+  NavyLight60: '#6676aa',
+  NavyLight40: '#919fcf',
+  NavyLight20: '#c1c6e5',
+  NavyLight10: '#eef0ff',
+  NavyLightTransparent: '#33488e40',
+
+  NavyDark140: '#1b2445',
+  NavyDark120: '#122154',
+  NavyDark100: '#001a72',
+  NavyDark80: '#0a2688',
+  NavyDark70: '#33488e',
+  NavyDark60: '#7485bd',
+  NavyDark40: '#abbcf5',
+  NavyDark20: '#c1c6e5',
+
+  PurpleLight100: '#782aeb',
+  PurpleLight80: '#b58df1',
+  PurpleLight60: '#d1bbf3',
+  PurpleLight40: '#e8dafc',
+  PurpleLight20: '#f5eeff',
+  PurpleLightTtransparent: '#f5eeff40',
+
+  PurpleDark140: '#473d68',
+  PurpleDark120: '#6a539a',
+  PurpleDark100: '#b07eff',
+  PurpleDark80: '#c49ffe',
+  PurpleDark60: '#d0b2ff',
+  PurpleDark40: '#e9dbff',
+  PurpleDarkTransparent: '#473d6840',
+
+  BlueLight100: '#38acdd',
+  BlueLight80: '#5bb9e0',
+  BlueLight60: '#87cce8',
+  BlueLight40: '#b5e1f1',
+  BlueLight20: '#e1f3fa',
+
+  BlueDark140: '#1b4865',
+  BlueDark120: '#126893',
+  BlueDark100: '#00a9f0',
+  BlueDark80: '#6fcef5',
+  BlueDark60: '#a8dbf0',
+  BlueDark40: '#d7f0fa',
+
+  GreenLight100: '#57b495',
+  GreenLight80: '#82cab2',
+  GreenLight60: '#b1dfd0',
+  GreenLight40: '#dff2ec',
+  GreenLight20: '#ebfcf7',
+
+  GreenDark140: '#2a4f4a',
+  GreenDark120: '#31775d',
+  GreenDark100: '#3fc684',
+  GreenDark80: '#7adead',
+  GreenDark60: '#a0dfc0',
+  GreenDark40: '#d3f5e4',
+
+  RedLight100: '#ff6259',
+  RedLight80: '#fa7f7c',
+  RedLight60: '#ffa3a1',
+  RedLight40: '#ffd2d7',
+  RedLight20: '#ffedf0',
+
+  RedDark140: '#5a3b46',
+  RedDark120: '#914f55',
+  RedDark110: '#c86364',
+  RedDark100: '#ff7774',
+  RedDark80: '#ff8b88',
+  RedDark60: '#ffb4b2',
+  RedDark40: '#ffdcdb',
+
+  YellowLight100: '#ffd61e',
+  YellowLight80: '#ffe04b',
+  YellowLight60: '#ffe780',
+  YellowLight40: '#fff1b2',
+  YellowLight20: '#fffae1',
+
+  YellowDark140: '#5a553a',
+  YellowDark120: '#91823d',
+  YellowDark100: '#ffdd44',
+  YellowDark80: '#ffe678',
+  YellowDark60: '#fff1b2',
+  YellowDark40: '#fff9db',
+
+  OffWhite: '#f8f9ff',
+  White: '#fcfcff',
+  WhiteTransparentLight: '#fcfcff40',
+  WhiteTransparentDark: '#fcfcff80',
+
+  LightOffNavy: '#30354a',
+  OffNavy: '#272b3c',
+  Navy: '#32736',
+};
+
+const Colors = {
+  ...Palette,
+  background: Palette.White,
+  offBackground: Palette.OffWhite,
+  border: Palette.NavyLight40,
+  badge: Palette.NavyLight100,
+};
+
+export default Colors;
+

--- a/apps/src/shared/styling/adapter/react-navigation/index.ts
+++ b/apps/src/shared/styling/adapter/react-navigation/index.ts
@@ -1,0 +1,25 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DarkColors, LightColors } from '../../Colors';
+
+export const ScreensLightTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: LightColors.primary as string,
+    background: LightColors.background as string,
+    card: LightColors.cardBackground as string,
+    border: LightColors.cardBorder as string,
+  },
+};
+
+export const ScreensDarkTheme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    primary: DarkColors.primary as string,
+    background: DarkColors.background as string,
+    card: DarkColors.cardBackground as string,
+    border: DarkColors.cardBorder as string,
+  },
+};
+

--- a/apps/src/shared/styling/adapter/react-navigation/useColorPallette.tsx
+++ b/apps/src/shared/styling/adapter/react-navigation/useColorPallette.tsx
@@ -1,0 +1,11 @@
+import { useTheme } from '@react-navigation/native';
+import { ColorPallette, DarkColors, LightColors } from '../../Colors';
+
+/**
+ * Requires `ThemeContext` (from react-navigation) presence.
+ * Use this to get whole collor pallete current theme is based on.
+ */
+export default function useThemeColorPallette(): ColorPallette {
+  const theme = useTheme();
+  return theme.dark ? DarkColors : LightColors;
+}

--- a/apps/src/shared/styling/adapter/react-navigation/useColorPallette.tsx
+++ b/apps/src/shared/styling/adapter/react-navigation/useColorPallette.tsx
@@ -1,11 +1,14 @@
-import { useTheme } from '@react-navigation/native';
+import { Theme, useTheme } from '@react-navigation/native';
 import { ColorPallette, DarkColors, LightColors } from '../../Colors';
 
 /**
  * Requires `ThemeContext` (from react-navigation) presence.
  * Use this to get whole collor pallete current theme is based on.
  */
-export default function useThemeColorPallette(): ColorPallette {
+export default function useThemeColorPallette(): { theme: Theme, colors: ColorPallette } {
   const theme = useTheme();
-  return theme.dark ? DarkColors : LightColors;
+  return {
+    theme,
+    colors: theme.dark ? DarkColors : LightColors,
+  };
 }


### PR DESCRIPTION
## Description

Adding shared, reusable color values here. I get a bit frustrated when I have to comeup with colors each time I made an example 
& for some reason `ColorValue` does not have typing for color-literals. 

I've stolen the values from reanimated docs (they use swm color palette), thought it might look nicely & consistent.

I would recommend using these in any future examples.

## Changes

:point_up:

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
