### PR TITLE
fix(Android): status bar insets for formSheet

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserverProxy.kt
@@ -2,6 +2,8 @@ package com.swmansion.rnscreens
 
 import android.util.Log
 import android.view.View
+import androidx.collection.ArraySet
+import androidx.collection.arraySetOf
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -10,7 +12,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import java.lang.ref.WeakReference
 
 object InsetsObserverProxy : OnApplyWindowInsetsListener, LifecycleEventListener {
-    private val listeners: ArrayList<OnApplyWindowInsetsListener> = arrayListOf()
+    private val listeners: ArraySet<OnApplyWindowInsetsListener> = arraySetOf()
     private var eventSourceView: WeakReference<View> = WeakReference(null)
 
     // Please note semantics of this property. This is not `isRegistered`, because somebody, could unregister

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -527,6 +527,23 @@ class Screen(
         }
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        // Insets handler for formSheet is added onResume but it is often
+        // too late if we use input with autofocus. It happens because onResume is called after
+        // finishing animator animation. onAttachedToWindow is called before onApplyWindowInsets
+        // so we use it to set the handler earlier.
+        // More details: https://github.com/software-mansion/react-native-screens/pull/2911
+        if (usesFormSheetPresentation()) {
+            (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
+                InsetsObserverProxy.addOnApplyWindowInsetsListener(
+                    it,
+                )
+            }
+        }
+    }
+
     private fun dispatchSheetDetentChanged(
         detentIndex: Int,
         isStable: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -544,12 +544,11 @@ class Screen(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        // Insets handler for formSheet is added onResume but it is often
-        // too late if we use input with autofocus. It happens because onResume is called after
-        // finishing animator animation. onAttachedToWindow is called before onApplyWindowInsets
-        // so we use it to set the handler earlier.
-        // More details: https://github.com/software-mansion/react-native-screens/pull/2911
-        if (usesFormSheetPresentation()) {
+        // Insets handler for formSheet is added onResume but it is often too late if we use input
+        // with autofocus - onResume is called after finishing animator animation.
+        // onAttachedToWindow is called before onApplyWindowInsets so we use it to set the handler
+        // earlier. More details: https://github.com/software-mansion/react-native-screens/pull/2911
+        if (usesFormSheetPresentation() && isNativeStackScreen) {
             (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
                 InsetsObserverProxy.addOnApplyWindowInsetsListener(
                     it,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -557,6 +557,21 @@ class Screen(
         }
     }
 
+    override fun setOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener?) {
+        val effectiveListener =
+            if (usesFormSheetPresentation() && listener != null) {
+                OnApplyWindowInsetsListener { v, insets ->
+                    listener.onApplyWindowInsets(v, insets).also {
+                        parent.requestLayout()
+                    }
+                }
+            } else {
+                listener
+            }
+
+        super.setOnApplyWindowInsetsListener(effectiveListener)
+    }
+
     private fun dispatchSheetDetentChanged(
         detentIndex: Int,
         isStable: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -31,6 +31,7 @@ import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
+import com.swmansion.rnscreens.ext.parentAsView
 import com.swmansion.rnscreens.ext.parentAsViewGroup
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
@@ -562,7 +563,7 @@ class Screen(
             if (usesFormSheetPresentation() && listener != null) {
                 OnApplyWindowInsetsListener { v, insets ->
                     listener.onApplyWindowInsets(v, insets).also {
-                        parent.requestLayout()
+                        parentAsView()?.takeIf { !it.isInLayout }?.requestLayout()
                     }
                 }
             } else {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -249,18 +249,6 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     DISPATCH_MODE_STOP,
                 ) {
-                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
-                        // FormSheet's onResume is called after finishing animator animation but adding
-                        // insets handler then is often too late if we use input autofocus.
-                        // This callback's onPrepare is called before onApplyWindowInsets so we use it
-                        // to set the handler earlier.
-                        (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
-                            InsetsObserverProxy.addOnApplyWindowInsetsListener(
-                                it
-                            )
-                        }
-                    }
-
                     override fun onProgress(
                         insets: WindowInsetsCompat,
                         runningAnimations: MutableList<WindowInsetsAnimationCompat>,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -74,7 +74,7 @@ class ScreenStackFragment :
 
     private var dimmingDelegate: DimmingViewManager? = null
 
-    private var sheetDelegate: SheetDelegate? = null
+    internal var sheetDelegate: SheetDelegate? = null
 
     @SuppressLint("ValidFragment")
     constructor(screenView: Screen) : super(screenView)
@@ -249,6 +249,18 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     DISPATCH_MODE_STOP,
                 ) {
+                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                        // FormSheet's onResume is called after finishing animator animation but adding
+                        // insets handler then is often too late if we use input autofocus.
+                        // This callback's onPrepare is called before onApplyWindowInsets so we use it
+                        // to set the handler earlier.
+                        (fragment as ScreenStackFragment?)?.sheetDelegate?.let {
+                            InsetsObserverProxy.addOnApplyWindowInsetsListener(
+                                it
+                            )
+                        }
+                    }
+
                     override fun onProgress(
                         insets: WindowInsetsCompat,
                         runningAnimations: MutableList<WindowInsetsAnimationCompat>,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -175,12 +175,20 @@ class SheetDelegate(
             }
 
             is KeyboardVisible -> {
-                val newMaxHeight =
-                    if (behavior.maxHeight - keyboardState.height > 1) {
-                        behavior.maxHeight - keyboardState.height
-                    } else {
-                        behavior.maxHeight
-                    }
+                // This code currently does not work (changing maxHeight requires relayout)
+                // but it creates visual glitch when closing formSheet with keyboard still open.
+                // Decided to temporarily comment it out.
+                // More details: https://github.com/software-mansion/react-native-screens/pull/2911
+
+                // val newMaxHeight =
+                //     if (behavior.maxHeight - keyboardState.height > 1) {
+                //         behavior.maxHeight - keyboardState.height
+                //     } else {
+                //         behavior.maxHeight
+                //     }
+
+                val newMaxHeight = behavior.maxHeight
+
                 when (screen.sheetDetents.count()) {
                     1 ->
                         behavior.apply {

--- a/apps/src/tests/Test2896.tsx
+++ b/apps/src/tests/Test2896.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  NavigationContainer,
+  ParamListBase,
+  RouteProp,
+} from '@react-navigation/native';
+import {
+  NativeStackNavigationOptions,
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, StyleSheet, View, Text } from 'react-native';
+
+const FORM_SHEET_CONFIGURATIONS: Record<string, NativeStackNavigationOptions> =
+  {
+    SingleDetentFullExpanded: {
+      sheetAllowedDetents: [1],
+    },
+    SingleDetentCloseToFullExpanded: {
+      sheetAllowedDetents: [0.99],
+    },
+    TwoDetentsInitCollapsed: {
+      sheetAllowedDetents: [0.5, 1],
+    },
+    TwoDetentsInitExpanded: {
+      sheetAllowedDetents: [0.5, 1],
+      sheetInitialDetentIndex: 1,
+    },
+    ThreeDetentsInitCollapsed: {
+      sheetAllowedDetents: [0.3, 0.5, 1],
+    },
+    ThreeDetentsInitHalfExpanded: {
+      sheetAllowedDetents: [0.3, 0.5, 1],
+      sheetInitialDetentIndex: 1,
+    },
+    ThreeDetentsInitExpanded: {
+      sheetAllowedDetents: [0.3, 0.5, 1],
+      sheetInitialDetentIndex: 2,
+    },
+  };
+
+type StackRouteParamList = {
+  Home: undefined;
+} & {
+  [P in keyof typeof FORM_SHEET_CONFIGURATIONS]: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+  route: RouteProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<StackRouteParamList>;
+
+const Stack = createNativeStackNavigator<StackRouteParamList>();
+
+function Home({ navigation }: StackNavigationProp) {
+  return (
+    <View style={{ backgroundColor: 'goldenrod', flex: 1 }}>
+      <View>
+        <Text
+          style={{ fontSize: 10, marginTop: 5, textAlign: 'center' }}
+          testID="home-text-behind-status-bar">
+          This shouldn't be covered by formSheet.
+        </Text>
+      </View>
+      <View
+        style={{
+          flex: 0,
+          minHeight: 200,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+          <Text testID="home-text-behind-form-sheet">This should be covered by expanded formSheet.</Text>
+        </View>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 10,
+        }}>
+        {Object.keys(FORM_SHEET_CONFIGURATIONS).map(key => (
+          <Button
+            title={key}
+            onPress={() => navigation.navigate(key)}
+            testID={`home-button-open-${key}`}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function FormSheet({ route }: StackNavigationProp) {
+  return (
+    <View style={styles.wrapper}>
+      <Text style={styles.heading}>{route.name}</Text>
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={Home}
+          options={{
+            headerShown: false,
+          }}
+        />
+        {Object.keys(FORM_SHEET_CONFIGURATIONS).map(key => (
+          <Stack.Screen
+            name={key}
+            component={FormSheet}
+            options={{
+              presentation: 'formSheet',
+              ...FORM_SHEET_CONFIGURATIONS[key],
+            }}
+          />
+        ))}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    margin: 15,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  label: {
+    textTransform: 'capitalize',
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 5,
+    marginBottom: 12,
+    height: 40,
+  },
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -134,6 +134,7 @@ export { default as Test2819 } from './Test2819';
 export { default as Test2855 } from './Test2855';
 export { default as Test2877 } from './Test2877'; // [E2E created](iOS): issue is related to formSheet on iOS
 export { default as Test2895 } from './Test2895';
+export { default as Test2896 } from './Test2896'; // [E2E skipped]: unable to test visibility interactions with formSheet
 export { default as Test2899 } from './Test2899';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';


### PR DESCRIPTION
## Description

Status bar insets were not handled properly when opening the formSheet with initial height that was greater than safe content area. The bug is directly connected with how `BottomSheetBehavior` works. For unknown reasons, `onChildLayout` sometimes isn't called after `BottomSheetBehavior`'s insets handler runs. In this PR, we override `Screen`'s `setOnApplyWindowInsetsListener` (used by `BottomSheetBehavior` to register its handler), to make sure to request the layout after the listener runs.

### The problem
On first layout, `BottomSheetBehavior` registers the inset listener which updates `insetsTop` field. In `onLayoutChild`, `BottomSheetBehavior` uses `insetsTop` value to calculate `childHeight` which is then used to calculate `fitToContentsOffset`. `fitToContentsOffset` is returned from `getExpandedOffset()` if `isFitToContents == true` (which is the case for single and two detents in `screens`). If `isFitToContents == false` (i.e. we use 3 detents), `getExpandedOffset()` uses `insetsTop` directly. When layout wasn't called after the insets handler, previous value was used which caused the sheet to go under the status bar.

Fixes https://github.com/software-mansion/react-native-screens/issues/2896.

## Changes

- add custom setter for `onApplyWindowInsetsListener`
- add `Test2896` test screen (unable to create e2e test because content behind formSheet still has `visibility = VISIBLE`)

## Screenshots / GIFs
| Nested stack flash | Bottom tabs disappearing |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/527ec68c-e292-4610-b2cb-9066b9d500ef" alt="before" /> | <video src="https://github.com/user-attachments/assets/ac035057-f0b6-4a8d-b844-42eab202927b" alt="after" />  |

## Test code and steps to reproduce

Run example app and open `Test2896` test screen.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
