### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 702..726

### DIFF
--- a/FabricExample/e2e/issuesTests/Test726.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test726.e2e.ts
@@ -1,0 +1,33 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS } from '../e2e-utils';
+
+// issue related to iOS
+describeIfiOS('Test726', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test726 should exist', async () => {
+    await waitFor(element(by.id('root-screen-tests-Test726')))
+      .toBeVisible()
+      .whileElement(by.id('root-screen-examples-scrollview'))
+      .scroll(600, 'down', NaN, 0.85);
+
+    await expect(element(by.id('root-screen-tests-Test726'))).toBeVisible();
+    await element(by.id('root-screen-tests-Test726')).tap();
+  });
+
+  it('swiping back should not cause the freeze', async () => {
+    await expect(element(by.id('test-screen-button-push-me'))).toBeVisible();
+    await element(by.id('test-screen-button-push-me')).tap();
+
+    await expect(element(by.id('test-screen-2-text'))).toBeVisible();
+    await element(by.id('test-screen-2-view')).swipe('right', 'slow', 0.9, 0.0);
+
+    // Check that the app is still responsive by navigating to TestScreen2 again
+    await expect(element(by.id('test-screen-button-push-me'))).toBeVisible();
+    await element(by.id('test-screen-button-push-me')).tap();
+
+    await expect(element(by.id('test-screen-2-text'))).toBeVisible();
+  });
+});

--- a/apps/src/tests/Test726.js
+++ b/apps/src/tests/Test726.js
@@ -10,6 +10,7 @@ function TestScreen({ navigation }) {
         title="PUSH ME"
         onPress={() => navigation.push('Test')}
         style={styles.button}
+        testID="test-screen-button-push-me"
       />
     </View>
   );
@@ -17,8 +18,8 @@ function TestScreen({ navigation }) {
 
 function TestScreen2() {
   return (
-    <View style={styles.content}>
-      <Text>Try to swipe back, it will freeze</Text>
+    <View style={styles.content} testID="test-screen-2-view">
+      <Text testID="test-screen-2-text">Try to swipe back, it will freeze</Text>
       <TextInput autoFocus />
     </View>
   );

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -23,8 +23,8 @@ export { default as Test654 } from './Test654';     // [E2E created](iOS): issue
 export { default as Test658 } from './Test658';     // [E2E created]
 export { default as Test662 } from './Test662';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test691 } from './Test691';     // [E2E created](iOS): issue related to iOS modal behavior
-export { default as Test702 } from './Test702';
-export { default as Test706 } from './Test706';
+export { default as Test702 } from './Test702';     // [E2E skipped]: can't check animation in a meaningful way
+export { default as Test706 } from './Test706';     // [E2E skipped]: can't check font weight
 export { default as Test713 } from './Test713';
 export { default as Test726 } from './Test726';
 export { default as Test748 } from './Test748';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -26,7 +26,7 @@ export { default as Test691 } from './Test691';     // [E2E created](iOS): issue
 export { default as Test702 } from './Test702';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test706 } from './Test706';     // [E2E skipped]: can't check font weight
 export { default as Test713 } from './Test713';     // [E2E skipped]: issue still present
-export { default as Test726 } from './Test726';
+export { default as Test726 } from './Test726';     // [E2E created](iOS): issue related to iOS
 export { default as Test748 } from './Test748';
 export { default as Test750 } from './Test750';
 export { default as Test758 } from './Test758';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -25,7 +25,7 @@ export { default as Test662 } from './Test662';     // [E2E skipped]: can't chec
 export { default as Test691 } from './Test691';     // [E2E created](iOS): issue related to iOS modal behavior
 export { default as Test702 } from './Test702';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test706 } from './Test706';     // [E2E skipped]: can't check font weight
-export { default as Test713 } from './Test713';
+export { default as Test713 } from './Test713';     // [E2E skipped]: issue still present
 export { default as Test726 } from './Test726';
 export { default as Test748 } from './Test748';
 export { default as Test750 } from './Test750';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test702, ..., Test726` and implement them if possible for Fabric. 

### Test702
Skipped because we can't check animation in any meaningful way.

### Test706
Skipped because we can't check font weight.

### Test713
Skipped because the issue is still present (`transitionStart/End` events are not fired when leaving the screen due to a call from the JS side; the decision was that [this will not be fixed](https://github.com/software-mansion/react-native-screens/issues/713#issuecomment-732209901) if there is no important use case for it).

### Test726
Test created, only on iOS (original issue was related to iOS). It checks if the app freezes after going back from screen with autofocus input. It is important to note that the issue was reopened with similar, but not the same, bug.

## Changes

- add `Test726` e2e test
- add testIDs to `Test726` test screen
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [x] Ensured that CI passes
