### PR TITLE
fix: remove javapart ref from cpp nativeproxy

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
@@ -20,6 +20,8 @@ class NativeProxy {
 
     external fun nativeAddMutationsListener(fabricUIManager: FabricUIManager)
 
+    external fun invalidateCpp()
+
     companion object {
         // we use ConcurrentHashMap here since it will be read on the JS thread,
         // and written to on the UI thread.

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -14,14 +14,13 @@ namespace rnscreens {
 NativeProxy::NativeProxy(jni::alias_ref<NativeProxy::javaobject> jThis)
     : javaPart_(jni::make_global(jThis)) {}
 
-NativeProxy::~NativeProxy() {}
-
 void NativeProxy::registerNatives() {
   registerHybrid(
       {makeNativeMethod("initHybrid", NativeProxy::initHybrid),
        makeNativeMethod(
            "nativeAddMutationsListener",
-           NativeProxy::nativeAddMutationsListener)});
+           NativeProxy::nativeAddMutationsListener),
+       makeNativeMethod("invalidateCpp", NativeProxy::invalidateCpp)});
 }
 
 void NativeProxy::nativeAddMutationsListener(
@@ -46,6 +45,10 @@ void NativeProxy::nativeAddMutationsListener(
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
     jni::alias_ref<jhybridobject> jThis) {
   return makeCxxInstance(jThis);
+}
+
+void NativeProxy::invalidateCpp() {
+    javaPart_ = nullptr;
 }
 
 } // namespace rnscreens

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -19,8 +19,6 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       jni::alias_ref<jhybridobject> jThis);
   static void registerNatives();
 
-  ~NativeProxy();
-
  private:
   friend HybridBase;
   jni::global_ref<NativeProxy::javaobject> javaPart_;
@@ -30,6 +28,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   void nativeAddMutationsListener(
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
           fabricUIManager);
+
+  void invalidateCpp();
 };
 
 } // namespace rnscreens

--- a/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
@@ -39,6 +39,7 @@ class ScreensModule(
 
     override fun invalidate() {
         super.invalidate()
+        proxy?.invalidateCpp();
         nativeUninstall()
     }
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

PR analogous to https://github.com/software-mansion/react-native-reanimated/pull/7515 regarding the `javaPart_`. 
Right now when you do a reload in a simple app with screens installed, you will see in AS profiler that instances of all NativeProxys are still in the memory. It is caused by `javaPart_` never being released thus keeping java part after reload.

## Test code and steps to reproduce

Make simple app with screens and do a couple of reloads and check in profiler if the NativeProxy leaks.


