### PR TITLE
refactor(Android): replace inset listeners on decor with multiple insets listeners on screen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -1,0 +1,66 @@
+package com.swmansion.rnscreens
+
+import android.view.View
+import android.view.WindowInsets
+import androidx.core.view.OnApplyWindowInsetsListener
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.ReactApplicationContext
+
+class InsetsObserver(
+    view: View,
+) {
+    private val observedView = view
+    private var systemListener: View.OnApplyWindowInsetsListener? = null
+    private val ownListeners: HashSet<OnApplyWindowInsetsListener> = hashSetOf()
+
+    constructor(view: View, context: ReactApplicationContext) : this(view) {
+        context.addLifecycleEventListener(
+            object : LifecycleEventListener {
+                override fun onHostDestroy() {
+                    clear()
+                }
+
+                override fun onHostPause() = Unit
+
+                override fun onHostResume() = Unit
+            },
+        )
+    }
+
+    fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
+        var rollingInsets = insets
+
+        systemListener?.onApplyWindowInsets(observedView, insets)?.let {
+            rollingInsets = it
+        }
+
+        ownListeners.forEach {
+            it.onApplyWindowInsets(observedView, WindowInsetsCompat.toWindowInsetsCompat(insets)).toWindowInsets()?.let { windowInsets ->
+                rollingInsets = windowInsets
+            }
+        }
+
+        return rollingInsets
+    }
+
+    fun setOnApplyWindowListener(listener: View.OnApplyWindowInsetsListener?) {
+        systemListener = listener
+    }
+
+    fun addOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener) {
+        ownListeners.add(listener)
+        println("InsetsObserver addOnApplyWindowInsetsListener count=${ownListeners.count()}")
+    }
+
+    fun removeOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener) {
+        ownListeners.remove(listener)
+    }
+
+    fun clear() {
+        ownListeners.clear()
+        systemListener = null
+        ViewCompat.setOnApplyWindowInsetsListener(observedView, null)
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -8,6 +8,7 @@ import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.webkit.WebView
 import android.widget.ImageView
@@ -39,6 +40,8 @@ class Screen(
     val reactContext: ThemedReactContext,
 ) : FabricEnabledViewGroup(reactContext),
     ScreenContentWrapper.OnLayoutCallback {
+    val insetsObserver = InsetsObserver(this, reactContext.reactApplicationContext)
+
     val fragment: Fragment?
         get() = fragmentWrapper?.fragment
 
@@ -551,11 +554,17 @@ class Screen(
         // earlier. More details: https://github.com/software-mansion/react-native-screens/pull/2911
         if (usesFormSheetPresentation()) {
             fragment?.asScreenStackFragment()?.sheetDelegate?.let {
-                InsetsObserverProxy.addOnApplyWindowInsetsListener(
-                    it,
-                )
+                insetsObserver.addOnApplyWindowInsetsListener(it);
             }
         }
+    }
+
+    override fun setOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener?) {
+        insetsObserver.setOnApplyWindowListener(listener)
+    }
+
+    override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
+        return insetsObserver.onApplyWindowInsets( insets)
     }
 
     private fun dispatchSheetDetentChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -7,6 +7,7 @@ import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import androidx.core.graphics.Insets
 import androidx.core.view.OnApplyWindowInsetsListener
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -72,16 +73,14 @@ class SheetDelegate(
         }
     }
 
-    private fun handleHostFragmentOnStart() {
-        InsetsObserverProxy.registerOnView(requireDecorView())
-    }
+    private fun handleHostFragmentOnStart() = Unit
 
     private fun handleHostFragmentOnResume() {
-        InsetsObserverProxy.addOnApplyWindowInsetsListener(this)
+        screen.insetsObserver.addOnApplyWindowInsetsListener(this)
     }
 
     private fun handleHostFragmentOnPause() {
-        InsetsObserverProxy.removeOnApplyWindowInsetsListener(this)
+        screen.insetsObserver.removeOnApplyWindowInsetsListener(this)
     }
 
     private fun onSheetStateChanged(newState: Int) {
@@ -251,19 +250,6 @@ class SheetDelegate(
             sheetBehavior?.let {
                 this.configureBottomSheetBehaviour(it, keyboardState)
             }
-
-            val prevInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            return WindowInsetsCompat
-                .Builder(insets)
-                .setInsets(
-                    WindowInsetsCompat.Type.navigationBars(),
-                    Insets.of(
-                        prevInsets.left,
-                        prevInsets.top,
-                        prevInsets.right,
-                        0,
-                    ),
-                ).build()
         } else {
             sheetBehavior?.let {
                 if (isKeyboardVisible) {
@@ -278,13 +264,7 @@ class SheetDelegate(
             isKeyboardVisible = false
         }
 
-        val prevInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-        return WindowInsetsCompat
-            .Builder(insets)
-            .setInsets(
-                WindowInsetsCompat.Type.navigationBars(),
-                Insets.of(prevInsets.left, prevInsets.top, prevInsets.right, 0),
-            ).build()
+        return insets
     }
 
     private fun shouldDismissSheetInState(

--- a/apps/src/tests/Test2774.tsx
+++ b/apps/src/tests/Test2774.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { Button, View, TextInput} from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import Colors from '../shared/styling/Colors';
+
+
+const RootStack = createNativeStackNavigator();
+
+function RootStackHost() {
+  return (
+    <RootStack.Navigator screenOptions={{headerShown: false}}>
+      <RootStack.Screen name="Root" component={RootScreen} options={{}} />
+      <RootStack.Screen name="FormSheet" component={FormSheet} options={{
+        presentation: 'formSheet',
+        // sheetAllowedDetents: 'fitToContents',
+        sheetAllowedDetents: [0.2, 1.0],
+      }} />
+    </RootStack.Navigator>
+  );
+}
+
+const RootScreen = ({navigation}) => (
+  <View style={{flex: 1, justifyContent: 'center', padding: 20}}>
+    <TextInput style={{borderColor: Colors.NavyLightTransparent, borderWidth: 1, padding: 10, backgroundColor: '#fff'}} />
+    <Button title="Open formsheet" onPress={() => navigation.navigate('FormSheet')} />
+  </View>
+);
+
+const FormSheet = ({navigation}) => {
+
+  return (
+      <View style={{
+        flex: 1,
+        // height: 400,
+        borderWidth: 4,
+        borderColor: Colors.GreenDark60,
+      }}>
+        <TextInput style={{borderColor: Colors.NavyLightTransparent, borderWidth: 1, padding: 10, backgroundColor: '#fff'}} />
+        <Button title="Press" onPress={() => {}} />
+      </View>
+  );
+};
+
+function App() {
+  return (
+    <NavigationContainer>
+      <RootStackHost />
+    </NavigationContainer>
+  );
+}
+export default App;

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -128,6 +128,7 @@ export { default as Test2675 } from './Test2675';
 export { default as Test2714 } from './Test2714';
 export { default as Test2717 } from './Test2717';
 export { default as Test2767 } from './Test2767';
+export { default as Test2774 } from './Test2774';
 export { default as Test2789 } from './Test2789';
 export { default as Test2809 } from './Test2809';
 export { default as Test2811 } from './Test2811';


### PR DESCRIPTION
## Description

Currently we have one singleton proxy listener that is attached to decor and we use that to listen for keyboard events. That sometimes may leads to problems, that some underlying view will consume insets and we won't get notified about this. This PR fixes is by allowing to add multiple events listeners on screen and using it for foresheets. 

## Test code and steps to reproduce

- Test2774.tsx
- Test2895.tsx
- TestFormSheet.tsx

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
