### PR TITLE
fix(Fabric,iOS): cancel conflicting presses in modals on swipe back gesture

### DIFF
--- a/ios/utils/UIView+RNSUtility.mm
+++ b/ios/utils/UIView+RNSUtility.mm
@@ -1,8 +1,8 @@
-
 #import "UIView+RNSUtility.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTSurfaceView.h>
+#import "RNSModalScreen.h"
 #endif
 
 @implementation UIView (RNSUtility)
@@ -17,7 +17,10 @@
   // hosts `RCTSurfaceTouchHandler` as a private field. When initialised, `RCTSurfaceTouchHandler` is attached to the
   // surface view as a gestureRecognizer <- and this is where we can lay our hands on it.
 
-  while (parent != nil && ![parent isKindOfClass:RCTSurfaceView.class]) {
+  // On Fabric, every screen not mounted under react root view has it's own surface touch handler attached
+  // (done when the screen is moved to window).
+  while (parent != nil && ![parent isKindOfClass:RCTSurfaceView.class] &&
+         ![parent isKindOfClass:RNSModalScreen.class]) {
     parent = parent.superview;
   }
 


### PR DESCRIPTION

## Description

Previously, when looking for `RCTSurfaceTouchHanlder` we've looked only
for `RCTSurfaceView`, however on Fabric in modal view hierarchies,
the `RCTSurfaceView` can not be reached directly when iterating
over UIKit view ancestor chain. However, we do attach
`RCTSurfaceTouchHanlder` to every `RNSModalScreen` anyway
& we can use that to dispatch / cancel appropriate events.

## Changes

:point_up:

## Test code and steps to reproduce

`Test780` should now work on Fabric

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
