### PR TITLE
review of 2938

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -10,9 +10,8 @@ import com.facebook.react.bridge.ReactApplicationContext
 
 class InsetsObserver(
     context: ReactApplicationContext,
-    view: View,
+    private val observedView: View,
 ) {
-    private val observedView = view
     private var systemListener: View.OnApplyWindowInsetsListener? = null
     private val ownListeners: HashSet<OnApplyWindowInsetsListener> = hashSetOf()
 

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -47,6 +47,7 @@ class InsetsObserver(
                 }
         }
 
+        // These are insets of last registered observer!
         return currentInsets
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -48,7 +48,7 @@ class InsetsObserver(
         return rollingInsets
     }
 
-    fun setOnApplyWindowListener(listener: View.OnApplyWindowInsetsListener?) {
+    fun setExternalOnApplyWindowInsetsListener(listener: View.OnApplyWindowInsetsListener?) {
         externalListener = listener
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -33,19 +33,21 @@ class InsetsObserver(
     }
 
     fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
-        var rollingInsets = insets
+        var currentInsets = insets
 
         externalListener?.onApplyWindowInsets(observedView, insets)?.let {
-            rollingInsets = it
+            currentInsets = it
         }
 
         ownListeners.forEach {
-            it.onApplyWindowInsets(observedView, WindowInsetsCompat.toWindowInsetsCompat(insets)).toWindowInsets()?.let { windowInsets ->
-                rollingInsets = windowInsets
-            }
+            val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets)
+            currentInsets =
+                checkNotNull(it.onApplyWindowInsets(observedView, insetsCompat).toWindowInsets()) {
+                    "[RNScreens] Window insets conversion should never fail above API level 20"
+                }
         }
 
-        return rollingInsets
+        return currentInsets
     }
 
     fun setExternalOnApplyWindowInsetsListener(listener: View.OnApplyWindowInsetsListener?) {

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -12,7 +12,10 @@ class InsetsObserver(
     context: ReactApplicationContext,
     private val observedView: View,
 ) {
-    private var systemListener: View.OnApplyWindowInsetsListener? = null
+    /**
+     * Listener set from outside of this package.
+     */
+    private var externalListener: View.OnApplyWindowInsetsListener? = null
     private val ownListeners: HashSet<OnApplyWindowInsetsListener> = hashSetOf()
 
     init {
@@ -32,7 +35,7 @@ class InsetsObserver(
     fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
         var rollingInsets = insets
 
-        systemListener?.onApplyWindowInsets(observedView, insets)?.let {
+        externalListener?.onApplyWindowInsets(observedView, insets)?.let {
             rollingInsets = it
         }
 
@@ -46,7 +49,7 @@ class InsetsObserver(
     }
 
     fun setOnApplyWindowListener(listener: View.OnApplyWindowInsetsListener?) {
-        systemListener = listener
+        externalListener = listener
     }
 
     fun addOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener) {
@@ -59,7 +62,7 @@ class InsetsObserver(
 
     fun clear() {
         ownListeners.clear()
-        systemListener = null
+        externalListener = null
         ViewCompat.setOnApplyWindowInsetsListener(observedView, null)
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt
@@ -9,13 +9,14 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 
 class InsetsObserver(
+    context: ReactApplicationContext,
     view: View,
 ) {
     private val observedView = view
     private var systemListener: View.OnApplyWindowInsetsListener? = null
     private val ownListeners: HashSet<OnApplyWindowInsetsListener> = hashSetOf()
 
-    constructor(view: View, context: ReactApplicationContext) : this(view) {
+    init {
         context.addLifecycleEventListener(
             object : LifecycleEventListener {
                 override fun onHostDestroy() {

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -40,7 +40,7 @@ class Screen(
     val reactContext: ThemedReactContext,
 ) : FabricEnabledViewGroup(reactContext),
     ScreenContentWrapper.OnLayoutCallback {
-    val insetsObserver = InsetsObserver(this, reactContext.reactApplicationContext)
+    val insetsObserver = InsetsObserver(reactContext.reactApplicationContext, this)
 
     val fragment: Fragment?
         get() = fragmentWrapper?.fragment
@@ -554,7 +554,7 @@ class Screen(
         // earlier. More details: https://github.com/software-mansion/react-native-screens/pull/2911
         if (usesFormSheetPresentation()) {
             fragment?.asScreenStackFragment()?.sheetDelegate?.let {
-                insetsObserver.addOnApplyWindowInsetsListener(it);
+                insetsObserver.addOnApplyWindowInsetsListener(it)
             }
         }
     }
@@ -563,9 +563,7 @@ class Screen(
         insetsObserver.setOnApplyWindowListener(listener)
     }
 
-    override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
-        return insetsObserver.onApplyWindowInsets( insets)
-    }
+    override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets = insetsObserver.onApplyWindowInsets(insets)
 
     private fun dispatchSheetDetentChanged(
         detentIndex: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -566,7 +566,7 @@ class Screen(
      * If you want to register a listener on this view, you should use `insetsObserver` directly.
      */
     override fun setOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener?) {
-        insetsObserver.setOnApplyWindowListener(listener)
+        insetsObserver.setExternalOnApplyWindowInsetsListener(listener)
     }
 
     override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets = insetsObserver.onApplyWindowInsets(insets)

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -559,6 +559,12 @@ class Screen(
         }
     }
 
+    /**
+     * This should not be called from inside this package. Any call to this method is treated
+     * as a call from external source & added listener is treated in a special manner.
+     *
+     * If you want to register a listener on this view, you should use `insetsObserver` directly.
+     */
     override fun setOnApplyWindowInsetsListener(listener: OnApplyWindowInsetsListener?) {
         insetsObserver.setOnApplyWindowListener(listener)
     }


### PR DESCRIPTION

## Description

Review notes for #2938. Please note that I've described each change in commit details.

## Changes

- **refactor insets managment for sheets**
- **Update android/src/main/java/com/swmansion/rnscreens/InsetsObserver.kt**
- **Remove secondary constructor & add context as first parameter**
- **Update callsite**
- **Make use of ctor param instead of introducing additional variable**
- **Rename systemListener -> externalListener**
- **Add a comment explaining semantics of `Screen.setOnApplyWindowInsetsListener`**
- **Renmae setOnApplyWindowListener -> setExternalOnApplyWindowInsetsListener**
- **Rename rollingInsets -> currentInsets & assert nullability**
- **Add comment explaining what is being returned there**

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
