### PR TITLE
fix(Android): remove setting system bar translucent props from JS if in edge to edge

### DIFF
--- a/apps/src/tests/Test2949.tsx
+++ b/apps/src/tests/Test2949.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, Text, View } from 'react-native';
+
+// @ts-ignore: react-native-edge-to-edge is a dependency of example apps, not the library itself,
+//             so we get an error here but it works correctly
+import { SystemBars } from 'react-native-edge-to-edge';
+
+type RouteParamList = {
+  Home: undefined;
+  Second: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function Home({ navigation }: StackNavigationProp) {
+  const [style, setStyle] = useState<'dark' | 'light'>('dark');
+
+  useEffect(() => {
+    SystemBars.setStyle({
+      statusBar: style,
+      navigationBar: style,
+    });
+  }, [style]);
+
+  return (
+    <>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 10,
+        }}>
+        <View style={{ padding: 20 }}>
+          <Text>
+            The goal of this test is to check react-native-edge-to-edge's
+            SystemBars.setStyle().
+          </Text>
+          <Text>
+            Props from react-navigation/react-native-screens that modify the
+            system bars interfere with the react-native-edge-to-edge's
+            SystemBars so in order to test this properly, run this test as the
+            main app content (without Example screen menu) by changing App.tsx.
+          </Text>
+        </View>
+        <Button
+          title="Change style"
+          onPress={() =>
+            style === 'dark' ? setStyle('light') : setStyle('dark')
+          }
+        />
+        <Button
+          title="Open second"
+          onPress={() => navigation.navigate('Second')}
+        />
+      </View>
+    </>
+  );
+}
+
+function Second({ navigation }: StackNavigationProp) {
+  return (
+    <>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </>
+  );
+}
+
+export default function App() {
+  return (
+    <>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={Home} />
+          <Stack.Screen name="Second" component={Second} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </>
+  );
+}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -138,6 +138,7 @@ export { default as Test2877 } from './Test2877'; // [E2E created](iOS): issue i
 export { default as Test2895 } from './Test2895';
 export { default as Test2899 } from './Test2899';
 export { default as Test2926 } from './Test2926'; // [E2E created](iOS): PR related to iOS search bar
+export { default as Test2949 } from './Test2949'; // [E2E skipped]: can't check system bars styles
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/src/components/helpers/edge-to-edge.tsx
+++ b/src/components/helpers/edge-to-edge.tsx
@@ -25,9 +25,5 @@ export function transformEdgeToEdgeProps(props: ScreenProps): ScreenProps {
     });
   }
 
-  return {
-    ...rest,
-    statusBarTranslucent: true,
-    navigationBarTranslucent: true,
-  };
+  return rest;
 }


### PR DESCRIPTION
## Description

Fixes #2948

Fixes an issue where system bar styles set using `SystemBars.setStyle` function from `react-native-edge-to-edge` would be overridden by default values set in `react-native-screens`. Those should only work when we define system bar styles via screen options but in https://github.com/software-mansion/react-native-screens/pull/2464 that integrated `react-native-edge-to-edge` with `react-native-screens`, we would always set `statusBarTranslucent` and `navigationBarTranslucent` props when in edge to edge ([code here](https://github.com/software-mansion/react-native-screens/pull/2464/files#diff-d51c072177510e603797455a4c3c14a049d0cfdbd39132fb53a6c187de8b7789R30-R31)), which would set `didSetStatusBarAppearance`/`didSetNavigationBarAppearance` and in result, make `screens` use default values for system bar styles.

Setting `statusBarTranslucent` and `navigationBarTranslucent` props to `true` in edge-to-edge is not necessary and it's currently ignored in native code when in edge-to-edge after https://github.com/software-mansion/react-native-screens/pull/2913 ([here](https://github.com/software-mansion/react-native-screens/pull/2913/files#diff-49e80f92048eb21d46beae35985ce78f79217693be04df175e5e679878d0f2c7R158) and [there](https://github.com/software-mansion/react-native-screens/pull/2913/files#diff-49e80f92048eb21d46beae35985ce78f79217693be04df175e5e679878d0f2c7R234)).

Thanks to @efstathiosntonas for [reporting the issue and finding](https://github.com/software-mansion/react-native-screens/pull/2913#issuecomment-2912403953) the culprit!

## Changes

- remove setting `statusBarTranslucent` and `navigationBarTranslucent` in `edge-to-edge.tsx`
- add test screen

## Screenshots / GIFs

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/09739d52-7db6-49ac-8e48-1311734e8ff2" /> | <video src="https://github.com/user-attachments/assets/cd0dee11-135e-4134-a56c-1dbd20218304" /> |

## Test code and steps to reproduce

Run `Test2949` **as a main app** by modifying `App.tsx` in example app.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
