### PR TITLE
docs: add missing information about statusBarStyle

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -289,7 +289,7 @@ Defaults to `false`.
 
 ### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. On iOS, the possible values are: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`. On Android, the status bar will be dark if set to `dark` and `light` otherwise.
+Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file. On iOS, the possible values are: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc)), `inverted` (colors opposite to `auto`), `light`, `dark`. On Android, the status bar will be dark if set to `dark` and `light` otherwise.
 
 Defaults to `auto`.
 

--- a/native-stack/README.md
+++ b/native-stack/README.md
@@ -503,7 +503,7 @@ Defaults to `false`.
 
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). On iOS, the possible values are: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc), `inverted` (colors opposite to `auto`), `light`, `dark`. On Android, the status bar will be dark if set to `dark` and `light` otherwise.
+Sets the status bar color (similar to the `StatusBar` component). On iOS, the possible values are: `auto` (based on [user interface style](https://developer.apple.com/documentation/uikit/uiuserinterfacestyle?language=objc)), `inverted` (colors opposite to `auto`), `light`, `dark`. On Android, the status bar will be dark if set to `dark` and `light` otherwise.
 
 Defaults to `auto`.
 

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -499,7 +499,9 @@ export type NativeStackNavigationOptions = {
    */
   statusBarHidden?: boolean;
   /**
-   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file on iOS. Defaults to `auto`.
+   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file on iOS.
+   * `auto` and `inverted` are supported only on iOS. On Android, they will fallback to `light`.
+   * Defaults to `auto` on iOS and `light` on Android.
    */
   statusBarStyle?: ScreenProps['statusBarStyle'];
   /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -449,7 +449,9 @@ export interface ScreenProps extends ViewProps {
    */
   statusBarHidden?: boolean;
   /**
-   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file on iOS. Defaults to `auto`.
+   * Sets the status bar color (similar to the `StatusBar` component). Requires enabling (or deleting) `View controller-based status bar appearance` in your Info.plist file on iOS.
+   * `auto` and `inverted` are supported only on iOS. On Android, they will fallback to `light`.
+   * Defaults to `auto` on iOS and `light` on Android.
    */
   statusBarStyle?: 'inverted' | 'auto' | 'light' | 'dark';
   /**


### PR DESCRIPTION
## Description

Add information about supported values for `statusBarStyle` on Android.

## Changes

- add information about `auto` and `inverted` not being supported on Android
- add information about `light` being default value for `statusBarStyle` on Android
- fix missing parenthesis

## Checklist

- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
