### PR TITLE
test(e2e, Fabric): add e2e tests for issue/PR examples 761..791

### DIFF
--- a/FabricExample/e2e/issuesTests/Test791.e2e.ts
+++ b/FabricExample/e2e/issuesTests/Test791.e2e.ts
@@ -1,0 +1,29 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS, selectTestScreen } from '../e2e-utils';
+
+// issue related to iOS
+describeIfiOS('Test791', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('Test791 should exist', async () => {
+    await selectTestScreen('Test791');
+  });
+
+  it('the app should not crash after quickly pushing multiple card screens behind the modal', async () => {
+    await element(by.id('main-button-push-modal')).tap();
+    await element(by.id('push-button-push-multiple')).tap();
+  });
+
+  it('pushed screens should be visible after closing modal', async () => {
+    await element(by.text('Modal')).swipe('down', 'fast');
+
+    for (let i = 0; i < 5; ++i) {
+      await expect(element(by.id('push-text'))).toBeVisible();
+      await element(by.type('_UIButtonBarButton')).atIndex(0).tap();
+    }
+
+    await expect(element(by.id('main-text'))).toBeVisible();
+  });
+});

--- a/apps/src/tests/Test791.tsx
+++ b/apps/src/tests/Test791.tsx
@@ -20,12 +20,13 @@ const MainScreen = ({ navigation }: NativeStackScreenProps<ParamListBase>) => {
         title="Click this button to see the crash if native changes not applied"
       />
       <Button
+        testID="main-button-push-modal"
         onPress={() => {
           navigation.push('Modal');
         }}
         title="Push modal"
       />
-      <Text>Issue 791</Text>
+      <Text testID="main-text">Issue 791</Text>
     </View>
   );
 };
@@ -33,6 +34,7 @@ const MainScreen = ({ navigation }: NativeStackScreenProps<ParamListBase>) => {
 const PushScreen = ({ navigation }: NativeStackScreenProps<ParamListBase>) => (
   <View style={styles.screen}>
     <Button
+      testID="push-button-push-multiple"
       onPress={() => {
         navigation.push('Push');
         setTimeout(() => navigation.push('Push'), 10);
@@ -50,6 +52,7 @@ const PushScreen = ({ navigation }: NativeStackScreenProps<ParamListBase>) => (
       }}
       title="Click this button to pop"
     />
+    <Text testID="push-text">Push screen</Text>
   </View>
 );
 
@@ -59,7 +62,11 @@ const App = () => (
   <NavigationContainer>
     <Stack.Navigator>
       <Stack.Screen name="Main" component={MainScreen} />
-      <Stack.Screen name="Push" component={PushScreen} />
+      <Stack.Screen
+        name="Push"
+        component={PushScreen}
+        options={{ presentation: 'card' }}
+      />
       <Stack.Screen
         name="Modal"
         component={PushScreen}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -32,8 +32,8 @@ export { default as Test750 } from './Test750';
 export { default as Test758 } from './Test758';
 export { default as Test761 } from './Test761';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test779 } from './Test779';     // [E2E skipped]: can't check animation in a meaningful way
-export { default as Test780 } from './Test780';
-export { default as Test791 } from './Test791';
+export { default as Test780 } from './Test780';     // [E2E skipped]: can't use native swipe back gesture
+export { default as Test791 } from './Test791';     // [E2E created](iOS): issue related to iOS
 export { default as Test800 } from './Test800';
 export { default as Test817 } from './Test817';
 export { default as Test830 } from './Test830';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -30,8 +30,8 @@ export { default as Test726 } from './Test726';     // [E2E created](iOS): issue
 export { default as Test748 } from './Test748';
 export { default as Test750 } from './Test750';
 export { default as Test758 } from './Test758';
-export { default as Test761 } from './Test761';     // [E2E skipped]: can't check animation
-export { default as Test779 } from './Test779';
+export { default as Test761 } from './Test761';     // [E2E skipped]: can't check animation in a meaningful way
+export { default as Test779 } from './Test779';     // [E2E skipped]: can't check animation in a meaningful way
 export { default as Test780 } from './Test780';
 export { default as Test791 } from './Test791';
 export { default as Test800 } from './Test800';

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -30,7 +30,7 @@ export { default as Test726 } from './Test726';     // [E2E created](iOS): issue
 export { default as Test748 } from './Test748';
 export { default as Test750 } from './Test750';
 export { default as Test758 } from './Test758';
-export { default as Test761 } from './Test761';
+export { default as Test761 } from './Test761';     // [E2E skipped]: can't check animation
 export { default as Test779 } from './Test779';
 export { default as Test780 } from './Test780';
 export { default as Test791 } from './Test791';


### PR DESCRIPTION
## Description

Check which example screens from issues/PRs can be used in e2e testing for tests `Test761, ..., Test791` and implement them if possible for Fabric. 

### Test761
Skipped because we can't check animation.

### Test779
Skipped because we can't check animation.

### Test780
Skipped because we can't use native swipe back gesture with Detox.

### Test791
Test created, only on iOS (original issue was about crashes on iOS). It tests if the app crashes when you push multiple screens quickly behind modal.

## Changes

- add `Test791` e2e test
- modify`Test791` test screen (add explicit `presentation: 'card'` for push screen, add testIDs)
- add comments for every test screen from this PR in `apps/src/tests/index.ts` with the reason for (not) implementing e2e test for it

## Test code and steps to reproduce

CI

## Checklist

- [ ] Ensured that CI passes
