### PR TITLE
chore(iOS): remove unused variables in modal updating function

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -421,9 +421,6 @@ RNS_IGNORE_SUPER_CALL_END
 
   _updatingModals = YES;
 
-  NSMutableArray<UIViewController *> *newControllers = [NSMutableArray arrayWithArray:controllers];
-  [newControllers removeObjectsInArray:_presentedModals];
-
   // We need to find bottom-most view controller that should stay on the stack
   // for the duration of transition.
 


### PR DESCRIPTION

## Description

The `newControllers` variable seems to be unused and there is no reason for it to exist.

The variable has been added here: https://github.com/software-mansion/react-native-screens/commit/80a466970e6423ec188c6c22e526e487780fac0c#diff-1c3e13a1b0dcbaa5f7cff5f3ce12cc915fb509725faf693fb65cd23ceb49c4a9
Looks like somewhere along the way the logic was refactored but the variable was not removed.

## Changes

Removed the unused variable.

## Test code and steps to reproduce

I've done some sanity checks on `TestModalNavigation`.

## Checklist

- [ ] Ensured that CI passes
