### PR TITLE
feat: add support for `screenId` prop allowing for native screen recognition

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -59,6 +59,7 @@ class Screen(
     var isGestureEnabled = true
     var screenOrientation: Int? = null
         private set
+    var screenId: String? = null
     var isStatusBarAnimated: Boolean? = null
     var isBeingRemoved = false
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -91,6 +91,11 @@ class ScreenStack(
         }
     }
 
+    /**
+     * Integration function. Allows other solutions to retrieve list of screens owned by this stack.
+     */
+    fun getScreenIds(): List<String?> = screenWrappers.map { it.screen.screenId }
+
     private fun dispatchOnFinishTransitioning() {
         val surfaceId = UIManagerHelper.getSurfaceId(this)
         UIManagerHelper

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -377,6 +377,10 @@ open class ScreenViewManager :
         view.sheetInitialDetentIndex = value
     }
 
+    override fun setScreenId(view: Screen, value: String?) {
+        view.screenId = if (value.isNullOrEmpty()) null else value
+    }
+
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
         mutableMapOf(
             ScreenDismissedEvent.EVENT_NAME to MapBuilder.of("registrationName", "onDismissed"),

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -25,6 +25,9 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManager<
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
+      case "screenId":
+        mViewManager.setScreenId(view, value == null ? "" : (String) value);
+        break;
       case "sheetAllowedDetents":
         mViewManager.setSheetAllowedDetents(view, (ReadableArray) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReadableMap;
 
 
 public interface RNSScreenManagerInterface<T extends View>  {
+  void setScreenId(T view, @Nullable String value);
   void setSheetAllowedDetents(T view, @Nullable ReadableArray value);
   void setSheetLargestUndimmedDetent(T view, int value);
   void setSheetGrabberVisible(T view, boolean value);

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -78,6 +78,7 @@ namespace react = facebook::react;
 @property (nonatomic, retain) RNSScreen *controller;
 @property (nonatomic, copy) NSDictionary *gestureResponseDistance;
 @property (nonatomic) int activityState;
+@property (nonatomic, nullable) NSString *screenId;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 
 #if !TARGET_OS_TV

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1348,6 +1348,17 @@ RNS_IGNORE_SUPER_CALL_END
 #pragma mark - Paper specific
 #else
 
+// On Fabric the setter is not needed, because value invariant (empty string to nil translation)
+// is upheld in `- [updateProps:oldProps:]`
+- (void)setScreenId:(NSString *)screenId
+{
+  if (screenId != nil && screenId.length == 0) {
+    _screenId = nil;
+  } else {
+    _screenId = screenId;
+  }
+}
+
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
   [super didSetProps:changedProps];

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1305,6 +1305,10 @@ RNS_IGNORE_SUPER_CALL_END
     [self setReplaceAnimation:[RNSConvert RNSScreenReplaceAnimationFromCppEquivalent:newScreenProps.replaceAnimation]];
   }
 
+  if (newScreenProps.screenId != oldScreenProps.screenId) {
+    [self setScreenId:RCTNSStringFromStringNilIfEmpty(newScreenProps.screenId)];
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -1969,6 +1973,7 @@ RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
 RCT_EXPORT_VIEW_PROPERTY(swipeDirection, RNSScreenSwipeDirection)
 RCT_EXPORT_VIEW_PROPERTY(transitionDuration, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(screenId, NSString);
 
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onDisappear, RCTDirectEventBlock);

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -36,6 +36,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark-- Integration
+
+@interface RNSScreenStackView ()
+
+/**
+ * \return Arrray with ids of screens owned by this stack. Ids are returned in no particular order. The list might be
+ * empty. The strings inside the list are nullable if the screen has not been assigned an ID.
+ */
+@property (nonatomic, readonly, nonnull) NSArray<NSString *> *screenIds;
+
+@end
+
 @interface RNSScreenStackManager : RCTViewManager <RCTInvalidating>
 
 @end

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1157,6 +1157,15 @@ RNS_IGNORE_SUPER_CALL_END
   _interactionController = nil;
 }
 
+- (nonnull NSArray<NSString *> *)screenIds
+{
+  NSMutableArray<NSString *> *ids = [NSMutableArray arrayWithCapacity:_reactSubviews.count];
+  for (RNSScreenView *childScreenView in _reactSubviews) {
+    [ids addObject:childScreenView.screenId];
+  }
+  return ids;
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - Fabric specific
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -91,7 +91,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       sheetElevation = 24,
       sheetInitialDetentIndex = 0,
       // Other
-      screenId = '',
+      screenId,
       stackPresentation,
       // Events for override
       onAppear,

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -91,6 +91,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       sheetElevation = 24,
       sheetInitialDetentIndex = 0,
       // Other
+      screenId = '',
       stackPresentation,
       // Events for override
       onAppear,
@@ -210,6 +211,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             // Detailed information can be found here https://github.com/software-mansion/react-native-screens/pull/2351
             style={[style, { zIndex: undefined }]}
             activityState={activityState}
+            screenId={screenId}
             sheetAllowedDetents={resolvedSheetAllowedDetents}
             sheetLargestUndimmedDetent={resolvedSheetLargestUndimmedDetent}
             sheetElevation={sheetElevation}

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -137,6 +137,7 @@ function ScreenStackItem(
       isNativeStack
       activityState={activityState}
       shouldFreeze={shouldFreeze}
+      screenId={screenId}
       stackPresentation={stackPresentation}
       hasLargeHeader={headerConfig?.largeTitle ?? false}
       sheetAllowedDetents={sheetAllowedDetents}

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -78,6 +78,7 @@ export interface NativeProps extends ViewProps {
   onGestureCancel?: DirectEventHandler<ScreenEvent>;
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;
+  screenId?: WithDefault<string, ''>;
   sheetAllowedDetents?: number[];
   sheetLargestUndimmedDetent?: WithDefault<Int32, -1>;
   sheetGrabberVisible?: WithDefault<boolean, false>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -78,6 +78,7 @@ export interface NativeProps extends ViewProps {
   onGestureCancel?: DirectEventHandler<ScreenEvent>;
   onHeaderBackButtonClicked?: DirectEventHandler<ScreenEvent>;
   onSheetDetentChanged?: DirectEventHandler<SheetDetentChangedEvent>;
+  screenId?: WithDefault<string, ''>;
   sheetAllowedDetents?: number[];
   sheetLargestUndimmedDetent?: WithDefault<Int32, -1>;
   sheetGrabberVisible?: WithDefault<boolean, false>;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -283,6 +283,16 @@ export interface ScreenProps extends ViewProps {
    */
   replaceAnimation?: ScreenReplaceTypes;
   /**
+   * A way to identify the screen in native code. This value will be passed down to native side,
+   * where it can be later consulted. Meant for native integration with the library.
+   * This should be unique value across all screen instances, however it is not asserted on native side.
+   *
+   * Empty string translates to `undefined`.
+   *
+   * @platform ios
+   */
+  screenId?: string | undefined;
+  /**
    * In which orientation should the screen appear.
    * The following values are currently supported:
    * - "default" - resolves to "all" without "portrait_down" on iOS. On Android, this lets the system decide the best orientation.


### PR DESCRIPTION
## Description

Add support for `screenId` prop on native side. At the moment we use this value only in JS code.
It was brought to my attention, however, that other libs that wanna integrate might want that
to be exposed also on native side. 

## Changes

Added `screenId` prop & exposed it on both platforms.

## Test code and steps to reproduce

Any example & add a breakpoint at setter method.

## Checklist

- [ ] Ensured that CI passes
