### PR TITLE
fix(iOS): handle presenting custom modal when attempting to exit screen with preventNativeDismiss 

### DIFF
--- a/apps/src/tests/Test2125.tsx
+++ b/apps/src/tests/Test2125.tsx
@@ -1,0 +1,97 @@
+import {
+  NavigationAction,
+  NavigationContainer,
+  ParamListBase,
+  useIsFocused,
+  usePreventRemove,
+} from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import React, { useCallback, useState } from 'react';
+import { Button, Modal, StyleSheet, Text, View } from 'react-native';
+
+type StackRouteParamList = {
+  Home: undefined;
+  SecondScreen: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<StackRouteParamList>;
+
+const Stack = createNativeStackNavigator<StackRouteParamList>();
+
+function SecondScreen({ navigation }: StackNavigationProp) {
+  const [pendingAction, setPendingAction] = useState<NavigationAction>();
+
+  const isFocused = useIsFocused();
+
+  usePreventRemove(isFocused && !pendingAction, event => {
+    setPendingAction(event.data.action);
+  });
+
+  const handlePressCancel = useCallback(() => {
+    setPendingAction(undefined);
+  }, []);
+
+  const handlePressConfirm = useCallback(() => {
+    if (pendingAction) {
+      navigation.dispatch(pendingAction);
+      setPendingAction(undefined);
+    }
+  }, [navigation, pendingAction]);
+
+  return (
+    <View style={styles.container}>
+      <Text>This is second</Text>
+      <Modal visible={!!pendingAction} transparent>
+        <View
+          style={[styles.container, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>
+          <View style={styles.content}>
+            <Button title={'Go back'} onPress={handlePressConfirm} />
+            <Button title={'Cancel'} onPress={handlePressCancel} />
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+function HomeScreen({ navigation }: StackNavigationProp) {
+  return (
+    <View style={styles.container}>
+      <Button
+        title={'Go To Second Screen'}
+        onPress={() => navigation.navigate('SecondScreen')}
+      />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="SecondScreen" component={SecondScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    backgroundColor: 'white',
+    padding: 25,
+    borderRadius: 25,
+  },
+});

--- a/apps/src/tests/Test2125.tsx
+++ b/apps/src/tests/Test2125.tsx
@@ -11,6 +11,7 @@ import {
 } from '@react-navigation/native-stack';
 import React, { useCallback, useState } from 'react';
 import { Button, Modal, StyleSheet, Text, View } from 'react-native';
+import Colors from '../shared/styling/Colors';
 
 type StackRouteParamList = {
   Home: undefined;
@@ -50,7 +51,10 @@ function SecondScreen({ navigation }: StackNavigationProp) {
       <Text>This is second</Text>
       <Modal visible={!!pendingAction} transparent>
         <View
-          style={[styles.container, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>
+          style={[
+            styles.container,
+            { backgroundColor: Colors.NavyLightTransparent },
+          ]}>
           <View style={styles.content}>
             <Button title={'Go back'} onPress={handlePressConfirm} />
             <Button title={'Cancel'} onPress={handlePressCancel} />
@@ -90,7 +94,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   content: {
-    backgroundColor: 'white',
+    backgroundColor: Colors.White,
     padding: 25,
     borderRadius: 25,
   },

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -101,6 +101,7 @@ export { default as Test2028 } from './Test2028';
 export { default as Test2048 } from './Test2048';
 export { default as Test2069 } from './Test2069';
 export { default as Test2118 } from './Test2118';
+export { default as Test2125 } from './Test2125'; // [E2E skipped]: issue happens nondeterministically
 export { default as Test2167 } from './Test2167';
 export { default as Test2175 } from './Test2175';
 export { default as Test2184 } from './Test2184';

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1927,7 +1927,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // In order to handle presenting modals other than react-native-screens modals (e.g. react-native's Modal),
   // we need to delay presenting it if we're in an ongoing transition. This might be necessary
   // when we use an animation to cancel back button dismiss and try to present a modal at the same time.
-  // For more details see: .
+  // For more details see: https://github.com/software-mansion/react-native-screens/pull/2976.
   if (self.parentViewController == nil) {
     UIViewController *controller = self.screenView.reactSuperview.reactViewController;
 


### PR DESCRIPTION
## Description

When trying to use a transparent full-screen `Modal` from `react-native` after attempting to close a screen that uses `usePreventRemove` hook, sometimes the `Modal` would not attatch to `rootViewController` but to `RNSScreen` - this would cause a visual bug and prevent any interaction with the modal.

This is connected to how we handle `preventNativeDismiss`, introduced in https://github.com/software-mansion/react-native-screens/pull/1773. We create an `interactionController` for the transition and after a small delay, we asynchronously dispatch a cancellation of the transition. 

When `react-native`'s Modal tries to present itself, the host component calls `presentViewController` on its controller (`RNSScreen`). Normally, `RNSScreen` forwards the request up to its ancestor because presenting a full-screen modal should be handled by a `rootViewController`. This behavior is described in [UIKit docs](https://developer.apple.com/documentation/uikit/uiviewcontroller/present(_:animated:completion:)?language=objc).

When the transition is still ongoing, `RNSScreen` is detached, `parentViewController` of `RNSScreen` is `nil`. It can't pass the modal up so it tries to present it but this obviously causes visual bugs and a warning: 

```
Presenting view controller <RCTFabricModalHostViewController: 0x1193a2000> 
from detached view controller <RNSScreen: 0x11931fc00> is not supported, 
and may result in incorrect safe area insets and a corrupt root presentation. 
Make sure <RNSScreen: 0x11931fc00> is in the view controller hierarchy 
before presenting from it. Will become a hard exception in a future release.
```

The workaround is to delay presenting the modal after the transition completes but `transitionCoordinator` in `RNSScreen` is `nil` - this might be due to the screen being detached from the stack that handles the transition.

Instead, we use `reactSuperView` and `reactViewController` to access `RNSNavigationController` and check if `transitionCoordinator != nil`.

Fixes https://github.com/software-mansion/react-native-screens/issues/2125.
Includes reproduction from https://github.com/software-mansion/react-native-screens/pull/2357 by @adrianryt, @alduzy.

## Changes

- override `presentViewController` in `RNSScreen` to delay presenting modals when in transition,
- add Test2125 test screen.

## Screenshots / GIFs

https://github.com/user-attachments/assets/a2b7a3f5-6d65-490e-82cf-bc89c99d6716

## Test code and steps to reproduce

Run `Test2125` from example app.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
