### PR TITLE
feat(iOS): support UIBarButtonItem in header

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FBLazyVector (0.80.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.80.0-rc.4):
-    - hermes-engine/Pre-built (= 0.80.0-rc.4)
-  - hermes-engine/Pre-built (0.80.0-rc.4)
+  - hermes-engine (0.80.0-rc.5):
+    - hermes-engine/Pre-built (= 0.80.0-rc.5)
+  - hermes-engine/Pre-built (0.80.0-rc.5)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2586,79 +2586,79 @@ SPEC CHECKSUMS:
   FBLazyVector: 04f59172f2d1bc4c8afd36bbff2485df293fab12
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 1072a7bafbd85639139f2078868a83dfd89d331b
+  hermes-engine: 7b7ffc2a07cbaa556b4a75a6da50e73f4c138ea7
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 06e57a11be6128124a3c7cbfceb09b78f6c9ffc2
   RCTRequired: 843cc1fe500b0ba58512287c5116e31a45181bca
   RCTTypeSafety: 71eeceddb7e708c224909ba99c37a145c98c02a7
   React: d24621fc58bfcf5015e3286eac7b76c05040d914
   React-callinvoker: f36300fae0e5d711e6b9991976f64ae0cb8fad3a
-  React-Core: f284fdea10a4778b736eaa065769a2b843b530f0
-  React-CoreModules: 45ab4e286895a2312e036f5e48639bdc1a73902f
-  React-cxxreact: 7c6d58dd92feca44a013988f6282956b5f2b3229
+  React-Core: aef4f9c7ab58928f5d422cb5b48550cf7308d34e
+  React-CoreModules: 281bd2743374f8bfe665eddc90980e32da86c961
+  React-cxxreact: 37dd3694abbdea4e4973c0039e1a793c60c9f677
   React-debug: 3005e18d181d33277445c99e201d37f3114233b6
-  React-defaultsnativemodule: f78ad0be2080633d0c2dd5a48905fa556bc030a2
-  React-domnativemodule: 0686da969f67cb81b8555fb3123d1906f62d44f6
-  React-Fabric: 9e8e3acfa8c8daa36dd11c98d612c25c1e11ea59
-  React-FabricComponents: ff54b3fc511695d209a219162371d484d62dec9a
-  React-FabricImage: f1e3f9bd46068b1d5406484406c4897473756b68
-  React-featureflags: 4963e06d1885257e2d109d733837c39cfc97f836
-  React-featureflagsnativemodule: 8a91773c93c38b11bf6af402c9287155d69a1f86
-  React-graphics: da7f5a1e95962b39fb5fc02ea5c615231b4e5626
-  React-hermes: bd76cb1d809d7dd27c9ad31a7d663047e4864f92
-  React-idlecallbacksnativemodule: acb58fd1bf494f1331e3a8765a855a85942d573e
-  React-ImageManager: 251cb54baff0af00e88f96dc01e4d1ca795e2928
-  React-jserrorhandler: 74a5109317e35632dd26ffbb38243d1b5aaebed3
-  React-jsi: 904806629c68f61d6e128d19c0cee1e3605eceec
-  React-jsiexecutor: d4fab673c926d913d6e1530155378833462fde57
-  React-jsinspector: 85113ed82fd449942151731f1051d46a9e5b2830
-  React-jsinspectorcdp: 538cb3eea51969564d0d57e23de3039fb22c8d28
-  React-jsinspectornetwork: 0be7cd0206b62c86d22b864a3147d9bfcc020477
-  React-jsinspectortracing: 9c772ac4f0df8f2940a34185e6e0e67bf91148cf
-  React-jsitooling: ea0874c51c43798dc4a83feaf6ffa57b929cacdc
-  React-jsitracing: 9f866cdc3a7f8b8eda89b52c409934bc9f85903a
-  React-logger: 34f13c3effe44410ccf62b255fc12f085ac7d038
-  React-Mapbuffer: 0e9c84c9a8e55645a1f19ae14e79a761b843ddc2
-  React-microtasksnativemodule: 3302ad49a9b619ca411acfca32534f3696894b95
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: 8870dc3e45c8d241336cd8ee3fa3fc76f3a040ac
-  React-NativeModulesApple: db5c62dfdee373bfacb3ce4fe86469a84d8047d9
+  React-defaultsnativemodule: ba8a3f1abcd5913630340f3e936ea07d27febdf7
+  React-domnativemodule: 88466afb07953e47ebf231182d0980cda5377d95
+  React-Fabric: a1c2e1bb9871fb9888a1db7b6a40e0db3d91b73c
+  React-FabricComponents: ff325c6cedbe89507de0eae224a42b2e67d5ff1c
+  React-FabricImage: fb3c27d5e7603a230bdeaa9568e6dc72735936fc
+  React-featureflags: dd3ccec1d8112ecac993cd0ca35a67df48b9daeb
+  React-featureflagsnativemodule: 3c1d81f4b2909c8fd3ecd6623b1de549fade3524
+  React-graphics: f32dfa6aff8c9bbd8c47ab654034ce4e58ab4c67
+  React-hermes: 13f04dd474bea52f96ad10d80a5a60e3ac0c3785
+  React-idlecallbacksnativemodule: cb2e3a3c0ff157372909174dc9f23c642c2b7a35
+  React-ImageManager: 172ee56abdc3817dd9d26ecb38376cdf4a038105
+  React-jserrorhandler: e45b1e30a6abee55c8074cf215a58da05b0096f7
+  React-jsi: e612dba0b66803c573ddf250759041c9596b3ee9
+  React-jsiexecutor: 8c70fee59074dea4b4a567fa8f7d41cd25d8f0b3
+  React-jsinspector: 8bdf4a5b551d47b4fa394be3c108234be16dfabf
+  React-jsinspectorcdp: 6b32ca1f748a5e11e93653c4da25b7dc8bf6abcb
+  React-jsinspectornetwork: 2095a657777880b4e725cd96ab75d9b7b8666eb4
+  React-jsinspectortracing: 051b2c19b945eeecb66cd135b0a9f1cd92028cab
+  React-jsitooling: f37797ceda2a44770bb888d1e606cdd656612240
+  React-jsitracing: f1f946a3f997c472bda7a920770a42af7ad4a469
+  React-logger: b2ab8954b7d31968fab60aa505035561636fc9b8
+  React-Mapbuffer: 0da76ab0049249334a38eeb813022624e9638bb0
+  React-microtasksnativemodule: 01d07c914986385e1a87527e060e6d1d3c4afd4b
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: 9d72abf6d8473da73033b597090a80b709c0b2f1
+  React-NativeModulesApple: 47b8a4ee974150ccef0cd6d0277801ebdb8e65d9
   React-oscompat: acc1d2b40174ce9a8c3d61912572a51ff76a94e6
-  React-perflogger: bb0332a02764f3c6570244635ac4318211514f3c
-  React-performancetimeline: e005006283a2acb109fe0821b75c35c1cfe6e769
+  React-perflogger: 524aa1464e26057b878dae4e57cfa66ac041b912
+  React-performancetimeline: 3b935d6cdb86d6094b515d55aca87d546be29448
   React-RCTActionSheet: dad33af1be68c5e92d5d00482f5a42f49822531c
-  React-RCTAnimation: aa0e7ddf90d94a6f625b96fc29e9c58d9bb1c449
-  React-RCTAppDelegate: 83f593bfa5364adecc0ed4c982b6e94b5d03a04a
-  React-RCTBlob: 14655d7b0ef157dd76d26db1fd75c4d7b92a2692
-  React-RCTFabric: b219b7dc7b27fdb5c3c4f5cc12c2a6f2910dc4f4
-  React-RCTFBReactNativeSpec: f7d644339cddab9ae50411de570465a0fd9c1657
-  React-RCTImage: 379dc52f16dc25fe9ab843053eb785461b0ffcb5
-  React-RCTLinking: 833b53827195f23a639bebe64e048497edd28a04
-  React-RCTNetwork: e005e7b11632bb1dfcc1b13e79f11d8d9bc531d9
-  React-RCTRuntime: c6425b7fb3bb18013b46cd60a294c1afba61ecd7
-  React-RCTSettings: ebe3edb605bade8c0bde36f51a75d95e96a2ef81
-  React-RCTText: ba698614a19a41249036227b52213f6f8a982ec3
-  React-RCTVibration: 4385bc7b39e2a435933d6447eb37f54e099a00be
+  React-RCTAnimation: 8533e01f03cd26c14cf799825f7e602e74f45068
+  React-RCTAppDelegate: d9b2830c57f56236607974b5a691493da7a3a462
+  React-RCTBlob: 346bcef8187d919789bed64ecca0ef60efb9ad2a
+  React-RCTFabric: f42710d747feb75d669e2999201fbd8e0d6bfcec
+  React-RCTFBReactNativeSpec: ec21c84f9f90896acc52e94f0d2843924cbb7426
+  React-RCTImage: 8b6ffa3db3e954657efef692a436563dcabeb109
+  React-RCTLinking: 7feb092c09d1ab3a079bf45a5e9a2893744ea018
+  React-RCTNetwork: fdaddb5b2c4b4dc817fad1c574055783a79d52b2
+  React-RCTRuntime: f122454c5d4fccc47ae63f7eff92eb400154171c
+  React-RCTSettings: 89330584241a7030b01a8af838f9a6c3048b22a6
+  React-RCTText: 05886210ae16e511b1ebc736c48a3ce7f225b49b
+  React-RCTVibration: f50b13abc67b0b7084bafb5aa6a42c3aa9fec23a
   React-rendererconsistency: 103d24d9fd9eed1760f0874edfbdc4b98288a20b
-  React-renderercss: 4841823f6d3bcc65fdbaf00906b17bee7415d598
-  React-rendererdebug: 9d95f3e58b504e4fa28798caa7c1e40cd5fc6f4a
+  React-renderercss: fc7a0d92d1db6763c60af66bbad8277f9e6169a7
+  React-rendererdebug: 8c47c35e8f5a309e5d9fc30ba6bfae895d52fcc1
   React-rncore: c555e70ebd3dc73ebc494ce4e30cbaa381fa5731
-  React-RuntimeApple: 8033fb3a15d4234d92612aa293bdd358f7897bc5
-  React-RuntimeCore: ba41b7e036428a80789e755de7cbdfcffaaac973
+  React-RuntimeApple: f252ae433f9b9cea9bb7ba15272affbf895b09e0
+  React-RuntimeCore: d8275e446134baf1b9ccaacca7707b1258d7ecbf
   React-runtimeexecutor: 52df6be38a17311756f9fbb39b9bb055f4bd01c2
-  React-RuntimeHermes: 996d88f40374434c31a859d888dff541c277cd60
-  React-runtimescheduler: 5eacdcd1db313e2d6950fb8872cc8038327d2b31
+  React-RuntimeHermes: 9d4f426e36f26cc0101bfaa5483d162c72ec229e
+  React-runtimescheduler: 3c02c1e26324cc2cb802853d194bb95637f2c657
   React-timing: d44a981781952fe0ac6dac355473b2248700cdf1
-  React-utils: 81dcddf4ae56d8defae035f0e4500572321a7fbd
-  ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
-  ReactCodegen: 8b92aba599d781d4a10b8dd86b40bafe69712231
-  ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
-  RNGestureHandler: cad0a1b7e766a42852f8fb211f35a85b6199a26d
-  RNReanimated: 4f8f7e87f1e9869d2373416c3c8aabe614e3aeee
-  RNScreens: f75a433d5966ab2b0570fa5e5e487f1c46488972
+  React-utils: 650abce2396b9c6cdeea3e7dca563d5d9ede8663
+  ReactAppDependencyProvider: 05a7e34b5973a0258aab697b734a1f07c6b9fc02
+  ReactCodegen: 5edf192e4506ca9b86c1103a4c739c0e891e7540
+  ReactCommon: 2a36c33c9f2d60fe8e760685ff99628730b25d43
+  RNGestureHandler: 876822d8062d5acdb53aa07d8e58ff1f44371f36
+  RNReanimated: 7e273cda8e13a7efef02a4942f9680b7b5262ca3
+  RNScreens: 6f26eb84a9475b21246f1a515923837771ff9be3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c8798357f928802015a217ccd2fe692b61a090c2
 
 PODFILE CHECKSUM: e1c705abfb728b259283bd3b94a9aaac16e72096
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.view.View
 import com.facebook.react.bridge.JSApplicationCausedNativeException
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ReactStylesDiffMap
@@ -318,5 +319,19 @@ class ScreenStackHeaderConfigViewManager :
         value: String?,
     ) {
         logNotAvailable("blurEffect")
+    }
+
+    override fun setHeaderLeftBarButtonItems(
+        view: ScreenStackHeaderConfig?, 
+        value: ReadableArray?
+    ) {
+        logNotAvailable("headerLeftBarButtonItems")
+    }
+
+    override fun setHeaderRightBarButtonItems(
+        view: ScreenStackHeaderConfig?, 
+        value: ReadableArray?
+    ) {
+        logNotAvailable("headerRightBarButtonItems")
     }
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerDelegate.java
@@ -12,6 +12,7 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -106,6 +107,12 @@ public class RNSScreenStackHeaderConfigManagerDelegate<T extends View, U extends
         break;
       case "topInsetEnabled":
         mViewManager.setTopInsetEnabled(view, value == null ? false : (boolean) value);
+        break;
+      case "headerLeftBarButtonItems":
+        mViewManager.setHeaderLeftBarButtonItems(view, (ReadableArray) value);
+        break;
+      case "headerRightBarButtonItems":
+        mViewManager.setHeaderRightBarButtonItems(view, (ReadableArray) value);
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -11,6 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableArray;
 
 
 public interface RNSScreenStackHeaderConfigManagerInterface<T extends View>  {
@@ -42,4 +43,6 @@ public interface RNSScreenStackHeaderConfigManagerInterface<T extends View>  {
   void setBackButtonInCustomView(T view, boolean value);
   void setBlurEffect(T view, @Nullable String value);
   void setTopInsetEnabled(T view, boolean value);
+  void setHeaderLeftBarButtonItems(T view, @Nullable ReadableArray value);
+  void setHeaderRightBarButtonItems(T view, @Nullable ReadableArray value);
 }

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -30,6 +30,7 @@ import Orientation from './src/screens/Orientation';
 import SearchBar from './src/screens/SearchBar';
 import Events from './src/screens/Events';
 import Gestures from './src/screens/Gestures';
+import BarButtonItems from './src/screens/BarButtonItems';
 
 import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -125,6 +126,11 @@ const SCREENS: Record<
   Gestures: {
     title: 'Gestures',
     component: Gestures,
+    type: 'playground',
+  },
+  BarButtonItems: {
+    title: 'Bar Button Items',
+    component: BarButtonItems,
     type: 'playground',
   },
 };

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -33,6 +33,12 @@ export default function BarButtonItemsExample() {
               titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800', color: 'black' },
               style: 'prominent',
               tintColor: 'yellow',
+              badge: {
+                value: '1',
+                color: 'white',
+                backgroundColor: 'red',
+                style: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '100' },
+              },
             },
             {
               image: require('../assets/search_black.png'),

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -25,26 +25,34 @@ export default function BarButtonItemsExample() {
         name="BarButtonItems Demo"
         options={{
           headerTransparent: true,
-          headerBlurEffect: 'regular',
           title: 'BarButtonItems Demo',
           headerLeftBarButtonItems: [
             {
-              title: 'Plain',
+              title: '+allt',
               onPress: () => Alert.alert('Plain pressed'),
-              titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800' },
+              titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800', color: 'black' },
+              style: 'Prominent',
+              tintColor: 'yellow',
+            },
+            {
+              image: require('../assets/search_black.png'),
+              onPress: () => Alert.alert('Search pressed'),
             },
           ],
           headerRightBarButtonItems: [
             {
-              onPress: () => Alert.alert('Search pressed'),
-              image: require('../assets/search_black.png'),
-              style: 'Plain',
-            },
-            {
-              onPress: () => Alert.alert('Button pressed 2'),
-              image: require('../assets/search_black.png'),
               style: 'Prominent',
-              tintColor: 'green',
+              title: 'Menu',
+              menu: [
+                {
+                  title: 'Search',
+                  onPress: () => Alert.alert('Search pressed'),
+                },
+                {
+                  title: 'Search with long text that wraps',
+                  onPress: () => Alert.alert('Search with long text pressed'),
+                },
+              ],
             },
           ],
         }}

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -37,23 +37,42 @@ export default function BarButtonItemsExample() {
             {
               image: require('../assets/search_black.png'),
               onPress: () => Alert.alert('Search pressed'),
+              accessibilityLabel: 'SÖK HÄR',
+              accessibilityHint: 'Tryck för att söka',
             },
           ],
           headerRightBarButtonItems: [
             {
               style: 'Prominent',
               title: 'Menu',
-              menu: [
+              tintColor: 'purple',
+              menu: {
+                items: [
                 {
                   title: 'Search',
+                  systemImage: 'magnifyingglass.circle.fill',
                   onPress: () => Alert.alert('Search pressed'),
                 },
                 {
                   title: 'Search with long text that wraps',
                   onPress: () => Alert.alert('Search with long text pressed'),
                 },
+                {
+                  title: 'Submenu',
+                  items: [
+                    {
+                      title: 'Submenu Item 1',
+                      systemImage: 'magnifyingglass.circle.fill',
+                      onPress: () => Alert.alert('Submenu Item 1 pressed'),
+                    },
+                    {
+                      title: 'Submenu Item 2',
+                      onPress: () => Alert.alert('Submenu Item 2 pressed'),
+                    },
+                  ],
+                },
               ],
-            },
+            }},
           ],
         }}
         component={Screen}

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -31,8 +31,7 @@ export default function BarButtonItemsExample() {
             {
               title: 'Plain',
               onPress: () => Alert.alert('Plain pressed'),
-              tintColor: 'red',
-              style: 2,
+              tintColor: '#ff0000',
             },
           ],
           // Example: Right bar button items (using only typed props)
@@ -40,13 +39,13 @@ export default function BarButtonItemsExample() {
             {
               onPress: () => Alert.alert('Search pressed'),
               image: require('../assets/search_black.png'),
-              style: 1,
+              style: 'Plain',
               enabled: false,
             },
             {
               onPress: () => Alert.alert('Search pressed'),
               image: require('../assets/search_black.png'),
-              style: 2,
+              style: 'Prominent',
             },
           ],
         }}

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -25,15 +25,15 @@ export default function BarButtonItemsExample() {
         name="BarButtonItems Demo"
         options={{
           headerTransparent: true,
+          headerBlurEffect: 'regular',
           title: 'BarButtonItems Demo',
-          // Example: Left bar button items (using only typed props)
           headerLeftBarButtonItems: [
             {
               title: 'Plain',
               onPress: () => Alert.alert('Plain pressed'),
+              titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800' },
             },
           ],
-          // Example: Right bar button items (using only typed props)
           headerRightBarButtonItems: [
             {
               onPress: () => Alert.alert('Search pressed'),

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -43,6 +43,9 @@ export default function BarButtonItemsExample() {
               enabled: false,
             },
             {
+              spacing: 0,
+            },
+            {
               onPress: () => Alert.alert('Search pressed'),
               image: require('../assets/search_black.png'),
               style: 'Prominent',

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -1,6 +1,6 @@
 // NOTE: The full native feature set (style, image, menu, etc.) is available, but the TS types in src/types.tsx need to be updated to match. This example uses only the currently typed props (title, icon, onPress, enabled).
 import React from 'react';
-import { View, Alert, Button, Text } from 'react-native';
+import { View, Alert, Button, Text, Platform } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ScrollView } from 'react-native-gesture-handler';
 
@@ -63,7 +63,7 @@ const AdvancedMenuButtonDemo = DemoScreenContent;
 
 export default function BarButtonItemsExample() {
   return (
-    <Stack.Navigator screenOptions={{ headerTransparent: true }}>
+    <Stack.Navigator screenOptions={{ headerTransparent: Platform.OS === 'ios' && parseInt(Platform.Version) >= 26 }}>
       <Stack.Screen
         name="Main"
         component={MainScreen}

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -1,37 +1,36 @@
 // NOTE: The full native feature set (style, image, menu, etc.) is available, but the TS types in src/types.tsx need to be updated to match. This example uses only the currently typed props (title, icon, onPress, enabled).
-import React, { useCallback } from 'react';
-import { View, Text, Alert, Image } from 'react-native';
+import React from 'react';
+import { View, Alert } from 'react-native';
 import {
   createNativeStackNavigator,
 } from '@react-navigation/native-stack';
+import { ScrollView } from 'react-native-gesture-handler';
 
 const Screen = () => {
-  return         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-  <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 16 }}>
-    UIBarButtonItem Features Demo
-  </Text>
-  <Text style={{ marginBottom: 8 }}>• Title, icon, enabled/disabled, ergonomic onPress</Text>
-  <Text style={{ marginBottom: 8 }}>• Full feature set (style, image, menu, etc.) available natively</Text>
-  <Text style={{ marginBottom: 8 }}>• Update src/types.tsx to use all features in your app</Text>
-</View>;
+  return (
+    <ScrollView style={{ flex: 1}} contentInsetAdjustmentBehavior="automatic">
+      <View style={{width: '100%', height: 200, backgroundColor: 'black'}} />
+      <View style={{width: '100%', height: 200, backgroundColor: 'grey'}} />
+      <View style={{width: '100%', height: 1000, backgroundColor: 'white'}} />
+    </ScrollView>
+  );
 };
 
 const Stack = createNativeStackNavigator();
 
 export default function BarButtonItemsExample() {
-  // Handlers for demonstration
   return (
     <Stack.Navigator>
-        <Stack.Screen
-          name="BarButtonItems Demo"
-          options={{
+      <Stack.Screen
+        name="BarButtonItems Demo"
+        options={{
+          headerTransparent: true,
           title: 'BarButtonItems Demo',
           // Example: Left bar button items (using only typed props)
           headerLeftBarButtonItems: [
             {
               title: 'Plain',
               onPress: () => Alert.alert('Plain pressed'),
-              tintColor: '#ff0000',
             },
           ],
           // Example: Right bar button items (using only typed props)
@@ -40,20 +39,17 @@ export default function BarButtonItemsExample() {
               onPress: () => Alert.alert('Search pressed'),
               image: require('../assets/search_black.png'),
               style: 'Plain',
-              enabled: false,
             },
             {
-              spacing: 0,
-            },
-            {
-              onPress: () => Alert.alert('Search pressed'),
+              onPress: () => Alert.alert('Button pressed 2'),
               image: require('../assets/search_black.png'),
               style: 'Prominent',
+              tintColor: 'green',
             },
           ],
         }}
         component={Screen}
-        />
+      />
 
     </Stack.Navigator>
   );

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -31,7 +31,7 @@ export default function BarButtonItemsExample() {
               title: '+allt',
               onPress: () => Alert.alert('Plain pressed'),
               titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800', color: 'black' },
-              style: 'Prominent',
+              style: 'prominent',
               tintColor: 'yellow',
             },
             {
@@ -43,7 +43,7 @@ export default function BarButtonItemsExample() {
           ],
           headerRightBarButtonItems: [
             {
-              style: 'Prominent',
+              style: 'prominent',
               title: 'Menu',
               tintColor: 'purple',
               menu: {
@@ -52,10 +52,12 @@ export default function BarButtonItemsExample() {
                   title: 'Search',
                   systemImage: 'magnifyingglass.circle.fill',
                   onPress: () => Alert.alert('Search pressed'),
+                  state: 'mixed',
                 },
                 {
                   title: 'Search with long text that wraps',
                   onPress: () => Alert.alert('Search with long text pressed'),
+                  attributes: 'keepsMenuPresented',
                 },
                 {
                   title: 'Submenu',

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -1,0 +1,58 @@
+// NOTE: The full native feature set (style, image, menu, etc.) is available, but the TS types in src/types.tsx need to be updated to match. This example uses only the currently typed props (title, icon, onPress, enabled).
+import React, { useCallback } from 'react';
+import { View, Text, Alert, Image } from 'react-native';
+import {
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+
+const Screen = () => {
+  return         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+  <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 16 }}>
+    UIBarButtonItem Features Demo
+  </Text>
+  <Text style={{ marginBottom: 8 }}>• Title, icon, enabled/disabled, ergonomic onPress</Text>
+  <Text style={{ marginBottom: 8 }}>• Full feature set (style, image, menu, etc.) available natively</Text>
+  <Text style={{ marginBottom: 8 }}>• Update src/types.tsx to use all features in your app</Text>
+</View>;
+};
+
+const Stack = createNativeStackNavigator();
+
+export default function BarButtonItemsExample() {
+  // Handlers for demonstration
+  return (
+    <Stack.Navigator>
+        <Stack.Screen
+          name="BarButtonItems Demo"
+          options={{
+          title: 'BarButtonItems Demo',
+          // Example: Left bar button items (using only typed props)
+          headerLeftBarButtonItems: [
+            {
+              title: 'Plain',
+              onPress: () => Alert.alert('Plain pressed'),
+              tintColor: 'red',
+              style: 2,
+            },
+          ],
+          // Example: Right bar button items (using only typed props)
+          headerRightBarButtonItems: [
+            {
+              onPress: () => Alert.alert('Search pressed'),
+              image: require('../assets/search_black.png'),
+              style: 1,
+              enabled: false,
+            },
+            {
+              onPress: () => Alert.alert('Search pressed'),
+              image: require('../assets/search_black.png'),
+              style: 2,
+            },
+          ],
+        }}
+        component={Screen}
+        />
+
+    </Stack.Navigator>
+  );
+}

--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -1,91 +1,346 @@
 // NOTE: The full native feature set (style, image, menu, etc.) is available, but the TS types in src/types.tsx need to be updated to match. This example uses only the currently typed props (title, icon, onPress, enabled).
 import React from 'react';
-import { View, Alert } from 'react-native';
-import {
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import { View, Alert, Button, Text } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ScrollView } from 'react-native-gesture-handler';
-
-const Screen = () => {
-  return (
-    <ScrollView style={{ flex: 1}} contentInsetAdjustmentBehavior="automatic">
-      <View style={{width: '100%', height: 200, backgroundColor: 'black'}} />
-      <View style={{width: '100%', height: 200, backgroundColor: 'grey'}} />
-      <View style={{width: '100%', height: 1000, backgroundColor: 'white'}} />
-    </ScrollView>
-  );
-};
 
 const Stack = createNativeStackNavigator();
 
+const demoScreens = [
+  { name: 'PlainButtonDemo', title: 'Plain Button' },
+  { name: 'IconButtonDemo', title: 'Icon Button' },
+  { name: 'MenuButtonDemo', title: 'Menu Button' },
+  { name: 'BadgeButtonDemo', title: 'Badge Button' },
+  { name: 'DisabledButtonDemo', title: 'Disabled Button' },
+  { name: 'CustomColorButtonDemo', title: 'Custom Color Button' },
+  { name: 'ProminentStyleButtonDemo', title: 'Prominent Style Button' },
+  { name: 'TitleStyleButtonDemo', title: 'Title Style Button' },
+  { name: 'IconSharesBgButtonDemo', title: 'Icon SharesBackground' },
+  { name: 'TextButtonWithWidthDemo', title: 'Text Button With Width' },
+  { name: 'IconButtonsWithSpacingDemo', title: 'Icon Buttons With Spacing' },
+  { name: 'HeaderTintColorDemo', title: 'Header Tint Color' },
+  { name: 'DoneStyleButtonDemo', title: 'Done Style Button' },
+  { name: 'AdvancedMenuButtonDemo', title: 'Advanced Menu Button' },
+];
+
+const MainScreen = ({ navigation }: any) => (
+  <ScrollView contentInsetAdjustmentBehavior="automatic" style={{ flex: 1 }}>
+    <View style={{padding: 8}}>
+      <Text style={{fontSize: 16, fontWeight: 'bold', textAlign: 'center'}}>iOS only</Text>
+    </View>
+    {demoScreens.map((screen) => (
+      <Button
+        key={screen.name}
+        onPress={() => navigation.navigate(screen.name)}
+        title={screen.title}
+      />
+    ))}
+  </ScrollView>
+);
+
+const DemoScreenContent = () => (
+  <ScrollView style={{ flex: 1 }} contentInsetAdjustmentBehavior="automatic">
+    <View style={{ width: '100%', height: 200, backgroundColor: 'black' }} />
+    <View style={{ width: '100%', height: 200, backgroundColor: 'grey' }} />
+    <View style={{ width: '100%', height: 1000, backgroundColor: 'white' }} />
+  </ScrollView>
+);
+
+const PlainButtonDemo = DemoScreenContent;
+const IconButtonDemo = DemoScreenContent;
+const MenuButtonDemo = DemoScreenContent;
+const BadgeButtonDemo = DemoScreenContent;
+const DisabledButtonDemo = DemoScreenContent;
+const CustomColorButtonDemo = DemoScreenContent;
+const ProminentStyleButtonDemo = DemoScreenContent;
+const TitleStyleButtonDemo = DemoScreenContent;
+const IconSharesBgButtonDemo = DemoScreenContent;
+const TextButtonWithWidthDemo = DemoScreenContent;
+const IconButtonsWithSpacingDemo = DemoScreenContent;
+const HeaderTintColorDemo = DemoScreenContent;
+const DoneStyleButtonDemo = DemoScreenContent;
+const AdvancedMenuButtonDemo = DemoScreenContent;
+
 export default function BarButtonItemsExample() {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={{ headerTransparent: true }}>
       <Stack.Screen
-        name="BarButtonItems Demo"
+        name="Main"
+        component={MainScreen}
+        options={{ title: 'BarButtonItems Demos' }}
+      />
+      <Stack.Screen
+        name="PlainButtonDemo"
+        component={PlainButtonDemo}
         options={{
-          headerTransparent: true,
-          title: 'BarButtonItems Demo',
-          headerLeftBarButtonItems: [
+          title: 'Plain Button',
+          headerRightBarButtonItems: [
             {
-              title: '+allt',
-              onPress: () => Alert.alert('Plain pressed'),
-              titleStyle: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '800', color: 'black' },
-              style: 'prominent',
-              tintColor: 'yellow',
+              title: 'Info',
+              onPress: () => Alert.alert('Info pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="IconButtonDemo"
+        component={IconButtonDemo}
+        options={{
+          title: 'Icon Button',
+          headerRightBarButtonItems: [
+            {
+              image: require('../assets/search_black.png'),
+              onPress: () => Alert.alert('Icon pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="MenuButtonDemo"
+        component={MenuButtonDemo}
+        options={{
+          title: 'Menu Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Menu',
+              menu: {
+                items: [
+                  {
+                    title: 'Option 1',
+                    onPress: () => Alert.alert('Option 1 pressed'),
+                  },
+                  {
+                    title: 'Option 2',
+                    onPress: () => Alert.alert('Option 2 pressed'),
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="BadgeButtonDemo"
+        component={BadgeButtonDemo}
+        options={{
+          title: 'Badge Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Badge',
               badge: {
-                value: '1',
+                value: '3',
                 color: 'white',
                 backgroundColor: 'red',
-                style: { fontFamily: 'Georgia', fontSize: 16, fontWeight: '100' },
               },
+              onPress: () => Alert.alert('Badge pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="DisabledButtonDemo"
+        component={DisabledButtonDemo}
+        options={{
+          title: 'Disabled Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Disabled',
+              enabled: false,
+              onPress: () => Alert.alert('Should not fire'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="CustomColorButtonDemo"
+        component={CustomColorButtonDemo}
+        options={{
+          title: 'Custom Color Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Purple',
+              tintColor: 'purple',
+              onPress: () => Alert.alert('Purple pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="ProminentStyleButtonDemo"
+        component={ProminentStyleButtonDemo}
+        options={{
+          title: 'Prominent Style Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Prominent',
+              style: 'prominent',
+              tintColor: 'green',
+              onPress: () => Alert.alert('Prominent pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="TitleStyleButtonDemo"
+        component={TitleStyleButtonDemo}
+        options={{
+          title: 'Title Style Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Styled',
+              titleStyle: {
+                fontFamily: 'Georgia',
+                fontSize: 18,
+                fontWeight: 'bold',
+                color: 'blue',
+              },
+              onPress: () => Alert.alert('Styled pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="IconSharesBgButtonDemo"
+        component={IconSharesBgButtonDemo}
+        options={{
+          title: 'Icon SharesBackground',
+          headerRightBarButtonItems: [
+            {
+              image: require('../assets/search_black.png'),
+              onPress: () => Alert.alert('Icon with sharesBackground pressed'),
             },
             {
               image: require('../assets/search_black.png'),
-              onPress: () => Alert.alert('Search pressed'),
-              accessibilityLabel: 'SÖK HÄR',
-              accessibilityHint: 'Tryck för att söka',
+              onPress: () => Alert.alert('Icon with sharesBackground pressed'),
+            },
+            {
+              image: require('../assets/search_black.png'),
+              sharesBackground: false,
+              onPress: () => Alert.alert('Icon with sharesBackground false pressed'),
             },
           ],
+        }}
+      />
+      <Stack.Screen
+        name="TextButtonWithWidthDemo"
+        component={TextButtonWithWidthDemo}
+        options={{
+          title: 'Text Button With Width',
           headerRightBarButtonItems: [
             {
-              style: 'prominent',
-              title: 'Menu',
-              tintColor: 'purple',
-              menu: {
-                items: [
-                {
-                  title: 'Search',
-                  systemImage: 'magnifyingglass.circle.fill',
-                  onPress: () => Alert.alert('Search pressed'),
-                  state: 'mixed',
-                },
-                {
-                  title: 'Search with long text that wraps',
-                  onPress: () => Alert.alert('Search with long text pressed'),
-                  attributes: 'keepsMenuPresented',
-                },
-                {
-                  title: 'Submenu',
-                  items: [
-                    {
-                      title: 'Submenu Item 1',
-                      systemImage: 'magnifyingglass.circle.fill',
-                      onPress: () => Alert.alert('Submenu Item 1 pressed'),
-                    },
-                    {
-                      title: 'Submenu Item 2',
-                      onPress: () => Alert.alert('Submenu Item 2 pressed'),
-                    },
-                  ],
-                },
-              ],
-            }},
+              title: 'Wide',
+              width: 100,
+              onPress: () => Alert.alert('Wide text button pressed'),
+            },
           ],
         }}
-        component={Screen}
       />
-
+      <Stack.Screen
+        name="IconButtonsWithSpacingDemo"
+        component={IconButtonsWithSpacingDemo}
+        options={{
+          title: 'Icon Buttons With Spacing',
+          headerRightBarButtonItems: [
+            {
+              image: require('../assets/search_black.png'),
+              onPress: () => Alert.alert('First icon pressed'),
+            },
+            {
+              spacing: 100,
+            },
+            {
+              image: require('../assets/search_white.png'),
+              onPress: () => Alert.alert('Second icon pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="HeaderTintColorDemo"
+        component={HeaderTintColorDemo}
+        options={{
+          title: 'Header Tint Color',
+          headerTintColor: 'red',
+          headerRightBarButtonItems: [
+            {
+              title: 'Tinted',
+              onPress: () => Alert.alert('Tinted pressed'),
+            },
+            {
+              image: require('../assets/search_black.png'),
+              onPress: () => Alert.alert('Tinted icon pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="DoneStyleButtonDemo"
+        component={DoneStyleButtonDemo}
+        options={{
+          title: 'Done Style Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Done',
+              style: 'done',
+              onPress: () => Alert.alert('Done text pressed'),
+            },
+            {
+              image: require('../assets/search_black.png'),
+              style: 'done',
+              onPress: () => Alert.alert('Done icon pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="AdvancedMenuButtonDemo"
+        component={AdvancedMenuButtonDemo}
+        options={{
+          title: 'Advanced Menu Button',
+          headerRightBarButtonItems: [
+            {
+              title: 'Menu',
+              menu: {
+                title: 'Context menu',
+                items: [
+                  {
+                    title: 'Action 1',
+                    systemImage: 'star',
+                    state: 'on',
+                    attributes: 'destructive',
+                    discoverabilityTitle: 'Favorite',
+                    onPress: () => Alert.alert('Action 1 pressed'),
+                  },
+                  {
+                    title: 'Action 2',
+                    systemImage: 'square.and.arrow.up',
+                    state: 'off',
+                    attributes: 'disabled',
+                    discoverabilityTitle: 'Disabled Action',
+                    onPress: () => Alert.alert('Action 2 pressed'),
+                  },
+                  {
+                    title: 'Submenu',
+                    items: [
+                      {
+                        title: 'Sub Action 1',
+                        state: 'mixed',
+                        onPress: () => Alert.alert('Sub Action 1 pressed'),
+                        attributes: 'keepsMenuPresented',
+                        discoverabilityTitle: 'Sub Action 1',
+                      },
+                      {
+                        title: 'Sub Action 2',
+                        onPress: () => Alert.alert('Sub Action 2 pressed'),
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+      />
     </Stack.Navigator>
   );
 }

--- a/ios/RNSBarButtonItem.h
+++ b/ios/RNSBarButtonItem.h
@@ -1,10 +1,10 @@
 #import <UIKit/UIKit.h>
 
 typedef void (^RNSBarButtonItemAction)(NSString *buttonId);
+typedef void (^RNSBarButtonMenuItemAction)(NSString *menuId);
 
 @interface RNSBarButtonItem : UIBarButtonItem
 
-- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict
-                           action:(RNSBarButtonItemAction)action;
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict   action:(RNSBarButtonItemAction)action menuAction:(RNSBarButtonMenuItemAction)menuAction;
 
 @end 

--- a/ios/RNSBarButtonItem.h
+++ b/ios/RNSBarButtonItem.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+
+typedef void (^RNSBarButtonItemAction)(NSString *buttonId);
+
+@interface RNSBarButtonItem : UIBarButtonItem
+
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict
+                           action:(RNSBarButtonItemAction)action;
+
+@end 

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -1,6 +1,7 @@
 #import "RNSBarButtonItem.h"
 #import <React/RCTConvert.h>
 #import <objc/runtime.h>
+#import <React/RCTFont.h>
 
 static char RNSBarButtonItemActionKey;
 static char RNSBarButtonItemIdKey;
@@ -18,18 +19,45 @@ static char RNSBarButtonItemIdKey;
     if (imageObj) {
       self.image = [RCTConvert UIImage:imageObj];
     }
+    
+    NSDictionary *titleStyle = dict[@"titleStyle"];
+    if (titleStyle) {
+      NSString *fontFamily = titleStyle[@"fontFamily"];
+      NSNumber *fontSize = titleStyle[@"fontSize"];
+      NSString *fontWeight = titleStyle[@"fontWeight"];
+      NSMutableDictionary *attrs = [NSMutableDictionary new];
+      if (fontFamily || fontWeight) {
+        attrs[NSFontAttributeName] = [RCTFont updateFont:nil
+                                              withFamily:fontFamily
+                                                    size:fontSize
+                                                  weight:fontWeight
+                                                   style:nil
+                                                 variant:nil
+                                         scaleMultiplier:1.0];
+      } else {
+        attrs[NSFontAttributeName] = [UIFont systemFontOfSize:[fontSize floatValue]];
+      }
+      [self setTitleTextAttributes:attrs forState:UIControlStateNormal];
+      [self setTitleTextAttributes:attrs forState:UIControlStateHighlighted];
+      [self setTitleTextAttributes:attrs forState:UIControlStateDisabled];
+      [self setTitleTextAttributes:attrs forState:UIControlStateSelected];
+      [self setTitleTextAttributes:attrs forState:UIControlStateFocused];
+    }
       
     id tintColorObj = dict[@"tintColor"];
     if (tintColorObj) {
       self.tintColor = [RCTConvert UIColor:tintColorObj];
     }
       
+    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
     if (@available(iOS 16.0, *)) {
       NSNumber *hiddenNum = dict[@"hidden"];
       if (hiddenNum != nil) {
         self.hidden = [hiddenNum boolValue];
       }
     }
+    #endif
     
     NSNumber *selectedNum = dict[@"selected"];
     if (selectedNum != nil) {
@@ -45,14 +73,18 @@ static char RNSBarButtonItemIdKey;
     if (width) {
       self.width = [width doubleValue];
     }
-    
+    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
     if (@available(iOS 15.0, *)) {
       NSNumber *changesSelectionAsPrimaryActionNum = dict[@"changesSelectionAsPrimaryAction"];
       if (changesSelectionAsPrimaryActionNum != nil) {
         self.changesSelectionAsPrimaryAction = [changesSelectionAsPrimaryActionNum boolValue];
       }
     }
+    #endif
     
+    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
       NSNumber *hidesSharedBackgroundNum = dict[@"hidesSharedBackground"];
       if (hidesSharedBackgroundNum != nil) {
@@ -67,6 +99,7 @@ static char RNSBarButtonItemIdKey;
         //self.identifier = identifier;
       }
     }
+    #endif
   
     
     NSString *style = dict[@"style"];
@@ -74,9 +107,12 @@ static char RNSBarButtonItemIdKey;
       if ([style isEqualToString:@"Done"]) {
         self.style = UIBarButtonItemStyleDone;
       } else if ([style isEqualToString:@"Prominent"]) {
+        #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+        __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
         if (@available(iOS 26.0, *)) {
           self.style = UIBarButtonItemStyleProminent;
         }
+        #endif
       } else {
         self.style = UIBarButtonItemStylePlain;
       }

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -1,0 +1,41 @@
+#import "RNSBarButtonItem.h"
+#import <React/RCTConvert.h>
+#import <objc/runtime.h>
+
+static char RNSBarButtonItemActionKey;
+static char RNSBarButtonItemIdKey;
+
+@implementation RNSBarButtonItem
+
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict
+                           action:(RNSBarButtonItemAction)action
+{
+  self = [super init];
+  if (self) {
+    self.title = dict[@"title"];
+    NSDictionary *imageObj = dict[@"image"];
+    if (imageObj) {
+      self.image = [RCTConvert UIImage:imageObj];
+    }
+    
+    NSString *buttonId = dict[@"buttonId"];
+    if (buttonId && action) {
+      self.target = self;
+      self.action = @selector(handleBarButtonItemPress:);
+      objc_setAssociatedObject(self, &RNSBarButtonItemIdKey, buttonId, OBJC_ASSOCIATION_COPY_NONATOMIC);
+      objc_setAssociatedObject(self, &RNSBarButtonItemActionKey, action, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+  }
+  return self;
+}
+
+- (void)handleBarButtonItemPress:(UIBarButtonItem *)item
+{
+  NSString *buttonId = objc_getAssociatedObject(self, &RNSBarButtonItemIdKey);
+  RNSBarButtonItemAction action = objc_getAssociatedObject(self, &RNSBarButtonItemActionKey);
+  if (action && buttonId) {
+    action(buttonId);
+  }
+}
+
+@end 

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -110,9 +110,9 @@ static char RNSBarButtonItemIdKey;
     
     NSString *style = dict[@"style"];
     if (style) {
-      if ([style isEqualToString:@"Done"]) {
+      if ([style isEqualToString:@"done"]) {
         self.style = UIBarButtonItemStyleDone;
-      } else if ([style isEqualToString:@"Prominent"]) {
+      } else if ([style isEqualToString:@"prominent"]) {
         #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
         __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
         if (@available(iOS 26.0, *)) {
@@ -169,6 +169,31 @@ static char RNSBarButtonItemIdKey;
                                     handler:^(__kindof UIAction * _Nonnull a) {
                                       menuAction(menuId);
                                     }];
+          NSString *state = item[@"state"];
+          if ([state isEqualToString:@"on"]) {
+            actionElement.state = UIMenuElementStateOn;
+          } else if ([state isEqualToString:@"off"]) {
+            actionElement.state = UIMenuElementStateOff;
+          } else if ([state isEqualToString:@"mixed"]) {
+            actionElement.state = UIMenuElementStateMixed;
+          }
+          
+          NSString *attributes = item[@"attributes"];
+          if ([attributes isEqualToString:@"destructive"]) {
+            actionElement.attributes = UIMenuElementAttributesDestructive;
+          } else if ([attributes isEqualToString:@"disabled"]) {
+            actionElement.attributes = UIMenuElementAttributesDisabled;
+          } else if ([attributes isEqualToString:@"hidden"]) {
+            actionElement.attributes = UIMenuElementAttributesHidden;
+          }
+          #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && \
+          __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0
+          else if (@available(iOS 16.0, *)) {
+            if ([attributes isEqualToString:@"keepsMenuPresented"]) {
+              actionElement.attributes = UIMenuElementAttributesKeepsMenuPresented;
+            }
+          }
+          #endif
           [elements addObject:actionElement];
         } else {
           UIMenu *childMenu = [self initUIMenuWithDict:item menuAction:menuAction];

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -100,7 +100,7 @@ static char RNSBarButtonItemIdKey;
       }
       NSString *identifier = dict[@"identifier"];
       if (identifier != nil) {
-        //self.identifier = identifier;
+        self.identifier = identifier;
       }
     }
     #endif
@@ -120,6 +120,13 @@ static char RNSBarButtonItemIdKey;
       } else {
         self.style = UIBarButtonItemStylePlain;
       }
+    }
+    
+    if (dict[@"accessibilityLabel"]) {
+      self.accessibilityLabel = dict[@"accessibilityLabel"];
+    }
+    if (dict[@"accessibilityHint"]) {
+      self.accessibilityHint = dict[@"accessibilityHint"];
     }
     
     #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -104,6 +104,36 @@ static char RNSBarButtonItemIdKey;
       if (identifier != nil) {
         self.identifier = identifier;
       }
+      NSDictionary *badgeObj = dict[@"badge"];
+      if (badgeObj != nil) {
+        UIBarButtonItemBadge *badge = [UIBarButtonItemBadge badgeWithString:badgeObj[@"value"]];
+        id colorObj = badgeObj[@"color"];
+        if (colorObj) {
+          badge.foregroundColor = [RCTConvert UIColor:colorObj];
+        }
+        id backgroundColorObj = badgeObj[@"backgroundColor"];
+        if (colorObj) {
+          badge.backgroundColor = [RCTConvert UIColor:backgroundColorObj];
+        }
+        NSDictionary *style = badgeObj[@"style"];
+        if (style) {
+          NSString *fontFamily = style[@"fontFamily"];
+          NSNumber *fontSize = style[@"fontSize"];
+          NSString *fontWeight = style[@"fontWeight"];
+          if (fontSize || fontWeight) {
+            badge.font = [RCTFont updateFont:nil
+                                  withFamily:fontFamily
+                                        size:fontSize
+                                      weight:fontWeight
+                                       style:nil
+                                     variant:nil
+                             scaleMultiplier:1.0];
+          } else {
+            badge.font = [UIFont systemFontOfSize:[fontSize floatValue]];
+          }
+        }
+        self.badge = badge;
+      }
     }
     #endif
   

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -37,6 +37,10 @@ static char RNSBarButtonItemIdKey;
       } else {
         attrs[NSFontAttributeName] = [UIFont systemFontOfSize:[fontSize floatValue]];
       }
+      id titleColor = titleStyle[@"color"];
+      if (titleColor) {
+        attrs[NSForegroundColorAttributeName] = [RCTConvert UIColor:titleColor];
+      }
       [self setTitleTextAttributes:attrs forState:UIControlStateNormal];
       [self setTitleTextAttributes:attrs forState:UIControlStateHighlighted];
       [self setTitleTextAttributes:attrs forState:UIControlStateDisabled];
@@ -118,6 +122,33 @@ static char RNSBarButtonItemIdKey;
       }
     }
     
+    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+    if (@available(iOS 14.0, *)) {
+      NSArray *menuItems = dict[@"menu"];
+      if (menuItems.count > 0) {
+        NSMutableArray<UIMenuElement *> *actions = [NSMutableArray new];
+        for (NSDictionary *item in menuItems) {
+          NSString *title = item[@"title"];
+          if (![title isKindOfClass:[NSString class]]) continue;
+          UIAction *actionElement = [UIAction actionWithTitle:title
+                                                        image:nil
+                                                   identifier:nil
+                                                      handler:^(__kindof UIAction * _Nonnull a) {
+            RNSBarButtonItemAction parentAction = objc_getAssociatedObject(self, &RNSBarButtonItemActionKey);
+            if (parentAction) {
+              parentAction(title);
+            }
+          }];
+          [actions addObject:actionElement];
+        }
+        NSMutableArray<UIMenuElement *> *children = [NSMutableArray new];
+        
+        [children addObject:[UIMenu menuWithTitle:@"på" children:actions]];
+        self.menu = [UIMenu menuWithTitle:@"hej" children:children];
+      }
+    }
+    #endif
+    
     NSString *buttonId = dict[@"buttonId"];
     if (buttonId && action) {
       self.target = self;
@@ -138,4 +169,4 @@ static char RNSBarButtonItemIdKey;
   }
 }
 
-@end 
+@end

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -13,9 +13,50 @@ static char RNSBarButtonItemIdKey;
   self = [super init];
   if (self) {
     self.title = dict[@"title"];
+
     NSDictionary *imageObj = dict[@"image"];
     if (imageObj) {
       self.image = [RCTConvert UIImage:imageObj];
+    }
+      
+    id tintColorObj = dict[@"tintColor"];
+    if (tintColorObj) {
+      self.tintColor = [RCTConvert UIColor:tintColorObj];
+    }
+      
+    if (@available(iOS 16.0, *)) {
+      NSNumber *hiddenNum = dict[@"hidden"];
+      if (hiddenNum != nil) {
+        self.hidden = [hiddenNum boolValue];
+      }
+    }
+    
+    NSNumber *selectedNum = dict[@"selected"];
+    if (selectedNum != nil) {
+      self.selected = [selectedNum boolValue];
+    }
+    
+    NSNumber *enabledNum = dict[@"enabled"];
+    if (enabledNum != nil) {
+      self.enabled = [enabledNum boolValue];
+    }
+    
+    NSNumber *width = dict[@"width"];
+    if (width) {
+      self.width = [width doubleValue];
+    }
+    
+    NSString *style = dict[@"style"];
+    if (style) {
+      if ([style isEqualToString:@"Done"]) {
+        self.style = UIBarButtonItemStyleDone;
+      } else if ([style isEqualToString:@"Prominent"]) {
+        if (@available(iOS 26.0, *)) {
+          self.style = UIBarButtonItemStyleProminent;
+        }
+      } else {
+        self.style = UIBarButtonItemStylePlain;
+      }
     }
     
     NSString *buttonId = dict[@"buttonId"];

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -46,6 +46,29 @@ static char RNSBarButtonItemIdKey;
       self.width = [width doubleValue];
     }
     
+    if (@available(iOS 15.0, *)) {
+      NSNumber *changesSelectionAsPrimaryActionNum = dict[@"changesSelectionAsPrimaryAction"];
+      if (changesSelectionAsPrimaryActionNum != nil) {
+        self.changesSelectionAsPrimaryAction = [changesSelectionAsPrimaryActionNum boolValue];
+      }
+    }
+    
+    if (@available(iOS 26.0, *)) {
+      NSNumber *hidesSharedBackgroundNum = dict[@"hidesSharedBackground"];
+      if (hidesSharedBackgroundNum != nil) {
+        self.hidesSharedBackground = [hidesSharedBackgroundNum boolValue];
+      }
+      NSNumber *sharesBackgroundNum = dict[@"sharesBackground"];
+      if (sharesBackgroundNum != nil) {
+        self.sharesBackground = [sharesBackgroundNum boolValue];
+      }
+      NSString *identifier = dict[@"identifier"];
+      if (identifier != nil) {
+        //self.identifier = identifier;
+      }
+    }
+  
+    
     NSString *style = dict[@"style"];
     if (style) {
       if ([style isEqualToString:@"Done"]) {

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -47,6 +47,8 @@ namespace react = facebook::react;
 
 + (RNSBlurEffectStyle)RNSBlurEffectStyleFromCppEquivalent:(react::RNSScreenStackHeaderConfigBlurEffect)blurEffect;
 
++ (id)idFromFollyDynamic:(const folly::dynamic &)dyn;
+
 #endif // RCT_NEW_ARCH_ENABLED
 
 /// This method fails (by assertion) when `blurEffect == RNSBlurEffectStyleNone` which has no counter part in the UIKit

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -259,6 +259,33 @@
   }
 }
 
++ (id)idFromFollyDynamic:(const folly::dynamic &)dyn {
+  if (dyn.isNull()) {
+    return nil;
+  } else if (dyn.isBool()) {
+    return [NSNumber numberWithBool:dyn.getBool()];
+  } else if (dyn.isInt()) {
+    return [NSNumber numberWithLongLong:dyn.getInt()];
+  } else if (dyn.isDouble()) {
+    return [NSNumber numberWithDouble:dyn.getDouble()];
+  } else if (dyn.isString()) {
+    return [NSString stringWithUTF8String:dyn.getString().c_str()];
+  } else if (dyn.isArray()) {
+    NSMutableArray *array = [NSMutableArray arrayWithCapacity:dyn.size()];
+    for (const auto &item : dyn) {
+      [array addObject:[self idFromFollyDynamic:item]];
+    }
+    return array;
+  } else if (dyn.isObject()) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:dyn.size()];
+    for (const auto &pair : dyn.items()) {
+      dict[@(pair.first.c_str())] = [self idFromFollyDynamic:pair.second];
+    }
+    return dict;
+  }
+  return nil;
+}
+
 #endif // RCT_NEW_ARCH_ENABLED
 
 + (UIBlurEffectStyle)tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:(RNSBlurEffectStyle)blurEffect

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSArray<NSDictionary<NSString *, id> *> *headerRightBarButtonItems;
 @property (nonatomic, copy, nullable) NSArray<NSDictionary<NSString *, id> *> *headerLeftBarButtonItems;
 @property (nonatomic) RCTDirectEventBlock onPressHeaderBarButtonItem;
+@property (nonatomic) RCTDirectEventBlock onPressHeaderBarButtonMenuItem;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -59,6 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UISemanticContentAttribute direction;
 @property (nonatomic) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic) RNSBlurEffectStyle blurEffect;
+@property (nonatomic, copy, nullable) NSArray<NSDictionary<NSString *, id> *> *headerRightBarButtonItems;
+@property (nonatomic, copy, nullable) NSArray<NSDictionary<NSString *, id> *> *headerLeftBarButtonItems;
+@property (nonatomic) RCTDirectEventBlock onPressHeaderBarButtonItem;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -819,11 +819,11 @@ RNS_IGNORE_SUPER_CALL_END
       }
     }];
     [items addObject:item];
-    if (i < dicts.count - 1) {
-      UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
-      fixedSpace.width = 0;
-      [items addObject:fixedSpace];
-    }
+    // if (i < dicts.count - 1) {
+    //   UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+    //   fixedSpace.width = 0;
+    //   [items addObject:fixedSpace];
+    // }
   }
   return items;
 }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -813,7 +813,7 @@ RNS_IGNORE_SUPER_CALL_END
   NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithCapacity:dicts.count * 2 - 1];
   for (NSUInteger i = 0; i < dicts.count; i++) {
     NSDictionary *dict = dicts[i];
-    if (dict[@"buttonId"]) {
+    if (dict[@"buttonId"] || dict[@"menu"]) {
       RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithDictionary:dict action:^(NSString *buttonId) {
         if (self.onPressHeaderBarButtonItem && buttonId) {
           self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -31,6 +31,7 @@
 #import "RNSScreenStackHeaderConfig.h"
 #import "RNSSearchBar.h"
 #import "RNSUIBarButtonItem.h"
+#import "RNSBarButtonItem.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 namespace react = facebook::react;
@@ -613,6 +614,8 @@ RNS_IGNORE_SUPER_CALL_END
 #endif
   navitem.leftBarButtonItem = nil;
   navitem.rightBarButtonItem = nil;
+  navitem.leftBarButtonItems = nil;
+  navitem.rightBarButtonItems = nil;
   navitem.titleView = nil;
 
 #if !TARGET_OS_TV
@@ -682,6 +685,15 @@ RNS_IGNORE_SUPER_CALL_END
   // This assignment should be done after `navitem.titleView = ...` assignment (iOS 16.0 bug).
   // See: https://github.com/software-mansion/react-native-screens/issues/1570 (comments)
   navitem.title = config.title;
+
+  // Set leftBarButtonItems if provided
+  if (config.headerLeftBarButtonItems) {
+      navitem.leftBarButtonItems = [config barButtonItemsFromDictionaries:config.headerLeftBarButtonItems];
+  }
+  // Set rightBarButtonItems if provided
+  if (config.headerRightBarButtonItems) {
+    navitem.rightBarButtonItems = [config barButtonItemsFromDictionaries:config.headerRightBarButtonItems];
+  }
 
   if (animated && vc.transitionCoordinator != nil &&
       vc.transitionCoordinator.presentationStyle == UIModalPresentationNone && !wasHidden) {
@@ -796,6 +808,26 @@ RNS_IGNORE_SUPER_CALL_END
         setSemanticContentAttribute:self.direction];
   }
 }
+
+- (NSArray<UIBarButtonItem *> *)barButtonItemsFromDictionaries:(NSArray<NSDictionary<NSString *, id> *> *)dicts {
+  NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithCapacity:dicts.count * 2 - 1];
+  for (NSUInteger i = 0; i < dicts.count; i++) {
+    NSDictionary *dict = dicts[i];
+    RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithDictionary:dict action:^(NSString *buttonId) {
+      if (self.onPressHeaderBarButtonItem && buttonId) {
+        self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
+      }
+    }];
+    [items addObject:item];
+    if (i < dicts.count - 1) {
+      UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+      fixedSpace.width = 0;
+      [items addObject:fixedSpace];
+    }
+  }
+  return items;
+}
+
 
 RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)insertReactSubview:(RNSScreenStackHeaderSubview *)subview atIndex:(NSInteger)atIndex
@@ -1080,6 +1112,7 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 }
 
 #endif
+
 @end
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -1135,6 +1168,9 @@ RCT_EXPORT_VIEW_PROPERTY(disableBackButtonMenu, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(backButtonDisplayMode, UINavigationItemBackButtonDisplayMode)
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL) // `hidden` is an UIView property, we need to use different name internally
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(headerLeftBarButtonItems, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(headerRightBarButtonItems, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(onPressHeaderBarButtonItem, RCTDirectEventBlock);
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -813,17 +813,19 @@ RNS_IGNORE_SUPER_CALL_END
   NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithCapacity:dicts.count * 2 - 1];
   for (NSUInteger i = 0; i < dicts.count; i++) {
     NSDictionary *dict = dicts[i];
-    RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithDictionary:dict action:^(NSString *buttonId) {
-      if (self.onPressHeaderBarButtonItem && buttonId) {
-        self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
-      }
-    }];
-    [items addObject:item];
-    // if (i < dicts.count - 1) {
-    //   UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
-    //   fixedSpace.width = 0;
-    //   [items addObject:fixedSpace];
-    // }
+    if (dict[@"buttonId"]) {
+      RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithDictionary:dict action:^(NSString *buttonId) {
+        if (self.onPressHeaderBarButtonItem && buttonId) {
+          self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
+        }
+      }];
+      [items addObject:item];
+    } else if (dict[@"spacing"]) {
+      UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+      NSNumber *spacingValue = dict[@"spacing"];
+      fixedSpace.width = [spacingValue doubleValue];
+      [items addObject:fixedSpace];
+    }
   }
   return items;
 }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -814,11 +814,18 @@ RNS_IGNORE_SUPER_CALL_END
   for (NSUInteger i = 0; i < dicts.count; i++) {
     NSDictionary *dict = dicts[i];
     if (dict[@"buttonId"] || dict[@"menu"]) {
-      RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithDictionary:dict action:^(NSString *buttonId) {
-        if (self.onPressHeaderBarButtonItem && buttonId) {
-          self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
-        }
-      }];
+      RNSBarButtonItem *item = [[RNSBarButtonItem alloc]
+                                initWithDictionary:dict
+                                action:^(NSString *buttonId) {
+                                  if (self.onPressHeaderBarButtonItem && buttonId) {
+                                    self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
+                                  }
+                                }
+                                menuAction:^(NSString *menuId) {
+                                  if (self.onPressHeaderBarButtonMenuItem && menuId) {
+                                      self.onPressHeaderBarButtonMenuItem(@{ @"menuId": menuId });
+                                  }
+                                }];
       [items addObject:item];
     } else if (dict[@"spacing"]) {
       UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
@@ -1173,6 +1180,7 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(headerLeftBarButtonItems, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(headerRightBarButtonItems, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(onPressHeaderBarButtonItem, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onPressHeaderBarButtonMenuItem, RCTDirectEventBlock);
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -4,6 +4,7 @@
 #import <React/RCTImageComponentView.h>
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/UIView+React.h>
+#import <ReactCommon/TurboModuleUtils.h>
 #import <react/renderer/components/image/ImageProps.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
@@ -817,15 +818,35 @@ RNS_IGNORE_SUPER_CALL_END
       RNSBarButtonItem *item = [[RNSBarButtonItem alloc]
                                 initWithDictionary:dict
                                 action:^(NSString *buttonId) {
-                                  if (self.onPressHeaderBarButtonItem && buttonId) {
-                                    self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
-                                  }
-                                }
+#ifdef RCT_NEW_ARCH_ENABLED
+        auto eventEmitter = std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigEventEmitter>(self->_eventEmitter);
+        if (eventEmitter && buttonId) {
+          eventEmitter->onPressHeaderBarButtonItem
+          (facebook::react::RNSScreenStackHeaderConfigEventEmitter::OnPressHeaderBarButtonItem {
+            .buttonId = std::string([buttonId UTF8String])
+          });
+        }
+#else
+        if (self.onPressHeaderBarButtonItem && buttonId) {
+          self.onPressHeaderBarButtonItem(@{ @"buttonId": buttonId });
+        }
+#endif
+      }
                                 menuAction:^(NSString *menuId) {
-                                  if (self.onPressHeaderBarButtonMenuItem && menuId) {
-                                      self.onPressHeaderBarButtonMenuItem(@{ @"menuId": menuId });
-                                  }
-                                }];
+#ifdef RCT_NEW_ARCH_ENABLED
+        auto eventEmitter = std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigEventEmitter>(self->_eventEmitter);
+        if (eventEmitter && menuId) {
+          eventEmitter->onPressHeaderBarButtonMenuItem
+          (facebook::react::RNSScreenStackHeaderConfigEventEmitter::OnPressHeaderBarButtonMenuItem {
+            .menuId = std::string([menuId UTF8String])
+          });
+        }
+#else
+        if (self.onPressHeaderBarButtonMenuItem && menuId) {
+          self.onPressHeaderBarButtonMenuItem(@{ @"menuId": menuId });
+        }
+#endif
+      }];
       [items addObject:item];
     } else if (dict[@"spacing"]) {
       UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
@@ -939,6 +960,11 @@ RNS_IGNORE_SUPER_CALL_END
         RCTLogError(@"[RNScreens] Unhandled subview type: %ld", childComponentView.type);
     }
   }
+}
+
+- (void)onPressHeaderBarButtonItemHandler:(NSString *)buttonId
+{
+  
 }
 
 static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
@@ -1067,7 +1093,32 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
   if (newScreenProps.blurEffect != oldScreenProps.blurEffect) {
     _blurEffect = [RNSConvert RNSBlurEffectStyleFromCppEquivalent:newScreenProps.blurEffect];
   }
-
+  
+  if (newScreenProps.headerLeftBarButtonItems != oldScreenProps.headerLeftBarButtonItems) {
+    const auto &vec = newScreenProps.headerLeftBarButtonItems;
+    NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
+    for (const auto &item : vec) {
+      NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
+      if ([dict isKindOfClass:[NSDictionary class]]) {
+        [array addObject:dict];
+      }
+    }
+    _headerLeftBarButtonItems = array;
+  }
+  
+  
+  if (newScreenProps.headerRightBarButtonItems != oldScreenProps.headerRightBarButtonItems) {
+    const auto &vec = newScreenProps.headerRightBarButtonItems;
+    NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
+    for (const auto &item : vec) {
+      NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
+      if ([dict isKindOfClass:[NSDictionary class]]) {
+        [array addObject:dict];
+      }
+    }
+    _headerRightBarButtonItems = array;
+  }
+  
   [self updateViewControllerIfNeeded];
 
   if (needsNavigationControllerLayout) {

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -6,6 +6,7 @@ import type {
   Int32,
   WithDefault,
   DirectEventHandler,
+  UnsafeMixed,
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 type DirectionType = 'rtl' | 'ltr';
@@ -14,6 +15,10 @@ type DirectionType = 'rtl' | 'ltr';
 type OnAttachedEvent = Readonly<{}>;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type OnDetachedEvent = Readonly<{}>;
+
+type OnPressHeaderBarButtonItemEvent = Readonly<{buttonId: string}>;
+type OnPressHeaderBarButtonMenuItemEvent = Readonly<{menuId: string}>;
+
 
 type BackButtonDisplayMode = 'minimal' | 'default' | 'generic';
 
@@ -72,6 +77,10 @@ export interface NativeProps extends ViewProps {
   blurEffect?: WithDefault<BlurEffect, 'none'>;
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean;
+  headerLeftBarButtonItems?: UnsafeMixed[];
+  headerRightBarButtonItems?: UnsafeMixed[];
+  onPressHeaderBarButtonItem?: DirectEventHandler<OnPressHeaderBarButtonItemEvent>;
+  onPressHeaderBarButtonMenuItem?: DirectEventHandler<OnPressHeaderBarButtonMenuItemEvent>;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Description

The current implementation of `headerLeft` and `headerRight` adds a react view as a custom view in a UIBarButtonItem. This implementation is sufficient at most times but I believe we can achieve greater "native feel" if the native stack has an protocol for adding actual UIBarButtonItems in the header. As the UIBarButtonItems has properties and features that can be difficult to mimic with a react view.

Also with the introduction of iOS 26, using only custom views in UIBarButtonItem presents some limitations. Mainly that the adaptive tint color (based on the underlying view) is not working on UIBarButtonItem with a custom view as demonstrated below under "Screenshots".

## Changes

This PR adds the properties `headerRightBarButtonItems` and `headerLeftBarButtonsItems` on the native stack Screen that makes it possible to add one or several UIBarButtonItem to the right/left of the header. Most of the features of the UIBarButtonItem is supported (see either the example "Bar Button Items" in the example apps or the [type definition](https://github.com/johankasperi/react-navigation/blob/5e120f1aee81ac23375700d43ca8dc2da827c3a5/packages/native-stack/src/types.tsx#L694).

## Screenshots / GIFs

#### Non adaptive tint color when using old property `headerRight` on iOS 26
https://github.com/user-attachments/assets/194c70b5-7492-48df-aa2c-8fb889ece461

#### Adaptive tint color when using new property `headerRightBarButtonItems` on iOS 26
https://github.com/user-attachments/assets/9acb1981-3461-4f28-8a0d-54ea9956d3c0

#### UIBarButtonItem with style "prominent" on iOS 26
![Simulator Screenshot - iPhone 16 Pro - 2025-06-27 at 16 28 39](https://github.com/user-attachments/assets/e674d295-928b-4a97-bed3-17c86a1f541d)

#### UIBarButtonItem with UIMenu on iOS 26
https://github.com/user-attachments/assets/db2f7bab-3ade-423f-b80b-9c35b6cee578

## Test code and steps to reproduce

I've created a screen named "Bar Button Items" in the example app that showcases all of the proposed features.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
