### PR TITLE
fix: removeView on update if needed

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -335,8 +335,13 @@ class ScreenStackHeaderConfig(
 
                 else -> {}
             }
-            view.layoutParams = params
-            toolbar.addView(view)
+            if (view.parent === toolbar) {
+                view.layoutParams = params
+            } else {
+                (view.parent as? ViewGroup)?.removeView(view)
+                view.layoutParams = params
+                toolbar.addView(view)
+            }
             i++
         }
     }


### PR DESCRIPTION
## Description

I'm noticing with Fabric enabled on Android with these packages an increase in crashes on Android have begun to occur. The error is `"Exception thrown when executing UIFrameGuarded"`

```
07-07 14:23:29.069 18919 18919 E DevLauncher: Caused by: java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at android.view.ViewGroup.addViewInner(ViewGroup.java:5256)
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at android.view.ViewGroup.addView(ViewGroup.java:5085)
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at android.view.ViewGroup.addView(ViewGroup.java:5025)
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at android.view.ViewGroup.addView(ViewGroup.java:4997)
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at com.swmansion.rnscreens.ScreenStackHeaderConfig.onUpdate(ScreenStackHeaderConfig.kt:339)
07-07 14:23:29.069 18919 18919 E DevLauncher: 	at com.swmansion.rnscreens.ScreenStackHeaderConfig.onAttachedToWindow(ScreenStackHeaderConfig.kt:156)
```
package.json:
```
"expo": "^53.0.18",
"react-native": "0.79.5",
"react-native-screens": "~4.11.1",
"@react-navigation/bottom-tabs": "^6.5.8",
"@react-navigation/native": "^6.1.7",
"@react-navigation/native-stack": "^6.9.13",
```

Potentially fixes #2941 (and others)


I don't know if this "fix" is actually what you'd want or not, but maybe it'll give you guys an idea of somewhere to take a closer look?

The crash seems to be most reproducible when logging out and the navigation structure is changing:

```tsx
<RootStack.Navigator>
{isLoggedIn ? <LoggedInStack Etc/> : <LoggedOutStack /> }
</RootStack.Navigator>
```
I don't think this PR is really mergeable as is but maybe it'll lay the groundwork for something that is/future fixes?

