### PR TITLE
feat(iOS): add

### DIFF
--- a/ios/RNSDismissableModalProtocol.h
+++ b/ios/RNSDismissableModalProtocol.h
@@ -1,0 +1,12 @@
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSDismissibleModalProtocol <NSObject>
+
+
+// If NO is returned, the modal will not be dismissed when new modal is presented.
+// Use it on your own responsibility, as it can lead to unexpected behavior.
+- (BOOL)isDismissible;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -534,58 +534,62 @@ RNS_IGNORE_SUPER_CALL_END
 
   UIViewController *firstModalToBeDismissed = changeRootController.presentedViewController;
 
-  if (firstModalToBeDismissed != nil) {
-    const BOOL firstModalToBeDismissedIsOwned = [firstModalToBeDismissed isKindOfClass:RNSScreen.class];
-    const BOOL firstModalToBeDismissedIsOwnedByThisStack =
-        firstModalToBeDismissedIsOwned && [_presentedModals containsObject:firstModalToBeDismissed];
+  // This check is for external modals that are not owned by this stack. They can prevent the dismissal of the modal by extending
+  // RNSDismissibleModalProtocol and returning NO from isDismissible method.
+  if (![firstModalToBeDismissed conformsToProtocol:@protocol(RNSDismissibleModalProtocol)] || [(id<RNSDismissibleModalProtocol>)firstModalToBeDismissed isDismissible]) {
+    if (firstModalToBeDismissed != nil) {
+      const BOOL firstModalToBeDismissedIsOwned = [firstModalToBeDismissed isKindOfClass:RNSScreen.class];
+      const BOOL firstModalToBeDismissedIsOwnedByThisStack =
+          firstModalToBeDismissedIsOwned && [_presentedModals containsObject:firstModalToBeDismissed];
 
-    if (firstModalToBeDismissedIsOwnedByThisStack || !firstModalToBeDismissedIsOwned) {
-      // We dismiss every VC that was presented by changeRootController VC or its descendant.
-      // After the series of dismissals is completed we run completion block in which
-      // we present modals on top of changeRootController (which may be the this stack VC)
-      //
-      // There also might the second case, where the firstModalToBeDismissed is foreign.
-      // See: https://github.com/software-mansion/react-native-screens/issues/2048
-      // For now, to mitigate the issue, we also decide to trigger its dismissal before
-      // starting the presentation chain down below in finish() callback.
-      if (!firstModalToBeDismissed.isBeingDismissed) {
-        // If the modal is owned we let it control whether the dismissal is animated or not. For foreign controllers
-        // we just assume animation.
-        const BOOL firstModalToBeDismissedPrefersAnimation = firstModalToBeDismissedIsOwned
-            ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation != RNSScreenStackAnimationNone
-            : YES;
-        [changeRootController dismissViewControllerAnimated:firstModalToBeDismissedPrefersAnimation completion:finish];
-      } else {
-        // We need to wait for its dismissal and then run our presentation code.
-        // This happens, e.g. when we have foreign modal presented on top of owned one & we dismiss foreign one and
-        // immediately present another owned one. Dismissal of the foreign one will be triggered by foreign controller.
-        [[firstModalToBeDismissed transitionCoordinator]
-            animateAlongsideTransition:nil
-                            completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
-                              finish();
-                            }];
+      if (firstModalToBeDismissedIsOwnedByThisStack || !firstModalToBeDismissedIsOwned) {
+        // We dismiss every VC that was presented by changeRootController VC or its descendant.
+        // After the series of dismissals is completed we run completion block in which
+        // we present modals on top of changeRootController (which may be the this stack VC)
+        //
+        // There also might the second case, where the firstModalToBeDismissed is foreign.
+        // See: https://github.com/software-mansion/react-native-screens/issues/2048
+        // For now, to mitigate the issue, we also decide to trigger its dismissal before
+        // starting the presentation chain down below in finish() callback.
+        if (!firstModalToBeDismissed.isBeingDismissed) {
+          // If the modal is owned we let it control whether the dismissal is animated or not. For foreign controllers
+          // we just assume animation.
+          const BOOL firstModalToBeDismissedPrefersAnimation = firstModalToBeDismissedIsOwned
+              ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation != RNSScreenStackAnimationNone
+              : YES;
+          [changeRootController dismissViewControllerAnimated:firstModalToBeDismissedPrefersAnimation completion:finish];
+        } else {
+          // We need to wait for its dismissal and then run our presentation code.
+          // This happens, e.g. when we have foreign modal presented on top of owned one & we dismiss foreign one and
+          // immediately present another owned one. Dismissal of the foreign one will be triggered by foreign controller.
+          [[firstModalToBeDismissed transitionCoordinator]
+              animateAlongsideTransition:nil
+                              completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
+                                finish();
+                              }];
+        }
+        return;
       }
-      return;
     }
-  }
 
-  // changeRootController does not have presentedViewController but it does not mean that no modals are in presentation;
-  // modals could be presented by another stack (nested / outer), third-party view controller or they could be using
-  // UIModalPresentationCurrentContext / UIModalPresentationOverCurrentContext presentation styles; in the last case
-  // for some reason system asks top-level (react root) vc to present instead of our stack, despite the fact that
-  // `definesPresentationContext` returns `YES` for UINavigationController.
-  // So we first need to find top-level controller manually:
-  UIViewController *reactRootVc = [self findReactRootViewController];
-  UIViewController *topMostVc = [RNSScreenStackView findTopMostPresentedViewControllerFromViewController:reactRootVc];
+    // changeRootController does not have presentedViewController but it does not mean that no modals are in presentation;
+    // modals could be presented by another stack (nested / outer), third-party view controller or they could be using
+    // UIModalPresentationCurrentContext / UIModalPresentationOverCurrentContext presentation styles; in the last case
+    // for some reason system asks top-level (react root) vc to present instead of our stack, despite the fact that
+    // `definesPresentationContext` returns `YES` for UINavigationController.
+    // So we first need to find top-level controller manually:
+    UIViewController *reactRootVc = [self findReactRootViewController];
+    UIViewController *topMostVc = [RNSScreenStackView findTopMostPresentedViewControllerFromViewController:reactRootVc];
 
-  if (topMostVc != reactRootVc) {
-    changeRootController = topMostVc;
+    if (topMostVc != reactRootVc) {
+      changeRootController = topMostVc;
 
-    // Here we handle just the simplest case where the top level VC was dismissed. In any more complex
-    // scenario we will still have problems, see: https://github.com/software-mansion/react-native-screens/issues/1813
-    if ([_presentedModals containsObject:topMostVc] && ![controllers containsObject:topMostVc]) {
-      [changeRootController dismissViewControllerAnimated:YES completion:finish];
-      return;
+      // Here we handle just the simplest case where the top level VC was dismissed. In any more complex
+      // scenario we will still have problems, see: https://github.com/software-mansion/react-native-screens/issues/1813
+      if ([_presentedModals containsObject:topMostVc] && ![controllers containsObject:topMostVc]) {
+        [changeRootController dismissViewControllerAnimated:YES completion:finish];
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

In some cases, dismissing a modal not owned by RNScreens may not be the expected behavior. 

## Changes

Added new protocol `RNSDismissibleModalProtocol` that can be used by external libraries to control wether their modal should be dismissed when pushing screen's modal on top. 

Then checking for presence of this protocol in the top modal that should be dismissed. If it implements the protocol and `isDismissible` is true then the dismiss should not happen. 

In any other case the behavior of `setModalViewControllers` is the same as before the change.

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
