### PR TITLE
chore: update react-native-is-edge-to-edge to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "homepage": "https://github.com/software-mansion/react-native-screens#readme",
   "dependencies": {
     "react-freeze": "^1.0.0",
-    "react-native-is-edge-to-edge": "^1.1.7",
+    "react-native-is-edge-to-edge": "^1.2.1",
     "warn-once": "^0.1.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13144,13 +13144,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:^1.1.7":
-  version: 1.1.7
-  resolution: "react-native-is-edge-to-edge@npm:1.1.7"
+"react-native-is-edge-to-edge@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "react-native-is-edge-to-edge@npm:1.2.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/b7a37437f439b1e27a4d980de01994aa71b9091dc3ed00c21172d5505fb11978cd5ed3a43f97c89d502a3a08cf26e5cea6435b8d6e93d3557a92dd43563f7021
+  checksum: 10c0/87d20b900aded7d44c90afb946a7aa03c23a94ca3dd547bdddc2303b85357e4aab22567a57b19f1558d6c8be7058e3dcf34faa1e15182d1604f90974266d9a1d
   languageName: node
   linkType: hard
 
@@ -13227,7 +13227,7 @@ __metadata:
     react-native: "npm:0.80.0-rc.5"
     react-native-builder-bob: "npm:^0.23.2"
     react-native-gesture-handler: "npm:^2.22.0"
-    react-native-is-edge-to-edge: "npm:^1.1.7"
+    react-native-is-edge-to-edge: "npm:^1.2.1"
     react-native-reanimated: "npm:3.16.7"
     react-native-safe-area-context: "npm:5.1.0"
     react-native-windows: "npm:^0.64.8"


### PR DESCRIPTION
## Summary

This PR updates `react-native-is-edge-to-edge` to the latest version: `1.2.1`.

As `edgeToEdgeEnabled` will be available in the next React Native release (https://github.com/facebook/react-native/pull/52088), we need to ensure that `react-native-is-edge-to-edge` supports both `react-native-edge-to-edge` and `edgeToEdgeEnabled`.

Similar issue on reanimated: https://github.com/software-mansion/react-native-reanimated/pull/7729