### PR TITLE
chore(CI): disable e2e workflows temporarily

### DIFF
--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -1,18 +1,5 @@
 name: Test Android e2e - new architecture
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/android-e2e-test-fabric.yml'
-      - 'package.json'
-      - 'android/**'
-      - 'common/**'
-      - 'FabricExample/**'
-      - 'src/**'
-  push:
-    branches:
-      - main
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -1,18 +1,5 @@
 name: Test Android e2e - old architecture
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/android-e2e-test.yml'
-      - 'package.json'
-      - 'android/**'
-      - 'common/**'
-      - 'Example/**'
-      - 'src/**'
-  push:
-    branches:
-      - main
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/ios-e2e-test-fabric.yml
+++ b/.github/workflows/ios-e2e-test-fabric.yml
@@ -1,19 +1,5 @@
 name: Test iOS e2e - new architecture
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/ios-e2e-test-fabric.yml'
-      - 'RNScreens.podspec'
-      - 'package.json'
-      - 'ios/**'
-      - 'common/**'
-      - 'FabricExample/**'
-      - 'src/**'
-  push:
-    branches:
-      - main
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -1,19 +1,5 @@
 name: Test iOS e2e - old architecture
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/ios-e2e-test.yml'
-      - 'RNScreens.podspec'
-      - 'package.json'
-      - 'ios/**'
-      - 'common/**'
-      - 'Example/**'
-      - 'src/**'
-  push:
-    branches:
-      - main
   workflow_dispatch:
 jobs:
   test:


### PR DESCRIPTION
## Description

These do not bring any value right now, since all of them fail due to
detox not supporting recent version of react-native.

We should enable these back once detox releases support for
react-native@0.80+.

Right now, I believe its better to avoid wasting CI time.

## Test code and steps to reproduce

e2e CI should not run

## Checklist

- [ ] Ensured that CI passes
