### PR TITLE
feat(iOS, SplitView): Add support for preferredDisplayMode prop

### DIFF
--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -23,7 +23,7 @@ const SplitViewBaseApp = () => {
   const [buttonState4, setButtonState4] = React.useState('Initial');
 
   return (
-    <SplitViewHost splitBehavior='tile' primaryEdge='leading'>
+    <SplitViewHost displayMode='oneOverSecondary' primaryEdge='leading' splitBehavior='tile'>
       <SplitViewScreen>
         <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
           <TestButton setButtonState={setButtonState} />

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -73,30 +73,6 @@ typedef NS_ENUM(NSInteger, RNSSearchBarPlacement) {
   RNSSearchBarPlacementStacked,
 };
 
-#pragma mark - SplitView
-
-typedef NS_ENUM(NSInteger, RNSSplitViewSplitBehavior) {
-  RNSSplitViewSplitBehaviorAutomatic,
-  RNSSplitViewSplitBehaviorDisplace,
-  RNSSplitViewSplitBehaviorOverlay,
-  RNSSplitViewSplitBehaviorTile,
-};
-
-typedef NS_ENUM(NSInteger, RNSSplitViewPrimaryEdge) {
-  RNSSplitViewPrimaryEdgeLeading,
-  RNSSplitViewPrimaryEdgeTrailing
-};
-
-typedef NS_ENUM(NSInteger, RNSSplitViewDisplayMode) {
-  RNSSplitViewDisplayModeAutomatic,
-  RNSSplitViewDisplayModeSecondaryOnly,
-  RNSSplitViewDisplayModeOneBesideSecondary,
-  RNSSplitViewDisplayModeOneOverSecondary,
-  RNSSplitViewDisplayModeTwoBesideSecondary,
-  RNSSplitViewDisplayModeTwoOverSecondary,
-  RNSSplitViewDisplayModeTwoDisplaceSecondary,
-};
-
 // Redefinition of UIBlurEffectStyle. We need to represent additional case of `None`.
 typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   /// No blur effect should be visible

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -87,6 +87,16 @@ typedef NS_ENUM(NSInteger, RNSSplitViewPrimaryEdge) {
   RNSSplitViewPrimaryEdgeTrailing
 };
 
+typedef NS_ENUM(NSInteger, RNSSplitViewDisplayMode) {
+  RNSSplitViewDisplayModeAutomatic,
+  RNSSplitViewDisplayModeSecondaryOnly,
+  RNSSplitViewDisplayModeOneBesideSecondary,
+  RNSSplitViewDisplayModeOneOverSecondary,
+  RNSSplitViewDisplayModeTwoBesideSecondary,
+  RNSSplitViewDisplayModeTwoOverSecondary,
+  RNSSplitViewDisplayModeTwoDisplaceSecondary,
+};
+
 // Redefinition of UIBlurEffectStyle. We need to represent additional case of `None`.
 typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   /// No blur effect should be visible

--- a/ios/conversion/RNSConversions-SplitView.mm
+++ b/ios/conversion/RNSConversions-SplitView.mm
@@ -36,6 +36,29 @@ RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(
   }
 }
 
+RNSSplitViewDisplayMode RNSSplitViewDisplayModeFromHostProp(facebook::react::RNSSplitViewHostDisplayMode displayMode)
+{
+  using enum facebook::react::RNSSplitViewHostDisplayMode;
+
+  switch (displayMode) {
+    case SecondaryOnly:
+      return RNSSplitViewDisplayModeSecondaryOnly;
+    case OneBesideSecondary:
+      return RNSSplitViewDisplayModeOneBesideSecondary;
+    case OneOverSecondary:
+      return RNSSplitViewDisplayModeOneOverSecondary;
+    case TwoBesideSecondary:
+      return RNSSplitViewDisplayModeTwoBesideSecondary;
+    case TwoOverSecondary:
+      return RNSSplitViewDisplayModeTwoOverSecondary;
+    case TwoDisplaceSecondary:
+      return RNSSplitViewDisplayModeTwoDisplaceSecondary;
+    case Automatic:
+    default:
+      return RNSSplitViewDisplayModeAutomatic;
+  }
+}
+
 #pragma mark Internal enum to UISplitViewController enum conversions
 
 UISplitViewControllerSplitBehavior RNSSplitBehaviorToUISplitViewControllerSplitBehavior(

--- a/ios/conversion/RNSConversions-SplitView.mm
+++ b/ios/conversion/RNSConversions-SplitView.mm
@@ -8,7 +8,7 @@ RNSSplitViewSplitBehavior RNSSplitViewSplitBehaviorFromHostProp(
     facebook::react::RNSSplitViewHostSplitBehavior splitBehavior)
 {
   using enum facebook::react::RNSSplitViewHostSplitBehavior;
-  
+
   switch (splitBehavior) {
     case Displace:
       return RNSSplitViewSplitBehaviorDisplace;
@@ -22,11 +22,10 @@ RNSSplitViewSplitBehavior RNSSplitViewSplitBehaviorFromHostProp(
   }
 }
 
-RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(
-    facebook::react::RNSSplitViewHostPrimaryEdge primaryEdge)
+RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(facebook::react::RNSSplitViewHostPrimaryEdge primaryEdge)
 {
   using enum facebook::react::RNSSplitViewHostPrimaryEdge;
-  
+
   switch (primaryEdge) {
     case Trailing:
       return RNSSplitViewPrimaryEdgeTrailing;
@@ -77,8 +76,7 @@ UISplitViewControllerSplitBehavior RNSSplitBehaviorToUISplitViewControllerSplitB
   }
 }
 
-UISplitViewControllerPrimaryEdge RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(
-    RNSSplitViewPrimaryEdge primaryEdge)
+UISplitViewControllerPrimaryEdge RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(RNSSplitViewPrimaryEdge primaryEdge)
 {
   switch (primaryEdge) {
     case RNSSplitViewPrimaryEdgeTrailing:
@@ -86,6 +84,27 @@ UISplitViewControllerPrimaryEdge RNSPrimaryEdgeToUISplitViewControllerPrimaryEdg
     case RNSSplitViewPrimaryEdgeLeading:
     default:
       return UISplitViewControllerPrimaryEdgeLeading;
+  }
+}
+
+UISplitViewControllerDisplayMode RNSDisplayModeToUISplitViewControllerDisplayMode(RNSSplitViewDisplayMode displayMode)
+{
+  switch (displayMode) {
+    case RNSSplitViewDisplayModeSecondaryOnly:
+      return UISplitViewControllerDisplayModeSecondaryOnly;
+    case RNSSplitViewDisplayModeOneBesideSecondary:
+      return UISplitViewControllerDisplayModeOneBesideSecondary;
+    case RNSSplitViewDisplayModeOneOverSecondary:
+      return UISplitViewControllerDisplayModeOneOverSecondary;
+    case RNSSplitViewDisplayModeTwoBesideSecondary:
+      return UISplitViewControllerDisplayModeTwoBesideSecondary;
+    case RNSSplitViewDisplayModeTwoOverSecondary:
+      return UISplitViewControllerDisplayModeTwoOverSecondary;
+    case RNSSplitViewDisplayModeTwoDisplaceSecondary:
+      return UISplitViewControllerDisplayModeTwoDisplaceSecondary;
+    case RNSSplitViewDisplayModeAutomatic:
+    default:
+      return UISplitViewControllerDisplayModeAutomatic;
   }
 }
 

--- a/ios/conversion/RNSConversions-SplitView.mm
+++ b/ios/conversion/RNSConversions-SplitView.mm
@@ -4,105 +4,57 @@ namespace rnscreens::conversion {
 
 #pragma mark RN Codegen enum to internal enum conversions
 
-RNSSplitViewSplitBehavior RNSSplitViewSplitBehaviorFromHostProp(
+UISplitViewControllerSplitBehavior SplitViewSplitBehaviorFromHostProp(
     facebook::react::RNSSplitViewHostSplitBehavior splitBehavior)
 {
   using enum facebook::react::RNSSplitViewHostSplitBehavior;
 
   switch (splitBehavior) {
     case Displace:
-      return RNSSplitViewSplitBehaviorDisplace;
-    case Overlay:
-      return RNSSplitViewSplitBehaviorOverlay;
-    case Tile:
-      return RNSSplitViewSplitBehaviorTile;
-    case Automatic:
-    default:
-      return RNSSplitViewSplitBehaviorAutomatic;
-  }
-}
-
-RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(facebook::react::RNSSplitViewHostPrimaryEdge primaryEdge)
-{
-  using enum facebook::react::RNSSplitViewHostPrimaryEdge;
-
-  switch (primaryEdge) {
-    case Trailing:
-      return RNSSplitViewPrimaryEdgeTrailing;
-    case Leading:
-    default:
-      return RNSSplitViewPrimaryEdgeLeading;
-  }
-}
-
-RNSSplitViewDisplayMode RNSSplitViewDisplayModeFromHostProp(facebook::react::RNSSplitViewHostDisplayMode displayMode)
-{
-  using enum facebook::react::RNSSplitViewHostDisplayMode;
-
-  switch (displayMode) {
-    case SecondaryOnly:
-      return RNSSplitViewDisplayModeSecondaryOnly;
-    case OneBesideSecondary:
-      return RNSSplitViewDisplayModeOneBesideSecondary;
-    case OneOverSecondary:
-      return RNSSplitViewDisplayModeOneOverSecondary;
-    case TwoBesideSecondary:
-      return RNSSplitViewDisplayModeTwoBesideSecondary;
-    case TwoOverSecondary:
-      return RNSSplitViewDisplayModeTwoOverSecondary;
-    case TwoDisplaceSecondary:
-      return RNSSplitViewDisplayModeTwoDisplaceSecondary;
-    case Automatic:
-    default:
-      return RNSSplitViewDisplayModeAutomatic;
-  }
-}
-
-#pragma mark Internal enum to UISplitViewController enum conversions
-
-UISplitViewControllerSplitBehavior RNSSplitBehaviorToUISplitViewControllerSplitBehavior(
-    RNSSplitViewSplitBehavior behavior)
-{
-  switch (behavior) {
-    case RNSSplitViewSplitBehaviorDisplace:
       return UISplitViewControllerSplitBehaviorDisplace;
-    case RNSSplitViewSplitBehaviorOverlay:
+    case Overlay:
       return UISplitViewControllerSplitBehaviorOverlay;
-    case RNSSplitViewSplitBehaviorTile:
+    case Tile:
       return UISplitViewControllerSplitBehaviorTile;
-    case RNSSplitViewSplitBehaviorAutomatic:
+    case Automatic:
     default:
       return UISplitViewControllerSplitBehaviorAutomatic;
   }
 }
 
-UISplitViewControllerPrimaryEdge RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(RNSSplitViewPrimaryEdge primaryEdge)
+UISplitViewControllerPrimaryEdge SplitViewPrimaryEdgeFromHostProp(
+    facebook::react::RNSSplitViewHostPrimaryEdge primaryEdge)
 {
+  using enum facebook::react::RNSSplitViewHostPrimaryEdge;
+
   switch (primaryEdge) {
-    case RNSSplitViewPrimaryEdgeTrailing:
+    case Trailing:
       return UISplitViewControllerPrimaryEdgeTrailing;
-    case RNSSplitViewPrimaryEdgeLeading:
+    case Leading:
     default:
       return UISplitViewControllerPrimaryEdgeLeading;
   }
 }
 
-UISplitViewControllerDisplayMode RNSDisplayModeToUISplitViewControllerDisplayMode(RNSSplitViewDisplayMode displayMode)
+UISplitViewControllerDisplayMode SplitViewDisplayModeFromHostProp(
+    facebook::react::RNSSplitViewHostDisplayMode displayMode)
 {
+  using enum facebook::react::RNSSplitViewHostDisplayMode;
+
   switch (displayMode) {
-    case RNSSplitViewDisplayModeSecondaryOnly:
+    case SecondaryOnly:
       return UISplitViewControllerDisplayModeSecondaryOnly;
-    case RNSSplitViewDisplayModeOneBesideSecondary:
+    case OneBesideSecondary:
       return UISplitViewControllerDisplayModeOneBesideSecondary;
-    case RNSSplitViewDisplayModeOneOverSecondary:
+    case OneOverSecondary:
       return UISplitViewControllerDisplayModeOneOverSecondary;
-    case RNSSplitViewDisplayModeTwoBesideSecondary:
+    case TwoBesideSecondary:
       return UISplitViewControllerDisplayModeTwoBesideSecondary;
-    case RNSSplitViewDisplayModeTwoOverSecondary:
+    case TwoOverSecondary:
       return UISplitViewControllerDisplayModeTwoOverSecondary;
-    case RNSSplitViewDisplayModeTwoDisplaceSecondary:
+    case TwoDisplaceSecondary:
       return UISplitViewControllerDisplayModeTwoDisplaceSecondary;
-    case RNSSplitViewDisplayModeAutomatic:
+    case Automatic:
     default:
       return UISplitViewControllerDisplayModeAutomatic;
   }

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -32,26 +32,14 @@ UIOffset RNSBottomTabsScreenTabBarItemTitlePositionAdjustmentStruct(
 
 #pragma mark SplitView
 
-RNSSplitViewSplitBehavior RNSSplitViewSplitBehaviorFromHostProp(
-    react::RNSSplitViewHostSplitBehavior);
+UISplitViewControllerSplitBehavior SplitViewSplitBehaviorFromHostProp(
+    react::RNSSplitViewHostSplitBehavior behavior);
 
-RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(
-    react::RNSSplitViewHostPrimaryEdge);
+UISplitViewControllerPrimaryEdge SplitViewPrimaryEdgeFromHostProp(
+    react::RNSSplitViewHostPrimaryEdge primaryEdge);
 
-RNSSplitViewDisplayMode RNSSplitViewDisplayModeFromHostProp(
-    react::RNSSplitViewHostDisplayMode);
-
-UISplitViewControllerSplitBehavior
-RNSSplitBehaviorToUISplitViewControllerSplitBehavior(
-    RNSSplitViewSplitBehavior behavior);
-
-UISplitViewControllerPrimaryEdge
-RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(
-    RNSSplitViewPrimaryEdge primaryEdge);
-
-UISplitViewControllerDisplayMode
-RNSDisplayModeToUISplitViewControllerDisplayMode(
-    RNSSplitViewDisplayMode displayMode);
+UISplitViewControllerDisplayMode SplitViewDisplayModeFromHostProp(
+    react::RNSSplitViewHostDisplayMode displayMode);
 
 }; // namespace rnscreens::conversion
 

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -49,6 +49,10 @@ UISplitViewControllerPrimaryEdge
 RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(
     RNSSplitViewPrimaryEdge primaryEdge);
 
+UISplitViewControllerDisplayMode
+RNSDisplayModeToUISplitViewControllerDisplayMode(
+    RNSSplitViewDisplayMode displayMode);
+
 }; // namespace rnscreens::conversion
 
 #endif

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -38,6 +38,9 @@ RNSSplitViewSplitBehavior RNSSplitViewSplitBehaviorFromHostProp(
 RNSSplitViewPrimaryEdge RNSSplitViewPrimaryEdgeFromHostProp(
     react::RNSSplitViewHostPrimaryEdge);
 
+RNSSplitViewDisplayMode RNSSplitViewDisplayModeFromHostProp(
+    react::RNSSplitViewHostDisplayMode);
+
 UISplitViewControllerSplitBehavior
 RNSSplitBehaviorToUISplitViewControllerSplitBehavior(
     RNSSplitViewSplitBehavior behavior);
@@ -45,6 +48,7 @@ RNSSplitBehaviorToUISplitViewControllerSplitBehavior(
 UISplitViewControllerPrimaryEdge
 RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(
     RNSSplitViewPrimaryEdge primaryEdge);
+
 }; // namespace rnscreens::conversion
 
 #endif

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) RNSSplitViewSplitBehavior splitBehavior;
 @property (nonatomic, readonly) RNSSplitViewPrimaryEdge primaryEdge;
+@property (nonatomic, readonly) RNSSplitViewDisplayMode displayMode;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -18,9 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSSplitViewHostComponentView ()
 
-@property (nonatomic, readonly) RNSSplitViewSplitBehavior splitBehavior;
-@property (nonatomic, readonly) RNSSplitViewPrimaryEdge primaryEdge;
-@property (nonatomic, readonly) RNSSplitViewDisplayMode displayMode;
+@property (nonatomic, readonly) UISplitViewControllerSplitBehavior splitBehavior;
+@property (nonatomic, readonly) UISplitViewControllerPrimaryEdge primaryEdge;
+@property (nonatomic, readonly) UISplitViewControllerDisplayMode displayMode;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -48,6 +48,7 @@ namespace react = facebook::react;
 
   _splitBehavior = RNSSplitViewSplitBehaviorAutomatic;
   _primaryEdge = RNSSplitViewPrimaryEdgeLeading;
+  _displayMode = RNSSplitViewDisplayModeAutomatic;
 }
 
 - (void)didMoveToWindow
@@ -149,6 +150,11 @@ RNS_IGNORE_SUPER_CALL_END
     _primaryEdge = rnscreens::conversion::RNSSplitViewPrimaryEdgeFromHostProp(newComponentProps.primaryEdge);
     _controller.primaryEdge =
         rnscreens::conversion::RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(_primaryEdge);
+  }
+
+  if (oldComponentProps.displayMode != newComponentProps.displayMode) {
+    _displayMode = rnscreens::conversion::RNSSplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
+    _controller.preferredDisplayMode = convertRNSDisplayModeToUISplitViewControllerDisplayMode(_displayMode);
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -148,13 +148,13 @@ RNS_IGNORE_SUPER_CALL_END
 
   if (oldComponentProps.primaryEdge != newComponentProps.primaryEdge) {
     _primaryEdge = rnscreens::conversion::RNSSplitViewPrimaryEdgeFromHostProp(newComponentProps.primaryEdge);
-    _controller.primaryEdge =
-        rnscreens::conversion::RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(_primaryEdge);
+    _controller.primaryEdge = rnscreens::conversion::RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(_primaryEdge);
   }
 
   if (oldComponentProps.displayMode != newComponentProps.displayMode) {
     _displayMode = rnscreens::conversion::RNSSplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
-    _controller.preferredDisplayMode = convertRNSDisplayModeToUISplitViewControllerDisplayMode(_displayMode);
+    _controller.preferredDisplayMode =
+        rnscreens::conversion::RNSDisplayModeToUISplitViewControllerDisplayMode(_displayMode);
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -46,9 +46,9 @@ namespace react = facebook::react;
   static const auto defaultProps = std::make_shared<const react::RNSSplitViewHostProps>();
   _props = defaultProps;
 
-  _splitBehavior = RNSSplitViewSplitBehaviorAutomatic;
-  _primaryEdge = RNSSplitViewPrimaryEdgeLeading;
-  _displayMode = RNSSplitViewDisplayModeAutomatic;
+  _splitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
+  _primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
+  _displayMode = UISplitViewControllerDisplayModeAutomatic;
 }
 
 - (void)didMoveToWindow
@@ -141,20 +141,18 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &newComponentProps = *std::static_pointer_cast<const react::RNSSplitViewHostProps>(props);
 
   if (oldComponentProps.splitBehavior != newComponentProps.splitBehavior) {
-    _splitBehavior = rnscreens::conversion::RNSSplitViewSplitBehaviorFromHostProp(newComponentProps.splitBehavior);
-    _controller.preferredSplitBehavior =
-        rnscreens::conversion::RNSSplitBehaviorToUISplitViewControllerSplitBehavior(_splitBehavior);
+    _splitBehavior = rnscreens::conversion::SplitViewSplitBehaviorFromHostProp(newComponentProps.splitBehavior);
+    _controller.preferredSplitBehavior = _splitBehavior;
   }
 
   if (oldComponentProps.primaryEdge != newComponentProps.primaryEdge) {
-    _primaryEdge = rnscreens::conversion::RNSSplitViewPrimaryEdgeFromHostProp(newComponentProps.primaryEdge);
-    _controller.primaryEdge = rnscreens::conversion::RNSPrimaryEdgeToUISplitViewControllerPrimaryEdge(_primaryEdge);
+    _primaryEdge = rnscreens::conversion::SplitViewPrimaryEdgeFromHostProp(newComponentProps.primaryEdge);
+    _controller.primaryEdge = _primaryEdge;
   }
 
   if (oldComponentProps.displayMode != newComponentProps.displayMode) {
-    _displayMode = rnscreens::conversion::RNSSplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
-    _controller.preferredDisplayMode =
-        rnscreens::conversion::RNSDisplayModeToUISplitViewControllerDisplayMode(_displayMode);
+    _displayMode = rnscreens::conversion::SplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
+    _controller.preferredDisplayMode = _displayMode;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -4,12 +4,14 @@ import type { ViewProps } from 'react-native';
 import SplitViewHostNativeComponent from '../../fabric/gamma/SplitViewHostNativeComponent';
 import type {
   NativeProps,
+  SplitViewDisplayMode,
   SplitViewSplitBehavior,
 } from '../../fabric/gamma/SplitViewHostNativeComponent';
 
 export type SplitViewNativeProps = NativeProps & {
   // SplitView appearance
 
+  displayMode?: SplitViewDisplayMode;
   splitBehavior?: SplitViewSplitBehavior;
 };
 
@@ -17,9 +19,57 @@ type SplitViewHostProps = {
   children?: ViewProps['children'];
 } & SplitViewNativeProps;
 
-function SplitViewHost({ children, splitBehavior, primaryEdge }: SplitViewHostProps) {
+const displayModeForSplitViewCompatibilityMap: Record<
+  SplitViewSplitBehavior,
+  SplitViewDisplayMode[]
+> = {
+  tile: ['secondaryOnly', 'oneBesideSecondary', 'twoBesideSecondary'],
+  overlay: ['secondaryOnly', 'oneOverSecondary', 'twoOverSecondary'],
+  displace: ['secondaryOnly', 'oneBesideSecondary', 'twoDisplaceSecondary'],
+  automatic: [], // placeholder for satisfying types; we'll handle it specially in logic
+};
+
+const isValidDisplayModeForSplitBehavior = (
+  displayMode: SplitViewDisplayMode,
+  splitBehavior: SplitViewSplitBehavior,
+) => {
+  if (splitBehavior === 'automatic') {
+    // for automatic we cannot easily verify the compatibility, because it depends on the system preference for display mode, therefore we're assuming that 'automatic' has only valid combinations
+    return true;
+  }
+  return displayModeForSplitViewCompatibilityMap[splitBehavior].includes(
+    displayMode,
+  );
+};
+
+function SplitViewHost({
+  children,
+  displayMode,
+  primaryEdge,
+  splitBehavior,
+}: SplitViewHostProps) {
+  React.useEffect(() => {
+    if (displayMode && splitBehavior) {
+      const isValid = isValidDisplayModeForSplitBehavior(
+        displayMode,
+        splitBehavior,
+      );
+      if (!isValid) {
+        const validDisplayModes =
+          displayModeForSplitViewCompatibilityMap[splitBehavior];
+        console.warn(
+          `Invalid display mode "${displayMode}" for split behavior "${splitBehavior}".` +
+            `\nValid modes for "${splitBehavior}" are: ${validDisplayModes.join(
+              ', ',
+            )}.`,
+        );
+      }
+    }
+  }, [displayMode, splitBehavior]);
+
   return (
     <SplitViewHostNativeComponent
+      displayMode={displayMode}
       style={styles.container}
       splitBehavior={splitBehavior}
       primaryEdge={primaryEdge}>

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -19,6 +19,10 @@ type SplitViewHostProps = {
   children?: ViewProps['children'];
 } & SplitViewNativeProps;
 
+// According to the UIKit documentation: https://developer.apple.com/documentation/uikit/uisplitviewcontroller/displaymode-swift.enum
+// Only specific pairs for displayMode - splitBehavior are valid and others may lead to unexpected results.
+// Therefore, we're adding check on the JS side to return a feedback to the client when that pairing isn't valid.
+// However, we're not blocking these props to be set on the native side, because it doesn't crash, just the result or transitions may not work as expected.
 const displayModeForSplitViewCompatibilityMap: Record<
   SplitViewSplitBehavior,
   SplitViewDisplayMode[]

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -12,8 +12,19 @@ export type SplitViewSplitBehavior =
 
 export type SplitViewPrimaryEdge = 'leading' | 'trailing';
 
+export type SplitViewDisplayMode =
+  | 'automatic'
+  | 'secondaryOnly'
+  | 'oneBesideSecondary'
+  | 'oneOverSecondary'
+  | 'twoBesideSecondary'
+  | 'twoOverSecondary'
+  | 'twoDisplaceSecondary';
+
 export interface NativeProps extends ViewProps {
   // Appearance
+
+  displayMode?: WithDefault<SplitViewDisplayMode, 'automatic'>;
   splitBehavior?: WithDefault<SplitViewSplitBehavior, 'automatic'>;
   primaryEdge?: WithDefault<SplitViewPrimaryEdge, 'leading'>;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-screens-labs/issues/223

This property specifies the display mode which will be preferred to use in SplitView, when the layout requirements are met.

Possible DisplayMode values:

- `secondaryOnly` - only the secondary column is displayed
- `oneBesideSecondary` - a sidebar is displayed side-by-side with the secondary column
- `twoBesideSecondary` - two sidebars are displayed side-by-side with the secondary column
- `oneOverSecondary` - a one sidebar is displayed over the secondary column
- `twoOverSecondary` - two sidebars are displayed over the secondary column
- `twoDisplaceSecondary` - two sidebars are displacind the secondary column, moving it partially offscreen
- `automatic` - leaving the choice to OS (default)

## Changes

- Added prop definition in TS
- Added enums and converters on the native side
- Included new prop in `updateProps` and `resetProps` methods
- Added warning for non-matching splitBehavior-displayMode pairs

## Test code and steps to reproduce

`SplitViewBaseApp` was updated to cover the specific prop.

https://github.com/user-attachments/assets/c722cfb3-f066-4b21-9e45-cbb156ac0220

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes

Closes: #223 