### PR TITLE
feat(iOS, SplitView): Add support for presentsWithGesture prop

### DIFF
--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -23,7 +23,7 @@ const SplitViewBaseApp = () => {
   const [buttonState4, setButtonState4] = React.useState('Initial');
 
   return (
-    <SplitViewHost displayMode='twoBesideSecondary' primaryEdge='leading' enableSwipeToDismiss={false} splitBehavior='tile'>
+    <SplitViewHost displayMode='twoBesideSecondary' primaryEdge='leading' enableSwipe={false} splitBehavior='tile'>
       <SplitViewScreen>
         <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
           <TestButton setButtonState={setButtonState} />

--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -23,7 +23,7 @@ const SplitViewBaseApp = () => {
   const [buttonState4, setButtonState4] = React.useState('Initial');
 
   return (
-    <SplitViewHost displayMode='oneOverSecondary' primaryEdge='leading' splitBehavior='tile'>
+    <SplitViewHost displayMode='twoBesideSecondary' primaryEdge='leading' enableSwipeToDismiss={false} splitBehavior='tile'>
       <SplitViewScreen>
         <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
           <TestButton setButtonState={setButtonState} />

--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -23,7 +23,7 @@ const SplitViewBaseApp = () => {
   const [buttonState4, setButtonState4] = React.useState('Initial');
 
   return (
-    <SplitViewHost displayMode='twoBesideSecondary' primaryEdge='leading' enableSwipe={false} splitBehavior='tile'>
+    <SplitViewHost displayMode='twoBesideSecondary' primaryEdge='leading' presentsWithGesture={false} splitBehavior='tile'>
       <SplitViewScreen>
         <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
           <TestButton setButtonState={setButtonState} />

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UISplitViewControllerSplitBehavior splitBehavior;
 @property (nonatomic, readonly) UISplitViewControllerPrimaryEdge primaryEdge;
 @property (nonatomic, readonly) UISplitViewControllerDisplayMode displayMode;
-@property (nonatomic, readonly) BOOL enableSwipeToDismiss;
+@property (nonatomic, readonly) BOOL enableSwipe;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UISplitViewControllerSplitBehavior splitBehavior;
 @property (nonatomic, readonly) UISplitViewControllerPrimaryEdge primaryEdge;
 @property (nonatomic, readonly) UISplitViewControllerDisplayMode displayMode;
+@property (nonatomic, readonly) BOOL enableSwipeToDismiss;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UISplitViewControllerSplitBehavior splitBehavior;
 @property (nonatomic, readonly) UISplitViewControllerPrimaryEdge primaryEdge;
 @property (nonatomic, readonly) UISplitViewControllerDisplayMode displayMode;
-@property (nonatomic, readonly) BOOL enableSwipe;
+@property (nonatomic, readonly) BOOL presentsWithGesture;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -49,7 +49,7 @@ namespace react = facebook::react;
   _splitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
   _primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
   _displayMode = UISplitViewControllerDisplayModeAutomatic;
-  _enableSwipeToDismiss = true;
+  _enableSwipe = true;
 }
 
 - (void)didMoveToWindow
@@ -156,9 +156,9 @@ RNS_IGNORE_SUPER_CALL_END
     _controller.preferredDisplayMode = _displayMode;
   }
 
-  if (oldComponentProps.enableSwipeToDismiss != newComponentProps.enableSwipeToDismiss) {
-    _enableSwipeToDismiss = newComponentProps.enableSwipeToDismiss;
-    _controller.presentsWithGesture = _enableSwipeToDismiss;
+  if (oldComponentProps.enableSwipe != newComponentProps.enableSwipe) {
+    _enableSwipe = newComponentProps.enableSwipe;
+    _controller.presentsWithGesture = _enableSwipe;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -49,7 +49,7 @@ namespace react = facebook::react;
   _splitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
   _primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
   _displayMode = UISplitViewControllerDisplayModeAutomatic;
-  _enableSwipe = true;
+  _presentsWithGesture = true;
 }
 
 - (void)didMoveToWindow
@@ -156,9 +156,9 @@ RNS_IGNORE_SUPER_CALL_END
     _controller.preferredDisplayMode = _displayMode;
   }
 
-  if (oldComponentProps.enableSwipe != newComponentProps.enableSwipe) {
-    _enableSwipe = newComponentProps.enableSwipe;
-    _controller.presentsWithGesture = _enableSwipe;
+  if (oldComponentProps.presentsWithGesture != newComponentProps.presentsWithGesture) {
+    _presentsWithGesture = newComponentProps.presentsWithGesture;
+    _controller.presentsWithGesture = _presentsWithGesture;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -49,6 +49,7 @@ namespace react = facebook::react;
   _splitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
   _primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
   _displayMode = UISplitViewControllerDisplayModeAutomatic;
+  _enableSwipeToDismiss = true;
 }
 
 - (void)didMoveToWindow
@@ -153,6 +154,11 @@ RNS_IGNORE_SUPER_CALL_END
   if (oldComponentProps.displayMode != newComponentProps.displayMode) {
     _displayMode = rnscreens::conversion::SplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
     _controller.preferredDisplayMode = _displayMode;
+  }
+
+  if (oldComponentProps.enableSwipeToDismiss != newComponentProps.enableSwipeToDismiss) {
+    _enableSwipeToDismiss = newComponentProps.enableSwipeToDismiss;
+    _controller.presentsWithGesture = _enableSwipeToDismiss;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -16,7 +16,7 @@ export type SplitViewNativeProps = NativeProps & {
 
   // SplitView interactions
 
-  enableSwipe?: boolean;
+  presentsWithGesture?: boolean;
 };
 
 type SplitViewHostProps = {

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -13,6 +13,10 @@ export type SplitViewNativeProps = NativeProps & {
 
   displayMode?: SplitViewDisplayMode;
   splitBehavior?: SplitViewSplitBehavior;
+
+  // SplitView interactions
+
+  enableSwipeToDismiss?: boolean;
 };
 
 type SplitViewHostProps = {
@@ -49,6 +53,7 @@ const isValidDisplayModeForSplitBehavior = (
 function SplitViewHost({
   children,
   displayMode,
+  enableSwipeToDismiss,
   primaryEdge,
   splitBehavior,
 }: SplitViewHostProps) {
@@ -74,6 +79,7 @@ function SplitViewHost({
   return (
     <SplitViewHostNativeComponent
       displayMode={displayMode}
+      enableSwipeToDismiss={enableSwipeToDismiss}
       style={styles.container}
       splitBehavior={splitBehavior}
       primaryEdge={primaryEdge}>

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -50,13 +50,9 @@ const isValidDisplayModeForSplitBehavior = (
   );
 };
 
-function SplitViewHost({
-  children,
-  displayMode,
-  enableSwipe,
-  primaryEdge,
-  splitBehavior,
-}: SplitViewHostProps) {
+function SplitViewHost(props: SplitViewHostProps) {
+  const { displayMode, splitBehavior } = props;
+
   React.useEffect(() => {
     if (displayMode && splitBehavior) {
       const isValid = isValidDisplayModeForSplitBehavior(
@@ -77,13 +73,8 @@ function SplitViewHost({
   }, [displayMode, splitBehavior]);
 
   return (
-    <SplitViewHostNativeComponent
-      displayMode={displayMode}
-      enableSwipe={enableSwipe}
-      style={styles.container}
-      splitBehavior={splitBehavior}
-      primaryEdge={primaryEdge}>
-      {children}
+    <SplitViewHostNativeComponent {...props} style={styles.container}>
+      {props.children}
     </SplitViewHostNativeComponent>
   );
 }

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -16,7 +16,7 @@ export type SplitViewNativeProps = NativeProps & {
 
   // SplitView interactions
 
-  enableSwipeToDismiss?: boolean;
+  enableSwipe?: boolean;
 };
 
 type SplitViewHostProps = {
@@ -53,7 +53,7 @@ const isValidDisplayModeForSplitBehavior = (
 function SplitViewHost({
   children,
   displayMode,
-  enableSwipeToDismiss,
+  enableSwipe,
   primaryEdge,
   splitBehavior,
 }: SplitViewHostProps) {
@@ -79,7 +79,7 @@ function SplitViewHost({
   return (
     <SplitViewHostNativeComponent
       displayMode={displayMode}
-      enableSwipeToDismiss={enableSwipeToDismiss}
+      enableSwipe={enableSwipe}
       style={styles.container}
       splitBehavior={splitBehavior}
       primaryEdge={primaryEdge}>

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -27,6 +27,10 @@ export interface NativeProps extends ViewProps {
   displayMode?: WithDefault<SplitViewDisplayMode, 'automatic'>;
   splitBehavior?: WithDefault<SplitViewSplitBehavior, 'automatic'>;
   primaryEdge?: WithDefault<SplitViewPrimaryEdge, 'leading'>;
+
+  // Interactions
+
+  enableSwipeToDismiss?: WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSSplitViewHost', {});

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -30,7 +30,7 @@ export interface NativeProps extends ViewProps {
 
   // Interactions
 
-  enableSwipeToDismiss?: WithDefault<boolean, true>;
+  enableSwipe?: WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSSplitViewHost', {});

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -30,7 +30,7 @@ export interface NativeProps extends ViewProps {
 
   // Interactions
 
-  enableSwipe?: WithDefault<boolean, true>;
+  presentsWithGesture?: WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSSplitViewHost', {});


### PR DESCRIPTION
## Description

SplitView installs its own GestureRecognizer for changing the display mode. There's a method `presentsWithGesture` which can disable this GestureRecognizer. In this PR I am adding a setter for this API from the JS native component.

## Changes

- Updated example
- Added native setter
- Updated JS native component definition

## Test code and steps to reproduce

Updated `SplitViewBaseApp`

https://github.com/user-attachments/assets/a5cf2bd3-0183-4258-89bf-34c84b7ed589

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes

Closes https://github.com/software-mansion/react-native-screens-labs/issues/230 
