### PR TITLE
feat(iOS, Tabs): add support for tabBarMinimizeBehavior

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -186,6 +186,7 @@ class TabsHostViewManager :
     ) {
         view.tabBarItemRippleColor = value
     }
+
     override fun setTabBarMinimizeBehavior(
         view: TabsHost,
         value: String?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -186,6 +186,10 @@ class TabsHostViewManager :
     ) {
         view.tabBarItemRippleColor = value
     }
+    override fun setTabBarMinimizeBehavior(
+        view: TabsHost,
+        value: String?,
+    ) = Unit
 
     @ReactProp(name = "tabBarItemLabelVisibilityMode")
     override fun setTabBarItemLabelVisibilityMode(

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
@@ -72,6 +72,9 @@ public class RNSBottomTabsManagerDelegate<T extends View, U extends BaseViewMana
       case "tabBarItemRippleColor":
         mViewManager.setTabBarItemRippleColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
+      case "tabBarMinimizeBehavior":
+        mViewManager.setTabBarMinimizeBehavior(view, (String) value);
+        break;
       case "tabBarItemLabelVisibilityMode":
         mViewManager.setTabBarItemLabelVisibilityMode(view, (String) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
@@ -72,11 +72,11 @@ public class RNSBottomTabsManagerDelegate<T extends View, U extends BaseViewMana
       case "tabBarItemRippleColor":
         mViewManager.setTabBarItemRippleColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
-      case "tabBarMinimizeBehavior":
-        mViewManager.setTabBarMinimizeBehavior(view, (String) value);
-        break;
       case "tabBarItemLabelVisibilityMode":
         mViewManager.setTabBarItemLabelVisibilityMode(view, (String) value);
+        break;
+      case "tabBarMinimizeBehavior":
+        mViewManager.setTabBarMinimizeBehavior(view, (String) value);
         break;
       case "controlNavigationStateInJS":
         mViewManager.setControlNavigationStateInJS(view, value == null ? false : (boolean) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
@@ -32,5 +32,6 @@ public interface RNSBottomTabsManagerInterface<T extends View>  {
   void setTabBarItemActivityIndicatorColor(T view, @Nullable Integer value);
   void setTabBarItemRippleColor(T view, @Nullable Integer value);
   void setTabBarItemLabelVisibilityMode(T view, @Nullable String value);
+  void setTabBarMinimizeBehavior(T view, @Nullable String value);
   void setControlNavigationStateInJS(T view, boolean value);
 }

--- a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
@@ -84,7 +84,6 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
   return (
     <BottomTabs
       onNativeFocusChange={onNativeFocusChangeCallback}
-
       tabBarBackgroundColor={Colors.NavyLight100}
       tabBarItemActivityIndicatorColor={Colors.GreenLight40}
       tabBarTintColor={Colors.YellowLight100}
@@ -96,11 +95,12 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
       tabBarItemTitleFontSize={10}
       tabBarItemTitleFontSizeActive={15}
       tabBarItemRippleColor={Colors.WhiteTransparentDark}
-      tabBarItemTitleFontFamily='monospace'
-      tabBarItemTitleFontStyle='italic'
+      tabBarItemTitleFontFamily="monospace"
+      tabBarItemTitleFontStyle="italic"
       tabBarItemTitleFontWeight="700"
       tabBarItemLabelVisibilityMode="auto"
 
+      tabBarMinimizeBehavior="onScrollDown"
       experimentalControlNavigationStateInJS={
         configWrapper.config.controlledBottomTabs
       }>

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -129,3 +129,10 @@ typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeTemplate,
   RNSBottomTabsIconTypeSfSymbol,
 };
+
+typedef NS_ENUM(NSInteger, RNSTabBarMinimizeBehavior) {
+  RNSTabBarMinimizeBehaviorAutomatic,
+  RNSTabBarMinimizeBehaviorNever,
+  RNSTabBarMinimizeBehaviorOnScrollDown,
+  RNSTabBarMinimizeBehaviorOnScrollUp,
+};

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -129,10 +129,3 @@ typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeTemplate,
   RNSBottomTabsIconTypeSfSymbol,
 };
-
-typedef NS_ENUM(NSInteger, RNSTabBarMinimizeBehavior) {
-  RNSTabBarMinimizeBehaviorAutomatic,
-  RNSTabBarMinimizeBehaviorNever,
-  RNSTabBarMinimizeBehaviorOnScrollDown,
-  RNSTabBarMinimizeBehaviorOnScrollUp,
-};

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
@@ -47,7 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
 
-@property (nonatomic, readonly) RNSTabBarMinimizeBehavior tabBarMinimizeBehavior;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+@property (nonatomic, readonly) UITabBarMinimizeBehavior tabBarMinimizeBehavior API_AVAILABLE(ios(26.0));
+#endif // Check for iOS >= 26
 
 @end
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
 
+@property (nonatomic, readonly) RNSTabBarMinimizeBehavior tabBarMinimizeBehavior;
+
 @end
 
 #pragma mark - React Events

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -268,23 +268,7 @@ namespace react = facebook::react;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
-      switch (_tabBarMinimizeBehavior) {
-        case RNSTabBarMinimizeBehaviorAutomatic:
-          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorAutomatic;
-          break;
-          
-        case RNSTabBarMinimizeBehaviorNever:
-          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorNever;
-          break;
-          
-        case RNSTabBarMinimizeBehaviorOnScrollDown:
-          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorOnScrollDown;
-          break;
-          
-        case RNSTabBarMinimizeBehaviorOnScrollUp:
-          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorOnScrollUp;
-          break;
-      }
+      _controller.tabBarMinimizeBehavior = rnscreens::conversion::UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(_tabBarMinimizeBehavior);
     } else if (_tabBarMinimizeBehavior != RNSTabBarMinimizeBehaviorAutomatic) {
       RCTLogWarn(@"[RNScreens] tabBarMinimizeBehavior is supported for iOS >= 26");
     }

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -263,16 +263,17 @@ namespace react = facebook::react;
   }
   
   if (newComponentProps.tabBarMinimizeBehavior != oldComponentProps.tabBarMinimizeBehavior) {
-    _tabBarMinimizeBehavior = rnscreens::conversion::RNSTabBarMinimizeBehaviorFromHostProp(newComponentProps.tabBarMinimizeBehavior);
-    
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
-      _controller.tabBarMinimizeBehavior = rnscreens::conversion::UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(_tabBarMinimizeBehavior);
-    } else if (_tabBarMinimizeBehavior != RNSTabBarMinimizeBehaviorAutomatic) {
-      RCTLogWarn(@"[RNScreens] tabBarMinimizeBehavior is supported for iOS >= 26");
-    }
+      _tabBarMinimizeBehavior = rnscreens::conversion::UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimizeBehavior(
+          newComponentProps.tabBarMinimizeBehavior);
+      _controller.tabBarMinimizeBehavior = _tabBarMinimizeBehavior;
+    } else
 #endif // Check for iOS >= 26
+      if (newComponentProps.tabBarMinimizeBehavior != react::RNSBottomTabsTabBarMinimizeBehavior::Automatic) {
+        RCTLogWarn(@"[RNScreens] tabBarMinimizeBehavior is supported for iOS >= 26");
+      }
   }
 
   // Super call updates _props pointer. We should NOT update it before calling super.

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -261,6 +261,35 @@ namespace react = facebook::react;
         newComponentProps.tabBarItemTitlePositionAdjustment);
     _needsTabBarAppearanceUpdate = YES;
   }
+  
+  if (newComponentProps.tabBarMinimizeBehavior != oldComponentProps.tabBarMinimizeBehavior) {
+    _tabBarMinimizeBehavior = rnscreens::conversion::RNSTabBarMinimizeBehaviorFromHostProp(newComponentProps.tabBarMinimizeBehavior);
+    
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+    if (@available(iOS 26.0, *)) {
+      switch (_tabBarMinimizeBehavior) {
+        case RNSTabBarMinimizeBehaviorAutomatic:
+          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorAutomatic;
+          break;
+          
+        case RNSTabBarMinimizeBehaviorNever:
+          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorNever;
+          break;
+          
+        case RNSTabBarMinimizeBehaviorOnScrollDown:
+          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorOnScrollDown;
+          break;
+          
+        case RNSTabBarMinimizeBehaviorOnScrollUp:
+          _controller.tabBarMinimizeBehavior = UITabBarMinimizeBehaviorOnScrollUp;
+          break;
+      }
+    } else if (_tabBarMinimizeBehavior != RNSTabBarMinimizeBehaviorAutomatic) {
+      RCTLogWarn(@"[RNScreens] tabBarMinimizeBehavior is supported for iOS >= 26");
+    }
+#endif // Check for iOS >= 26
+  }
 
   // Super call updates _props pointer. We should NOT update it before calling super.
   [super updateProps:props oldProps:oldProps];

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -88,40 +88,22 @@ UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
   return UIOffsetMake(titlePositionAdjustment.horizontal, titlePositionAdjustment.vertical);
 }
 
-RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
-    react::RNSBottomTabsTabBarMinimizeBehavior tabBarMinimizeBehavior)
-{
-  using enum facebook::react::RNSBottomTabsTabBarMinimizeBehavior;
-  
-  switch (tabBarMinimizeBehavior) {
-    case Automatic:
-      return RNSTabBarMinimizeBehaviorAutomatic;
-    case Never:
-      return RNSTabBarMinimizeBehaviorNever;
-    case OnScrollDown:
-      return RNSTabBarMinimizeBehaviorOnScrollDown;
-    case OnScrollUp:
-      return RNSTabBarMinimizeBehaviorOnScrollUp;
-  }
-}
-
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
 API_AVAILABLE(ios(26.0))
-UITabBarMinimizeBehavior
-    UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(RNSTabBarMinimizeBehavior tabBarMinimizeBehavior)
+UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimizeBehavior(
+    react::RNSBottomTabsTabBarMinimizeBehavior tabBarMinimizeBehavior)
 {
+  using enum facebook::react::RNSBottomTabsTabBarMinimizeBehavior;
+
   switch (tabBarMinimizeBehavior) {
-    case RNSTabBarMinimizeBehaviorAutomatic:
+    case Automatic:
       return UITabBarMinimizeBehaviorAutomatic;
-
-    case RNSTabBarMinimizeBehaviorNever:
+    case Never:
       return UITabBarMinimizeBehaviorNever;
-
-    case RNSTabBarMinimizeBehaviorOnScrollDown:
+    case OnScrollDown:
       return UITabBarMinimizeBehaviorOnScrollDown;
-
-    case RNSTabBarMinimizeBehaviorOnScrollUp:
+    case OnScrollUp:
       return UITabBarMinimizeBehaviorOnScrollUp;
   }
 }

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -88,6 +88,23 @@ UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
   return UIOffsetMake(titlePositionAdjustment.horizontal, titlePositionAdjustment.vertical);
 }
 
+RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
+    react::RNSBottomTabsTabBarMinimizeBehavior tabBarMinimizeBehavior)
+{
+  using enum facebook::react::RNSBottomTabsTabBarMinimizeBehavior;
+  
+  switch (tabBarMinimizeBehavior) {
+    case Automatic:
+      return RNSTabBarMinimizeBehaviorAutomatic;
+    case Never:
+      return RNSTabBarMinimizeBehaviorNever;
+    case OnScrollDown:
+      return RNSTabBarMinimizeBehaviorOnScrollDown;
+    case OnScrollUp:
+      return RNSTabBarMinimizeBehaviorOnScrollUp;
+  }
+}
+
 std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
 {

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -105,6 +105,28 @@ RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
   }
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+API_AVAILABLE(ios(26.0))
+UITabBarMinimizeBehavior
+    UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(RNSTabBarMinimizeBehavior tabBarMinimizeBehavior)
+{
+  switch (tabBarMinimizeBehavior) {
+    case RNSTabBarMinimizeBehaviorAutomatic:
+      return UITabBarMinimizeBehaviorAutomatic;
+
+    case RNSTabBarMinimizeBehaviorNever:
+      return UITabBarMinimizeBehaviorNever;
+
+    case RNSTabBarMinimizeBehaviorOnScrollDown:
+      return UITabBarMinimizeBehaviorOnScrollDown;
+
+    case RNSTabBarMinimizeBehaviorOnScrollUp:
+      return UITabBarMinimizeBehaviorOnScrollUp;
+  }
+}
+#endif // Check for iOS >= 26
+
 std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
 {

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -97,14 +97,14 @@ UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimize
   using enum facebook::react::RNSBottomTabsTabBarMinimizeBehavior;
 
   switch (tabBarMinimizeBehavior) {
-    case Automatic:
-      return UITabBarMinimizeBehaviorAutomatic;
     case Never:
       return UITabBarMinimizeBehaviorNever;
     case OnScrollDown:
       return UITabBarMinimizeBehaviorOnScrollDown;
     case OnScrollUp:
       return UITabBarMinimizeBehaviorOnScrollUp;
+    default:
+      return UITabBarMinimizeBehaviorAutomatic;
   }
 }
 #endif // Check for iOS >= 26

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -23,6 +23,13 @@ UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
 RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
     react::RNSBottomTabsTabBarMinimizeBehavior);
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+API_AVAILABLE(ios(26.0))
+UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(
+    RNSTabBarMinimizeBehavior tabBarMinimizeBehavior);
+#endif // Check for iOS >= 26
+
 std::optional<UIBlurEffectStyle>
 RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -20,14 +20,12 @@ UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
     react::RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct
         titlePositionAdjustment);
 
-RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
-    react::RNSBottomTabsTabBarMinimizeBehavior);
-
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
 API_AVAILABLE(ios(26.0))
-UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(
-    RNSTabBarMinimizeBehavior tabBarMinimizeBehavior);
+UITabBarMinimizeBehavior
+UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimizeBehavior(
+    react::RNSBottomTabsTabBarMinimizeBehavior tabBarMinimizeBehavior);
 #endif // Check for iOS >= 26
 
 std::optional<UIBlurEffectStyle>

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -20,6 +20,9 @@ UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
     react::RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct
         titlePositionAdjustment);
 
+RNSTabBarMinimizeBehavior RNSTabBarMinimizeBehaviorFromHostProp(
+    react::RNSBottomTabsTabBarMinimizeBehavior);
+
 std::optional<UIBlurEffectStyle>
 RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -52,6 +52,7 @@ export interface BottomTabsProps extends ViewProps {
   tabBarItemRippleColor?: ColorValue;
   tabBarItemLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
 
+  // iOS-specific
   tabBarMinimizeBehavior?: TabBarMinimizeBehavior;
 
   // Control

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import BottomTabsNativeComponent, {
   BlurEffect,
+  TabBarMinimizeBehavior,
   NativeFocusChangeEvent,
   TabBarItemLabelVisibilityMode,
   type NativeProps as BottomTabsNativeComponentProps,
@@ -50,6 +51,8 @@ export interface BottomTabsProps extends ViewProps {
   tabBarItemActivityIndicatorColor?: ColorValue;
   tabBarItemRippleColor?: ColorValue;
   tabBarItemLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
+  
+  tabBarMinimizeBehavior?: TabBarMinimizeBehavior;
 
   // Control
 

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import BottomTabsNativeComponent, {
-  BlurEffect,
-  TabBarMinimizeBehavior,
-  NativeFocusChangeEvent,
-  TabBarItemLabelVisibilityMode,
+  type BlurEffect,
+  type TabBarMinimizeBehavior,
+  type NativeFocusChangeEvent,
+  type TabBarItemLabelVisibilityMode,
   type NativeProps as BottomTabsNativeComponentProps,
 } from '../fabric/BottomTabsNativeComponent';
 import {
@@ -51,7 +51,7 @@ export interface BottomTabsProps extends ViewProps {
   tabBarItemActivityIndicatorColor?: ColorValue;
   tabBarItemRippleColor?: ColorValue;
   tabBarItemLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
-  
+
   tabBarMinimizeBehavior?: TabBarMinimizeBehavior;
 
   // Control

--- a/src/components/BottomTabsScreen.tsx
+++ b/src/components/BottomTabsScreen.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import BottomTabsScreenNativeComponent, {
-  BlurEffect,
+  type BlurEffect,
   type IconType,
   type NativeProps,
 } from '../fabric/BottomTabsScreenNativeComponent';

--- a/src/fabric/BottomTabsNativeComponent.ts
+++ b/src/fabric/BottomTabsNativeComponent.ts
@@ -48,6 +48,12 @@ export type TabBarItemLabelVisibilityMode =
   | 'labeled'
   | 'unlabeled';
 
+export type TabBarMinimizeBehavior =
+  | 'automatic'
+  | 'never'
+  | 'onScrollDown'
+  | 'onScrollUp';
+
 export interface NativeProps extends ViewProps {
   // Events
   onNativeFocusChange?: DirectEventHandler<NativeFocusChangeEvent>;
@@ -82,6 +88,8 @@ export interface NativeProps extends ViewProps {
     TabBarItemLabelVisibilityMode,
     'auto'
   >;
+
+  tabBarMinimizeBehavior?: WithDefault<TabBarMinimizeBehavior, 'automatic'>;
 
   // Control
 

--- a/src/fabric/BottomTabsNativeComponent.ts
+++ b/src/fabric/BottomTabsNativeComponent.ts
@@ -89,6 +89,7 @@ export interface NativeProps extends ViewProps {
     'auto'
   >;
 
+  // iOS-specific
   tabBarMinimizeBehavior?: WithDefault<TabBarMinimizeBehavior, 'automatic'>;
 
   // Control


### PR DESCRIPTION
## Description

Adds support for `tabBarMinimizeBehavior`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/178.

Moved from https://github.com/software-mansion/react-native-screens-labs/pull/214.

## Changes

- add support for `tabBarMinimizeBehavior`

## Test code and steps to reproduce

Add `tabBarMinimizeBehavior` for `BottomTabs` component, e.g. `onScrollDown` and check behavior with ScrollView.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
