### PR TITLE
fix(iOS, Tabs+native-stack): allow for bottom, left, right extended layout edges with native stack header non-translucent

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -554,7 +554,7 @@ RNS_IGNORE_SUPER_CALL_END
   if (!shouldHide && !config.translucent) {
     // when nav bar is not translucent we change edgesForExtendedLayout to avoid system laying out
     // the screen underneath navigation controllers
-    vc.edgesForExtendedLayout = UIRectEdgeNone;
+    vc.edgesForExtendedLayout = UIRectEdgeAll - UIRectEdgeTop;
   } else {
     // system default is UIRectEdgeAll
     vc.edgesForExtendedLayout = UIRectEdgeAll;


### PR DESCRIPTION
## Description

Previously, if native-stack's header was non-translucent, stack would not allow any extended edges, therefore preventing content from rendering under translucent tab bar controller (this was especially noticable with iOS 26).

Now, we only prevent from extending layout for top edge, where UINavigationController has its UINavigationBar.

I tested basic test screens (`SimpleNativeStack`, `TestHeaderTitle`, `BottomTabsAndStack`, `HeaderOptions`) on iOS 18 and 26 beta 3 and did not find any problems related to this change - `edgesForExtendedLayout` applies for system-related navigation bars and views and I don't think that we used those on any other edges until now - with native bottom tabs implementation.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/216.

Moved from https://github.com/software-mansion/react-native-screens-labs/pull/243.

## Changes

- change `edgesForExtendedLayout` to all apart from top instead of none


## Screenshots / GIFs

| before | after |
| --- | --- |
| <img width="1206" height="2622" alt="edgesForExtendedLayout_before" src="https://github.com/user-attachments/assets/fe7dd302-30ef-46a1-8e20-d679ae11387a" /> | <img width="1206" height="2622" alt="edgesForExtendedLayout_after" src="https://github.com/user-attachments/assets/9ef16617-46ef-4ab1-aa40-3f8dfc83f953" /> |



## Test code and steps to reproduce

Open Tab4 on iOS 26.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
