### PR TITLE
fix(iOS, Tabs): add temporary workaround to avoid UIScrollEdgeEffect glitch on iOS 26

### DIFF
--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -57,6 +57,12 @@ namespace react = facebook::react;
 #if !RCT_NEW_ARCH_ENABLED
   _tabItemNeedsAppearanceUpdate = NO;
 #endif
+
+  // This is a temporary workaround to avoid UIScrollEdgeEffect glitch
+  // when changing tabs when ScrollView is present.
+  // TODO: don't hardcode color here
+  self.backgroundColor = [UIColor whiteColor];
+
   [self resetProps];
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/213.

Moved from https://github.com/software-mansion/react-native-screens-labs/pull/253.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/dedd187a-fe56-47bd-be5d-6d7aceaba199" /> | <video src="https://github.com/user-attachments/assets/c1791562-dd33-49bd-9902-73ab217738ac" /> |

In order to avoid the glitch, we set background color of tab screens to white. In the future, we need to find a better workaround that will account for color of the content.

> [!IMPORTANT]
> Please note that there is another visual glitch with the background from the first tab remaining visible behing the tab bar while transition is ongoing. This also happens on native SwiftUI iOS 26 beta 3 app so there's probably nothing we can do with it for now.
> <video src="https://github.com/user-attachments/assets/d5f6f7dd-38f1-4a08-a7d7-670ee676ce8b" />

## Changes

- add white background to tab screen

## Test code and steps to reproduce

Run TestBottomTabs, change from tab1 to tab4.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
