### PR TITLE
feat(Android, Tabs): support badge in bottom navigation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
@@ -43,6 +43,14 @@ class TabScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
+    var tabBarItemBadgeBackgroundColor: Int? by Delegates.observable(null) { _, oldValue, newValue ->
+        updateMenuItemAttributesIfNeeded(oldValue, newValue)
+    }
+
+    var badgeValue: String? by Delegates.observable(null) { _, oldValue, newValue ->
+        updateMenuItemAttributesIfNeeded(oldValue, newValue)
+    }
+
     var iconResourceName: String? by Delegates.observable(null) { _, oldValue, newValue ->
         if (newValue != oldValue) {
             icon = getSystemDrawableResource(reactContext, newValue)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -86,7 +86,9 @@ class TabScreenViewManager :
     override fun setTabBarItemBadgeBackgroundColor(
         view: TabScreen,
         value: Int?,
-    ) = Unit
+    ) {
+        view.tabBarItemBadgeBackgroundColor = value
+    }
 
     override fun setTabBarItemTitlePositionAdjustment(
         view: TabScreen?,
@@ -142,9 +144,11 @@ class TabScreenViewManager :
     }
 
     override fun setBadgeValue(
-        view: TabScreen?,
+        view: TabScreen,
         value: String?,
-    ) = Unit
+    ) {
+        view.badgeValue = value
+    }
 
     @ReactProp(name = "title")
     override fun setTitle(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -304,7 +304,8 @@ class TabsHost(
         bottomNavigationView.itemIconTintList = ColorStateList(states, iconColors)
 
         // ActivityIndicator color
-        val activityIndicatorColor = tabBarItemActivityIndicatorColor ?: com.google.android.material.R.color.m3_sys_color_dynamic_light_on_secondary_container
+        val activityIndicatorColor =
+            tabBarItemActivityIndicatorColor ?: com.google.android.material.R.color.m3_sys_color_dynamic_light_on_secondary_container
         bottomNavigationView.itemActiveIndicatorColor = ColorStateList.valueOf(activityIndicatorColor)
 
         // First clean the menu, then populate it
@@ -376,7 +377,10 @@ class TabsHost(
         }
     }
 
-    private fun updateBadgeAppearance(menuItemIndex: Int, tabScreen: TabScreen) {
+    private fun updateBadgeAppearance(
+        menuItemIndex: Int,
+        tabScreen: TabScreen,
+    ) {
         val badgeValue = tabScreen.badgeValue?.toIntOrNull()
         if (tabScreen.badgeValue != null && badgeValue == null) {
             Log.e(TAG, "[RNScreens] Android supports only numbers as badge value")
@@ -386,7 +390,9 @@ class TabsHost(
             val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
             badge.isVisible = true
             badge.number = badgeValue
-            badge.backgroundColor = tabScreen.tabBarItemBadgeBackgroundColor ?: wrappedContext.getColor(com.google.android.material.R.color.error_color_material_light)
+            badge.backgroundColor =
+                tabScreen.tabBarItemBadgeBackgroundColor
+                    ?: wrappedContext.getColor(com.google.android.material.R.color.error_color_material_light)
         } else {
             val badge = bottomNavigationView.getBadge(menuItemIndex)
             badge?.isVisible = false
@@ -473,8 +479,7 @@ class TabsHost(
         menuItem.icon = tabScreen.icon
 
         // Badge
-        updateBadgeAppearance(bottomNavigationView.menu.children.indexOf(menuItem), tabScreen);
-
+        updateBadgeAppearance(bottomNavigationView.menu.children.indexOf(menuItem), tabScreen)
     }
 
     internal fun onViewManagerAddEventEmitters() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -92,8 +92,10 @@ class TabsHost(
 
     private val containerUpdateCoordinator = ContainerUpdateCoordinator()
 
+    private val wrappedContext = ContextThemeWrapper(reactContext, R.style.custom)
+
     private val bottomNavigationView: BottomNavigationView =
-        BottomNavigationView(ContextThemeWrapper(reactContext, R.style.custom)).apply {
+        BottomNavigationView(wrappedContext).apply {
             layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         }
 
@@ -318,7 +320,11 @@ class TabsHost(
                     fragment.tabScreen.tabTitle,
                 )
 
+            // Icon
             item.icon = fragment.tabScreen.icon
+
+            // Badge
+            updateBadgeAppearance(index, fragment.tabScreen)
         }
 
         // Update font styles
@@ -367,6 +373,23 @@ class TabsHost(
             // Active
             largeLabel.textSize = largeFontSize
             largeLabel.typeface = fontFamily
+        }
+    }
+
+    private fun updateBadgeAppearance(menuItemIndex: Int, tabScreen: TabScreen) {
+        val badgeValue = tabScreen.badgeValue?.toIntOrNull()
+        if (tabScreen.badgeValue != null && badgeValue == null) {
+            Log.e(TAG, "[RNScreens] Android supports only numbers as badge value")
+        }
+
+        if (badgeValue != null) {
+            val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
+            badge.isVisible = true
+            badge.number = badgeValue
+            badge.backgroundColor = tabScreen.tabBarItemBadgeBackgroundColor ?: wrappedContext.getColor(com.google.android.material.R.color.error_color_material_light)
+        } else {
+            val badge = bottomNavigationView.getBadge(menuItemIndex)
+            badge?.isVisible = false
         }
     }
 
@@ -448,6 +471,10 @@ class TabsHost(
     ) {
         menuItem.title = tabScreen.tabTitle
         menuItem.icon = tabScreen.icon
+
+        // Badge
+        updateBadgeAppearance(bottomNavigationView.menu.children.indexOf(menuItem), tabScreen);
+
     }
 
     internal fun onViewManagerAddEventEmitters() {

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -18,7 +18,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab1',
-      badgeValue: '1',
+      badgeValue: '42',
       title: 'Tab1',
       isFocused: true,
       icon: {
@@ -34,7 +34,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab2',
-      badgeValue: '2',
+      badgeValue: 'SWM',
       tabBarItemBadgeBackgroundColor: Colors.PurpleLight100,
       tabBarBackgroundColor: Colors.NavyDark140,
       tabBarItemTitleFontSize: 20,
@@ -60,7 +60,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab3',
-      badgeValue: '3',
+      badgeValue: '2137',
       tabBarItemBadgeBackgroundColor: Colors.YellowDark120,
       icon: {
         imageSource: require('../../../assets/variableIcons/icon.png'),


### PR DESCRIPTION
## Description
Resolves: #256

This PRs adds basic support for badge for android. It allows to set color and label. To reuse the iOS logic (which allows string as badge value) I need to parse it to int and I log error otherwise. This isn't ideal and I created low-priority task to change it at some point https://github.com/software-mansion/react-native-screens-labs/issues/249. 

## Screenshots / GIFs

<img width="439" height="925" alt="image" src="https://github.com/user-attachments/assets/16312981-2f09-46f0-ac5d-7350a3e7e6a4" />

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
