### PR TITLE
feat(iOS, SplitView): Add support for setting column widths

### DIFF
--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -1,29 +1,26 @@
 import React from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { SplitViewHost, SplitViewScreen } from 'react-native-screens';
 import { Colors } from '../../shared/styling/Colors';
 
 const SplitViewBaseApp = () => {
-  const [buttonVisibility, setButtonVisibility] = React.useState('automatic');
-
   return (
-    <SplitViewHost displayModeButtonVisibility={buttonVisibility} displayMode='twoBesideSecondary' splitBehavior='tile'>
+    <SplitViewHost 
+      columnMetrics={{preferredPrimaryColumnWidth: 250, preferredSupplementaryColumnWidth: 250}} 
+      displayMode='twoBesideSecondary' 
+      primaryEdge='leading' 
+      presentsWithGesture={false} 
+      splitBehavior='tile'
+    >
+      <SplitViewScreen.Column>
+        <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]} />
+      </SplitViewScreen.Column>
+      <SplitViewScreen.Column>
+        <View style={[styles.container, { backgroundColor: Colors.YellowDark100 }]} />
+      </SplitViewScreen.Column>
       <SplitViewScreen.Column>
         <View style={[styles.container, { backgroundColor: Colors.White }]}>
           <Text style={styles.text}>Primary column</Text>
-        </View>
-      </SplitViewScreen.Column>
-      <SplitViewScreen.Column>
-        <View style={[styles.container, { backgroundColor: Colors.YellowDark100 }]}>
-          <Text style={styles.text}>DisplayModeButtonVisibility demo</Text>
-          <Button onPress={() => setButtonVisibility('always')} title='always' />
-          <Button onPress={() => setButtonVisibility('automatic')} title='automatic' />
-          <Button onPress={() => setButtonVisibility('never')} title='never' />
-        </View>
-      </SplitViewScreen.Column>
-      <SplitViewScreen.Column>
-        <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
-          <Text style={styles.text}>Secondary column</Text>
         </View>
       </SplitViewScreen.Column>
     </SplitViewHost>

--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -13,14 +13,18 @@ const SplitViewBaseApp = () => {
       splitBehavior='tile'
     >
       <SplitViewScreen.Column>
-        <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]} />
+        <View style={[styles.container, { backgroundColor: Colors.RedDark100 }]}>
+          <Text style={styles.text}>Primary column</Text>
+        </View>
       </SplitViewScreen.Column>
       <SplitViewScreen.Column>
-        <View style={[styles.container, { backgroundColor: Colors.YellowDark100 }]} />
+        <View style={[styles.container, { backgroundColor: Colors.YellowDark100 }]}>
+          <Text style={styles.text}>Supplementary column</Text>
+        </View>
       </SplitViewScreen.Column>
       <SplitViewScreen.Column>
         <View style={[styles.container, { backgroundColor: Colors.White }]}>
-          <Text style={styles.text}>Primary column</Text>
+          <Text style={styles.text}>Secondary column</Text>
         </View>
       </SplitViewScreen.Column>
     </SplitViewHost>

--- a/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
+++ b/apps/src/tests/TestSplitView/SplitViewBaseApp.tsx
@@ -6,7 +6,7 @@ import { Colors } from '../../shared/styling/Colors';
 const SplitViewBaseApp = () => {
   return (
     <SplitViewHost 
-      columnMetrics={{preferredPrimaryColumnWidth: 250, preferredSupplementaryColumnWidth: 250}} 
+      columnMetrics={{preferredSupplementaryColumnWidth: 250}} 
       displayMode='twoBesideSecondary' 
       primaryEdge='leading' 
       presentsWithGesture={false} 

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -34,6 +34,17 @@
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSupplementaryColumnWidth);
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumSupplementaryColumnWidth);
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSupplementaryColumnWidth);
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSecondaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumSecondaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSecondaryColumnWidth);
+
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumInspectorColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumInspectorColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredInspectorColumnWidth);
+#endif
 }
 
 @end

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -38,7 +38,6 @@
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSecondaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumSecondaryColumnWidth);
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSecondaryColumnWidth);
 
   ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumInspectorColumnWidth);

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -5,6 +5,11 @@
 
 @implementation RNSSplitViewAppearanceCoordinator
 
+#define ASSIGN_PROP_IF_NONNEGATIVE(target, source, property) \
+  if ((source).property >= 0) {                              \
+    (target).property = (source).property;                   \
+  }
+
 - (void)updateAppearanceOfSplitView:(RNSSplitViewHostComponentView *_Nonnull)splitView
                      withController:(RNSSplitViewHostController *_Nonnull)controller
 {
@@ -21,6 +26,14 @@
 
   // Step 2 - manipulating columns
   [controller toggleSplitViewInspector:splitView.showInspector];
+
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumPrimaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumPrimaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredPrimaryColumnWidth);
+
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSupplementaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumSupplementaryColumnWidth);
+  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSupplementaryColumnWidth);
 }
 
 @end

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -46,4 +46,6 @@
 #endif
 }
 
+#undef ASSIGN_PROP_IF_NONNEGATIVE
+
 @end

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -37,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
 @property (nonatomic, readonly) int minimumSecondaryColumnWidth;
-@property (nonatomic, readonly) int maximumSecondaryColumnWidth;
 @property (nonatomic, readonly) int preferredSecondaryColumnWidth;
 @property (nonatomic, readonly) int minimumInspectorColumnWidth;
 @property (nonatomic, readonly) int maximumInspectorColumnWidth;

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -34,6 +34,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) int maximumSupplementaryColumnWidth;
 @property (nonatomic, readonly) int preferredSupplementaryColumnWidth;
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+@property (nonatomic, readonly) int minimumSecondaryColumnWidth;
+@property (nonatomic, readonly) int maximumSecondaryColumnWidth;
+@property (nonatomic, readonly) int preferredSecondaryColumnWidth;
+@property (nonatomic, readonly) int minimumInspectorColumnWidth;
+@property (nonatomic, readonly) int maximumInspectorColumnWidth;
+@property (nonatomic, readonly) int preferredInspectorColumnWidth;
+#endif
+
 @end
 
 #pragma mark - Events

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -27,6 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL showSecondaryToggleButton;
 @property (nonatomic, readonly) BOOL showInspector;
 
+@property (nonatomic, readonly) int minimumPrimaryColumnWidth;
+@property (nonatomic, readonly) int maximumPrimaryColumnWidth;
+@property (nonatomic, readonly) int preferredPrimaryColumnWidth;
+@property (nonatomic, readonly) int minimumSupplementaryColumnWidth;
+@property (nonatomic, readonly) int maximumSupplementaryColumnWidth;
+@property (nonatomic, readonly) int preferredSupplementaryColumnWidth;
+
 @end
 
 #pragma mark - Events

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -67,7 +67,6 @@ namespace react = facebook::react;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
   _minimumSecondaryColumnWidth = -1;
-  _maximumSecondaryColumnWidth = -1;
   _preferredSecondaryColumnWidth = -1;
   _minimumInspectorColumnWidth = -1;
   _maximumInspectorColumnWidth = -1;
@@ -273,12 +272,6 @@ RNS_IGNORE_SUPER_CALL_END
       newComponentProps.columnMetrics.minimumSecondaryColumnWidth) {
     _needsSplitViewAppearanceUpdate = true;
     _minimumSecondaryColumnWidth = newComponentProps.columnMetrics.minimumSecondaryColumnWidth;
-  }
-
-  if (oldComponentProps.columnMetrics.maximumSecondaryColumnWidth !=
-      newComponentProps.columnMetrics.maximumSecondaryColumnWidth) {
-    _needsSplitViewAppearanceUpdate = true;
-    _maximumSecondaryColumnWidth = newComponentProps.columnMetrics.maximumSecondaryColumnWidth;
   }
 
   if (oldComponentProps.columnMetrics.preferredSecondaryColumnWidth !=

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -57,6 +57,13 @@ namespace react = facebook::react;
   _showSecondaryToggleButton = false;
   _showInspector = false;
 
+  _minimumPrimaryColumnWidth = -1;
+  _maximumPrimaryColumnWidth = -1;
+  _preferredPrimaryColumnWidth = -1;
+  _minimumSupplementaryColumnWidth = -1;
+  _maximumSupplementaryColumnWidth = -1;
+  _preferredSupplementaryColumnWidth = -1;
+
   _isShowSecondaryToggleButtonSet = false;
 }
 
@@ -212,6 +219,42 @@ RNS_IGNORE_SUPER_CALL_END
     _needsSplitViewAppearanceUpdate = true;
     _displayModeButtonVisibility = rnscreens::conversion::SplitViewDisplayModeButtonVisibilityFromHostProp(
         newComponentProps.displayModeButtonVisibility);
+  }
+
+  if (oldComponentProps.columnMetrics.minimumPrimaryColumnWidth !=
+      newComponentProps.columnMetrics.minimumPrimaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _minimumPrimaryColumnWidth = newComponentProps.columnMetrics.minimumPrimaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.maximumPrimaryColumnWidth !=
+      newComponentProps.columnMetrics.maximumPrimaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _maximumPrimaryColumnWidth = newComponentProps.columnMetrics.maximumPrimaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.preferredPrimaryColumnWidth !=
+      newComponentProps.columnMetrics.preferredPrimaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _preferredPrimaryColumnWidth = newComponentProps.columnMetrics.preferredPrimaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.minimumSupplementaryColumnWidth !=
+      newComponentProps.columnMetrics.minimumSupplementaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _minimumSupplementaryColumnWidth = newComponentProps.columnMetrics.minimumSupplementaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.maximumSupplementaryColumnWidth !=
+      newComponentProps.columnMetrics.maximumSupplementaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _maximumSupplementaryColumnWidth = newComponentProps.columnMetrics.maximumSupplementaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.preferredSupplementaryColumnWidth !=
+      newComponentProps.columnMetrics.preferredSupplementaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _preferredSupplementaryColumnWidth = newComponentProps.columnMetrics.preferredSupplementaryColumnWidth;
   }
 
   // This flag is set to true when showsSecondaryOnlyButton prop is assigned for the first time.

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -64,6 +64,16 @@ namespace react = facebook::react;
   _maximumSupplementaryColumnWidth = -1;
   _preferredSupplementaryColumnWidth = -1;
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  _minimumSecondaryColumnWidth = -1;
+  _maximumSecondaryColumnWidth = -1;
+  _preferredSecondaryColumnWidth = -1;
+  _minimumInspectorColumnWidth = -1;
+  _maximumInspectorColumnWidth = -1;
+  _preferredInspectorColumnWidth = -1;
+#endif
+
   _isShowSecondaryToggleButtonSet = false;
 }
 
@@ -256,6 +266,45 @@ RNS_IGNORE_SUPER_CALL_END
     _needsSplitViewAppearanceUpdate = true;
     _preferredSupplementaryColumnWidth = newComponentProps.columnMetrics.preferredSupplementaryColumnWidth;
   }
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (oldComponentProps.columnMetrics.minimumSecondaryColumnWidth !=
+      newComponentProps.columnMetrics.minimumSecondaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _minimumSecondaryColumnWidth = newComponentProps.columnMetrics.minimumSecondaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.maximumSecondaryColumnWidth !=
+      newComponentProps.columnMetrics.maximumSecondaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _maximumSecondaryColumnWidth = newComponentProps.columnMetrics.maximumSecondaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.preferredSecondaryColumnWidth !=
+      newComponentProps.columnMetrics.preferredSecondaryColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _preferredSecondaryColumnWidth = newComponentProps.columnMetrics.preferredSecondaryColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.minimumInspectorColumnWidth !=
+      newComponentProps.columnMetrics.minimumInspectorColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _minimumInspectorColumnWidth = newComponentProps.columnMetrics.minimumInspectorColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.maximumInspectorColumnWidth !=
+      newComponentProps.columnMetrics.maximumInspectorColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _maximumInspectorColumnWidth = newComponentProps.columnMetrics.maximumInspectorColumnWidth;
+  }
+
+  if (oldComponentProps.columnMetrics.preferredInspectorColumnWidth !=
+      newComponentProps.columnMetrics.preferredInspectorColumnWidth) {
+    _needsSplitViewAppearanceUpdate = true;
+    _preferredInspectorColumnWidth = newComponentProps.columnMetrics.preferredInspectorColumnWidth;
+  }
+#endif
 
   // This flag is set to true when showsSecondaryOnlyButton prop is assigned for the first time.
   // This allows us to identify any subsequent changes to this prop,

--- a/src/components/gamma/SplitViewScreen.tsx
+++ b/src/components/gamma/SplitViewScreen.tsx
@@ -16,22 +16,13 @@ type SplitViewScreenProps = {
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
-function Column({
-  children,
-  onDidAppear,
-  onDidDisappear,
-  onWillAppear,
-  onWillDisappear,
-}: SplitViewScreenProps) {
+function Column(props: SplitViewScreenProps) {
   return (
     <SplitViewScreenNativeComponent
       columnType="column"
-      onDidAppear={onDidAppear}
-      onDidDisappear={onDidDisappear}
-      onWillAppear={onWillAppear}
-      onWillDisappear={onWillDisappear}
+      {...props}
       style={StyleSheet.absoluteFill}>
-      {children}
+      {props.children}
     </SplitViewScreenNativeComponent>
   );
 }
@@ -39,22 +30,13 @@ function Column({
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
-function Inspector({
-  children,
-  onDidAppear,
-  onDidDisappear,
-  onWillAppear,
-  onWillDisappear,
-}: SplitViewScreenProps) {
+function Inspector(props: SplitViewScreenProps) {
   return (
     <SplitViewScreenNativeComponent
       columnType="inspector"
-      onDidAppear={onDidAppear}
-      onDidDisappear={onDidDisappear}
-      onWillAppear={onWillAppear}
-      onWillDisappear={onWillDisappear}
+      {...props}
       style={StyleSheet.absoluteFill}>
-      {children}
+      {props.children}
     </SplitViewScreenNativeComponent>
   );
 }

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -40,6 +40,14 @@ interface ColumnMetrics {
   minimumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
   maximumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
   preferredSupplementaryColumnWidth?: WithDefault<Int32, -1>;
+
+  // iOS 26 only
+  minimumSecondaryColumnWidth?: WithDefault<Int32, -1>;
+  maximumSecondaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredSecondaryColumnWidth?: WithDefault<Int32, -1>;
+  minimumInspectorColumnWidth?: WithDefault<Int32, -1>;
+  maximumInspectorColumnWidth?: WithDefault<Int32, -1>;
+  preferredInspectorColumnWidth?: WithDefault<Int32, -1>;
 }
 
 export interface NativeProps extends ViewProps {

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -43,7 +43,6 @@ interface ColumnMetrics {
 
   // iOS 26 only
   minimumSecondaryColumnWidth?: WithDefault<Int32, -1>;
-  maximumSecondaryColumnWidth?: WithDefault<Int32, -1>;
   preferredSecondaryColumnWidth?: WithDefault<Int32, -1>;
   minimumInspectorColumnWidth?: WithDefault<Int32, -1>;
   maximumInspectorColumnWidth?: WithDefault<Int32, -1>;

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -4,6 +4,7 @@ import type { ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {
   DirectEventHandler,
+  Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 
@@ -32,6 +33,15 @@ export type SplitViewDisplayMode =
   | 'twoOverSecondary'
   | 'twoDisplaceSecondary';
 
+interface ColumnMetrics {
+  minimumPrimaryColumnWidth?: WithDefault<Int32, -1>;
+  maximumPrimaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredPrimaryColumnWidth?: WithDefault<Int32, -1>;
+  minimumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
+  maximumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredSupplementaryColumnWidth?: WithDefault<Int32, -1>;
+}
+
 export interface NativeProps extends ViewProps {
   // Appearance
 
@@ -43,6 +53,7 @@ export interface NativeProps extends ViewProps {
     SplitViewDisplayModeButtonVisibility,
     'automatic'
   >;
+  columnMetrics?: ColumnMetrics;
 
   // Interactions
 


### PR DESCRIPTION
## Description

For all primary and supplementary columns (but from iOS 26 - also for secondary and inspector), we can manage their widths, passing width in px for following APIs:

- preferred[COLUMN]ColumnWidth
- maximum[COLUMN]ColumnWidth
- minimum[COLUMN]ColumnWidth

Closes https://github.com/software-mansion/react-native-screens-labs/issues/234 

## Changes

- defined JS types
- added native setters
- updated app

## Screenshots / GIFs

<img width="594" height="823" alt="Screenshot 2025-07-17 at 16 28 21" src="https://github.com/user-attachments/assets/43db687a-a0d2-49b7-ab7d-e90e29b094be" />

Example with primary and supplementary columns with fixed preferred width set to 250

## Test code and steps to reproduce

Updated demo app

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
