### PR TITLE
feat(Android, Tabs): allow to change text color of a badge in android bottom navigation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
@@ -43,6 +43,10 @@ class TabScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
+    var tabBarItemBadgeTextColor: Int? by Delegates.observable(null) { _, oldValue, newValue ->
+        updateMenuItemAttributesIfNeeded(oldValue, newValue)
+    }
+
     var tabBarItemBadgeBackgroundColor: Int? by Delegates.observable(null) { _, oldValue, newValue ->
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -158,14 +158,6 @@ class TabScreenViewManager :
         view.tabTitle = value
     }
 
-    @ReactProp(name = "iconResourceName")
-    override fun setIconResourceName(
-        view: TabScreen,
-        value: String?,
-    ) {
-        view.iconResourceName = value
-    }
-
     override fun setSpecialEffects(
         view: TabScreen,
         value: ReadableMap?,
@@ -175,6 +167,23 @@ class TabScreenViewManager :
         view: TabScreen,
         value: Boolean
     ) = Unit
+
+    // Android specific
+    @ReactProp(name = "tabBarItemBadgeTextColor")
+    override fun setTabBarItemBadgeTextColor(
+        view: TabScreen,
+        value: Int?,
+    ) {
+        view.tabBarItemBadgeTextColor = value
+    }
+
+    @ReactProp(name = "iconResourceName")
+    override fun setIconResourceName(
+        view: TabScreen,
+        value: String?,
+    ) {
+        view.iconResourceName = value
+    }
 
     companion object {
         const val REACT_CLASS = "RNSBottomTabsScreen"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.gamma.tabs
 
 import com.swmansion.rnscreens.R
+import android.annotation.SuppressLint
 import android.content.res.ColorStateList
 import android.util.Log
 import android.view.Choreographer
@@ -23,6 +24,7 @@ import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
 import kotlin.properties.Delegates
 
+@SuppressLint("PrivateResource") // We want to use variables from material design for default values
 class TabsHost(
     val reactContext: ThemedReactContext,
 ) : LinearLayout(reactContext),
@@ -390,9 +392,10 @@ class TabsHost(
             val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
             badge.isVisible = true
             badge.number = badgeValue
+            badge.badgeTextColor = tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
             badge.backgroundColor =
                 tabScreen.tabBarItemBadgeBackgroundColor
-                    ?: wrappedContext.getColor(com.google.android.material.R.color.error_color_material_light)
+                    ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_error)
         } else {
             val badge = bottomNavigationView.getBadge(menuItemIndex)
             badge?.isVisible = false

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -70,6 +70,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
       },
       tabBarItemIconColor: Colors.RedDark120,
       iconResourceName: 'sym_call_outgoing', // Android specific
+      tabBarItemBadgeBackgroundColor: Colors.RedDark40,
+      tabBarItemBadgeTextColor: Colors.RedDark120,
       title: 'Tab3',
     },
     contentViewRenderFn: Tab3,

--- a/src/fabric/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/BottomTabsScreenNativeComponent.ts
@@ -82,6 +82,7 @@ export interface NativeProps extends ViewProps {
 
   // Android-specific image handling
   iconResourceName?: string;
+  tabBarItemBadgeTextColor?: ColorValue;
 
   // iOS-specific: SFSymbol usage
   iconType?: WithDefault<IconType, 'sfSymbol'>;


### PR DESCRIPTION
This PR allows to set badge text color. I suppressed the lint, as I believe we want to use original color variables from material design in cases like this. 

## Screenshots / GIFs

<img width="439" height="907" alt="image" src="https://github.com/user-attachments/assets/83e62206-b792-4fbf-962d-d72d935ee553" />

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes 
