### PR TITLE
feat(Android, Tabs): add badge visibility prop for android bottom navigation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
@@ -43,6 +43,15 @@ class TabScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
+    // Badge
+    var badgeValue: String? by Delegates.observable(null) { _, oldValue, newValue ->
+        updateMenuItemAttributesIfNeeded(oldValue, newValue)
+    }
+
+    var tabBarItemBadgeVisible: Boolean? by Delegates.observable(null) { _, oldValue, newValue ->
+        updateMenuItemAttributesIfNeeded(oldValue, newValue)
+    }
+
     var tabBarItemBadgeTextColor: Int? by Delegates.observable(null) { _, oldValue, newValue ->
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
@@ -51,10 +60,7 @@ class TabScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
-    var badgeValue: String? by Delegates.observable(null) { _, oldValue, newValue ->
-        updateMenuItemAttributesIfNeeded(oldValue, newValue)
-    }
-
+    // Icon
     var iconResourceName: String? by Delegates.observable(null) { _, oldValue, newValue ->
         if (newValue != oldValue) {
             icon = getSystemDrawableResource(reactContext, newValue)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -169,6 +169,14 @@ class TabScreenViewManager :
     ) = Unit
 
     // Android specific
+    @ReactProp(name = "tabBarItemBadgeVisible")
+    override fun setTabBarItemBadgeVisible(
+        view: TabScreen,
+        value: Boolean,
+    ) {
+        view.tabBarItemBadgeVisible = value
+    }
+
     @ReactProp(name = "tabBarItemBadgeTextColor")
     override fun setTabBarItemBadgeTextColor(
         view: TabScreen,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -401,6 +401,8 @@ class TabsHost(
 
         if (badgeValue != null) {
             badge.number = badgeValue
+        } else {
+            badge.clearNumber()
         }
 
         badge.badgeTextColor =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -403,7 +403,8 @@ class TabsHost(
             badge.number = badgeValue
         }
 
-        badge.badgeTextColor = tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
+        badge.badgeTextColor =
+            tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
         badge.backgroundColor =
             tabScreen.tabBarItemBadgeBackgroundColor
                 ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_error)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -390,21 +390,22 @@ class TabsHost(
             return
         }
 
-        val badgeValue = tabScreen.badgeValue?.toIntOrNull()
-
-        if (tabScreen.badgeValue != null && badgeValue == null) {
-            Log.e(TAG, "[RNScreens] Android supports only numbers as badge value")
-        }
+        val badgeValue = tabScreen.badgeValue
+        val badgeValueNumber = badgeValue?.toIntOrNull()
 
         val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
         badge.isVisible = true
 
-        if (badgeValue != null) {
-            badge.number = badgeValue
+        if (badgeValueNumber != null) {
+            badge.number = badgeValueNumber
+        } else if (badgeValue != null) {
+            badge.text = badgeValue
         } else {
             badge.clearNumber()
+            badge.clearText()
         }
 
+        // Styling
         badge.badgeTextColor =
             tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
         badge.backgroundColor =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -383,23 +383,30 @@ class TabsHost(
         menuItemIndex: Int,
         tabScreen: TabScreen,
     ) {
+        if (tabScreen.tabBarItemBadgeVisible != true) {
+            val badge = bottomNavigationView.getBadge(menuItemIndex)
+            badge?.isVisible = false
+
+            return
+        }
+
         val badgeValue = tabScreen.badgeValue?.toIntOrNull()
+
         if (tabScreen.badgeValue != null && badgeValue == null) {
             Log.e(TAG, "[RNScreens] Android supports only numbers as badge value")
         }
 
+        val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
+        badge.isVisible = true
+
         if (badgeValue != null) {
-            val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
-            badge.isVisible = true
             badge.number = badgeValue
-            badge.badgeTextColor = tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
-            badge.backgroundColor =
-                tabScreen.tabBarItemBadgeBackgroundColor
-                    ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_error)
-        } else {
-            val badge = bottomNavigationView.getBadge(menuItemIndex)
-            badge?.isVisible = false
         }
+
+        badge.badgeTextColor = tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
+        badge.backgroundColor =
+            tabScreen.tabBarItemBadgeBackgroundColor
+                ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_error)
     }
 
     private fun updateSelectedTab() {

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -19,6 +19,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
     tabScreenProps: {
       tabKey: 'Tab1',
       badgeValue: '42',
+      tabBarItemBadgeVisible: true,
       title: 'Tab1',
       isFocused: true,
       icon: {
@@ -35,6 +36,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
     tabScreenProps: {
       tabKey: 'Tab2',
       badgeValue: 'SWM',
+      tabBarItemBadgeVisible: true,
       tabBarItemBadgeBackgroundColor: Colors.PurpleLight100,
       tabBarBackgroundColor: Colors.NavyDark140,
       tabBarItemTitleFontSize: 20,
@@ -61,15 +63,16 @@ const TAB_CONFIGS: TabConfiguration[] = [
     tabScreenProps: {
       tabKey: 'Tab3',
       badgeValue: '2137',
-      tabBarItemBadgeBackgroundColor: Colors.YellowDark120,
+      tabBarItemBadgeVisible: true,
+      tabBarItemBadgeBackgroundColor: Colors.RedDark40,
+      tabBarItemBadgeTextColor: Colors.RedDark120,
       icon: {
         imageSource: require('../../../assets/variableIcons/icon.png'),
       },
       selectedIcon: {
         imageSource: require('../../../assets/variableIcons/icon_fill.png'),
       },
-      tabBarItemIconColor: Colors.RedDark120,
-      iconResourceName: 'sym_call_outgoing', // Android specific
+      iconResourceName: 'sym_action_email', // Android specific
       title: 'Tab3',
     },
     contentViewRenderFn: Tab3,
@@ -83,6 +86,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
       selectedIcon: {
         sfSymbolName: 'rectangle.stack.fill',
       },
+      tabBarItemBadgeVisible: true,
       iconResourceName: 'sym_action_chat', // Android specific
       title: 'Tab4',
     },

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -18,8 +18,6 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab1',
-      badgeValue: '42',
-      tabBarItemBadgeVisible: true,
       title: 'Tab1',
       isFocused: true,
       icon: {
@@ -35,9 +33,9 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab2',
-      badgeValue: 'SWM',
+      badgeValue: 'NEW',
       tabBarItemBadgeVisible: true,
-      tabBarItemBadgeBackgroundColor: Colors.PurpleLight100,
+      tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
       tabBarBackgroundColor: Colors.NavyDark140,
       tabBarItemTitleFontSize: 20,
       tabBarItemTitleFontStyle: 'italic',

--- a/src/components/BottomTabsScreen.tsx
+++ b/src/components/BottomTabsScreen.tsx
@@ -75,7 +75,8 @@ export interface BottomTabsScreenProps {
 
   // Android specific
   iconResourceName?: string;
-
+  tabBarItemBadgeVisible: boolean;
+  
   icon?: Icon;
   selectedIcon?: Icon;
 

--- a/src/fabric/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/BottomTabsScreenNativeComponent.ts
@@ -82,6 +82,7 @@ export interface NativeProps extends ViewProps {
 
   // Android-specific image handling
   iconResourceName?: string;
+  tabBarItemBadgeVisible?: WithDefault<boolean, false>;
   tabBarItemBadgeTextColor?: ColorValue;
 
   // iOS-specific: SFSymbol usage


### PR DESCRIPTION
## Description

This PR adds visibility prop for android badge. It changes the logic in a way that it required to add `tabBarItemBadgeVisible: true` alongside the number. The idea here is: this way we can allow to show small badges that don't have value (see below). 

## Screenshots / GIFs

<img width="425" height="917" alt="image" src="https://github.com/user-attachments/assets/ce70bee0-6acf-435d-9f3b-d9d78f5adf10" />

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes 