### PR TITLE
feat(Android, Tabs): allow text in android navigation badge

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -390,21 +390,22 @@ class TabsHost(
             return
         }
 
-        val badgeValue = tabScreen.badgeValue?.toIntOrNull()
-
-        if (tabScreen.badgeValue != null && badgeValue == null) {
-            Log.e(TAG, "[RNScreens] Android supports only numbers as badge value")
-        }
+        val badgeValue = tabScreen.badgeValue
+        val badgeValueNumber = badgeValue?.toIntOrNull()
 
         val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
         badge.isVisible = true
 
-        if (badgeValue != null) {
-            badge.number = badgeValue
+        if (badgeValueNumber != null) {
+            badge.number = badgeValueNumber
+        } else if (badgeValue != null) {
+            badge.text = badgeValue
         } else {
             badge.clearNumber()
+            badge.clearText()
         }
 
+        // Styling
         badge.badgeTextColor =
             tabScreen.tabBarItemBadgeTextColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_on_error)
         badge.backgroundColor =

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -18,8 +18,6 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab1',
-      badgeValue: '42',
-      tabBarItemBadgeVisible: true,
       title: 'Tab1',
       isFocused: true,
       icon: {
@@ -35,9 +33,9 @@ const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
       tabKey: 'Tab2',
-      badgeValue: 'SWM',
+      badgeValue: 'NEW',
       tabBarItemBadgeVisible: true,
-      tabBarItemBadgeBackgroundColor: Colors.PurpleLight100,
+      tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
       tabBarBackgroundColor: Colors.NavyDark140,
       tabBarItemTitleFontSize: 20,
       tabBarItemTitleFontStyle: 'italic',


### PR DESCRIPTION
## Description

I thought that android supports only number, but it seems [you can provide text](https://github.com/material-components/material-components-android/blob/master/docs/components/BadgeDrawable.md) using `.text`, so I'll change the logic so:
- if it can parse int -> pass as int 
- if it has value, but can't parse -> pass string 
- clear both values otherwise 

## Screenshots / GIFs

<img width="436" height="928" alt="image" src="https://github.com/user-attachments/assets/cb9f6b0b-8953-4061-a47f-2478842ef321" />

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes 