### PR TITLE
feat(Android, Tabs): Allow to disable active indicator

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -129,7 +129,11 @@ class TabsHost(
         updateNavigationMenuIfNeeded(oldValue, newValue)
     }
 
-    var tabBarItemActivityIndicatorColor: Int? by Delegates.observable<Int?>(null) { _, oldValue, newValue ->
+    var tabBarItemActiveIndicatorColor: Int? by Delegates.observable<Int?>(null) { _, oldValue, newValue ->
+        updateNavigationMenuIfNeeded(oldValue, newValue)
+    }
+
+    var tabBarItemActiveIndicatorEnabled: Boolean by Delegates.observable<Boolean>(false) { _, oldValue, newValue ->
         updateNavigationMenuIfNeeded(oldValue, newValue)
     }
 
@@ -336,10 +340,12 @@ class TabsHost(
             tabBarItemRippleColor ?: wrappedContext.getColor(com.google.android.material.R.color.m3_navigation_item_ripple_color)
         bottomNavigationView.itemRippleColor = ColorStateList.valueOf(rippleColor)
 
-        // ActivityIndicator color
+        // ActivityIndicator
         val activityIndicatorColor =
-            tabBarItemActivityIndicatorColor
+            tabBarItemActiveIndicatorColor
                 ?: wrappedContext.getColor(com.google.android.material.R.color.m3_sys_color_light_secondary_container)
+
+        bottomNavigationView.isItemActiveIndicatorEnabled = tabBarItemActiveIndicatorEnabled
         bottomNavigationView.itemActiveIndicatorColor = ColorStateList.valueOf(activityIndicatorColor)
 
         // First clean the menu, then populate it

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -155,12 +155,19 @@ class TabsHostViewManager :
         view.tabBarItemTitleFontColorActive = value
     }
 
-    @ReactProp(name = "tabBarItemActivityIndicatorColor", customType = "Color")
-    override fun setTabBarItemActivityIndicatorColor(
+    @ReactProp(name = "tabBarItemActiveIndicatorColor", customType = "Color")
+    override fun setTabBarItemActiveIndicatorColor(
         view: TabsHost,
         value: Int?,
     ) {
-        view.tabBarItemActivityIndicatorColor = value
+        view.tabBarItemActiveIndicatorColor = value
+    }
+
+    override fun setTabBarItemActiveIndicatorEnabled(
+        view: TabsHost,
+        value: Boolean,
+    ) {
+        view.tabBarItemActiveIndicatorEnabled = value
     }
 
     @ReactProp(name = "tabBarItemIconColorActive", customType = "Color")

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
@@ -66,8 +66,11 @@ public class RNSBottomTabsManagerDelegate<T extends View, U extends BaseViewMana
       case "tabBarItemTitleFontSizeActive":
         mViewManager.setTabBarItemTitleFontSizeActive(view, value == null ? 0f : ((Double) value).floatValue());
         break;
-      case "tabBarItemActivityIndicatorColor":
-        mViewManager.setTabBarItemActivityIndicatorColor(view, ColorPropConverter.getColor(value, view.getContext()));
+      case "tabBarItemActiveIndicatorColor":
+        mViewManager.setTabBarItemActiveIndicatorColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "tabBarItemActiveIndicatorEnabled":
+        mViewManager.setTabBarItemActiveIndicatorEnabled(view, value == null ? true : (boolean) value);
         break;
       case "tabBarItemRippleColor":
         mViewManager.setTabBarItemRippleColor(view, ColorPropConverter.getColor(value, view.getContext()));

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
@@ -29,7 +29,8 @@ public interface RNSBottomTabsManagerInterface<T extends View>  {
   void setTabBarItemTitleFontColorActive(T view, @Nullable Integer value);
   void setTabBarItemIconColorActive(T view, @Nullable Integer value);
   void setTabBarItemTitleFontSizeActive(T view, float value);
-  void setTabBarItemActivityIndicatorColor(T view, @Nullable Integer value);
+  void setTabBarItemActiveIndicatorColor(T view, @Nullable Integer value);
+  void setTabBarItemActiveIndicatorEnabled(T view, boolean value);
   void setTabBarItemRippleColor(T view, @Nullable Integer value);
   void setTabBarItemVisibilityMode(T view, @Nullable String value);
   void setControlNavigationStateInJS(T view, boolean value);

--- a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
@@ -86,7 +86,8 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
       onNativeFocusChange={onNativeFocusChangeCallback}
 
       tabBarBackgroundColor={Colors.NavyLight100}
-      tabBarItemActivityIndicatorColor={Colors.GreenLight40}
+      tabBarItemActiveIndicatorColor={Colors.GreenLight40}
+      tabBarItemActiveIndicatorEnabled={true}
       tabBarTintColor={Colors.YellowLight100}
       tabBarItemBadgeBackgroundColor={Colors.GreenDark100}
       tabBarItemIconColor={Colors.BlueLight100}

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -16,6 +16,7 @@ import {
   type ViewProps,
 } from 'react-native';
 import featureFlags from '../flags';
+import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface BottomTabsProps extends ViewProps {
   // Events
@@ -47,7 +48,8 @@ export interface BottomTabsProps extends ViewProps {
   tabBarItemTitleFontSizeActive?: TextStyle['fontSize'];
   tabBarItemTitleFontColorActive?: TextStyle['color']; 
   tabBarItemIconColorActive?: ColorValue;
-  tabBarItemActivityIndicatorColor?: ColorValue;
+  tabBarItemActiveIndicatorColor?: ColorValue;
+  tabBarItemActiveIndicatorEnabled?: WithDefault<boolean, true>;
   tabBarItemRippleColor?: ColorValue;
   tabBarItemVisibilityMode?: VisibilityMode;
   

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -16,7 +16,6 @@ import {
   type ViewProps,
 } from 'react-native';
 import featureFlags from '../flags';
-import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface BottomTabsProps extends ViewProps {
   // Events
@@ -49,7 +48,7 @@ export interface BottomTabsProps extends ViewProps {
   tabBarItemTitleFontColorActive?: TextStyle['color']; 
   tabBarItemIconColorActive?: ColorValue;
   tabBarItemActiveIndicatorColor?: ColorValue;
-  tabBarItemActiveIndicatorEnabled?: WithDefault<boolean, true>;
+  tabBarItemActiveIndicatorEnabled?: boolean;
   tabBarItemRippleColor?: ColorValue;
   tabBarItemVisibilityMode?: VisibilityMode;
   

--- a/src/fabric/BottomTabsNativeComponent.ts
+++ b/src/fabric/BottomTabsNativeComponent.ts
@@ -76,7 +76,8 @@ export interface NativeProps extends ViewProps {
   tabBarItemTitleFontColorActive?: ColorValue; 
   tabBarItemIconColorActive?: ColorValue;
   tabBarItemTitleFontSizeActive?: Float;
-  tabBarItemActivityIndicatorColor?: ColorValue;
+  tabBarItemActiveIndicatorColor?: ColorValue;
+  tabBarItemActiveIndicatorEnabled?: WithDefault<boolean, true>;
   tabBarItemRippleColor?: ColorValue;
   tabBarItemVisibilityMode?: WithDefault<VisibilityMode, "auto">;
 


### PR DESCRIPTION
## Changes
I added prop that allows to disable active indicator. At the same time I noticed it's active not activity, so I fixed the typo in both places. 

## Screenshots / GIFs

https://github.com/user-attachments/assets/384cd2fd-8570-4ae4-a616-466373be31fa

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes
