### PR TITLE
feat(iOS, Tabs): add support for `default` blur effect value

### DIFF
--- a/ios/RCTConvert+RNScreens.mm
+++ b/ios/RCTConvert+RNScreens.mm
@@ -41,7 +41,7 @@
   return blurEffects;
 }
 
-RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleNone, integerValue)
+RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleDefault, integerValue)
 
 @end
 

--- a/ios/RCTConvert+RNScreens.mm
+++ b/ios/RCTConvert+RNScreens.mm
@@ -42,6 +42,47 @@
 
 RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleNone, integerValue)
 
++ (NSMutableDictionary *)extendedBlurEffectsForIOSVersion
+{
+  NSMutableDictionary *blurEffects = [NSMutableDictionary new];
+  [blurEffects addEntriesFromDictionary:@{
+    @"none" : @(RNSExtendedBlurEffectStyleNone),
+    @"default" : @(RNSExtendedBlurEffectStyleDefault),
+    @"extraLight" : @(RNSExtendedBlurEffectStyleExtraLight),
+    @"light" : @(RNSExtendedBlurEffectStyleLight),
+    @"dark" : @(RNSExtendedBlurEffectStyleDark),
+    @"regular" : @(RNSExtendedBlurEffectStyleRegular),
+    @"prominent" : @(RNSExtendedBlurEffectStyleProminent),
+  }];
+
+#if !TARGET_OS_TV
+  [blurEffects addEntriesFromDictionary:@{
+    @"systemUltraThinMaterial" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterial),
+    @"systemThinMaterial" : @(RNSExtendedBlurEffectStyleSystemThinMaterial),
+    @"systemMaterial" : @(RNSExtendedBlurEffectStyleSystemMaterial),
+    @"systemThickMaterial" : @(RNSExtendedBlurEffectStyleSystemThickMaterial),
+    @"systemChromeMaterial" : @(RNSExtendedBlurEffectStyleSystemChromeMaterial),
+    @"systemUltraThinMaterialLight" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight),
+    @"systemThinMaterialLight" : @(RNSExtendedBlurEffectStyleSystemThinMaterialLight),
+    @"systemMaterialLight" : @(RNSExtendedBlurEffectStyleSystemMaterialLight),
+    @"systemThickMaterialLight" : @(RNSExtendedBlurEffectStyleSystemThickMaterialLight),
+    @"systemChromeMaterialLight" : @(RNSExtendedBlurEffectStyleSystemChromeMaterialLight),
+    @"systemUltraThinMaterialDark" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark),
+    @"systemThinMaterialDark" : @(RNSExtendedBlurEffectStyleSystemThinMaterialDark),
+    @"systemMaterialDark" : @(RNSExtendedBlurEffectStyleSystemMaterialDark),
+    @"systemThickMaterialDark" : @(RNSExtendedBlurEffectStyleSystemThickMaterialDark),
+    @"systemChromeMaterialDark" : @(RNSExtendedBlurEffectStyleSystemChromeMaterialDark),
+  }];
+#endif
+  return blurEffects;
+}
+
+RCT_ENUM_CONVERTER(
+    RNSExtendedBlurEffectStyle,
+    ([self extendedBlurEffectsForIOSVersion]),
+    RNSExtendedBlurEffectStyleDefault,
+    integerValue)
+
 @end
 
 #endif // !RCT_NEW_ARCH_ENABLED

--- a/ios/RCTConvert+RNScreens.mm
+++ b/ios/RCTConvert+RNScreens.mm
@@ -11,6 +11,7 @@
   NSMutableDictionary *blurEffects = [NSMutableDictionary new];
   [blurEffects addEntriesFromDictionary:@{
     @"none" : @(RNSBlurEffectStyleNone),
+    @"default" : @(RNSBlurEffectStyleDefault),
     @"extraLight" : @(RNSBlurEffectStyleExtraLight),
     @"light" : @(RNSBlurEffectStyleLight),
     @"dark" : @(RNSBlurEffectStyleDark),
@@ -41,47 +42,6 @@
 }
 
 RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleNone, integerValue)
-
-+ (NSMutableDictionary *)extendedBlurEffectsForIOSVersion
-{
-  NSMutableDictionary *blurEffects = [NSMutableDictionary new];
-  [blurEffects addEntriesFromDictionary:@{
-    @"none" : @(RNSExtendedBlurEffectStyleNone),
-    @"default" : @(RNSExtendedBlurEffectStyleDefault),
-    @"extraLight" : @(RNSExtendedBlurEffectStyleExtraLight),
-    @"light" : @(RNSExtendedBlurEffectStyleLight),
-    @"dark" : @(RNSExtendedBlurEffectStyleDark),
-    @"regular" : @(RNSExtendedBlurEffectStyleRegular),
-    @"prominent" : @(RNSExtendedBlurEffectStyleProminent),
-  }];
-
-#if !TARGET_OS_TV
-  [blurEffects addEntriesFromDictionary:@{
-    @"systemUltraThinMaterial" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterial),
-    @"systemThinMaterial" : @(RNSExtendedBlurEffectStyleSystemThinMaterial),
-    @"systemMaterial" : @(RNSExtendedBlurEffectStyleSystemMaterial),
-    @"systemThickMaterial" : @(RNSExtendedBlurEffectStyleSystemThickMaterial),
-    @"systemChromeMaterial" : @(RNSExtendedBlurEffectStyleSystemChromeMaterial),
-    @"systemUltraThinMaterialLight" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight),
-    @"systemThinMaterialLight" : @(RNSExtendedBlurEffectStyleSystemThinMaterialLight),
-    @"systemMaterialLight" : @(RNSExtendedBlurEffectStyleSystemMaterialLight),
-    @"systemThickMaterialLight" : @(RNSExtendedBlurEffectStyleSystemThickMaterialLight),
-    @"systemChromeMaterialLight" : @(RNSExtendedBlurEffectStyleSystemChromeMaterialLight),
-    @"systemUltraThinMaterialDark" : @(RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark),
-    @"systemThinMaterialDark" : @(RNSExtendedBlurEffectStyleSystemThinMaterialDark),
-    @"systemMaterialDark" : @(RNSExtendedBlurEffectStyleSystemMaterialDark),
-    @"systemThickMaterialDark" : @(RNSExtendedBlurEffectStyleSystemThickMaterialDark),
-    @"systemChromeMaterialDark" : @(RNSExtendedBlurEffectStyleSystemChromeMaterialDark),
-  }];
-#endif
-  return blurEffects;
-}
-
-RCT_ENUM_CONVERTER(
-    RNSExtendedBlurEffectStyle,
-    ([self extendedBlurEffectsForIOSVersion]),
-    RNSExtendedBlurEffectStyleDefault,
-    integerValue)
 
 @end
 

--- a/ios/RCTConvert+RNScreens.mm
+++ b/ios/RCTConvert+RNScreens.mm
@@ -11,7 +11,7 @@
   NSMutableDictionary *blurEffects = [NSMutableDictionary new];
   [blurEffects addEntriesFromDictionary:@{
     @"none" : @(RNSBlurEffectStyleNone),
-    @"default" : @(RNSBlurEffectStyleDefault),
+    @"systemDefault" : @(RNSBlurEffectStyleSystemDefault),
     @"extraLight" : @(RNSBlurEffectStyleExtraLight),
     @"light" : @(RNSBlurEffectStyleLight),
     @"dark" : @(RNSBlurEffectStyleDark),
@@ -41,7 +41,7 @@
   return blurEffects;
 }
 
-RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleDefault, integerValue)
+RCT_ENUM_CONVERTER(RNSBlurEffectStyle, ([self blurEffectsForIOSVersion]), RNSBlurEffectStyleSystemDefault, integerValue)
 
 @end
 

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -49,8 +49,8 @@ namespace react = facebook::react;
 
 #endif // RCT_NEW_ARCH_ENABLED
 
-/// This method fails (by assertion) when `blurEffect == RNSBlurEffectStyleNone` which has no counter part in the UIKit
-/// type.
+/// This method fails (by assertion) when `blurEffect == RNSBlurEffectStyleNone` or `blurEffect ==
+/// RNSBlurEffectStyleDefault` which have no counter parts in the UIKit types.
 + (UIBlurEffectStyle)tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:(RNSBlurEffectStyle)blurEffect;
 
 @end

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -50,7 +50,7 @@ namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
 /// This method fails (by assertion) when `blurEffect == RNSBlurEffectStyleNone` or `blurEffect ==
-/// RNSBlurEffectStyleDefault` which have no counter parts in the UIKit types.
+/// RNSBlurEffectStyleSystemDefault` which have no counter parts in the UIKit types.
 + (UIBlurEffectStyle)tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:(RNSBlurEffectStyle)blurEffect;
 
 @end

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -198,8 +198,8 @@
   switch (blurEffect) {
     case None:
       return RNSBlurEffectStyleNone;
-    case Default:
-      return RNSBlurEffectStyleDefault;
+    case SystemDefault:
+      return RNSBlurEffectStyleSystemDefault;
     case ExtraLight:
       return RNSBlurEffectStyleExtraLight;
     case Light:
@@ -256,15 +256,15 @@
 + (UIBlurEffectStyle)tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:(RNSBlurEffectStyle)blurEffect
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-  react_native_assert(blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleDefault);
+  react_native_assert(blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleSystemDefault);
 #else
   RCTAssert(
-      blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleDefault,
-      @"RNSBlurEffectStyleNone and RNSBlurEffectStyleDefualt variants are not convertible to UIBlurEffectStyle");
+      blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleSystemDefault,
+      @"RNSBlurEffectStyleNone and RNSBlurEffectStyleSystemDefault variants are not convertible to UIBlurEffectStyle");
 #endif // RCT_NEW_ARCH_ENABLED
 
   // Cast safety: RNSBlurEffectStyle is defined in such way that its values map 1:1 with
-  // UIBlurEffectStyle, except RNSBlurEffectStyleNone and RNSBlurEffectStyleDefault which are excluded above.
+  // UIBlurEffectStyle, except RNSBlurEffectStyleNone and RNSBlurEffectStyleSystemDefault which are excluded above.
   return (UIBlurEffectStyle)blurEffect;
 }
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -1,4 +1,5 @@
 #import "RNSConvert.h"
+#import <React/RCTLog.h>
 
 #ifndef RCT_NEW_ARCH_ENABLED
 #import <React/RCTAssert.h>
@@ -198,8 +199,6 @@
   switch (blurEffect) {
     case None:
       return RNSBlurEffectStyleNone;
-    case SystemDefault:
-      return RNSBlurEffectStyleSystemDefault;
     case ExtraLight:
       return RNSBlurEffectStyleExtraLight;
     case Light:

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -195,10 +195,11 @@
 + (RNSBlurEffectStyle)RNSBlurEffectStyleFromCppEquivalent:(react::RNSScreenStackHeaderConfigBlurEffect)blurEffect
 {
   using enum react::RNSScreenStackHeaderConfigBlurEffect;
-#if !TARGET_OS_TV
   switch (blurEffect) {
     case None:
       return RNSBlurEffectStyleNone;
+    case Default:
+      return RNSBlurEffectStyleDefault;
     case ExtraLight:
       return RNSBlurEffectStyleExtraLight;
     case Light:
@@ -209,6 +210,7 @@
       return RNSBlurEffectStyleRegular;
     case Prominent:
       return RNSBlurEffectStyleProminent;
+#if !TARGET_OS_TV
     case SystemUltraThinMaterial:
       return RNSBlurEffectStyleSystemUltraThinMaterial;
     case SystemThinMaterial:
@@ -239,23 +241,13 @@
       return RNSBlurEffectStyleSystemThickMaterialDark;
     case SystemChromeMaterialDark:
       return RNSBlurEffectStyleSystemChromeMaterialDark;
-  }
-#endif
-
-  switch (blurEffect) {
-    case None:
+    default:
+      RCTLogError(@"[RNScreens] unsupported blur effect style");
       return RNSBlurEffectStyleNone;
-    case Light:
-      return RNSBlurEffectStyleLight;
-    case Dark:
-      return RNSBlurEffectStyleDark;
-    case Regular:
-      return RNSBlurEffectStyleRegular;
-    case Prominent:
-      return RNSBlurEffectStyleProminent;
-    case ExtraLight:
+#else // !TARGET_OS_TV
     default:
       return RNSBlurEffectStyleNone;
+#endif // !TARGET_OS_TV
   }
 }
 
@@ -264,14 +256,15 @@
 + (UIBlurEffectStyle)tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:(RNSBlurEffectStyle)blurEffect
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-  react_native_assert(blurEffect != RNSBlurEffectStyleNone);
+  react_native_assert(blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleDefault);
 #else
   RCTAssert(
-      blurEffect != RNSBlurEffectStyleNone, @"RNSBlurEffectStyleNone variant is not convertible to UIBlurEffectStyle");
+      blurEffect != RNSBlurEffectStyleNone && blurEffect != RNSBlurEffectStyleDefault,
+      @"RNSBlurEffectStyleNone and RNSBlurEffectStyleDefualt variants are not convertible to UIBlurEffectStyle");
 #endif // RCT_NEW_ARCH_ENABLED
 
   // Cast safety: RNSBlurEffectStyle is defined in such way that its values map 1:1 with
-  // UIBlurEffectStyle, except RNSBlurEffectStyleNone which is excluded above.
+  // UIBlurEffectStyle, except RNSBlurEffectStyleNone and RNSBlurEffectStyleDefault which are excluded above.
   return (UIBlurEffectStyle)blurEffect;
 }
 

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, RNSSplitViewScreenColumnType) {
   RNSSplitViewScreenColumnTypeInspector,
 };
 
-// Redefinition of UIBlurEffectStyle. We need to represent additional cases of `None` and `Default`.
+// Redefinition of UIBlurEffectStyle. We need to represent additional cases of `None` and `SystemDefault`.
 typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   /// Default blur effect should be used
   RNSBlurEffectStyleSystemDefault = -2,

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -78,8 +78,10 @@ typedef NS_ENUM(NSInteger, RNSSplitViewScreenColumnType) {
   RNSSplitViewScreenColumnTypeInspector,
 };
 
-// Redefinition of UIBlurEffectStyle. We need to represent additional case of `None`.
+// Redefinition of UIBlurEffectStyle. We need to represent additional cases of `None` and `Default`.
 typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
+  /// Default blur effect should be used
+  RNSBlurEffectStyleDefault = -2,
   /// No blur effect should be visible
   RNSBlurEffectStyleNone = -1,
   RNSBlurEffectStyleExtraLight = UIBlurEffectStyleExtraLight,
@@ -120,54 +122,6 @@ typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   RNSBlurEffectStyleSystemThickMaterialDark API_AVAILABLE(ios(13.0))
       API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,
   RNSBlurEffectStyleSystemChromeMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialDark
-
-} API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
-
-// The same as above but with Default option, to be renamed after removing old stack implementation.
-typedef NS_ENUM(NSInteger, RNSExtendedBlurEffectStyle) {
-  /// Default blur effect should be used
-  RNSExtendedBlurEffectStyleDefault = -2,
-  /// No blur effect should be visible
-  RNSExtendedBlurEffectStyleNone = -1,
-  RNSExtendedBlurEffectStyleExtraLight = UIBlurEffectStyleExtraLight,
-  RNSExtendedBlurEffectStyleLight = UIBlurEffectStyleLight,
-  RNSExtendedBlurEffectStyleDark = UIBlurEffectStyleDark,
-  // TODO: Add support for this variant on tvOS
-  //  RNSExtendedBlurEffectStyleExtraDark = UIBlurEffectStyleExtraDark API_AVAILABLE(tvos(10.0)) API_UNAVAILABLE(ios)
-  //  API_UNAVAILABLE(watchos),
-  RNSExtendedBlurEffectStyleRegular API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleRegular,
-  RNSExtendedBlurEffectStyleProminent API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleProminent,
-  RNSExtendedBlurEffectStyleSystemUltraThinMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterial,
-  RNSExtendedBlurEffectStyleSystemThinMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterial,
-  RNSExtendedBlurEffectStyleSystemMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterial,
-  RNSExtendedBlurEffectStyleSystemThickMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterial,
-  RNSExtendedBlurEffectStyleSystemChromeMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterial,
-  RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialLight,
-  RNSExtendedBlurEffectStyleSystemThinMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialLight,
-  RNSExtendedBlurEffectStyleSystemMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialLight,
-  RNSExtendedBlurEffectStyleSystemThickMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialLight,
-  RNSExtendedBlurEffectStyleSystemChromeMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialLight,
-
-  RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialDark,
-  RNSExtendedBlurEffectStyleSystemThinMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialDark,
-  RNSExtendedBlurEffectStyleSystemMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialDark,
-  RNSExtendedBlurEffectStyleSystemThickMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,
-  RNSExtendedBlurEffectStyleSystemChromeMaterialDark API_AVAILABLE(ios(13.0))
       API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialDark
 
 } API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -124,6 +124,54 @@ typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
 
 } API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
 
+// The same as above but with Default option, to be renamed after removing old stack implementation.
+typedef NS_ENUM(NSInteger, RNSExtendedBlurEffectStyle) {
+  /// Default blur effect should be used
+  RNSExtendedBlurEffectStyleDefault = -2,
+  /// No blur effect should be visible
+  RNSExtendedBlurEffectStyleNone = -1,
+  RNSExtendedBlurEffectStyleExtraLight = UIBlurEffectStyleExtraLight,
+  RNSExtendedBlurEffectStyleLight = UIBlurEffectStyleLight,
+  RNSExtendedBlurEffectStyleDark = UIBlurEffectStyleDark,
+  // TODO: Add support for this variant on tvOS
+  //  RNSExtendedBlurEffectStyleExtraDark = UIBlurEffectStyleExtraDark API_AVAILABLE(tvos(10.0)) API_UNAVAILABLE(ios)
+  //  API_UNAVAILABLE(watchos),
+  RNSExtendedBlurEffectStyleRegular API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleRegular,
+  RNSExtendedBlurEffectStyleProminent API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleProminent,
+  RNSExtendedBlurEffectStyleSystemUltraThinMaterial API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterial,
+  RNSExtendedBlurEffectStyleSystemThinMaterial API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterial,
+  RNSExtendedBlurEffectStyleSystemMaterial API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterial,
+  RNSExtendedBlurEffectStyleSystemThickMaterial API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterial,
+  RNSExtendedBlurEffectStyleSystemChromeMaterial API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterial,
+  RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialLight,
+  RNSExtendedBlurEffectStyleSystemThinMaterialLight API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialLight,
+  RNSExtendedBlurEffectStyleSystemMaterialLight API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialLight,
+  RNSExtendedBlurEffectStyleSystemThickMaterialLight API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialLight,
+  RNSExtendedBlurEffectStyleSystemChromeMaterialLight API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialLight,
+
+  RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialDark,
+  RNSExtendedBlurEffectStyleSystemThinMaterialDark API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialDark,
+  RNSExtendedBlurEffectStyleSystemMaterialDark API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialDark,
+  RNSExtendedBlurEffectStyleSystemThickMaterialDark API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,
+  RNSExtendedBlurEffectStyleSystemChromeMaterialDark API_AVAILABLE(ios(13.0))
+      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialDark
+
+} API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+
 typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeImage,
   RNSBottomTabsIconTypeTemplate,

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSInteger, RNSSplitViewScreenColumnType) {
 // Redefinition of UIBlurEffectStyle. We need to represent additional cases of `None` and `Default`.
 typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   /// Default blur effect should be used
-  RNSBlurEffectStyleDefault = -2,
+  RNSBlurEffectStyleSystemDefault = -2,
   /// No blur effect should be visible
   RNSBlurEffectStyleNone = -1,
   RNSBlurEffectStyleExtraLight = UIBlurEffectStyleExtraLight,

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -458,8 +458,8 @@ RNS_IGNORE_SUPER_CALL_END
       appearance.backgroundEffect = nil;
       break;
 
-    case RNSBlurEffectStyleDefault:
-      RCTLogError(@"[RNScreens] ScreenStack does not support RNSBlurEffectStyleDefault.");
+    case RNSBlurEffectStyleSystemDefault:
+      RCTLogError(@"[RNScreens] ScreenStack does not support RNSBlurEffectStyleSystemDefault.");
       break;
 
     default:

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -453,11 +453,18 @@ RNS_IGNORE_SUPER_CALL_END
     appearance.backgroundColor = config.backgroundColor;
   }
 
-  if (config.blurEffect != RNSBlurEffectStyleNone) {
-    appearance.backgroundEffect =
-        [UIBlurEffect effectWithStyle:[RNSConvert tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:config.blurEffect]];
-  } else {
-    appearance.backgroundEffect = nil;
+  switch (config.blurEffect) {
+    case RNSBlurEffectStyleNone:
+      appearance.backgroundEffect = nil;
+      break;
+
+    case RNSBlurEffectStyleDefault:
+      RCTLogError(@"[RNScreens] ScreenStack does not support RNSBlurEffectStyleDefault.");
+      break;
+
+    default:
+      appearance.backgroundEffect =
+          [UIBlurEffect effectWithStyle:[RNSConvert tryConvertRNSBlurEffectStyleToUIBlurEffectStyle:config.blurEffect]];
   }
 
   if (config.hideShadow) {

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSBottomTabsHostComponentView () <RNSTabBarAppearanceProvider>
 
 @property (nonatomic, strong, readonly, nullable) UIColor *tabBarBackgroundColor;
-@property (nonatomic, strong, readonly, nullable) UIBlurEffect *tabBarBlurEffect;
+@property (nonatomic, readonly) RNSExtendedBlurEffectStyle tabBarBlurEffect;
 
 @property (nonatomic, strong, readonly, nullable) UIColor *tabBarTintColor;
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSBottomTabsHostComponentView () <RNSTabBarAppearanceProvider>
 
 @property (nonatomic, strong, readonly, nullable) UIColor *tabBarBackgroundColor;
-@property (nonatomic, readonly) RNSExtendedBlurEffectStyle tabBarBlurEffect;
+@property (nonatomic, readonly) RNSBlurEffectStyle tabBarBlurEffect;
 
 @property (nonatomic, strong, readonly, nullable) UIColor *tabBarTintColor;
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -83,7 +83,7 @@ namespace react = facebook::react;
   static const auto defaultProps = std::make_shared<const react::RNSBottomTabsProps>();
   _props = defaultProps;
 #endif
-  _tabBarBlurEffect = RNSExtendedBlurEffectStyleDefault;
+  _tabBarBlurEffect = RNSBlurEffectStyleDefault;
   _tabBarBackgroundColor = nil;
   _tabBarTintColor = nil;
 
@@ -209,8 +209,8 @@ namespace react = facebook::react;
 
   if (newComponentProps.tabBarBlurEffect != oldComponentProps.tabBarBlurEffect) {
     _needsTabBarAppearanceUpdate = YES;
-    _tabBarBlurEffect = rnscreens::conversion::RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
-        newComponentProps.tabBarBlurEffect);
+    _tabBarBlurEffect =
+        rnscreens::conversion::RNSBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(newComponentProps.tabBarBlurEffect);
   }
 
   if (newComponentProps.tabBarTintColor != oldComponentProps.tabBarTintColor) {
@@ -261,7 +261,7 @@ namespace react = facebook::react;
         newComponentProps.tabBarItemTitlePositionAdjustment);
     _needsTabBarAppearanceUpdate = YES;
   }
-  
+
   if (newComponentProps.tabBarMinimizeBehavior != oldComponentProps.tabBarMinimizeBehavior) {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
@@ -414,7 +414,7 @@ RNS_IGNORE_SUPER_CALL_END
   [self invalidateTabBarAppearance];
 }
 
-- (void)setTabBarBlurEffect:(RNSExtendedBlurEffectStyle)tabBarBlurEffect
+- (void)setTabBarBlurEffect:(RNSBlurEffectStyle)tabBarBlurEffect
 {
   _tabBarBlurEffect = tabBarBlurEffect;
   [self invalidateTabBarAppearance];

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -83,7 +83,7 @@ namespace react = facebook::react;
   static const auto defaultProps = std::make_shared<const react::RNSBottomTabsProps>();
   _props = defaultProps;
 #endif
-  _tabBarBlurEffect = nil;
+  _tabBarBlurEffect = RNSExtendedBlurEffectStyleDefault;
   _tabBarBackgroundColor = nil;
   _tabBarTintColor = nil;
 
@@ -209,8 +209,8 @@ namespace react = facebook::react;
 
   if (newComponentProps.tabBarBlurEffect != oldComponentProps.tabBarBlurEffect) {
     _needsTabBarAppearanceUpdate = YES;
-    _tabBarBlurEffect =
-        rnscreens::conversion::RNSUIBlurEffectFromRNSBottomTabsTabBarBlurEffect(newComponentProps.tabBarBlurEffect);
+    _tabBarBlurEffect = rnscreens::conversion::RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
+        newComponentProps.tabBarBlurEffect);
   }
 
   if (newComponentProps.tabBarTintColor != oldComponentProps.tabBarTintColor) {
@@ -414,11 +414,9 @@ RNS_IGNORE_SUPER_CALL_END
   [self invalidateTabBarAppearance];
 }
 
-// This is a Paper-only setter method that will be called by the mounting code.
-// It allows us to store UIBlurEffect in the component while accepting a custom enum as input from JS.
-- (void)setTabBarBlurEffectFromRNSBlurEffectStyle:(RNSBlurEffectStyle)tabBarBlurEffect
+- (void)setTabBarBlurEffect:(RNSExtendedBlurEffectStyle)tabBarBlurEffect
 {
-  _tabBarBlurEffect = rnscreens::conversion::RNSUIBlurEffectFromRNSBlurEffectStyle(tabBarBlurEffect);
+  _tabBarBlurEffect = tabBarBlurEffect;
   [self invalidateTabBarAppearance];
 }
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -83,7 +83,7 @@ namespace react = facebook::react;
   static const auto defaultProps = std::make_shared<const react::RNSBottomTabsProps>();
   _props = defaultProps;
 #endif
-  _tabBarBlurEffect = RNSBlurEffectStyleDefault;
+  _tabBarBlurEffect = RNSBlurEffectStyleSystemDefault;
   _tabBarBackgroundColor = nil;
   _tabBarTintColor = nil;
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
@@ -23,7 +23,7 @@ RCT_EXPORT_MODULE(RNSBottomTabsManager)
 #pragma mark - LEGACY Props
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarBackgroundColor, UIColor);
-RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSExtendedBlurEffectStyle);
+RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSBlurEffectStyle);
 RCT_EXPORT_VIEW_PROPERTY(tabBarTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontFamily, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontSize, NSNumber);

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
@@ -23,10 +23,7 @@ RCT_EXPORT_MODULE(RNSBottomTabsManager)
 #pragma mark - LEGACY Props
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarBackgroundColor, UIColor);
-
-// This remapping allows us to store UIBlurEffect in the component while accepting a custom enum as input from JS.
-RCT_REMAP_VIEW_PROPERTY(tabBarBlurEffect, tabBarBlurEffectFromRNSBlurEffectStyle, RNSBlurEffectStyle);
-
+RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSExtendedBlurEffectStyle);
 RCT_EXPORT_VIEW_PROPERTY(tabBarTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontFamily, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontSize, NSNumber);

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *badgeValue;
 
 @property (nonatomic, strong, nullable) UIColor *tabBarBackgroundColor;
-@property (nonatomic, strong, nullable) UIBlurEffect *tabBarBlurEffect;
+@property (nonatomic, readonly) RNSExtendedBlurEffectStyle tabBarBlurEffect;
 
 @property (nonatomic, strong, nullable) NSString *tabBarItemTitleFontFamily;
 @property (nonatomic, strong, nullable) NSNumber *tabBarItemTitleFontSize;

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *badgeValue;
 
 @property (nonatomic, strong, nullable) UIColor *tabBarBackgroundColor;
-@property (nonatomic, readonly) RNSExtendedBlurEffectStyle tabBarBlurEffect;
+@property (nonatomic, readonly) RNSBlurEffectStyle tabBarBlurEffect;
 
 @property (nonatomic, strong, nullable) NSString *tabBarItemTitleFontFamily;
 @property (nonatomic, strong, nullable) NSNumber *tabBarItemTitleFontSize;

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -71,7 +71,7 @@ namespace react = facebook::react;
   _isSelectedScreen = NO;
   _badgeValue = nil;
   _title = nil;
-  _tabBarBlurEffect = RNSExtendedBlurEffectStyleDefault;
+  _tabBarBlurEffect = RNSBlurEffectStyleDefault;
   _tabBarBackgroundColor = nil;
 
   _tabBarItemTitleFontFamily = nil;
@@ -179,7 +179,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
   if (newComponentProps.tabBarBlurEffect != oldComponentProps.tabBarBlurEffect) {
-    _tabBarBlurEffect = rnscreens::conversion::RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
+    _tabBarBlurEffect = rnscreens::conversion::RNSBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
         newComponentProps.tabBarBlurEffect);
     tabItemNeedsAppearanceUpdate = YES;
   }
@@ -373,7 +373,7 @@ RNS_IGNORE_SUPER_CALL_END
   _tabItemNeedsAppearanceUpdate = YES;
 }
 
-- (void)setTabBarBlurEffect:(RNSExtendedBlurEffectStyle)tabBarBlurEffect
+- (void)setTabBarBlurEffect:(RNSBlurEffectStyle)tabBarBlurEffect
 {
   _tabBarBlurEffect = tabBarBlurEffect;
   _tabItemNeedsAppearanceUpdate = YES;

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -71,7 +71,7 @@ namespace react = facebook::react;
   _isSelectedScreen = NO;
   _badgeValue = nil;
   _title = nil;
-  _tabBarBlurEffect = nil;
+  _tabBarBlurEffect = RNSExtendedBlurEffectStyleDefault;
   _tabBarBackgroundColor = nil;
 
   _tabBarItemTitleFontFamily = nil;
@@ -179,7 +179,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 
   if (newComponentProps.tabBarBlurEffect != oldComponentProps.tabBarBlurEffect) {
-    _tabBarBlurEffect = rnscreens::conversion::RNSUIBlurEffectFromRNSBottomTabsScreenTabBarBlurEffect(
+    _tabBarBlurEffect = rnscreens::conversion::RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
         newComponentProps.tabBarBlurEffect);
     tabItemNeedsAppearanceUpdate = YES;
   }
@@ -373,11 +373,9 @@ RNS_IGNORE_SUPER_CALL_END
   _tabItemNeedsAppearanceUpdate = YES;
 }
 
-// This is a Paper-only setter method that will be called by the mounting code.
-// It allows us to store UIBlurEffect in the component while accepting a custom enum as input from JS.
-- (void)setTabBarBlurEffectFromRNSBlurEffectStyle:(RNSBlurEffectStyle)tabBarBlurEffect
+- (void)setTabBarBlurEffect:(RNSExtendedBlurEffectStyle)tabBarBlurEffect
 {
-  _tabBarBlurEffect = rnscreens::conversion::RNSUIBlurEffectFromRNSBlurEffectStyle(tabBarBlurEffect);
+  _tabBarBlurEffect = tabBarBlurEffect;
   _tabItemNeedsAppearanceUpdate = YES;
 }
 

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -71,7 +71,7 @@ namespace react = facebook::react;
   _isSelectedScreen = NO;
   _badgeValue = nil;
   _title = nil;
-  _tabBarBlurEffect = RNSBlurEffectStyleDefault;
+  _tabBarBlurEffect = RNSBlurEffectStyleSystemDefault;
   _tabBarBackgroundColor = nil;
 
   _tabBarItemTitleFontFamily = nil;

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentViewManager.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentViewManager.mm
@@ -23,9 +23,7 @@ RCT_REMAP_VIEW_PROPERTY(isFocused, isSelectedScreen, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(title, NSString);
 RCT_EXPORT_VIEW_PROPERTY(badgeValue, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarBackgroundColor, UIColor);
-
-// This remapping allows us to store UIBlurEffect in the component while accepting a custom enum as input from JS.
-RCT_REMAP_VIEW_PROPERTY(tabBarBlurEffect, tabBarBlurEffectFromRNSBlurEffectStyle, RNSBlurEffectStyle);
+RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSExtendedBlurEffectStyle);
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontFamily, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontSize, NSNumber);

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentViewManager.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentViewManager.mm
@@ -23,7 +23,7 @@ RCT_REMAP_VIEW_PROPERTY(isFocused, isSelectedScreen, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(title, NSString);
 RCT_EXPORT_VIEW_PROPERTY(badgeValue, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarBackgroundColor, UIColor);
-RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSExtendedBlurEffectStyle);
+RCT_EXPORT_VIEW_PROPERTY(tabBarBlurEffect, RNSBlurEffectStyle);
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontFamily, NSString);
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitleFontSize, NSNumber);

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -78,7 +78,7 @@
       appearance.backgroundEffect = nil;
       break;
 
-    case RNSBlurEffectStyleDefault:
+    case RNSBlurEffectStyleSystemDefault:
       // Initialized appearance already has default blur effect.
 
       // This won't work as expected with current inheriting appearance logic:

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -74,11 +74,11 @@
   }
 
   switch (appearanceProvider.tabBarBlurEffect) {
-    case RNSExtendedBlurEffectStyleNone:
+    case RNSBlurEffectStyleNone:
       appearance.backgroundEffect = nil;
       break;
 
-    case RNSExtendedBlurEffectStyleDefault:
+    case RNSBlurEffectStyleDefault:
       // Initialized appearance already has default blur effect.
 
       // This won't work as expected with current inheriting appearance logic:
@@ -88,7 +88,7 @@
 
     default:
       appearance.backgroundEffect =
-          rnscreens::conversion::RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(appearanceProvider.tabBarBlurEffect);
+          rnscreens::conversion::RNSUIBlurEffectFromRNSBlurEffectStyle(appearanceProvider.tabBarBlurEffect);
   }
 }
 

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -89,7 +89,6 @@
     default:
       appearance.backgroundEffect =
           rnscreens::conversion::RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(appearanceProvider.tabBarBlurEffect);
-      break;
   }
 }
 

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -47,6 +47,7 @@
     }
 
     // Inherit general properties from host
+    // TODO: don't inherit properties from host
     UITabBarAppearance *tabAppearance = [[UITabBarAppearance alloc] initWithBarAppearance:appearance];
 
     [self configureTabBarAppearance:tabAppearance fromAppearanceProvider:tabScreenCtrl.tabScreenComponentView];
@@ -72,8 +73,23 @@
     appearance.backgroundColor = appearanceProvider.tabBarBackgroundColor;
   }
 
-  if (appearanceProvider.tabBarBlurEffect != nil) {
-    appearance.backgroundEffect = appearanceProvider.tabBarBlurEffect;
+  switch (appearanceProvider.tabBarBlurEffect) {
+    case RNSExtendedBlurEffectStyleNone:
+      appearance.backgroundEffect = nil;
+      break;
+
+    case RNSExtendedBlurEffectStyleDefault:
+      // Initialized appearance already has default blur effect.
+
+      // This won't work as expected with current inheriting appearance logic:
+      // screen will not revert to default but inherit blur from host
+      // TODO: remove appearance inheritance
+      break;
+
+    default:
+      appearance.backgroundEffect =
+          rnscreens::conversion::RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(appearanceProvider.tabBarBlurEffect);
+      break;
   }
 }
 
@@ -100,27 +116,27 @@
     tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
   } else if (imageLoader != nil) {
     bool isTemplate = screenView.iconType == RNSBottomTabsIconTypeTemplate;
-    
+
     // Normal icon
     if (screenView.iconImageSource != nil) {
       [self loadImageFrom:screenView.iconImageSource
           withImageLoader:imageLoader
                asTemplate:isTemplate
           completionBlock:^(UIImage *image) {
-                   tabBarItem.image = image;
-                 }];
+            tabBarItem.image = image;
+          }];
     } else {
       tabBarItem.image = nil;
     }
-    
+
     // Selected icon
     if (screenView.selectedIconImageSource != nil) {
       [self loadImageFrom:screenView.selectedIconImageSource
           withImageLoader:imageLoader
                asTemplate:isTemplate
           completionBlock:^(UIImage *image) {
-                   tabBarItem.selectedImage = image;
-                 }];
+            tabBarItem.selectedImage = image;
+          }];
     } else {
       tabBarItem.selectedImage = nil;
     }
@@ -136,7 +152,7 @@
 {
   RCTAssert(imageSource != nil, @"[RNScreens] imageSource must not be nil");
   RCTAssert(imageLoader != nil, @"[RNScreens] imageLoader must not be nil");
-  
+
   [imageLoader loadImageWithURLRequest:imageSource.request
       size:imageSource.size
       scale:imageSource.scale

--- a/ios/bottom-tabs/RNSTabBarAppearanceProvider.h
+++ b/ios/bottom-tabs/RNSTabBarAppearanceProvider.h
@@ -1,11 +1,12 @@
 #import <UIKit/UIKit.h>
+#import "RNSEnums.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSTabBarAppearanceProvider
 
 - (UIColor *)tabBarBackgroundColor;
-- (UIBlurEffect *)tabBarBlurEffect;
+- (RNSExtendedBlurEffectStyle)tabBarBlurEffect;
 
 - (NSString *)tabBarItemTitleFontFamily;
 - (NSNumber *)tabBarItemTitleFontSize;

--- a/ios/bottom-tabs/RNSTabBarAppearanceProvider.h
+++ b/ios/bottom-tabs/RNSTabBarAppearanceProvider.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol RNSTabBarAppearanceProvider
 
 - (UIColor *)tabBarBackgroundColor;
-- (RNSExtendedBlurEffectStyle)tabBarBlurEffect;
+- (RNSBlurEffectStyle)tabBarBlurEffect;
 
 - (NSString *)tabBarItemTitleFontFamily;
 - (NSNumber *)tabBarItemTitleFontSize;

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -132,7 +132,7 @@ RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlur
       return RNSExtendedBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
 #endif
   }
 }
@@ -220,7 +220,7 @@ RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabB
       return RNSExtendedBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
 #endif
   }
 }

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -164,7 +164,7 @@ UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimize
 }
 #endif // Check for iOS >= 26
 
-RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
+RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
 {
   using enum facebook::react::RNSBottomTabsScreenTabBarBlurEffect;

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -16,7 +16,7 @@ std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle
 {
   switch (blurEffect) {
     case RNSBlurEffectStyleNone:
-    case RNSBlurEffectStyleDefault:
+    case RNSBlurEffectStyleSystemDefault:
       return std::nullopt;
     case RNSBlurEffectStyleExtraLight:
       return {UIBlurEffectStyleExtraLight};
@@ -82,8 +82,8 @@ RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(react::RN
   switch (blurEffect) {
     case None:
       return RNSBlurEffectStyleNone;
-    case Default:
-      return RNSBlurEffectStyleDefault;
+    case SystemDefault:
+      return RNSBlurEffectStyleSystemDefault;
     case ExtraLight:
       return RNSBlurEffectStyleExtraLight;
     case Light:
@@ -170,8 +170,8 @@ RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
   switch (blurEffect) {
     case None:
       return RNSBlurEffectStyleNone;
-    case Default:
-      return RNSBlurEffectStyleDefault;
+    case SystemDefault:
+      return RNSBlurEffectStyleSystemDefault;
     case ExtraLight:
       return RNSBlurEffectStyleExtraLight;
     case Light:

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -12,52 +12,53 @@ UIBlurEffect *RNSUIBlurEffectFromOptionalUIBlurEffectStyle(std::optional<UIBlurE
   return nil;
 }
 
-#if !RCT_NEW_ARCH_ENABLED
-std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect)
+std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(
+    RNSExtendedBlurEffectStyle blurEffect)
 {
   switch (blurEffect) {
-    case RNSBlurEffectStyleNone:
+    case RNSExtendedBlurEffectStyleNone:
+    case RNSExtendedBlurEffectStyleDefault:
       return std::nullopt;
-    case RNSBlurEffectStyleExtraLight:
+    case RNSExtendedBlurEffectStyleExtraLight:
       return {UIBlurEffectStyleExtraLight};
-    case RNSBlurEffectStyleLight:
+    case RNSExtendedBlurEffectStyleLight:
       return {UIBlurEffectStyleLight};
-    case RNSBlurEffectStyleDark:
+    case RNSExtendedBlurEffectStyleDark:
       return {UIBlurEffectStyleDark};
-    case RNSBlurEffectStyleRegular:
+    case RNSExtendedBlurEffectStyleRegular:
       return {UIBlurEffectStyleRegular};
-    case RNSBlurEffectStyleProminent:
+    case RNSExtendedBlurEffectStyleProminent:
       return {UIBlurEffectStyleProminent};
 #if !TARGET_OS_TV
-    case RNSBlurEffectStyleSystemUltraThinMaterial:
+    case RNSExtendedBlurEffectStyleSystemUltraThinMaterial:
       return {UIBlurEffectStyleSystemUltraThinMaterial};
-    case RNSBlurEffectStyleSystemThinMaterial:
+    case RNSExtendedBlurEffectStyleSystemThinMaterial:
       return {UIBlurEffectStyleSystemThinMaterial};
-    case RNSBlurEffectStyleSystemMaterial:
+    case RNSExtendedBlurEffectStyleSystemMaterial:
       return {UIBlurEffectStyleSystemMaterial};
-    case RNSBlurEffectStyleSystemThickMaterial:
+    case RNSExtendedBlurEffectStyleSystemThickMaterial:
       return {UIBlurEffectStyleSystemThickMaterial};
-    case RNSBlurEffectStyleSystemChromeMaterial:
+    case RNSExtendedBlurEffectStyleSystemChromeMaterial:
       return {UIBlurEffectStyleSystemChromeMaterial};
-    case RNSBlurEffectStyleSystemUltraThinMaterialLight:
+    case RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight:
       return {UIBlurEffectStyleSystemUltraThinMaterialLight};
-    case RNSBlurEffectStyleSystemThinMaterialLight:
+    case RNSExtendedBlurEffectStyleSystemThinMaterialLight:
       return {UIBlurEffectStyleSystemThinMaterialLight};
-    case RNSBlurEffectStyleSystemMaterialLight:
+    case RNSExtendedBlurEffectStyleSystemMaterialLight:
       return {UIBlurEffectStyleSystemMaterialLight};
-    case RNSBlurEffectStyleSystemThickMaterialLight:
+    case RNSExtendedBlurEffectStyleSystemThickMaterialLight:
       return {UIBlurEffectStyleSystemThickMaterialLight};
-    case RNSBlurEffectStyleSystemChromeMaterialLight:
+    case RNSExtendedBlurEffectStyleSystemChromeMaterialLight:
       return {UIBlurEffectStyleSystemChromeMaterialLight};
-    case RNSBlurEffectStyleSystemUltraThinMaterialDark:
+    case RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark:
       return {UIBlurEffectStyleSystemUltraThinMaterialDark};
-    case RNSBlurEffectStyleSystemThinMaterialDark:
+    case RNSExtendedBlurEffectStyleSystemThinMaterialDark:
       return {UIBlurEffectStyleSystemThinMaterialDark};
-    case RNSBlurEffectStyleSystemMaterialDark:
+    case RNSExtendedBlurEffectStyleSystemMaterialDark:
       return {UIBlurEffectStyleSystemMaterialDark};
-    case RNSBlurEffectStyleSystemThickMaterialDark:
+    case RNSExtendedBlurEffectStyleSystemThickMaterialDark:
       return {UIBlurEffectStyleSystemThickMaterialDark};
-    case RNSBlurEffectStyleSystemChromeMaterialDark:
+    case RNSExtendedBlurEffectStyleSystemChromeMaterialDark:
       return {UIBlurEffectStyleSystemChromeMaterialDark};
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
@@ -69,62 +70,63 @@ std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle
   }
 }
 
-UIBlurEffect *RNSUIBlurEffectFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect)
+UIBlurEffect *RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(RNSExtendedBlurEffectStyle blurEffect)
 {
-  std::optional<UIBlurEffectStyle> maybeStyle = RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(blurEffect);
+  std::optional<UIBlurEffectStyle> maybeStyle = RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(blurEffect);
   return RNSUIBlurEffectFromOptionalUIBlurEffectStyle(maybeStyle);
 }
-#endif // !RCT_NEW_ARCH_ENABLED
 
-std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
+RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
     react::RNSBottomTabsTabBarBlurEffect blurEffect)
 {
   using enum facebook::react::RNSBottomTabsTabBarBlurEffect;
 
   switch (blurEffect) {
     case None:
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
+    case Default:
+      return RNSExtendedBlurEffectStyleDefault;
     case ExtraLight:
-      return {UIBlurEffectStyleExtraLight};
+      return RNSExtendedBlurEffectStyleExtraLight;
     case Light:
-      return {UIBlurEffectStyleLight};
+      return RNSExtendedBlurEffectStyleLight;
     case Dark:
-      return {UIBlurEffectStyleDark};
+      return RNSExtendedBlurEffectStyleDark;
     case Regular:
-      return {UIBlurEffectStyleRegular};
+      return RNSExtendedBlurEffectStyleRegular;
     case Prominent:
-      return {UIBlurEffectStyleProminent};
+      return RNSExtendedBlurEffectStyleProminent;
 #if !TARGET_OS_TV
     case SystemUltraThinMaterial:
-      return {UIBlurEffectStyleSystemUltraThinMaterial};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterial;
     case SystemThinMaterial:
-      return {UIBlurEffectStyleSystemThinMaterial};
+      return RNSExtendedBlurEffectStyleSystemThinMaterial;
     case SystemMaterial:
-      return {UIBlurEffectStyleSystemMaterial};
+      return RNSExtendedBlurEffectStyleSystemMaterial;
     case SystemThickMaterial:
-      return {UIBlurEffectStyleSystemThickMaterial};
+      return RNSExtendedBlurEffectStyleSystemThickMaterial;
     case SystemChromeMaterial:
-      return {UIBlurEffectStyleSystemChromeMaterial};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterial;
     case SystemUltraThinMaterialLight:
-      return {UIBlurEffectStyleSystemUltraThinMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight;
     case SystemThinMaterialLight:
-      return {UIBlurEffectStyleSystemThinMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemThinMaterialLight;
     case SystemMaterialLight:
-      return {UIBlurEffectStyleSystemMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemMaterialLight;
     case SystemThickMaterialLight:
-      return {UIBlurEffectStyleSystemThickMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemThickMaterialLight;
     case SystemChromeMaterialLight:
-      return {UIBlurEffectStyleSystemChromeMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterialLight;
     case SystemUltraThinMaterialDark:
-      return {UIBlurEffectStyleSystemUltraThinMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark;
     case SystemThinMaterialDark:
-      return {UIBlurEffectStyleSystemThinMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemThinMaterialDark;
     case SystemMaterialDark:
-      return {UIBlurEffectStyleSystemMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemMaterialDark;
     case SystemThickMaterialDark:
-      return {UIBlurEffectStyleSystemThickMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemThickMaterialDark;
     case SystemChromeMaterialDark:
-      return {UIBlurEffectStyleSystemChromeMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
       return std::nullopt;
@@ -133,12 +135,6 @@ std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsTabBa
       return std::nullopt;
 #endif
   }
-}
-
-UIBlurEffect *RNSUIBlurEffectFromRNSBottomTabsTabBarBlurEffect(react::RNSBottomTabsTabBarBlurEffect blurEffect)
-{
-  std::optional<UIBlurEffectStyle> maybeStyle = RNSMaybeUIBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(blurEffect);
-  return RNSUIBlurEffectFromOptionalUIBlurEffectStyle(maybeStyle);
 }
 
 UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
@@ -168,55 +164,57 @@ UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimize
 }
 #endif // Check for iOS >= 26
 
-std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
+RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
 {
   using enum facebook::react::RNSBottomTabsScreenTabBarBlurEffect;
 
   switch (blurEffect) {
     case None:
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
+    case Default:
+      return RNSExtendedBlurEffectStyleDefault;
     case ExtraLight:
-      return {UIBlurEffectStyleExtraLight};
+      return RNSExtendedBlurEffectStyleExtraLight;
     case Light:
-      return {UIBlurEffectStyleLight};
+      return RNSExtendedBlurEffectStyleLight;
     case Dark:
-      return {UIBlurEffectStyleDark};
+      return RNSExtendedBlurEffectStyleDark;
     case Regular:
-      return {UIBlurEffectStyleRegular};
+      return RNSExtendedBlurEffectStyleRegular;
     case Prominent:
-      return {UIBlurEffectStyleProminent};
+      return RNSExtendedBlurEffectStyleProminent;
 #if !TARGET_OS_TV
     case SystemUltraThinMaterial:
-      return {UIBlurEffectStyleSystemUltraThinMaterial};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterial;
     case SystemThinMaterial:
-      return {UIBlurEffectStyleSystemThinMaterial};
+      return RNSExtendedBlurEffectStyleSystemThinMaterial;
     case SystemMaterial:
-      return {UIBlurEffectStyleSystemMaterial};
+      return RNSExtendedBlurEffectStyleSystemMaterial;
     case SystemThickMaterial:
-      return {UIBlurEffectStyleSystemThickMaterial};
+      return RNSExtendedBlurEffectStyleSystemThickMaterial;
     case SystemChromeMaterial:
-      return {UIBlurEffectStyleSystemChromeMaterial};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterial;
     case SystemUltraThinMaterialLight:
-      return {UIBlurEffectStyleSystemUltraThinMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight;
     case SystemThinMaterialLight:
-      return {UIBlurEffectStyleSystemThinMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemThinMaterialLight;
     case SystemMaterialLight:
-      return {UIBlurEffectStyleSystemMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemMaterialLight;
     case SystemThickMaterialLight:
-      return {UIBlurEffectStyleSystemThickMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemThickMaterialLight;
     case SystemChromeMaterialLight:
-      return {UIBlurEffectStyleSystemChromeMaterialLight};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterialLight;
     case SystemUltraThinMaterialDark:
-      return {UIBlurEffectStyleSystemUltraThinMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark;
     case SystemThinMaterialDark:
-      return {UIBlurEffectStyleSystemThinMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemThinMaterialDark;
     case SystemMaterialDark:
-      return {UIBlurEffectStyleSystemMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemMaterialDark;
     case SystemThickMaterialDark:
-      return {UIBlurEffectStyleSystemThickMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemThickMaterialDark;
     case SystemChromeMaterialDark:
-      return {UIBlurEffectStyleSystemChromeMaterialDark};
+      return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
       return std::nullopt;
@@ -225,14 +223,6 @@ std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScree
       return std::nullopt;
 #endif
   }
-}
-
-UIBlurEffect *RNSUIBlurEffectFromRNSBottomTabsScreenTabBarBlurEffect(
-    react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
-{
-  std::optional<UIBlurEffectStyle> maybeStyle =
-      RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(blurEffect);
-  return RNSUIBlurEffectFromOptionalUIBlurEffectStyle(maybeStyle);
 }
 
 UIOffset RNSBottomTabsScreenTabBarItemTitlePositionAdjustmentStruct(

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -12,53 +12,52 @@ UIBlurEffect *RNSUIBlurEffectFromOptionalUIBlurEffectStyle(std::optional<UIBlurE
   return nil;
 }
 
-std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(
-    RNSExtendedBlurEffectStyle blurEffect)
+std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect)
 {
   switch (blurEffect) {
-    case RNSExtendedBlurEffectStyleNone:
-    case RNSExtendedBlurEffectStyleDefault:
+    case RNSBlurEffectStyleNone:
+    case RNSBlurEffectStyleDefault:
       return std::nullopt;
-    case RNSExtendedBlurEffectStyleExtraLight:
+    case RNSBlurEffectStyleExtraLight:
       return {UIBlurEffectStyleExtraLight};
-    case RNSExtendedBlurEffectStyleLight:
+    case RNSBlurEffectStyleLight:
       return {UIBlurEffectStyleLight};
-    case RNSExtendedBlurEffectStyleDark:
+    case RNSBlurEffectStyleDark:
       return {UIBlurEffectStyleDark};
-    case RNSExtendedBlurEffectStyleRegular:
+    case RNSBlurEffectStyleRegular:
       return {UIBlurEffectStyleRegular};
-    case RNSExtendedBlurEffectStyleProminent:
+    case RNSBlurEffectStyleProminent:
       return {UIBlurEffectStyleProminent};
 #if !TARGET_OS_TV
-    case RNSExtendedBlurEffectStyleSystemUltraThinMaterial:
+    case RNSBlurEffectStyleSystemUltraThinMaterial:
       return {UIBlurEffectStyleSystemUltraThinMaterial};
-    case RNSExtendedBlurEffectStyleSystemThinMaterial:
+    case RNSBlurEffectStyleSystemThinMaterial:
       return {UIBlurEffectStyleSystemThinMaterial};
-    case RNSExtendedBlurEffectStyleSystemMaterial:
+    case RNSBlurEffectStyleSystemMaterial:
       return {UIBlurEffectStyleSystemMaterial};
-    case RNSExtendedBlurEffectStyleSystemThickMaterial:
+    case RNSBlurEffectStyleSystemThickMaterial:
       return {UIBlurEffectStyleSystemThickMaterial};
-    case RNSExtendedBlurEffectStyleSystemChromeMaterial:
+    case RNSBlurEffectStyleSystemChromeMaterial:
       return {UIBlurEffectStyleSystemChromeMaterial};
-    case RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight:
+    case RNSBlurEffectStyleSystemUltraThinMaterialLight:
       return {UIBlurEffectStyleSystemUltraThinMaterialLight};
-    case RNSExtendedBlurEffectStyleSystemThinMaterialLight:
+    case RNSBlurEffectStyleSystemThinMaterialLight:
       return {UIBlurEffectStyleSystemThinMaterialLight};
-    case RNSExtendedBlurEffectStyleSystemMaterialLight:
+    case RNSBlurEffectStyleSystemMaterialLight:
       return {UIBlurEffectStyleSystemMaterialLight};
-    case RNSExtendedBlurEffectStyleSystemThickMaterialLight:
+    case RNSBlurEffectStyleSystemThickMaterialLight:
       return {UIBlurEffectStyleSystemThickMaterialLight};
-    case RNSExtendedBlurEffectStyleSystemChromeMaterialLight:
+    case RNSBlurEffectStyleSystemChromeMaterialLight:
       return {UIBlurEffectStyleSystemChromeMaterialLight};
-    case RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark:
+    case RNSBlurEffectStyleSystemUltraThinMaterialDark:
       return {UIBlurEffectStyleSystemUltraThinMaterialDark};
-    case RNSExtendedBlurEffectStyleSystemThinMaterialDark:
+    case RNSBlurEffectStyleSystemThinMaterialDark:
       return {UIBlurEffectStyleSystemThinMaterialDark};
-    case RNSExtendedBlurEffectStyleSystemMaterialDark:
+    case RNSBlurEffectStyleSystemMaterialDark:
       return {UIBlurEffectStyleSystemMaterialDark};
-    case RNSExtendedBlurEffectStyleSystemThickMaterialDark:
+    case RNSBlurEffectStyleSystemThickMaterialDark:
       return {UIBlurEffectStyleSystemThickMaterialDark};
-    case RNSExtendedBlurEffectStyleSystemChromeMaterialDark:
+    case RNSBlurEffectStyleSystemChromeMaterialDark:
       return {UIBlurEffectStyleSystemChromeMaterialDark};
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
@@ -70,69 +69,68 @@ std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEff
   }
 }
 
-UIBlurEffect *RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(RNSExtendedBlurEffectStyle blurEffect)
+UIBlurEffect *RNSUIBlurEffectFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect)
 {
-  std::optional<UIBlurEffectStyle> maybeStyle = RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(blurEffect);
+  std::optional<UIBlurEffectStyle> maybeStyle = RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(blurEffect);
   return RNSUIBlurEffectFromOptionalUIBlurEffectStyle(maybeStyle);
 }
 
-RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
-    react::RNSBottomTabsTabBarBlurEffect blurEffect)
+RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(react::RNSBottomTabsTabBarBlurEffect blurEffect)
 {
   using enum facebook::react::RNSBottomTabsTabBarBlurEffect;
 
   switch (blurEffect) {
     case None:
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
     case Default:
-      return RNSExtendedBlurEffectStyleDefault;
+      return RNSBlurEffectStyleDefault;
     case ExtraLight:
-      return RNSExtendedBlurEffectStyleExtraLight;
+      return RNSBlurEffectStyleExtraLight;
     case Light:
-      return RNSExtendedBlurEffectStyleLight;
+      return RNSBlurEffectStyleLight;
     case Dark:
-      return RNSExtendedBlurEffectStyleDark;
+      return RNSBlurEffectStyleDark;
     case Regular:
-      return RNSExtendedBlurEffectStyleRegular;
+      return RNSBlurEffectStyleRegular;
     case Prominent:
-      return RNSExtendedBlurEffectStyleProminent;
+      return RNSBlurEffectStyleProminent;
 #if !TARGET_OS_TV
     case SystemUltraThinMaterial:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterial;
+      return RNSBlurEffectStyleSystemUltraThinMaterial;
     case SystemThinMaterial:
-      return RNSExtendedBlurEffectStyleSystemThinMaterial;
+      return RNSBlurEffectStyleSystemThinMaterial;
     case SystemMaterial:
-      return RNSExtendedBlurEffectStyleSystemMaterial;
+      return RNSBlurEffectStyleSystemMaterial;
     case SystemThickMaterial:
-      return RNSExtendedBlurEffectStyleSystemThickMaterial;
+      return RNSBlurEffectStyleSystemThickMaterial;
     case SystemChromeMaterial:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterial;
+      return RNSBlurEffectStyleSystemChromeMaterial;
     case SystemUltraThinMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight;
+      return RNSBlurEffectStyleSystemUltraThinMaterialLight;
     case SystemThinMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemThinMaterialLight;
+      return RNSBlurEffectStyleSystemThinMaterialLight;
     case SystemMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemMaterialLight;
+      return RNSBlurEffectStyleSystemMaterialLight;
     case SystemThickMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemThickMaterialLight;
+      return RNSBlurEffectStyleSystemThickMaterialLight;
     case SystemChromeMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterialLight;
+      return RNSBlurEffectStyleSystemChromeMaterialLight;
     case SystemUltraThinMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark;
+      return RNSBlurEffectStyleSystemUltraThinMaterialDark;
     case SystemThinMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemThinMaterialDark;
+      return RNSBlurEffectStyleSystemThinMaterialDark;
     case SystemMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemMaterialDark;
+      return RNSBlurEffectStyleSystemMaterialDark;
     case SystemThickMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemThickMaterialDark;
+      return RNSBlurEffectStyleSystemThickMaterialDark;
     case SystemChromeMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
+      return RNSBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
 #endif
   }
 }
@@ -164,63 +162,63 @@ UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimize
 }
 #endif // Check for iOS >= 26
 
-RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
+RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect)
 {
   using enum facebook::react::RNSBottomTabsScreenTabBarBlurEffect;
 
   switch (blurEffect) {
     case None:
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
     case Default:
-      return RNSExtendedBlurEffectStyleDefault;
+      return RNSBlurEffectStyleDefault;
     case ExtraLight:
-      return RNSExtendedBlurEffectStyleExtraLight;
+      return RNSBlurEffectStyleExtraLight;
     case Light:
-      return RNSExtendedBlurEffectStyleLight;
+      return RNSBlurEffectStyleLight;
     case Dark:
-      return RNSExtendedBlurEffectStyleDark;
+      return RNSBlurEffectStyleDark;
     case Regular:
-      return RNSExtendedBlurEffectStyleRegular;
+      return RNSBlurEffectStyleRegular;
     case Prominent:
-      return RNSExtendedBlurEffectStyleProminent;
+      return RNSBlurEffectStyleProminent;
 #if !TARGET_OS_TV
     case SystemUltraThinMaterial:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterial;
+      return RNSBlurEffectStyleSystemUltraThinMaterial;
     case SystemThinMaterial:
-      return RNSExtendedBlurEffectStyleSystemThinMaterial;
+      return RNSBlurEffectStyleSystemThinMaterial;
     case SystemMaterial:
-      return RNSExtendedBlurEffectStyleSystemMaterial;
+      return RNSBlurEffectStyleSystemMaterial;
     case SystemThickMaterial:
-      return RNSExtendedBlurEffectStyleSystemThickMaterial;
+      return RNSBlurEffectStyleSystemThickMaterial;
     case SystemChromeMaterial:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterial;
+      return RNSBlurEffectStyleSystemChromeMaterial;
     case SystemUltraThinMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialLight;
+      return RNSBlurEffectStyleSystemUltraThinMaterialLight;
     case SystemThinMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemThinMaterialLight;
+      return RNSBlurEffectStyleSystemThinMaterialLight;
     case SystemMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemMaterialLight;
+      return RNSBlurEffectStyleSystemMaterialLight;
     case SystemThickMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemThickMaterialLight;
+      return RNSBlurEffectStyleSystemThickMaterialLight;
     case SystemChromeMaterialLight:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterialLight;
+      return RNSBlurEffectStyleSystemChromeMaterialLight;
     case SystemUltraThinMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemUltraThinMaterialDark;
+      return RNSBlurEffectStyleSystemUltraThinMaterialDark;
     case SystemThinMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemThinMaterialDark;
+      return RNSBlurEffectStyleSystemThinMaterialDark;
     case SystemMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemMaterialDark;
+      return RNSBlurEffectStyleSystemMaterialDark;
     case SystemThickMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemThickMaterialDark;
+      return RNSBlurEffectStyleSystemThickMaterialDark;
     case SystemChromeMaterialDark:
-      return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
+      return RNSBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
-      return RNSExtendedBlurEffectStyleNone;
+      return RNSBlurEffectStyleNone;
 #endif
   }
 }

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -129,7 +129,7 @@ RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlur
       return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
       return std::nullopt;
@@ -217,7 +217,7 @@ RNSExtendedBlurEffectStyle RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabB
       return RNSExtendedBlurEffectStyleSystemChromeMaterialDark;
     default:
       RCTLogError(@"[RNScreens] unsupported blur effect style");
-      return std::nullopt;
+      return RNSExtendedBlurEffectStyleNone;
 #else // !TARGET_OS_TV
     default:
       return std::nullopt;

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -10,14 +10,12 @@ namespace rnscreens::conversion {
 namespace react = facebook::react;
 
 std::optional<UIBlurEffectStyle>
-RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(
-    RNSExtendedBlurEffectStyle blurEffect);
+RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect);
 
-UIBlurEffect *RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(
-    RNSExtendedBlurEffectStyle blurEffect);
+UIBlurEffect *RNSUIBlurEffectFromRNSBlurEffectStyle(
+    RNSBlurEffectStyle blurEffect);
 
-RNSExtendedBlurEffectStyle
-RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
+RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
     react::RNSBottomTabsTabBarBlurEffect blurEffect);
 
 UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
@@ -36,8 +34,7 @@ std::optional<UIBlurEffectStyle>
 RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);
 
-RNSExtendedBlurEffectStyle
-RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
+RNSBlurEffectStyle RNSBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);
 
 UIOffset RNSBottomTabsScreenTabBarItemTitlePositionAdjustmentStruct(

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -9,19 +9,15 @@ namespace rnscreens::conversion {
 
 namespace react = facebook::react;
 
-#if !RCT_NEW_ARCH_ENABLED
 std::optional<UIBlurEffectStyle>
-RNSMaybeUIBlurEffectStyleFromRNSBlurEffectStyle(RNSBlurEffectStyle blurEffect);
+RNSMaybeUIBlurEffectStyleFromRNSExtendedBlurEffectStyle(
+    RNSExtendedBlurEffectStyle blurEffect);
 
-UIBlurEffect *RNSUIBlurEffectFromRNSBlurEffectStyle(
-    RNSBlurEffectStyle blurEffect);
-#endif // !RCT_NEW_ARCH_ENABLED
+UIBlurEffect *RNSUIBlurEffectFromRNSExtendedBlurEffectStyle(
+    RNSExtendedBlurEffectStyle blurEffect);
 
-std::optional<UIBlurEffectStyle>
-RNSMaybeUIBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
-    react::RNSBottomTabsTabBarBlurEffect blurEffect);
-
-UIBlurEffect *RNSUIBlurEffectFromRNSBottomTabsTabBarBlurEffect(
+RNSExtendedBlurEffectStyle
+RNSExtendedBlurEffectStyleFromRNSBottomTabsTabBarBlurEffect(
     react::RNSBottomTabsTabBarBlurEffect blurEffect);
 
 UIOffset RNSBottomTabsTabBarItemTitlePositionAdjustmentStruct(
@@ -40,7 +36,8 @@ std::optional<UIBlurEffectStyle>
 RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);
 
-UIBlurEffect *RNSUIBlurEffectFromRNSBottomTabsScreenTabBarBlurEffect(
+RNSExtendedBlurEffectStyle
+RNSExtendedBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(
     react::RNSBottomTabsScreenTabBarBlurEffect blurEffect);
 
 UIOffset RNSBottomTabsScreenTabBarItemTitlePositionAdjustmentStruct(

--- a/src/fabric/BottomTabsNativeComponent.ts
+++ b/src/fabric/BottomTabsNativeComponent.ts
@@ -21,6 +21,7 @@ export type NativeFocusChangeEvent = {
 
 export type BlurEffect =
   | 'none'
+  | 'default'
   | 'extraLight'
   | 'light'
   | 'dark'
@@ -61,7 +62,7 @@ export interface NativeProps extends ViewProps {
   // Appearance
   // tabBarAppearance?: TabBarAppearance; // Does not work due to codegen issue.
   tabBarBackgroundColor?: ColorValue;
-  tabBarBlurEffect?: WithDefault<BlurEffect, 'none'>;
+  tabBarBlurEffect?: WithDefault<BlurEffect, 'default'>;
   tabBarTintColor?: ColorValue;
 
   tabBarItemTitleFontFamily?: string;

--- a/src/fabric/BottomTabsNativeComponent.ts
+++ b/src/fabric/BottomTabsNativeComponent.ts
@@ -21,7 +21,7 @@ export type NativeFocusChangeEvent = {
 
 export type BlurEffect =
   | 'none'
-  | 'default'
+  | 'systemDefault'
   | 'extraLight'
   | 'light'
   | 'dark'
@@ -62,7 +62,7 @@ export interface NativeProps extends ViewProps {
   // Appearance
   // tabBarAppearance?: TabBarAppearance; // Does not work due to codegen issue.
   tabBarBackgroundColor?: ColorValue;
-  tabBarBlurEffect?: WithDefault<BlurEffect, 'default'>;
+  tabBarBlurEffect?: WithDefault<BlurEffect, 'systemDefault'>;
   tabBarTintColor?: ColorValue;
 
   tabBarItemTitleFontFamily?: string;

--- a/src/fabric/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/BottomTabsScreenNativeComponent.ts
@@ -25,6 +25,7 @@ export type LifecycleStateChangeEvent = Readonly<{
 
 export type BlurEffect =
   | 'none'
+  | 'default'
   | 'extraLight'
   | 'light'
   | 'dark'
@@ -61,7 +62,7 @@ export interface NativeProps extends ViewProps {
   // Tab Bar Appearance
   // tabBarAppearance?: TabBarAppearance; // Does not work due to codegen issue.
   tabBarBackgroundColor?: ColorValue;
-  tabBarBlurEffect?: WithDefault<BlurEffect, 'none'>;
+  tabBarBlurEffect?: WithDefault<BlurEffect, 'default'>;
 
   tabBarItemTitleFontFamily?: string;
   tabBarItemTitleFontSize?: Float;

--- a/src/fabric/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/BottomTabsScreenNativeComponent.ts
@@ -25,7 +25,7 @@ export type LifecycleStateChangeEvent = Readonly<{
 
 export type BlurEffect =
   | 'none'
-  | 'default'
+  | 'systemDefault'
   | 'extraLight'
   | 'light'
   | 'dark'
@@ -62,7 +62,7 @@ export interface NativeProps extends ViewProps {
   // Tab Bar Appearance
   // tabBarAppearance?: TabBarAppearance; // Does not work due to codegen issue.
   tabBarBackgroundColor?: ColorValue;
-  tabBarBlurEffect?: WithDefault<BlurEffect, 'default'>;
+  tabBarBlurEffect?: WithDefault<BlurEffect, 'systemDefault'>;
 
   tabBarItemTitleFontFamily?: string;
   tabBarItemTitleFontSize?: Float;


### PR DESCRIPTION
## Description

Adds support for `default` blur effect value.

Previously, `tabBarBlurEffect: 'none'` would enable default UIKit blur effect but this made disabling blur effect impossible. That's why we decided to add separate option for default value. Now, `none` disables the blur completely.

I decided to create new enum for blur styles instead of using previous one in order not to introduce any breaking changes for old stack implementation. When it gets removed, new enum can become the only one.

> [!IMPORTANT]
> UIKit's API allows setting appearance for host and tab bar items. This however seems problematic - deciding which and how properties are inherited. We think that this should be handled by the users of the library and `react-native-screens` should expose common appearance props only via screen component. This will be handled in another PR. Changes from this PR will work as expected after changing props inheritance behavior.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/108.

## Changes

- add `RNSExtendedBlurEffectStyle`
- update prop for Host and Screen component
- update appearance coordinator's logic to use new enum
- update conversion funcitons

## Test code and steps to reproduce

Run TestBottomTabs, add `tabBarBackgroundColor: 'transparent'`. Set `tabBarBlurEffect` to `none` or `default` (without any prop set on screen).

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
