### PR TITLE
fix(iOS, Paper, Tabs): fix badge value on iOS Paper

### DIFF
--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -84,7 +84,7 @@ namespace react = facebook::react;
 
   _overrideScrollViewContentInsetAdjustmentBehavior = YES;
   _isOverrideScrollViewContentInsetAdjustmentBehaviorSet = NO;
-  
+
   _iconType = RNSBottomTabsIconTypeSfSymbol;
 
   _iconImageSource = nil;
@@ -228,18 +228,18 @@ RNS_IGNORE_SUPER_CALL_END
         rnscreens::conversion::RCTImageSourceFromImageSourceAndIconType(&newComponentProps.iconImageSource, _iconType);
     tabItemNeedsAppearanceUpdate = YES;
   }
-  
+
   if (newComponentProps.iconSfSymbolName != oldComponentProps.iconSfSymbolName) {
     _iconSfSymbolName = RCTNSStringFromStringNilIfEmpty(newComponentProps.iconSfSymbolName);
     tabItemNeedsAppearanceUpdate = YES;
   }
 
   if (newComponentProps.selectedIconImageSource != oldComponentProps.selectedIconImageSource) {
-    _selectedIconImageSource =
-        rnscreens::conversion::RCTImageSourceFromImageSourceAndIconType(&newComponentProps.selectedIconImageSource, _iconType);
+    _selectedIconImageSource = rnscreens::conversion::RCTImageSourceFromImageSourceAndIconType(
+        &newComponentProps.selectedIconImageSource, _iconType);
     tabItemNeedsAppearanceUpdate = YES;
   }
-  
+
   if (newComponentProps.selectedIconSfSymbolName != oldComponentProps.selectedIconSfSymbolName) {
     _selectedIconSfSymbolName = RCTNSStringFromStringNilIfEmpty(newComponentProps.selectedIconSfSymbolName);
     tabItemNeedsAppearanceUpdate = YES;
@@ -358,6 +358,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)setBadgeValue:(NSString *)badgeValue
 {
   _badgeValue = [NSString rnscreens_stringOrNilIfBlank:badgeValue];
+  _controller.tabBarItem.badgeValue = _badgeValue;
 }
 
 - (void)setTabBarBackgroundColor:(UIColor *)tabBarBackgroundColor


### PR DESCRIPTION
## Description

Fixes missing badge values on iOS Paper.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/279.

## Changes

- update badge value in tab bar item when setting prop

## Test code and steps to reproduce

Run TestBottomTabs and verify if badges are visible.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
