### PR TITLE
refactor(iOS, SplitView): Add preferred prefix to some props

### DIFF
--- a/apps/src/tests/TestSplitView/index.tsx
+++ b/apps/src/tests/TestSplitView/index.tsx
@@ -13,8 +13,8 @@ import { SplitViewBaseConfig } from './helpers/types';
 
 const App = () => {
   const splitViewBaseConfig: SplitViewBaseConfig = {
-    displayMode: 'oneOverSecondary',
-    splitBehavior: 'overlay',
+    preferredDisplayMode: 'oneOverSecondary',
+    preferredSplitBehavior: 'overlay',
   }
 
   return (

--- a/ios/conversion/RNSConversions-SplitView.mm
+++ b/ios/conversion/RNSConversions-SplitView.mm
@@ -4,10 +4,10 @@ namespace rnscreens::conversion {
 
 #pragma mark SplitViewHost props
 
-UISplitViewControllerSplitBehavior SplitViewSplitBehaviorFromHostProp(
-    facebook::react::RNSSplitViewHostSplitBehavior splitBehavior)
+UISplitViewControllerSplitBehavior SplitViewPreferredSplitBehaviorFromHostProp(
+    facebook::react::RNSSplitViewHostPreferredSplitBehavior splitBehavior)
 {
-  using enum facebook::react::RNSSplitViewHostSplitBehavior;
+  using enum facebook::react::RNSSplitViewHostPreferredSplitBehavior;
 
   switch (splitBehavior) {
     case Displace:
@@ -36,10 +36,10 @@ UISplitViewControllerPrimaryEdge SplitViewPrimaryEdgeFromHostProp(
   }
 }
 
-UISplitViewControllerDisplayMode SplitViewDisplayModeFromHostProp(
-    facebook::react::RNSSplitViewHostDisplayMode displayMode)
+UISplitViewControllerDisplayMode SplitViewPreferredDisplayModeFromHostProp(
+    facebook::react::RNSSplitViewHostPreferredDisplayMode displayMode)
 {
-  using enum facebook::react::RNSSplitViewHostDisplayMode;
+  using enum facebook::react::RNSSplitViewHostPreferredDisplayMode;
 
   switch (displayMode) {
     case SecondaryOnly:

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -63,14 +63,14 @@ RCTImageSource *RCTImageSourceFromImageSourceAndIconType(
 
 #pragma mark SplitViewHost props
 
-UISplitViewControllerSplitBehavior SplitViewSplitBehaviorFromHostProp(
-    react::RNSSplitViewHostSplitBehavior behavior);
+UISplitViewControllerSplitBehavior SplitViewPreferredSplitBehaviorFromHostProp(
+    react::RNSSplitViewHostPreferredSplitBehavior behavior);
 
 UISplitViewControllerPrimaryEdge SplitViewPrimaryEdgeFromHostProp(
     react::RNSSplitViewHostPrimaryEdge primaryEdge);
 
-UISplitViewControllerDisplayMode SplitViewDisplayModeFromHostProp(
-    react::RNSSplitViewHostDisplayMode displayMode);
+UISplitViewControllerDisplayMode SplitViewPreferredDisplayModeFromHostProp(
+    react::RNSSplitViewHostPreferredDisplayMode displayMode);
 
 UISplitViewControllerDisplayModeButtonVisibility
 SplitViewDisplayModeButtonVisibilityFromHostProp(

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -18,8 +18,8 @@
 
   // Step 1 - general settings
   controller.displayModeButtonVisibility = splitView.displayModeButtonVisibility;
-  controller.preferredSplitBehavior = splitView.splitBehavior;
-  controller.preferredDisplayMode = splitView.displayMode;
+  controller.preferredSplitBehavior = splitView.preferredSplitBehavior;
+  controller.preferredDisplayMode = splitView.preferredDisplayMode;
   controller.presentsWithGesture = splitView.presentsWithGesture;
   controller.primaryEdge = splitView.primaryEdge;
   controller.showsSecondaryOnlyButton = splitView.showSecondaryToggleButton;

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -19,9 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSSplitViewHostComponentView ()
 
-@property (nonatomic, readonly) UISplitViewControllerSplitBehavior splitBehavior;
+@property (nonatomic, readonly) UISplitViewControllerSplitBehavior preferredSplitBehavior;
 @property (nonatomic, readonly) UISplitViewControllerPrimaryEdge primaryEdge;
-@property (nonatomic, readonly) UISplitViewControllerDisplayMode displayMode;
+@property (nonatomic, readonly) UISplitViewControllerDisplayMode preferredDisplayMode;
 @property (nonatomic, readonly) UISplitViewControllerDisplayModeButtonVisibility displayModeButtonVisibility;
 @property (nonatomic, readonly) BOOL presentsWithGesture;
 @property (nonatomic, readonly) BOOL showSecondaryToggleButton;

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -51,9 +51,9 @@ namespace react = facebook::react;
   static const auto defaultProps = std::make_shared<const react::RNSSplitViewHostProps>();
   _props = defaultProps;
 
-  _splitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
+  _preferredSplitBehavior = UISplitViewControllerSplitBehaviorAutomatic;
   _primaryEdge = UISplitViewControllerPrimaryEdgeLeading;
-  _displayMode = UISplitViewControllerDisplayModeAutomatic;
+  _preferredDisplayMode = UISplitViewControllerDisplayModeAutomatic;
   _displayModeButtonVisibility = UISplitViewControllerDisplayModeButtonVisibilityAutomatic;
   _presentsWithGesture = true;
   _showSecondaryToggleButton = false;
@@ -193,9 +193,10 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &oldComponentProps = *std::static_pointer_cast<const react::RNSSplitViewHostProps>(_props);
   const auto &newComponentProps = *std::static_pointer_cast<const react::RNSSplitViewHostProps>(props);
 
-  if (oldComponentProps.splitBehavior != newComponentProps.splitBehavior) {
+  if (oldComponentProps.preferredSplitBehavior != newComponentProps.preferredSplitBehavior) {
     _needsSplitViewAppearanceUpdate = true;
-    _splitBehavior = rnscreens::conversion::SplitViewSplitBehaviorFromHostProp(newComponentProps.splitBehavior);
+    _preferredSplitBehavior =
+        rnscreens::conversion::SplitViewPreferredSplitBehaviorFromHostProp(newComponentProps.preferredSplitBehavior);
   }
 
   if (oldComponentProps.primaryEdge != newComponentProps.primaryEdge) {
@@ -203,9 +204,10 @@ RNS_IGNORE_SUPER_CALL_END
     _primaryEdge = rnscreens::conversion::SplitViewPrimaryEdgeFromHostProp(newComponentProps.primaryEdge);
   }
 
-  if (oldComponentProps.displayMode != newComponentProps.displayMode) {
+  if (oldComponentProps.preferredDisplayMode != newComponentProps.preferredDisplayMode) {
     _needsSplitViewAppearanceUpdate = true;
-    _displayMode = rnscreens::conversion::SplitViewDisplayModeFromHostProp(newComponentProps.displayMode);
+    _preferredDisplayMode =
+        rnscreens::conversion::SplitViewPreferredDisplayModeFromHostProp(newComponentProps.preferredDisplayMode);
   }
 
   if (oldComponentProps.presentsWithGesture != newComponentProps.presentsWithGesture) {

--- a/src/components/gamma/SplitViewHost.tsx
+++ b/src/components/gamma/SplitViewHost.tsx
@@ -47,26 +47,26 @@ const isValidDisplayModeForSplitBehavior = (
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
 function SplitViewHost(props: SplitViewHostProps) {
-  const { displayMode, splitBehavior } = props;
+  const { preferredDisplayMode, preferredSplitBehavior } = props;
 
   React.useEffect(() => {
-    if (displayMode && splitBehavior) {
+    if (preferredDisplayMode && preferredSplitBehavior) {
       const isValid = isValidDisplayModeForSplitBehavior(
-        displayMode,
-        splitBehavior,
+        preferredDisplayMode,
+        preferredSplitBehavior,
       );
       if (!isValid) {
         const validDisplayModes =
-          displayModeForSplitViewCompatibilityMap[splitBehavior];
+          displayModeForSplitViewCompatibilityMap[preferredSplitBehavior];
         console.warn(
-          `Invalid display mode "${displayMode}" for split behavior "${splitBehavior}".` +
-            `\nValid modes for "${splitBehavior}" are: ${validDisplayModes.join(
+          `Invalid display mode "${preferredDisplayMode}" for split behavior "${preferredSplitBehavior}".` +
+            `\nValid modes for "${preferredSplitBehavior}" are: ${validDisplayModes.join(
               ', ',
             )}.`,
         );
       }
     }
-  }, [displayMode, splitBehavior]);
+  }, [preferredDisplayMode, preferredSplitBehavior]);
 
   return (
     <SplitViewHostNativeComponent {...props} style={styles.container}>

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -52,8 +52,8 @@ interface ColumnMetrics {
 export interface NativeProps extends ViewProps {
   // Appearance
 
-  displayMode?: WithDefault<SplitViewDisplayMode, 'automatic'>;
-  splitBehavior?: WithDefault<SplitViewSplitBehavior, 'automatic'>;
+  preferredDisplayMode?: WithDefault<SplitViewDisplayMode, 'automatic'>;
+  preferredSplitBehavior?: WithDefault<SplitViewSplitBehavior, 'automatic'>;
   primaryEdge?: WithDefault<SplitViewPrimaryEdge, 'leading'>;
   showSecondaryToggleButton?: WithDefault<boolean, false>;
   displayModeButtonVisibility?: WithDefault<


### PR DESCRIPTION
## Description

According to UIKit documentation, we don't set values for these two props directly - we're only instructing system to which value it should try to adapt. Renaming these props on our side to avoid any confusions.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/297 

## Changes

- Renamed props on JS and native side

## Test code and steps to reproduce

N/A, refactor

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
