### PR TITLE
feat(iOS, SplitView): Add support for fraction for columns widths

### DIFF
--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -5,11 +5,6 @@
 
 @implementation RNSSplitViewAppearanceCoordinator
 
-#define ASSIGN_PROP_IF_NONNEGATIVE(target, source, property) \
-  if ((source).property >= 0) {                              \
-    (target).property = (source).property;                   \
-  }
-
 - (void)updateAppearanceOfSplitView:(RNSSplitViewHostComponentView *_Nonnull)splitView
                      withController:(RNSSplitViewHostController *_Nonnull)controller
 {
@@ -25,27 +20,77 @@
   controller.showsSecondaryOnlyButton = splitView.showSecondaryToggleButton;
 
   // Step 2 - manipulating columns
-  [controller toggleSplitViewInspector:splitView.showInspector];
+  if (splitView.minimumPrimaryColumnWidth >= 0) {
+    controller.minimumPrimaryColumnWidth = splitView.minimumPrimaryColumnWidth;
+  }
 
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumPrimaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumPrimaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredPrimaryColumnWidth);
+  if (splitView.maximumPrimaryColumnWidth >= 0) {
+    controller.maximumPrimaryColumnWidth = splitView.maximumPrimaryColumnWidth;
+  }
 
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSupplementaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumSupplementaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSupplementaryColumnWidth);
+  if (splitView.preferredPrimaryColumnWidthOrFraction >= 0 && splitView.preferredPrimaryColumnWidthOrFraction < 1) {
+    controller.preferredPrimaryColumnWidthFraction = splitView.preferredPrimaryColumnWidthOrFraction;
+  } else if (splitView.preferredSupplementaryColumnWidthOrFraction >= 1) {
+    controller.preferredPrimaryColumnWidth = splitView.preferredPrimaryColumnWidthOrFraction;
+  }
+
+  if (splitView.minimumSupplementaryColumnWidth >= 0) {
+    controller.minimumSupplementaryColumnWidth = splitView.minimumSupplementaryColumnWidth;
+  }
+
+  if (splitView.maximumSupplementaryColumnWidth >= 0) {
+    controller.maximumSupplementaryColumnWidth = splitView.maximumSupplementaryColumnWidth;
+  }
+
+  if (splitView.preferredSupplementaryColumnWidthOrFraction >= 0 &&
+      splitView.preferredSupplementaryColumnWidthOrFraction < 1) {
+    controller.preferredSupplementaryColumnWidthFraction = splitView.preferredSupplementaryColumnWidthOrFraction;
+  } else if (splitView.preferredSupplementaryColumnWidthOrFraction >= 1) {
+    controller.preferredSupplementaryColumnWidth = splitView.preferredSupplementaryColumnWidthOrFraction;
+  }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumSecondaryColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredSecondaryColumnWidth);
+  if (splitView.minimumSecondaryColumnWidth >= 0) {
+    if (@available(iOS 26.0, *)) {
+      controller.minimumSecondaryColumnWidth = splitView.minimumSecondaryColumnWidth;
+    }
+  }
 
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, minimumInspectorColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, maximumInspectorColumnWidth);
-  ASSIGN_PROP_IF_NONNEGATIVE(controller, splitView, preferredInspectorColumnWidth);
+  if (splitView.preferredSecondaryColumnWidthOrFraction >= 0 && splitView.preferredSecondaryColumnWidthOrFraction < 1) {
+    if (@available(iOS 26.0, *)) {
+      controller.preferredSecondaryColumnWidthFraction = splitView.preferredSecondaryColumnWidthOrFraction;
+    }
+  } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
+    if (@available(iOS 26.0, *)) {
+      controller.preferredSecondaryColumnWidth = splitView.preferredSecondaryColumnWidthOrFraction;
+    }
+  }
+
+  if (splitView.minimumInspectorColumnWidth >= 0) {
+    if (@available(iOS 26.0, *)) {
+      controller.minimumInspectorColumnWidth = splitView.minimumInspectorColumnWidth;
+    }
+  }
+
+  if (splitView.maximumInspectorColumnWidth >= 0) {
+    if (@available(iOS 26.0, *)) {
+      controller.maximumInspectorColumnWidth = splitView.maximumInspectorColumnWidth;
+    }
+  }
+
+  if (splitView.preferredInspectorColumnWidthOrFraction >= 0 && splitView.preferredInspectorColumnWidthOrFraction < 1) {
+    if (@available(iOS 26.0, *)) {
+      controller.preferredInspectorColumnWidthFraction = splitView.preferredInspectorColumnWidthOrFraction;
+    }
+  } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
+    if (@available(iOS 26.0, *)) {
+      controller.preferredInspectorColumnWidth = splitView.preferredInspectorColumnWidthOrFraction;
+    }
+  }
 #endif
+    
+  [controller toggleSplitViewInspector:splitView.showInspector];
 }
-
-#undef ASSIGN_PROP_IF_NONNEGATIVE
 
 @end

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -51,45 +51,35 @@
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
-  if (splitView.minimumSecondaryColumnWidth >= 0) {
-    if (@available(iOS 26.0, *)) {
+  if (@available(iOS 26.0, *)) {
+    if (splitView.minimumSecondaryColumnWidth >= 0) {
       controller.minimumSecondaryColumnWidth = splitView.minimumSecondaryColumnWidth;
     }
-  }
 
-  if (splitView.preferredSecondaryColumnWidthOrFraction >= 0 && splitView.preferredSecondaryColumnWidthOrFraction < 1) {
-    if (@available(iOS 26.0, *)) {
+    if (splitView.preferredSecondaryColumnWidthOrFraction >= 0 &&
+        splitView.preferredSecondaryColumnWidthOrFraction < 1) {
       controller.preferredSecondaryColumnWidthFraction = splitView.preferredSecondaryColumnWidthOrFraction;
-    }
-  } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
-    if (@available(iOS 26.0, *)) {
+    } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
       controller.preferredSecondaryColumnWidth = splitView.preferredSecondaryColumnWidthOrFraction;
     }
-  }
 
-  if (splitView.minimumInspectorColumnWidth >= 0) {
-    if (@available(iOS 26.0, *)) {
+    if (splitView.minimumInspectorColumnWidth >= 0) {
       controller.minimumInspectorColumnWidth = splitView.minimumInspectorColumnWidth;
     }
-  }
 
-  if (splitView.maximumInspectorColumnWidth >= 0) {
-    if (@available(iOS 26.0, *)) {
+    if (splitView.maximumInspectorColumnWidth >= 0) {
       controller.maximumInspectorColumnWidth = splitView.maximumInspectorColumnWidth;
     }
-  }
 
-  if (splitView.preferredInspectorColumnWidthOrFraction >= 0 && splitView.preferredInspectorColumnWidthOrFraction < 1) {
-    if (@available(iOS 26.0, *)) {
+    if (splitView.preferredInspectorColumnWidthOrFraction >= 0 &&
+        splitView.preferredInspectorColumnWidthOrFraction < 1) {
       controller.preferredInspectorColumnWidthFraction = splitView.preferredInspectorColumnWidthOrFraction;
-    }
-  } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
-    if (@available(iOS 26.0, *)) {
+    } else if (splitView.preferredInspectorColumnWidthOrFraction >= 1) {
       controller.preferredInspectorColumnWidth = splitView.preferredInspectorColumnWidthOrFraction;
     }
   }
 #endif
-    
+
   [controller toggleSplitViewInspector:splitView.showInspector];
 }
 

--- a/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
+++ b/ios/gamma/split-view/RNSSplitViewAppearanceCoordinator.mm
@@ -20,6 +20,22 @@
   controller.showsSecondaryOnlyButton = splitView.showSecondaryToggleButton;
 
   // Step 2 - manipulating columns
+  // Step 2.1 - validating column constraints
+
+  [self validateColumnConstraintsWithMinWidth:splitView.minimumPrimaryColumnWidth
+                                     maxWidth:splitView.maximumPrimaryColumnWidth];
+  [self validateColumnConstraintsWithMinWidth:splitView.minimumSupplementaryColumnWidth
+                                     maxWidth:splitView.maximumSupplementaryColumnWidth];
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (@available(iOS 26.0, *)) {
+    [self validateColumnConstraintsWithMinWidth:splitView.minimumInspectorColumnWidth
+                                       maxWidth:splitView.maximumInspectorColumnWidth];
+  }
+#endif
+
+  // Step 2.2 - applying updates
   if (splitView.minimumPrimaryColumnWidth >= 0) {
     controller.minimumPrimaryColumnWidth = splitView.minimumPrimaryColumnWidth;
   }
@@ -81,6 +97,15 @@
 #endif
 
   [controller toggleSplitViewInspector:splitView.showInspector];
+}
+
+- (void)validateColumnConstraintsWithMinWidth:(CGFloat)minWidth maxWidth:(CGFloat)maxWidth
+{
+  RCTAssert(
+      minWidth <= maxWidth,
+      @"[RNScreens] SplitView column constraints are invalid: minWidth %f cannot be greater that maxWidth %f",
+      minWidth,
+      maxWidth);
 }
 
 @end

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -29,18 +29,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) int minimumPrimaryColumnWidth;
 @property (nonatomic, readonly) int maximumPrimaryColumnWidth;
-@property (nonatomic, readonly) int preferredPrimaryColumnWidth;
+@property (nonatomic, readonly) double preferredPrimaryColumnWidthOrFraction;
 @property (nonatomic, readonly) int minimumSupplementaryColumnWidth;
 @property (nonatomic, readonly) int maximumSupplementaryColumnWidth;
-@property (nonatomic, readonly) int preferredSupplementaryColumnWidth;
+@property (nonatomic, readonly) double preferredSupplementaryColumnWidthOrFraction;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
 @property (nonatomic, readonly) int minimumSecondaryColumnWidth;
-@property (nonatomic, readonly) int preferredSecondaryColumnWidth;
+@property (nonatomic, readonly) double preferredSecondaryColumnWidthOrFraction;
 @property (nonatomic, readonly) int minimumInspectorColumnWidth;
 @property (nonatomic, readonly) int maximumInspectorColumnWidth;
-@property (nonatomic, readonly) int preferredInspectorColumnWidth;
+@property (nonatomic, readonly) double preferredInspectorColumnWidthOrFraction;
 #endif
 
 @end

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -11,6 +11,8 @@
 
 namespace react = facebook::react;
 
+static const CGFloat epsilon = 1e-6;
+
 @interface RNSSplitViewHostComponentView () <RCTMountingTransactionObserving>
 @end
 
@@ -61,18 +63,18 @@ namespace react = facebook::react;
 
   _minimumPrimaryColumnWidth = -1;
   _maximumPrimaryColumnWidth = -1;
-  _preferredPrimaryColumnWidth = -1;
+  _preferredPrimaryColumnWidthOrFraction = -1.0;
   _minimumSupplementaryColumnWidth = -1;
   _maximumSupplementaryColumnWidth = -1;
-  _preferredSupplementaryColumnWidth = -1;
+  _preferredSupplementaryColumnWidthOrFraction = -1.0;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
   _minimumSecondaryColumnWidth = -1;
-  _preferredSecondaryColumnWidth = -1;
+  _preferredSecondaryColumnWidthOrFraction = -1.0;
   _minimumInspectorColumnWidth = -1;
   _maximumInspectorColumnWidth = -1;
-  _preferredInspectorColumnWidth = -1;
+  _preferredInspectorColumnWidthOrFraction = -1.0;
 #endif
 
   _isShowSecondaryToggleButtonSet = false;
@@ -242,10 +244,11 @@ RNS_IGNORE_SUPER_CALL_END
     _maximumPrimaryColumnWidth = newComponentProps.columnMetrics.maximumPrimaryColumnWidth;
   }
 
-  if (oldComponentProps.columnMetrics.preferredPrimaryColumnWidth !=
-      newComponentProps.columnMetrics.preferredPrimaryColumnWidth) {
+  if (fabs(
+          oldComponentProps.columnMetrics.preferredPrimaryColumnWidthOrFraction -
+          newComponentProps.columnMetrics.preferredPrimaryColumnWidthOrFraction) > epsilon) {
     _needsSplitViewAppearanceUpdate = true;
-    _preferredPrimaryColumnWidth = newComponentProps.columnMetrics.preferredPrimaryColumnWidth;
+    _preferredPrimaryColumnWidthOrFraction = newComponentProps.columnMetrics.preferredPrimaryColumnWidthOrFraction;
   }
 
   if (oldComponentProps.columnMetrics.minimumSupplementaryColumnWidth !=
@@ -260,10 +263,12 @@ RNS_IGNORE_SUPER_CALL_END
     _maximumSupplementaryColumnWidth = newComponentProps.columnMetrics.maximumSupplementaryColumnWidth;
   }
 
-  if (oldComponentProps.columnMetrics.preferredSupplementaryColumnWidth !=
-      newComponentProps.columnMetrics.preferredSupplementaryColumnWidth) {
+  if (fabs(
+          oldComponentProps.columnMetrics.preferredSupplementaryColumnWidthOrFraction -
+          newComponentProps.columnMetrics.preferredSupplementaryColumnWidthOrFraction) > epsilon) {
     _needsSplitViewAppearanceUpdate = true;
-    _preferredSupplementaryColumnWidth = newComponentProps.columnMetrics.preferredSupplementaryColumnWidth;
+    _preferredSupplementaryColumnWidthOrFraction =
+        newComponentProps.columnMetrics.preferredSupplementaryColumnWidthOrFraction;
   }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
@@ -274,10 +279,11 @@ RNS_IGNORE_SUPER_CALL_END
     _minimumSecondaryColumnWidth = newComponentProps.columnMetrics.minimumSecondaryColumnWidth;
   }
 
-  if (oldComponentProps.columnMetrics.preferredSecondaryColumnWidth !=
-      newComponentProps.columnMetrics.preferredSecondaryColumnWidth) {
+  if (fabs(
+          oldComponentProps.columnMetrics.preferredSecondaryColumnWidthOrFraction -
+          newComponentProps.columnMetrics.preferredSecondaryColumnWidthOrFraction) > epsilon) {
     _needsSplitViewAppearanceUpdate = true;
-    _preferredSecondaryColumnWidth = newComponentProps.columnMetrics.preferredSecondaryColumnWidth;
+    _preferredSecondaryColumnWidthOrFraction = newComponentProps.columnMetrics.preferredSecondaryColumnWidthOrFraction;
   }
 
   if (oldComponentProps.columnMetrics.minimumInspectorColumnWidth !=
@@ -292,10 +298,11 @@ RNS_IGNORE_SUPER_CALL_END
     _maximumInspectorColumnWidth = newComponentProps.columnMetrics.maximumInspectorColumnWidth;
   }
 
-  if (oldComponentProps.columnMetrics.preferredInspectorColumnWidth !=
-      newComponentProps.columnMetrics.preferredInspectorColumnWidth) {
+  if (fabs(
+          oldComponentProps.columnMetrics.preferredInspectorColumnWidthOrFraction -
+          newComponentProps.columnMetrics.preferredInspectorColumnWidthOrFraction) > epsilon) {
     _needsSplitViewAppearanceUpdate = true;
-    _preferredInspectorColumnWidth = newComponentProps.columnMetrics.preferredInspectorColumnWidth;
+    _preferredInspectorColumnWidthOrFraction = newComponentProps.columnMetrics.preferredInspectorColumnWidthOrFraction;
   }
 #endif
 

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -4,6 +4,7 @@ import type { ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {
   DirectEventHandler,
+  Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
@@ -36,17 +37,17 @@ export type SplitViewDisplayMode =
 interface ColumnMetrics {
   minimumPrimaryColumnWidth?: WithDefault<Int32, -1>;
   maximumPrimaryColumnWidth?: WithDefault<Int32, -1>;
-  preferredPrimaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredPrimaryColumnWidthOrFraction?: WithDefault<Float, -1.0>;
   minimumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
   maximumSupplementaryColumnWidth?: WithDefault<Int32, -1>;
-  preferredSupplementaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredSupplementaryColumnWidthOrFraction?: WithDefault<Float, -1.0>;
 
   // iOS 26 only
   minimumSecondaryColumnWidth?: WithDefault<Int32, -1>;
-  preferredSecondaryColumnWidth?: WithDefault<Int32, -1>;
+  preferredSecondaryColumnWidthOrFraction?: WithDefault<Float, -1.0>;
   minimumInspectorColumnWidth?: WithDefault<Int32, -1>;
   maximumInspectorColumnWidth?: WithDefault<Int32, -1>;
-  preferredInspectorColumnWidth?: WithDefault<Int32, -1>;
+  preferredInspectorColumnWidthOrFraction?: WithDefault<Float, -1.0>;
 }
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
## Description

In this PR I'm covering UISplitViewController APIs `preferred[ColumnType]ColumnWidthFraction`. As we discussed internally, we should try to cover it as the same prop for both fraction and points. This is slightly different from the Apple approach which has both versions separated, maintaining two props: `preferred[ColumnType]ColumnWidth` and `preferred[ColumnType]ColumnWidthFraction`.

In our case, if the value passed is between 0 and 1 - we're interpreting it as a fraction and for any value greater than 1, we're using points.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/296 

## Changes

- Updated `preferredColumnWidth` definitions to cover floats.
- Updated appearance coordinator to cover fractions.
- Updated prop definition in the host component.

## Screenshots / GIFs

https://github.com/user-attachments/assets/07ef660c-f74e-4bc8-b855-8d197e4db840

## Test code and steps to reproduce

Updated example for SplitView for testing this API

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
