### PR TITLE
fix(iOS, SplitView): Fix SplitViewHostController initialization

### DIFF
--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -87,12 +87,11 @@ namespace react = facebook::react;
   return numberOfColumns;
 }
 
-- (void)setupControllerIfNeeded
+- (void)setupController
 {
   // Controller needs to know about the number of reactSubviews before its initialization to pass proper number of
-  // columns to the constructor. Therefore, we must delay it's creation until updating Host's props.
-  // At this point, children screens are already attached to the Host component, therefore, we may create SplitView
-  // controller.
+  // columns to the constructor. Therefore, we must delay it's creation until attaching it to window.
+  // At this point, children are already attached to the Host component, therefore, we may create SplitView controller.
   if (_controller == nil) {
     int numberOfColumns = [self getNumberOfColumns];
 
@@ -103,8 +102,9 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
+  [self setupController];
   RCTAssert(_controller != nil, @"[RNScreens] Controller must not be nil while attaching to window");
-
+  [self requestSplitViewHostControllerForAppearanceUpdate];
   [self reactAddControllerToClosestParent:_controller];
 }
 
@@ -309,13 +309,16 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
-  if (_needsSplitViewAppearanceUpdate) {
-    [self setupControllerIfNeeded];
+  [self requestSplitViewHostControllerForAppearanceUpdate];
+  [super finalizeUpdates:updateMask];
+}
 
+- (void)requestSplitViewHostControllerForAppearanceUpdate
+{
+  if (_needsSplitViewAppearanceUpdate && _controller != nil) {
     _needsSplitViewAppearanceUpdate = false;
     [_controller setNeedsAppearanceUpdate];
   }
-  [super finalizeUpdates:updateMask];
 }
 
 #pragma mark - RCTMountingTransactionObserving


### PR DESCRIPTION
## Description

Initializing Host controller on `didMoveToWindow` is causing in losing some updates when the appearance coordinator was called earlier from `finalizeUpdates`. Props on the native side were already set, the native state was invalidated, but the appearance coordinator was skipped, because controller wasn't initialized at this point.

## Changes

- Updated a logic to consume appearance updates only after the controller was initialized.

## Test code and steps to reproduce

Verified that the current app sets all props properly.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
