### PR TITLE
refactor(Android): rewrite tab update logic

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -471,22 +471,15 @@ class TabsHost(
             return
         }
 
-        if (oldFocusedTab == null) {
-            requireFragmentManager
-                .beginTransaction()
-                .setReorderingAllowed(true)
-                .apply {
-                    this.add(contentView.id, newFocusedTab)
-                }.commitNowAllowingStateLoss()
-        } else {
-            requireFragmentManager
-                .beginTransaction()
-                .setReorderingAllowed(true)
-                .apply {
+        requireFragmentManager
+            .beginTransaction()
+            .setReorderingAllowed(true)
+            .apply {
+                if (oldFocusedTab != null) {
                     this.remove(oldFocusedTab)
-                    this.add(contentView.id, newFocusedTab)
-                }.commitNowAllowingStateLoss()
-        }
+                }
+                this.add(contentView.id, newFocusedTab)
+            }.commitNowAllowingStateLoss()
     }
 
     private val layoutCallback =


### PR DESCRIPTION
## Description

I find it notoriously hard to read, therefore decided to refactor it a
bit.

## Changes

Just put the decision, whether to detach previous tab into the transaction configuration block.

## Test code and steps to reproduce

Bottom tabs implementation `TestBottomTabs` should work exactly the same.

## Checklist

- [ ] Ensured that CI passes

