### PR TITLE
feat(iOS, Paper, Tabs): add support for tabBarMinimizeBehavior on Paper

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -129,3 +129,12 @@ typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeTemplate,
   RNSBottomTabsIconTypeSfSymbol,
 };
+
+#if !RCT_NEW_ARCH_ENABLED
+typedef NS_ENUM(NSInteger, RNSTabBarMinimizeBehavior) {
+  RNSTabBarMinimizeBehaviorAutomatic,
+  RNSTabBarMinimizeBehaviorNever,
+  RNSTabBarMinimizeBehaviorOnScrollDown,
+  RNSTabBarMinimizeBehaviorOnScrollUp,
+};
+#endif

--- a/ios/bottom-tabs/RCTConvert+RNSBottomTabs.mm
+++ b/ios/bottom-tabs/RCTConvert+RNSBottomTabs.mm
@@ -10,15 +10,25 @@
 }
 
 RCT_ENUM_CONVERTER(
-  RNSBottomTabsIconType,
-  (@{
-    @"image": @(RNSBottomTabsIconTypeImage),
-    @"template": @(RNSBottomTabsIconTypeTemplate),
-    @"sfSymbol": @(RNSBottomTabsIconTypeSfSymbol),
-  }),
-  RNSBottomTabsIconTypeSfSymbol,
-  integerValue
-)
+    RNSBottomTabsIconType,
+    (@{
+      @"image" : @(RNSBottomTabsIconTypeImage),
+      @"template" : @(RNSBottomTabsIconTypeTemplate),
+      @"sfSymbol" : @(RNSBottomTabsIconTypeSfSymbol),
+    }),
+    RNSBottomTabsIconTypeSfSymbol,
+    integerValue)
+
+RCT_ENUM_CONVERTER(
+    RNSTabBarMinimizeBehavior,
+    (@{
+      @"automatic" : @(RNSTabBarMinimizeBehaviorAutomatic),
+      @"never" : @(RNSTabBarMinimizeBehaviorNever),
+      @"onScrollDown" : @(RNSTabBarMinimizeBehaviorOnScrollDown),
+      @"onScrollUp" : @(RNSTabBarMinimizeBehaviorOnScrollUp),
+    }),
+    RNSTabBarMinimizeBehaviorAutomatic,
+    integerValue)
 
 @end
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -261,7 +261,7 @@ namespace react = facebook::react;
         newComponentProps.tabBarItemTitlePositionAdjustment);
     _needsTabBarAppearanceUpdate = YES;
   }
-  
+
   if (newComponentProps.tabBarMinimizeBehavior != oldComponentProps.tabBarMinimizeBehavior) {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
@@ -474,6 +474,23 @@ RNS_IGNORE_SUPER_CALL_END
 {
   _tabBarItemTitlePositionAdjustment = tabBarItemTitlePositionAdjustment;
   [self invalidateTabBarAppearance];
+}
+
+// This is a Paper-only setter method that will be called by the mounting code.
+// It allows us to store UITabBarMinimizeBehavior in the component while accepting a custom enum as input from JS.
+- (void)setTabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior:(RNSTabBarMinimizeBehavior)tabBarMinimizeBehavior
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (@available(iOS 26.0, *)) {
+    _tabBarMinimizeBehavior =
+        rnscreens::conversion::UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(tabBarMinimizeBehavior);
+    _controller.tabBarMinimizeBehavior = _tabBarMinimizeBehavior;
+  } else
+#endif // Check for iOS >= 26
+    if (tabBarMinimizeBehavior != RNSTabBarMinimizeBehaviorAutomatic) {
+      RCTLogWarn(@"[RNScreens] tabBarMinimizeBehavior is supported for iOS >= 26");
+    }
 }
 
 - (void)setOnNativeFocusChange:(RCTDirectEventBlock)onNativeFocusChange

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentViewManager.mm
@@ -39,6 +39,13 @@ RCT_EXPORT_VIEW_PROPERTY(tabBarItemBadgeBackgroundColor, UIColor);
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarItemTitlePositionAdjustment, UIOffset);
 
+// This remapping allows us to store UITabBarMinimizeBehavior in the component while accepting a custom enum as input
+// from JS.
+RCT_REMAP_VIEW_PROPERTY(
+    tabBarMinimizeBehavior,
+    tabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior,
+    RNSTabBarMinimizeBehavior);
+
 // TODO: Missing prop
 //@property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
 

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -166,6 +166,25 @@ UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimize
       return UITabBarMinimizeBehaviorAutomatic;
   }
 }
+
+#if !RCT_NEW_ARCH_ENABLED
+API_AVAILABLE(ios(26.0))
+UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(
+    RNSTabBarMinimizeBehavior tabBarMinimizeBehavior)
+{
+  switch (tabBarMinimizeBehavior) {
+    case RNSTabBarMinimizeBehaviorNever:
+      return UITabBarMinimizeBehaviorNever;
+    case RNSTabBarMinimizeBehaviorOnScrollDown:
+      return UITabBarMinimizeBehaviorOnScrollDown;
+    case RNSTabBarMinimizeBehaviorOnScrollUp:
+      return UITabBarMinimizeBehaviorOnScrollUp;
+    default:
+      return UITabBarMinimizeBehaviorAutomatic;
+  }
+}
+#endif // !RCT_NEW_ARCH_ENABLED
+
 #endif // Check for iOS >= 26
 
 std::optional<UIBlurEffectStyle> RNSMaybeUIBlurEffectStyleFromRNSBottomTabsScreenTabBarBlurEffect(

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -34,6 +34,13 @@ API_AVAILABLE(ios(26.0))
 UITabBarMinimizeBehavior
 UITabBarMinimizeBehaviorFromRNSBottomTabsTabBarMinimizeBehavior(
     react::RNSBottomTabsTabBarMinimizeBehavior tabBarMinimizeBehavior);
+
+#if !RCT_NEW_ARCH_ENABLED
+API_AVAILABLE(ios(26.0))
+UITabBarMinimizeBehavior UITabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior(
+    RNSTabBarMinimizeBehavior tabBarMinimizeBehavior);
+#endif // !RCT_NEW_ARCH_ENABLED
+
 #endif // Check for iOS >= 26
 
 std::optional<UIBlurEffectStyle>


### PR DESCRIPTION
## Description

Adds support for `tabBarMinimizeBehavior` on Paper.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/308.

## Changes

- add `RNSTabBarMinimizeBehavior` for Paper to allow the same prop setting logic as Fabric
- add conversions
- export property

## Test code and steps to reproduce

Run TestBottomTabs on Paper, open Tab3, scroll down. On iOS 26, tab bar should hide. On iOS versions prior to 26, there should be a warning in the logs.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
