### PR TITLE
fix(Android, Tabs): add missing paper annotations 

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -144,6 +144,7 @@ class TabScreenViewManager :
         view.tabKey = value
     }
 
+    @ReactProp(name = "badgeValue")
     override fun setBadgeValue(
         view: TabScreen,
         value: String?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -98,6 +98,7 @@ class TabsHostViewManager :
         value: Boolean,
     ) = Unit
 
+    @ReactProp(name = "tabBarItemTitleFontFamily")
     override fun setTabBarItemTitleFontFamily(
         view: TabsHost,
         value: String?,
@@ -105,6 +106,7 @@ class TabsHostViewManager :
         view.tabBarItemTitleFontFamily = value
     }
 
+    @ReactProp(name = "tabBarItemTitleFontWeight")
     override fun setTabBarItemTitleFontWeight(
         view: TabsHost,
         value: String?,
@@ -112,6 +114,7 @@ class TabsHostViewManager :
         view.tabBarItemTitleFontWeight = value
     }
 
+    @ReactProp(name = "tabBarItemTitleFontStyle")
     override fun setTabBarItemTitleFontStyle(
         view: TabsHost,
         value: String?,


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/287

This PR fixes not working styles by adding missing paper annotations


## Screenshots / GIFs

|Fabric|Paper|
|-|-|
|<video src="https://github.com/user-attachments/assets/b6790b07-f1dd-4262-850f-20857d5be5a9"/>|<video src="https://github.com/user-attachments/assets/be25c370-de26-4524-9a28-571a50d886fe"/>| 

## Test code and steps to reproduce

See `TestBottomTabs/index.tsx`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes 