### PR TITLE
feat(iOS, Tabs): enable scrollToTop for screens other than root when popToRoot is disabled

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -162,9 +162,7 @@ namespace react = facebook::react;
   if ([[self viewControllers] count] > 1 &&
       tabScreenController.tabScreenComponentView.shouldUseRepeatedTabSelectionPopToRootSpecialEffect) {
     return [[self popToRootViewControllerAnimated:true] count] > 0;
-  } else if (
-      [[self viewControllers] count] == 1 &&
-      tabScreenController.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
+  } else if (tabScreenController.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
     UIScrollView *scrollView =
         [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:[[self topViewController] view]];
     return [scrollView rnscreens_scrollToTop];


### PR DESCRIPTION
## Description

Removes guard that prevented scrollToTop from working for screens other than root when popToRoot is disabled.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/306.

## Changes

- remove stack screens count check for scrollToTop special effect

## Test code and steps to reproduce

Open Tab4 in TestBottomTabs, disable popToRoot special effect, push some screens to the stack, scroll down, click on Tab4 tab bar item. ScrollView should scroll to top.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
