### PR TITLE
feat(Example): Fix sorting for multiple tests with same issue number

### DIFF
--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -149,12 +149,16 @@ if (isTestSectionEnabled()) {
 const screens = Object.keys(SCREENS);
 const examples = screens.filter(name => SCREENS[name].type === 'example');
 const playgrounds = screens.filter(name => SCREENS[name].type === 'playground');
+const issueRegex = /Test(?<issue>\d+)(?<case>.*)/
 const tests = isTestSectionEnabled()
   ? screens
     .filter(name => SCREENS[name].type === 'test')
     .sort((name1, name2) => {
-      const testNumber1 = Number(name1.substring(4));
-      const testNumber2 = Number(name2.substring(4));
+      const spec1 = issueRegex.exec(name1)?.groups
+      const spec2 = issueRegex.exec(name2)?.groups
+
+      const testNumber1 = parseInt(spec1?.issue as string)
+      const testNumber2 = parseInt(spec2?.issue as string)
 
       if (Number.isNaN(testNumber1) && Number.isNaN(testNumber2)) {
         return 0;
@@ -162,8 +166,10 @@ const tests = isTestSectionEnabled()
         return 1;
       } else if (Number.isNaN(testNumber2)) {
         return -1;
-      } else {
+      } else if (testNumber1 !== testNumber2) {
         return testNumber1 - testNumber2;
+      } else {
+        return (spec1?.case as string) < (spec2?.case as string) ? 0 : 1
       }
     })
   : [];

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -168,8 +168,10 @@ const tests = isTestSectionEnabled()
         return -1;
       } else if (testNumber1 !== testNumber2) {
         return testNumber1 - testNumber2;
+      } else if ((spec1?.case as string) < (spec2?.case as string)) {
+        return -1;
       } else {
-        return (spec1?.case as string) < (spec2?.case as string) ? 0 : 1
+        return (spec1?.case as string) > (spec2?.case as string) ? 1 : 0;
       }
     })
   : [];


### PR DESCRIPTION
## Description

Currently, we write tests as issue reproductions which we name Test<issue number> - one for each issue, and more general tests/examples which we name as Test<descriptive name>. In order to have the former sorted correctly, we need to stick to the scheme and not have anything non-digit after issue number.

We can change the sorting logic to make it possible to define Test123_1 and Test123_2.

## Changes

Implementation of sort function that understands names like Test123_1