### PR TITLE
fix: Remove newly added logs from user land

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -118,14 +118,6 @@ void RNSScreenShadowNode::appendChild(const ShadowNode::Shared &child) {
 void RNSScreenShadowNode::layout(facebook::react::LayoutContext layoutContext) {
   YogaLayoutableShadowNode::layout(layoutContext);
 
-  std::printf(
-      "ScreenSN [%d] layout {{%.2lf, %.2lf}, {%.2lf, %.2lf}}\n",
-      getTag(),
-      layoutMetrics_.frame.origin.x,
-      layoutMetrics_.frame.origin.y,
-      layoutMetrics_.frame.size.width,
-      layoutMetrics_.frame.size.height);
-
 #ifdef ANDROID
   applyFrameCorrections();
 #endif // ANDROID

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1166,18 +1166,6 @@ RNS_IGNORE_SUPER_CALL_END
 
 #endif // !TARGET_OS_TV && !TARGET_OS_VISION
 
-- (void)setFrame:(CGRect)frame
-{
-  NSLog(@"ScreenView [%ld] setFrame: %@", self.tag, NSStringFromCGRect(frame));
-  [super setFrame:frame];
-}
-
-- (void)setBounds:(CGRect)bounds
-{
-  NSLog(@"ScreenView [%ld] setBounds: %@", self.tag, NSStringFromCGRect(bounds));
-  [super setBounds:bounds];
-}
-
 #pragma mark - RNSScrollViewBehaviorOverriding
 
 - (BOOL)shouldOverrideScrollViewContentInsetAdjustmentBehavior


### PR DESCRIPTION
## Description
When upgrading `react-native-screens` to `4.13.x` the app starts to output debug logs from `react-native-screens`:

```
[App.debug.dylib] ScreenView [0] setFrame: {{0, 0}, {0, 0}}
[App.debug.dylib] ScreenView [102] setBounds: {{0, 0}, {440, 956}}
[App.debug.dylib] ScreenView [102] setFrame: {{0, 0}, {440, 956}}
```

They seem to have been introduces in this change: https://github.com/software-mansion/react-native-screens/commit/896c2c6ef83941afb9d1146d5c7e510623e5fc64

This PR fixes #3066 🥳 

## Changes
 - Removed NSLog statements from `iOS/RNSScreen.mm`
 - Removed NSLog statements from `ios/bottom-tabs/*`

## Test code and steps to reproduce

It seems to just be NSlog-statements left in the code by mistake. Reply if you need a reproduction app.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
