### PR TITLE
chore(Android, Tabs): document props for android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -148,6 +148,11 @@ class TabsHostViewManager :
         view.tabBarItemIconColor = value
     }
 
+    override fun setTabBarMinimizeBehavior(
+        view: TabsHost,
+        value: String?,
+    ) = Unit
+
     // Android additional
 
     @ReactProp(name = "tabBarItemTitleFontColorActive", customType = "Color")
@@ -197,11 +202,6 @@ class TabsHostViewManager :
     ) {
         view.tabBarItemRippleColor = value
     }
-
-    override fun setTabBarMinimizeBehavior(
-        view: TabsHost,
-        value: String?,
-    ) = Unit
 
     @ReactProp(name = "tabBarItemLabelVisibilityMode")
     override fun setTabBarItemLabelVisibilityMode(

--- a/src/components/bottom-tabs/BottomTabs.types.ts
+++ b/src/components/bottom-tabs/BottomTabs.types.ts
@@ -79,6 +79,8 @@ export interface BottomTabsProps extends ViewProps {
   /**
    * @summary Specifies the font size used for the title of each tab bar item.
    *
+   * On Android, the size is represented in scale-independent pixels (sp).
+   *
    * @platform android, ios
    */
   tabBarItemTitleFontSize?: TextStyle['fontSize'];
@@ -110,7 +112,7 @@ export interface BottomTabsProps extends ViewProps {
    * Starting from iOS 26, it only applies to selected tab bar item. Other items
    * adopt a dark or light appearance depending on the theme of the tab bar.
    *
-   * On iOS, it is overriden by `tabBarItemTitleFontColor` (for title text color)
+   * On iOS, it is overridden by `tabBarItemTitleFontColor` (for title text color)
    * and it overrides `tabBarTintColor`.
    *
    * @platform android, ios
@@ -119,12 +121,63 @@ export interface BottomTabsProps extends ViewProps {
   // #endregion Common appearance
 
   // #region Android-only appearance
+  /**
+   * @summary Specifies the font size used for the title of each tab bar item in active state.
+   *
+   * The size is represented in scale-independent pixels (sp).
+   *
+   * @platform android
+   */
   tabBarItemTitleFontSizeActive?: TextStyle['fontSize'];
+  /**
+   * @summary Specifies the font color used for the title of each tab bar item in active state.
+   *
+   * If not provided, `tabBarItemTitleFontColor` is used.
+   *
+   * @platform android
+   */
   tabBarItemTitleFontColorActive?: TextStyle['color'];
+  /**
+   * @summary Specifies the icon color for each tab bar item in active state.
+   *
+   * If not provided, `tabBarItemIconColor` is used.
+   *
+   * @platform android
+   */
   tabBarItemIconColorActive?: ColorValue;
+  /**
+   * @summary Specifies the background color of the active indicator.
+   *
+   * @platform android
+   */
   tabBarItemActiveIndicatorColor?: ColorValue;
+  /**
+   * @summary Specifies if the active indicator should be used.
+   *
+   * @default true
+   *
+   * @platform android
+   */
   tabBarItemActiveIndicatorEnabled?: boolean;
+  /**
+   * @summary Specifies the color of each tab bar item's ripple effect.
+   *
+   * @platform android
+   */
   tabBarItemRippleColor?: ColorValue;
+  /**
+   * @summary Specifies the label visibility mode - when the labels of each item bar should be visible.
+   *
+   * The fallowing values are available:
+   * - `auto` - android's `LABEL_VISIBILITY_AUTO` -  the label behaves as “labeled” when there are 3 items or less, or “selected” when there are 4 items or more
+   * - `selected` - android's `LABEL_VISIBILITY_SELECTED` - the label is only shown on the selected navigation item
+   * - `labeled` - android's `LABEL_VISIBILITY_LABELED` - the label is shown on all navigation items
+   * - `unlabeled` - android's `LABEL_VISIBILITY_UNLABELED` - the label is hidden for all navigation items
+   *
+   * @default auto
+   * @platform android
+   * @see {@link https://github.com/material-components/material-components-android/blob/master/docs/components/BottomNavigation.md#making-navigation-bar-accessible}
+   */
   tabBarItemLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
   // #endregion Android-only appearance
 
@@ -195,7 +248,7 @@ export interface BottomTabsProps extends ViewProps {
    * - `onScrollUp` - the tab bar minimizes when scrolling up and expands
    *   when scrolling back down
    *
-   * The supported values correspond to the official UIKit documentaion:
+   * The supported values correspond to the official UIKit documentation:
    * @see {@link https://developer.apple.com/documentation/uikit/uitabbarcontroller/minimizebehavior|UITabBarController.MinimizeBehavior}
    *
    * @default Defaults to `automatic`.

--- a/src/components/bottom-tabs/BottomTabs.types.ts
+++ b/src/components/bottom-tabs/BottomTabs.types.ts
@@ -168,7 +168,7 @@ export interface BottomTabsProps extends ViewProps {
   /**
    * @summary Specifies the label visibility mode - when the labels of each item bar should be visible.
    *
-   * The fallowing values are available:
+   * The following values are available:
    * - `auto` - android's `LABEL_VISIBILITY_AUTO` -  the label behaves as “labeled” when there are 3 items or less, or “selected” when there are 4 items or more
    * - `selected` - android's `LABEL_VISIBILITY_SELECTED` - the label is only shown on the selected navigation item
    * - `labeled` - android's `LABEL_VISIBILITY_LABELED` - the label is shown on all navigation items

--- a/src/components/bottom-tabs/BottomTabs.types.ts
+++ b/src/components/bottom-tabs/BottomTabs.types.ts
@@ -166,17 +166,21 @@ export interface BottomTabsProps extends ViewProps {
    */
   tabBarItemRippleColor?: ColorValue;
   /**
-   * @summary Specifies the label visibility mode - when the labels of each item bar should be visible.
+   * @summary Specifies the label visibility mode.
+   *
+   * The label visibility mode defines when the labels of each item bar should be displayed.
    *
    * The following values are available:
-   * - `auto` - android's `LABEL_VISIBILITY_AUTO` -  the label behaves as “labeled” when there are 3 items or less, or “selected” when there are 4 items or more
-   * - `selected` - android's `LABEL_VISIBILITY_SELECTED` - the label is only shown on the selected navigation item
-   * - `labeled` - android's `LABEL_VISIBILITY_LABELED` - the label is shown on all navigation items
-   * - `unlabeled` - android's `LABEL_VISIBILITY_UNLABELED` - the label is hidden for all navigation items
+   * - `auto` - the label behaves as in “labeled” mode when there are 3 items or less, or as in “selected” mode when there are 4 items or more
+   * - `selected` - the label is only shown on the selected navigation item
+   * - `labeled` - the label is shown on all navigation items
+   * - `unlabeled` - the label is hidden for all navigation items
+   *
+   * The supported values correspond to the official Material Components documentation:
+   * @see {@link https://github.com/material-components/material-components-android/blob/master/docs/components/BottomNavigation.md#making-navigation-bar-accessible|Material Components documentation}
    *
    * @default auto
    * @platform android
-   * @see {@link https://github.com/material-components/material-components-android/blob/master/docs/components/BottomNavigation.md#making-navigation-bar-accessible}
    */
   tabBarItemLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
   // #endregion Android-only appearance

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -105,10 +105,10 @@ export interface BottomTabsScreenProps {
    *
    * On iOS, badge is displayed as regular string.
    *
-   * On Android the value is interpreted as follows:
-   * - displays the value as a number, when the string can be parsed to integer
-   * - displays "small dot" badge, when the string is empty
-   * - displays the value as a text, otherwise
+   * On Android, the value is interpreted in the following order:
+   * - if the string can be parsed to integer, displays the value as a number;
+   * - otherwise if the string is empty, displays "small dot" badge;
+   * - otherwise, displays the value as a text.
    *
    * @platform android, ios
    */
@@ -119,7 +119,9 @@ export interface BottomTabsScreenProps {
   /**
    * @summary Specifies the icon for the tab bar item.
    *
-   * It takes the string that represents resource name. First it checks the drawable resources in app scope, then it falls back to the android scope.
+   * Accepts a string corresponding to the resource name. Initially searches within
+   * the app's drawable resources. If no matching resource is found, it defaults to
+   * searching within the Android's drawable resources.
    *
    * @platform android
    */
@@ -251,7 +253,7 @@ export interface BottomTabsScreenProps {
    * Starting from iOS 26, it only applies to selected tab bar item. Other items
    * adopt a dark or light appearance depending on the theme of the tab bar.
    *
-   * Is overriden by `tabBarItemTitleFontColor` (for title text color).
+   * Is overridden by `tabBarItemTitleFontColor` (for title text color).
    * Overrides `tabBarTintColor`.
    *
    * @platform ios
@@ -290,7 +292,7 @@ export interface BottomTabsScreenProps {
   };
   /**
    * @summary Specifies if `contentInsetAdjustmentBehavior` of first ScrollView
-   * in first descendant chain from tab screen should be overriden back from `never`
+   * in first descendant chain from tab screen should be overridden back from `never`
    * to `automatic`.
    *
    * By default, `react-native`'s ScrollView has `contentInsetAdjustmentBehavior`

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -95,7 +95,7 @@ export interface BottomTabsScreenProps {
 
   // #region General
   /**
-   * @summary Title of the tab screen, displayed in the tab bar.
+   * @summary Title of the tab screen, displayed in the tab bar item.
    *
    * @platform android, ios
    */
@@ -103,8 +103,12 @@ export interface BottomTabsScreenProps {
   /**
    * @summary Specifies content of tab bar item badge.
    *
-   * @todo Describe prop behavior on Android.
    * On iOS, badge is displayed as regular string.
+   *
+   * On Android the value is interpreted as follows:
+   * - displays the value as a number, when the string can be parsed to integer
+   * - displays "small dot" badge, when the string is empty
+   * - displays the value as a text, otherwise
    *
    * @platform android, ios
    */
@@ -112,7 +116,19 @@ export interface BottomTabsScreenProps {
   // #endregion General
 
   // #region Android-only appearance
+  /**
+   * @summary Specifies the icon for the tab bar item.
+   *
+   * It takes the string that represents resource name. First it checks the drawable resources in app scope, then it falls back to the android scope.
+   *
+   * @platform android
+   */
   iconResourceName?: string;
+  /**
+   * @summary Specifies the color of the text in the badge.
+   *
+   * @platform android
+   */
   tabBarItemBadgeTextColor?: ColorValue;
   // #endregion Android-only appearance
 


### PR DESCRIPTION
## Description

Continuation of https://github.com/software-mansion/react-native-screens/pull/3048
Adds docs for props in BottomTabs and BottomTabsScreen for Android.

## Test code and steps to reproduce

Hover over `apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx` to see the results

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Ensured that CI passes 