### PR TITLE
fix (android, tabs): Use childFragmentManager if tabs are used inside Stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -33,13 +33,15 @@ import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.ext.parentAsViewGroup
+import com.swmansion.rnscreens.gamma.common.FragmentProviding
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
 class Screen(
     val reactContext: ThemedReactContext,
 ) : FabricEnabledViewGroup(reactContext),
-    ScreenContentWrapper.OnLayoutCallback {
-    val fragment: Fragment?
+    ScreenContentWrapper.OnLayoutCallback,
+    FragmentProviding {
+    override val fragment: Fragment?
         get() = fragmentWrapper?.fragment
 
     val sheetBehavior: BottomSheetBehavior<Screen>?

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -176,26 +176,27 @@ open class ScreenContainer(
     private fun setupFragmentManager() {
         var parent: ViewParent = this
         // We traverse view hierarchy up until we find screen parent or a root view
-        while (!(parent is ReactRootView || parent is Screen || parent is FragmentProviding) &&
+        while (!(parent is ReactRootView || parent is FragmentProviding) &&
             parent.parent != null
         ) {
             parent = parent.parent
         }
-        // If parent is of type Screen it means we are inside a nested fragment structure.
+        // If parent is of type FragmentProviding it means we are inside a nested fragment structure.
         // Otherwise we expect to connect directly with root view and get root fragment manager
-        if (parent is Screen) {
-            checkNotNull(
-                parent.fragmentWrapper?.let { fragmentWrapper ->
-                    parentScreenWrapper = fragmentWrapper
-                    fragmentWrapper.addChildScreenContainer(this)
-                    setFragmentManager(fragmentWrapper.fragment.childFragmentManager)
-                },
-            ) { "Parent Screen does not have its Fragment attached" }
-        } else if (parent is FragmentProviding) {
-            // TODO: We're missing parent-child relationship here between old container & new one
+        if (parent is FragmentProviding) {
+            if (parent is Screen) {
+                checkNotNull(
+                    parent.fragmentWrapper?.let { fragmentWrapper ->
+                        parentScreenWrapper = fragmentWrapper
+                        fragmentWrapper.addChildScreenContainer(this)
+                    },
+                ) { "Parent Screen does not have its Fragment attached" }
+            }  else {
+              // TODO: We're missing parent-child relationship here between old container & new one
+            }
             val fragmentManager =
                 checkNotNull(
-                    parent.getFragment(),
+                    parent.fragment,
                 ) { "[RNScreens] Parent $parent returned nullish fragment" }.childFragmentManager
             setFragmentManager(fragmentManager)
         } else {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt
@@ -7,5 +7,5 @@ import androidx.fragment.app.Fragment
  * can be used to retrieve child fragment manager for nesting operations.
  */
 interface FragmentProviding {
-    fun getFragment(): Fragment?
+    val fragment: Fragment?
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt
@@ -23,7 +23,7 @@ object FragmentManagerHelper {
         // If parent adheres to FragmentProviding interface it means we are inside a nested fragment structure.
         // Otherwise we expect to connect directly with root view and get root fragment manager
         if (parent is FragmentProviding) {
-            return checkNotNull(parent.getFragment()) {
+            return checkNotNull(parent.fragment) {
                 "[RNScreens] Parent fragment providing view $parent returned nullish fragment"
             }.childFragmentManager
         } else {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
@@ -29,6 +29,9 @@ class TabScreen(
 
     internal lateinit var eventEmitter: TabScreenEventEmitter
 
+    override val fragment: Fragment?
+        get() = tabScreenDelegate.get()?.getFragmentForTabScreen(this)
+
     var tabKey: String? = null
         set(value) {
             field =
@@ -92,8 +95,6 @@ class TabScreen(
     internal fun setTabScreenDelegate(delegate: TabScreenDelegate?) {
         tabScreenDelegate = WeakReference(delegate)
     }
-
-    override fun getFragment(): Fragment? = tabScreenDelegate.get()?.getFragmentForTabScreen(this)
 
     private fun onTabFocusChangedFromJS() {
         tabScreenDelegate.get()?.onTabFocusChangedFromJS(this, isFocusedTab)


### PR DESCRIPTION
## Description

When tabs were used inside the Stack, the blank screen was presented. This was because in this case, tabs and stack shared FragmentManager and tabs removed ScreenStackFragment

https://github.com/software-mansion/react-native-screens/blob/main/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt#L466-L477

There is an issue when using Tabs in Stack with header:

```tsx
<ScreenStack style={StyleSheet.absoluteFill}>
      <ScreenStackItem
        // headerConfig={{ hidden: true }}
        screenId="12345"
        activityState={2}
        style={{ flex: 1 }}>
        <BottomTabs
```

moves tabs below the screen

<img height="400" alt="image" src="https://github.com/user-attachments/assets/df8a8355-3c2e-4e92-9cc1-b605e5fab03c" />




## Changes

1. Make Screen extend `FragmentProviding` interface
2. Use `FragmentProviding` as the base to decide wether there is nested Fragment structure

## Test code and steps to reproduce

Create Tabs inside Stack, Stack inside Tabs and Stack inside Stack and test if the app work

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
