### PR TITLE
fix(iOS, Tabs): fix condition for applying text attributes in Appearance Coordinator

### DIFF
--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -175,10 +175,10 @@
 - (void)configureTabBarItemAppearance:(nonnull UITabBarItemAppearance *)tabBarItemAppearance
                          withTabsHost:(nonnull RNSBottomTabsHostComponentView *)hostComponent
 {
-  NSMutableDictionary *titleTextAttributes = nil;
+  NSMutableDictionary *titleTextAttributes = [[NSMutableDictionary alloc] init];
 
-  if (hostComponent.tabBarItemTitleFontSize != nil) {
-    titleTextAttributes = [[NSMutableDictionary alloc] init];
+  if (hostComponent.tabBarItemTitleFontSize != nil || hostComponent.tabBarItemTitleFontFamily != nil ||
+      hostComponent.tabBarItemTitleFontWeight != nil || hostComponent.tabBarItemTitleFontStyle != nil) {
     titleTextAttributes[NSFontAttributeName] = [RCTFont updateFont:nil
                                                         withFamily:hostComponent.tabBarItemTitleFontFamily
                                                               size:hostComponent.tabBarItemTitleFontSize
@@ -186,6 +186,9 @@
                                                              style:hostComponent.tabBarItemTitleFontStyle
                                                            variant:nil
                                                    scaleMultiplier:1.0];
+  }
+
+  if (hostComponent.tabBarItemTitleFontColor != nil) {
     titleTextAttributes[NSForegroundColorAttributeName] = hostComponent.tabBarItemTitleFontColor;
   }
 
@@ -207,10 +210,12 @@
                forTabScreenController:(nonnull RNSTabsScreenViewController *)tabScreenCtrl
                 withHostComponentView:(nonnull RNSBottomTabsHostComponentView *)tabsHostComponent
 {
-  NSMutableDictionary *titleTextAttributes = nil;
+  NSMutableDictionary *titleTextAttributes = [[NSMutableDictionary alloc] init];
 
-  if (tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontSize != nil) {
-    titleTextAttributes = [[NSMutableDictionary alloc] init];
+  if (tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontSize != nil ||
+      tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontFamily != nil ||
+      tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontWeight != nil ||
+      tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontStyle != nil) {
     titleTextAttributes[NSFontAttributeName] =
         [RCTFont updateFont:nil
                  withFamily:tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontFamily
@@ -219,6 +224,9 @@
                       style:tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontStyle
                     variant:nil
             scaleMultiplier:1.0];
+  }
+
+  if (tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontColor != nil) {
     titleTextAttributes[NSForegroundColorAttributeName] = tabScreenCtrl.tabScreenComponentView.tabBarItemTitleFontColor;
   }
 
@@ -238,13 +246,13 @@
 
 - (void)configureTabBarItemStateAppearance:(nonnull UITabBarItemStateAppearance *)tabBarItemStateAppearance
                     withAppearanceProvider:(id<RNSTabBarAppearanceProvider>)appearanceProvider
-                   withTitleTextAttributes:(nullable NSDictionary<NSAttributedStringKey, id> *)titleTextAttributes
+                   withTitleTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)titleTextAttributes
 {
   if (appearanceProvider.tabBarItemBadgeBackgroundColor != nil) {
     tabBarItemStateAppearance.badgeBackgroundColor = appearanceProvider.tabBarItemBadgeBackgroundColor;
   }
 
-  if (titleTextAttributes != nil) {
+  if ([titleTextAttributes count] > 0) {
     tabBarItemStateAppearance.titleTextAttributes = titleTextAttributes;
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/323.

Before this fix, you couldn't modify font if you did not change size as well.

## Changes

- separate color and other font attributes to different if statements
- check all relevant font props in condition
- change nullability of text attributes
- change check (count > 0 instead of nil-check)

## Test code and steps to reproduce
Run TestBottomTabs, change font props other than font size. Props should apply to the text.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
