### PR TITLE
fix(Android,Tabs): allow for nesting tabs inside v4 stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -33,12 +33,14 @@ import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.ext.parentAsViewGroup
+import com.swmansion.rnscreens.gamma.common.FragmentProviding
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
 class Screen(
     val reactContext: ThemedReactContext,
 ) : FabricEnabledViewGroup(reactContext),
-    ScreenContentWrapper.OnLayoutCallback {
+    ScreenContentWrapper.OnLayoutCallback,
+    FragmentProviding {
     val fragment: Fragment?
         get() = fragmentWrapper?.fragment
 
@@ -119,6 +121,8 @@ class Screen(
         // for the time being
         layoutParams = WindowManager.LayoutParams(WindowManager.LayoutParams.TYPE_APPLICATION)
     }
+
+    override fun getAssociatedFragment(): Fragment? = fragment
 
     /**
      * ScreenContentWrapper notifies us here on it's layout. It is essential for implementing

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -176,7 +176,7 @@ open class ScreenContainer(
     private fun setupFragmentManager() {
         var parent: ViewParent = this
         // We traverse view hierarchy up until we find screen parent or a root view
-        while (!(parent is ReactRootView || parent is Screen || parent is FragmentProviding) &&
+        while (!(parent is ReactRootView || parent is FragmentProviding) &&
             parent.parent != null
         ) {
             parent = parent.parent

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
@@ -195,7 +195,7 @@ open class ScreenContainer(
             // TODO: We're missing parent-child relationship here between old container & new one
             val fragmentManager =
                 checkNotNull(
-                    parent.getFragment(),
+                    parent.getAssociatedFragment(),
                 ) { "[RNScreens] Parent $parent returned nullish fragment" }.childFragmentManager
             setFragmentManager(fragmentManager)
         } else {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/FragmentProviding.kt
@@ -7,5 +7,5 @@ import androidx.fragment.app.Fragment
  * can be used to retrieve child fragment manager for nesting operations.
  */
 interface FragmentProviding {
-    fun getFragment(): Fragment?
+    fun getAssociatedFragment(): Fragment?
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/FragmentManagerHelper.kt
@@ -23,7 +23,7 @@ object FragmentManagerHelper {
         // If parent adheres to FragmentProviding interface it means we are inside a nested fragment structure.
         // Otherwise we expect to connect directly with root view and get root fragment manager
         if (parent is FragmentProviding) {
-            return checkNotNull(parent.getFragment()) {
+            return checkNotNull(parent.getAssociatedFragment()) {
                 "[RNScreens] Parent fragment providing view $parent returned nullish fragment"
             }.childFragmentManager
         } else {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreen.kt
@@ -93,7 +93,7 @@ class TabScreen(
         tabScreenDelegate = WeakReference(delegate)
     }
 
-    override fun getFragment(): Fragment? = tabScreenDelegate.get()?.getFragmentForTabScreen(this)
+    override fun getAssociatedFragment(): Fragment? = tabScreenDelegate.get()?.getFragmentForTabScreen(this)
 
     private fun onTabFocusChangedFromJS() {
         tabScreenDelegate.get()?.onTabFocusChangedFromJS(this, isFocusedTab)


### PR DESCRIPTION
## Description

Currently only nesting a stack inside tabs is supported & not the other way around. 

This PR changes that. 

## Changes

`Screen` now implements `FragmentProviding`, which allows the `TabHost` to use it
as a source for child fragment manager.

## Test code and steps to reproduce

<details>

<summary>Code example</summary>


```javascript
import React from 'react';

import { Screen, ScreenStack, enableFreeze } from 'react-native-screens';
import ConfigWrapperContext, {
  type Configuration,
  DEFAULT_GLOBAL_CONFIGURATION,
} from '../../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
import {
  BottomTabsContainer,
  type TabConfiguration,
} from '../../shared/gamma/containers/bottom-tabs/BottomTabsContainer';
import { Tab1, Tab2, Tab3, Tab4 } from './tabs';
import Colors from '../../shared/styling/Colors';
import { StyleSheet } from 'react-native';

enableFreeze(true);

const TAB_CONFIGS: TabConfiguration[] = [
  {
    tabScreenProps: {
      tabKey: 'Tab1',
      title: 'Tab1',
      isFocused: true,
      icon: {
        sfSymbolName: 'house',
      },
      selectedIcon: {
        sfSymbolName: 'house.fill',
      },
      iconResourceName: 'sym_call_incoming', // Android specific
    },
    contentViewRenderFn: Tab1,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab2',
      badgeValue: 'NEW',
      tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
      tabBarBackgroundColor: Colors.NavyDark140,
      tabBarItemTitleFontSize: 20,
      tabBarItemTitleFontStyle: 'italic',
      tabBarItemTitleFontColor: Colors.RedDark120,
      tabBarItemTitleFontWeight: 'bold',
      tabBarItemTitleFontFamily: 'Baskerville',
      tabBarItemTitlePositionAdjustment: {
        vertical: 8,
      },
      icon: {
        templateSource: require('../../../assets/variableIcons/icon.png'),
      },
      selectedIcon: {
        templateSource: require('../../../assets/variableIcons/icon_fill.png'),
      },
      tabBarItemIconColor: Colors.RedDark120,
      iconResourceName: 'sym_call_missed', // Android specific
      title: 'Tab2',
    },
    contentViewRenderFn: Tab2,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab3',
      badgeValue: '2137',
      tabBarItemBadgeBackgroundColor: Colors.RedDark40,
      tabBarItemBadgeTextColor: Colors.RedDark120,
      icon: {
        imageSource: require('../../../assets/variableIcons/icon.png'),
      },
      selectedIcon: {
        imageSource: require('../../../assets/variableIcons/icon_fill.png'),
      },
      iconResourceName: 'sym_action_email', // Android specific
      title: 'Tab3',
    },
    contentViewRenderFn: Tab3,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab4',
      icon: {
        sfSymbolName: 'rectangle.stack',
      },
      selectedIcon: {
        sfSymbolName: 'rectangle.stack.fill',
      },
      iconResourceName: 'sym_action_chat', // Android specific
      title: 'Tab4',
      badgeValue: '',
    },
    contentViewRenderFn: Tab4,
  },
];

function App() {
  const [config, setConfig] = React.useState<Configuration>(
    DEFAULT_GLOBAL_CONFIGURATION,
  );

  return (
    <ConfigWrapperContext.Provider
      value={{
        config,
        setConfig,
      }}>
      <ScreenStack style={[StyleSheet.absoluteFill]}>
        <Screen isNativeStack activityState={2} screenId="hello">
          <BottomTabsContainer tabConfigs={TAB_CONFIGS} />
        </Screen>
      </ScreenStack>
    </ConfigWrapperContext.Provider>
  );
}

export default App;
```

</details>

## Checklist

- [ ] Ensured that CI passes

## Initial solution

See https://github.com/software-mansion/react-native-screens/pull/3077 for problem description & solution suggestion.


Co-authored-by: Jakub Tkacz <jtkacz@expo.io>

