### PR TITLE
fix(iOS, Tabs): Break retain cycle for bottom tabs screen

### DIFF
--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -107,6 +107,13 @@ namespace react = facebook::react;
 
 #pragma mark - UIView methods
 
+- (void)willMoveToWindow:(UIWindow *)newWindow
+{
+  if (newWindow == nil) {
+    [self invalidate];
+  }
+}
+
 - (void)didMoveToWindow
 {
   [self reactAddControllerToClosestParent:_controller];
@@ -131,6 +138,17 @@ namespace react = facebook::react;
       parentView = (UIView *)parentView.reactSuperview;
     }
     return;
+  }
+}
+
+- (void)invalidate
+{
+  // We assume that bottom tabs host is removed from view hierarchy **only** when
+  // whole component is destroyed & therefore we do the necessary cleanup here.
+  // If at some point that statement does not hold anymore, this cleanup
+  // should be moved to a different place.
+  for (RNSBottomTabsScreenComponentView *subview in _reactSubviews) {
+    [subview invalidate];
   }
 }
 

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -116,12 +116,14 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
-  [self reactAddControllerToClosestParent:_controller];
+  if ([self window] != nil) {
+    [self reactAddControllerToClosestParent:_controller];
 
 #if !RCT_NEW_ARCH_ENABLED
-  // This is required on legacy architecture to prevent a bug with doubled size of UIViewControllerWrapperView.
-  _controller.view.frame = self.bounds;
+    // This is required on legacy architecture to prevent a bug with doubled size of UIViewControllerWrapperView.
+    _controller.view.frame = self.bounds;
 #endif // !RCT_NEW_ARCH_ENABLED
+  }
 }
 
 - (void)reactAddControllerToClosestParent:(UIViewController *)controller

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -150,6 +150,7 @@ namespace react = facebook::react;
   for (RNSBottomTabsScreenComponentView *subview in _reactSubviews) {
     [subview invalidate];
   }
+  _controller = nil;
 }
 
 #pragma mark - RNSScreenContainerDelegate

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.h
@@ -26,6 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, weak, nullable) RNSBottomTabsHostComponentView *reactSuperview;
 
+/**
+ * @brief A function responsible for requesting a cleanup in the BottomTabsScreen component.
+ *
+ * Should be called when the component is about to be deleted.
+ */
+- (void)invalidate;
+
 @end
 
 #pragma mark - Props

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -100,6 +100,14 @@ namespace react = facebook::react;
   _selectedIconSfSymbolName = nil;
 }
 
+- (void)invalidate
+{
+  // Controller keeps the strong reference to the component via the `.view` property.
+  // Therefore, we need to enforce a proper cleanup, breaking the retain cycle,
+  // when we want to destroy the component.
+  _controller = nil;
+}
+
 RNS_IGNORE_SUPER_CALL_BEGIN
 - (nullable RNSBottomTabsHostComponentView *)reactSuperview
 {


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/156 (the task was originally created for SplitView, but I extended it to cover BottomTabs - if you feel that I should attach a separate task - please leave it as a comment)

Problem:
- Controller has a strong reference to an associated component via `.view` property.
- In our case, Component keeps a strong reference to the controller.
- This creates a retain cycle, which we're not breaking anywhere at the moment.

Solution:
BottomTabs host keeps references to all subviews of type BottomTabsScreen all the time (tabs might be hidden, but they won't disappear). It means that we can consider Host as an owner of the BottomTabsScreens' lifecycles. If the host is about to be unmounted from the view hierarchy, we can perform some additional cleanup in child components to detach the reference to theirs controllers.

## Changes

- Added a method for invalidating a screen component that removes a reference to the controller.

## Test code and steps to reproduce

Paste this code inside `react-native-screens/apps/src/tests/TestBottomTabs/index.tsx` - add locally a log inside `invalidate` method - observe that it's called on navigating back from the 2nd screen.

```js
import React from 'react';
import { enableFreeze } from 'react-native-screens';
import ConfigWrapperContext, {
  type Configuration,
  DEFAULT_GLOBAL_CONFIGURATION,
} from '../../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
import {
  BottomTabsContainer,
  type TabConfiguration,
} from '../../shared/gamma/containers/bottom-tabs/BottomTabsContainer';
import { Tab1, Tab2, Tab3, Tab4 } from './tabs';
import Colors from '../../shared/styling/Colors';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import { NavigationContainer } from '@react-navigation/native';
import { Button, View } from 'react-native';
enableFreeze(true);
const Stack = createNativeStackNavigator();
const TAB_CONFIGS: TabConfiguration[] = [
  {
    tabScreenProps: {
      tabKey: 'Tab1',
      title: 'Tab1',
      isFocused: true,
      icon: {
        sfSymbolName: 'house',
      },
      selectedIcon: {
        sfSymbolName: 'house.fill',
      },
      iconResourceName: 'sym_call_incoming', // Android specific
    },
    contentViewRenderFn: Tab1,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab2',
      badgeValue: 'NEW',
      tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
      tabBarBackgroundColor: Colors.NavyDark140,
      tabBarItemTitleFontSize: 20,
      tabBarItemTitleFontStyle: 'italic',
      tabBarItemTitleFontColor: Colors.RedDark120,
      tabBarItemTitleFontWeight: 'bold',
      tabBarItemTitleFontFamily: 'Baskerville',
      tabBarItemTitlePositionAdjustment: {
        vertical: 8,
      },
      icon: {
        templateSource: require('../../../assets/variableIcons/icon.png'),
      },
      selectedIcon: {
        templateSource: require('../../../assets/variableIcons/icon_fill.png'),
      },
      tabBarItemIconColor: Colors.RedDark120,
      iconResourceName: 'sym_call_missed', // Android specific
      title: 'Tab2',
    },
    contentViewRenderFn: Tab2,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab3',
      badgeValue: '2137',
      tabBarItemBadgeBackgroundColor: Colors.RedDark40,
      tabBarItemBadgeTextColor: Colors.RedDark120,
      icon: {
        imageSource: require('../../../assets/variableIcons/icon.png'),
      },
      selectedIcon: {
        imageSource: require('../../../assets/variableIcons/icon_fill.png'),
      },
      iconResourceName: 'sym_action_email', // Android specific
      title: 'Tab3',
    },
    contentViewRenderFn: Tab3,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab4',
      icon: {
        sfSymbolName: 'rectangle.stack',
      },
      selectedIcon: {
        sfSymbolName: 'rectangle.stack.fill',
      },
      iconResourceName: 'sym_action_chat', // Android specific
      title: 'Tab4',
      badgeValue: '',
    },
    contentViewRenderFn: Tab4,
  },
];
const ScreenOne = ({navigation}) => (
  <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
    <Button onPress={() => navigation.navigate('ScreenTwo')} title='Go to Bottom Tabs' />
  </View>
)
function BottomTabsApp() {
  const [config, setConfig] = React.useState<Configuration>(
    DEFAULT_GLOBAL_CONFIGURATION,
  );
  return (
    <ConfigWrapperContext.Provider
      value={{
        config,
        setConfig,
      }}>
      <BottomTabsContainer tabConfigs={TAB_CONFIGS} />
    </ConfigWrapperContext.Provider>
  );
}
const App = () => (
  <NavigationContainer>
    <Stack.Navigator>
      <Stack.Screen component={ScreenOne} name="ScreenOne" />
      <Stack.Screen component={BottomTabsApp} name="ScreenTwo" />
    </Stack.Navigator>
  </NavigationContainer>
)
export default App;
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
