### PR TITLE
fix(Android, Tabs): JS focus change fix

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -281,7 +281,7 @@ class TabsHost(
         isFocused: Boolean,
     ) {
         containerUpdateCoordinator.let {
-            it.invalidateSelectedTab()
+            it.invalidateAll()
             it.postContainerUpdateIfNeeded()
         }
     }


### PR DESCRIPTION
## Description

When JS focus prop changed only the content view updated and the tab bar item stayed the same.

## Before

https://github.com/user-attachments/assets/1712d7e4-cde7-42fc-a428-51cc9db47473

## After

https://github.com/user-attachments/assets/0bd42229-0d8b-4d23-9b6c-7e6cd3ca45f2

## Changes

Changed `invalidateSelectedTab` to `invalidateAll`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
