### PR TITLE
docs(Tabs): add tabBarItemBadgeBackgroundColor prop docs for Android

### DIFF
--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -115,6 +115,20 @@ export interface BottomTabsScreenProps {
   badgeValue?: string;
   // #endregion General
 
+  // #region Common appearance
+  /**
+   * @summary Specifies the background color for the badge.
+   *
+   * On Android, it applies to the badge inside the tab bar item.
+   *
+   * On iOS, it applies to each badge for every tab bar item when tab screen
+   * is selected.
+   *
+   * @platform android, ios
+   */
+  tabBarItemBadgeBackgroundColor?: ColorValue;
+  // #endregion Common appearance
+
   // #region Android-only appearance
   /**
    * @summary Specifies the icon for the tab bar item.
@@ -259,13 +273,6 @@ export interface BottomTabsScreenProps {
    * @platform ios
    */
   tabBarItemIconColor?: ColorValue;
-  /**
-   * @summary Specifies the background color of badges for each tab bar item
-   * when tab screen is selected.
-   *
-   * @platform ios
-   */
-  tabBarItemBadgeBackgroundColor?: ColorValue;
   /**
    * @summary Specifies which special effects (also known as microinteractions)
    * are enabled for the tab screen.


### PR DESCRIPTION
## Description

Add missing `tabBarItemBadgeBackgroundColor` docs for Android.
