### PR TITLE
fix(iOS, Stack v4): fix missing search bar on root screen on iOS 26

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -673,6 +673,8 @@ RNS_IGNORE_SUPER_CALL_END
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
           if (@available(iOS 26.0, *)) {
+            // Workaround for missing search bar on root stack screen. 
+            // See: https://github.com/software-mansion/react-native-screens/pull/3098
             navitem.searchBarPlacementAllowsToolbarIntegration = NO;
           }
 #endif /* Check for iOS 26.0 */


### PR DESCRIPTION
## Description

Fixes missing search bar on root screen on iOS 26. (Part of https://github.com/software-mansion/react-native-screens-labs/issues/331).

The search bar is missing on root screen on iOS 26 beta 4 (only on iPhones). I wasn't able to reproduce this issue in bare UIKit app.

I found that on iOS 26, there are new properties for search bar, including [searchBarPlacementAllowsToolbarIntegration](https://developer.apple.com/documentation/uikit/uinavigationitem/searchbarplacementallowstoolbarintegration?language=objc). Setting this prop to `false` fixes the issue. I am not 100% sure what is the intended use case for this prop. If I understand correctly (but I might be wrong here), if this is set to `true` and `preferredSearchBarPlacement` is set to `integrated` or `integratedButton`, then you can use search bar button from [searchBarPlacementBarButtonItem](https://developer.apple.com/documentation/uikit/uinavigationitem/searchbarplacementbarbuttonitem?language=objc) to place it inside `toolbarItems` in a position you want, but in our case, both `preferredSearchBarPlacement` and `searchBarPlacement` are set to `UINavigationItemSearchBarPlacementStacked` so this does not add up.

This might be a bug because even in the most recent release notes for iOS 26 beta 4, some workarounds connected to this prop are mentioned:

> [UIKit](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#UIKit)
> [Known Issues](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#Known-Issues)
> 
> In apps using UIToolbar, the Search bar sometimes does not respond to taps and displays without the magnifying glass, dictation button, or placeholder text. (151126350)
> 
> Workaround: Quit the app then re-launch it.
> 
> On iPhone only, the searchTextField property of a UISearchBar belonging to a UISearchController (i.e. searchController.searchBar.searchTextField) might not return the same instance when called at different times. (153550157)
> 
> Workaround: Look for UISearchBar or UISearchController API equivalent to the UISearchTextField API you’re using. If none can be found, you can prevent the issue by setting the UINavigationItem.searchBarPlacementAllowsToolbarIntegration property to false on the navigation item the search controller has been assigned to.
> 
> On iPhone, the search bar might be missing from a tab’s navigation bar due to usual client code timing of assembling the view controller hierarchy. (156174227)
> 
> Workaround: Set the searchBarPlacementAllowsToolbarIntegration property of the UINavigationItem to false at the same time you set the searchController.


## Changes

- set `searchBarPlacementAllowsToolbarIntegration` to `NO`

## Screenshots / GIFs

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8ac87d94-5908-4734-8526-ae8b1c39b934" /> | <video src="https://github.com/user-attachments/assets/e88ee4a2-2f8c-493c-99bd-85334df1f9d4" /> |

## Test code and steps to reproduce

Run `Test758`. You should be able to use search bar on the root screen.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
