### PR TITLE
Update RNSScreenShadowNode.h

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.h
@@ -28,7 +28,7 @@ class JSI_EXPORT RNSScreenShadowNode final : public ConcreteViewShadowNode<
 
   Point getContentOriginOffset(bool includeTransform) const override;
 
-  void appendChild(const ShadowNode::Shared &child) override;
+  void appendChild(const std::shared_ptr<const ShadowNode> &child) override;
 
   void layout(LayoutContext layoutContext) override;
 


### PR DESCRIPTION
## Description
Fix deprecated shared type
for some reason it is breaking Android build on RN 81 altho it is a deprecation notice but it is showing error.

## Changes
Fix Shared to std::shared

## Test code and steps to reproduce

Install react-native-screens on 81 and try to build Android.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
