### PR TITLE
fix(iOS, Tabs): Fix more controller handling

### DIFF
--- a/ios/bottom-tabs/RNSTabBarControllerDelegate.mm
+++ b/ios/bottom-tabs/RNSTabBarControllerDelegate.mm
@@ -8,7 +8,10 @@
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
     shouldSelectViewController:(UIViewController *)viewController
 {
-  // TODO: This will crash with "More" view controller.
+  // When the moreNavigationController is selected, we want to show it
+  if (viewController == tabBarController.moreNavigationController) {
+    return YES;
+  }
   RCTAssert(
       [tabBarController isKindOfClass:RNSTabBarController.class],
       @"[RNScreens] Unexpected type of controller: %@",
@@ -44,6 +47,12 @@
 - (void)tabBarController:(UITabBarController *)tabBarController
     didSelectViewController:(UIViewController *)viewController
 {
+  // When the moreNavigationController is selected, we want to show it
+  if (viewController == tabBarController.moreNavigationController) {
+    // Hide the navigation bar for the more controller
+    [tabBarController.moreNavigationController setNavigationBarHidden:YES animated:NO];
+    return;
+  }
   RCTAssert(
       [tabBarController isKindOfClass:RNSTabBarController.class],
       @"[RNScreens] Unexpected type of controller: %@",

--- a/ios/bottom-tabs/RNSTabBarControllerDelegate.mm
+++ b/ios/bottom-tabs/RNSTabBarControllerDelegate.mm
@@ -8,10 +8,13 @@
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
     shouldSelectViewController:(UIViewController *)viewController
 {
+#if !TARGET_OS_TV
   // When the moreNavigationController is selected, we want to show it
+  // TODO: this solution only works for uncontrolled mode. Add support for controlled mode as well.
   if (viewController == tabBarController.moreNavigationController) {
     return YES;
   }
+#endif // !TARGET_OS_TV
   RCTAssert(
       [tabBarController isKindOfClass:RNSTabBarController.class],
       @"[RNScreens] Unexpected type of controller: %@",
@@ -47,12 +50,14 @@
 - (void)tabBarController:(UITabBarController *)tabBarController
     didSelectViewController:(UIViewController *)viewController
 {
+#if !TARGET_OS_TV
   // When the moreNavigationController is selected, we want to show it
   if (viewController == tabBarController.moreNavigationController) {
     // Hide the navigation bar for the more controller
     [tabBarController.moreNavigationController setNavigationBarHidden:YES animated:NO];
     return;
   }
+#endif // !TARGET_OS_TV
   RCTAssert(
       [tabBarController isKindOfClass:RNSTabBarController.class],
       @"[RNScreens] Unexpected type of controller: %@",

--- a/ios/bottom-tabs/RNSTabsScreenViewController.mm
+++ b/ios/bottom-tabs/RNSTabsScreenViewController.mm
@@ -61,9 +61,14 @@
   }
 
   RCTAssert(
-      [parent isKindOfClass:RNSTabBarController.class],
+      [parent isKindOfClass:RNSTabBarController.class] || [parent isKindOfClass:UINavigationController.class],
       @"[RNScreens] TabScreenViewController added to parent of unexpected type: %@",
       parent.class);
+
+  if([parent isKindOfClass:UINavigationController.class]){
+    // Hide the navigation bar for the more controller
+    [(UINavigationController*)parent setNavigationBarHidden:YES animated:YES];
+  }
 
   RNSTabBarController *tabBarCtrl = [self findTabBarController];
 

--- a/ios/bottom-tabs/RNSTabsScreenViewController.mm
+++ b/ios/bottom-tabs/RNSTabsScreenViewController.mm
@@ -60,14 +60,15 @@
     return;
   }
 
+  // Can be UINavigationController in case of MoreNavigationController
   RCTAssert(
       [parent isKindOfClass:RNSTabBarController.class] || [parent isKindOfClass:UINavigationController.class],
       @"[RNScreens] TabScreenViewController added to parent of unexpected type: %@",
       parent.class);
 
-  if([parent isKindOfClass:UINavigationController.class]){
+  if ([parent isKindOfClass:UINavigationController.class]) {
     // Hide the navigation bar for the more controller
-    [(UINavigationController*)parent setNavigationBarHidden:YES animated:YES];
+    [(UINavigationController *)parent setNavigationBarHidden:YES animated:YES];
   }
 
   RNSTabBarController *tabBarCtrl = [self findTabBarController];


### PR DESCRIPTION
## Description

**This only works for not-controlled mode**

An error is thrown right now when user clicks on the more tab (It shows when more then 5 tabs are added)

## Changes

1. Handle UIMoreNavigationController (private API). We can check for it using `moreNavigationController` from `UITabBarController`
2. Hide the NavigationBar from more controller, so it does not break designs in the tab screens

### Video

This is a recording from integration into `expo-router`

https://github.com/user-attachments/assets/ad0fa8e0-53ea-4a49-9ff7-b90bad45a5c7

## Test code and steps to reproduce

Add this code to `apps/src/tests/TestBottomTabs/index.tsx`. Click on the more tab.

```tsx
  {
    tabScreenProps: {
      tabKey: 'Tab5',
      icon: {
        sfSymbolName: '0.circle',
      },
      selectedIcon: {
        sfSymbolName: '0.circle.fill',
      },
      iconResourceName: 'sym_action_chat', // Android specific
      title: 'Tab5',
      badgeValue: '',
    },
    contentViewRenderFn: Tab4,
  },
  {
    tabScreenProps: {
      tabKey: 'Tab6',
      icon: {
        sfSymbolName: '0.circle',
      },
      selectedIcon: {
        sfSymbolName: '0.circle.fill',
      },
      iconResourceName: 'sym_action_chat', // Android specific
      title: 'Tab6',
      badgeValue: '',
    },
    contentViewRenderFn: Tab4,
  },
```

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
