### PR TITLE
fix(Android): prevent frequent crash in `RNSScreenProps::~RNSScreenProps` by setting `RN_SERIALIZABLE_STATE` compile flag

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -68,18 +68,23 @@ else()
   )
 endif()
 
-target_compile_options(
-  ${LIB_TARGET_NAME}
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()
 
 target_include_directories(
  ${CMAKE_PROJECT_NAME}
  PUBLIC
  ${CMAKE_CURRENT_SOURCE_DIR}
 )
+


### PR DESCRIPTION
## Description

The function has been introduced with RN 0.80 and later modified in
https://github.com/facebook/react-native/commit/c059ae1b77.

The #c059ae1b77 added RN_SERIALIZABLE_STATE compile time definition,
which helps to resolve an ridiculous crash / hang we had. To give some
context - the crash occured in codegened C++ code in
`RNSScreenProps::~RNSScreenProps` (yes, this is a compiler generated
default dtor) or in other dtors, depending on exact timing. It is still
unknown exactly what was the error mechanism, but most likely due to
some timing / concurrency related issues dtor attempted to free some
memory that was no longer mapped to a process or something. Anyway,
setting this flag resolves the problem.

Additionally, this is also a way-to-go in terms of setting compile
options required by RN since 0.80.


## Test code and steps to reproduce

<details>

<summary>Crash reproduction setup</summary>

```tsx

import React from 'react';
import { useState } from 'react';
import { Button } from 'react-native';
import { ScreenStack, ScreenStackItem } from 'react-native-screens';

export default function BasicBareScreens() {
  const [secondShown, setSecondShown] = useState(false);

  return (
    <ScreenStack>
      <ScreenStackItem screenId="1" activityState={2}>
        <Button title="Go to screen 2" onPress={() => setSecondShown(true)} />
      </ScreenStackItem>
      {secondShown && (
        <ScreenStackItem screenId="2" activityState={2}>
          <Button title="Go back" onPress={() => setSecondShown(false)} />
        </ScreenStackItem>
      )}
    </ScreenStack>
  );
}

```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
