### PR TITLE
chore(iOS): Rename RNSUIBarButtonItem to RNSBackBarButtonItem

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -25,7 +25,7 @@
 #import <React/RCTFont.h>
 #import <React/RCTImageLoader.h>
 #import <React/RCTImageSource.h>
-#import "RNSBarBackButtonItem.h"
+#import "RNSBackBarButtonItem.h"
 #import "RNSConvert.h"
 #import "RNSDefines.h"
 #import "RNSScreen.h"
@@ -746,7 +746,7 @@ RNS_IGNORE_SUPER_CALL_END
   prevItem.backButtonDisplayMode = config.backButtonDisplayMode;
 
   if (config.isBackTitleVisible) {
-    RNSBarBackButtonItem *backBarButtonItem = [[RNSBarBackButtonItem alloc] initWithTitle:resolvedBackTitle
+    RNSBackBarButtonItem *backBarButtonItem = [[RNSBackBarButtonItem alloc] initWithTitle:resolvedBackTitle
                                                                                     style:UIBarButtonItemStylePlain
                                                                                    target:nil
                                                                                    action:nil];

--- a/ios/utils/RNSBackBarButtonItem.h
+++ b/ios/utils/RNSBackBarButtonItem.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-@interface RNSBarBackButtonItem : UIBarButtonItem
+@interface RNSBackBarButtonItem : UIBarButtonItem
 
 @property (nonatomic) BOOL menuHidden;
 

--- a/ios/utils/RNSBackBarButtonItem.mm
+++ b/ios/utils/RNSBackBarButtonItem.mm
@@ -1,6 +1,6 @@
-#import "./RNSBarBackButtonItem.h"
+#import "./RNSBackBarButtonItem.h"
 
-@implementation RNSBarBackButtonItem
+@implementation RNSBackBarButtonItem
 
 - (void)setMenuHidden:(BOOL)menuHidden
 {


### PR DESCRIPTION
## Description

From discussion in https://github.com/software-mansion/react-native-screens/pull/2987#discussion_r2253525009. We should rename the class into something more specific because it really does one specific thing.

## Changes

title

## Test code and steps to reproduce

No changes, disabling back button menu should still work. You can modify BottomTabsTest / Tab4 with `screenOption={{ headerBackButtonMenuEnabled: false }}`