### PR TITLE
fix(iOS, Stack) Fix calculating insets for header title

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -254,7 +254,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (NSDirectionalEdgeInsets)computeEdgeInsetsOfNavigationBar:(nonnull UINavigationBar *)navigationBar
 {
   NSDirectionalEdgeInsets navBarMargins = [navigationBar directionalLayoutMargins];
-  NSDirectionalEdgeInsets navBarContentMargins = [navigationBar.rnscreens_findContentView directionalLayoutMargins];
+  NSDirectionalEdgeInsets navBarContentMargins = [navigationBar rnscreens_sumTitleControlDirectionalMargins];
 
   BOOL isDisplayingBackButton = [self shouldBackButtonBeVisibleInNavigationBar:navigationBar];
 
@@ -673,7 +673,7 @@ RNS_IGNORE_SUPER_CALL_END
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
           if (@available(iOS 26.0, *)) {
-            // Workaround for missing search bar on root stack screen. 
+            // Workaround for missing search bar on root stack screen.
             // See: https://github.com/software-mansion/react-native-screens/pull/3098
             navitem.searchBarPlacementAllowsToolbarIntegration = NO;
           }

--- a/ios/utils/UINavigationBar+RNSUtility.h
+++ b/ios/utils/UINavigationBar+RNSUtility.h
@@ -32,6 +32,21 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable UIView *)rnscreens_findBackButtonWrapperView;
 
+/**
+ * @brief Responsible for calculating the cumulative directional layout margins the will be applied to the title in the
+ * header.
+ *
+ * The method depends on private UIKit internals, such as the presence of `_UINavigationBarTitleControll`
+ * If the title control is not found in the UINavigationBar view hierarchy, the method logs a warning
+ * and returns zeroed margins.
+ *
+ * Tested to work reliably on iOS 26.0, 18.5.
+ *
+ * @returns NSDirectionalEdgeInsets containing the combined layout margins from the title control
+ * up to its ancestor navigation bar.
+ */
+- (NSDirectionalEdgeInsets)rnscreens_sumTitleControlDirectionalMargins;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/utils/UINavigationBar+RNSUtility.mm
+++ b/ios/utils/UINavigationBar+RNSUtility.mm
@@ -41,4 +41,44 @@
   return nil;
 }
 
+- (NSDirectionalEdgeInsets)rnscreens_sumTitleControlDirectionalMargins
+{
+  NSDirectionalEdgeInsets totalMargins = NSDirectionalEdgeInsetsMake(0, 0, 0, 0);
+  UIView *titleControl = RNScreensFindTitleControlInView(self);
+
+  if (!titleControl) {
+    NSLog(@"[RNScreens] _UINavigationBarTitleControl not found under the UINavigationBar hierarchy");
+    return totalMargins;
+  }
+
+  UIView *currentView = titleControl.superview;
+  while (currentView && currentView != self) {
+    NSDirectionalEdgeInsets margins = currentView.directionalLayoutMargins;
+    totalMargins.top += margins.top;
+    totalMargins.leading += margins.leading;
+    totalMargins.bottom += margins.bottom;
+    totalMargins.trailing += margins.trailing;
+    currentView = currentView.superview;
+  }
+  return totalMargins;
+}
+
+static UIView *RNScreensFindTitleControlInView(UIView *view)
+{
+  static Class UINavBarTitleControlClass = NSClassFromString(@"_UINavigationBarTitleControl");
+
+  if ([view isKindOfClass:UINavBarTitleControlClass]) {
+    return view;
+  }
+
+  for (UIView *subview in view.subviews) {
+    UIView *result = RNScreensFindTitleControlInView(subview);
+    if (result) {
+      return result;
+    }
+  }
+
+  return nil;
+}
+
 @end


### PR DESCRIPTION
## Description

This PR is changing the approach for calculating edge insets of the navigation bar.
On iOS 26, the hierarchy has changed significantly, resulting in placing too long header content, which might be covered by the right button.

Old hierarchy:

```
Class: UINavigationBar | Frame: {{0, 56.333333333333343}, {440, 44}} | Margins => top: 13.67, leading: 8.00, bottom: 8.00, trailing: 8.00
  Class: _UINavigationBarContentView | Frame: {{0, 0}, {440, 44}} | Margins => top: 5.67, leading: 20.00, bottom: 0.00, trailing: 20.00
    ...
    Class: _UINavigationBarTitleControl | Frame: {{66, 13.666666666666664}, {268, 17}} | Margins => top: 8.00, leading: 8.00, bottom: 8.00, trailing: 8.00
```

New hierarchy:

```
Class: UINavigationBar | Frame: {{0, 56.333333333333343}, {440, 54}} | Margins => top: 5.67, leading: 20.00, bottom: 0.00, trailing: 20.00
  Class: UIKit.NavigationBarContentView | Frame: {{0, 0}, {440, 54}} | Margins => top: 5.67, leading: 0.00, bottom: 0.00, trailing: 0.00
    Class: UIKit.NavigationBarTransitionContainer | Frame: {{0, 0}, {440, 54}} | Margins => top: 8.00, leading: 8.00, bottom: 8.00, trailing: 8.00
      Class: _UINavigationBarHostedViewContainer | Frame: {{0, 0}, {440, 54}} | Margins => top: 8.00, leading: 8.00, bottom: 8.00, trailing: 8.00
        Class: _UINavigationBarHostedViewWrapper | Frame: {{80, 13.5}, {240, 17}} | Margins => top: 8.00, leading: 8.00, bottom: 8.00, trailing: 8.00
          Class: _UINavigationBarTitleControl | Frame: {{0, 0}, {240, 17}} | Margins => top: 8.00, leading: 8.00, bottom: 8.00, trailing: 8.00
```

In the new approach, I'm summing up all `directionalLayoutMargins` between `_UINavigationBarTitleControl` and `NavigationBarContentView`. I know that this approach doesn't seem to be super-solid, but somehow I need to traverse the structure to get `_UINavigationBarTitleControl` and calculate cumulative layout properly.

## Changes

- Extended `UINavigationBar` with the new method for calculating the insets between the content and title views.

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

## Test code and steps to reproduce

`TestHeaderTitle` example on iOS 26 and 18.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
