### PR TITLE
fix(Android): prevent view tag of `TabsHost` colliding with `ReactSurfaceView`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,7 +127,6 @@ android {
         versionCode 1
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", IS_NEW_ARCHITECTURE_ENABLED.toString()
-        buildConfigField "int", "REACT_NATIVE_VERSION_MINOR", REACT_NATIVE_MINOR_VERSION.toString()
         ndk {
             abiFilters (*reactNativeArchitectures())
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,6 +127,7 @@ android {
         versionCode 1
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", IS_NEW_ARCHITECTURE_ENABLED.toString()
+        buildConfigField "int", "REACT_NATIVE_VERSION_MINOR", REACT_NATIVE_MINOR_VERSION.toString()
         ndk {
             abiFilters (*reactNativeArchitectures())
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
@@ -1,0 +1,58 @@
+package com.swmansion.rnscreens.gamma.helpers
+
+import androidx.annotation.UiThread
+import com.swmansion.rnscreens.BuildConfig
+
+interface ViewIdProviding {
+    fun generateViewId(): Int
+}
+
+/**
+ * This class generates view id that should not collide with ids (tags) assigned by renderer to React
+ * components.
+ *
+ * This class relies on internal renderer behaviours, that happened to change over the time, therefore
+ * it must be revisited & kept up to date with current RN behaviour until better solution is found.
+ *
+ * Until RN 0.81 ReactSurfaceView had tag `11`. In later versions it was changed to `1` (new arch only change).
+ *
+ * Up to the time of writing this (RN 0.81.0-rc.5) every version incremented tag version by 2,
+ * starting from `(ReactSurfaceView.tag + 1)`, therefore all tags were even. We start generating all
+ * odd numbers from `(ReactSurfaceView.tag + 2)`, except valid root view tags, which are 1, 11, 21, etc.
+ *
+ * Reference:
+ *
+ * * https://github.com/facebook/react-native/blob/739dfd2141015a8126448bda64a559f5bf22672e/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java#L136
+ * * https://github.com/facebook/react-native/commit/8bcf13407183285bf54b336593357889764de230
+ * * https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRootViewTagGenerator.kt
+ * * https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/core/ReactRootViewTagGenerator.cpp
+ */
+@UiThread
+private class NewArchAwareViewIdGenerator : ViewIdProviding {
+    var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCH_ENABLED) 3 else 13
+
+    override fun generateViewId(): Int = nextId.also { progressViewId() }
+
+    private fun progressViewId() {
+        nextId += 2
+        if (isValidReactRootTag(nextId)) {
+            nextId += 2
+        }
+    }
+
+    private fun isValidReactRootTag(tag: Int): Boolean = tag % 10 == 1
+}
+
+@UiThread
+object ViewIdGenerator: ViewIdProviding {
+    /**
+     * Set this field to customize view ids utilized by the library.
+     */
+    var externalGenerator: ViewIdProviding? = null
+    val defaultGenerator: ViewIdProviding = NewArchAwareViewIdGenerator()
+
+    override fun generateViewId(): Int {
+        externalGenerator?.let { return it.generateViewId() }
+        return defaultGenerator.generateViewId()
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
@@ -29,7 +29,7 @@ interface ViewIdProviding {
  */
 @UiThread
 private class NewArchAwareViewIdGenerator : ViewIdProviding {
-    var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCH_ENABLED) 3 else 13
+    var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) 3 else 13
 
     override fun generateViewId(): Int = nextId.also { progressViewId() }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
@@ -29,7 +29,7 @@ interface ViewIdProviding {
  */
 @UiThread
 private class NewArchAwareViewIdGenerator : ViewIdProviding {
-    var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) 3 else 13
+    private var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) 3 else 13
 
     override fun generateViewId(): Int = nextId.also { progressViewId() }
 
@@ -49,7 +49,7 @@ object ViewIdGenerator: ViewIdProviding {
      * Set this field to customize view ids utilized by the library.
      */
     var externalGenerator: ViewIdProviding? = null
-    val defaultGenerator: ViewIdProviding = NewArchAwareViewIdGenerator()
+    private val defaultGenerator: ViewIdProviding = NewArchAwareViewIdGenerator()
 
     override fun generateViewId(): Int {
         externalGenerator?.let { return it.generateViewId() }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewIdHelpers.kt
@@ -18,7 +18,8 @@ interface ViewIdProviding {
  *
  * Up to the time of writing this (RN 0.81.0-rc.5) every version incremented tag version by 2,
  * starting from `(ReactSurfaceView.tag + 1)`, therefore all tags were even. We start generating all
- * odd numbers from `(ReactSurfaceView.tag + 2)`, except valid root view tags, which are 1, 11, 21, etc.
+ * odd numbers from 3, except valid root view tags, which are 1, 11, 21, etc. This should work no matter
+ * exact RN version.
  *
  * Reference:
  *
@@ -29,7 +30,7 @@ interface ViewIdProviding {
  */
 @UiThread
 private class NewArchAwareViewIdGenerator : ViewIdProviding {
-    private var nextId: Int = if (BuildConfig.REACT_NATIVE_VERSION_MINOR >= 81 && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) 3 else 13
+    private var nextId: Int = 3
 
     override fun generateViewId(): Int = nextId.also { progressViewId() }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -12,6 +12,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
+import com.swmansion.rnscreens.gamma.helpers.ViewIdGenerator
 import kotlin.properties.Delegates
 
 class TabsHost(
@@ -100,7 +101,7 @@ class TabsHost(
                     ).apply {
                         weight = 1f
                     }
-            id = generateViewId()
+            id = ViewIdGenerator.generateViewId()
         }
 
     internal lateinit var eventEmitter: TabsHostEventEmitter

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
@@ -75,7 +75,7 @@ public class RNSSearchBarManagerDelegate<T extends View, U extends BaseViewManag
   }
 
   @Override
-  public void receiveCommand(T view, String commandName, ReadableArray args) {
+  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
     switch (commandName) {
       case "blur":
         mViewManager.blur(view);


### PR DESCRIPTION
## Description

`TabsHost.id` collied with `ReactSurfaceView.id`, because RN 0.81
started to number the root views from 1, instead of 11 as it was before.
This caused issues, becuase `FragmentTransaction.add(containerViewId:
Int, ...)` requires us to pass the `containerViewId`, which it then uses
to find a view in hierarchy with that id & it mounts added fragment's
view there. If collision occurs, Android Framework mounts the fragment
directly under `ReactSurfaceView` instead of our `TabsHost`.

Proposed workaround does the following:

1. ~it passes int value of react native minor version down from gradle
   script to build config, so that it is accessible in platform code.
   AFAIK there is no dedicated API as of 0.81 for this, therefore we
   need a workaround.~ We start counting from 3, it should work no matter RN version.
2. It adds new `ViewIdGenerator` that implements new `ViewIdProviding`.
   It has capability of overriding the view generator, so that the lib
   can be integrated in brownfield scenarios. We should use this object
   to generate view id for any of our views that need it.
3. The `ViewIdGenerator` relies on internals of RN, that are referenced
   in the code comments, to provide non-colliding view ids (tags).


## Test code and steps to reproduce

`TestBottomTabs` should work on 0.81. W/o this patch you won't see the bottom tab bar (it will be rendered, but under the top screen. The view would be mounted directly under `ReactSurfaceView`. 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
