### PR TITLE
fix(web): Add missing exports to web versions of components

### DIFF
--- a/src/components/gamma/ScreenStackHost.web.tsx
+++ b/src/components/gamma/ScreenStackHost.web.tsx
@@ -1,4 +1,10 @@
-import { View } from 'react-native';
+import { View, ViewProps } from 'react-native';
+
+interface NativeProps extends ViewProps {}
+
+export type ScreenStackNativeProps = NativeProps & {
+  // Overrides
+};
 
 const ScreenStackHost = View;
 

--- a/src/components/gamma/StackScreen.web.tsx
+++ b/src/components/gamma/StackScreen.web.tsx
@@ -1,4 +1,17 @@
-import { View } from 'react-native';
+import { View, ViewProps } from 'react-native';
+
+interface NativeProps extends ViewProps {}
+
+export const StackScreenLifecycleState = {
+  INITIAL: 0,
+  DETACHED: 1,
+  ATTACHED: 2,
+} as const;
+
+export type StackScreenNativeProps = NativeProps & {
+  // Overrides
+  maxLifecycleState: (typeof StackScreenLifecycleState)[keyof typeof StackScreenLifecycleState];
+};
 
 const StackScreen = View;
 


### PR DESCRIPTION
## Description

Fixes #3131.

This PR adds missing named exports in StackScreen and ScreenStackHost for web versions of components.