### PR TITLE
fix(iOS, Stack v4): crash on modal dismiss gesture with Pressable

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -730,6 +730,24 @@ RNS_IGNORE_SUPER_CALL_END
 #endif
 }
 
+#if !RCT_NEW_ARCH_ENABLED
+- (void)presentationControllerWillDismiss:(UIPresentationController *)presentationController
+{
+  // On Paper, we need to call both "cancel" and "reset" here because RN's gesture
+  // recognizer does not handle the scenario when it gets cancelled by other top
+  // level gesture recognizer. In this case by the modal dismiss gesture.
+  // Because of that, at the moment when this method gets called the React's
+  // gesture recognizer is already in FAILED state but cancel events never gets
+  // send to JS. Calling "reset" forces RCTTouchHanler to dispatch cancel event.
+  // To test this behavior one need to open a dismissable modal and start
+  // pulling down starting at some touchable item. Without "reset" the touchable
+  // will never go back from highlighted state even when the modal start sliding
+  // down.
+  [_touchHandler cancel];
+  [_touchHandler reset];
+}
+#endif // !RCT_NEW_ARCH_ENABLED
+
 - (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController
 {
   if (_preventNativeDismiss) {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -730,27 +730,6 @@ RNS_IGNORE_SUPER_CALL_END
 #endif
 }
 
-- (void)presentationControllerWillDismiss:(UIPresentationController *)presentationController
-{
-  // We need to call both "cancel" and "reset" here because RN's gesture recognizer
-  // does not handle the scenario when it gets cancelled by other top
-  // level gesture recognizer. In this case by the modal dismiss gesture.
-  // Because of that, at the moment when this method gets called the React's
-  // gesture recognizer is already in FAILED state but cancel events never gets
-  // send to JS. Calling "reset" forces RCTTouchHanler to dispatch cancel event.
-  // To test this behavior one need to open a dismissable modal and start
-  // pulling down starting at some touchable item. Without "reset" the touchable
-  // will never go back from highlighted state even when the modal start sliding
-  // down.
-#ifdef RCT_NEW_ARCH_ENABLED
-  [_touchHandler setEnabled:NO];
-  [_touchHandler setEnabled:YES];
-#else
-  [_touchHandler cancel];
-#endif
-  [_touchHandler reset];
-}
-
 - (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController
 {
   if (_preventNativeDismiss) {


### PR DESCRIPTION
## Description

Removes manual gesture cancel for modal dismiss on Fabric.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/360.

The logic for cancelling gesture when modal will be dismissed has been added in https://github.com/software-mansion/react-native-screens/pull/1485. 

On iOS 26 + Fabric, this code causes a crash (gesture update comes after resetting `_activeTouches` array, inconsistency is detected).

The logic seems redundant now as the case described in the comment works without it on Fabric. I suspect this might've been patched in [this commit in `react-native`](https://github.com/facebook/react-native/commit/379d9d4918886e002d70dd30fff29f8e6a8cf48f).

On Paper, it is still necesssary. During testing, I noticed another bug - you can "catch" another pressable during animation. This however happens only on Paper.

| Paper | Fabric |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a29d7a59-74b1-4ae8-8250-36bb1fafd362" /> | <video src="https://github.com/user-attachments/assets/b264caaa-91ff-433e-8618-6d946b6370ce" />

There are more places where we force the reset but I don't think that removing them all now is a good idea. We can go one-by-one, when any problems emerge.

## Changes

- remove `presentationControllerWillDismiss` override on Fabric

## Screenshots / GIFs

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bb6ad158-04af-4ca2-a0c7-4cd2fae86de9" /> | <video src="https://github.com/user-attachments/assets/aefadd8e-6106-43b5-bf8f-dfd8a148c617" /> |

## Test code and steps to reproduce

Run `Test3111` (that PR hasn't been merged at the moment) or `Test780`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
