### PR TITLE
chore: run formatter with updated `clang-format`

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -109,9 +109,10 @@ void RNSScreenShadowNode::appendChild(
 
       screenShadowNode.setPadding({0, 0, 0, headerHeight});
       screenShadowNode.setHeaderHeight(headerHeight);
-      screenShadowNode.getFrameCorrectionModes().set(FrameCorrectionModes::Mode(
-          FrameCorrectionModes::Mode::FrameHeightCorrection |
-          FrameCorrectionModes::Mode::FrameOriginCorrection));
+      screenShadowNode.getFrameCorrectionModes().set(
+          FrameCorrectionModes::Mode(
+              FrameCorrectionModes::Mode::FrameHeightCorrection |
+              FrameCorrectionModes::Mode::FrameOriginCorrection));
     }
   }
 #endif // ANDROID

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderSubviewState.h
@@ -28,12 +28,14 @@ class JSI_EXPORT RNSScreenStackHeaderSubviewState final {
   RNSScreenStackHeaderSubviewState(
       RNSScreenStackHeaderSubviewState const &previousState,
       folly::dynamic data)
-      : frameSize(Size{
-            (Float)data["frameWidth"].getDouble(),
-            (Float)data["frameHeight"].getDouble()}),
-        contentOffset(Point{
-            (Float)data["contentOffsetX"].getDouble(),
-            (Float)data["contentOffsetY"].getDouble()}) {}
+      : frameSize(
+            Size{
+                (Float)data["frameWidth"].getDouble(),
+                (Float)data["frameHeight"].getDouble()}),
+        contentOffset(
+            Point{
+                (Float)data["contentOffsetX"].getDouble(),
+                (Float)data["contentOffsetY"].getDouble()}) {}
 #endif // ANDROID
 
 #ifdef ANDROID

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenState.h
@@ -26,12 +26,14 @@ class JSI_EXPORT RNSScreenState final {
 
 #ifdef ANDROID
   RNSScreenState(RNSScreenState const &previousState, folly::dynamic data)
-      : frameSize(Size{
-            (Float)data["frameWidth"].getDouble(),
-            (Float)data["frameHeight"].getDouble()}),
-        contentOffset(Point{
-            (Float)data["contentOffsetX"].getDouble(),
-            (Float)data["contentOffsetY"].getDouble()}),
+      : frameSize(
+            Size{
+                (Float)data["frameWidth"].getDouble(),
+                (Float)data["frameHeight"].getDouble()}),
+        contentOffset(
+            Point{
+                (Float)data["contentOffsetX"].getDouble(),
+                (Float)data["contentOffsetY"].getDouble()}),
         lastKnownHeaderHeight_{previousState.lastKnownHeaderHeight_},
         headerCorrectionModes_{previousState.headerCorrectionModes_} {};
 #endif

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -709,8 +709,9 @@ RNS_IGNORE_SUPER_CALL_END
 #ifdef RCT_NEW_ARCH_ENABLED
   if (_eventEmitter != nullptr) {
     std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onTransitionProgress(react::RNSScreenEventEmitter::OnTransitionProgress{
-            .progress = progress, .closing = closing ? 1 : 0, .goingForward = goingForward ? 1 : 0});
+        ->onTransitionProgress(
+            react::RNSScreenEventEmitter::OnTransitionProgress{
+                .progress = progress, .closing = closing ? 1 : 0, .goingForward = goingForward ? 1 : 0});
   }
   RNSScreenViewEvent *event = [[RNSScreenViewEvent alloc] initWithEventName:@"onTransitionProgress"
                                                                    reactTag:[NSNumber numberWithInt:self.tag]


### PR DESCRIPTION
## Description

Follow-up to https://github.com/software-mansion/react-native-screens/pull/3134.

It turns out that different versions of `clang-format` produce different output. Maybe we should have a look at our formatting pipeline.

## Changes

- formatting via `yarn format` with `clang-format@20.1.8`

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Ensured that CI passes
