### PR TITLE
feat(android, Tabs): Loading bottom tab icons from external source

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -245,7 +245,6 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation 'com.github.bumptech.glide:glide:4.14.2'
 
     def COIL_VERSION = "3.0.2"
     

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -246,7 +246,13 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
     implementation 'com.github.bumptech.glide:glide:4.14.2'
+
+    def COIL_VERSION = "3.0.2"
     
+    implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")
+    implementation("io.coil-kt.coil3:coil-svg:${COIL_VERSION}")
+        
     constraints {
         implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
             because("on older React Native versions this dependency conflicts with react-native-screens")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -245,7 +245,8 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
-
+    implementation 'com.github.bumptech.glide:glide:4.14.2'
+    
     constraints {
         implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
             because("on older React Native versions this dependency conflicts with react-native-screens")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -246,7 +246,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
 
-    def COIL_VERSION = "3.0.2"
+    def COIL_VERSION = "3.3.0"
     
     implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
     implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -21,8 +21,6 @@ import com.swmansion.rnscreens.gamma.tabs.event.TabScreenDidDisappearEvent
 import com.swmansion.rnscreens.gamma.tabs.event.TabScreenWillAppearEvent
 import com.swmansion.rnscreens.gamma.tabs.event.TabScreenWillDisappearEvent
 import com.swmansion.rnscreens.utils.RNSLog
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 @ReactModule(name = TabScreenViewManager.REACT_CLASS)
 class TabScreenViewManager :
@@ -226,7 +224,7 @@ class TabScreenViewManager :
         }
     }
 
-    fun loadUsingCoil(
+    private fun loadUsingCoil(
         context: Context,
         uri: String,
         onLoad: (img: Drawable) -> Unit,
@@ -240,10 +238,10 @@ class TabScreenViewManager :
                     onLoad(stateDrawable)
                 }.listener(
                     onError = { _, result ->
-                        Log.e("RCTTabView", "Error loading image: $uri", result.throwable)
+                        Log.e("[RNScreens]", "Error loading image: $uri", result.throwable)
                     },
                     onCancel = {
-                        Log.w("Cancel", "WTF?")
+                        Log.w("[RNScreens]", "Image loading request: $uri has been cancelled")
                     },
                 ).build()
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -1,5 +1,24 @@
 package com.swmansion.rnscreens.gamma.tabs
 
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.Log
+import androidx.core.net.toUri
+import coil3.ImageLoader
+import coil3.asDrawable
+import coil3.request.ImageRequest
+import coil3.svg.SvgDecoder
+import com.bumptech.glide.Glide
+import com.facebook.common.executors.CallerThreadExecutor
+import com.facebook.common.references.CloseableReference
+import com.facebook.datasource.BaseDataSubscriber
+import com.facebook.datasource.DataSource
+import com.facebook.datasource.DataSubscriber
+import com.facebook.drawee.backends.pipeline.Fresco
+import com.facebook.imagepipeline.image.CloseableBitmap
+import com.facebook.imagepipeline.image.CloseableImage
+import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
@@ -14,6 +33,8 @@ import com.swmansion.rnscreens.gamma.tabs.event.TabScreenDidDisappearEvent
 import com.swmansion.rnscreens.gamma.tabs.event.TabScreenWillAppearEvent
 import com.swmansion.rnscreens.gamma.tabs.event.TabScreenWillDisappearEvent
 import com.swmansion.rnscreens.utils.RNSLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @ReactModule(name = TabScreenViewManager.REACT_CLASS)
 class TabScreenViewManager :
@@ -23,7 +44,18 @@ class TabScreenViewManager :
 
     override fun getName() = REACT_CLASS
 
+    var imageLoader: ImageLoader? = null
+
+    var context: ThemedReactContext? = null
+
     override fun createViewInstance(reactContext: ThemedReactContext): TabScreen {
+        imageLoader =
+            ImageLoader
+                .Builder(reactContext)
+                .components {
+                    add(SvgDecoder.Factory())
+                }.build()
+        context = reactContext
         RNSLog.d(REACT_CLASS, "createViewInstance")
         return TabScreen(reactContext)
     }
@@ -191,6 +223,127 @@ class TabScreenViewManager :
         view: TabScreen,
         value: String?,
     ) = Unit
+
+    @ReactProp("iconResource")
+    override fun setIconResource(
+        view: TabScreen,
+        value: ReadableMap?,
+    ) {
+        val uri = value?.getString("uri")
+
+        /*
+            This works, but the first icon is loaded to early, and it don't respect icon color
+            We should be able to handle the first problem using controller from fresco or something
+            similar to listen for finish event. The seccond thing is probably about the difference
+            BitmapDrawable vs RootDrawable, not sure how to resolve that. Tried converting to bitmap and
+            back to BitmapDrawable without luck.
+         */
+
+//        if (uri != null) {
+//            val draweeView = SimpleDraweeView(context)
+//            draweeView.setImageURI(uri)
+//            view.icon = draweeView.drawable
+//        }
+
+        // Works fine lib (coil3) around 160kb in final bundle
+        if (uri != null) {
+            loadUsingCoil(view.context, uri) {
+                view.icon = it
+            }
+        }
+
+        // Works fine lib (glide) around 270kb in final bundle
+//        if (uri != null) {
+//            runBlocking {
+//                val drawable = loadGlideImage(view.context, uri)
+//                view.icon = drawable
+//            }
+//        }
+
+    /*
+        When you debug you can see that the drawable is properly downloaded, but it's not visible
+        My guess is that fresco may clear it automatically
+        Additionaly active indicator seems to be broken I have no idea why
+     */
+
+//        if (uri != null) {
+//            loadUsingFresco(uri) {
+//                view.icon = it
+//            }
+//        }
+    }
+
+    suspend fun loadGlideImage(
+        context: Context,
+        uri: String,
+    ): Drawable =
+        withContext(Dispatchers.IO) {
+            Glide
+                .with(context)
+                .asDrawable()
+                .load(uri.toUri())
+                .submit()
+                .get()
+        }
+
+    fun loadUsingCoil(
+        context: Context,
+        uri: String,
+        onLoad: (img: Drawable) -> Unit,
+    ) {
+        val request =
+            ImageRequest
+                .Builder(context)
+                .data(uri)
+                .target { drawable ->
+                    val stateDrawable = drawable.asDrawable(context.resources)
+                    onLoad(stateDrawable)
+                }.listener(
+                    onError = { _, result ->
+                        Log.e("RCTTabView", "Error loading image: $uri", result.throwable)
+                    },
+                    onCancel = {
+                        Log.w("Cancel", "WTF?")
+                    },
+                ).build()
+
+        imageLoader?.enqueue(request)
+    }
+
+    fun loadUsingFresco(
+        uri: String,
+        onLoad: (img: Drawable) -> Unit,
+    ) {
+        val request =
+            ImageRequestBuilder
+                .newBuilderWithSource(uri.toUri())
+                .build()
+        val imagePipeline = Fresco.getImagePipeline()
+        val dataSource =
+            imagePipeline.fetchDecodedImage(request, null)
+        val dataSubscriber: DataSubscriber<CloseableReference<CloseableImage>> =
+            object : BaseDataSubscriber<CloseableReference<CloseableImage>>() {
+                override fun onNewResultImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
+                    if (!dataSource.isFinished) {
+                        return
+                    }
+                    val ref = dataSource.result!!.get()
+                    if (ref is CloseableBitmap) {
+                        val bitmap = ref.underlyingBitmap
+                        val bitmapDrawable = BitmapDrawable(context!!.resources, bitmap)
+                        onLoad(bitmapDrawable)
+                    } else {
+                        println("NOPE")
+                    }
+                }
+
+                override fun onFailureImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
+                    TODO("Not yet implemented")
+                }
+            }
+
+        dataSource.subscribe(dataSubscriber, CallerThreadExecutor.getInstance())
+    }
 
     companion object {
         const val REACT_CLASS = "RNSBottomTabsScreen"

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerDelegate.java
@@ -69,6 +69,9 @@ public class RNSBottomTabsScreenManagerDelegate<T extends View, U extends BaseVi
       case "iconResourceName":
         mViewManager.setIconResourceName(view, value == null ? null : (String) value);
         break;
+      case "iconResource":
+        mViewManager.setIconResource(view, (ReadableMap) value);
+        break;
       case "tabBarItemBadgeTextColor":
         mViewManager.setTabBarItemBadgeTextColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerInterface.java
@@ -30,6 +30,7 @@ public interface RNSBottomTabsScreenManagerInterface<T extends View>  {
   void setTitle(T view, @Nullable String value);
   void setOrientation(T view, @Nullable String value);
   void setIconResourceName(T view, @Nullable String value);
+  void setIconResource(T view, @Nullable ReadableMap value);
   void setTabBarItemBadgeTextColor(T view, @Nullable Integer value);
   void setIconType(T view, @Nullable String value);
   void setIconImageSource(T view, @Nullable ReadableMap value);

--- a/apps/assets/svg/cart.svg
+++ b/apps/assets/svg/cart.svg
@@ -1,0 +1,3 @@
+<svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M4 4a1 1 0 0 1 1-1h1.5a1 1 0 0 1 .979.796L7.939 6H19a1 1 0 0 1 .979 1.204l-1.25 6a1 1 0 0 1-.979.796H9.605l.208 1H17a3 3 0 1 1-2.83 2h-2.34a3 3 0 1 1-4.009-1.76L5.686 5H5a1 1 0 0 1-1-1Z" clip-rule="evenodd"/>
+</svg>

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -90,7 +90,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
         sfSymbolName: 'rectangle.stack.fill',
       },
       // iconResourceName: 'sym_action_chat', // Android specific
-      iconResource: require('../../../assets/variableIcons/icon.png'),
+      iconResource: require('../../../assets/svg/cart.svg'),
       title: 'Tab4',
       badgeValue: '',
       orientation: 'portrait',

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -28,7 +28,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
       selectedIcon: {
         sfSymbolName: 'house.fill',
       },
-      iconResourceName: 'sym_call_incoming', // Android specific
+      // iconResourceName: 'sym_call_incoming', // Android specific
+      iconResource: require('../../../assets/variableIcons/icon_fill.png'),
     },
     component: Tab1,
   },
@@ -53,7 +54,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
         templateSource: require('../../../assets/variableIcons/icon_fill.png'),
       },
       tabBarItemIconColor: Colors.RedDark120,
-      iconResourceName: 'sym_call_missed', // Android specific
+      // iconResourceName: 'sym_call_missed', // Android specific
+      iconResource: require('../../../assets/variableIcons/icon.png'),
       title: 'Tab2',
       orientation: 'landscape',
     },
@@ -71,7 +73,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
       selectedIcon: {
         imageSource: require('../../../assets/variableIcons/icon_fill.png'),
       },
-      iconResourceName: 'sym_action_email', // Android specific
+      // iconResourceName: 'sym_action_email', // Android specific
+      iconResource: require('../../../assets/variableIcons/icon_fill.png'),
       title: 'Tab3',
       orientation: 'portrait',
     },
@@ -86,7 +89,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
       selectedIcon: {
         sfSymbolName: 'rectangle.stack.fill',
       },
-      iconResourceName: 'sym_action_chat', // Android specific
+      // iconResourceName: 'sym_action_chat', // Android specific
+      iconResource: require('../../../assets/variableIcons/icon.png'),
       title: 'Tab4',
       badgeValue: '',
       orientation: 'portrait',

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -110,7 +110,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
   const iconProps = parseIconsToNativeProps(icon, selectedIcon);
 
   let parsedIconResource;
-  if(iconResource) {
+  if (iconResource) {
     parsedIconResource = Image.resolveAssetSource(iconResource);
   }
 

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Freeze } from 'react-freeze';
 import {
+  Image,
   StyleSheet,
   findNodeHandle,
   type ImageSourcePropType,
@@ -48,6 +49,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
     freezeContents,
     icon,
     selectedIcon,
+    iconResource,
     ...rest
   } = props;
 
@@ -107,6 +109,11 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
 
   const iconProps = parseIconsToNativeProps(icon, selectedIcon);
 
+  let parsedIconResource;
+  if(iconResource) {
+    parsedIconResource = Image.resolveAssetSource(iconResource);
+  }
+
   return (
     <BottomTabsScreenNativeComponent
       collapsable={false}
@@ -116,6 +123,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
       onWillDisappear={onWillDisappearCallback}
       onDidDisappear={onDidDisappearCallback}
       isFocused={isFocused}
+      iconResource={parsedIconResource || iconResource}
       {...iconProps}
       // @ts-ignore - This is debug only anyway
       ref={componentNodeRef}

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -128,7 +128,10 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
       onWillDisappear={onWillDisappearCallback}
       onDidDisappear={onDidDisappearCallback}
       isFocused={isFocused}
-      // I'm keeping iconResource as a fallback if `Image.resolveAssetSource` has failed for some reason.
+      // I'm keeping undefined as a fallback if `Image.resolveAssetSource` has failed for some reason.
+      // It won't render any icon, but it will prevent from crashing on the native side which is expecting
+      // ReadableMap. Passing `iconResource` directly will result in crash, because `require` API is returning
+      // double as a value.
       iconResource={parsedIconResource || undefined}
       {...iconProps}
       // @ts-ignore - This is debug only anyway

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -123,6 +123,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
       onWillDisappear={onWillDisappearCallback}
       onDidDisappear={onDidDisappearCallback}
       isFocused={isFocused}
+      // I'm keeping iconResource as a fallback if `Image.resolveAssetSource` has failed for some reason.
       iconResource={parsedIconResource || iconResource}
       {...iconProps}
       // @ts-ignore - This is debug only anyway

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -112,6 +112,11 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
   let parsedIconResource;
   if (iconResource) {
     parsedIconResource = Image.resolveAssetSource(iconResource);
+    if (!parsedIconResource) {
+      console.error(
+        '[RNScreens] failed to resolve an asset for bottom tab icon',
+      );
+    }
   }
 
   return (
@@ -124,7 +129,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
       onDidDisappear={onDidDisappearCallback}
       isFocused={isFocused}
       // I'm keeping iconResource as a fallback if `Image.resolveAssetSource` has failed for some reason.
-      iconResource={parsedIconResource || iconResource}
+      iconResource={parsedIconResource || undefined}
       {...iconProps}
       // @ts-ignore - This is debug only anyway
       ref={componentNodeRef}

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -202,6 +202,12 @@ export interface BottomTabsScreenProps {
    */
   iconResourceName?: string;
   /**
+   * TODO: @t0maboro - add description
+   *
+   * @platform android
+   */
+  iconResource?: ImageSourcePropType;
+  /**
    * @summary Specifies the color of the text in the badge.
    *
    * @platform android

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -202,7 +202,10 @@ export interface BottomTabsScreenProps {
    */
   iconResourceName?: string;
   /**
-   * TODO: @t0maboro - add description
+   * @summary Specifies the icon for the tab bar item.
+   * 
+   * Accepts a path to the external image asset. As for now, it respects an image from local assets
+   * and passed by `source.uri` property.
    *
    * @platform android
    */

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -203,7 +203,7 @@ export interface BottomTabsScreenProps {
   iconResourceName?: string;
   /**
    * @summary Specifies the icon for the tab bar item.
-   * 
+   *
    * Accepts a path to the external image asset. As for now, it respects an image from local assets
    * and passed by `source.uri` property.
    *

--- a/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
@@ -97,6 +97,7 @@ export interface NativeProps extends ViewProps {
 
   // Android-specific image handling
   iconResourceName?: string;
+  iconResource?: ImageSource;
   tabBarItemBadgeTextColor?: ColorValue;
 
   // iOS-specific: SFSymbol usage


### PR DESCRIPTION
## Description

Adding a basic support for loading bottom-tabs icon from assets. This provides an alternative way to `iconResourceName`  for setting icon for the specific tab.

## Changes

- Adding `coil`: https://coil-kt.github.io/coil/ - a library that handles image loading.
- Adding basic ImageRequest - ImageBuilder integration
- Exposing a prop for setting icon from JS sources.

## Screenshots / GIFs

<img width="401" height="882" alt="Screenshot 2025-08-18 at 13 30 04" src="https://github.com/user-attachments/assets/6313dcf5-c8dd-4e1e-b4e8-6c4a82657d5e" />

## Test code and steps to reproduce

Adding `iconResource` prop to `TestBottomTabs`.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
