### PR TITLE
chore: Update imports after 0.81 upgrade

### DIFF
--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/ScreenContainerNativeComponent.ts
+++ b/src/fabric/ScreenContainerNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenContentWrapperNativeComponent.ts
+++ b/src/fabric/ScreenContentWrapperNativeComponent.ts
@@ -1,4 +1,4 @@
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 export interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenFooterNativeComponent.ts
+++ b/src/fabric/ScreenFooterNativeComponent.ts
@@ -1,4 +1,4 @@
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 export interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/ScreenNavigationContainerNativeComponent.ts
+++ b/src/fabric/ScreenNavigationContainerNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   Int32,

--- a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/ScreenStackNativeComponent.ts
+++ b/src/fabric/ScreenStackNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ColorValue, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type { ColorValue, ViewProps } from 'react-native';
 import {
   DirectEventHandler,
@@ -10,7 +10,7 @@ import {
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 // @ts-ignore: ImageSource type has been recently added: https://github.com/facebook/react-native/pull/51969
-import type { ImageSource } from 'react-native/Libraries/Image/ImageSource';
+import type { ImageSource } from 'react-native';
 
 // iOS-specific: SFSymbol, image as a template usage
 export type IconType = 'image' | 'template' | 'sfSymbol';

--- a/src/fabric/gamma/ScreenStackHostNativeComponent.ts
+++ b/src/fabric/gamma/ScreenStackHostNativeComponent.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 
 export interface NativeProps extends ViewProps {}
 

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 import type {
   DirectEventHandler,
   Float,

--- a/src/fabric/gamma/SplitViewScreenNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewScreenNativeComponent.ts
@@ -5,7 +5,7 @@ import {
   DirectEventHandler,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;

--- a/src/fabric/gamma/StackScreenNativeComponent.ts
+++ b/src/fabric/gamma/StackScreenNativeComponent.ts
@@ -5,7 +5,7 @@ import {
   DirectEventHandler,
   Int32,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GenericEmptyEvent = Readonly<{}>;


### PR DESCRIPTION
## Description

After running `yarn lint-js` I noticed that deep imports are replaced. Related to: https://reactnative.dev/blog/2025/06/12/react-native-0.80#javascript-deep-imports-deprecation  

## Changes

- Updated imports after running linter

## Test code and steps to reproduce

N/A

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Ensured that CI passes
