### PR TITLE
fix(JS): Keep relative imports for backward compatibility

### DIFF
--- a/src/fabric/FullWindowOverlayNativeComponent.ts
+++ b/src/fabric/FullWindowOverlayNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/ScreenContainerNativeComponent.ts
+++ b/src/fabric/ScreenContainerNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 
 interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenContentWrapperNativeComponent.ts
+++ b/src/fabric/ScreenContentWrapperNativeComponent.ts
@@ -1,4 +1,5 @@
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 
 export interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenFooterNativeComponent.ts
+++ b/src/fabric/ScreenFooterNativeComponent.ts
@@ -1,4 +1,5 @@
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 
 export interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/ScreenNavigationContainerNativeComponent.ts
+++ b/src/fabric/ScreenNavigationContainerNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 
 interface NativeProps extends ViewProps {}

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue } from 'react-native';
 import type {
   Int32,

--- a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/ScreenStackNativeComponent.ts
+++ b/src/fabric/ScreenStackNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
 /* eslint-disable */
+ 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, ColorValue, HostComponent } from 'react-native';
 import type {

--- a/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ColorValue, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,

--- a/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {
   ColorValue,
   ImageSource,

--- a/src/fabric/gamma/ScreenStackHostNativeComponent.ts
+++ b/src/fabric/gamma/ScreenStackHostNativeComponent.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import type { ViewProps } from 'react-native';
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 export interface NativeProps extends ViewProps {}
 

--- a/src/fabric/gamma/SplitViewHostNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewHostNativeComponent.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import type { ViewProps } from 'react-native';
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {
   DirectEventHandler,
   Float,

--- a/src/fabric/gamma/SplitViewScreenNativeComponent.ts
+++ b/src/fabric/gamma/SplitViewScreenNativeComponent.ts
@@ -5,7 +5,8 @@ import {
   DirectEventHandler,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;

--- a/src/fabric/gamma/StackScreenNativeComponent.ts
+++ b/src/fabric/gamma/StackScreenNativeComponent.ts
@@ -5,7 +5,8 @@ import {
   DirectEventHandler,
   Int32,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import { codegenNativeComponent } from 'react-native';
+// eslint-disable-next-line -- required for backward compatibility
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GenericEmptyEvent = Readonly<{}>;


### PR DESCRIPTION
## Description

In this commit: https://github.com/software-mansion/react-native-screens/commit/3a3a6c5449796aeef229d40b5805721b808bf3ab `eslint` was complaining about the import. Moreover, running `lint-js` changes this line itself after upgrading to 0.81. As for now, we need to keep relative import for a backward compatibility with versions that we support and for which `codegenNativeComponent` wasn't exported.

Fixes https://github.com/software-mansion/react-native-screens/issues/3152 .

## Changes

- Skipping linter check for the line with the relative import.

## Test code and steps to reproduce

- Create a project from template, using for example 0.79.6
- Add `react-native-screens@^4.15.0` and `@react-navigation` 
- Add native stack to `App.tsx`
- Run `yarn test`

For testing my changes I packed RNScreens from this PR to tarball and sideloaded it to the application with `file://`

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
