### PR TITLE
fix(android): Fix RNScreens 4.15 build on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -246,7 +246,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
 
-    def COIL_VERSION = "3.3.0"
+    def COIL_VERSION = "3.0.4"
     
     implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
     implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabScreenViewManager.kt
@@ -180,7 +180,7 @@ class TabScreenViewManager :
         value: String?,
     ) = Unit
 
-    @ReactProp("iconResource")
+    @ReactProp(name = "iconResource")
     override fun setIconResource(
         view: TabScreen,
         value: ReadableMap?,


### PR DESCRIPTION
## Description

[Coil](https://coil-kt.github.io/coil/) image loading library for android was integrated with `react-native-screens` in `4.15` release for loading icons from external sources in bottom tab icons. However, the chosen version has broken a backward compatibility with RN 0.79, forcing too high kotlin version. This PR contains fixes for 0.79 build failures.

Fixes https://github.com/software-mansion/react-native-screens/issues/3155

## Changes

- Downgraded coil from 3.3.x to 3.0.x
- Added named property

## Test code and steps to reproduce

Created and confirmed all supported RN versions are working properly:
- [ ] RN 0.79
- [ ] RN 0.80
- [ ] RN 0.81
Tested that downgrading Coil doesn't break loading icons in bottom tabs
- [ ] Fabric
- [ ] Paper

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
