### PR TITLE
fix(iOS, Tabs): don't reset system item icon to undefined when no icon is provided

### DIFF
--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -53,8 +53,11 @@
               withImageLoader:(RCTImageLoader *_Nullable)imageLoader
 {
   if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol) {
-    tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
-    tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
+    // We don't want to set the icon to undefined when system item is used. Otherwise the system icon will be reset.
+    if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone || screenView.iconSfSymbolName != nil) {
+      tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
+      tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
+    }
   } else if (imageLoader != nil) {
     bool isTemplate = screenView.iconType == RNSBottomTabsIconTypeTemplate;
 


### PR DESCRIPTION
## Description

When `systemItem` was used without icon, the icon was reset. This resulted in no icon being rendered.

## Changes

### Before

<img height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-25 at 14 43 33" src="https://github.com/user-attachments/assets/e75c24e1-c59f-4de1-bc07-7e088578a4b5" />


### After

<img height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-25 at 14 44 16" src="https://github.com/user-attachments/assets/8c8a1d8f-8672-4fd2-a6c2-288b016e0a67" />


## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
