### PR TITLE
fix(iOS, Tabs): refactor setting systemItem

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-// import Example from './Example';
-import * as Test from './src/tests';
+import Example from './Example';
+// import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  // return <Example />;
-  return <Test.TestBottomTabs />;
+  return <Example />;
+  // return <Test.TestBottomTabs />;
 }

--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-import Example from './Example';
-// import * as Test from './src/tests';
+// import Example from './Example';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  return <Example />;
-  // return <Test.TestBottomTabs />;
+  // return <Example />;
+  return <Test.TestBottomTabs />;
 }

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -149,8 +149,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
       // iconResourceName: 'sym_action_chat', // Android specific
       iconResource: require('../../../assets/svg/cart.svg'),
       title: 'Tab4',
-      // systemItem: 'search', // iOS specific
-      badgeValue: '',
+      systemItem: 'search', // iOS specific
+      badgeValue: '123',
       orientation: 'portrait',
     },
     component: Tab4,

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -57,8 +57,6 @@
       tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
     } else if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone) {
       // We don't want to override systemItem's icon if no custom icon is provided.
-      // There is unhandled edge case: if you use systemItem, set custom icon and then remove custom icon -> we won't
-      // restore systemItem's icon.
       tabBarItem.image = nil;
     }
 

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -53,8 +53,21 @@
               withImageLoader:(RCTImageLoader *_Nullable)imageLoader
 {
   if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol) {
-    tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
-    tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
+    if (screenView.iconSfSymbolName != nil) {
+      tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
+    } else if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone) {
+      // We don't want to override systemItem's icon if no custom icon is provided.
+      // There is unhandled edge case: if you use systemItem, set custom icon and then remove custom icon -> we won't
+      // restore systemItem's icon.
+      tabBarItem.image = nil;
+    }
+
+    if (screenView.selectedIconSfSymbolName != nil) {
+      tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
+    } else if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone) {
+      // We don't want to override systemItem's icon if no custom icon is provided.
+      tabBarItem.selectedImage = nil;
+    }
   } else if (imageLoader != nil) {
     bool isTemplate = screenView.iconType == RNSBottomTabsIconTypeTemplate;
 

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -55,16 +55,10 @@
   if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol) {
     if (screenView.iconSfSymbolName != nil) {
       tabBarItem.image = [UIImage systemImageNamed:screenView.iconSfSymbolName];
-    } else if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone) {
-      // We don't want to override systemItem's icon if no custom icon is provided.
-      tabBarItem.image = nil;
     }
 
     if (screenView.selectedIconSfSymbolName != nil) {
       tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconSfSymbolName];
-    } else if (screenView.systemItem == RNSBottomTabsScreenSystemItemNone) {
-      // We don't want to override systemItem's icon if no custom icon is provided.
-      tabBarItem.selectedImage = nil;
     }
   } else if (imageLoader != nil) {
     bool isTemplate = screenView.iconType == RNSBottomTabsIconTypeTemplate;


### PR DESCRIPTION
## Description

This PR addresses some problems related to `systemItem`:
1. on startup, tab bar item with `systemItem` but without custom icon would not show the default icon (it was overriden by nil SFSymbol),
2. when using custom icon with `systemItem` and then removing the custom icon, the default icon for `systemItem` would not be restored,
3. if badge value was updated as the same time as `systemItem` was set, the value of the badge would not be updated (due to badge value being updated _before_ `systemItem`).

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/380.

## Changes

- move updates to `tabBarItem` to separate method after setting props

## Screenshots / GIFs

### Before 

https://github.com/user-attachments/assets/d5b197d0-d29c-4587-8cfa-5c9ed96734e6

### After

https://github.com/user-attachments/assets/96c71b0b-6c89-4677-a726-a17588dca4a7

## Test code and steps to reproduce

1. Run `TestBottomTabs` with and without custom icon for Tab4 (with systemItem). Correct icon should be visible.
5. Run `TestBottomTabs` without systemItem for Tab4. Change both badgeValue and systemItem at the same time and save file. Badge value should be updated.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
