### PR TITLE
feat(iOS): Handle interactiveContentPopGesture for iOS 26

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 import Example from './Example';
-// import * as Test from './src/tests';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
   return <Example />;
-  // return <Test.TestBottomTabs />;
+  // return <Test.TestFoo />;
 }

--- a/apps/src/tests/Test3093.tsx
+++ b/apps/src/tests/Test3093.tsx
@@ -4,7 +4,7 @@ import {
   NativeStackNavigationProp,
   createNativeStackNavigator,
 } from '@react-navigation/native-stack';
-import { Button, Text, ScrollView } from 'react-native';
+import { Button, Text, View, ScrollView } from 'react-native';
 import Colors from '../shared/styling/Colors';
 
 type StackRouteParamList = {
@@ -37,7 +37,6 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{
-        fullScreenGestureEnabled: true,
         headerStyle: {
           backgroundColor: Colors.PurpleDark120
         }

--- a/apps/src/tests/TestFoo.tsx
+++ b/apps/src/tests/TestFoo.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { View, Text, Button } from 'react-native';
+import { Screen, ScreenStack, ScreenStackHeaderConfig } from '../../../src';
+import { useState } from 'react';
+import Colors from '../shared/styling/Colors';
+
+function HomeScreen({ add }: { add: () => void }) {
+  console.log('Render home');
+  return (
+    <View
+      style={{
+        flex: 1,
+        gap: 8,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: Colors.RedLight40,
+      }}>
+      <Text>Home!</Text>
+      <Button
+        title="Next"
+        onPress={add}
+      />
+    </View>
+  );
+}
+
+function ProfileScreen({ add, idx }: { add: () => void, idx: number }) {
+  const colors = [Colors.BlueLight40, Colors.GreenLight40, Colors.YellowLight40];
+  const [colorIndex, setColorIndex] = useState(0);
+  console.log('Render another');
+  return (
+    <View
+      style={{
+        flex: 1,
+        gap: 8,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors[colorIndex]
+      }}>
+      <Text>Another! #{idx}</Text>
+      <Button
+        title="More"
+        onPress={add}
+      />
+      <Button
+        title="Recolor"
+        onPress={() => setColorIndex(i => (i+1) % 3)}
+      />
+    </View>
+  );
+}
+
+const App = () => {
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <ScreenStack style={{ flex: 1 }}>
+      <Screen key='home' activityState={2} isNativeStack onAppear={() => {setCount(0)}}>
+        <ScreenStackHeaderConfig title='Home'/>
+        <HomeScreen add={() => setCount(n => n+1)}/>
+      </Screen>
+      { Array.from({length: count}).map((_, i) => (
+        <Screen key={`prof${i}`} activityState={2} isNativeStack>
+          <ScreenStackHeaderConfig title={'Another #' + (i+1)}/>
+          <ProfileScreen add={() => setCount(n => n+1)} idx={i+1}/>
+        </Screen>
+      )) }
+    </ScreenStack>
+  );
+};
+export default App;

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -146,6 +146,7 @@ export { default as Test3045 } from './Test3045';
 export { default as Test3093 } from './Test3093';
 export { default as Test3111 } from './Test3111';
 export { default as Test3115 } from './Test3115';
+export { default as TestFoo } from './TestFoo';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -55,6 +55,7 @@ Defaults to `false`. When `enableFreeze()` is run at the top of the application 
 ### `fullScreenSwipeEnabled` (iOS only)
 
 Boolean indicating whether the swipe gesture should work on whole screen. Swiping with this option results in the same transition animation as `simple_push` by default. It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation is not achievable due to usage of custom recognizer. Defaults to `false`.
+IMPORTANT: Starting from iOS 26, full screen swipe to dismiss is the native behavior, and this prop is ignored.
 
 ### `fullScreenSwipeShadowEnabled` (iOS only)
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1466,6 +1466,12 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 // TODO: Find out why this is executed when screen is going out
 - (void)viewWillAppear:(BOOL)animated
 {
+  if (@available(iOS 26, *)) {
+    // In iOS 26, as soon as another screen appears in transition, it is interactable
+    // To avoid glitches resulting from clicking buttons mid transition, we temporarily disable all interactions
+    // Because nested stack exist, we need to find a common top view for the whole app
+    [self findReactRootViewController].view.userInteractionEnabled = false;
+  }
   [super viewWillAppear:animated];
   if (!_isSwiping) {
     [self.screenView notifyWillAppear];
@@ -1530,6 +1536,10 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (void)viewDidAppear:(BOOL)animated
 {
+  if (@available(iOS 26, *)) {
+    // Reenable interactions, see viewWillAppear
+    [self findReactRootViewController].view.userInteractionEnabled = true;
+  }
   [super viewDidAppear:animated];
   if (!_isSwiping || _shouldNotify) {
     // we are going forward or dismissing without swipe
@@ -1599,6 +1609,18 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     }
 #endif
   }
+}
+
+- (UIViewController *)findReactRootViewController
+{
+  UIView *parent = self.view;
+  while (parent) {
+    parent = parent.reactSuperview;
+    if (parent.isReactRootView) {
+      return parent.reactViewController;
+    }
+  }
+  return nil;
 }
 
 - (BOOL)isModalWithHeader

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -62,27 +62,6 @@ namespace react = facebook::react;
 
 @implementation RNSNavigationController
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
-- (void)viewDidLoad
-{
-  // iOS 26 introduces new gesture recognizer which replaces our RNSPanGestureRecognizer.
-  // The problem is that we are not able to handle it here for various reasons:
-  // - the new recognizer comes with its own delegate and our current approach is to wire
-  //   all recognizers to RNSScreenStackView; to be 100% sure we don't break the logic,
-  //   we would have to decorate its delegate and call it after our code, which would
-  //   break other recognizers that the stack view is the delegate for
-  // - when RNSScreenStackView.setupGestureHandler method is called, the recognizer hasn't been
-  //   loaded yet and there is no other place to configure in a not "hacky" way
-  // - the official docs warn us to not use it for anything other than "setting up failure requirements with it"
-  // - we expose fullScreenGestureEnabled prop to enable/disable the feature,
-  //   so we need control over the delegate
-  if (@available(iOS 26.0, *)) {
-    self.interactiveContentPopGestureRecognizer.enabled = NO;
-  }
-}
-#endif // iOS 26
-
 #if !TARGET_OS_TV
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
@@ -220,51 +199,6 @@ namespace react = facebook::react;
   return false;
 }
 
-#pragma mark - UINavigationBarDelegate
-
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_26_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
-- (BOOL)navigationBar:(UINavigationBar *)navigationBar shouldPopItem:(UINavigationItem *)item
-{
-  if (@available(iOS 26, *)) {
-    // To prevent popping multiple screens when back button is pressed repeatedly,
-    // We allow for pop operation to proceed only if no transition is in progress,
-    // which we check indirectly by checking if transitionCoordinator is set.
-    // If it's not, we are safe to proceed.
-    if (self.transitionCoordinator == nil) {
-      // We still need to disable interactions for back button so click effects are not applied,
-      // and there is unfortunately no better place for it currently
-      UIView *button = [navigationBar rnscreens_findBackButtonWrapperView];
-      if (button != nil) {
-        button.userInteractionEnabled = false;
-      }
-
-      return true;
-    }
-
-    return false;
-  }
-
-  return true;
-}
-
-- (void)navigationBar:(UINavigationBar *)navigationBar didPopItem:(UINavigationItem *)item
-{
-  if (@available(iOS 26, *)) {
-    // Reset interactions on back button -> see navigationBar:shouldPopItem
-    // IMPORTANT: This reset won't execute when preventNativeDismiss is on.
-    // However, on iOS 26, unlike in previous versions, the back button instance changes
-    // when handling preventNativeDismiss and userIteractionEnabled is reset.
-    // The instance also changes when regular screen pop happens, but in that case
-    // the value of userInteractionEnabled is carried on, and we reset it here.
-    UIView *button = [navigationBar rnscreens_findBackButtonWrapperView];
-    if (button != nil) {
-      button.userInteractionEnabled = true;
-    }
-  }
-}
-#endif // Check for iOS >= 26
-
 #pragma mark - RNSFrameCorrectionProvider
 
 #ifdef RNS_GAMMA_ENABLED
@@ -329,7 +263,7 @@ namespace react = facebook::react;
   UINavigationController *_controller;
   NSMutableArray<RNSScreenView *> *_reactSubviews;
   BOOL _invalidated;
-  BOOL _isFullWidthSwiping;
+  BOOL _isFullWidthSwipingWithPanGesture;
   RNSPercentDrivenInteractiveTransition *_interactionController;
   __weak RNSScreenStackManager *_manager;
   BOOL _updateScheduled;
@@ -524,6 +458,9 @@ RNS_IGNORE_SUPER_CALL_END
         [self addSubview:controller.view];
 #if !TARGET_OS_TV
         _controller.interactivePopGestureRecognizer.delegate = self;
+        if (@available(iOS 26, *)) {
+          _controller.interactiveContentPopGestureRecognizer.delegate = self;
+        }
 #endif
         [controller didMoveToParentViewController:parentView.reactViewController];
         // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
@@ -945,7 +882,7 @@ RNS_IGNORE_SUPER_CALL_END
       // when preventing the native dismiss with back button, we have to return the animator.
       // Also, we need to return the animator when full width swiping even if the animation is not custom,
       // otherwise the screen will be just popped immediately due to no animation
-      ((operation == UINavigationControllerOperationPop && shouldCancelDismiss) || _isFullWidthSwiping ||
+      ((operation == UINavigationControllerOperationPop && shouldCancelDismiss) || _isFullWidthSwipingWithPanGesture ||
        [RNSScreenStackAnimator isCustomAnimation:screen.stackAnimation] || _customAnimation)) {
     return [[RNSScreenStackAnimator alloc] initWithOperation:operation];
   }
@@ -973,15 +910,21 @@ RNS_IGNORE_SUPER_CALL_END
   [self cancelTouchesInParent];
   return YES;
 #else
-  // RNSPanGestureRecognizer will receive events iff topScreen.fullScreenSwipeEnabled == YES;
-  // Events are filtered in gestureRecognizer:shouldReceivePressOrTouchEvent: method
-  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    if ([self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
-      _isFullWidthSwiping = YES;
-      [self cancelTouchesInParent];
-      return YES;
+  if (@available(iOS 26, *)) {
+    // do nothing
+    // RNSPanGestureRecognizer is not needed anymore, it's been replaced
+    // by native interactiveContentPopGestureRecognizer and enabled by default
+  } else {
+    // RNSPanGestureRecognizer will receive events iff topScreen.fullScreenSwipeEnabled == YES;
+    // Events are filtered in gestureRecognizer:shouldReceivePressOrTouchEvent: method
+    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
+      if ([self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
+        _isFullWidthSwipingWithPanGesture = YES;
+        [self cancelTouchesInParent];
+        return YES;
+      }
+      return NO;
     }
-    return NO;
   }
 
   // Now we're dealing with RNSScreenEdgeGestureRecognizer (or _UIParallaxTransitionPanGestureRecognizer)
@@ -1030,11 +973,17 @@ RNS_IGNORE_SUPER_CALL_END
   rightEdgeSwipeGestureRecognizer.delegate = self;
   [self addGestureRecognizer:rightEdgeSwipeGestureRecognizer];
 
-  // gesture recognizer for full width swipe gesture
-  RNSPanGestureRecognizer *panRecognizer = [[RNSPanGestureRecognizer alloc] initWithTarget:self
-                                                                                    action:@selector(handleSwipe:)];
-  panRecognizer.delegate = self;
-  [self addGestureRecognizer:panRecognizer];
+  if (@available(iOS 26, *)) {
+    // do nothing
+    // RNSPanGestureRecognizer is not needed anymore, it's been replaced
+    // by native interactiveContentPopGestureRecognizer and enabled by default
+  } else {
+    // gesture recognizer for full width swipe gesture
+    RNSPanGestureRecognizer *panRecognizer = [[RNSPanGestureRecognizer alloc] initWithTarget:self
+                                                                                      action:@selector(handleSwipe:)];
+    panRecognizer.delegate = self;
+    [self addGestureRecognizer:panRecognizer];
+  }
 }
 
 - (void)handleSwipe:(UIPanGestureRecognizer *)gestureRecognizer
@@ -1093,7 +1042,7 @@ RNS_IGNORE_SUPER_CALL_END
         [_interactionController cancelInteractiveTransition];
       }
       _interactionController = nil;
-      _isFullWidthSwiping = NO;
+      _isFullWidthSwipingWithPanGesture = NO;
     }
     default: {
       break;
@@ -1251,9 +1200,15 @@ RNS_IGNORE_SUPER_CALL_END
     return NO;
   }
 
-  // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
-  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    return topScreen.fullScreenSwipeEnabled;
+  if (@available(iOS 26, *)) {
+    // do nothing
+    // RNSPanGestureRecognizer is not needed anymore, it's been replaced
+    // by native interactiveContentPopGestureRecognizer and enabled by default
+  } else {
+    // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
+    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
+      return topScreen.fullScreenSwipeEnabled;
+    }
   }
 
   // RNSScreenEdgeGestureRecognizer || _UIParallaxTransitionPanGestureRecognizer
@@ -1282,18 +1237,25 @@ RNS_IGNORE_SUPER_CALL_END
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-  if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
-      [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
-    RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
-    BOOL isBackGesture = [panGestureRecognizer translationInView:panGestureRecognizer.view].x > 0 &&
-        _controller.viewControllers.count > 1;
+  if (@available(iOS 26, *)) {
+    // do nothing
+    // RNSPanGestureRecognizer is not needed anymore, it's been replaced
+    // by native interactiveContentPopGestureRecognizer and enabled by default
+  } else {
+    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
+        [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
+      RNSPanGestureRecognizer *panGestureRecognizer = (RNSPanGestureRecognizer *)gestureRecognizer;
+      BOOL isBackGesture = [panGestureRecognizer translationInView:panGestureRecognizer.view].x > 0 &&
+          _controller.viewControllers.count > 1;
 
-    if (gestureRecognizer.state == UIGestureRecognizerStateBegan || isBackGesture) {
-      return NO;
+      if (gestureRecognizer.state == UIGestureRecognizerStateBegan || isBackGesture) {
+        return NO;
+      }
+
+      return YES;
     }
-
-    return YES;
   }
+
   return NO;
 }
 


### PR DESCRIPTION
## Description

Resolves https://github.com/software-mansion/react-native-screens-labs/issues/369, might resolve https://github.com/software-mansion/react-native-screens/issues/3161, reverts https://github.com/software-mansion/react-native-screens/pull/3141, https://github.com/software-mansion/react-native-screens/pull/3142

This PR attempts to enable interactiveContentPopGestureRecognizer for iOS 26 to achieve native screen popping behavior. Until 26, the default was to swipe from the edge of the screen. We had the option to do fullscreen switch, which was controlled by a `fullScreenSwipeEnabled` prop. Since the default behavior has changed, this prop needs rethinking, along with `gestureResponseDistance`. The new swipe is strictly for navigation purposes, and the old one, I believe, was more general-purpose.

New iOS allows for popping multiple screens almost at once, which we still cannot support due to asynchronous nature of stack updates coming from host to JS that would create a "feedback loop" in situation like the following: host pops 1. screen + sends update, pops  2. screen + sends update -> JS acknowledges 1. update + sends updated state -> host gets 2. screen from JS and pushes it again. This PR attempts to block more than 1 pop at once by removing interactions from the whole screen. As a (desired) side effect, this also disables interactions on the screen below the one that is popped until the transition finishes.

## Changes

- removed `RNSPanGestureRecognizer` from iOS 26 build and replace it with native `interactiveContentPopGestureRecognizer`
- disabled all interactions when screens are in transition

## Test code and steps to reproduce

TBD