### PR TITLE
refactor: review of #3073 - rename few methods, move update logic to shadow state proxy

### DIFF
--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
@@ -157,7 +157,7 @@ namespace react = facebook::react;
   // 3. `setFrame` is called with the width 'B'
   // 4. in the same time, we want to track updates and treat intermediate value A' indicated from the presentation layer
   // as our source of truth
-  if (![_controller isTransitionInProgress]) {
+  if (![_controller isViewSizeTransitionInProgress]) {
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
   }
 }

--- a/ios/gamma/split-view/RNSSplitViewScreenController.swift
+++ b/ios/gamma/split-view/RNSSplitViewScreenController.swift
@@ -17,7 +17,7 @@ public class RNSSplitViewScreenController: UIViewController {
   private var reactEventEmitter: RNSSplitViewScreenComponentEventEmitter {
     return splitViewScreenComponentView.reactEventEmitter()
   }
-  
+
   private var viewSizeTransitionState: ViewSizeTransitionState? = nil
 
   @objc public required init(splitViewScreenComponentView: RNSSplitViewScreenComponentView) {
@@ -99,9 +99,10 @@ public class RNSSplitViewScreenController: UIViewController {
       alongsideTransition: { [weak self] context in
         guard let self = self else { return }
         guard let viewSizeTransitionState = self.viewSizeTransitionState else { return }
-        
+
         if viewSizeTransitionState.displayLink == nil {
-          viewSizeTransitionState.setupDisplayLink(forTarget: self, selector: #selector(trackTransitionProgress))
+          viewSizeTransitionState.setupDisplayLink(
+            forTarget: self, selector: #selector(trackTransitionProgress))
         }
       },
       completion: { [weak self] context in
@@ -165,11 +166,15 @@ public class RNSSplitViewScreenController: UIViewController {
     // If the resize animation is currently running, we prefer to apply dynamic updates,
     // based on the results from the presentation layer
     // which is read from `trackTransitionProgress` method.
-    if let lastViewPresentationFrame = viewSizeTransitionState?.lastViewPresentationFrame, !lastViewPresentationFrame.isNull {
-      shadowStateProxy.updateShadowState(ofComponent: splitViewScreenComponentView, withFrame: lastViewPresentationFrame, inContextOfAncestorView: ancestorView!)
+    if let lastViewPresentationFrame = viewSizeTransitionState?.lastViewPresentationFrame,
+      !lastViewPresentationFrame.isNull
+    {
+      shadowStateProxy.updateShadowState(
+        ofComponent: splitViewScreenComponentView, withFrame: lastViewPresentationFrame,
+        inContextOfAncestorView: ancestorView!)
       return
     }
-    
+
     // There might be the case, when transition is about to start and in the meantime,
     // sth else is triggering frame update relatively to the parent. As we know
     // that dynamic updates from the presentation layer are coming, we're blocking this
@@ -177,7 +182,8 @@ public class RNSSplitViewScreenController: UIViewController {
     // This works fine, because after the animation completion, we're sending the last update
     // which is compatible with the frame which would be calculated relatively to the ancestor here.
     if !isViewSizeTransitionInProgress() {
-      shadowStateProxy.updateShadowState(ofComponent: splitViewScreenComponentView, inContextOfAncestorView: ancestorView)
+      shadowStateProxy.updateShadowState(
+        ofComponent: splitViewScreenComponentView, inContextOfAncestorView: ancestorView)
     }
   }
 
@@ -223,16 +229,16 @@ public class RNSSplitViewScreenController: UIViewController {
 private class ViewSizeTransitionState {
   public var displayLink: CADisplayLink?
   public var lastViewPresentationFrame: CGRect = CGRect.null
-  
+
   public func setupDisplayLink(forTarget target: Any, selector sel: Selector) {
-    if (displayLink != nil) {
+    if displayLink != nil {
       displayLink?.invalidate()
     }
-    
+
     displayLink = CADisplayLink(target: target, selector: sel)
     displayLink!.add(to: .main, forMode: .common)
   }
-  
+
   public func invalidate() {
     displayLink?.invalidate()
     displayLink = nil

--- a/ios/gamma/split-view/RNSSplitViewScreenController.swift
+++ b/ios/gamma/split-view/RNSSplitViewScreenController.swift
@@ -17,15 +17,11 @@ public class RNSSplitViewScreenController: UIViewController {
   private var reactEventEmitter: RNSSplitViewScreenComponentEventEmitter {
     return splitViewScreenComponentView.reactEventEmitter()
   }
-
-  private var displayLink: CADisplayLink?
-  private var lastAnimationFrame: CGRect?
-  private var transitionInProgress: Bool
+  
+  private var viewSizeTransitionState: ViewSizeTransitionState? = nil
 
   @objc public required init(splitViewScreenComponentView: RNSSplitViewScreenComponentView) {
     self.splitViewScreenComponentView = splitViewScreenComponentView
-    self.transitionInProgress = false
-
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -74,8 +70,8 @@ public class RNSSplitViewScreenController: UIViewController {
   /// @return true if the transition is running, false otherwise.
   ///
   @objc
-  public func isTransitionInProgress() -> Bool {
-    return transitionInProgress
+  public func isViewSizeTransitionInProgress() -> Bool {
+    return viewSizeTransitionState != nil
   }
 
   // MARK: Signals
@@ -97,20 +93,20 @@ public class RNSSplitViewScreenController: UIViewController {
   ) {
     super.viewWillTransition(to: size, with: coordinator)
 
-    transitionInProgress = true
+    viewSizeTransitionState = ViewSizeTransitionState()
 
     coordinator.animate(
       alongsideTransition: { [weak self] context in
         guard let self = self else { return }
-        if self.displayLink == nil {
-          self.displayLink = CADisplayLink(
-            target: self, selector: #selector(trackTransitionProgress))
-          self.displayLink?.add(to: .main, forMode: .common)
+        guard let viewSizeTransitionState = self.viewSizeTransitionState else { return }
+        
+        if viewSizeTransitionState.displayLink == nil {
+          viewSizeTransitionState.setupDisplayLink(forTarget: self, selector: #selector(trackTransitionProgress))
         }
       },
       completion: { [weak self] context in
         guard let self = self else { return }
-        self.stopAnimation()
+        self.cleanupViewSizeTransitionState()
         // After the animation completion, ensure that ShadowTree state
         // is calculated relatively to the ancestor's frame by requesting
         // the state update.
@@ -118,12 +114,9 @@ public class RNSSplitViewScreenController: UIViewController {
       })
   }
 
-  private func stopAnimation() {
-    lastAnimationFrame = nil
-    transitionInProgress = false
-
-    displayLink?.invalidate()
-    displayLink = nil
+  private func cleanupViewSizeTransitionState() {
+    viewSizeTransitionState?.invalidate()
+    viewSizeTransitionState = nil
   }
 
   ///
@@ -133,7 +126,7 @@ public class RNSSplitViewScreenController: UIViewController {
   @objc
   private func trackTransitionProgress() {
     if let currentFrame = view.layer.presentation()?.frame {
-      lastAnimationFrame = currentFrame
+      viewSizeTransitionState?.lastViewPresentationFrame = currentFrame
       updateShadowTreeState()
     }
   }
@@ -172,39 +165,20 @@ public class RNSSplitViewScreenController: UIViewController {
     // If the resize animation is currently running, we prefer to apply dynamic updates,
     // based on the results from the presentation layer
     // which is read from `trackTransitionProgress` method.
-    if let currentSize = lastAnimationFrame?.size {
-      applyTransitioningShadowState(
-        size: currentSize,
-        ancestorView: ancestorView!
-      )
+    if let lastViewPresentationFrame = viewSizeTransitionState?.lastViewPresentationFrame, !lastViewPresentationFrame.isNull {
+      shadowStateProxy.updateShadowState(ofComponent: splitViewScreenComponentView, withFrame: lastViewPresentationFrame, inContextOfAncestorView: ancestorView!)
       return
     }
-
+    
     // There might be the case, when transition is about to start and in the meantime,
     // sth else is triggering frame update relatively to the parent. As we know
     // that dynamic updates from the presentation layer are coming, we're blocking this
     // to prevent interrupting with the frames that are less important for us.
     // This works fine, because after the animation completion, we're sending the last update
     // which is compatible with the frame which would be calculated relatively to the ancestor here.
-    if !isTransitionInProgress() {
-      applyStaticShadowStateRelativeToAncestor(ancestorView!)
+    if !isViewSizeTransitionInProgress() {
+      shadowStateProxy.updateShadowState(ofComponent: splitViewScreenComponentView, inContextOfAncestorView: ancestorView)
     }
-  }
-
-  private func applyTransitioningShadowState(size: CGSize, ancestorView: UIView) {
-    let localOrigin = splitViewScreenComponentView.convert(
-      splitViewScreenComponentView.frame.origin,
-      to: ancestorView
-    )
-    let convertedFrame = CGRect(origin: localOrigin, size: size)
-    shadowStateProxy.updateShadowState(withFrame: convertedFrame)
-  }
-
-  private func applyStaticShadowStateRelativeToAncestor(_ ancestorView: UIView) {
-    shadowStateProxy.updateShadowState(
-      ofComponent: splitViewScreenComponentView,
-      inContextOfAncestorView: ancestorView
-    )
   }
 
   ///
@@ -220,7 +194,7 @@ public class RNSSplitViewScreenController: UIViewController {
     // During the transition, we're listening for the animation
     // frame updates on the presentation layer and we're
     // treating these updates as the source of truth
-    if !isTransitionInProgress() {
+    if !isViewSizeTransitionInProgress() {
       shadowStateProxy.updateShadowState(
         ofComponent: splitViewScreenComponentView, inContextOfAncestorView: splitViewController.view
       )
@@ -243,5 +217,25 @@ public class RNSSplitViewScreenController: UIViewController {
 
   public override func viewDidDisappear(_ animated: Bool) {
     reactEventEmitter.emitOnDidDisappear()
+  }
+}
+
+private class ViewSizeTransitionState {
+  public var displayLink: CADisplayLink?
+  public var lastViewPresentationFrame: CGRect = CGRect.null
+  
+  public func setupDisplayLink(forTarget target: Any, selector sel: Selector) {
+    if (displayLink != nil) {
+      displayLink?.invalidate()
+    }
+    
+    displayLink = CADisplayLink(target: target, selector: sel)
+    displayLink!.add(to: .main, forMode: .common)
+  }
+  
+  public func invalidate() {
+    displayLink?.invalidate()
+    displayLink = nil
+    lastViewPresentationFrame = CGRect.null
   }
 }

--- a/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.h
@@ -43,6 +43,21 @@ NS_ASSUME_NONNULL_BEGIN
              inContextOfAncestorView:(UIView *_Nullable)ancestorView;
 
 /**
+ * @brief Send an update to ShadowNode state with given frame if needed.
+ *
+ * Converts the frame to coordinates of the specified ancestor view,
+ * before applying the update to the Shadow Tree.
+ *
+ * @param screenComponentView an instance of RNSSplitViewScreenComponentView whose state should be updated,
+ * @param frame frame to update the shadow state with; it must be in coordinate system of `screenComponentView`,
+ * @param ancestorView coordinate-system provider view, relative to which the frame should be converted before sending
+ * the update.
+ */
+- (void)updateShadowStateOfComponent:(RNSSplitViewScreenComponentView *)screenComponentView
+                           withFrame:(CGRect)frame
+             inContextOfAncestorView:(nonnull UIView *)ancestorView;
+
+/**
  * @brief Send an update to ShadowNode state with given layout metrics.
  *
  * Updates size and origin in the ShadowNode state, if changed.

--- a/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.mm
@@ -1,6 +1,7 @@
 #import "RNSSplitViewScreenShadowStateProxy.h"
 #import "RNSSplitViewScreenComponentView.h"
 
+#import <React/RCTAssert.h>
 #import <React/RCTConversions.h>
 #import <rnscreens/RNSSplitViewScreenShadowNode.h>
 
@@ -46,6 +47,15 @@ namespace react = facebook::react;
     _state->updateState(std::move(newState));
     _lastScheduledFrame = frame;
   }
+}
+
+- (void)updateShadowStateOfComponent:(RNSSplitViewScreenComponentView *)screenComponentView
+                           withFrame:(CGRect)frame
+             inContextOfAncestorView:(nonnull UIView *)ancestorView
+{
+  RCTAssert(ancestorView != nil, @"[RNScreens] ancestorView must not be nil");
+  CGRect convertedFrame = [screenComponentView convertRect:frame toView:ancestorView];
+  [self updateShadowStateWithFrame:convertedFrame];
 }
 
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState


### PR DESCRIPTION
## Description

Retrospective review for #3073.

## Changes

* moved all the state related to view size transitioning do dedicated file-private type `ViewSizeTransitionState`,
* renamed `isTransitionInProgress -> isViewSizeTransitionInProgress`,
* renamed `stopAnimation` -> `cleanupViewSizeTransitionState`,
* removed `applyTransitioningShadowState(...)` & `applyStaticShadowStateRelativeToAncestor(...)` methods & moved the appropriate logic to shadow state proxy. 

## Test code and steps to reproduce

See #3073

## Checklist

- [ ] Ensured that CI passes
