### PR TITLE
refactor: review 3097 - make split screen controller & component the frame correction provider

### DIFF
--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -12,10 +12,6 @@
 #import "RNSOrientationProviding.h"
 #endif // !TARGET_OS_TV
 
-#ifdef RNS_GAMMA_ENABLED
-#import "RNSFrameCorrectionProvider.h"
-#endif // RNS_GAMMA_ENABLED
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSNavigationController : UINavigationController <
@@ -25,10 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
                                          ,
                                          RNSOrientationProviding
 #endif // !TARGET_OS_TV
-#ifdef RNS_GAMMA_ENABLED
-                                         ,
-                                         RNSFrameCorrectionProvider
-#endif // RNS_GAMMA_ENABLED
                                          >
 
 @end

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -202,7 +202,9 @@ namespace react = facebook::react;
     [parentTabsScreenVC setTabsSpecialEffectsDelegate:self];
   }
 #ifdef RNS_GAMMA_ENABLED
-  [self maybeRegisterForSplitViewFrameCorrectionWorkaround];
+  if (parent != nil) {
+    [self maybeRegisterForSplitViewFrameCorrectionWorkaround];
+  }
 #endif // RNS_GAMMA_ENABLED
 }
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -272,7 +272,7 @@ namespace react = facebook::react;
 #ifdef RNS_GAMMA_ENABLED
 - (void)maybeRegisterForSplitViewFrameCorrectionWorkaround
 {
-  if (auto frameCorrectionProvider = [self findAncestorSplitViewScreenController]) {
+  if (auto frameCorrectionProvider = [self findAncestorFrameCorrectionProvider]) {
     // We need to apply an update for the parent of the view which `RNSNavigationController` is describing
     [frameCorrectionProvider registerForFrameCorrection:self.view.superview];
   }
@@ -280,13 +280,13 @@ namespace react = facebook::react;
 
 - (void)maybeUnregisterFromSplitViewFrameCorrectionWorkaround
 {
-  if (auto frameCorrectionProvider = [self findAncestorSplitViewScreenController]) {
+  if (auto frameCorrectionProvider = [self findAncestorFrameCorrectionProvider]) {
     // We need to apply an update for the parent of the view which `RNSNavigationController` is describing
     [frameCorrectionProvider unregisterFromFrameCorrection:self.view.superview];
   }
 }
 
-- (id<RNSFrameCorrectionProvider>)findAncestorSplitViewScreenController
+- (id<RNSFrameCorrectionProvider>)findAncestorFrameCorrectionProvider
 {
   auto parent = [self parentViewController];
   while (parent != nil) {

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -277,7 +277,7 @@ namespace react = facebook::react;
         @"[RNScreens] splitViewControllerView must be type of RNSSplitViewScreenComponentView");
     auto splitViewScreen = (RNSSplitViewScreenComponentView *)splitViewControllerView;
     // We need to apply an update for the parent of the view which `RNSNavigationController` is describing
-    [splitViewScreen registerForFrameUpdates:self.view.superview];
+    [splitViewScreen registerForFrameCorrection:self.view.superview];
   }
 }
 
@@ -290,7 +290,7 @@ namespace react = facebook::react;
         @"[RNScreens] splitViewControllerView must be type of RNSSplitViewScreenComponentView");
     auto splitViewScreen = (RNSSplitViewScreenComponentView *)splitViewControllerView;
     // We need to apply an update for the parent of the view which `RNSNavigationController` is describing
-    [splitViewScreen unregisterFromFrameUpdates:self.view.superview];
+    [splitViewScreen unregisterFromFrameCorrection:self.view.superview];
   }
 }
 

--- a/ios/bridging/Swift-Bridging.h
+++ b/ios/bridging/Swift-Bridging.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef RNS_GAMMA_ENABLED
+#import "RNSFrameCorrectionProvider.h"
+#endif // RNS_GAMMA_ENABLED
+
 #if __has_include(<RNScreens/RNScreens-Swift.h>)
 #import <RNScreens/RNScreens-Swift.h>
 #else

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
@@ -15,8 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Responsible for a lifecycle management, layout, and event emission for a single screen; used as a child
  * of RNSSplitViewHostComponentView.
+ *
+ * Implements `RNSFrameCorrectionProvider` as a workaround for issue described in
+ * https://github.com/software-mansion/react-native-screens/pull/3097
  */
-@interface RNSSplitViewScreenComponentView : RNSReactBaseView
+@interface RNSSplitViewScreenComponentView : RNSReactBaseView <RNSFrameCorrectionProvider>
 
 @property (nonatomic, strong, readonly, nonnull) RNSSplitViewScreenController *controller;
 @property (nonatomic, weak, readwrite, nullable) RNSSplitViewHostComponentView *splitViewHost;
@@ -27,20 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Should be called when the component is about to be deleted.
  */
 - (void)invalidate;
-
-/**
- * @brief Adds UIView that needs frame correction when SplitViewScreen calculates a layout
- *
- * @param view - UIView which subscribes for SplitViewScreen layout updates
- */
-- (void)registerForFrameCorrection:(UIView *)view;
-
-/**
- * @brief Removes UIView that doesn't need frame correction no longer
- *
- * @param view - UIView which unsubscribes for SplitViewScreen layout updates
- */
-- (void)unregisterFromFrameCorrection:(UIView *)view;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
@@ -33,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param view - UIView which subscribes for SplitViewScreen layout updates
  */
-- (void)registerForFrameUpdates:(UIView *)view;
+- (void)registerForFrameCorrection:(UIView *)view;
 
 /**
  * @brief Removes UIView that doesn't need frame correction no longer
  *
  * @param view - UIView which unsubscribes for SplitViewScreen layout updates
  */
-- (void)unregisterFromFrameUpdates:(UIView *)view;
+- (void)unregisterFromFrameCorrection:(UIView *)view;
 
 @end
 

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
@@ -93,12 +93,12 @@ namespace react = facebook::react;
   _controller = nil;
 }
 
-- (void)registerForFrameUpdates:(UIView *)view
+- (void)registerForFrameCorrection:(UIView *)view
 {
   [_viewsForFrameUpdate addObject:view];
 }
 
-- (void)unregisterFromFrameUpdates:(UIView *)view
+- (void)unregisterFromFrameCorrection:(UIView *)view
 {
   [_viewsForFrameUpdate removeObject:view];
 }

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
@@ -14,7 +14,7 @@ namespace react = facebook::react;
   RNSSplitViewScreenController *_Nullable _controller;
   RNSSplitViewScreenShadowStateProxy *_Nonnull _shadowStateProxy;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
-  NSMutableSet<UIView *> *_viewsForFrameUpdate;
+  NSMutableSet<UIView *> *_viewsForFrameCorrection;
 }
 
 - (RNSSplitViewScreenController *)controller
@@ -43,7 +43,7 @@ namespace react = facebook::react;
   _reactEventEmitter = [RNSSplitViewScreenComponentEventEmitter new];
   _shadowStateProxy = [RNSSplitViewScreenShadowStateProxy new];
 
-  _viewsForFrameUpdate = [NSMutableSet set];
+  _viewsForFrameCorrection = [NSMutableSet set];
 }
 
 - (void)setupController
@@ -95,12 +95,12 @@ namespace react = facebook::react;
 
 - (void)registerForFrameCorrection:(UIView *)view
 {
-  [_viewsForFrameUpdate addObject:view];
+  [_viewsForFrameCorrection addObject:view];
 }
 
 - (void)unregisterFromFrameCorrection:(UIView *)view
 {
-  [_viewsForFrameUpdate removeObject:view];
+  [_viewsForFrameCorrection removeObject:view];
 }
 
 #pragma mark - Layout
@@ -116,7 +116,7 @@ namespace react = facebook::react;
 {
   [super layoutSubviews];
 
-  for (UIView *view in _viewsForFrameUpdate) {
+  for (UIView *view in _viewsForFrameCorrection) {
     [RNSFrameCorrector applyFrameCorrectionFor:view inContextOfSplitViewColumn:self];
   }
 }

--- a/ios/gamma/split-view/RNSSplitViewScreenController.swift
+++ b/ios/gamma/split-view/RNSSplitViewScreenController.swift
@@ -226,6 +226,18 @@ public class RNSSplitViewScreenController: UIViewController {
   }
 }
 
+extension RNSSplitViewScreenController : RNSFrameCorrectionProvider {
+  @objc
+  public func register(forFrameCorrection view: UIView) {
+    self.splitViewScreenComponentView.register(forFrameCorrection: view)
+  }
+  
+  @objc
+  public func unregister(fromFrameCorrection view: UIView) {
+    self.splitViewScreenComponentView.unregister(fromFrameCorrection: view)
+  }
+}
+
 private class ViewSizeTransitionState {
   public var displayLink: CADisplayLink?
   public var lastViewPresentationFrame: CGRect = CGRect.null

--- a/ios/gamma/split-view/RNSSplitViewScreenController.swift
+++ b/ios/gamma/split-view/RNSSplitViewScreenController.swift
@@ -226,12 +226,12 @@ public class RNSSplitViewScreenController: UIViewController {
   }
 }
 
-extension RNSSplitViewScreenController : RNSFrameCorrectionProvider {
+extension RNSSplitViewScreenController: RNSFrameCorrectionProvider {
   @objc
   public func register(forFrameCorrection view: UIView) {
     self.splitViewScreenComponentView.register(forFrameCorrection: view)
   }
-  
+
   @objc
   public func unregister(fromFrameCorrection view: UIView) {
     self.splitViewScreenComponentView.unregister(fromFrameCorrection: view)

--- a/ios/gamma/split-view/compat/RNSFrameCorrectionProvider.h
+++ b/ios/gamma/split-view/compat/RNSFrameCorrectionProvider.h
@@ -27,7 +27,7 @@
  * SplitView layout update.
  *
  * As for now, it should find a proper `RNSSplitViewScreenComponentView` and use
- * `RNSSplitViewScreenComponentView::unregisterFromFrameUpdates`.
+ * `RNSSplitViewScreenComponentView::unregisterFromFrameCorrection`.
  */
 - (void)unregisterFromSplitView;
 

--- a/ios/gamma/split-view/compat/RNSFrameCorrectionProvider.h
+++ b/ios/gamma/split-view/compat/RNSFrameCorrectionProvider.h
@@ -17,18 +17,16 @@
  * @brief Responsible for adding `view` to the SplitView set for observing views that need to adapt layout on SplitView
  * layout update.
  *
- * As for now, it should find a proper `RNSSplitViewScreenComponentView` and use
- * `RNSSplitViewScreenComponentView::registerForFrameUpdates`.
+ * @param view - UIView which subscribes for SplitViewScreen layout updates
  */
-- (void)registerForSplitView;
+- (void)registerForFrameCorrection:(nonnull UIView *)view;
 
 /**
  * @brief Responsible for removing `view` from the SplitView set for observing views that need to adapt layout on
  * SplitView layout update.
  *
- * As for now, it should find a proper `RNSSplitViewScreenComponentView` and use
- * `RNSSplitViewScreenComponentView::unregisterFromFrameCorrection`.
+ * @param view - UIView which unsubscribes for SplitViewScreen layout updates
  */
-- (void)unregisterFromSplitView;
+- (void)unregisterFromFrameCorrection:(nonnull UIView *)view;
 
 @end

--- a/ios/gamma/split-view/compat/RNSFrameCorrector.mm
+++ b/ios/gamma/split-view/compat/RNSFrameCorrector.mm
@@ -3,15 +3,15 @@
 @implementation RNSFrameCorrector
 
 /**
- This correction is performed synchronously to resolve the following issue:
- 1. On the transition begin, the animation may expect the target frame to be set immediately, e.g. in SplitView
- for triggering the transition animation, we need to know the final frame on animation start.
- 2. When a layout recalculation is dependent on Yoga - it's performed asynchronously, so the frame for the nested
- component might be in 'stale' state, e.g. when the transition begins.
- 3. Until Yoga will compute the new layout, the reference value for the frame passed to the animation will be
- wrong.
- 4. As we don't have a control, when the animation will start, we need to apply frame correction synchronously to
- guarantee that it takes the proper frame width as a reference.
+ * This correction is performed synchronously to resolve the following issue:
+ * 1. On the transition begin, the animation may expect the target frame to be set immediately, e.g. in SplitView
+ * for triggering the transition animation, we need to know the final frame on animation start.
+ * 2. When a layout recalculation is dependent on Yoga - it's performed asynchronously, so the frame for the nested
+ * component might be in 'stale' state, e.g. when the transition begins.
+ * 3. Until Yoga will compute the new layout, the reference value for the frame passed to the animation will be
+ * wrong.
+ * 4. As we don't have a control, when the animation will start, we need to apply frame correction synchronously to
+ * guarantee that it takes the proper frame width as a reference.
  */
 + (void)applyFrameCorrectionFor:(UIView *)view
      inContextOfSplitViewColumn:(RNSSplitViewScreenComponentView *)splitViewScreen


### PR DESCRIPTION
## Description

Retrospective review of #3097

## Changes

- **Give register & unregister functions more descriptive names**
  * -[RNSSplitViewScreenComponentView registerForFrameUpdates:] -> -[RNSSplitViewScreenComponentView registerForFrameCorrection:]
  * -[RNSSplitViewScreenComponentView unregisterFromFrameUpdates:] -> -[RNSSplitViewScreenComponentView unregisterFromFrameCorrection:]

  I think this has more sense, as this isn't a regular frame update but
  rather a correction related to `FrameCORRECTOR` &
  `FrameCORRECTIONProvider`.

- **Add missing stars in multiline comment**

- **Refactor the logic according to review**

  * Make `RNSSplitViewScreenComponentView` implement
    `RNSFrameCorrectionProvider`, as it does provide the correct frame for
    the navigation controller,
  * update method signatures in `RNSFrameCorrectionProvider` protocol, so
    that they accept appropriate view parameter,
  * rename `_viewsForFrameUpdate` -> `_viewsForFrameCorrection`,
  * rename registering methods.


- **Do not attempt to register when parent controller is nil**

  Doing so does not make sense, as we will silently fail when looking for
  parent. I prefer to handle this case explicitly.
  
- **Rename findAncestorSplitViewScreenController -> findAncestorFrameCorrectionProvider**

## Test code and steps to reproduce

See #3097

## Checklist

- [x] Ensured that CI passes
