### PR TITLE
feat(iOS, Tabs): add shadow color to appearance

### DIFF
--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -121,6 +121,11 @@ const TAB_CONFIGS: TabConfiguration[] = [
           },
         },
       },
+      scrollEdgeAppearance: {
+        tabBarShadowColor: 'red',
+        tabBarBackgroundColor: 'transparent',
+        tabBarBlurEffect: 'none',
+      },
       icon: {
         imageSource: require('../../../assets/variableIcons/icon.png'),
       },

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -131,6 +131,10 @@
     }
   }
 
+  if (appearanceProps[@"tabBarShadowColor"] != nil) {
+    tabBarAppearance.shadowColor = [RCTConvert UIColor:appearanceProps[@"tabBarShadowColor"]];
+  }
+
   if ([appearanceProps[@"stacked"] isKindOfClass:[NSDictionary class]]) {
     [self configureTabBarItemAppearance:tabBarAppearance.stackedLayoutAppearance
                 fromItemAppearanceProps:appearanceProps[@"stacked"]];

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -160,7 +160,13 @@ function mapAppearanceToNativeProp(
 ): Appearance | undefined {
   if (!appearance) return undefined;
 
-  const { stacked, inline, compactInline, tabBarBackgroundColor } = appearance;
+  const {
+    stacked,
+    inline,
+    compactInline,
+    tabBarBackgroundColor,
+    tabBarShadowColor,
+  } = appearance;
 
   return {
     ...appearance,
@@ -168,6 +174,7 @@ function mapAppearanceToNativeProp(
     inline: mapItemAppearanceToNativeProp(inline),
     compactInline: mapItemAppearanceToNativeProp(compactInline),
     tabBarBackgroundColor: processColor(tabBarBackgroundColor),
+    tabBarShadowColor: processColor(tabBarShadowColor),
   };
 }
 

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -153,6 +153,15 @@ export interface BottomTabsScreenAppearance {
    * @supported iOS 18 or lower
    */
   tabBarBlurEffect?: BottomTabsScreenBlurEffect;
+  /**
+   * @summary Specifies the shadow color for the tab bar when tab screen is selected.
+   *
+   * This property does not affect the tab bar starting from iOS 26.
+   *
+   * @platform ios
+   * @supported iOS 18 or lower
+   */
+  tabBarShadowColor?: ColorValue;
 }
 
 // iOS-specific

--- a/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
@@ -55,6 +55,7 @@ export type Appearance = {
   compactInline?: ItemAppearance;
 
   tabBarBackgroundColor?: ProcessedColorValue | null;
+  tabBarShadowColor?: ProcessedColorValue | null;
   tabBarBlurEffect?: WithDefault<BlurEffect, 'systemDefault'>;
 };
 


### PR DESCRIPTION
## Description

`shadowColor` was missing in appearance. With this prop, the tab bar can be fully hidden

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
