### PR TITLE
feat(iOS, Stack v4): bring back view recycling for ContentWrapper

### DIFF
--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -189,11 +189,6 @@ Class<RCTComponentViewProtocol> RNSScreenContentWrapperCls(void)
 {
   [super load];
 }
-
-+ (BOOL)shouldBeRecycled
-{
-  return NO;
-}
 #endif // RCT_NEW_ARCH_ENABLED
 
 @end

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -1010,6 +1010,13 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
   _initialPropsSet = NO;
 
   // See comment above _safeAreaConstraints declaration for reason why this is necessary.
+  if (_safeAreaConstraints.count > 0 &&
+      [_safeAreaConstraints[0].firstItem isKindOfClass:[RNSScreenContentWrapper class]]) {
+    RNSScreenContentWrapper *contentWrapper = static_cast<RNSScreenContentWrapper *>(_safeAreaConstraints[0].firstItem);
+
+    // Disable auto-layout
+    contentWrapper.translatesAutoresizingMaskIntoConstraints = YES;
+  }
   [NSLayoutConstraint deactivateConstraints:_safeAreaConstraints];
   _safeAreaConstraints = nil;
 


### PR DESCRIPTION
## Description

Brings back view recycling for `RNSScreenContentWrapper` that has been disabled in https://github.com/software-mansion/react-native-screens/pull/3111.

More detailed explanation is available in https://github.com/software-mansion/react-native-screens/pull/3111#discussion_r2313482040.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/391.

## Changes

- reenable view recycling for `ContentWrapper`
- disable auto layout for `ContentWrapper` when preparing to recycle `HeaderConfig`

## Test code and steps to reproduce

Open Test3111, fist open `ModalWithScrollView`, then `ModalWithScrollViewAndNoHeader`. Scroll should work properly in `ModalWithScrollViewAndNoHeader`.
You can also open `ModalWithScrollView`, add `headerShown: false`, and save - scroll should also work now.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
