### PR TITLE
fix(iOS 26, Stack v4): fix workaround for RNSScreen being partially obstructed by UINavigationBar on iOS 26 Paper

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -571,24 +571,14 @@ RNS_IGNORE_SUPER_CALL_END
   // See comment above _safeAreaConstraints declaration for reason why this is necessary.
   RNSScreenContentWrapper *contentWrapper = nil;
   if (@available(iOS 26, *)) {
-#if !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
-    // On Paper in debug mode, there are some views between RNSScreenView and RNSScreenContentWrapper.
     UIView *currentView = vc.view;
-    while (currentView != nil) {
+    while ([currentView.subviews count] > 0) {
+      currentView = currentView.subviews[0];
       if ([currentView isKindOfClass:RNSScreenContentWrapper.class]) {
         contentWrapper = static_cast<RNSScreenContentWrapper *>(currentView);
         break;
-      } else if ([currentView.subviews count] > 0) {
-        currentView = currentView.subviews[0];
-      } else {
-        break;
       }
     }
-#else // !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
-    if (vc.view.subviews.count > 0 && [vc.view.subviews[0] isKindOfClass:[RNSScreenContentWrapper class]]) {
-      contentWrapper = static_cast<RNSScreenContentWrapper *>(vc.view.subviews[0]);
-    }
-#endif // !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
   }
 
   if (!shouldHide && !config.translucent) {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -571,9 +571,24 @@ RNS_IGNORE_SUPER_CALL_END
   // See comment above _safeAreaConstraints declaration for reason why this is necessary.
   RNSScreenContentWrapper *contentWrapper = nil;
   if (@available(iOS 26, *)) {
+#if !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
+    // On Paper in debug mode, there are some views between RNSScreenView and RNSScreenContentWrapper.
+    UIView *currentView = vc.view;
+    while (currentView != nil) {
+      if ([currentView isKindOfClass:RNSScreenContentWrapper.class]) {
+        contentWrapper = static_cast<RNSScreenContentWrapper *>(currentView);
+        break;
+      } else if ([currentView.subviews count] > 0) {
+        currentView = currentView.subviews[0];
+      } else {
+        break;
+      }
+    }
+#else // !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
     if (vc.view.subviews.count > 0 && [vc.view.subviews[0] isKindOfClass:[RNSScreenContentWrapper class]]) {
       contentWrapper = static_cast<RNSScreenContentWrapper *>(vc.view.subviews[0]);
     }
+#endif // !RCT_NEW_ARCH_ENABLED && !defined(NDEBUG)
   }
 
   if (!shouldHide && !config.translucent) {


### PR DESCRIPTION
## Description

Fixes the workaround from https://github.com/software-mansion/react-native-screens/pull/3111 on Paper.

On Paper, in debug mode, sometimes there are some views between `RNSScreenView` and `RNSScreenContentWrapper`. This has been an issue before: https://github.com/software-mansion/react-native-screens/pull/2683.

To make the workaround work correctly, we look for `RNSScreenContentWrapper` in first descendant chain, when in debug mode on Paper.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/412.

## Changes

- look for `RNSScreenContentWrapper` in first descendant chain, when in debug mode on Paper

## Test code and steps to reproduce

Run `Test3111` on Paper in debug mode.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
