### PR TITLE
fix(iOS, Stack v4): ensure consistent defaults for `obscureBackground` and `hideNavigationBar`

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
@@ -43,7 +43,7 @@ public class RNSSearchBarManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setObscureBackground(view, value == null ? false : (boolean) value);
         break;
       case "hideNavigationBar":
-        mViewManager.setHideNavigationBar(view, value == null ? false : (boolean) value);
+        mViewManager.setHideNavigationBar(view, value == null ? true : (boolean) value);
         break;
       case "cancelButtonText":
         mViewManager.setCancelButtonText(view, value == null ? null : (String) value);

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -461,7 +461,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `hideNavigationBar` - Boolean indicating whether to hide the navigation bar during searching. Defaults to `true`. (iOS only)
 - `hideWhenScrolling` - Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`. (iOS only)
 - `inputType` - Specifies type of input and keyboard for search bar. Can be one of `'text'`, `'phone'`, `'number'`, `'email'`. Defaults to `'text'`. (Android only)
-- `obscureBackground` - Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`. (iOS only)
+- `obscureBackground` - Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `false`. (iOS only)
 - `onBlur` - A callback that gets called when search bar has lost focus.
 - `onChangeText` - A callback that gets called when the text changes. It receives the current text value of the search bar.
 - `onCancelButtonPress` - A callback that gets called when the cancel button is pressed.

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -66,6 +66,11 @@ namespace react = facebook::react;
 #endif
 
   _controller.searchBar.delegate = self;
+
+  // Ensure consistent default values on both architectures
+  _controller.hidesNavigationBarDuringPresentation = YES;
+  _controller.obscuresBackgroundDuringPresentation = NO;
+
   _hideWhenScrolling = YES;
   _placement = RNSSearchBarPlacementAutomatic;
 
@@ -149,9 +154,7 @@ namespace react = facebook::react;
 
 - (void)setObscureBackground:(BOOL)obscureBackground
 {
-  if (@available(iOS 9.1, *)) {
-    [_controller setObscuresBackgroundDuringPresentation:obscureBackground];
-  }
+  [_controller setObscuresBackgroundDuringPresentation:obscureBackground];
 }
 
 - (void)setHideNavigationBar:(BOOL)hideNavigationBar

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -40,8 +40,8 @@ export interface NativeProps extends ViewProps {
   placeholder?: string;
   placement?: WithDefault<SearchBarPlacement, 'automatic'>;
   allowToolbarIntegration?: WithDefault<boolean, true>;
-  obscureBackground?: boolean;
-  hideNavigationBar?: boolean;
+  obscureBackground?: WithDefault<boolean, false>;
+  hideNavigationBar?: WithDefault<boolean, true>;
   cancelButtonText?: string;
   // TODO: implement these on iOS
   barTintColor?: ColorValue;


### PR DESCRIPTION
## Description

Fixes default values for `obscureBackground` and `hideNavigationBar` props in `RNSSearchBar`.

### `obscureBackground`

Even though that `react-navigation`'s docs state that `obscureBackground`'s default is `true`, this hasn't been the case. On both architectures, setter for the prop would not run (on Fabric, due to `false` being the default value for boolean; on Paper due to not running the setter if prop was `undefined`), resulting in native behavior:

```obj-c
/* On iOS, default is NO for apps linked on iOS 15.0 and later, YES otherwise.
 On tvOS, default is NO when contained in UISearchContainerViewController, YES otherwise.
 */
@property (nonatomic, assign) BOOL obscuresBackgroundDuringPresentation API_AVAILABLE(ios(9.1));
```

Unfortunately, if we want to use `bool` for this prop, we need to decide which option is the default to ensure consistent behavior (on Fabric, we can't have undefined value for boolean). Aligning this prop to `false` by default seems reasonable, as this is the default on iOS 15+.

If we really want to maintain native behavior but we don't want to change API from boolean to enum, we can consider using `boolean | undefined` for user API in `SearchBar` component and enum for native component (mapping `true` -> `TRUE`, `false` -> `FALSE`, `undefined` -> `SYSTEM_DEFAULT`). The only problem would be to handle dynamic change from `true`/`false` to `undefined` - we would need to ignore this change and log a warning or create new searchController just to take the default value from it.

The change will require updating `react-navigation` docs: https://github.com/software-mansion/react-native-screens-labs/issues/384.

### `hideNavigationBar`

On Fabric, spec file did not specify `true` as default value for the prop. When user set the initial value to `false`, setter would not run (no change in prop value; `oldScreenProps.hideNavigationBar == newScreenProps.hideNavigationBar`), maintaining UIKit default:

```obj-c
/// Default is `YES` for apps linked before iOS 26.0, other than on MacCatalyst, where the default is `NO`.
/// On iOS 26.0 for apps linked on iOS 26.0 and later, the value is determined by context unless directly set through the API. The default remains `NO` on MacCatalyst.
@property (nonatomic, assign) BOOL hidesNavigationBarDuringPresentation;
```

In the current version of this PR, we fix the default value in spec file.

As starting from iOS 26, default value of this prop is determined by context, we can consider taking similar approach as proposed for `obscureBackground` (mapping `true` -> `TRUE`, `false` -> `FALSE`, `undefined` -> `SYSTEM_DEFAULT`), however, dynamic change from `true`/`false` to `undefined` will probably need to be handled by logging a warning (if context decides the behavior, we might not be able to just extract the value from other instance).

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/404.

## Changes

- ensure consistent default for `obscureBackground` (`false`) by setting default value on init
- ensure consistent default for `hideNavigationBar` (`true`) by setting default value on init and fixing Fabric spec file
- remove redundant SDK version runtime check

## Screenshots / GIFs

### `hideNavigationBar`, Paper
| before, ✅ | after, ✅ |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/9cb2e594-9812-4c8a-96cd-0012365ac1ea" /> | <video src="https://github.com/user-attachments/assets/23ef9189-5bb3-44b3-aed3-b47a2b8f9adb" /> |

### `hideNavigationBar`, Fabric
| before, ❌ | after, ✅ |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/216b915f-c8ca-40f1-b091-70a67f3ceb7e" /> | <video src="https://github.com/user-attachments/assets/f84f54b5-ea56-44f8-bbad-734cef905950" /> |

## Test code and steps to reproduce

Run `SearchBar` example screen. To test default `obscureBackground` behavior, you can use `Test758` - just comment out this prop.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
