### PR TITLE
chore(iOS): remove outdated SDK version checks (iOS < 15.1)

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -91,8 +91,7 @@ typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   RNSBlurEffectStyleLight = UIBlurEffectStyleLight,
   RNSBlurEffectStyleDark = UIBlurEffectStyleDark,
   // TODO: Add support for this variant on tvOS
-  //  RNSBlurEffectStyleExtraDark = UIBlurEffectStyleExtraDark API_AVAILABLE(tvos(10.0)) API_UNAVAILABLE(ios)
-  //  API_UNAVAILABLE(watchos),
+  //  RNSBlurEffectStyleExtraDark = UIBlurEffectStyleExtraDark API_UNAVAILABLE(ios) API_UNAVAILABLE(watchos),
   RNSBlurEffectStyleRegular API_UNAVAILABLE(watchos) = UIBlurEffectStyleRegular,
   RNSBlurEffectStyleProminent API_UNAVAILABLE(watchos) = UIBlurEffectStyleProminent,
   RNSBlurEffectStyleSystemUltraThinMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterial,

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -93,41 +93,29 @@ typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   // TODO: Add support for this variant on tvOS
   //  RNSBlurEffectStyleExtraDark = UIBlurEffectStyleExtraDark API_AVAILABLE(tvos(10.0)) API_UNAVAILABLE(ios)
   //  API_UNAVAILABLE(watchos),
-  RNSBlurEffectStyleRegular API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleRegular,
-  RNSBlurEffectStyleProminent API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos) = UIBlurEffectStyleProminent,
-  RNSBlurEffectStyleSystemUltraThinMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterial,
-  RNSBlurEffectStyleSystemThinMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterial,
-  RNSBlurEffectStyleSystemMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterial,
-  RNSBlurEffectStyleSystemThickMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterial,
-  RNSBlurEffectStyleSystemChromeMaterial API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterial,
-  RNSBlurEffectStyleSystemUltraThinMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialLight,
-  RNSBlurEffectStyleSystemThinMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialLight,
-  RNSBlurEffectStyleSystemMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialLight,
-  RNSBlurEffectStyleSystemThickMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialLight,
-  RNSBlurEffectStyleSystemChromeMaterialLight API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialLight,
+  RNSBlurEffectStyleRegular API_UNAVAILABLE(watchos) = UIBlurEffectStyleRegular,
+  RNSBlurEffectStyleProminent API_UNAVAILABLE(watchos) = UIBlurEffectStyleProminent,
+  RNSBlurEffectStyleSystemUltraThinMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterial,
+  RNSBlurEffectStyleSystemThinMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterial,
+  RNSBlurEffectStyleSystemMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterial,
+  RNSBlurEffectStyleSystemThickMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterial,
+  RNSBlurEffectStyleSystemChromeMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterial,
+  RNSBlurEffectStyleSystemUltraThinMaterialLight API_UNAVAILABLE(watchos, tvos) =
+      UIBlurEffectStyleSystemUltraThinMaterialLight,
+  RNSBlurEffectStyleSystemThinMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialLight,
+  RNSBlurEffectStyleSystemMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialLight,
+  RNSBlurEffectStyleSystemThickMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialLight,
+  RNSBlurEffectStyleSystemChromeMaterialLight API_UNAVAILABLE(watchos, tvos) =
+      UIBlurEffectStyleSystemChromeMaterialLight,
 
-  RNSBlurEffectStyleSystemUltraThinMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemUltraThinMaterialDark,
-  RNSBlurEffectStyleSystemThinMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialDark,
-  RNSBlurEffectStyleSystemMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialDark,
-  RNSBlurEffectStyleSystemThickMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,
-  RNSBlurEffectStyleSystemChromeMaterialDark API_AVAILABLE(ios(13.0))
-      API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialDark
+  RNSBlurEffectStyleSystemUltraThinMaterialDark API_UNAVAILABLE(watchos, tvos) =
+      UIBlurEffectStyleSystemUltraThinMaterialDark,
+  RNSBlurEffectStyleSystemThinMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialDark,
+  RNSBlurEffectStyleSystemMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialDark,
+  RNSBlurEffectStyleSystemThickMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,
+  RNSBlurEffectStyleSystemChromeMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterialDark
 
-} API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+} API_UNAVAILABLE(watchos);
 
 typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeImage,

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -977,124 +977,118 @@ RNS_IGNORE_SUPER_CALL_END
   // defined in the detents array. In any other case we do use system defined detents.
   bool systemDetentsInUse = false;
 
-  if (@available(iOS 15.0, *)) {
-    UISheetPresentationController *sheet = _controller.sheetPresentationController;
-    if (sheet == nil) {
-      return;
-    }
-    sheet.delegate = self;
+  UISheetPresentationController *sheet = _controller.sheetPresentationController;
+  if (sheet == nil) {
+    return;
+  }
+  sheet.delegate = self;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-    if (@available(iOS 16.0, *)) {
-      if (_sheetAllowedDetents.count > 0) {
-        if (_sheetAllowedDetents.count == 1 && [_sheetAllowedDetents[0] integerValue] == SHEET_FIT_TO_CONTENTS) {
-          // This is `fitToContents` case, where sheet should be just high to display its contents.
-          // Paper: we do not set anything here, we will set once React computed layout of our React's children, namely
-          // RNSScreenContentWrapper, which in case of formSheet presentation style does have exactly the same frame as
-          // actual content. The update will be triggered once our child is mounted and laid out by React.
-          // Fabric: no nested stack: in this very moment our children are already mounted & laid out. In the very end
-          // of this method, after all other configuration is applied we trigger content wrapper to send us update on
-          // its frame. Fabric: nested stack: we wait until nested content wrapper registers itself with this view and
-          // then update the dimensions.
-        } else {
-          [self setAllowedDetentsForSheet:sheet
-                                       to:[self detentsFromMaxHeightFractions:_sheetAllowedDetents]
-                                  animate:NO];
-        }
+  if (@available(iOS 16.0, *)) {
+    if (_sheetAllowedDetents.count > 0) {
+      if (_sheetAllowedDetents.count == 1 && [_sheetAllowedDetents[0] integerValue] == SHEET_FIT_TO_CONTENTS) {
+        // This is `fitToContents` case, where sheet should be just high to display its contents.
+        // Paper: we do not set anything here, we will set once React computed layout of our React's children, namely
+        // RNSScreenContentWrapper, which in case of formSheet presentation style does have exactly the same frame as
+        // actual content. The update will be triggered once our child is mounted and laid out by React.
+        // Fabric: no nested stack: in this very moment our children are already mounted & laid out. In the very end
+        // of this method, after all other configuration is applied we trigger content wrapper to send us update on
+        // its frame. Fabric: nested stack: we wait until nested content wrapper registers itself with this view and
+        // then update the dimensions.
+      } else {
+        [self setAllowedDetentsForSheet:sheet to:[self detentsFromMaxHeightFractions:_sheetAllowedDetents] animate:NO];
       }
-    } else
+    }
+  } else
 #endif // Check for iOS >= 16
-    {
-      systemDetentsInUse = true;
-      if (_sheetAllowedDetents.count == 0) {
+  {
+    systemDetentsInUse = true;
+    if (_sheetAllowedDetents.count == 0) {
+      [self setAllowedDetentsForSheet:sheet
+                                   to:@[
+                                     UISheetPresentationControllerDetent.mediumDetent,
+                                     UISheetPresentationControllerDetent.largeDetent
+                                   ]
+                              animate:YES];
+    } else if (_sheetAllowedDetents.count >= 2) {
+      float firstDetentFraction = _sheetAllowedDetents[0].floatValue;
+      float secondDetentFraction = _sheetAllowedDetents[1].floatValue;
+      firstDimmedDetentIndex = 2;
+
+      if (firstDetentFraction < secondDetentFraction) {
         [self setAllowedDetentsForSheet:sheet
                                      to:@[
                                        UISheetPresentationControllerDetent.mediumDetent,
                                        UISheetPresentationControllerDetent.largeDetent
                                      ]
                                 animate:YES];
-      } else if (_sheetAllowedDetents.count >= 2) {
-        float firstDetentFraction = _sheetAllowedDetents[0].floatValue;
-        float secondDetentFraction = _sheetAllowedDetents[1].floatValue;
-        firstDimmedDetentIndex = 2;
-
-        if (firstDetentFraction < secondDetentFraction) {
-          [self setAllowedDetentsForSheet:sheet
-                                       to:@[
-                                         UISheetPresentationControllerDetent.mediumDetent,
-                                         UISheetPresentationControllerDetent.largeDetent
-                                       ]
-                                  animate:YES];
-        } else {
-          RCTLogError(@"[RNScreens] The values in sheetAllowedDetents array must be sorted");
-        }
       } else {
-        float firstDetentFraction = _sheetAllowedDetents[0].floatValue;
-        if (firstDetentFraction == SHEET_FIT_TO_CONTENTS) {
-          RCTLogError(@"[RNScreens] Unsupported on iOS versions below 16");
-        } else if (firstDetentFraction < 1.0) {
-          [self setAllowedDetentsForSheet:sheet to:@[ UISheetPresentationControllerDetent.mediumDetent ] animate:YES];
-          [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierMedium animate:YES];
-        } else {
-          [self setAllowedDetentsForSheet:sheet to:@[ UISheetPresentationControllerDetent.largeDetent ] animate:YES];
-          [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
-        }
-      }
-    }
-
-    // Handle initial detent on the first update.
-    if (!_sheetHasInitialDetentSet) {
-      if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-        if (@available(iOS 16.0, *)) {
-          UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
-          [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
-        } else
-#endif // Check for iOS >= 16
-        {
-          if (_sheetInitialDetent < 2) {
-            [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
-          } else {
-            RCTLogError(
-                @"[RNScreens] sheetInitialDetent out of bounds, on iOS versions below 16 sheetAllowedDetents is ignored in favor of an array of two system-defined detents");
-          }
-        }
-      } else if (_sheetInitialDetent != 0) {
-        RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
-      }
-      _sheetHasInitialDetentSet = true;
-    }
-
-    sheet.prefersScrollingExpandsWhenScrolledToEdge = _sheetExpandsWhenScrolledToEdge;
-    [self setGrabberVisibleForSheet:sheet to:_sheetGrabberVisible animate:YES];
-    [self setCornerRadiusForSheet:sheet to:_sheetCornerRadius animate:YES];
-
-    // lud - largest undimmed detent
-    // First we try to take value from the prop or default.
-    int ludIndex = _sheetLargestUndimmedDetent != nil ? _sheetLargestUndimmedDetent.intValue : -1;
-    // Rationalize the value in case the user set something that did not make sense.
-    ludIndex = ludIndex >= firstDimmedDetentIndex ? firstDimmedDetentIndex - 1 : ludIndex;
-    if (ludIndex == SHEET_LARGEST_UNDIMMED_DETENT_NONE) {
-      [self setLargestUndimmedDetentForSheet:sheet to:nil animate:YES];
-    } else if (ludIndex >= 0) {
-      if (systemDetentsInUse) {
-        // We're on iOS 15 or do not have custom detents specified by the user.
-        if (firstDimmedDetentIndex == 0 || (firstDimmedDetentIndex == 1 && _sheetAllowedDetents[0].floatValue < 1.0)) {
-          // There are no detents specified or there is exactly one & it is less than 1.0 we default to medium.
-          [self setLargestUndimmedDetentForSheet:sheet
-                                              to:UISheetPresentationControllerDetentIdentifierMedium
-                                         animate:YES];
-        } else {
-          [self setLargestUndimmedDetentForSheet:sheet
-                                              to:UISheetPresentationControllerDetentIdentifierLarge
-                                         animate:YES];
-        }
-      } else {
-        // We're on iOS 16+ & have custom detents.
-        [self setLargestUndimmedDetentForSheet:sheet to:[NSNumber numberWithInt:ludIndex].stringValue animate:YES];
+        RCTLogError(@"[RNScreens] The values in sheetAllowedDetents array must be sorted");
       }
     } else {
-      RCTLogError(@"[RNScreens] Value of sheetLargestUndimmedDetent prop must be >= -1");
+      float firstDetentFraction = _sheetAllowedDetents[0].floatValue;
+      if (firstDetentFraction == SHEET_FIT_TO_CONTENTS) {
+        RCTLogError(@"[RNScreens] Unsupported on iOS versions below 16");
+      } else if (firstDetentFraction < 1.0) {
+        [self setAllowedDetentsForSheet:sheet to:@[ UISheetPresentationControllerDetent.mediumDetent ] animate:YES];
+        [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierMedium animate:YES];
+      } else {
+        [self setAllowedDetentsForSheet:sheet to:@[ UISheetPresentationControllerDetent.largeDetent ] animate:YES];
+        [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+      }
     }
+  }
+
+  // Handle initial detent on the first update.
+  if (!_sheetHasInitialDetentSet) {
+    if (_sheetInitialDetent > 0 && _sheetInitialDetent < _sheetAllowedDetents.count) {
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+      if (@available(iOS 16.0, *)) {
+        UISheetPresentationControllerDetent *detent = sheet.detents[_sheetInitialDetent];
+        [self setSelectedDetentForSheet:sheet to:detent.identifier animate:YES];
+      } else
+#endif // Check for iOS >= 16
+      {
+        if (_sheetInitialDetent < 2) {
+          [self setSelectedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+        } else {
+          RCTLogError(
+              @"[RNScreens] sheetInitialDetent out of bounds, on iOS versions below 16 sheetAllowedDetents is ignored in favor of an array of two system-defined detents");
+        }
+      }
+    } else if (_sheetInitialDetent != 0) {
+      RCTLogError(@"[RNScreens] sheetInitialDetent out of bounds for sheetAllowedDetents array");
+    }
+    _sheetHasInitialDetentSet = true;
+  }
+
+  sheet.prefersScrollingExpandsWhenScrolledToEdge = _sheetExpandsWhenScrolledToEdge;
+  [self setGrabberVisibleForSheet:sheet to:_sheetGrabberVisible animate:YES];
+  [self setCornerRadiusForSheet:sheet to:_sheetCornerRadius animate:YES];
+
+  // lud - largest undimmed detent
+  // First we try to take value from the prop or default.
+  int ludIndex = _sheetLargestUndimmedDetent != nil ? _sheetLargestUndimmedDetent.intValue : -1;
+  // Rationalize the value in case the user set something that did not make sense.
+  ludIndex = ludIndex >= firstDimmedDetentIndex ? firstDimmedDetentIndex - 1 : ludIndex;
+  if (ludIndex == SHEET_LARGEST_UNDIMMED_DETENT_NONE) {
+    [self setLargestUndimmedDetentForSheet:sheet to:nil animate:YES];
+  } else if (ludIndex >= 0) {
+    if (systemDetentsInUse) {
+      // We're on iOS 15 or do not have custom detents specified by the user.
+      if (firstDimmedDetentIndex == 0 || (firstDimmedDetentIndex == 1 && _sheetAllowedDetents[0].floatValue < 1.0)) {
+        // There are no detents specified or there is exactly one & it is less than 1.0 we default to medium.
+        [self setLargestUndimmedDetentForSheet:sheet
+                                            to:UISheetPresentationControllerDetentIdentifierMedium
+                                       animate:YES];
+      } else {
+        [self setLargestUndimmedDetentForSheet:sheet to:UISheetPresentationControllerDetentIdentifierLarge animate:YES];
+      }
+    } else {
+      // We're on iOS 16+ & have custom detents.
+      [self setLargestUndimmedDetentForSheet:sheet to:[NSNumber numberWithInt:ludIndex].stringValue animate:YES];
+    }
+  } else {
+    RCTLogError(@"[RNScreens] Value of sheetLargestUndimmedDetent prop must be >= -1");
   }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -1915,29 +1909,27 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // In that case default iOS header will be shown. To fix this we hide header when the screens that appears has header
   // hidden and search bar was active on previous screen. We need to do it asynchronously, because default header is
   // added after viewWillAppear.
-  if (@available(iOS 13.0, *)) {
-    NSUInteger currentIndex = [self.navigationController.viewControllers indexOfObject:self];
+  NSUInteger currentIndex = [self.navigationController.viewControllers indexOfObject:self];
 
-    // we need to check whether reactSubviews array is empty, because on Fabric child nodes are unmounted first ->
-    // reactSubviews array may be empty
-    RNSScreenStackHeaderConfig *config = [self.screenView findHeaderConfig];
-    if (currentIndex > 0 && config != nil) {
-      UINavigationItem *prevNavigationItem =
-          [self.navigationController.viewControllers objectAtIndex:currentIndex - 1].navigationItem;
-      BOOL wasSearchBarActive = prevNavigationItem.searchController.active;
+  // we need to check whether reactSubviews array is empty, because on Fabric child nodes are unmounted first ->
+  // reactSubviews array may be empty
+  RNSScreenStackHeaderConfig *config = [self.screenView findHeaderConfig];
+  if (currentIndex > 0 && config != nil) {
+    UINavigationItem *prevNavigationItem =
+        [self.navigationController.viewControllers objectAtIndex:currentIndex - 1].navigationItem;
+    BOOL wasSearchBarActive = prevNavigationItem.searchController.active;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-      BOOL shouldHideHeader = !config.show;
+    BOOL shouldHideHeader = !config.show;
 #else
-      BOOL shouldHideHeader = config.hide;
+    BOOL shouldHideHeader = config.hide;
 #endif
 
-      if (wasSearchBarActive && shouldHideHeader) {
-        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 0);
-        dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
-          [self.navigationController setNavigationBarHidden:YES animated:NO];
-        });
-      }
+    if (wasSearchBarActive && shouldHideHeader) {
+      dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 0);
+      dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
+        [self.navigationController setNavigationBarHidden:YES animated:NO];
+      });
     }
   }
 #endif

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -848,9 +848,7 @@ RNS_IGNORE_SUPER_CALL_END
 
 #if !TARGET_OS_TV && !TARGET_OS_VISION
 
-- (void)setPropertyForSheet:(UISheetPresentationController *)sheet
-                  withBlock:(void (^)(void))block
-                    animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+- (void)setPropertyForSheet:(UISheetPresentationController *)sheet withBlock:(void (^)(void))block animate:(BOOL)animate
 {
   if (animate) {
     [sheet animateChanges:block];
@@ -861,7 +859,7 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)setAllowedDetentsForSheet:(UISheetPresentationController *)sheet
                                to:(NSArray<UISheetPresentationControllerDetent *> *)detents
-                          animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+                          animate:(BOOL)animate
 {
   [self setPropertyForSheet:sheet
                   withBlock:^{
@@ -872,7 +870,7 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)setSelectedDetentForSheet:(UISheetPresentationController *)sheet
                                to:(UISheetPresentationControllerDetentIdentifier)detent
-                          animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+                          animate:(BOOL)animate
 {
   if (sheet.selectedDetentIdentifier != detent) {
     [self setPropertyForSheet:sheet
@@ -883,9 +881,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
-- (void)setCornerRadiusForSheet:(UISheetPresentationController *)sheet
-                             to:(CGFloat)radius
-                        animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+- (void)setCornerRadiusForSheet:(UISheetPresentationController *)sheet to:(CGFloat)radius animate:(BOOL)animate
 {
   if (sheet.preferredCornerRadius != radius) {
     [self setPropertyForSheet:sheet
@@ -897,9 +893,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
-- (void)setGrabberVisibleForSheet:(UISheetPresentationController *)sheet
-                               to:(BOOL)visible
-                          animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+- (void)setGrabberVisibleForSheet:(UISheetPresentationController *)sheet to:(BOOL)visible animate:(BOOL)animate
 {
   if (sheet.prefersGrabberVisible != visible) {
     [self setPropertyForSheet:sheet
@@ -912,7 +906,7 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)setLargestUndimmedDetentForSheet:(UISheetPresentationController *)sheet
                                       to:(UISheetPresentationControllerDetentIdentifier)detent
-                                 animate:(BOOL)animate API_AVAILABLE(ios(15.0))
+                                 animate:(BOOL)animate
 {
   if (sheet.largestUndimmedDetentIdentifier != detent) {
     [self setPropertyForSheet:sheet
@@ -924,7 +918,6 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 - (NSInteger)detentIndexFromDetentIdentifier:(UISheetPresentationControllerDetentIdentifier)identifier
-    API_AVAILABLE(ios(15.0))
 {
   // We first check if we are running on iOS 16+ as the API is different
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
@@ -952,7 +945,7 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
-    (UISheetPresentationController *)sheetPresentationController API_AVAILABLE(ios(15.0))
+    (UISheetPresentationController *)sheetPresentationController
 {
   UISheetPresentationControllerDetentIdentifier ident = sheetPresentationController.selectedDetentIdentifier;
   [self notifySheetDetentChangeToIndex:[self detentIndexFromDetentIdentifier:ident] isStable:YES];

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -438,8 +438,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
-+ (UINavigationBarAppearance *)buildAppearance:(UIViewController *)vc
-                                    withConfig:(RNSScreenStackHeaderConfig *)config API_AVAILABLE(ios(13.0))
++ (UINavigationBarAppearance *)buildAppearance:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
 

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -149,9 +149,7 @@ namespace react = facebook::react;
 
 - (void)setObscureBackground:(BOOL)obscureBackground
 {
-  if (@available(iOS 9.1, *)) {
-    [_controller setObscuresBackgroundDuringPresentation:obscureBackground];
-  }
+  [_controller setObscuresBackgroundDuringPresentation:obscureBackground];
 }
 
 - (void)setHideNavigationBar:(BOOL)hideNavigationBar

--- a/ios/utils/RNSBackBarButtonItem.mm
+++ b/ios/utils/RNSBackBarButtonItem.mm
@@ -10,10 +10,8 @@
 
 - (void)setMenu:(UIMenu *)menu
 {
-  if (@available(iOS 14.0, *)) {
-    if (!_menuHidden) {
-      super.menu = menu;
-    }
+  if (!_menuHidden) {
+    super.menu = menu;
   }
 }
 


### PR DESCRIPTION
## Description

Removes outdated runtime SDK version checks + `API_AVAILABLE` macro usages for iOS < 15.1.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/392.

## Changes

- remove outdated usages of `@available`
- remove outdated usages of `API_AVAILABLE`

## Test code and steps to reproduce

Verify that project builds correctly.

## Checklist

- [ ] Ensured that CI passes
