### PR TITLE
fix(iOS 26, Stack v4): remove workaround for content under header in modal

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -71,14 +71,6 @@ static constexpr auto DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
 
 @implementation RNSScreenStackHeaderConfig {
   NSMutableArray<RNSScreenStackHeaderSubview *> *_reactSubviews;
-
-  // Workaround for UIKit edgesForExtendedLayout bug on iOS 26.
-  // On iOS 26, there is additional offset for UINavigationBar that is not
-  // accounted for when using edgesForExtendedLayout. That's why we additionaly
-  // use safeAreaLayoutGuide when header is visible. When bug gets fixed, we can
-  // get rid of all code related to this workaround.
-  // More information: https://github.com/software-mansion/react-native-screens/pull/3111
-  NSArray<NSLayoutConstraint *> *_safeAreaConstraints;
 #ifdef RCT_NEW_ARCH_ENABLED
   BOOL _initialPropsSet;
 
@@ -114,7 +106,6 @@ static constexpr auto DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
     _translucent = NO;
     _addedReactSubviewsInCurrentTransaction = false;
     _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});
-    _safeAreaConstraints = nil;
     [self initProps];
   }
   return self;
@@ -568,44 +559,13 @@ RNS_IGNORE_SUPER_CALL_END
   BOOL wasHidden = navctr.navigationBarHidden;
   BOOL shouldHide = config == nil || !config.shouldHeaderBeVisible;
 
-  // See comment above _safeAreaConstraints declaration for reason why this is necessary.
-  RNSScreenContentWrapper *contentWrapper = nil;
-  if (@available(iOS 26, *)) {
-    if (vc.view.subviews.count > 0 && [vc.view.subviews[0] isKindOfClass:[RNSScreenContentWrapper class]]) {
-      contentWrapper = static_cast<RNSScreenContentWrapper *>(vc.view.subviews[0]);
-    }
-  }
-
   if (!shouldHide && !config.translucent) {
     // when nav bar is not translucent we change edgesForExtendedLayout to avoid system laying out
     // the screen underneath navigation controllers
     vc.edgesForExtendedLayout = UIRectEdgeAll - UIRectEdgeTop;
-
-    // See comment above _safeAreaConstraints declaration for reason why this is necessary.
-    if (contentWrapper != nil) {
-      // Use auto-layout
-      contentWrapper.translatesAutoresizingMaskIntoConstraints = NO;
-
-      if (config->_safeAreaConstraints == nil) {
-        config->_safeAreaConstraints = @[
-          [contentWrapper.topAnchor constraintEqualToAnchor:vc.view.safeAreaLayoutGuide.topAnchor],
-          [contentWrapper.bottomAnchor constraintEqualToAnchor:vc.view.bottomAnchor],
-          [contentWrapper.leadingAnchor constraintEqualToAnchor:vc.view.leadingAnchor],
-          [contentWrapper.trailingAnchor constraintEqualToAnchor:vc.view.trailingAnchor]
-        ];
-      }
-      [NSLayoutConstraint activateConstraints:config->_safeAreaConstraints];
-    }
   } else {
     // system default is UIRectEdgeAll
     vc.edgesForExtendedLayout = UIRectEdgeAll;
-
-    // See comment above _safeAreaConstraints declaration for reason why this is necessary.
-    if (contentWrapper != nil) {
-      [NSLayoutConstraint deactivateConstraints:config->_safeAreaConstraints];
-      config->_safeAreaConstraints = nil;
-      contentWrapper.translatesAutoresizingMaskIntoConstraints = YES;
-    }
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:animated];
@@ -1018,17 +978,6 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 {
   [super prepareForRecycle];
   _initialPropsSet = NO;
-
-  // See comment above _safeAreaConstraints declaration for reason why this is necessary.
-  if (_safeAreaConstraints.count > 0 &&
-      [_safeAreaConstraints[0].firstItem isKindOfClass:[RNSScreenContentWrapper class]]) {
-    RNSScreenContentWrapper *contentWrapper = static_cast<RNSScreenContentWrapper *>(_safeAreaConstraints[0].firstItem);
-
-    // Disable auto-layout
-    contentWrapper.translatesAutoresizingMaskIntoConstraints = YES;
-  }
-  [NSLayoutConstraint deactivateConstraints:_safeAreaConstraints];
-  _safeAreaConstraints = nil;
 
 #ifdef RCT_NEW_ARCH_ENABLED
   _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});


### PR DESCRIPTION
## Description

Removes workaround introduced in https://github.com/software-mansion/react-native-screens/pull/3111.

Unfortunately, not only it doesn't fix all bugs related to the issue (e.g. https://github.com/software-mansion/react-native-screens-labs/issues/408) but also introduces new one as well (ScrollView not adapting to smaller height).

We also want to keep `ContentWrapper` in the same size as the content of the screen in order to correctly handle `fitToContents` in formSheets.

That's why we decided to remove the workaround, even though the bug with `edgesForExtendedLayout` hasn't been fixed yet (iOS 26 beta 6).

Current workaround is to use `react-native-safe-area-context` library. Wrap your screen's content in:
```tsx
<SafeAreaProvider>
  <SafeAreaView edges={['top']}>
    {/* content */}
  </SafeAreaView>
</SaveAreaProvider>
```

https://github.com/software-mansion/react-native-screens-labs/issues/408 isn't fixed by this workaround but it works correctly with ScrollView.

While we hope Apple fixes this before release, we're actively working on another solution that won't require using `react-native-safe-area-context`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/358.

## Changes

- remove workaround from #3111

## Test code and steps to reproduce

Run `Test3111` after wrapping `Screen1`, ..., `Screen4` in `SafeAreaView`, as described above. Remember to test landscape orientation on main screen as well (bug also happens there if you change orientation from portrait to landscape).

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
