### PR TITLE
fix(iOS): Reorder back button setup logic so iOS renders it correctly when displayMode=minimal

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-import Example from './Example';
-// import * as Test from './src/tests';
+// import Example from './Example';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  return <Example />;
-  // return <Test.TestBottomTabs />;
+  // return <Example />;
+  return <Test.Test2991 />;
 }

--- a/apps/src/tests/Test2991.tsx
+++ b/apps/src/tests/Test2991.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, ScrollView } from 'react-native';
+
+type RouteParamList = {
+  Home: undefined;
+  Second: undefined;
+  Third: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+const Home = ({ navigation }: StackNavigationProp) => <>
+  <ScrollView contentInsetAdjustmentBehavior='automatic'>
+    <Button title="Open second" onPress={() => navigation.navigate('Second')} />
+    <Button title="Open third" onPress={() => navigation.navigate('Third')} />
+  </ScrollView>
+</>
+
+const Second = ({ navigation }: StackNavigationProp) => <>
+  <ScrollView contentInsetAdjustmentBehavior='automatic'>
+    <Button title="Back" onPress={() => navigation.goBack()} />
+  </ScrollView>
+</>
+
+const Third = ({ navigation }: StackNavigationProp) => <>
+  <ScrollView contentInsetAdjustmentBehavior='automatic'>
+    <Button title="Back" onPress={() => navigation.goBack()} />
+  </ScrollView>
+</>
+
+export default function App() {
+  return (
+    <>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Home"
+            component={Home}
+            options={{
+              headerShown: false,
+              headerTitle: "Long back button label"
+            }} />
+          <Stack.Screen
+            name="Second"
+            component={Second}
+            options={{
+              headerBackButtonDisplayMode: 'minimal', // <--- REQUIRED
+              headerTitle: "Short title"
+            }}
+          />
+          <Stack.Screen
+            name="Third"
+            component={Third}
+            options={{
+              headerBackButtonDisplayMode: 'minimal',
+              headerTitle: "Really long title that will not fit the phone screen"
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </>
+  );
+}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -141,6 +141,7 @@ export { default as Test2899 } from './Test2899';
 export { default as Test2926 } from './Test2926'; // [E2E created](iOS): PR related to iOS search bar
 export { default as Test2949 } from './Test2949'; // [E2E skipped]: can't check system bars styles
 export { default as Test2963 } from './Test2963'; // [E2E created](iOS): issue related to iOS
+export { default as Test2991 } from './Test2991';
 export { default as Test3004 } from './Test3004';
 export { default as Test3045 } from './Test3045';
 export { default as Test3093 } from './Test3093';

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -608,11 +608,10 @@ RNS_IGNORE_SUPER_CALL_END
     }
   }
 
-  [navctr setNavigationBarHidden:shouldHide animated:animated];
-
   [config applySemanticContentAttributeIfNeededToNavCtrl:navctr];
 
   if (shouldHide) {
+    [navctr setNavigationBarHidden:true animated:animated];
     navitem.title = config.title;
     return;
   }
@@ -626,6 +625,8 @@ RNS_IGNORE_SUPER_CALL_END
   navitem.largeTitleDisplayMode =
       config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
 #endif
+
+  [navctr setNavigationBarHidden:false animated:animated];
 
   UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
   navitem.standardAppearance = appearance;


### PR DESCRIPTION
## Description

Partially fixes #2991. Unfortunately, not all cases are covered; see below.

When navigating from screen with headerShown: false to a screen that has a back button with displayMode=minimal, the width of the button appears to be the same as if it was meant for the first screen, with space allocated for a label that is not visible.

## Changes

Simply moving the line that updates the displayMode after the rest of back button's setup code, solves the problem for apps which use displayMode=minimal.

### Before

https://github.com/user-attachments/assets/d9abc075-ba47-44d9-a350-78f7199b64cc

### After

https://github.com/user-attachments/assets/149044b3-572b-451c-bdbb-a5a5331e9190

## What still needs fixing

When mixing headerShown=false, displayMode=default and displayMode=minimal, the screen with displayMode=minimal still doesn't work. For now, please use workarounds suggested by the community.

https://github.com/user-attachments/assets/68a864f7-a8f1-4567-8df7-d2de27e5d282