### PR TITLE
feat(android, Tabs): Update approach for loading external sources for tab icons

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -246,12 +246,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.core:core-ktx:1.8.0"
 
-    def COIL_VERSION = "3.0.4"
-    
-    implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
-    implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")
-    implementation("io.coil-kt.coil3:coil-svg:${COIL_VERSION}")
-        
     constraints {
         implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
             because("on older React Native versions this dependency conflicts with react-native-screens")


### PR DESCRIPTION
## Description

In the initial approach, we used Coil image loading library. However, after the 1st release, Coil has introduced several issues that had an impact on the stability and maintainability.

After reevaluating other options, we've decided to try migrating to Fresco. This choice aligns better because React Native also relies on Fresco internally. Using Fresco should improve consistency with the RN and reduce our maintenance overhead.

One known limitation is that Fresco doesn't support loading images in SVG format. We’ll need to explore alternative strategies to adapt.

## Changes

- Removed Coil
- Replaced logic for Coil ImageLoader with Fresco APIs

## Test code and steps to reproduce

Tested with BottomTabs example.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
