### PR TITLE
chore: Configure OIDC for nightly builds

### DIFF
--- a/.github/workflows/npm-screens-publish-nightly.yml
+++ b/.github/workflows/npm-screens-publish-nightly.yml
@@ -5,13 +5,16 @@ on:
   schedule:
     - cron: '27 23 * * *' # at 23:27 every day
   workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
 jobs:
   npm-build:
     if: github.repository == 'software-mansion/react-native-screens'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # for OIDC
     env:
       PACKAGE_NAME: PLACEHOLDER # Will be reassigned later on.
     steps:
@@ -24,6 +27,10 @@ jobs:
           node-version: 22
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
+      
+      # Ensure npm 11.5.1 or later is installed for OIDC
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
@@ -50,5 +57,3 @@ jobs:
 
       - name: Publish npm package
         run: npm publish $PACKAGE_NAME --tag nightly --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/npm-screens-publish-nightly.yml
+++ b/.github/workflows/npm-screens-publish-nightly.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: '27 23 * * *' # at 23:27 every day
   workflow_dispatch:
-permissions:
-  id-token: write
-  contents: read
 jobs:
   npm-build:
     if: github.repository == 'software-mansion/react-native-screens'


### PR DESCRIPTION
## Description

Recently npm enabled an option to use OIDC for publishing package artifacts from Github Actions: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

This PR follows the configuration instructions, namely:
1) We add "permissions" for "id-token" which permits the action to retrieve and temporarily store the OIDC token
2) We update npm version to latest in order to use a version that supports OIDC
3) We delete the env variable for the NPM access token we used before. Now the token is provided by OIDC mechanism
4) We're keeping provenance flag for NPM publish despite the fact it is forced when OIDC is enabled

The remaining part of the configuration is already setup on the NPM site and we should expect this workflow to "just work" after the changes.