### PR TITLE
fix(iOS, Tabs): Implement missing method from RNSViewControllerInvalidating protocol for Screen

### DIFF
--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -115,6 +115,12 @@ RNS_IGNORE_SUPER_CALL_END
   _controller = nil;
 }
 
+- (BOOL)shouldInvalidateOnMutation:(const facebook::react::ShadowViewMutation &)mutation
+{
+  // For bottom tabs, Host is responsible for invalidating children.
+  return NO;
+}
+
 #else
 
 #pragma mark - RCTInvalidating


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/382

Adding empty method from `RNSViewControllerInvalidating` protocol for `BottomTabsScreen`. For BottomTabs, `Host` is responsible for invalidating its children.

## Changes

- Adding missing method impl.

## Test code and steps to reproduce

No functional changes, just removing warning.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
