### PR TITLE
[ios] - add support for `hidesSharedBackground`

### DIFF
--- a/apps/src/screens/HeaderOptions.tsx
+++ b/apps/src/screens/HeaderOptions.tsx
@@ -65,6 +65,12 @@ const SettingsScreen = ({
   const [headerTransparent, setHeaderTransparent] = useState(false);
   const [headerBlurEffect, setHeaderBlurEffect] =
     useState<BlurEffectTypes>('extraLight');
+  const [headerLeftHidesSharedBackground, setHeaderLeftHidesSharedBackground] =
+    useState(false);
+  const [
+    headerRightHidesSharedBackground,
+    setHeaderRightHidesSharedBackground,
+  ] = useState(false);
 
   const square = (props: { tintColor?: string }) => (
     <Square {...props} color="green" size={20} />
@@ -84,6 +90,8 @@ const SettingsScreen = ({
       headerShadowVisible,
       headerTransparent,
       headerBlurEffect,
+      headerLeftHidesSharedBackground,
+      headerRightHidesSharedBackground,
     });
   }, [
     navigation,
@@ -97,6 +105,8 @@ const SettingsScreen = ({
     headerShadowVisible,
     headerTransparent,
     headerBlurEffect,
+    headerLeftHidesSharedBackground,
+    headerRightHidesSharedBackground,
   ]);
 
   return (
@@ -201,6 +211,16 @@ const SettingsScreen = ({
           'systemChromeMaterialDark',
         ]}
         onValueChange={setHeaderBlurEffect}
+      />
+      <SettingsSwitch
+        label="Header left hides shared background (iOS 26.0+)"
+        value={headerLeftHidesSharedBackground}
+        onValueChange={setHeaderLeftHidesSharedBackground}
+      />
+      <SettingsSwitch
+        label="Header right hides shared background (iOS 26.0+)"
+        value={headerRightHidesSharedBackground}
+        onValueChange={setHeaderRightHidesSharedBackground}
       />
       <Button title="Go back" onPress={() => navigation.goBack()} />
     </ScrollView>

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UISemanticContentAttribute direction;
 @property (nonatomic) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic) RNSBlurEffectStyle blurEffect;
+@property (nonatomic) BOOL headerLeftHidesSharedBackground;
+@property (nonatomic) BOOL headerRightHidesSharedBackground;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -637,11 +637,17 @@ RNS_IGNORE_SUPER_CALL_END
         navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
 #endif
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
+        if (@available(iOS 26.0, *)) {
+          [buttonItem setHidesSharedBackground: config.headerLeftHidesSharedBackground];
+        }
         navitem.leftBarButtonItem = buttonItem;
         break;
       }
       case RNSScreenStackHeaderSubviewTypeRight: {
         UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
+        if (@available(iOS 26.0, *)) {
+          [buttonItem setHidesSharedBackground: config.headerRightHidesSharedBackground];
+        }
         navitem.rightBarButtonItem = buttonItem;
         break;
       }
@@ -1062,6 +1068,9 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
     _blurEffect = [RNSConvert RNSBlurEffectStyleFromCppEquivalent:newScreenProps.blurEffect];
   }
 
+  _headerLeftHidesSharedBackground = newScreenProps.headerLeftHidesSharedBackground;
+  _headerRightHidesSharedBackground = newScreenProps.headerRightHidesSharedBackground;
+
   [self updateViewControllerIfNeeded];
 
   if (needsNavigationControllerLayout) {
@@ -1170,6 +1179,8 @@ RCT_EXPORT_VIEW_PROPERTY(disableBackButtonMenu, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(backButtonDisplayMode, UINavigationItemBackButtonDisplayMode)
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL) // `hidden` is an UIView property, we need to use different name internally
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(headerLeftHidesSharedBackground, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(headerRightHidesSharedBackground, BOOL)
 
 @end
 

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -71,6 +71,8 @@ export interface NativeProps extends ViewProps {
   hideBackButton?: boolean;
   backButtonInCustomView?: boolean;
   blurEffect?: WithDefault<BlurEffect, 'none'>;
+  headerLeftHidesSharedBackground?: boolean;
+  headerRightHidesSharedBackground?: boolean;
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean;
 }

--- a/src/native-stack/types.tsx
+++ b/src/native-stack/types.tsx
@@ -272,9 +272,23 @@ export type NativeStackNavigationOptions = {
    */
   headerLeft?: (props: { tintColor?: ColorValue }) => React.ReactNode;
   /**
+   * Boolean indicating whether the left header button should hide the shared background. Defaults to `false`.
+   * Only supported on iOS 26.0+.
+   *
+   * @platform ios
+   */
+  headerLeftHidesSharedBackground?: boolean;
+  /**
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: (props: { tintColor?: ColorValue }) => React.ReactNode;
+  /**
+   * Boolean indicating whether the right header button should hide the shared background. Defaults to `false`.
+   * Only supported on iOS 26.0+.
+   *
+   * @platform ios
+   */
+  headerRightHidesSharedBackground?: boolean;
   /**
    * Whether to show the header.
    */

--- a/src/native-stack/views/HeaderConfig.tsx
+++ b/src/native-stack/views/HeaderConfig.tsx
@@ -41,7 +41,9 @@ export default function HeaderConfig({
   headerLargeTitleHideShadow,
   headerLargeTitleStyle = {},
   headerLeft,
+  headerLeftHidesSharedBackground,
   headerRight,
+  headerRightHidesSharedBackground,
   headerShown,
   headerStyle = {},
   headerTintColor,
@@ -127,6 +129,8 @@ export default function HeaderConfig({
       hidden={headerShown === false}
       hideBackButton={headerHideBackButton}
       hideShadow={headerHideShadow}
+      headerLeftHidesSharedBackground={headerLeftHidesSharedBackground}
+      headerRightHidesSharedBackground={headerRightHidesSharedBackground}
       largeTitle={headerLargeTitle}
       largeTitleBackgroundColor={headerLargeStyle.backgroundColor}
       largeTitleColor={headerLargeTitleStyle.color}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -617,6 +617,20 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
    */
   hideBackButton?: boolean;
   /**
+   * Boolean indicating whether the left header button should draw the default glass effect background. Defaults to `false`.
+   * Only supported on iOS 26.0+.
+   *
+   * @platform ios
+   */
+  headerLeftHidesSharedBackground?: boolean;
+  /**
+   * Boolean indicating whether the right header button should draw the default glass effect background. Defaults to `false`.
+   * Only supported on iOS 26.0+.
+   *
+   * @platform ios
+   */
+  headerRightHidesSharedBackground?: boolean;
+  /**
    * Boolean indicating whether to hide the elevation shadow or the bottom border on the header.
    */
   hideShadow?: boolean;


### PR DESCRIPTION
## Description

Adds [hidesSharedBackground](https://developer.apple.com/documentation/uikit/uibarbuttonitem/hidessharedbackground) support to header right and left buttons. This enables us to remove the default glass effect button in iOS 26 from header right and left items. This is useful when someone wants to use a custom button. We needed it to add our own glass effect buttons.

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

Updated native Header config, types file and added example in HeaderOption screen.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

https://github.com/user-attachments/assets/e8ff33b7-e830-44bb-8085-ba44861925f5


Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

There was no way to remove the glass effect default button from header items.

### After

We can remove the default button and pass a custom UI.

-->

## Test code and steps to reproduce

Added an example in HeaderOption screen. We also need [these change](https://github.com/intergalacticspacehighway/react-navigation/commit/d84ca024c6bd99ba6dc195137615d36300935e11)s in react-navigation to test the example.
<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
