### PR TITLE
feat(iOS, Tabs): use `SafeAreaView` in Bottom Tabs

### DIFF
--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
@@ -37,6 +37,12 @@ export default function BottomTabsComponent() {
           config.tabBarItemSystemItem !== 'disabled'
             ? config.tabBarItemSystemItem
             : undefined,
+        respectedSafeAreaEdges: {
+          top: config.safeAreaTopEdge,
+          bottom: config.safeAreaBottomEdge,
+          left: config.safeAreaLeftEdge,
+          right: config.safeAreaRightEdge,
+        },
       },
       component: TestTab,
     },

--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/TestTab.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/TestTab.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useBottomTabsSAVExampleContext } from './BottomTabsSAVExampleContext';
-import { SafeAreaView } from 'react-native-screens/private';
 import { mapContentStringToComponent } from '../shared';
 
 export default function TestTab() {
@@ -11,15 +10,5 @@ export default function TestTab() {
     [config.content],
   );
 
-  return (
-    <SafeAreaView
-      edges={{
-        top: config.safeAreaTopEdge,
-        bottom: config.safeAreaBottomEdge,
-        left: config.safeAreaLeftEdge,
-        right: config.safeAreaRightEdge,
-      }}>
-      {content}
-    </SafeAreaView>
-  );
+  return content;
 }

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { Freeze } from 'react-freeze';
 import {
   Image,
+  Platform,
   StyleSheet,
+  View,
   findNodeHandle,
   processColor,
   type ImageSourcePropType,
@@ -24,10 +26,13 @@ import type {
   BottomTabsScreenItemAppearance,
   BottomTabsScreenItemStateAppearance,
   BottomTabsScreenProps,
+  BottomTabsScreenSafeAreaEdges,
   EmptyObject,
   Icon,
 } from './BottomTabsScreen.types';
 import { bottomTabsDebugLog } from '../../private/logging';
+import { SafeAreaView } from 'react-native-screens/private';
+import { SafeAreaViewProps } from 'react-native-screens/private/types';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -59,6 +64,8 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
     selectedIcon,
     standardAppearance,
     scrollEdgeAppearance,
+    respectedSafeAreaEdges,
+    contentStyle,
     ...rest
   } = props;
 
@@ -149,7 +156,11 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
       ref={componentNodeRef}
       {...rest}>
       <Freeze freeze={shouldFreeze} placeholder={rest.placeholder}>
-        {rest.children}
+        <View style={[contentStyle, styles.flex]}>
+          <SafeAreaView edges={getSafeAreaViewEdges(respectedSafeAreaEdges)}>
+            {rest.children}
+          </SafeAreaView>
+        </View>
       </Freeze>
     </BottomTabsScreenNativeComponent>
   );
@@ -241,6 +252,23 @@ function shouldFreezeScreen(
   return !nativeViewVisible;
 }
 
+function getSafeAreaViewEdges(
+  edges?: BottomTabsScreenSafeAreaEdges,
+): SafeAreaViewProps['edges'] {
+  let defaultEdges: SafeAreaViewProps['edges'];
+
+  switch (Platform.OS) {
+    case 'android':
+      defaultEdges = { bottom: true };
+      break;
+    default:
+      defaultEdges = {};
+      break;
+  }
+
+  return { ...defaultEdges, ...edges };
+}
+
 function parseIconToNativeProps(icon: Icon | undefined): {
   iconType?: IconType;
   iconImageSource?: ImageSourcePropType;
@@ -323,5 +351,8 @@ const styles = StyleSheet.create({
     flex: 1,
     width: '100%',
     height: '100%',
+  },
+  flex: {
+    flex: 1,
   },
 });

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -17,6 +17,13 @@ export type LifecycleStateChangeEvent = Readonly<{
   newState: number;
 }>;
 
+export interface BottomTabsScreenSafeAreaEdges {
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+}
+
 // iOS-specific: SFSymbol usage
 export interface SFIcon {
   sfSymbolName: string;
@@ -370,6 +377,23 @@ export interface BottomTabsScreenProps {
    * @platform ios
    */
   orientation?: BottomTabsScreenOrientation;
+
+  /**
+   * @summary Specifies which edges should respect safe area.
+   *
+   * @default
+   * On Android, bottom edge is enabled.
+   * On iOS, all edges are disabled.
+   */
+  respectedSafeAreaEdges?: BottomTabsScreenSafeAreaEdges;
+
+  /**
+   * @summary Specifies styling for enitre screen.
+   *
+   * This allows modification of the style props for the view visible
+   * outside screen's respected safe area.
+   */
+  contentStyle?: ViewProps['style'];
   // #endregion General
 
   // #region Android-only appearance

--- a/src/private/types.ts
+++ b/src/private/types.ts
@@ -1,0 +1,1 @@
+export * from '../components/safe-area/SafeAreaView.types';


### PR DESCRIPTION
## Description

Integrates `SafeAreaView` component into `BottomTabsScreen`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/167.

This PR adds partial support for Android but full support (with `insetType`) needs to be handled in separate PR, after this is merged to `main`. 

## Changes

- add `respectedSafeAreaEdges` prop to `BottomTabsScreen`
  - on iOS, all edges are disabled by default,
- add `contentStyle` prop to `BottomTabsScreen` to allow adding style to view behind `SafeAreaView`

## Test code and steps to reproduce

Run `TestBottomTabs`, verify that default behavior did not change, use new props e.g. on `Tab2`.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
