### PR TITLE
fix(iOS, Stack v4): use `SafeAreaView` in Stack v4 to fix content rendering under UINavigationBar on iOS 26

### DIFF
--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -15,6 +15,8 @@ import Screen from './Screen';
 import ScreenStack from './ScreenStack';
 import { RNSScreensRefContext } from '../contexts';
 import { FooterComponent } from './ScreenFooter';
+import { SafeAreaView } from 'react-native-screens/private';
+import { SafeAreaViewProps } from './safe-area/SafeAreaView.types';
 
 type Props = Omit<
   ScreenProps,
@@ -65,6 +67,8 @@ function ScreenStackItem(
     headerHiddenPreviousRef.current = headerConfig?.hidden;
   }, [headerConfig?.hidden, stackPresentation]);
 
+  const shouldUseSafeAreaView = Platform.OS === 'ios';
+
   const content = (
     <>
       <DebugContainer
@@ -79,7 +83,13 @@ function ScreenStackItem(
           contentStyle,
         ]}
         stackPresentation={stackPresentation ?? 'push'}>
-        {children}
+        {shouldUseSafeAreaView ? (
+          <SafeAreaView edges={getSafeAreaEdges(headerConfig)}>
+            {children}
+          </SafeAreaView>
+        ) : (
+          children
+        )}
       </DebugContainer>
       {/**
        * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
@@ -163,6 +173,25 @@ function ScreenStackItem(
 }
 
 export default React.forwardRef(ScreenStackItem);
+
+function getSafeAreaEdges(
+  headerConfig?: ScreenStackHeaderConfigProps,
+): SafeAreaViewProps['edges'] {
+  if (Platform.OS !== 'ios') {
+    return {};
+  }
+
+  let defaultEdges: SafeAreaViewProps['edges'];
+  if (headerConfig?.translucent || headerConfig?.hidden) {
+    defaultEdges = {};
+  } else {
+    defaultEdges = {
+      top: true,
+    };
+  }
+
+  return defaultEdges;
+}
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
## Description

Integrates `SafeAreaView` component into `ScreenStackItem` to mitigate native UIKit bug with `edgesForExtendedLayout` on iOS 26 (more details in PR with previous workaround attempt: https://github.com/software-mansion/react-native-screens/pull/3111)

## Changes

- wrap content in `SafeAreaView` on iOS
- enable top edge inset if header `(!translucent && !hidden)`

## Test code and steps to reproduce

Run `Test3111`.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
