### PR TITLE
fix: Android 16 KB memory page support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,9 +137,12 @@ android {
         }
         externalNativeBuild {
             cmake {
+                cppFlags "-Wl,-z,max-page-size=16384", "-Wl,-z,common-page-size=16384"
+                cFlags "-Wl,-z,max-page-size=16384", "-Wl,-z,common-page-size=16384"
                 arguments "-DANDROID_STL=c++_shared",
                         "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
-                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
+                        "-DANDROID_MAX_PAGE_SIZE_SUPPORTED=16384"
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes support for Android 16KB page size by configuring appropriate CMake linker flags to ensure compatibility with devices using larger memory page sizes.

## Changes

- Added linker flags `-Wl,-z,max-page-size=16384` and `-Wl,-z,common-page-size=16384` to both `cppFlags` and `cFlags`
- Added `ANDROID_MAX_PAGE_SIZE_SUPPORTED=16384` CMake argument

## Test
 **Device Testing:**
  - Tested on Xiaomi Redmi Note 7 (device with 16KB page size support)
  - Screen navigation works normally without crashes
  - No native module loading errors observed

  **Build Verification:**
  - APK analysis in Android Studio shows successful native library loading
  - No page size related build errors
  - CMake configuration applies correctly with new linker flags
