### PR TITLE
feat(iOS): Implement ScrollViewProviding protocol

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1242,9 +1242,8 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)updateContentScrollViewEdgeEffectsIfExists
 {
-  [RNSScrollEdgeEffectApplicator
-      applyToScrollView:[RNSScrollViewFinder findContentScrollViewWithFirstDescendantsChain:self]
-           withProvider:self];
+  [RNSScrollEdgeEffectApplicator applyToScrollView:[RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:self]
+                                      withProvider:self];
 }
 
 #pragma mark - RNSSafeAreaProviding

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -194,7 +194,7 @@ namespace react = facebook::react;
     return [[self popToRootViewControllerAnimated:true] count] > 0;
   } else if (tabScreenController.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
     UIScrollView *scrollView =
-        [RNSScrollViewFinder findContentScrollViewWithFirstDescendantsChain:[[self topViewController] view]];
+        [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:[[self topViewController] view]];
     return [scrollView rnscreens_scrollToTop];
   }
 

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -165,9 +165,8 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)updateContentScrollViewEdgeEffectsIfExists
 {
-  [RNSScrollEdgeEffectApplicator
-      applyToScrollView:[RNSScrollViewFinder findContentScrollViewWithFirstDescendantsChain:self]
-           withProvider:self];
+  [RNSScrollEdgeEffectApplicator applyToScrollView:[RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:self]
+                                      withProvider:self];
 }
 
 #pragma mark - Prop update utils

--- a/ios/bottom-tabs/RNSTabsScreenViewController.mm
+++ b/ios/bottom-tabs/RNSTabsScreenViewController.mm
@@ -107,7 +107,7 @@
     return [[self tabsSpecialEffectsDelegate] onRepeatedTabSelectionOfTabScreenController:self];
   } else if (self.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
     UIScrollView *scrollView =
-        [RNSScrollViewFinder findContentScrollViewWithFirstDescendantsChain:[self tabScreenComponentView]];
+        [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:[self tabScreenComponentView]];
     return [scrollView rnscreens_scrollToTop];
   }
 

--- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
+++ b/ios/helpers/scroll-view/RNSScrollViewFinder.h
@@ -2,23 +2,24 @@
 #import "RNSContentScrollViewProviding.h"
 
 @interface RNSScrollViewFinder : NSObject
+
 /**
  * Searches for content ScrollView by traversing down the hierarchy using first subview, similar to UIKit behavior.
  * It will fail if:
  * - UIScrollView is not a first subview of view or one of its descendants in the hierarchy,
  * - if UIScrollView's parent is not yet attached.
+ *
+ * When `view == nil`, it should also return `nil`.
  */
-+ (nullable UIScrollView *)findContentScrollViewWithFirstDescendantsChain:(nullable UIView *)view;
++ (nullable UIScrollView *)findScrollViewInFirstDescendantChainFrom:(nullable UIView *)view;
 
 /**
- * Looks for UIScrollView in a similar way to `findContentScrollViewWithFirstDescendantsChain`, until it finds
+ * Looks for UIScrollView in a similar way to `findScrollViewInFirstDescendantChainFrom`, until it finds
  * `RNSContentScrollViewProviding`. Then, it delegates the task to the provider, and returns the results. This can
  * overcome the problems of subviews' children not being mounted yet, or ScrollView being mounted at index different
  * than 0.
  *
- * Caveat: when traversing the hierarchy, we don't check for conformance to protocol,
- * but whether the view responds to `RNSContentScrollViewProviding.findContentScrollView`.
- * This doesn't place locks and is faster.
+ * When `view == nil`, it should also return `nil`.
  */
 + (nullable UIScrollView *)findContentScrollViewWithDelegatingToProvider:(nullable UIView *)view;
 

--- a/ios/helpers/scroll-view/RNSScrollViewFinder.mm
+++ b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
@@ -2,7 +2,7 @@
 
 @implementation RNSScrollViewFinder
 
-+ (UIScrollView *)findContentScrollViewWithFirstDescendantsChain:(UIView *)view
++ (UIScrollView *)findScrollViewInFirstDescendantChainFrom:(UIView *)view
 {
   UIView *currentView = view;
 
@@ -27,6 +27,9 @@
     if ([currentView isKindOfClass:UIScrollView.class]) {
       return static_cast<UIScrollView *>(currentView);
     } else if ([currentView respondsToSelector:@selector(findContentScrollView)]) {
+      // When traversing the hierarchy, we don't check for conformance to protocol,
+      // but whether the view responds to `RNSContentScrollViewProviding.findContentScrollView`.
+      // This doesn't place locks and is faster.
       return [static_cast<id<RNSContentScrollViewProviding>>(currentView) findContentScrollView];
     } else if ([currentView.subviews count] > 0) {
       currentView = currentView.subviews[0];

--- a/ios/helpers/scroll-view/RNSScrollViewHelper.mm
+++ b/ios/helpers/scroll-view/RNSScrollViewHelper.mm
@@ -5,7 +5,7 @@
 
 + (void)overrideScrollViewBehaviorInFirstDescendantChainFrom:(nullable UIView *)view
 {
-  UIScrollView *scrollView = [RNSScrollViewFinder findContentScrollViewWithFirstDescendantsChain:view];
+  UIScrollView *scrollView = [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:view];
 
   if ([scrollView contentInsetAdjustmentBehavior] == UIScrollViewContentInsetAdjustmentNever) {
     [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentAutomatic];


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/456

## Description

This PR implements ScrollViewProviding protocol as per internal discussion. The protocol enables us to be smarter about finding content ScrollView than simply descending into 0th child. A class that implements this protocol can decide how to continue the search. To complement the feature, ScrollViewFinder is updated with new method, `findContentScrollViewWithDelegatingToProvider` that takes advantage of the protocol.

## Changes

- Added `ScrollViewProviding` protocol, with implementations for `RNSScreenStack`, `BottomTabsHostComponentView`. The implementations continue search directly from their currently selected screens. This has the desired side-effect of completing the search even if the screen is not yet mounted in host hierarchy.
- Modified `ScrollViewFinder` to include a method that takes advantage of the new protocol, while leaving the simple version
- Concrete implementations of the new protocol will be added in future PRs

## Test code and steps to reproduce

Use Test3212; For now, nested containers may not behave as expected, because the new "smart" method is not called yet; things will change in the following PRs