### PR TITLE
feat(iOS): Bring back fullScreenSwipeEnabled prop

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -273,7 +273,7 @@ open class ScreenViewManager :
     // these props are not available on Android, however we must override their setters
     override fun setFullScreenSwipeEnabled(
         view: Screen?,
-        value: Boolean,
+        value: String?,
     ) = Unit
 
     override fun setFullScreenSwipeShadowEnabled(

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -53,7 +53,7 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);
         break;
       case "fullScreenSwipeEnabled":
-        mViewManager.setFullScreenSwipeEnabled(view, value == null ? false : (boolean) value);
+        mViewManager.setFullScreenSwipeEnabled(view, (String) value);
         break;
       case "fullScreenSwipeShadowEnabled":
         mViewManager.setFullScreenSwipeShadowEnabled(view, value == null ? true : (boolean) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -25,7 +25,7 @@ public interface RNSScreenManagerInterface<T extends View>  {
   void setSheetInitialDetent(T view, int value);
   void setSheetElevation(T view, int value);
   void setCustomAnimationOnSwipe(T view, boolean value);
-  void setFullScreenSwipeEnabled(T view, boolean value);
+  void setFullScreenSwipeEnabled(T view, @Nullable String value);
   void setFullScreenSwipeShadowEnabled(T view, boolean value);
   void setHomeIndicatorHidden(T view, boolean value);
   void setPreventNativeDismiss(T view, boolean value);

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -54,8 +54,16 @@ Defaults to `false`. When `enableFreeze()` is run at the top of the application 
 
 ### `fullScreenSwipeEnabled` (iOS only)
 
-Boolean indicating whether the swipe gesture should work on whole screen. Swiping with this option results in the same transition animation as `simple_push` by default. It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation is not achievable due to usage of custom recognizer. Defaults to `false`.
-IMPORTANT: Starting from iOS 26, full screen swipe is handled by native recognizer, and this prop is ignored.
+Boolean indicating whether the swipe gesture should work on whole screen. The behavior depends on iOS version.
+
+For iOS prior to 26, swiping with this option results in the same transition animation as `simple_push` by default.
+It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation
+is not achievable due to usage of custom recognizer.
+
+For iOS 26 and up, native `interactiveContentPopGestureRecognizer` is used, and this prop controls whether it should 
+be enabled or not.
+
+When not set, it defaults to `false` on iOS < 26 and `true` for iOS >= 26.
 
 ### `fullScreenSwipeShadowEnabled` (iOS only)
 

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -60,8 +60,8 @@ For iOS prior to 26, swiping with this option results in the same transition ani
 It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation
 is not achievable due to usage of custom recognizer.
 
-For iOS 26 and up, native `interactiveContentPopGestureRecognizer` is used, and this prop controls whether it should 
-be enabled or not.
+For iOS 26 and up, native `interactiveContentPopGestureRecognizer` is used for all cases except for `customAnimationOnSwipe`,
+however the prop still can be used to controls whether it should be enabled or not.
 
 When not set, it defaults to `false` on iOS < 26 and `true` for iOS >= 26.
 

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -18,6 +18,9 @@ namespace react = facebook::react;
 + (UINavigationItemBackButtonDisplayMode)UINavigationItemBackButtonDisplayModeFromCppEquivalent:
     (react::RNSScreenStackHeaderConfigBackButtonDisplayMode)backButtonDisplayMode;
 
++ (RNSOptionalBoolean)RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
+    (react::RNSScreenFullScreenSwipeEnabled)fullScreenSwipeEnabled;
+
 + (RNSScreenStackPresentation)RNSScreenStackPresentationFromCppEquivalent:
     (react::RNSScreenStackPresentation)stackPresentation;
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -36,6 +36,20 @@
   }
 }
 
++ (RNSOptionalBoolean)RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
+    (react::RNSScreenFullScreenSwipeEnabled)fullScreenSwipeEnabled
+{
+  switch (fullScreenSwipeEnabled) {
+    using enum react::RNSScreenFullScreenSwipeEnabled;
+    case Undefined:
+      return RNSOptionalBooleanUndefined;
+    case True:
+      return RNSOptionalBooleanTrue;
+    case False:
+      return RNSOptionalBooleanFalse;
+  }
+}
+
 + (RNSScreenStackPresentation)RNSScreenStackPresentationFromCppEquivalent:
     (react::RNSScreenStackPresentation)stackPresentation
 {

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -72,7 +72,7 @@ namespace react = facebook::react;
      RNSSafeAreaProviding,
      RNSScrollEdgeEffectProviding>
 
-@property (nonatomic) BOOL fullScreenSwipeEnabled;
+@property (nonatomic) RNSOptionalBoolean fullScreenSwipeEnabled;
 @property (nonatomic) BOOL fullScreenSwipeShadowEnabled;
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;
@@ -163,6 +163,8 @@ namespace react = facebook::react;
 - (void)notifyDismissCancelledWithDismissCount:(int)dismissCount;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;
+
+- (BOOL)isFullScreenSwipeBackEnabled;
 
 /**
  * Tell `Screen` component that it has been removed from react state and can safely cleanup

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -72,7 +72,7 @@ namespace react = facebook::react;
      RNSSafeAreaProviding,
      RNSScrollEdgeEffectProviding>
 
-@property (nonatomic) RNSOptionalBoolean fullScreenSwipeEnabled;
+@property (nonatomic, readonly) BOOL fullScreenSwipeEnabled;
 @property (nonatomic) BOOL fullScreenSwipeShadowEnabled;
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;
@@ -163,12 +163,6 @@ namespace react = facebook::react;
 - (void)notifyDismissCancelledWithDismissCount:(int)dismissCount;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;
-
-/**
- * Returns a boolean equivalent of fullScreenSwipeEnabled OptionalBoolean, resolves Undefined as `false` for iOS < 26,
- * `true` otherwise.
- */
-- (BOOL)fullScreenSwipeEnabledBoolean;
 
 /**
  * Tell `Screen` component that it has been removed from react state and can safely cleanup

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -164,7 +164,11 @@ namespace react = facebook::react;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;
 
-- (BOOL)isFullScreenSwipeBackEnabled;
+/**
+ * Returns a boolean equivalen of fullScreenSwipeEnabled OptionalBoolean, resolves Undefined as `false` for iOS < 26,
+ * `true` otherwise.
+ */
+- (BOOL)fullScreenSwipeEnabledBoolean;
 
 /**
  * Tell `Screen` component that it has been removed from react state and can safely cleanup

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -72,7 +72,13 @@ namespace react = facebook::react;
      RNSSafeAreaProviding,
      RNSScrollEdgeEffectProviding>
 
-@property (nonatomic, readonly) BOOL fullScreenSwipeEnabled;
+/**
+ * This is value of the prop as passed by the user. To get effective value see derived property
+ * `isFullScreenSwipeEffectivelyEnabled`
+ */
+@property (nonatomic) RNSOptionalBoolean fullScreenSwipeEnabled;
+@property (nonatomic, readonly, getter=isFullScreenSwipeEffectivelyEnabled) BOOL fullScreenSwipeEffectivelyEnabled;
+
 @property (nonatomic) BOOL fullScreenSwipeShadowEnabled;
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -165,7 +165,7 @@ namespace react = facebook::react;
 - (BOOL)isPresentedAsNativeModal;
 
 /**
- * Returns a boolean equivalen of fullScreenSwipeEnabled OptionalBoolean, resolves Undefined as `false` for iOS < 26,
+ * Returns a boolean equivalent of fullScreenSwipeEnabled OptionalBoolean, resolves Undefined as `false` for iOS < 26,
  * `true` otherwise.
  */
 - (BOOL)fullScreenSwipeEnabledBoolean;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -74,7 +74,6 @@ struct ContentWrapperBox {
   ContentWrapperBox _contentWrapperBox;
   bool _sheetHasInitialDetentSet;
   BOOL _shouldUpdateScrollEdgeEffects;
-  RNSOptionalBoolean _fullScreenSwipeEnabled;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
   react::RNSScreenShadowNode::ConcreteState::Shared _state;
@@ -467,6 +466,21 @@ RNS_IGNORE_SUPER_CALL_END
 {
   _shouldUpdateScrollEdgeEffects = YES;
   _topScrollEdgeEffect = topScrollEdgeEffect;
+}
+
+- (BOOL)isFullScreenSwipeEffectivelyEnabled
+{
+  switch (_fullScreenSwipeEnabled) {
+    case RNSOptionalBooleanTrue:
+      return YES;
+    case RNSOptionalBooleanFalse:
+      return NO;
+    case RNSOptionalBooleanUndefined:
+      if (@available(iOS 26, *)) {
+        return YES;
+      }
+      return NO;
+  }
 }
 
 RNS_IGNORE_SUPER_CALL_BEGIN
@@ -891,21 +905,6 @@ RNS_IGNORE_SUPER_CALL_END
 - (BOOL)isPresentedAsNativeModal
 {
   return self.controller.parentViewController == nil && self.controller.presentingViewController != nil;
-}
-
-- (BOOL)fullScreenSwipeEnabled
-{
-  switch (_fullScreenSwipeEnabled) {
-    case RNSOptionalBooleanTrue:
-      return YES;
-    case RNSOptionalBooleanFalse:
-      return NO;
-    case RNSOptionalBooleanUndefined:
-      if (@available(iOS 26, *)) {
-        return YES;
-      }
-      return NO;
-  }
 }
 
 - (BOOL)isFullscreenModal
@@ -1541,11 +1540,6 @@ RNS_IGNORE_SUPER_CALL_END
   // the screen dimensions and we wait for the screen VC to update and then we
   // pass the dimensions to ui view manager to take into account when laying out
   // subviews
-}
-
-- (void)setFullScreenSwipeEnabled:(RNSOptionalBoolean)fullScreenSwipeEnabled
-{
-  _fullScreenSwipeEnabled = fullScreenSwipeEnabled;
 }
 
 #endif

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -891,6 +891,21 @@ RNS_IGNORE_SUPER_CALL_END
   return self.controller.parentViewController == nil && self.controller.presentingViewController != nil;
 }
 
+- (BOOL)isFullScreenSwipeBackEnabled
+{
+  switch (self.fullScreenSwipeEnabled) {
+    case RNSOptionalBooleanTrue:
+      return YES;
+    case RNSOptionalBooleanFalse:
+      return NO;
+    case RNSOptionalBooleanUndefined:
+      if (@available(iOS 26, *)) {
+        return YES;
+      }
+      return NO;
+  }
+}
+
 - (BOOL)isFullscreenModal
 {
   switch (self.controller.modalPresentationStyle) {
@@ -1333,7 +1348,8 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &oldScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(_props);
   const auto &newScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(props);
 
-  [self setFullScreenSwipeEnabled:newScreenProps.fullScreenSwipeEnabled];
+  [self setFullScreenSwipeEnabled:[RNSConvert RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
+                                                  newScreenProps.fullScreenSwipeEnabled]];
 
   [self setFullScreenSwipeShadowEnabled:newScreenProps.fullScreenSwipeShadowEnabled];
 
@@ -2171,7 +2187,7 @@ RCT_EXPORT_MODULE()
 // we want to handle the case when activityState is nil
 RCT_REMAP_VIEW_PROPERTY(activityState, activityStateOrNil, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(customAnimationOnSwipe, BOOL);
-RCT_EXPORT_VIEW_PROPERTY(fullScreenSwipeEnabled, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(fullScreenSwipeEnabled, RNSOptionalBoolean);
 RCT_EXPORT_VIEW_PROPERTY(fullScreenSwipeShadowEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(gestureResponseDistance, NSDictionary)

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -74,6 +74,7 @@ struct ContentWrapperBox {
   ContentWrapperBox _contentWrapperBox;
   bool _sheetHasInitialDetentSet;
   BOOL _shouldUpdateScrollEdgeEffects;
+  RNSOptionalBoolean _fullScreenSwipeEnabled;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
   react::RNSScreenShadowNode::ConcreteState::Shared _state;
@@ -892,9 +893,9 @@ RNS_IGNORE_SUPER_CALL_END
   return self.controller.parentViewController == nil && self.controller.presentingViewController != nil;
 }
 
-- (BOOL)fullScreenSwipeEnabledBoolean
+- (BOOL)fullScreenSwipeEnabled
 {
-  switch (self.fullScreenSwipeEnabled) {
+  switch (_fullScreenSwipeEnabled) {
     case RNSOptionalBooleanTrue:
       return YES;
     case RNSOptionalBooleanFalse:
@@ -1349,8 +1350,8 @@ RNS_IGNORE_SUPER_CALL_END
   const auto &oldScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(_props);
   const auto &newScreenProps = *std::static_pointer_cast<const react::RNSScreenProps>(props);
 
-  [self setFullScreenSwipeEnabled:[RNSConvert RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
-                                                  newScreenProps.fullScreenSwipeEnabled]];
+  _fullScreenSwipeEnabled =
+      [RNSConvert RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:newScreenProps.fullScreenSwipeEnabled];
 
   [self setFullScreenSwipeShadowEnabled:newScreenProps.fullScreenSwipeShadowEnabled];
 
@@ -1540,6 +1541,11 @@ RNS_IGNORE_SUPER_CALL_END
   // the screen dimensions and we wait for the screen VC to update and then we
   // pass the dimensions to ui view manager to take into account when laying out
   // subviews
+}
+
+- (void)setFullScreenSwipeEnabled:(RNSOptionalBoolean)fullScreenSwipeEnabled
+{
+  _fullScreenSwipeEnabled = fullScreenSwipeEnabled;
 }
 
 #endif

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -131,6 +131,7 @@ struct ContentWrapperBox {
   _hasOrientationSet = NO;
   _hasHomeIndicatorHiddenSet = NO;
   _activityState = RNSActivityStateUndefined;
+  _fullScreenSwipeEnabled = RNSOptionalBooleanUndefined;
   _fullScreenSwipeShadowEnabled = YES;
   _shouldUpdateScrollEdgeEffects = NO;
 #if !TARGET_OS_TV

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -891,7 +891,7 @@ RNS_IGNORE_SUPER_CALL_END
   return self.controller.parentViewController == nil && self.controller.presentingViewController != nil;
 }
 
-- (BOOL)isFullScreenSwipeBackEnabled
+- (BOOL)fullScreenSwipeEnabledBoolean
 {
   switch (self.fullScreenSwipeEnabled) {
     case RNSOptionalBooleanTrue:

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1198,24 +1198,25 @@ RNS_IGNORE_SUPER_CALL_END
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   if (@available(iOS 26, *)) {
-    // On iOS 26, fullScreenSwipeEnabled takes no effect, and depending on whether custom animations are on,
-    // we select either interactiveContentPopGestureRecognizer or RNSPanGestureRecognizer
-    if (([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]] &&
-         !customAnimationOnSwipePropSetAndSelectedAnimationIsCustom) ||
-        (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer &&
-         customAnimationOnSwipePropSetAndSelectedAnimationIsCustom)) {
-      return NO;
+    // On iOS 26, depending on whether custom animations are on, we select
+    // either interactiveContentPopGestureRecognizer or RNSPanGestureRecognizer,
+    // then we allow them to proceed iff full screen swipe is enabled.
+    if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen isFullScreenSwipeBackEnabled] : NO;
+    }
+    if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer) {
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen isFullScreenSwipeBackEnabled];
     }
   } else {
     // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return topScreen.fullScreenSwipeEnabled;
+      return [topScreen isFullScreenSwipeBackEnabled];
     }
   }
 #else // check for iOS >= 26
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    return topScreen.fullScreenSwipeEnabled;
+    return [topScreen isFullScreenSwipeBackEnabled];
   }
 #endif // check for iOS >= 26
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1202,21 +1202,21 @@ RNS_IGNORE_SUPER_CALL_END
     // either interactiveContentPopGestureRecognizer or RNSPanGestureRecognizer,
     // then we allow them to proceed iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen fullScreenSwipeEnabledBoolean] : NO;
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen fullScreenSwipeEnabled] : NO;
     }
     if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen fullScreenSwipeEnabledBoolean];
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen fullScreenSwipeEnabled];
     }
   } else {
     // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return [topScreen fullScreenSwipeEnabledBoolean];
+      return [topScreen fullScreenSwipeEnabled];
     }
   }
 #else // check for iOS >= 26
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    return [topScreen fullScreenSwipeEnabledBoolean];
+    return [topScreen fullScreenSwipeEnabled];
   }
 #endif // check for iOS >= 26
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1202,21 +1202,21 @@ RNS_IGNORE_SUPER_CALL_END
     // either interactiveContentPopGestureRecognizer or RNSPanGestureRecognizer,
     // then we allow them to proceed iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen isFullScreenSwipeBackEnabled] : NO;
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen fullScreenSwipeEnabledBoolean] : NO;
     }
     if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen isFullScreenSwipeBackEnabled];
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen fullScreenSwipeEnabledBoolean];
     }
   } else {
     // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return [topScreen isFullScreenSwipeBackEnabled];
+      return [topScreen fullScreenSwipeEnabledBoolean];
     }
   }
 #else // check for iOS >= 26
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    return [topScreen isFullScreenSwipeBackEnabled];
+    return [topScreen fullScreenSwipeEnabledBoolean];
   }
 #endif // check for iOS >= 26
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1202,21 +1202,23 @@ RNS_IGNORE_SUPER_CALL_END
     // either interactiveContentPopGestureRecognizer or RNSPanGestureRecognizer,
     // then we allow them to proceed iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? [topScreen fullScreenSwipeEnabled] : NO;
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? topScreen.isFullScreenSwipeEffectivelyEnabled
+                                                                       : NO;
     }
     if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer) {
-      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO : [topScreen fullScreenSwipeEnabled];
+      return customAnimationOnSwipePropSetAndSelectedAnimationIsCustom ? NO
+                                                                       : topScreen.isFullScreenSwipeEffectivelyEnabled;
     }
   } else {
     // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
     if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-      return [topScreen fullScreenSwipeEnabled];
+      return topScreen.isFullScreenSwipeEffectivelyEnabled;
     }
   }
 #else // check for iOS >= 26
   // We want to pass events to RNSPanGestureRecognizer iff full screen swipe is enabled.
   if ([gestureRecognizer isKindOfClass:[RNSPanGestureRecognizer class]]) {
-    return [topScreen fullScreenSwipeEnabled];
+    return topScreen.isFullScreenSwipeEffectivelyEnabled;
   }
 #endif // check for iOS >= 26
 

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -88,7 +88,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     if ([screen.reactSuperview isKindOfClass:[RNSScreenStackView class]] &&
         ((RNSScreenStackView *)(screen.reactSuperview)).customAnimation) {
       [self animateWithNoAnimation:transitionContext toVC:toViewController fromVC:fromViewController];
-    } else if ([screen fullScreenSwipeEnabledBoolean] && transitionContext.isInteractive) {
+    } else if ([screen fullScreenSwipeEnabled] && transitionContext.isInteractive) {
       // we are swiping with full width gesture
       if (screen.customAnimationOnSwipe) {
         [self animateTransitionWithStackAnimation:screen.stackAnimation

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -88,7 +88,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     if ([screen.reactSuperview isKindOfClass:[RNSScreenStackView class]] &&
         ((RNSScreenStackView *)(screen.reactSuperview)).customAnimation) {
       [self animateWithNoAnimation:transitionContext toVC:toViewController fromVC:fromViewController];
-    } else if ([screen fullScreenSwipeEnabled] && transitionContext.isInteractive) {
+    } else if (screen.isFullScreenSwipeEffectivelyEnabled && transitionContext.isInteractive) {
       // we are swiping with full width gesture
       if (screen.customAnimationOnSwipe) {
         [self animateTransitionWithStackAnimation:screen.stackAnimation

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -88,7 +88,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     if ([screen.reactSuperview isKindOfClass:[RNSScreenStackView class]] &&
         ((RNSScreenStackView *)(screen.reactSuperview)).customAnimation) {
       [self animateWithNoAnimation:transitionContext toVC:toViewController fromVC:fromViewController];
-    } else if (screen.fullScreenSwipeEnabled && transitionContext.isInteractive) {
+    } else if ([screen isFullScreenSwipeBackEnabled] && transitionContext.isInteractive) {
       // we are swiping with full width gesture
       if (screen.customAnimationOnSwipe) {
         [self animateTransitionWithStackAnimation:screen.stackAnimation

--- a/ios/RNSScreenStackAnimator.mm
+++ b/ios/RNSScreenStackAnimator.mm
@@ -88,7 +88,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
     if ([screen.reactSuperview isKindOfClass:[RNSScreenStackView class]] &&
         ((RNSScreenStackView *)(screen.reactSuperview)).customAnimation) {
       [self animateWithNoAnimation:transitionContext toVC:toViewController fromVC:fromViewController];
-    } else if ([screen isFullScreenSwipeBackEnabled] && transitionContext.isInteractive) {
+    } else if ([screen fullScreenSwipeEnabledBoolean] && transitionContext.isInteractive) {
       // we are swiping with full width gesture
       if (screen.customAnimationOnSwipe) {
         [self animateTransitionWithStackAnimation:screen.stackAnimation

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -138,6 +138,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         activityState,
         children,
         isNativeStack,
+        fullScreenSwipeEnabled,
         gestureResponseDistance,
         scrollEdgeEffects,
         onGestureCancel,
@@ -220,6 +221,13 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             sheetCornerRadius={sheetCornerRadius}
             sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
             sheetInitialDetent={resolvedSheetInitialDetentIndex}
+            fullScreenSwipeEnabled={
+              fullScreenSwipeEnabled === undefined
+                ? 'undefined'
+                : fullScreenSwipeEnabled
+                ? 'true'
+                : 'false'
+            }
             gestureResponseDistance={{
               start: gestureResponseDistance?.start ?? -1,
               end: gestureResponseDistance?.end ?? -1,

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -29,6 +29,7 @@ import {
   resolveSheetInitialDetentIndex,
   resolveSheetLargestUndimmedDetent,
 } from './helpers/sheet';
+import { parseBooleanToOptionalBooleanNativeProp } from '../utils';
 
 type NativeProps = ScreenNativeComponentProps | ModalScreenNativeComponentProps;
 const AnimatedNativeScreen = Animated.createAnimatedComponent(
@@ -221,13 +222,9 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             sheetCornerRadius={sheetCornerRadius}
             sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
             sheetInitialDetent={resolvedSheetInitialDetentIndex}
-            fullScreenSwipeEnabled={
-              fullScreenSwipeEnabled === undefined
-                ? 'undefined'
-                : fullScreenSwipeEnabled
-                ? 'true'
-                : 'false'
-            }
+            fullScreenSwipeEnabled={parseBooleanToOptionalBooleanNativeProp(
+              fullScreenSwipeEnabled,
+            )}
             gestureResponseDistance={{
               start: gestureResponseDistance?.start ?? -1,
               end: gestureResponseDistance?.end ?? -1,

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -67,6 +67,8 @@ type SwipeDirection = 'vertical' | 'horizontal';
 
 type ReplaceAnimation = 'pop' | 'push';
 
+type OptionalBoolean = 'undefined' | 'false' | 'true';
+
 export interface NativeProps extends ViewProps {
   onAppear?: DirectEventHandler<ScreenEvent>;
   onDisappear?: DirectEventHandler<ScreenEvent>;
@@ -88,7 +90,7 @@ export interface NativeProps extends ViewProps {
   sheetInitialDetent?: WithDefault<Int32, 0>;
   sheetElevation?: WithDefault<Int32, 24>;
   customAnimationOnSwipe?: boolean;
-  fullScreenSwipeEnabled?: boolean;
+  fullScreenSwipeEnabled?: WithDefault<OptionalBoolean, 'undefined'>;
   fullScreenSwipeShadowEnabled?: WithDefault<boolean, true>;
   homeIndicatorHidden?: boolean;
   preventNativeDismiss?: boolean;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -69,6 +69,8 @@ type ReplaceAnimation = 'pop' | 'push';
 
 type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
 
+type OptionalBoolean = 'undefined' | 'false' | 'true';
+
 export interface NativeProps extends ViewProps {
   onAppear?: DirectEventHandler<ScreenEvent>;
   onDisappear?: DirectEventHandler<ScreenEvent>;
@@ -90,7 +92,7 @@ export interface NativeProps extends ViewProps {
   sheetInitialDetent?: WithDefault<Int32, 0>;
   sheetElevation?: WithDefault<Int32, 24>;
   customAnimationOnSwipe?: boolean;
-  fullScreenSwipeEnabled?: boolean;
+  fullScreenSwipeEnabled?: WithDefault<OptionalBoolean, 'undefined'>;
   fullScreenSwipeShadowEnabled?: WithDefault<boolean, true>;
   homeIndicatorHidden?: boolean;
   preventNativeDismiss?: boolean;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -139,11 +139,16 @@ export interface ScreenProps extends ViewProps {
    */
   freezeOnBlur?: boolean;
   /**
-   * Boolean indicating whether the swipe gesture should work on whole screen. Swiping with this option results in the same transition animation as `simple_push` by default.
-   * It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation is not achievable due to usage of custom recognizer.
-   * Defaults to `false`.
+   * Boolean indicating whether the swipe gesture should work on whole screen. The behavior depends on iOS version.
    *
-   * @deprecated since iOS 26, full screen swipe is handled by native recognizer, and this prop is ignored.
+   * For iOS prior to 26, swiping with this option results in the same transition animation as `simple_push` by default.
+   * It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation
+   * is not achievable due to usage of custom recognizer.
+   *
+   * For iOS 26 and up, native `interactiveContentPopGestureRecognizer` is used, and this prop controls whether it should
+   * be enabled or not.
+   *
+   * When not set, it defaults to `false` on iOS < 26 and `true` for iOS >= 26.
    *
    * @platform ios
    */


### PR DESCRIPTION
## Description

Resolves [[iOS] Bring back fullScreenSwipeEnabled on iOS 26](https://github.com/software-mansion/react-native-screens-labs/issues/466).

This PR brings back `fullScreenSwipeEnabled` prop on iOS 26. The type of the prop is changed internally to OptionalBoolean with default value differing between versions.

## Test code and steps to reproduce

Use `Test3093`