### PR TITLE
fix(Android, Stack v4): fix keyboard navigation focus for form sheet

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.graphics.Paint
+import android.os.Build
 import android.os.Parcelable
 import android.util.SparseArray
 import android.view.MotionEvent
@@ -11,6 +12,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
 import android.widget.ImageView
+import androidx.annotation.RequiresApi
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
@@ -343,6 +345,35 @@ class Screen(
     fun changeAccessibilityMode(mode: Int) {
         this.importantForAccessibility = mode
         this.headerConfig?.toolbar?.importantForAccessibility = mode
+    }
+
+    // Accepts one of 3 focusable flags and one of 3 descendantFocusability flags.
+    // https://developer.android.com/reference/android/view/View#setFocusable(int)
+    // https://developer.android.com/reference/android/view/ViewGroup#setDescendantFocusability(int)
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun changeFocusability(
+        focusable: Int,
+        descendantFocusability: Int,
+    ) {
+        this.focusable = focusable
+        this.headerConfig?.toolbar?.focusable = focusable
+
+        this.descendantFocusability = descendantFocusability
+        this.headerConfig?.toolbar?.descendantFocusability = descendantFocusability
+    }
+
+    // Accepts boolean for focusability and one of 3 descendantFocusability flags.
+    // This method is provided for compatibility reasons only (SDK_API <= 25).
+    // https://developer.android.com/reference/android/view/ViewGroup#setDescendantFocusability(int)
+    fun changeFocusabilityCompat(
+        focusable: Boolean,
+        descendantFocusability: Int,
+    ) {
+        this.setFocusable(focusable)
+        this.headerConfig?.toolbar?.setFocusable(focusable)
+
+        this.descendantFocusability = descendantFocusability
+        this.headerConfig?.toolbar?.descendantFocusability = descendantFocusability
     }
 
     var statusBarStyle: String? = null

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.os.Build
 import android.view.View
+import androidx.core.view.ViewCompat
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.swmansion.rnscreens.Screen.StackAnimation
@@ -262,6 +263,7 @@ class ScreenStack(
                 transaction.add(id, newTop.fragment)
             }
 
+            val previousTopScreen: Screen? = topScreenWrapper?.screen
             topScreenWrapper = newTop as? ScreenStackFragmentWrapper
             stack.clear()
             stack.addAll(screenWrappers.asSequence().map { it as ScreenStackFragmentWrapper })
@@ -279,6 +281,13 @@ class ScreenStack(
                     .toList()
 
             turnOffA11yUnderTransparentScreen(visibleBottom)
+
+            // When form sheet is pushed to the top of the stack, we need to make sure that keyboard
+            // focus doesn't stay on the previous screen. We don't use requestFocus on newTop's
+            // screen because if there is an input field in the form sheet, it works as if autoFocus
+            // was enabled on the input field instead of focusing e.g. button above the input.
+            previousTopScreen?.clearFocus()
+
             transaction.commitNowAllowingStateLoss()
         }
     }
@@ -296,6 +305,20 @@ class ScreenStack(
                             IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS,
                         )
 
+                        // Keyboard navigation focus is separate from screen reader focus, that's
+                        // why we need to use focusable and descendantFocusability.
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            fragmentWrapper.screen.changeFocusability(
+                                NOT_FOCUSABLE,
+                                FOCUS_BLOCK_DESCENDANTS
+                            )
+                        } else {
+                            fragmentWrapper.screen.changeFocusabilityCompat(
+                                false,
+                                FOCUS_BLOCK_DESCENDANTS
+                            )
+                        }
+
                         // don't change a11y below non-transparent screens
                         if (fragmentWrapper == visibleBottom) {
                             break
@@ -306,6 +329,11 @@ class ScreenStack(
         }
 
         topScreen?.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_AUTO)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            topScreen?.changeFocusability(FOCUSABLE_AUTO, FOCUS_BEFORE_DESCENDANTS)
+        } else {
+            topScreen?.changeFocusabilityCompat(true, FOCUS_BEFORE_DESCENDANTS)
+        }
     }
 
     override fun notifyContainerUpdate() {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens.bottomsheet
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
+import android.os.Build
 import android.view.MotionEvent
 import android.view.ViewGroup
 import com.facebook.react.uimanager.ReactCompoundViewGroup
@@ -31,6 +32,7 @@ internal class DimmingView(
 
     init {
         pointerEventsProxy.pointerEventsImpl = DimmingViewPointerEventsImpl(this)
+        setFocusable(false)
     }
 
     internal val blockGestures


### PR DESCRIPTION
## Description

Fixes keyboard navigation focus handling for form sheets on Android.

Previously, it was possible to focus elements in the view displayed below the form sheet.

Closes https://github.com/software-mansion/react-native-screens/issues/3188.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/481435f7-5304-4b74-9d2c-65693a33ffed" /> | <video src="https://github.com/user-attachments/assets/68faf6cb-1ccb-4bdb-aab2-3aa9d20a936a" /> |

### Context

In `ScreenStack`, there is already logic to handle accessibility focus via `importantForAccessibility` prop. I checked that the prop is changed correctly - there were no regressions here.

I stumbled upon an issue in `react-native` repo [where one of the users explained](https://github.com/facebook/react-native/issues/30850#issuecomment-1184756886) that Android handles screen readers focus and keyboard navigation focus differently. In order to block keyboard navigation focus, you need to set [`focusable` and `descendantFocusability`](https://github.com/facebook/react-native/issues/30850#issuecomment-1184958396) properties - when implemented in `ScreenStack`, this started working correctly (after clicking `arrow-down`, focus did not leave the formsheet).

Another problem that appeared is that the button used to open the form sheet remained focused after form sheet had been already opened. I attempted to use `requestFocus()` on the form sheet's screen but if there is a text input in the form sheet, it started working as if we set `autoFocus` on the input field.

https://github.com/user-attachments/assets/40b0d027-f982-494c-9b0a-ed9ae6f52670

This also impacted regular touch navigation. I decided to use `clearFocus` on previous screen instead - this works as expected: first button in the screen is focused after opening the form sheet.

One thing I noticed is that when you go back from a screen, nothing is focused (I checked with layout inspector) - this is not a regression but we should have a look at it in the future. Native app (settings) on API 36 keeps focus when screen is popped.

### Changing focusability on Android

Starting from API 26, `focusable` can be set to [`NOT_FOCUSABLE/FOCUSABLE/FOCUSABLE_AUTO`](https://developer.android.com/reference/android/view/View#setFocusable(int)). Prior to API 26, this was a boolean prop - that's why there is some extra code to handle both cases.

## Changes

- add methods to set focusability for `Screen` for API <= 25 and API >= 26
- change focusability in sync with `importantForAccessibility`
- set `focusable` to `false/NOT_FOCUSABLE` for `DimmingView` (this caused missing focus after popping a `push` screen that was pushed over form sheet)
- clear focus from previous top screen in ScreenStack's `onUpdate`

## Test code and steps to reproduce

Run `TestFormSheet` and use the keyboard to navigate.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
