### PR TITLE
chore: Move BottomTabs props configuration outside of BottomTabsContainer

### DIFF
--- a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import type { NativeSyntheticEvent } from 'react-native';
 import {
   BottomTabs,
+  BottomTabsProps,
   BottomTabsScreen,
   BottomTabsScreenProps,
   NativeFocusChangeEvent,
 } from 'react-native-screens';
-import { Colors } from '../../../styling/Colors';
 import ConfigWrapperContext from './ConfigWrapperContext';
 
 export interface TabConfiguration {
@@ -14,13 +14,13 @@ export interface TabConfiguration {
   component: React.ComponentType;
 }
 
-export interface BottomTabsContainerProps {
-  tabConfigs: TabConfiguration[];
-}
+// Currently assumes controlled bottom tabs
+export type BottomTabsContainerProps = Omit<BottomTabsProps, 'experimentalControlNavigationStateInJS' | 'onNativeFocusChange'> & { tabConfigs: TabConfiguration[]; }
 
 export function BottomTabsContainer(props: BottomTabsContainerProps) {
-  // Currently assumes controlled bottom tabs
   console.info('BottomTabsContainer render');
+
+  const { tabConfigs, ...restProps } = props;
 
   const [focusedTabKey, setFocusedTabKey] = React.useState<string>(() => {
     console.log('BottomTabsContainer focusedStateKey initial state computed');
@@ -29,7 +29,7 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
       throw new Error('There must be at least one tab defined');
     }
 
-    const maybeUserRequestedFocusedTab = props.tabConfigs.find(
+    const maybeUserRequestedFocusedTab = tabConfigs.find(
       tabConfig => tabConfig.tabScreenProps.isFocused === true,
     )?.tabScreenProps.tabKey;
 
@@ -38,7 +38,7 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
     }
 
     // Default to first tab
-    return props.tabConfigs[0].tabScreenProps.tabKey;
+    return tabConfigs[0].tabScreenProps.tabKey;
   });
 
   const configWrapper = React.useContext(ConfigWrapperContext);
@@ -73,27 +73,12 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
 
   return (
     <BottomTabs
+      {...restProps}
       onNativeFocusChange={onNativeFocusChangeCallback}
-      tabBarBackgroundColor={Colors.NavyLight100}
-      tabBarItemActiveIndicatorColor={Colors.GreenLight40}
-      tabBarItemActiveIndicatorEnabled={true}
-      tabBarTintColor={Colors.YellowLight100}
-      tabBarItemIconColor={Colors.BlueLight100}
-      tabBarItemTitleFontColor={Colors.BlueLight40}
-      tabBarItemIconColorActive={Colors.GreenLight100}
-      tabBarItemTitleFontColorActive={Colors.GreenLight40}
-      tabBarItemTitleFontSize={10}
-      tabBarItemTitleFontSizeActive={15}
-      tabBarItemRippleColor={Colors.WhiteTransparentDark}
-      tabBarItemTitleFontFamily="monospace"
-      tabBarItemTitleFontStyle="italic"
-      tabBarItemTitleFontWeight="700"
-      tabBarItemLabelVisibilityMode="auto"
-      tabBarMinimizeBehavior="onScrollDown"
       experimentalControlNavigationStateInJS={
         configWrapper.config.controlledBottomTabs
       }>
-      {props.tabConfigs.map(tabConfig => {
+      {tabConfigs.map(tabConfig => {
         const tabKey = tabConfig.tabScreenProps.tabKey;
         const isFocused = tabConfig.tabScreenProps.tabKey === focusedTabKey;
         const ContentComponent = tabConfig.component;

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -173,7 +173,25 @@ function App() {
         config,
         setConfig,
       }}>
-      <BottomTabsContainer tabConfigs={TAB_CONFIGS} />
+      <BottomTabsContainer
+        tabConfigs={TAB_CONFIGS}
+        tabBarBackgroundColor={Colors.NavyLight100}
+        tabBarItemActiveIndicatorColor={Colors.GreenLight40}
+        tabBarItemActiveIndicatorEnabled={true}
+        tabBarTintColor={Colors.YellowLight100}
+        tabBarItemIconColor={Colors.BlueLight100}
+        tabBarItemTitleFontColor={Colors.BlueLight40}
+        tabBarItemIconColorActive={Colors.GreenLight100}
+        tabBarItemTitleFontColorActive={Colors.GreenLight40}
+        tabBarItemTitleFontSize={10}
+        tabBarItemTitleFontSizeActive={15}
+        tabBarItemRippleColor={Colors.WhiteTransparentDark}
+        tabBarItemTitleFontFamily="monospace"
+        tabBarItemTitleFontStyle="italic"
+        tabBarItemTitleFontWeight="700"
+        tabBarItemLabelVisibilityMode="auto"
+        tabBarMinimizeBehavior="onScrollDown"
+      />
     </ConfigWrapperContext.Provider>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/software-mansion/react-native-screens-labs/issues/398.

## Description

This PR removes hardcoded prop values from BottomTabsContainer and moves them to main BottomTabs so the test is left as is.

## Test code and steps to reproduce

Compare BottomTabsTest before & after, should have no difference.