### PR TITLE
chore: Uncomment tabBarMinimizeBehavior config in TestSafeAreaViewIOS

### DIFF
--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
@@ -60,7 +60,7 @@ export default function BottomTabsComponent() {
         config: tabsConfig,
         setConfig: setTabsConfig,
       }}>
-      <BottomTabsContainer tabConfigs={TAB_CONFIGS} />
+      <BottomTabsContainer tabConfigs={TAB_CONFIGS} tabBarMinimizeBehavior={config.tabBarMinimizeBehavior} />
     </ConfigWrapperContext.Provider>
   );
 }

--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/ConfigTab.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/ConfigTab.tsx
@@ -42,8 +42,7 @@ export default function ConfigTab() {
         }
       />
       <Text style={styles.title}>Tabs configuration</Text>
-      {/* Currently, you need to change tabBarMinimizeBehavior directly in BottomTabsContainer. */}
-      {/*<SettingsPicker<BottomTabsSAVExampleConfig['tabBarMinimizeBehavior']>
+      <SettingsPicker<BottomTabsSAVExampleConfig['tabBarMinimizeBehavior']>
         label="tabBarMinimizeBehavior"
         value={config.tabBarMinimizeBehavior}
         onValueChange={value =>
@@ -53,7 +52,7 @@ export default function ConfigTab() {
           })
         }
         items={['automatic', 'onScrollDown', 'onScrollUp', 'never']}
-      />*/}
+      />
       <SettingsPicker<BottomTabsSAVExampleConfig['tabBarItemSystemItem']>
         label="tabBarItemSystemItem"
         value={config.tabBarItemSystemItem}


### PR DESCRIPTION
## Description

This PR uncomments the config that had no effect when BottomTabs props were hardcoded in BottomTabsContainer before https://github.com/software-mansion/react-native-screens/pull/3246.

## Changes

Uncommented tabBarMinimizeBehavior in `TestSafeAreaViewIOS` so it can be configured.

## Testing

Use `TestSafeAreaViewIOS`, uncomment `BottomTabsSAVExample` from `index.tsx`