### PR TITLE
WIP - fix(Android, Stack): Moving formsheet above keyboard

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -252,7 +252,11 @@ class ScreenStackFragment :
                     override fun onProgress(
                         insets: WindowInsetsCompat,
                         runningAnimations: MutableList<WindowInsetsAnimationCompat>,
-                    ): WindowInsetsCompat = insets
+                    ): WindowInsetsCompat {
+                        val keyboardHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                        screen.translationY = -sheetDelegate.calculateSheetOffsetY(keyboardHeight).toFloat()
+                        return insets
+                    }
                 },
             )
         }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -237,6 +237,32 @@ class SheetDelegate(
         }
     }
 
+    internal fun calculateSheetOffsetY(keyboardHeight: Int): Int {
+        val containerHeight = tryResolveContainerHeight()
+        check(containerHeight != null) {
+            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
+        }
+
+        val isFitToContents = screen.isSheetFitToContents()
+
+        if (isFitToContents) {
+            val contentHeight = screen.contentWrapper?.height ?: 0
+            val offsetFromTop = containerHeight - contentHeight
+            return minOf(offsetFromTop, keyboardHeight)
+        }
+
+        val detents = screen.sheetDetents
+        if (detents.isEmpty()) {
+            throw IllegalStateException("[RNScreens] Cannot determine sheet detent - detents list is empty")
+        }
+
+        val detentValue = detents[detents.size - 1].coerceIn(0.0, 1.0)
+        val sheetHeight = (detentValue * containerHeight).toInt()
+        val offsetFromTop = containerHeight - sheetHeight
+
+        return minOf(offsetFromTop, keyboardHeight)
+    }
+
     // This is listener function, not the view's.
     override fun onApplyWindowInsets(
         v: View,


### PR DESCRIPTION
## Description

WIP - still a lot of work needs to be done:
1. slide-in transition on opening form sheet isn't working atm
2. the current implementation with translationY on `onProgress` doesn't look well - on progress is triggered just a few times and causes ugly form sheet jumps occasionally
3. https://developer.android.com/guide/topics/manifest/activity-element#wsoft - needs to be tested
4. going through all supported API levels

Fixes: https://github.com/software-mansion/react-native-screens/issues/3181

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
