### PR TITLE
Fix custom screen swipe transitions

### DIFF
--- a/src/gesture-handler/fabricUtils.ts
+++ b/src/gesture-handler/fabricUtils.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { View } from "react-native";
+
 /* eslint-disable */
 
 type LocalGlobal = typeof global & Record<string, unknown>;
@@ -14,7 +16,7 @@ export type HostInstance = {
   _viewConfig: Record<string, unknown>;
 };
 
-export function getShadowNodeWrapperAndTagFromRef(ref: HostInstance | null): {
+export function getShadowNodeWrapperAndTagFromRef(ref: View | null): {
   shadowNodeWrapper: any;
   tag: number;
 } {
@@ -24,8 +26,9 @@ export function getShadowNodeWrapperAndTagFromRef(ref: HostInstance | null): {
       tag: -1,
     }
   }
+  const internalRef = ref as unknown as HostInstance;
   return {
-    shadowNodeWrapper: ref.__internalInstanceHandle.stateNode.node,
-    tag: ref.__nativeTag,
+    shadowNodeWrapper: internalRef.__internalInstanceHandle.stateNode.node,
+    tag: internalRef.__nativeTag,
   }
 }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-native';
 import { NativeStackNavigatorProps } from './native-stack/types';
 import { ScrollEdgeEffect } from './components/shared/types';
-import { HostInstance } from './gesture-handler/fabricUtils';
 
 export type SearchBarCommands = {
   focus: () => void;
@@ -980,7 +979,7 @@ export type AnimatedScreenTransition = {
   ) => Record<string, unknown>;
 };
 
-export type ScreensRefsHolder = Record<string, React.RefObject<HostInstance>>;
+export type ScreensRefsHolder = Record<string, React.RefObject<View>>;
 
 export interface GestureProps {
   screensRefs?: React.MutableRefObject<ScreensRefsHolder>;


### PR DESCRIPTION
## Description

This PR fixes custom swipe-back transitions. The issue arose because, in the new version of React Native, they changed the way to obtain the shadow node wrapper. Since the ref to the screen is a native ref and we only need this on Fabric, it was possible to simplify the way we obtain that reference. Additionally, I found a small issue with the propagation of the ref and fixed it in the `Screen` implementation.

| before | after |
| --- | --- |
| <img width="443" height="939" alt="image" src="https://github.com/user-attachments/assets/c2c36f3a-6f46-4fdd-b107-a1e536eb8a9f" /> | <video src="https://github.com/user-attachments/assets/1352f57e-c789-4735-9e1d-0905ad396a1d" /> |

Example: https://github.com/software-mansion/react-native-reanimated/blob/main/apps/common-app/src/apps/reanimated/examples/ScreenTransitionExample.tsx

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
