### PR TITLE
fix(Android, Stack v4): fix canceling search on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
@@ -184,7 +184,7 @@ class SearchBarManager :
     }
 
     override fun cancelSearch(view: SearchBarView?) {
-        view?.handleFocusJsRequest()
+        view?.handleCancelSearchJsRequest()
     }
 
     // iOS only


### PR DESCRIPTION
## Description

Fixes canceling search on Android.

This seems to be a simple typo introduced in https://github.com/software-mansion/react-native-screens/pull/2163 refactor.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/403.

## Changes

- run proper method for cancelling search

## Screenshots / GIFs

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/21652838-fcb8-4989-ad8c-c13c3e777498" /> | <video src="https://github.com/user-attachments/assets/e6ecdd09-21aa-462d-8fb2-4f3e4191c457" /> |

## Test code and steps to reproduce

Run `SearchBar` example screen, use `cancel search` button.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
