### PR TITLE
chore(Example, Tabs): use SAV in BottomTabsContainer

### DIFF
--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -107,6 +107,12 @@ const TAB_CONFIGS: TabConfiguration[] = [
       orientation: 'landscape',
     },
     component: Tab2,
+    safeAreaConfiguration: {
+      edges: {
+        top: true,
+        bottom: true,
+      },
+    },
   },
   {
     tabScreenProps: {

--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
@@ -39,6 +39,14 @@ export default function BottomTabsComponent() {
             : undefined,
       },
       component: TestTab,
+      safeAreaConfiguration: {
+        edges: {
+          top: config.safeAreaTopEdge,
+          bottom: config.safeAreaBottomEdge,
+          left: config.safeAreaLeftEdge,
+          right: config.safeAreaRightEdge,
+        },
+      },
     },
   ];
 

--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/TestTab.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/TestTab.tsx
@@ -11,15 +11,5 @@ export default function TestTab() {
     [config.content],
   );
 
-  return (
-    <SafeAreaView
-      edges={{
-        top: config.safeAreaTopEdge,
-        bottom: config.safeAreaBottomEdge,
-        left: config.safeAreaLeftEdge,
-        right: config.safeAreaRightEdge,
-      }}>
-      {content}
-    </SafeAreaView>
-  );
+  return content;
 }

--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -1,6 +1,11 @@
+// Types
+export * from './types';
+
+// Logging
 export {
   internalEnableDetailedBottomTabsLogging,
   bottomTabsDebugLog,
 } from './logging';
 
+// Components
 export { default as SafeAreaView } from '../components/safe-area/SafeAreaView';

--- a/src/private/types.ts
+++ b/src/private/types.ts
@@ -1,0 +1,1 @@
+export * from '../components/safe-area/SafeAreaView.types';


### PR DESCRIPTION
## Description

Integrates `SaveAreaView` with our `BottomTabsContainer` test component.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/479.

## Changes

- add SAV in tab configurations passed to `BottomTabsContainer`
- add API to control enabled edges
- add default edges for `BottomTabsContainer`
- export SAV types from `react-native-screens/private`

## Test code and steps to reproduce

`TestBottomTabs`' `Tab2`, `TestSafeAreaViewIOS`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Ensured that CI passes
