### PR TITLE
fix(Android, Fabric, Stack v4): add `autoFocus` to SearchBar Fabric spec file

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
@@ -55,11 +55,11 @@ class SearchBarManager :
     }
 
     @ReactProp(name = "autoFocus")
-    fun setAutoFocus(
+    override fun setAutoFocus(
         view: SearchBarView,
-        autoFocus: Boolean?,
+        autoFocus: Boolean,
     ) {
-        view.autoFocus = autoFocus ?: false
+        view.autoFocus = autoFocus
     }
 
     @ReactProp(name = "barTintColor", customType = "Color")

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerDelegate.java
@@ -27,6 +27,9 @@ public class RNSSearchBarManagerDelegate<T extends View, U extends BaseViewManag
       case "hideWhenScrolling":
         mViewManager.setHideWhenScrolling(view, value == null ? true : (boolean) value);
         break;
+      case "autoFocus":
+        mViewManager.setAutoFocus(view, value == null ? false : (boolean) value);
+        break;
       case "autoCapitalize":
         mViewManager.setAutoCapitalize(view, (String) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 
 public interface RNSSearchBarManagerInterface<T extends View>  {
   void setHideWhenScrolling(T view, boolean value);
+  void setAutoFocus(T view, boolean value);
   void setAutoCapitalize(T view, @Nullable String value);
   void setPlaceholder(T view, @Nullable String value);
   void setPlacement(T view, @Nullable String value);

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -38,6 +38,7 @@ export interface NativeProps extends ViewProps {
   onCancelButtonPress?: DirectEventHandler<SearchBarEvent> | null;
   onChangeText?: DirectEventHandler<ChangeTextEvent> | null;
   hideWhenScrolling?: WithDefault<boolean, true>;
+  autoFocus?: WithDefault<boolean, false>;
   autoCapitalize?: WithDefault<AutoCapitalizeType, 'none'>;
   placeholder?: string;
   placement?: WithDefault<SearchBarPlacement, 'automatic'>;


### PR DESCRIPTION
## Description

Adds `autoFocus` prop to `SearchBar`'s Fabric spec file. It was probably missed when migrating `SearchBar` to new architecture.

## Changes

- add `autoFocus` to Fabric spec file
- update `SearchBarManager`
- sync architectures

## Screenshots / GIFs

https://github.com/user-attachments/assets/08ef3aa0-f282-429b-8c54-a4cfe768382f

## Test code and steps to reproduce

Run `SearchBar` example screen with `autoFocus: true` prop set.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
