### PR TITLE
fix(Android, Tabs): tab label flashing on tab change in `labeled` visbility mode

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostAppearanceApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostAppearanceApplicator.kt
@@ -154,8 +154,13 @@ class TabsHostAppearanceApplicator(
         menuItem: MenuItem,
         tabScreen: TabScreen,
     ) {
-        menuItem.title = tabScreen.tabTitle
-        menuItem.icon = tabScreen.icon
+        if (menuItem.title != tabScreen.tabTitle) {
+            menuItem.title = tabScreen.tabTitle
+        }
+
+        if (menuItem.icon != tabScreen.icon) {
+            menuItem.icon = tabScreen.icon
+        }
     }
 
     fun updateBadgeAppearance(


### PR DESCRIPTION
## Description

Fixes tab bar item label flashing on tab change when in `labeled` `tabBarItemLabelVisibilityMode`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/481.

### Reasoning

Setting `title/icon` causes the menu item to refresh. In `MenuItemImpl`, we see `onItemsChanged` callback being run:
```java
    @Override
    public MenuItem setTitle(CharSequence title) {
        mTitle = title;

        mMenu.onItemsChanged(false); // <--

        if (mSubMenu != null) {
            mSubMenu.setHeaderTitle(title);
        }

        return this;
    }
```

This results in other update-related methods being run but I did not investigate this much further as I'm not sure if this is necessary - limiting prop updates to only when the value has changed is desirable either way.

## Changes

- set `MenuItem`'s title and icon only when there was a change to the prop

## Screenshots / GIFs

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/77f44e1e-0632-4e2f-8ca8-197b2ca7676b" /> | <video src="https://github.com/user-attachments/assets/0b69e521-8aa3-44ba-98df-a668d59e86c1" /> |

## Test code and steps to reproduce

Run `TestBottomTabs`, set `tabBarItemLabelVisibilityMode="labeled"` in `BottomTabsContainer`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
