### PR TITLE
Verify that ScrollView gesture hasn't begun when triggering pan gesture

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1242,7 +1242,8 @@ RNS_IGNORE_SUPER_CALL_END
     BOOL isBackGesture = [panGestureRecognizer translationInView:panGestureRecognizer.view].x > 0 &&
         _controller.viewControllers.count > 1;
 
-    if (gestureRecognizer.state == UIGestureRecognizerStateBegan || isBackGesture) {
+    if (otherGestureRecognizer.state == UIGestureRecognizerStateBegan ||
+        gestureRecognizer.state == UIGestureRecognizerStateBegan || isBackGesture) {
       return NO;
     }
 


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/489

## Description

This PR addresses the issue that, when using custom PanGestureRecognizer on iOS 26 (for handling custom animations on swipe) with a screen that has a horizontal ScrollView, and when swiping for the second time before the view stopped scrolling, the screen is popped with pan gesture.

## Changes

Added check for ScrollGestureRecognizer state=Began in `shouldRecognizeSimultaneouslyWithGestureRecognizer` to return NO.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b7fd4bcc-1902-44b7-8f85-26dc215619db" /> | <video src="https://github.com/user-attachments/assets/8d76b11e-350f-4866-b751-43b88268795c" /> |

-->

## Test code and steps to reproduce

Use Test3265 on iOS 26; make sure that the screen has `animation` set to custom animation and `animationMatchesGesture: true`.