### PR TITLE
feat(iOS, SplitView): SplitView synchronous updates

### DIFF
--- a/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.mm
@@ -3,7 +3,6 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTConversions.h>
-#import <cxxreact/ReactNativeVersion.h>
 #import <rnscreens/RNSSplitViewScreenShadowNode.h>
 
 namespace react = facebook::react;
@@ -45,13 +44,7 @@ namespace react = facebook::react;
 
   if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
     auto newState = react::RNSSplitViewScreenState{RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin)};
-    _state->updateState(
-        std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        facebook::react::EventQueue::UpdateMode::unstable_Immediate
-#endif
-    );
+    _state->updateState(std::move(newState), facebook::react::EventQueue::UpdateMode::unstable_Immediate);
 
     _lastScheduledFrame = frame;
   }


### PR DESCRIPTION
## Description

We have an access to API for sending synchronous state updates, which makes it possible to resolve the issue of jumping content when resizing columns in SplitView.

> [!CAUTION]  
> Our assumption is that SplitView will be supported since RN minor version 0.82, compiling it with older version may fail!

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/493

## Changes

- Added `UpdateMode::unstable_Immediate` to SplitView shadow node state updates

## Screenshots / GIFs

### Before

https://github.com/user-attachments/assets/02d306df-aa1f-4e48-b1b6-25d36814b3aa


### After

https://github.com/user-attachments/assets/76eb6bce-e05f-43fb-b8c3-5185c8c7ad44


## Test code and steps to reproduce

Went through SplitView examples. Checked that it still compiles successfully with RN 0.81.

Some follow-up actions are needed to be taken:
- https://github.com/software-mansion/react-native-screens-labs/issues/495
- https://github.com/software-mansion/react-native-screens-labs/issues/496

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
