### PR TITLE
fix(Android): Restore TV focus in Jetpack Compose views

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -442,10 +442,33 @@ class ScreenStackFragment :
         }
     }
 
+    private fun isComposeView(view: View): Boolean {
+        val name = view.javaClass.name
+        return name.startsWith("androidx.compose.ui.platform.")
+    }
+
+    private fun findComposeContainer(view: View?): View? {
+        var current = view
+
+        while (current != null) {
+            if (!isComposeView(current)) return current
+            current = (current.parent as? View)
+        }
+
+        return null
+    }
+
     private fun findLastFocusedChild(): View? {
         var view: View? = screen
         while (view != null) {
-            if (view.isFocused) return view
+            if (view.isFocused) {
+                if (isComposeView(view)) {
+                    return findComposeContainer(view)
+                }
+
+                return view
+            }
+
             view = if (view is ViewGroup) view.focusedChild else null
         }
 


### PR DESCRIPTION
## Description

Currently, when navigating back to a screen containing a Compose-based view, lastFocusedChild is assigned to the internal AndroidComposeView leaving the screen without any focused element.

Instead of targeting the internal AndroidComposeView, Screens would restore it now to it's Android layout parent, that all custom RN views have, allowing developers to restore it back to compose via listeners or overriding the requestFocus method.

## Changes
Restore focus from Jetpack Compose views to the parent Android layout, allowing to redirect it back to Compose via focus listeners/overriding requestFocus
