### PR TITLE
fix(Android, SplitView): Add fallback for SplitView import error

### DIFF
--- a/src/components/gamma/split-view/SplitViewHost.android.tsx
+++ b/src/components/gamma/split-view/SplitViewHost.android.tsx
@@ -1,0 +1,9 @@
+import { View } from 'react-native';
+
+const SplitViewHost = View;
+
+console.warn(
+  'SplitView is supported only for iOS. Consider using an alternative layout for Android.',
+);
+
+export default SplitViewHost;

--- a/src/components/gamma/split-view/SplitViewScreen.android.tsx
+++ b/src/components/gamma/split-view/SplitViewScreen.android.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+
+const Column = View;
+const Inspector = View;
+
+console.warn(
+  'SplitView is supported only for iOS. Consider using an alternative layout for Android.',
+);
+
+export default { Column, Inspector };


### PR DESCRIPTION
## Description

SplitView is not currently supported on Android. So, I'm adding a fallback to avoid throwing an error on app launch.

## Changes

- Added fallback components for Android.

## Screenshots / GIFs

### Before

<img width="441" height="977" alt="Screenshot 2025-10-06 at 09 29 54" src="https://github.com/user-attachments/assets/53f4f999-c09d-43e5-8f74-865560edee43" />

### After

Displaying a clear warning in Metro

<img width="924" height="87" alt="Screenshot 2025-10-06 at 09 40 32" src="https://github.com/user-attachments/assets/492520f3-5884-42b5-8f5b-8f11aacbf595" />


## Test code and steps to reproduce

Open an example with SplitView (avoid the one with the new stack, because it will throw an error about missing components for the new stack on android)

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
