### PR TITLE
fix(iOS, Tabs): change `whiteColor` to `systemBackgroundColor` in tabs background workaround

### DIFF
--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -70,7 +70,9 @@ namespace react = facebook::react;
 
   // Prevents incorrect tab bar appearance after tab change on iOS 26.0
   // TODO: verify if it's still necessary on iOS 26.1
+#if !TARGET_OS_TV
   self.backgroundColor = [UIColor systemBackgroundColor];
+#endif // !TARGET_OS_TV
 
   [self resetProps];
 }


### PR DESCRIPTION
## Description

Changes `BottomTabsScreen`'s background color from `whiteColor` to `systemBackgroundColor`.

### Reasoning

#### Previous workaround

In https://github.com/software-mansion/react-native-screens-labs/pull/253, we introduced a workaround for `UIScrollEdgeEffect` bug. This bug has been fixed in iOS 26 beta 4 but we did not remove the workaround because it prevented another glitch (see below). At the first glance, it seems like the issue has been fixed in release version of iOS 26 (in both recordings we don't set any `backgroundColor`):

| iOS 26 beta 5 | iOS 26.0 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7ff537da-28a3-40f8-8781-af8c6bcfeb56" /> | <video src="https://github.com/user-attachments/assets/544e403f-36ea-4bc1-8cca-db25900923d5" />

Unfortunately, when I changed the color and dimensions of pressables in `Tab3`, this happens:

| iOS 26.0 |
| --- |
| <video src="https://github.com/user-attachments/assets/6d8808c1-18c4-4480-a1e3-b5da38bcc85e" /> |

Setting `style={{ backgroundColor: "white" }}` in `Tab3` fixes the issue but I don't think this should be the case. Previous workaround fixes the issue as well.

Unfortunately, previous workaround introduces some problems, see e.g. https://github.com/expo/expo/issues/39969, as we hardcoded `whiteColor`, without considering the dark mode. Using `systemBackgroundColor` fixes the problem mentioned in the linked issue. This shouldn't cause any problems - `UITabBarController`'s view (`BottomTabsHostComponentView`'s subview) also uses `systemBackgroundColor`.

#### iOS 26.1 beta

I decided to also check iOS 26.1 beta.

1. Without any workaround (i.e. without setting any `backgroundColor` for `BottomTabsScreenComponentView`), the issue seems to be fixed:

| iOS 26.1 beta 23B5044k |
| --- |
| <video src="https://github.com/user-attachments/assets/e3234eee-e7e4-42c5-9e1d-31a99766eed7" /> |

2. I also checked what happens with `self.backgroundColor = [UIColor systemBackgroundColor]` and currently, there is a new glitch with the screen flashing on first load (when using `natively-driven` tabs):

| iOS 26.0 | iOS 26.1 beta 23B5044k |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/6a09218d-4f35-4cfd-952c-d71d276ad58c" /> | <video src="https://github.com/user-attachments/assets/a16f874d-606c-4f03-92b9-b23ee1e28ac4" /> |

It's even more visible if views use background color opposite to `systemBackgroundColor`.

#### Conclusions

1. Workaround is still necessary on iOS 26.0 when using a view without background color -> that's why we still keep the workaround but we adjust it to account for dark mode.
2. We need to monitor iOS 26.1 betas and remove the workaround if possible, because it might not be necessary + it might introduce a new glitch.

#### Related bugs with tab bar appearance

While investigating this issue, I noticed more bugs related to the appearance of the tab bar but it's difficult to debug them as the situation changes with iOS versions, using View vs ScrollView, setting background color or not, setting color in a root view of the screen vs in one of the children, order of tab changes, position in the ScrollView. Sometimes, the bugs fix themselves after launching view hierarchy:

https://github.com/user-attachments/assets/cb89dacd-ceee-4343-bb1e-cf700f363821

These bugs are probably related to https://github.com/software-mansion/react-native-screens-labs/issues/401 - I'll add some additional info in that issue. 

## Changes

- change `BottomTabsScreenComponentView`'s `backgroundColor` from `whiteColor` to `systemBackgroundColor`.

## Test code and steps to reproduce

Run `TestBottomTabs`. Switch between Tab1 and Tab3. You can also change color of pressables to black and add more height.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
