### PR TITLE
fix(iOS): Clear _shouldUpdateScrollEdgeEffects flag in RNSScreen.finalizeUpdates

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1481,6 +1481,7 @@ RNS_IGNORE_SUPER_CALL_END
   [super finalizeUpdates:updateMask];
   if (_shouldUpdateScrollEdgeEffects) {
     [self updateContentScrollViewEdgeEffectsIfExists];
+    _shouldUpdateScrollEdgeEffects = NO;
   }
 
 #if !TARGET_OS_TV && !TARGET_OS_VISION


### PR DESCRIPTION
## Description

#3212 introduced a bug when scrolling the view would trigger a scroll edge effect prop change. This happened because there was one place that didn't clear the flag that the prop was already set.

## Changes

The `_shouldUpdateScrollEdgeEffects` flag is now being cleared in RNSScreen.finalizeUpdates.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/236e0317-b22d-45be-9513-081c57dadff8" /> | <video src="https://github.com/user-attachments/assets/753af5bd-7653-458e-8ca4-880ee728c468" /> |


## Test code and steps to reproduce

Use Test3212.