### PR TITLE
Add `swiping` to `onTransitionProgress`

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -165,7 +165,10 @@ namespace react = facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 #endif // RCT_NEW_ARCH_ENABLED
 
-- (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward;
+- (void)notifyTransitionProgress:(double)progress
+                         closing:(BOOL)closing
+                    goingForward:(BOOL)goingForward
+                         swiping:(BOOL)swiping;
 - (void)notifyDismissCancelledWithDismissCount:(int)dismissCount;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -22,6 +22,7 @@ type TransitionProgressEvent = Readonly<{
   progress: Double;
   closing: Int32;
   goingForward: Int32;
+  swiping: Int32;
 }>;
 
 type HeaderHeightChangeEvent = Readonly<{

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -22,6 +22,7 @@ type TransitionProgressEvent = Readonly<{
   progress: Double;
   closing: Int32;
   goingForward: Int32;
+  swiping: Int32;
 }>;
 
 type HeaderHeightChangeEvent = Readonly<{


### PR DESCRIPTION
## Description

This PR adds `swiping` parameter to the `onTransitionProgress` event. The main motivation for this change is so that we can use the event in Shared Element Transitions.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
