### PR TITLE
fix(iOS): build error in release mode - imageLoader not defined

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h
@@ -52,11 +52,11 @@ class RNSScreenStackHeaderConfigComponentDescriptor final
 #endif // ANDROID
 
     ConcreteComponentDescriptor::adopt(shadowNode);
-#if !defined(ANDROID) && !defined(NDEBUG)
+#if !defined(ANDROID)
     std::weak_ptr<void> imageLoader =
         contextContainer_->at<std::shared_ptr<void>>("RCTImageLoader");
     configShadowNode.setImageLoader(imageLoader);
-#endif // !ANDROID && !NDEBUG
+#endif // !ANDROID
   }
 };
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
@@ -18,7 +18,7 @@ void RNSScreenStackHeaderConfigShadowNode::layout(LayoutContext layoutContext) {
     // the toolbar & the correction is not needed.
     return;
   }
-#endif // ANDROID
+#endif // defined(ANDROID)
   applyFrameCorrections();
 }
 
@@ -29,7 +29,7 @@ void RNSScreenStackHeaderConfigShadowNode::applyFrameCorrections() {
   layoutMetrics_.frame.origin.y = -stateData.frameSize.height;
 }
 
-#if !defined(ANDROID) && !defined(NDEBUG)
+#if !defined(ANDROID)
 void RNSScreenStackHeaderConfigShadowNode::setImageLoader(
     std::weak_ptr<void> imageLoader) {
   getStateDataMutable().setImageLoader(imageLoader);
@@ -42,5 +42,5 @@ RNSScreenStackHeaderConfigShadowNode::getStateDataMutable() {
   return const_cast<RNSScreenStackHeaderConfigShadowNode::StateData &>(
       getStateData());
 }
-#endif // !ANDROID && !NDEBUG
+#endif // !defined(ANDROID)
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.h
@@ -29,14 +29,14 @@ class JSI_EXPORT RNSScreenStackHeaderConfigShadowNode final
 
 #pragma mark - Custom interface
 
-#if !defined(ANDROID) && !defined(NDEBUG)
+#if !defined(ANDROID)
   void setImageLoader(std::weak_ptr<void> imageLoader);
 #endif // !ANDROID && !NDEBUG
 
  private:
   void applyFrameCorrections();
 
-#if !defined(ANDROID) && !defined(NDEBUG)
+#if !defined(ANDROID)
   StateData &getStateDataMutable();
 #endif // !ANDROID && !NDEBUG
 };

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.cpp
@@ -11,7 +11,6 @@ folly::dynamic RNSScreenStackHeaderConfigState::getDynamic() const {
       "paddingEnd", paddingEnd);
 }
 #else // ANDROID
-#ifndef NDEBUG
 void RNSScreenStackHeaderConfigState::setImageLoader(
     std::weak_ptr<void> imageLoader) {
   imageLoader_ = imageLoader;
@@ -21,7 +20,6 @@ std::weak_ptr<void> RNSScreenStackHeaderConfigState::getImageLoader()
     const noexcept {
   return imageLoader_;
 }
-#endif // !NDEBUG
 #endif // ANDROID
 
 } // namespace react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -62,10 +62,8 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
     return MapBufferBuilder::EMPTY();
   };
 #else // ANDROID
-#if !defined(NDEBUG)
   void setImageLoader(std::weak_ptr<void> imageLoader);
   std::weak_ptr<void> getImageLoader() const noexcept;
-#endif // !NDEBUG
 #endif // ANDROID
 
   Size frameSize{};
@@ -82,9 +80,9 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
 #pragma mark - Getters
 
  private:
-#if !defined(ANDROID) && !defined(NDEBUG)
+#if !defined(ANDROID)
   std::weak_ptr<void> imageLoader_;
-#endif // !ANDROID && !NDEBUG
+#endif // !ANDROID
 };
 
 } // namespace facebook::react

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -10,12 +10,10 @@
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+#import <react/utils/ManagedObjectWrapper.h>
 #import <rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h>
 #import "RCTImageComponentView+RNSScreenStackHeaderConfig.h"
 #import "UINavigationBar+RNSUtility.h"
-#ifndef NDEBUG
-#import <react/utils/ManagedObjectWrapper.h>
-#endif // !NDEBUG
 #else
 #import <React/RCTImageView.h>
 #import <React/RCTShadowView.h>
@@ -82,9 +80,7 @@ static constexpr auto DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   /// Whether a react subview has been added / removed in current transaction. This flag is reset after each react
   /// transaction via RCTMountingTransactionObserving protocol.
   bool _addedReactSubviewsInCurrentTransaction;
-#ifndef NDEBUG
-  RCTImageLoader *imageLoader;
-#endif // !NDEBUG
+  RCTImageLoader *_imageLoader;
 #else
   NSDirectionalEdgeInsets _lastHeaderInsets;
   __weak RCTBridge *_bridge;
@@ -376,7 +372,9 @@ RNS_IGNORE_SUPER_CALL_END
         // in DEV MODE we try to load from cache (we use private API for that as it is not exposed
         // publically in headers).
         RCTImageSource *imageSource = [RNSScreenStackHeaderConfig imageSourceFromImageView:imageView];
-#ifndef RCT_NEW_ARCH_ENABLED
+#ifdef RCT_NEW_ARCH_ENABLED
+        RCTImageLoader *imageLoader = _imageLoader;
+#else
         RCTImageLoader *imageLoader = [_bridge moduleForClass:[RCTImageLoader class]];
 #endif // !RCT_NEW_ARCH_ENABLED
         image = [imageLoader.imageCache
@@ -883,7 +881,7 @@ RNS_IGNORE_SUPER_CALL_END
 #endif
           }
 #if RCT_NEW_ARCH_ENABLED
-          imageLoader:imageLoader];
+          imageLoader:_imageLoader];
 #else
           imageLoader:_bridge.imageLoader];
 #endif
@@ -1190,11 +1188,9 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
            oldState:(const facebook::react::State::Shared &)oldState
 {
   _state = std::static_pointer_cast<const react::RNSScreenStackHeaderConfigShadowNode::ConcreteState>(state);
-#ifndef NDEBUG
   if (auto imgLoaderPtr = _state.get()->getData().getImageLoader().lock()) {
-    imageLoader = react::unwrapManagedObject(imgLoaderPtr);
+    _imageLoader = react::unwrapManagedObject(imgLoaderPtr);
   }
-#endif // !NDEBUG
 }
 
 #else


### PR DESCRIPTION
## Description

Fixed #3299

Did an oopsie with 4.17.0 release, as iOS fails to build in release mode due to missing `imageLoader`.
Until recently we needed the `imageLoader` only in debug mode to load images for header. Right now 
it is required no matter the build configuration.

## Changes

Updated shadow node & header config code, so that the `imageLoader` is provided to header config shadow node state 
also in release mode.

## Test code and steps to reproduce

iOS (Paper & Fabric) should now build in release mode.

## Checklist

- [x] Ensured that CI passes

