### PR TITLE
fix(iOS, Tabs): use default UITabBarItem's title font as a base for font configuration 

### DIFF
--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -200,7 +200,7 @@
       itemStateAppearanceProps[@"tabBarItemTitleFontWeight"] != nil ||
       itemStateAppearanceProps[@"tabBarItemTitleFontStyle"] != nil) {
     titleTextAttributes[NSFontAttributeName] =
-        [RCTFont updateFont:nil
+        [RCTFont updateFont:tabBarItemStateAppearance.titleTextAttributes[NSFontAttributeName]
                  withFamily:itemStateAppearanceProps[@"tabBarItemTitleFontFamily"]
                        size:itemStateAppearanceProps[@"tabBarItemTitleFontSize"]
                      weight:itemStateAppearanceProps[@"tabBarItemTitleFontWeight"]


### PR DESCRIPTION
## Description

Updates tab bar item title font appearance configuration to use default `UITabBarItem`'s title font as a base. Previously, we would rely on default values in `[RCTFont updateFont:...]` method which were different than the font used in tab bar items by default.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d8b1840d-ecb0-40e5-bb34-5f10e8244073" /> | <video src="https://github.com/user-attachments/assets/f7037155-3e1e-4d44-bdeb-8b6578779cc9" /> |

> [!IMPORTANT]
>
> If someone previously relied on the default values from `[RCTFont updateFont:...]` (e.g. changed only font family and decided that the font size is correct), after this PR the title will likely look different than before - this might be considered a breaking change.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/504.

## Changes

- pass default font to `[RCTFont updateFont:...]`

## Test code and steps to reproduce

Run `TestBottomTabs`, change appearance configuration for Tab1: 

```tsx
      scrollEdgeAppearance: {
        stacked: {
          normal: {
            // tabBarItemTitleFontWeight: 'bold',
            // tabBarItemTitleFontFamily: 'Baskerville',
            // tabBarItemTitleFontStyle: 'italic',
          },
        },
      },
```

Uncomment lines one-by-one, save file, observe changes.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
