### PR TITLE
feat(Android, Tabs): hide the tab-bar on scroll on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -9,10 +9,12 @@ import android.view.View
 import android.view.WindowInsets
 import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.ThemedReactContext
+import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
@@ -25,7 +27,7 @@ import kotlin.properties.Delegates
 
 class TabsHost(
     val reactContext: ThemedReactContext,
-) : FrameLayout(reactContext),
+) : CoordinatorLayout(reactContext),
     TabScreenDelegate,
     SafeAreaProvider,
     View.OnLayoutChangeListener {
@@ -103,11 +105,14 @@ class TabsHost(
     private val bottomNavigationView: BottomNavigationView =
         BottomNavigationView(wrappedContext).apply {
             layoutParams =
-                LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.WRAP_CONTENT,
-                    Gravity.BOTTOM,
-                )
+                CoordinatorLayout
+                    .LayoutParams(
+                        CoordinatorLayout.LayoutParams.MATCH_PARENT,
+                        CoordinatorLayout.LayoutParams.WRAP_CONTENT,
+                    ).apply {
+                        gravity = Gravity.BOTTOM
+                        behavior = HideBottomViewOnScrollBehavior<BottomNavigationView>()
+                    }
         }
 
     private val contentView: FrameLayout =


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/b64e106f-edbf-49e7-8db1-860c8f81b38b

Requires `nestedScrollEnabled` to be set to `true` on `ScrollView`

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
