### PR TITLE
fix(iOS, Tabs): `tabBarTintColor` on iPadOS

### DIFF
--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -3,6 +3,7 @@
 #import <React/RCTImageLoader.h>
 #import "RCTConvert+RNSBottomTabs.h"
 #import "RNSConversions.h"
+#import "RNSTabBarController.h"
 #import "RNSTabsScreenViewController.h"
 
 @implementation RNSTabBarAppearanceCoordinator
@@ -18,6 +19,10 @@
 
   // Step 1 - configure host-specific appearance
   tabBar.tintColor = hostComponentView.tabBarTintColor;
+
+  // Set tint color for iPadOS tab bar. This is the official way recommended by Apple:
+  // https://developer.apple.com/forums/thread/761056?answerId=798245022#798245022
+  hostComponentView.controller.view.tintColor = hostComponentView.tabBarTintColor;
 
   if (tabScreenCtrls == nil) {
     return;


### PR DESCRIPTION
## Description

Fixes setting tint color for the tab bar on iPadOS (>= 18).

<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-10-20 at 14 09 05" src="https://github.com/user-attachments/assets/7efe321a-29c0-4eb0-b027-d87185cdcc7b" />


`tabBar.tintColor` does not work for the floating tab bar. [Apple recommends](https://developer.apple.com/forums/thread/761056?answerId=798245022#798245022) setting the tint color for the `UITabBarController`'s view - that's what we do in this PR.

Unfortunately, when using the sidebar, tint color is set after a delay. This is also reproducible in a native UIKit app and has been mentioned in the same forum thread from the link above to happen [in native iPadOS apps (e.g. Numbers)](https://developer.apple.com/forums/thread/761056?answerId=798343022#798343022).

https://github.com/user-attachments/assets/8e1e0d9f-91be-47ce-9712-a80030bf3b9b

## Changes

- set tint color for `tabBarController.view`

## Test code and steps to reproduce

Run `TestBottomTabs` on an iPad.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
