### PR TITLE
refactor(iOS): rename `label` -> `title` in context of header items API

### DIFF
--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -15,7 +15,7 @@ const demoScreens = [
   { name: 'DisabledButtonDemo', title: 'Disabled Button' },
   { name: 'CustomColorButtonDemo', title: 'Custom Color Button' },
   { name: 'ProminentStyleButtonDemo', title: 'Prominent Style Button' },
-  { name: 'LabelStyleButtonDemo', title: 'Label Style Button' },
+  { name: 'TitleStyleButtonDemo', title: 'Title Style Button' },
   { name: 'IconSharesBgButtonDemo', title: 'Icon SharesBackground' },
   { name: 'TextButtonWithWidthDemo', title: 'Text Button With Width' },
   { name: 'IconButtonsWithSpacingDemo', title: 'Icon Buttons With Spacing' },
@@ -59,7 +59,7 @@ const BadgeButtonDemo = DemoScreenContent;
 const DisabledButtonDemo = DemoScreenContent;
 const CustomColorButtonDemo = DemoScreenContent;
 const ProminentStyleButtonDemo = DemoScreenContent;
-const LabelStyleButtonDemo = DemoScreenContent;
+const TitleStyleButtonDemo = DemoScreenContent;
 const IconSharesBgButtonDemo = DemoScreenContent;
 const TextButtonWithWidthDemo = DemoScreenContent;
 const IconButtonsWithSpacingDemo = DemoScreenContent;
@@ -90,7 +90,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Info',
+              title: 'Info',
               onPress: () => Alert.alert('Info pressed'),
             },
           ],
@@ -108,7 +108,7 @@ export default function BarButtonItemsExample() {
                 type: "imageSource",
                 imageSource: require('../../assets/search_black.png')
               },
-              label: "Label",
+              title: "Title",
               onPress: () => Alert.alert('Icon pressed'),
             },
           ],
@@ -126,7 +126,7 @@ export default function BarButtonItemsExample() {
                 type: "sfSymbol",
                 name: "square.and.arrow.up"
               },
-              label: "Label",
+              title: "Title",
               onPress: () => Alert.alert('Icon pressed'),
             },
           ],
@@ -140,16 +140,16 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "menu",
-              label: 'Menu',
+              title: 'Menu',
               menu: {
                 items: [
                   {
-                    label: 'Option 1',
+                    title: 'Option 1',
                     type: "action",
                     onPress: () => Alert.alert('Option 1 pressed'),
                   },
                   {
-                    label: 'Option 2',
+                    title: 'Option 2',
                     type: "action",
                     onPress: () => Alert.alert('Option 2 pressed'),
                   },
@@ -167,7 +167,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Badge',
+              title: 'Badge',
               badge: {
                 value: '3',
                 style: {
@@ -188,7 +188,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Disabled',
+              title: 'Disabled',
               disabled: true,
               onPress: () => Alert.alert('Should not fire'),
             },
@@ -203,7 +203,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Purple',
+              title: 'Purple',
               tintColor: 'purple',
               onPress: () => Alert.alert('Purple pressed'),
             },
@@ -218,7 +218,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Prominent',
+              title: 'Prominent',
               variant: 'prominent',
               tintColor: 'green',
               onPress: () => Alert.alert('Prominent pressed'),
@@ -227,15 +227,15 @@ export default function BarButtonItemsExample() {
         }}
       />
       <Stack.Screen
-        name="LabelStyleButtonDemo"
-        component={LabelStyleButtonDemo}
+        name="TitleStyleButtonDemo"
+        component={TitleStyleButtonDemo}
         options={{
-          title: 'Label Style Button',
+          title: 'Title Style Button',
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Styled',
-              labelStyle: {
+              title: 'Styled',
+              titleStyle: {
                 fontFamily: 'Georgia',
                 fontSize: 18,
                 fontWeight: 'bold',
@@ -254,28 +254,28 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               onPress: () => Alert.alert('Icon with sharesBackground pressed'),
               sharesBackground: true,
             },
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               onPress: () => Alert.alert('Icon with sharesBackground pressed'),
               sharesBackground: true,
             },
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               onPress: () => Alert.alert('Icon with sharesBackground pressed'),
               sharesBackground: false,
             },
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               hidesSharedBackground: true,
               onPress: () => Alert.alert('Icon with sharesBackground false pressed'),
@@ -291,7 +291,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Wide',
+              title: 'Wide',
               width: 100,
               onPress: () => Alert.alert('Wide text button pressed'),
             },
@@ -306,7 +306,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               onPress: () => Alert.alert('First icon pressed'),
             },
@@ -316,7 +316,7 @@ export default function BarButtonItemsExample() {
             },
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_white.png') },
               onPress: () => Alert.alert('Second icon pressed'),
             },
@@ -332,12 +332,12 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Tinted',
+              title: 'Tinted',
               onPress: () => Alert.alert('Tinted pressed'),
             },
             {
               type: "button",
-              label: "Label",
+              title: "Title",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               onPress: () => Alert.alert('Tinted icon pressed'),
             },
@@ -352,13 +352,13 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Done',
+              title: 'Done',
               variant: 'done',
               onPress: () => Alert.alert('Done text pressed'),
             },
             {
               type: "button",
-              label: "DoneIcon",
+              title: "DoneIcon",
               icon: { type: "imageSource", imageSource: require('../../assets/search_black.png') },
               variant: 'done',
               onPress: () => Alert.alert('Done icon pressed'),
@@ -374,12 +374,12 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "menu",
-              label: 'Menu',
+              title: 'Menu',
               menu: {
-                label: 'Context menu',
+                title: 'Context menu',
                 items: [
                   {
-                    label: 'Action 1',
+                    title: 'Action 1',
                     icon: { type: "sfSymbol", name: 'star' },
                     type: "action",
                     state: 'on',
@@ -388,7 +388,7 @@ export default function BarButtonItemsExample() {
                     onPress: () => Alert.alert('Action 1 pressed'),
                   },
                   {
-                    label: 'Action 2',
+                    title: 'Action 2',
                     icon: { type: "sfSymbol", name: 'square.and.arrow.up' },
                     type: "action",
                     state: 'off',
@@ -397,12 +397,12 @@ export default function BarButtonItemsExample() {
                     onPress: () => Alert.alert('Action 2 pressed'),
                   },
                   {
-                    label: 'Submenu',
+                    title: 'Submenu',
                     icon: { type: "sfSymbol", name: "star" },
                     type: 'submenu',
                     items: [
                       {
-                        label: 'Sub Action 1',
+                        title: 'Sub Action 1',
                         state: 'mixed',
                         type: 'action',
                         onPress: () => Alert.alert('Sub Action 1 pressed'),
@@ -411,7 +411,7 @@ export default function BarButtonItemsExample() {
                         discoverabilityLabel: 'Sub Action 1',
                       },
                       {
-                        label: 'Sub Action 2',
+                        title: 'Sub Action 2',
                         type: 'action',
                         onPress: () => Alert.alert('Sub Action 2 pressed'),
                       },
@@ -438,7 +438,7 @@ export default function BarButtonItemsExample() {
             },
             {
               type: "button",
-              label: "Native",
+              title: "Native",
               onPress: () => Alert.alert('Native button pressed'),
               sharesBackground: true,
             },
@@ -464,7 +464,7 @@ export default function BarButtonItemsExample() {
             },
             {
               type: "button",
-              label: "Native",
+              title: "Native",
               onPress: () => Alert.alert('Native button pressed'),
             },
           ],
@@ -476,7 +476,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Button',
+              title: 'Button',
               onPress: () => {
                 navigation.navigate('IdentifierExample2');
               },
@@ -491,7 +491,7 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: 'Btn',
+              title: 'Btn',
               onPress: () => Alert.alert('Button 1 pressed'),
             },
           ],
@@ -503,22 +503,22 @@ export default function BarButtonItemsExample() {
           headerRightItems: () => [
             {
               type: "button",
-              label: "Button 1",
+              title: "Button 1",
               onPress: () => Alert.alert('Button 1 pressed'),
             },
             {
               type: "button",
-              label: "Button 2",
+              title: "Button 2",
               onPress: () => Alert.alert('Button 2 pressed'),
             },
             {
               type: "button",
-              label: "Button 3",
+              title: "Button 3",
               onPress: () => Alert.alert('Button 3 pressed'),
             },
             {
               type: "button",
-              label: "Button 4",
+              title: "Button 4",
               onPress: () => Alert.alert('Button 4 pressed'),
             },
           ]

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -577,9 +577,9 @@ An array of objects describing native bar button items to display on the left or
 
 `type: 'button' | 'menu'` — Type of the item.
 
-`label: string` — Label of the button.
+`title: string` — Title of the button.
 
-`labelStyle?: { fontFamily?: string; fontSize?: number; fontWeight?: string; color?: ColorValue; }` — Style for the button label.
+`titleStyle?: { fontFamily?: string; fontSize?: number; fontWeight?: string; color?: ColorValue; }` — Style for the button title.
 
 `icon?: PlatformIconIOS` — Icon for the item.
 

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -20,7 +20,7 @@
     return self;
   }
 
-  self.title = dict[@"label"];
+  self.title = dict[@"title"];
 
   NSDictionary *imageSourceObj = dict[@"imageSource"];
   if (imageSourceObj) {
@@ -37,9 +37,9 @@
     self.image = [UIImage systemImageNamed:sfSymbolName];
   }
 
-  NSDictionary *labelStyle = dict[@"labelStyle"];
-  if (labelStyle) {
-    [self setLabelStyleFromConfig:labelStyle];
+  NSDictionary *titleStyle = dict[@"titleStyle"];
+  if (titleStyle) {
+    [self setTitleStyleFromConfig:titleStyle];
   }
 
   id tintColorObj = dict[@"tintColor"];
@@ -153,9 +153,9 @@
       }
     }
   }
-  NSString *label = dict[@"label"];
+  NSString *title = dict[@"title"];
   NSString *sfSymbolName = dict[@"sfSymbolName"];
-  return [UIMenu menuWithTitle:label
+  return [UIMenu menuWithTitle:title
                          image:sfSymbolName ? [UIImage systemImageNamed:sfSymbolName] : nil
                     identifier:nil
                        options:0
@@ -165,9 +165,9 @@
 + (UIAction *)createActionItemFromConfig:(NSDictionary *)dict menuAction:(RNSBarButtonMenuItemAction)menuAction
 {
   NSString *menuId = dict[@"menuId"];
-  NSString *label = dict[@"label"];
+  NSString *title = dict[@"title"];
   NSString *sfSymbolName = dict[@"sfSymbolName"];
-  UIAction *actionElement = [UIAction actionWithTitle:label
+  UIAction *actionElement = [UIAction actionWithTitle:title
                                                 image:sfSymbolName ? [UIImage systemImageNamed:sfSymbolName] : nil
                                            identifier:nil
                                               handler:^(__kindof UIAction *_Nonnull a) {
@@ -228,11 +228,11 @@
   }
 }
 
-- (void)setLabelStyleFromConfig:(NSDictionary *)labelStyle
+- (void)setTitleStyleFromConfig:(NSDictionary *)titleStyle
 {
-  NSString *fontFamily = labelStyle[@"fontFamily"];
-  NSNumber *fontSize = labelStyle[@"fontSize"];
-  NSString *fontWeight = labelStyle[@"fontWeight"];
+  NSString *fontFamily = titleStyle[@"fontFamily"];
+  NSNumber *fontSize = titleStyle[@"fontSize"];
+  NSString *fontWeight = titleStyle[@"fontWeight"];
   NSMutableDictionary *attrs = [NSMutableDictionary new];
   if (fontFamily || fontWeight) {
     NSNumber *resolvedFontSize = fontSize;
@@ -263,9 +263,9 @@
 
     attrs[NSFontAttributeName] = [UIFont systemFontOfSize:resolvedFontSize];
   }
-  id labelColor = labelStyle[@"color"];
-  if (labelColor) {
-    attrs[NSForegroundColorAttributeName] = [RCTConvert UIColor:labelColor];
+  id titleColor = titleStyle[@"color"];
+  if (titleColor) {
+    attrs[NSForegroundColorAttributeName] = [RCTConvert UIColor:titleColor];
   }
   [self setTitleTextAttributes:attrs forState:UIControlStateNormal];
   [self setTitleTextAttributes:attrs forState:UIControlStateHighlighted];

--- a/src/components/bottom-tabs/BottomTabs.types.ts
+++ b/src/components/bottom-tabs/BottomTabs.types.ts
@@ -24,10 +24,7 @@ export type TabBarMinimizeBehavior =
   | 'onScrollUp';
 
 // iOS-specific
-export type TabBarControllerMode =
-  | 'automatic'
-  | 'tabBar'
-  | 'tabSidebar';
+export type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
 export interface BottomTabsProps extends ViewProps {
   // #region Events
@@ -191,7 +188,7 @@ export interface BottomTabsProps extends ViewProps {
    *
    * Available starting from iOS 18.
    * Not supported on tvOS.
-   * 
+   *
    * The following values are currently supported:
    *
    * - `automatic` - the system sets the display mode based on the tab’s content

--- a/src/components/helpers/prepareHeaderBarButtonItems.ts
+++ b/src/components/helpers/prepareHeaderBarButtonItems.ts
@@ -45,8 +45,8 @@ export const prepareHeaderBarButtonItems = (
       imageSource = Image.resolveAssetSource(item.icon.templateSource);
     }
 
-    const labelStyle = item.labelStyle
-      ? { ...item.labelStyle, color: processColor(item.labelStyle.color) }
+    const titleStyle = item.titleStyle
+      ? { ...item.titleStyle, color: processColor(item.titleStyle.color) }
       : undefined;
     const tintColor = item.tintColor ? processColor(item.tintColor) : undefined;
     const badge = item.badge
@@ -63,7 +63,7 @@ export const prepareHeaderBarButtonItems = (
       ...item,
       imageSource,
       sfSymbolName: item.icon?.type === 'sfSymbol' ? item.icon.name : undefined,
-      labelStyle,
+      titleStyle,
       tintColor,
       badge,
     };

--- a/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
@@ -32,10 +32,7 @@ type TabBarMinimizeBehavior =
   | 'onScrollDown'
   | 'onScrollUp';
 
-type TabBarControllerMode =
-  | 'automatic'
-  | 'tabBar'
-  | 'tabSidebar';
+type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
 export interface NativeProps extends ViewProps {
   // Events

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -984,13 +984,13 @@ interface SharedHeaderBarButtonItem {
    */
   index?: number;
   /**
-   * Label of the item.
+   * Title of the item.
    */
-  label?: string;
+  title?: string;
   /**
    * Style for the item label.
    */
-  labelStyle?: {
+  titleStyle?: {
     fontFamily?: string;
     fontSize?: number;
     fontWeight?: string;
@@ -1091,7 +1091,7 @@ export interface HeaderBarButtonItemWithAction
 
 export interface HeaderBarButtonItemMenuAction {
   type: 'action';
-  label?: string;
+  title?: string;
   onPress: () => void;
   icon?: PlatformIconIOSSfSymbol;
   /**
@@ -1134,7 +1134,7 @@ export interface HeaderBarButtonItemMenuAction {
 
 export interface HeaderBarButtonItemSubmenu {
   type: 'submenu';
-  label?: string;
+  title?: string;
   icon?: PlatformIconIOSSfSymbol;
   items: HeaderBarButtonItemWithMenu['menu']['items'];
 }
@@ -1142,7 +1142,7 @@ export interface HeaderBarButtonItemSubmenu {
 export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
   type: 'menu';
   menu: {
-    label?: string;
+    title?: string;
     items: (HeaderBarButtonItemMenuAction | HeaderBarButtonItemSubmenu)[];
   };
 }


### PR DESCRIPTION
## Description

This PR intends to align back prop naming with the [platform](https://developer.apple.com/documentation/uikit/uibaritem/title?language=objc)
nomenclature.

The header item API is iOS specific and there is really no reason to obfuscate in any way 
what we expose. 

## Changes

Renamed `label` -> `title` & `labelStyle` -> `titleStyle`.

I recognize that technically this is a breaking change, however since react-navigation 
has not published the API yet, and we're in coordination, API end-users won't be affected.

## Test code and steps to reproduce

`BarButtonItems` example should work the same.

## Checklist

- [ ] Ensured that CI passes

