### PR TITLE
fix(android): crash while drawing in `dispatchGetDisplayList`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/anim/ScreensAnimation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/anim/ScreensAnimation.kt
@@ -12,7 +12,12 @@ internal class ScreensAnimation(
         t: Transformation,
     ) {
         super.applyTransformation(interpolatedTime, t)
-        // interpolated time should be the progress of the current transition
-        mFragment.dispatchTransitionProgressEvent(interpolatedTime, !mFragment.isResumed)
+        // This is called while android is drawing. The event might be intercepted by reanimated
+        // which could trigger a sync mount, which can alter the native view hierarchy, which
+        // could lead to a crash, see: https://github.com/software-mansion/react-native-screens/issues/3321
+        mFragment.view?.post {
+            // interpolated time should be the progress of the current transition
+            mFragment.dispatchTransitionProgressEvent(interpolatedTime, !mFragment.isResumed)
+        }
     }
 }


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Fixes https://github.com/software-mansion/react-native-screens/issues/3321

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Updated `about.md` docs

-->

The `applyTransformation` callback is called while we are drawing in android, as can be seen in this stack:

<img width="1118" height="1268" alt="Screenshot 2025-10-22 at 11 18 43" src="https://github.com/user-attachments/assets/fed58a6d-36dc-4b25-8114-215ba47c637c" />

The event we dispatch might be intercepted by reanimated which will cause to synchronously execute a mount transaction, which can alter the native view hierarchy, causing the mentioned issue.

The fix here is to move the dispatching off of the drawing stack, and post to the next queue spot.

I think `mFragment.view` is always present? If not we can also use something like `UIThreadUtils` if thats preferred. 

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

/

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation: <!-- For adding new props to native-stack -->
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [x] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes
