### PR TITLE
fix(iOS): handle variable icons in header items

### DIFF
--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -106,7 +106,7 @@ export default function BarButtonItemsExample() {
               type: "button",
               icon: {
                 type: "imageSource",
-                imageSource: require('../../assets/search_black.png')
+                imageSource: require('../../assets/variableIcons/icon_fill.png')
               },
               title: "Title",
               onPress: () => Alert.alert('Icon pressed'),

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -26,11 +26,19 @@
   if (imageSourceObj) {
     RCTImageSource *imageSource = [RCTConvert RCTImageSource:imageSourceObj];
     [imageLoader loadImageWithURLRequest:imageSource.request
-                                callback:^(NSError *_Nullable error, UIImage *_Nullable image) {
-                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                    self.image = image;
-                                  });
-                                }];
+        size:imageSource.size
+        scale:imageSource.scale
+        clipped:true
+        resizeMode:RCTResizeModeContain
+        progressBlock:^(int64_t progress, int64_t total) {
+        }
+        partialLoadBlock:^(UIImage *_Nonnull image) {
+        }
+        completionBlock:^(NSError *_Nullable error, UIImage *_Nullable image) {
+          dispatch_async(dispatch_get_main_queue(), ^{
+            self.image = image;
+          });
+        }];
   }
   NSString *sfSymbolName = dict[@"sfSymbolName"];
   if (sfSymbolName) {


### PR DESCRIPTION
Didn't consider usage of variable icons (2x, 3x) in header items when I implemented RCTImageLoader in RNSBarButtonItem. Sorry about that! This PR fixes this.

**Before**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 11 55 20" src="https://github.com/user-attachments/assets/5512c0d6-f96c-4c2a-9088-746eb5f539a6" />

**After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 11 50 45" src="https://github.com/user-attachments/assets/20c05364-32fd-4054-b700-444e883c259c" />