### PR TITLE
fix: prevent freeze from unmounting native components

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -55,6 +55,13 @@ interface ViewConfig extends View {
       };
     };
   };
+  __viewConfig: {
+    validAttributes: {
+      style: {
+        display: boolean | null;
+      };
+    };
+  };
 }
 
 export const InnerScreen = React.forwardRef<View, ScreenProps>(
@@ -176,6 +183,11 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         } else if (ref?._viewConfig?.validAttributes?.style) {
           ref._viewConfig.validAttributes.style = {
             ...ref._viewConfig.validAttributes.style,
+            display: null,
+          };
+        } else if (ref?.__viewConfig?.validAttributes?.style) {
+          ref.__viewConfig.validAttributes.style = {
+            ...ref.__viewConfig.validAttributes.style,
             display: null,
           };
         }


### PR DESCRIPTION
## Description

~~No idea why the freeze worked up to 0.81, maybe there was something on
native side that prevented children from being unmounted and it is no
longer there. Our fix did not work, however. This commit fixes it.~~

~~Name of the filed has been changed here:~~
~~https://github.com/facebook/react-native/commit/a36dbae48657965027e63c5bf90e4982af554581~~

@kligarski:

Starting from RN 0.82, our workaround that prevented unmounting frozen views has stopped working - the bug is very similar to one described [here](https://github.com/software-mansion/react-native-screens/pull/2778). The details of the workaround are available [here](https://github.com/grahammendick/navigation/pull/860).

Due to introduction of DOM APIs, `react-native` replaced `ReactFabricHostComponent` with `ReactNativeElement`. This was hidden behind a feature flag until [this PR](https://github.com/facebook/react-native/pull/53360) to RN 0.82. The default value for `enableAccessToHostTreeInFabric` flag has been switched to `true`.

In the workaround, we relied on internal value of `_viewConfig` which has been renamed to `__viewConfig` in `ReactNativeElement` implementation.

In this PR, we handle all names of this property.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/3cf7b785-a91a-4f13-beb3-b71aaabc17ca" /> | <video src="https://github.com/user-attachments/assets/a2bbdf01-d2a9-4808-9401-8ad12839a190" /> |

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/502.

## Changes

- add check for `__viewConfig` prop name in workaround

## Test code and steps to reproduce

Run `Test1726`. Go to screen 3 and go back via native back button. Customization of back button on the second screen should be still visible.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
