### PR TITLE
refactor!(iOS): move `changesSelectionAsPrimaryAction` to menu button item

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -603,14 +603,13 @@ An array of objects describing native bar button items to display on the left or
 
 `selected?: boolean` — Whether the button is selected. Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/isselected
 
-`changesSelectionAsPrimaryAction?: boolean` — Whether selection changes as a primary action (iOS 15+). Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/changesselectionasprimaryaction
-
 #### The button with a menu also support:
 
 ```
 menu?: {
   type: 'menu';
   label?: string;
+  changesSelectionAsPrimaryAction?: boolean // Whether selection changes as a primary action (iOS 15+). Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/changesselectionasprimaryaction
   items: Array<
     | {
       label?: string;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1080,13 +1080,6 @@ export interface HeaderBarButtonItemWithAction
    * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/isselected
    */
   selected?: boolean;
-  /**
-   * A Boolean value that indicates whether the item represents an action or selection.
-   * Only available from iOS 15.0 and later.
-   *
-   * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/changesselectionasprimaryaction
-   */
-  changesSelectionAsPrimaryAction?: boolean;
 }
 
 export interface HeaderBarButtonItemMenuAction {
@@ -1145,6 +1138,13 @@ export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
     title?: string;
     items: (HeaderBarButtonItemMenuAction | HeaderBarButtonItemSubmenu)[];
   };
+  /**
+   * A Boolean value that indicates whether the button title should indicate selection or not.
+   * Only available from iOS 15.0 and later.
+   *
+   * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/changesselectionasprimaryaction
+   */
+  changesSelectionAsPrimaryAction?: boolean;
 }
 
 export interface HeaderBarButtonItemSpacing {


### PR DESCRIPTION
## Description

This prop has no effect when used with `HeaderBarButtonItemWithAction`,
as it is supposed to change selection value in context of menu button.

It is possible that there are some more behaviours introduced by this
prop, but not spotted yet.


https://github.com/user-attachments/assets/4b4e52bd-80f6-4613-943b-4479a849e732



## Test code and steps to reproduce

`BarButtonItems` example in our app. Add this prop to a menu button item.

## Checklist

- [ ] Ensured that CI passes
