### PR TITLE
feat(iOS, SafeAreaView): use synchronous state updates

### DIFF
--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -8,6 +8,7 @@
 #import "RNSSafeAreaViewNotifications.h"
 
 #if RCT_NEW_ARCH_ENABLED
+#include <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <rnscreens/RNSSafeAreaViewComponentDescriptor.h>
@@ -147,7 +148,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 
   auto newData = facebook::react::RNSSafeAreaViewState{RCTEdgeInsetsFromUIEdgeInsets(_currentSafeAreaInsets)};
-  _state->updateState(std::move(newData));
+  _state->updateState(
+      std::move(newData)
+#if REACT_NATIVE_VERSION_MINOR >= 82
+          ,
+      facebook::react::EventQueue::UpdateMode::unstable_Immediate
+#endif // REACT_NATIVE_VERSION_MINOR >= 82
+  );
 }
 #else
 - (void)updateLocalData


### PR DESCRIPTION
## Description

Adds support for synchronous state updates for `SafeAreaView` on iOS for RN 0.82+.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/68cd55ec-9845-40b0-b989-f68b9d840503" /> | <video src="https://github.com/user-attachments/assets/e4ad13d5-076c-40df-bda3-9b74feb831a6" />

## Changes

- add `immediate` flag to `updateState`

## Test code and steps to reproduce

Run `TestBottomTabs`. Switch between `Tab1` and `Tab2`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
