### PR TITLE
feat(iOS, SplitView): Add an option for changing number of columns dynamically

### DIFF
--- a/ios/gamma/split-view/RNSSplitViewHostController.swift
+++ b/ios/gamma/split-view/RNSSplitViewHostController.swift
@@ -21,6 +21,9 @@ public class RNSSplitViewHostController: UISplitViewController, ReactMountingTra
 
   private let splitViewHostComponentView: RNSSplitViewHostComponentView
 
+  /// This variable is keeping the value of how many columns were set in the initial render. It's used for validation, because SplitView doesn't support changing number of columns dynamically.
+  private let fixedColumnsCount: Int
+
   private let minNumberOfColumns: Int = 2
   private let maxNumberOfColumns: Int = 3
   private let maxNumberOfInspectors: Int = 1
@@ -48,6 +51,7 @@ public class RNSSplitViewHostController: UISplitViewController, ReactMountingTra
     self.splitViewHostComponentView = splitViewHostComponentView
     self.splitViewAppearanceCoordinator = RNSSplitViewAppearanceCoordinator()
     self.splitViewAppearanceApplicator = RNSSplitViewAppearanceApplicator()
+    self.fixedColumnsCount = numberOfColumns
 
     super.init(style: RNSSplitViewHostController.styleByNumberOfColumns(numberOfColumns))
 
@@ -296,6 +300,10 @@ public class RNSSplitViewHostController: UISplitViewController, ReactMountingTra
         && columns.count <= maxNumberOfColumns,
       "[RNScreens] SplitView can only have from \(minNumberOfColumns) to \(maxNumberOfColumns) columns"
     )
+
+    assert(
+      columns.count == fixedColumnsCount,
+      "[RNScreens] SplitView number of columns shouldn't change dynamically")
   }
 
   ///


### PR DESCRIPTION
## Description

Previously, the constructor of UISplitViewController relied on a predefined number of columns, and we enforced this constraint using an assert to prevent unexpected runtime behavior when the number of children changed dynamically.

Inspired by the `expo-router` approach, this PR removes the static assert and introduces a more dynamic pattern: the `SplitViewHost` now actively monitors the number of child columns. If the number of children changes, the entire `UISplitViewController` is remounted to reflect the updated configuration.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/499 .

## Changes

- Added counters to monitor the number of columns and inspectors

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

https://github.com/user-attachments/assets/8474db46-9c87-4523-a6fc-effae0ad8555


### After

https://github.com/user-attachments/assets/7a5522c2-c9c8-4afe-8b1f-a3144f97b140


## Test code and steps to reproduce

Run any example with SplitView and add/remove columns or inspector.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
