### PR TITLE
chore: Remove doubled "when" from types.tsx and GUIDE_FOR_LIBRARY_AUTHORS

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -71,7 +71,7 @@ Boolean indicating whether the full screen dismiss gesture has shadow under view
 doesn't have a shadow by default. When enabled, a custom shadow view is added during the transition which tries to mimic the
 default iOS shadow. Defaults to `true`.
 IMPORTANT: Starting from iOS 26, full screen swipe is handled by native recognizer, and this prop is ignored. We still fallback
-to the legacy implementation when when handling custom animations, but we assume `true` for shadows.
+to the legacy implementation when handling custom animations, but we assume `true` for shadows.
 
 ### `gestureEnabled` (iOS only)
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -193,7 +193,7 @@ export interface ScreenProps extends ViewProps {
    * This does not affect the behavior of transitions that don't use gestures, enabled by `fullScreenGestureEnabled` prop.
    *
    * @deprecated since iOS 26, full screen swipe is handled by native recognizer, and this prop is ignored. We still fallback
-   * to the legacy implementation when when handling custom animations, but we assume `true` for shadows.
+   * to the legacy implementation when handling custom animations, but we assume `true` for shadows.
    *
    * @platform ios
    */


### PR DESCRIPTION
## Description

Fixes some wording in the documentation