### PR TITLE
feat(Android, Tabs): handle preventing tab change on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -326,6 +326,10 @@ class TabsHost(
 
         appearanceCoordinator.updateTabAppearance(this)
 
+        menuItemSelectedViaContainerUpdate = true
+        bottomNavigationView.selectedItemId =
+            checkNotNull(getSelectedTabScreenFragmentId()) { "[RNScreens] A single selected tab must be present" }
+
         post {
             refreshLayout()
             RNSLog.d(TAG, "BottomNavigationView request layout")
@@ -342,10 +346,6 @@ class TabsHost(
         if (newFocusedTab === oldFocusedTab) {
             return
         }
-
-        menuItemSelectedViaContainerUpdate = true
-        bottomNavigationView.selectedItemId =
-            checkNotNull(getSelectedTabScreenFragmentId()) { "[RNScreens] A single selected tab must be present" }
 
         requireFragmentManager
             .beginTransaction()


### PR DESCRIPTION
## Description

Allows preventing tab change on Android. Previously, bottom navigation bar would be desynchronized with shown tab screen (menu item would change even if tab screen would not).

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ac6da530-29d3-4772-ac34-33dbb68cb951" /> | <video src="https://github.com/user-attachments/assets/dde80ace-aed1-4e2c-b34a-07478adb6e65" /> |

> [!IMPORTANT]
> 
> Due to changes in this PR, tab change behaves differently when tab screens are heavy.
> 
> | before | after |
> | --- | --- |
> | <video src="https://github.com/user-attachments/assets/351bf5cc-6520-4d89-97e1-125d47dafa7b" /> | <video src="https://github.com/user-attachments/assets/fe0d3765-6e39-4da3-b1f8-bfcd7268dc8e" />
>
> This matches behavior on iOS but I'm not sure if this is something we want.
>
> https://github.com/user-attachments/assets/505a5707-e89f-4c86-a4df-7742cd5643c3

Closes https://github.com/software-mansion/react-native-screens-labs/issues/561.

## Changes

- add `menuItemSelectedViaContainerUpdate` to differentiate between user menu item taps and updates from JS
- allow item selection only if `menuItemSelectedViaContainerUpdate`, otherwise just send event to JS

## Test code and steps to reproduce

Run `TestBottomTabs`. Apply this patch to `BottomTabsContainer` to simulate preventing tab change to Tab4:
<details>
  <summary>Patch</summary>
  
```
diff --git a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
index 7bba66b48..5f535c945 100644
--- a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
@@ -51,6 +51,10 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
     (event: NativeSyntheticEvent<NativeFocusChangeEvent>) => {
       const tabKey = event.nativeEvent.tabKey;
 
+      if (tabKey === 'Tab4') {
+        return;
+      }
+
       // Use `startTransition` only if the state is controlled in JS
       // const transitionFn = !configWrapper.config.controlledBottomTabs
       //   ? startTransition

```
  
</details>

Try to select tab4.


## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
