### PR TITLE
fix(iOS, FormSheet): Always use absolute positioning

### DIFF
--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -190,11 +190,7 @@ function getPositioningStyle(
   }
 
   if (isIOS) {
-    if (allowedDetents === 'fitToContents') {
-      return styles.absolute;
-    } else {
-      return styles.container;
-    }
+    return styles.absolute;
   }
 
   // Other platforms, tested reliably only on Android


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-screens/pull/3228 - introduced a regression, as before this PR,  absolute style positioning was always selected on iOS. This PR aims to address this issue.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/519

## Changes

- Fixed the condition for iOS positioning style for FormSheet

## Test code and steps to reproduce

Tested that the code linked in the reported issue behaves the same as before `3228`. Tested with `TestFormSheet`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
