### PR TITLE
fix(iOS, Stack): Prevent overriding invalidate callback on Fabric

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -171,13 +171,13 @@ namespace react = facebook::react;
 - (BOOL)isModal;
 - (BOOL)isPresentedAsNativeModal;
 
-#ifdef RCT_NEW_ARCH_ENABLED
 /**
  * Tell `Screen` component that it has been removed from react state and can safely cleanup
  * any retained resources.
  */
-- (void)invalidateSelf;
-#else
+- (void)invalidateImpl;
+
+#ifndef RCT_NEW_ARCH_ENABLED
 /**
  * Tell `Screen` component that it has been removed from react state and can safely cleanup
  * any retained resources.
@@ -185,7 +185,7 @@ namespace react = facebook::react;
  * On old architecture this method might be called by RN via `RCTInvalidating` protocol.
  */
 - (void)invalidate;
-#endif
+#endif // !RCT_NEW_ARCH_ENABLED
 
 /**
  * Looks for header configuration in instance's `reactSubviews` and returns it. If not present returns `nil`.

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -934,17 +934,16 @@ RNS_IGNORE_SUPER_CALL_END
       self.controller.modalPresentationStyle == UIModalPresentationOverCurrentContext;
 }
 
-#ifdef RCT_NEW_ARCH_ENABLED
-- (void)invalidateSelf
+- (void)invalidateImpl
 {
   _controller = nil;
   [_sheetsScrollView removeObserver:self forKeyPath:@"bounds" context:nil];
 }
-#else
+
+#ifndef RCT_NEW_ARCH_ENABLED
 - (void)invalidate
 {
-  _controller = nil;
-  [_sheetsScrollView removeObserver:self forKeyPath:@"bounds" context:nil];
+  [self invalidateImpl];
 }
 #endif
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1410,7 +1410,7 @@ RNS_IGNORE_SUPER_CALL_END
       }
       for (RNSScreenView *screenRef : strongSelf->_toBeDeletedScreens) {
 #ifdef RCT_NEW_ARCH_ENABLED
-        [screenRef invalidateSelf];
+        [screenRef invalidateImpl];
 #else
         [screenRef invalidate];
 #endif


### PR DESCRIPTION
## Description

Meta has introduced a callback for component invalidation in Fabric: https://github.com/facebook/react-native/commit/b1994dd547395dbeec868e56762b5de2202cb1a9, which conflicts with our existing method name.

To resolve the naming conflict and maintain compatibility with RCTInvalidating, I'm applying a naming split:

- `invalidateSelf` for Fabric
- `invalidate` for Paper

This ensures correct behavior across both rendering pipelines without breaking existing contracts.

Fixes https://github.com/software-mansion/react-native-screens/issues/3356

## Changes

- Renamed the method on the new arch.

## Test code and steps to reproduce

Any formsheet with scrollview

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
