### PR TITLE
fix: RCTViewComponentViewProtocol -> RCTComponentViewProtocol

### DIFF
--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -266,7 +266,7 @@ RNS_IGNORE_SUPER_CALL_END
   [super load];
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {

--- a/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsHostComponentView.mm
@@ -207,7 +207,7 @@ namespace react = facebook::react;
   return [_reactEventEmitter emitOnNativeFocusChange:OnNativeFocusChangePayload{.tabKey = tabScreen.tabKey}];
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 #if RCT_NEW_ARCH_ENABLED
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/RNSBottomTabsScreenComponentView.mm
@@ -243,7 +243,7 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 #if RCT_NEW_ARCH_ENABLED
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props
            oldProps:(const facebook::react::Props::Shared &)oldProps

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.mm
@@ -176,7 +176,7 @@ RNS_IGNORE_SUPER_CALL_END
   return _controller;
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.mm
@@ -155,7 +155,7 @@ namespace react = facebook::react;
   [self dispatchSafeAreaDidChangeNotification];
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/gamma/stack/RNSScreenStackHostComponentView.mm
+++ b/ios/gamma/stack/RNSScreenStackHostComponentView.mm
@@ -75,7 +75,7 @@ RNS_IGNORE_SUPER_CALL_END
   return _controller;
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {

--- a/ios/gamma/stack/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/RNSStackScreenComponentView.mm
@@ -66,7 +66,7 @@ namespace react = facebook::react;
   return _reactEventEmitter;
 }
 
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props
            oldProps:(const facebook::react::Props::Shared &)oldProps

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -166,7 +166,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 #endif // RCT_NEW_ARCH_ENABLED
 
 #if RCT_NEW_ARCH_ENABLED
-#pragma mark - RCTViewComponentViewProtocol
+#pragma mark - RCTComponentViewProtocol
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {


### PR DESCRIPTION
## Description

The proper name is `RCTComponentViewProtocol` currently

## Test code and steps to reproduce

N/A - just visual fix in the code

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
