### PR TITLE
fix(JS, Stack): consider default value for `stackPresentation` and `headerConfig.hidden` in `ScreenStackItem`

### DIFF
--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -185,7 +185,7 @@ export default React.forwardRef(ScreenStackItem);
 
 function getPositioningStyle(
   allowedDetents: ScreenProps['sheetAllowedDetents'],
-  presentation?: StackPresentationTypes,
+  presentation: StackPresentationTypes,
 ) {
   const isIOS = Platform.OS === 'ios';
 


### PR DESCRIPTION
## Description

Fixes logic in `ScreenStackItem` to properly take into account default values of `stackPresentation` and `headerConfig.hidden` props. Previously, if you e.g. specified `headerConfig.hidden = false` but did not `stackPresentation = 'push'`, `isHeaderInModal` would become true, which is incorrect.

In this PR, we consider those values taking into account default value.

## Changes

- consider default value for `stackPresentation` and `headerConfig.hidden` in `ScreenStackItem`

## Screenshots / GIFs

| before | after |
| --- | --- |
| <img width="696" height="767" alt="image" src="https://github.com/user-attachments/assets/b2f7d21d-5004-4416-9905-6038ef2f68e0" /> | <img width="707" height="551" alt="image" src="https://github.com/user-attachments/assets/0013723f-fc60-423a-bd10-146d5bd90457" /> |

## Test code and steps to reproduce

```tsx
import React from 'react';
import { Text } from 'react-native';
import { ScreenStack, ScreenStackItem } from 'react-native-screens';

export default function App() {
  return (
    <ScreenStack style={{ flex: 1 }}>
      <ScreenStackItem
        key="home"
        screenId="home"
        activityState={2}
        // stackPresentation="push"
        headerConfig={{
          title: 'Home',
          hidden: false,
        }}>
        <Text>Hello, World!</Text>
      </ScreenStackItem>
    </ScreenStack>
  );
}
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
