### PR TITLE
fix: circular import in `src/types.tsx`

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -10,7 +10,10 @@ import {
   ImageSourcePropType,
 } from 'react-native';
 import { NativeStackNavigatorProps } from './native-stack/types';
-import type { ScrollEdgeEffect, UserInterfaceStyle } from './types';
+import type {
+  ScrollEdgeEffect,
+  UserInterfaceStyle,
+} from './components/shared/types';
 
 export type SearchBarCommands = {
   focus: () => void;


### PR DESCRIPTION
## Description

Fixes circular import in `src/types.tsx`.

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/548.

## Changes

- change incorrect import
