### PR TITLE
feat(Tabs): expose style prop from screen

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
-import Example from './Example';
-// import * as Test from './src/tests';
+// import Example from './Example';
+import * as Test from './src/tests';
 
 enableFreeze(true);
 
 export default function App() {
-  return <Example />;
-  // return <Test.TestBottomTabs />;
+  // return <Example />;
+  return <Test.TestBottomTabs />;
 }

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -19,6 +19,7 @@ internalEnableDetailedBottomTabsLogging();
 const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
+      style: { backgroundColor: Colors.YellowDark100 },
       scrollEdgeAppearance: {
         tabBarBackgroundColor: Colors.NavyLight100,
         stacked: {
@@ -38,11 +39,11 @@ const TAB_CONFIGS: TabConfiguration[] = [
         ios: {
           type: 'sfSymbol',
           name: 'house.fill',
-        }, 
+        },
         android: {
           type: 'imageSource',
           imageSource: require('../../../assets/variableIcons/icon_fill.png'),
-        }
+        },
       },
       selectedIcon: {
         type: 'sfSymbol',
@@ -105,11 +106,11 @@ const TAB_CONFIGS: TabConfiguration[] = [
         ios: {
           type: 'templateSource',
           templateSource: require('../../../assets/variableIcons/icon.png'),
-        }, 
+        },
         android: {
           type: 'drawableResource',
           name: 'sym_call_missed',
-        }
+        },
       },
       selectedIcon: {
         type: 'templateSource',
@@ -148,7 +149,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
         shared: {
           type: 'imageSource',
           imageSource: require('../../../assets/variableIcons/icon.png'),
-        }
+        },
       },
       selectedIcon: {
         type: 'imageSource',
@@ -171,8 +172,8 @@ const TAB_CONFIGS: TabConfiguration[] = [
         },
         android: {
           type: 'drawableResource',
-          name: 'custom_home_icon'
-        }
+          name: 'custom_home_icon',
+        },
       },
       selectedIcon: {
         type: 'sfSymbol',

--- a/apps/src/tests/TestBottomTabs/tabs/Tab1.tsx
+++ b/apps/src/tests/TestBottomTabs/tabs/Tab1.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { CenteredLayoutView } from '../../../shared/CenteredLayoutView';
 import { TabContentView } from '../components/TabContentView';
-import Colors from '../../../shared/styling/Colors';
 
 export function Tab1() {
   return (
-    <CenteredLayoutView style={{ backgroundColor: Colors.OffWhite }}>
+    <CenteredLayoutView>
       <TabContentView selectNextTab={undefined} tabKey={'Tab1'} />
     </CenteredLayoutView>
   );

--- a/src/components/bottom-tabs/BottomTabsScreen.tsx
+++ b/src/components/bottom-tabs/BottomTabsScreen.tsx
@@ -65,6 +65,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
     standardAppearance,
     scrollEdgeAppearance,
     scrollEdgeEffects,
+    style,
     // eslint-disable-next-line camelcase -- we use sneak case experimental prefix
     experimental_userInterfaceStyle,
     ...rest
@@ -129,7 +130,7 @@ function BottomTabsScreen(props: BottomTabsScreenProps) {
   return (
     <BottomTabsScreenNativeComponent
       collapsable={false}
-      style={styles.fillParent}
+      style={[style, styles.fillParent]}
       onWillAppear={onWillAppearCallback}
       onDidAppear={onDidAppearCallback}
       onWillDisappear={onWillDisappearCallback}

--- a/src/components/bottom-tabs/BottomTabsScreen.types.ts
+++ b/src/components/bottom-tabs/BottomTabsScreen.types.ts
@@ -257,6 +257,7 @@ export interface BottomTabsScreenItemStateAppearance {
 
 export interface BottomTabsScreenProps {
   children?: ViewProps['children'];
+  style?: ViewProps['style'];
   /**
    * @summary Defines what should be rendered when tab screen is frozen.
    *


### PR DESCRIPTION
## Description

It would be great to be able to customize tab screen style. However I'm not sure if exposing all style props is a good idea, or wether only selected few like: `backgroundColor`, `experimental_backgroundImage` should be exposed.

## Changes

Expose `style` props in types and pass it to native component

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
