### PR TITLE
fix(iOS, Tabs): add support for bottom accessory environment none

### DIFF
--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -184,5 +184,6 @@ typedef NS_ENUM(NSInteger, RNSOptionalBoolean) {
 
 typedef NS_ENUM(NSInteger, RNSBottomTabsAccessoryEnvironment) {
   RNSBottomTabsAccessoryEnvironmentRegular,
-  RNSBottomTabsAccessoryEnvironmentInline
+  RNSBottomTabsAccessoryEnvironmentInline,
+  RNSBottomTabsAccessoryEnvironmentNone
 };

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -413,6 +413,8 @@ RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UI
       return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::Regular;
     case UITabAccessoryEnvironmentInline:
       return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::Inline;
+    case UITabAccessoryEnvironmentNone:
+      return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::None;
     default:
       RCTLogError(@"[RNScreens] Unsupported environment for onEnvironmentChange event");
       return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::Regular;
@@ -431,6 +433,9 @@ RNSBottomTabsAccessoryEnvironment RNSBottomTabsAccessoryEnvironmentFromCppEquiva
 
     case Inline:
       return RNSBottomTabsAccessoryEnvironmentInline;
+
+    case None:
+      return RNSBottomTabsAccessoryEnvironmentNone;
 
     default:
       RCTLogError(@"[RNScreens] Unsupported BottomTabsAccessory environment");

--- a/src/components/bottom-tabs/BottomTabsAccessory.types.ts
+++ b/src/components/bottom-tabs/BottomTabsAccessory.types.ts
@@ -1,6 +1,6 @@
 import { NativeSyntheticEvent, ViewProps } from 'react-native';
 
-export type BottomTabsAccessoryEnvironment = 'regular' | 'inline';
+export type BottomTabsAccessoryEnvironment = 'regular' | 'inline' | 'none';
 
 export type EnvironmentChangeEvent = {
   environment: BottomTabsAccessoryEnvironment;

--- a/src/fabric/bottom-tabs/BottomTabsAccessoryContentNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsAccessoryContentNativeComponent.ts
@@ -5,7 +5,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 import type { ViewProps } from 'react-native';
 import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
-type BottomAccessoryEnvironment = 'regular' | 'inline';
+type BottomAccessoryEnvironment = 'regular' | 'inline' | 'none';
 
 export interface NativeProps extends ViewProps {
   environment?: WithDefault<BottomAccessoryEnvironment, 'regular'>;

--- a/src/fabric/bottom-tabs/BottomTabsAccessoryNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsAccessoryNativeComponent.ts
@@ -6,7 +6,7 @@ import type { ViewProps } from 'react-native';
 import { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type EnvironmentChangeEvent = {
-  environment: 'regular' | 'inline';
+  environment: 'regular' | 'inline' | 'none';
 };
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
## Description

When closing a bottomaccessory you get a RCTLogError with "Unsupported environment for onEnvironmentChange event". Thats because the environment is of type ["none"](https://developer.apple.com/documentation/uikit/uitabaccessory/environment/none) when the bottom accessory is closed.

## Changes

Add support for "none".

## Screenshots / GIFs

### Before

https://github.com/user-attachments/assets/92c04ce5-742c-4426-8354-595918e95132

### After

Uploading Simulator Screen Recording - iPhone 17 Pro - 2025-11-20 at 16.10.15.mov…

## Test code and steps to reproduce

Run Test3288 and set shown to false using the button on the screen

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
