### PR TITLE
fix(iOS, Tabs): remove incorrect warning on `none` environment in Bottom Accessory

### DIFF
--- a/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryEventEmitter.mm
+++ b/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryEventEmitter.mm
@@ -44,7 +44,12 @@ namespace react = facebook::react;
         rnscreens::conversion::RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(
             environment);
 
-    _reactEventEmitter->onEnvironmentChange({.environment = payloadEnvironment});
+    // If environment is other than `regular` or `inline`, we don't emit the event.
+    if (!payloadEnvironment.has_value()) {
+      return NO;
+    }
+
+    _reactEventEmitter->onEnvironmentChange({.environment = payloadEnvironment.value()});
     return YES;
   } else {
     RCTLogWarn(@"[RNScreens] Skipped OnEnvironmentChange event emission due to nullish emitter");
@@ -55,6 +60,11 @@ namespace react = facebook::react;
     NSString *environmentString =
         rnscreens::conversion::RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(
             environment);
+
+    // If environment is other than `regular` or `inline`, we don't emit the event.
+    if (environmentString == nil) {
+      return NO;
+    }
 
     self.onEnvironmentChange(@{@"environment" : environmentString});
     return YES;

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -405,7 +405,7 @@ RNSScrollEdgeEffect RNSBottomTabsScrollEdgeEffectFromBottomTabsScreenTopScrollEd
 
 #if RCT_NEW_ARCH_ENABLED
 API_AVAILABLE(ios(26.0))
-react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment
+std::optional<react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment>
 RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UITabAccessoryEnvironment environment)
 {
   switch (environment) {
@@ -414,8 +414,8 @@ RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UI
     case UITabAccessoryEnvironmentInline:
       return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::Inline;
     default:
-      RCTLogError(@"[RNScreens] Unsupported environment for onEnvironmentChange event");
-      return react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment::Regular;
+      // We want to ignore other environments (e.g. `none`), that's why there is no warning here.
+      return std::nullopt;
   }
 }
 
@@ -446,7 +446,7 @@ API_AVAILABLE(ios(26.0))
 NSString *RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(
     UITabAccessoryEnvironment environment)
 {
-  NSString *environmentString = nil;
+  NSString *environmentString;
   switch (environment) {
     case UITabAccessoryEnvironmentRegular:
       environmentString = BOTTOM_TABS_ACCESSORY_REGULAR_ENVIRONMENT;
@@ -455,7 +455,8 @@ NSString *RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvi
       environmentString = BOTTOM_TABS_ACCESSORY_INLINE_ENVIRONMENT;
       break;
     default:
-      RCTLogError(@"[RNScreens] Unsupported environment for onEnvironmentChange event");
+      // We want to ignore other environments (e.g. `none`), that's why there is no warning here.
+      environmentString = nil;
       break;
   }
 

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -77,7 +77,7 @@ RNSScrollEdgeEffect RNSBottomTabsScrollEdgeEffectFromBottomTabsScreenTopScrollEd
 
 #if RCT_NEW_ARCH_ENABLED
 API_AVAILABLE(ios(26.0))
-react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment
+std::optional<react::RNSBottomTabsAccessoryEventEmitter::OnEnvironmentChangeEnvironment>
 RNSBottomTabsAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UITabAccessoryEnvironment environment);
 
 #if REACT_NATIVE_VERSION_MINOR >= 82


### PR DESCRIPTION
## Description

Removes incorrect warning when bottom accessory enters `none` environment. Reasoning is explained here: https://github.com/software-mansion/react-native-screens/pull/3411#issuecomment-3569777887.

Thanks to @johankasperi for letting us know about the bug.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/92c04ce5-742c-4426-8354-595918e95132" /> | <video src="https://github.com/user-attachments/assets/6e7c191d-f76d-4640-80df-3d7514451bfe" />

Supersedes https://github.com/software-mansion/react-native-screens/pull/3411.

## Changes

- remove warning

## Test code and steps to reproduce

Run `Test3288`. Hide the bottom accessory.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
