### PR TITLE
fix(iOS): Distinguish horizontal and vertical scroll in gesture failure requirements

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1152,6 +1152,14 @@ RNS_IGNORE_SUPER_CALL_END
   return scrollView.panGestureRecognizer == gestureRecognizer;
 }
 
+// Check if ScrollView has horizontal scrolling.
+// This is the same logic as in RCTScrollView:
+// https://github.com/facebook/react-native/blob/69b131c2b1627f64f34a534dac4cf48a542e6ea6/packages/react-native/React/Views/ScrollView/RCTScrollView.m#L557
+- (BOOL)scrollViewHasHorizontalPart:(UIScrollView *)scrollView
+{
+  return scrollView.contentSize.width > scrollView.frame.size.width;
+}
+
 // Custom method for compatibility with iOS < 13.4
 // RNSScreenStackView is a UIGestureRecognizerDelegate for three types of gesture recognizers:
 // RNSPanGestureRecognizer, RNSScreenEdgeGestureRecognizer, _UIParallaxTransitionPanGestureRecognizer
@@ -1253,7 +1261,10 @@ RNS_IGNORE_SUPER_CALL_END
   if (@available(iOS 26, *)) {
     if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer &&
         [self isScrollViewPanGestureRecognizer:otherGestureRecognizer]) {
-      return YES;
+      // ScrollView should take precedence when scrolling horizontally (it should be required to fail).
+      // However, if it does not allow for horizontal scrolling, there should be no such restriction,
+      // and swiping horizontally should dismiss the screen.
+      return [self scrollViewHasHorizontalPart:static_cast<UIScrollView *>(otherGestureRecognizer.view)];
     }
   }
 
@@ -1276,6 +1287,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 #endif // check for iOS >= 26
 
+  // edge swipe to dismiss should take precedence over scrolling (both horizontally and vertically)
   return isEdgeSwipeGestureRecognizer && [self isScrollViewPanGestureRecognizer:otherGestureRecognizer];
 }
 


### PR DESCRIPTION
Fixes https://github.com/software-mansion/react-native-screens/issues/3302

Supersedes https://github.com/software-mansion/react-native-screens/pull/3304

## Description

This PR fixes the failure requirements for content pop gesture. The changes introduced in #3265 fixed the immediate dismissing of screen when scrolling on horizontal ScrollView, but at the same time introduced a regression for vertical scrolling. Here, we apply the failure requirement only if the ScrollView has horizontal scrolling.

## Changes

Updated `RNSScreenStack`'s `gestureRecognizer:shouldRequireFailureOf:otherGestureRecognizer` to check if ScrollView has horizontal scrolling.

### After changes

https://github.com/user-attachments/assets/de8bfdaa-aa9b-4c25-917e-2d631bc590df

## Testing
Use `Test1072`. Make sure to check custom animations with `animation` and `animationMatchesGesture`.