### PR TITLE
chore: Add missing #pragma once in header files

### DIFF
--- a/cpp/RNScreensTurboModule.h
+++ b/cpp/RNScreensTurboModule.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Needed on Paper only to hide the files from Swift build process
 #if defined(__cplusplus)
 

--- a/ios/RCTConvert+RNScreens.h
+++ b/ios/RCTConvert+RNScreens.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #if !RCT_NEW_ARCH_ENABLED
 
 #import <React/RCTConvert.h>

--- a/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h
+++ b/ios/RCTImageComponentView+RNSScreenStackHeaderConfig.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <React/RCTImageComponentView.h>

--- a/ios/RNSBarButtonItem.h
+++ b/ios/RNSBarButtonItem.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTImageLoader.h>
 #import <UIKit/UIKit.h>
 

--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <react/renderer/components/rnscreens/Props.h>

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -1,3 +1,5 @@
+#pragma once
+
 typedef NS_ENUM(NSInteger, RNSScreenStackPresentation) {
   RNSScreenStackPresentationPush,
   RNSScreenStackPresentationModal,

--- a/ios/RNSFullWindowOverlay.h
+++ b/ios/RNSFullWindowOverlay.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTViewManager.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/RNSInvalidatedComponentsRegistry.h
+++ b/ios/RNSInvalidatedComponentsRegistry.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <UIKit/UIKit.h>

--- a/ios/RNSModalScreen.h
+++ b/ios/RNSModalScreen.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSScreen.h"
 
 @interface RNSModalScreen : RNSScreenView

--- a/ios/RNSModule.h
+++ b/ios/RNSModule.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <rnscreens/rnscreens.h>

--- a/ios/RNSOrientationProviding.h
+++ b/ios/RNSOrientationProviding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSEnums.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/RNSPercentDrivenInteractiveTransition.h
+++ b/ios/RNSPercentDrivenInteractiveTransition.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "RNSScreenStackAnimator.h"
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTComponent.h>
 #import <React/RCTViewManager.h>
 

--- a/ios/RNSScreenContainer.h
+++ b/ios/RNSScreenContainer.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>
 #else

--- a/ios/RNSScreenContentWrapper.h
+++ b/ios/RNSScreenContentWrapper.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTViewManager.h>
 #import <UIKit/UIKit.h>
 #import "RNSDefines.h"

--- a/ios/RNSScreenFooter.h
+++ b/ios/RNSScreenFooter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTViewManager.h>
 #import <UIKit/UIKit.h>
 

--- a/ios/RNSScreenNavigationContainer.h
+++ b/ios/RNSScreenNavigationContainer.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTViewManager.h>
 
 #import "RNSScreenContainer.h"

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>
 #else

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>
 #else

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/RNSScreenWindowTraits.h
+++ b/ios/RNSScreenWindowTraits.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSScreen.h"
 
 @interface RNSScreenWindowTraits : NSObject

--- a/ios/RNSScrollViewBehaviorOverriding.h
+++ b/ios/RNSScrollViewBehaviorOverriding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/RNSViewControllerInvalidating.h
+++ b/ios/RNSViewControllerInvalidating.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/mounting/ShadowViewMutation.h>

--- a/ios/RNSViewControllerInvalidator.h
+++ b/ios/RNSViewControllerInvalidator.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <UIKit/UIKit.h>

--- a/ios/UIScrollView+RNScreens.h
+++ b/ios/UIScrollView+RNScreens.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/UIViewController+RNScreens.h
+++ b/ios/UIViewController+RNScreens.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/UIWindow+RNScreens.h
+++ b/ios/UIWindow+RNScreens.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/bottom-tabs/RCTConvert+RNSBottomTabs.h
+++ b/ios/bottom-tabs/RCTConvert+RNSBottomTabs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTConvert.h>
 #import <UIKit/UIKit.h>
 

--- a/ios/bottom-tabs/RNSBottomTabsSpecialEffectsSupporting.h
+++ b/ios/bottom-tabs/RNSBottomTabsSpecialEffectsSupporting.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.h
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import "RNSBottomTabsHostComponentView.h"
 #import "RNSTabsScreenViewController.h"

--- a/ios/bottom-tabs/accessory/RNSBottomAccessoryHelper.h
+++ b/ios/bottom-tabs/accessory/RNSBottomAccessoryHelper.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <RNSDefines.h>
 
 #if RNS_BOTTOM_ACCESSORY_AVAILABLE

--- a/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryComponentView.h
+++ b/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSBottomTabsAccessoryEventEmitter.h"
 #import "RNSBottomTabsHostComponentView.h"
 #import "RNSReactBaseView.h"

--- a/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryContentComponentView.h
+++ b/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryContentComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSDefines.h"
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"

--- a/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryEventEmitter.h
+++ b/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <RNSDefines.h>
 
 #if RNS_BOTTOM_ACCESSORY_AVAILABLE

--- a/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryShadowStateProxy.h
+++ b/ios/bottom-tabs/accessory/RNSBottomTabsAccessoryShadowStateProxy.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSBottomAccessoryHelper.h"
 
 #if RNS_BOTTOM_ACCESSORY_AVAILABLE

--- a/ios/bottom-tabs/extensions/RNSBottomTabsHostComponentView+RNSImageLoader.h
+++ b/ios/bottom-tabs/extensions/RNSBottomTabsHostComponentView+RNSImageLoader.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSBottomTabsHostComponentView.h"
 
 #if defined(__cplusplus) && RCT_NEW_ARCH_ENABLED

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSBottomTabsHostComponentViewManager.h"
 #import "RNSBottomTabsHostEventEmitter.h"
 #import "RNSDefines.h"

--- a/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.h
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // Hide C++ symbols from C compiler used when building Swift module

--- a/ios/bottom-tabs/host/RNSTabBarController.h
+++ b/ios/bottom-tabs/host/RNSTabBarController.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "RNSTabBarAppearanceCoordinator.h"
 #import "RNSTabsScreenViewController.h"

--- a/ios/bottom-tabs/host/RNSTabBarControllerDelegate.h
+++ b/ios/bottom-tabs/host/RNSTabBarControllerDelegate.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.h
+++ b/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTImageSource.h>
 #import "RNSBottomTabsScreenEventEmitter.h"
 #import "RNSEnums.h"

--- a/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentViewManager.h
+++ b/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentViewManager.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTViewManager.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/bottom-tabs/screen/RNSBottomTabsScreenEventEmitter.h
+++ b/ios/bottom-tabs/screen/RNSBottomTabsScreenEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // Hide C++ symbols from C compiler used when building Swift module

--- a/ios/bottom-tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/bottom-tabs/screen/RNSTabsScreenViewController.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "RNSBottomTabsScreenComponentView.h"
 #import "RNSBottomTabsSpecialEffectsSupporting.h"

--- a/ios/bridging/RNSReactBaseView.h
+++ b/ios/bridging/RNSReactBaseView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Hide C++ symbols from C compiler used when building Swift module
 #if defined(__cplusplus)
 

--- a/ios/events/RNSHeaderHeightChangeEvent.h
+++ b/ios/events/RNSHeaderHeightChangeEvent.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTEventDispatcherProtocol.h>
 
 @interface RNSHeaderHeightChangeEvent : NSObject <RCTEvent>

--- a/ios/events/RNSScreenViewEvent.h
+++ b/ios/events/RNSScreenViewEvent.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTEventDispatcherProtocol.h>
 
 @interface RNSScreenViewEvent : NSObject <RCTEvent>

--- a/ios/gamma/split-view/RNSSplitViewHostComponentEventEmitter.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // Hide C++ symbols from C compiler used when building Swift module

--- a/ios/gamma/split-view/RNSSplitViewHostComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewHostComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSDefines.h"
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentEventEmitter.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // Hide C++ symbols from C compiler used when building Swift module

--- a/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"
 #import "RNSSafeAreaProviding.h"

--- a/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.h
+++ b/ios/gamma/split-view/RNSSplitViewScreenShadowStateProxy.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #if defined(__cplusplus)

--- a/ios/gamma/stack/RNSScreenStackHostComponentView.h
+++ b/ios/gamma/stack/RNSScreenStackHostComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSReactBaseView.h"
 #import "RNSStackScreenComponentView.h"
 

--- a/ios/gamma/stack/RNSStackScreenComponentEventEmitter.h
+++ b/ios/gamma/stack/RNSStackScreenComponentEventEmitter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // Hide C++ symbols from C compiler used when building Swift module

--- a/ios/gamma/stack/RNSStackScreenComponentView.h
+++ b/ios/gamma/stack/RNSStackScreenComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSReactBaseView.h"
 #import "RNSStackScreenComponentEventEmitter.h"
 

--- a/ios/helpers/image/RNSImageLoadingHelper.h
+++ b/ios/helpers/image/RNSImageLoadingHelper.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <React/RCTImageLoader.h>
 #import <React/RCTImageSource.h>
 

--- a/ios/helpers/scroll-view/RNSContentScrollViewProviding.h
+++ b/ios/helpers/scroll-view/RNSContentScrollViewProviding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 @protocol RNSContentScrollViewProviding
 
 /**

--- a/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.h
+++ b/ios/helpers/scroll-view/RNSScrollEdgeEffectApplicator.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import "RNSEnums.h"
 
 @protocol RNSScrollEdgeEffectProviding

--- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
+++ b/ios/helpers/scroll-view/RNSScrollViewFinder.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "RNSContentScrollViewProviding.h"
 

--- a/ios/helpers/scroll-view/RNSScrollViewHelper.h
+++ b/ios/helpers/scroll-view/RNSScrollViewHelper.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 @interface RNSScrollViewHelper : NSObject

--- a/ios/integrations/RNSDismissibleModalProtocol.h
+++ b/ios/integrations/RNSDismissibleModalProtocol.h
@@ -1,3 +1,5 @@
+#pragma once
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSDismissibleModalProtocol <NSObject>

--- a/ios/safe-area/RNSSafeAreaProviding.h
+++ b/ios/safe-area/RNSSafeAreaProviding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 /**

--- a/ios/safe-area/RNSSafeAreaViewComponentView.h
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Implementation adapted from `react-native-safe-area-context`:
 // https://github.com/AppAndFlow/react-native-safe-area-context/tree/v5.6.1
 

--- a/ios/safe-area/paper/RNSSafeAreaViewEdges.h
+++ b/ios/safe-area/paper/RNSSafeAreaViewEdges.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Implementation adapted from `react-native-safe-area-context`:
 // https://github.com/AppAndFlow/react-native-safe-area-context/tree/v5.6.1
 

--- a/ios/safe-area/paper/RNSSafeAreaViewLocalData.h
+++ b/ios/safe-area/paper/RNSSafeAreaViewLocalData.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Implementation adapted from `react-native-safe-area-context`:
 // https://github.com/AppAndFlow/react-native-safe-area-context/tree/v5.6.1
 

--- a/ios/safe-area/paper/RNSSafeAreaViewManager.h
+++ b/ios/safe-area/paper/RNSSafeAreaViewManager.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Implementation adapted from `react-native-safe-area-context`:
 // https://github.com/AppAndFlow/react-native-safe-area-context/tree/v5.6.1
 

--- a/ios/safe-area/paper/RNSSafeAreaViewShadowView.h
+++ b/ios/safe-area/paper/RNSSafeAreaViewShadowView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Implementation adapted from `react-native-safe-area-context`:
 // https://github.com/AppAndFlow/react-native-safe-area-context/tree/v5.6.1
 

--- a/ios/stubs/RNSGammaStubs.h
+++ b/ios/stubs/RNSGammaStubs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 // These symbols are a stubs for components defined in Gamma project implementation.

--- a/ios/utils/NSString+RNSUtility.h
+++ b/ios/utils/NSString+RNSUtility.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/utils/RCTSurfaceTouchHandler+RNSUtility.h
+++ b/ios/utils/RCTSurfaceTouchHandler+RNSUtility.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <React/RCTSurfaceTouchHandler.h>

--- a/ios/utils/RCTTouchHandler+RNSUtility.h
+++ b/ios/utils/RCTTouchHandler+RNSUtility.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef RCT_NEW_ARCH_ENABLED
 
 #import <React/RCTTouchHandler.h>

--- a/ios/utils/RNSBackBarButtonItem.h
+++ b/ios/utils/RNSBackBarButtonItem.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 @interface RNSBackBarButtonItem : UIBarButtonItem

--- a/ios/utils/RNSLog.h
+++ b/ios/utils/RNSLog.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef RNS_DEBUG_LOGGING
 #define RNSLog(...) NSLog(__VA_ARGS__)
 #else

--- a/ios/utils/UINavigationBar+RNSUtility.h
+++ b/ios/utils/UINavigationBar+RNSUtility.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/utils/UIView+RNSUtility.h
+++ b/ios/utils/UIView+RNSUtility.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/587

## Description

This PR adds missing #pragma once calls at the top of the header files for consistency.

## Changes

Added #pragma once here and there.

## Test code and steps to reproduce

Should be working exactly the same.