### PR TITLE
chore(android): Remove fixOldArchJavaForRN77Compat

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
@@ -11,9 +11,9 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSBottomTabsManagerInterface<T extends View>  {
+public interface RNSBottomTabsManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setTabBarBackgroundColor(T view, @Nullable Integer value);
   void setTabBarItemTitleFontFamily(T view, @Nullable String value);
   void setTabBarItemTitleFontSize(T view, float value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsScreenManagerInterface.java
@@ -13,9 +13,9 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSBottomTabsScreenManagerInterface<T extends View>  {
+public interface RNSBottomTabsScreenManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setIsFocused(T view, boolean value);
   void setTabKey(T view, @Nullable String value);
   void setTitle(T view, @Nullable String value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSafeAreaViewManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSafeAreaViewManagerInterface.java
@@ -12,9 +12,9 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSSafeAreaViewManagerInterface<T extends View>  {
+public interface RNSSafeAreaViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setEdges(T view, @Nullable ReadableMap value);
   void setInsetType(T view, @Nullable String value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContainerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContainerManagerInterface.java
@@ -10,8 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenContainerManagerInterface<T extends View>  {
+public interface RNSScreenContainerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContentWrapperManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenContentWrapperManagerInterface.java
@@ -10,8 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenContentWrapperManagerInterface<T extends View>  {
+public interface RNSScreenContentWrapperManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenFooterManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenFooterManagerInterface.java
@@ -10,8 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenFooterManagerInterface<T extends View>  {
+public interface RNSScreenFooterManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -13,9 +13,9 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenManagerInterface<T extends View>  {
+public interface RNSScreenManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setScreenId(T view, @Nullable String value);
   void setSheetAllowedDetents(T view, @Nullable ReadableArray value);
   void setSheetLargestUndimmedDetent(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderConfigManagerInterface.java
@@ -12,9 +12,9 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenStackHeaderConfigManagerInterface<T extends View>  {
+public interface RNSScreenStackHeaderConfigManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setBackgroundColor(T view, @Nullable Integer value);
   void setBackTitle(T view, @Nullable String value);
   void setBackTitleFontFamily(T view, @Nullable String value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderSubviewManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackHeaderSubviewManagerInterface.java
@@ -11,9 +11,9 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenStackHeaderSubviewManagerInterface<T extends View>  {
+public interface RNSScreenStackHeaderSubviewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setType(T view, @Nullable String value);
   void setHidesSharedBackground(T view, boolean value);
   void setSynchronousShadowStateUpdatesEnabled(T view, boolean value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenStackManagerInterface.java
@@ -10,8 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSScreenStackManagerInterface<T extends View>  {
+public interface RNSScreenStackManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   // No props
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSSearchBarManagerInterface.java
@@ -11,9 +11,9 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-
-public interface RNSSearchBarManagerInterface<T extends View>  {
+public interface RNSSearchBarManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setHideWhenScrolling(T view, boolean value);
   void setAutoCapitalize(T view, @Nullable String value);
   void setPlaceholder(T view, @Nullable String value);

--- a/scripts/codegen-utils.js
+++ b/scripts/codegen-utils.js
@@ -54,40 +54,6 @@ function throwIfFileMissing(filepath) {
   }
 }
 
-/**
-  * Adapts files codegend for the new architecture for paticular needs of old architecure.
-  * This usually comes down to keeping backward compat on old architecture.
-  *
-  * @param {string} dir - directory with codegened files
-  */
-function fixOldArchJavaForRN77Compat(dir) {
-  console.log(`${TAG} fixOldArchJavaForRN77Compat:  ${dir}`);
-  const files = readdirSync(dir);
-  files.forEach(file => {
-    const filePath = path.join(dir, file);
-    const fileExtension = path.extname(file);
-    if (fileExtension === '.java') {
-      const fileContent = fs.readFileSync(filePath, 'utf-8');
-      let newFileContent = fileContent.replace(
-        /extends ViewManagerWithGeneratedInterface/g,
-        '',
-      );
-      if (fileContent !== newFileContent) {
-        // Also remove redundant import
-        newFileContent = newFileContent.replace(
-          /import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;/,
-          '',
-        );
-
-        console.log(' => fixOldArchJava77 applied to:', filePath);
-        fs.writeFileSync(filePath, newFileContent, 'utf-8');
-      }
-    } else if (fs.lstatSync(filePath).isDirectory()) {
-      fixOldArchJavaForRN77Compat(filePath);
-    }
-  });
-}
-
 async function generateCodegen() {
   console.log(`${TAG} generateCodegen`);
   exec(`rm -rf ${GENERATED_DIR}`);
@@ -101,7 +67,6 @@ async function generateCodegen() {
   );
 
   const generatedJavaFilesDir = `${GENERATED_DIR}/source/codegen/java/`;
-  fixOldArchJavaForRN77Compat(generatedJavaFilesDir);
 }
 
 async function generateCodegenJavaOldArch() {


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/581

## Description

This PR removes `fixOldArchJavaForRN77Compat` function that would fix old react navigation versions <= 77 when changes in 78 were breaking the build. We no longer support either of these, so the workoround is unnecessary.

## Changes

Removed `fixOldArchJavaForRN77Compat` & rerun codegen.

## Test code and steps to reproduce

Build the app on Paper & Fabric. Nothing should change. No SoftExceptions about 'getDelegate()' should be thrown (https://github.com/facebook/react-native/blob/716303362aead08310e2101f15a319b64a602026/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java#L120)