### PR TITLE
fix(SplitView, Android & Web): move split view warnings to components

### DIFF
--- a/src/components/gamma/split-view/SplitViewHost.android.tsx
+++ b/src/components/gamma/split-view/SplitViewHost.android.tsx
@@ -1,9 +1,8 @@
-import { View } from 'react-native';
-
-const SplitViewHost = View;
-
-console.warn(
-  '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Android.',
-);
+const SplitViewHost = () => {
+  console.warn(
+    '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Android.',
+  );
+  return null;
+};
 
 export default SplitViewHost;

--- a/src/components/gamma/split-view/SplitViewHost.web.tsx
+++ b/src/components/gamma/split-view/SplitViewHost.web.tsx
@@ -1,5 +1,8 @@
-import { View } from 'react-native';
-
-const SplitViewHost = View;
+const SplitViewHost = () => {
+  console.warn(
+    '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Web.',
+  );
+  return null;
+};
 
 export default SplitViewHost;

--- a/src/components/gamma/split-view/SplitViewScreen.android.tsx
+++ b/src/components/gamma/split-view/SplitViewScreen.android.tsx
@@ -1,10 +1,11 @@
-import { View } from 'react-native';
+const NOOP = () => {
+  console.warn(
+    '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Android.',
+  );
+  return null;
+};
 
-const Column = View;
-const Inspector = View;
-
-console.warn(
-  '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Android.',
-);
+const Column = NOOP;
+const Inspector = NOOP;
 
 export default { Column, Inspector };

--- a/src/components/gamma/split-view/SplitViewScreen.web.tsx
+++ b/src/components/gamma/split-view/SplitViewScreen.web.tsx
@@ -1,6 +1,11 @@
-import { View } from 'react-native';
+const NOOP = () => {
+  console.warn(
+    '[RNScreens] SplitView is supported only for iOS. Consider using an alternative layout for Web.',
+  );
+  return null;
+};
 
-const Column = View;
-const Inspector = View;
+const Column = NOOP;
+const Inspector = NOOP;
 
 export default { Column, Inspector };


### PR DESCRIPTION
## Description

SplitView warning were shown on Android, as soon as something was imported from `/experimental`.

## Changes

- Move warnings from global scope to `SplitView` components
- Add warnings on web to unify the logic

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
