### PR TITLE
fix(examples): Stop triggering CPU intensive tasks in top level scope in example apps

### DIFF
--- a/apps/src/tests/Test2933.tsx
+++ b/apps/src/tests/Test2933.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 import {
+  Button,
   StyleSheet,
   Text,
   useColorScheme,
@@ -32,15 +33,7 @@ function floodJsThread() {
   }, 12);
 }
 
-/*
- * create artificial pressure in the JS thread to show off thep problem.
- * */
-floodJsThread();
-floodJsThread();
-
 function AppMain(): React.JSX.Element {
-  const isDarkMode = useColorScheme() === 'dark';
-
   const backgroundStyle = {
     flex: 1,
     backgroundColor: 'white',
@@ -90,6 +83,12 @@ function AppMain(): React.JSX.Element {
           flashes of the blue background.
         </Section>
         <Section title="Orientation"> {num} </Section>
+
+        <Section title="Extra computation">
+          To better show off the problem, you can add extra computation to the JS thread, so that the commits
+          are likely further apart from each other.
+          <Button title="Add extra computation to the JS thread" onPress={floodJsThread} />
+        </Section>
       </View>
     </View>
   );


### PR DESCRIPTION
When `Test2933` is imported (loaded) we always trigger CPU intensive
tasks leading to laggy application.

I've added a button to trigger the computation.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/601