### PR TITLE
chore(example): use direct import from screens instead of repository-relative

### DIFF
--- a/FabricExample/App.tsx
+++ b/FabricExample/App.tsx
@@ -1,5 +1,5 @@
 import App from '../apps';
-import { featureFlags } from '../src';
+import { featureFlags } from 'react-native-screens';
 
 featureFlags.experiment.synchronousScreenUpdatesEnabled = false
 featureFlags.experiment.synchronousHeaderConfigUpdatesEnabled = false


### PR DESCRIPTION
Use direct import instead of relative in example application

The app is not part of the lib. We should import things from screens as
from any other lib.


I've ensured that feature flags keep working correctly. If you're seeing type errors on your end, that the feature flags do not exist -> you need to run `yarn prepare` in the project top level directory.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/603