### PR TITLE
chore: remove unnecessary override of `prepareForRecycle` method in header subview

### DIFF
--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -138,11 +138,6 @@ namespace react = facebook::react;
 
 #pragma mark - RCTComponentViewProtocol
 
-- (void)prepareForRecycle
-{
-  [super prepareForRecycle];
-}
-
 - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::Shared const &)oldProps
 {
   const auto &newHeaderSubviewProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewProps>(props);


### PR DESCRIPTION

Remove unnecessary override of `prepareForRecycle` method
This is not needed for two reasons:

1. we return `NO` from `shouldBeRecycled`,
2. current implementation only calls to super implementation.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/675
