### PR TITLE
fix(iOS 26, Stack): center view inside bar button item

### DIFF
--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -174,8 +174,11 @@ RNS_IGNORE_SUPER_CALL_BEGIN
         self);
   } else {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+    BOOL sizeHasChanged = _layoutMetrics.frame.size != layoutMetrics.frame.size;
     _layoutMetrics = layoutMetrics;
-    [self invalidateIntrinsicContentSize];
+    if (sizeHasChanged) {
+      [self invalidateIntrinsicContentSize];
+    }
 #else // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
     self.bounds = CGRect{CGPointZero, frame.size};
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)


### PR DESCRIPTION
## Description

Fixes alignment of custom view inside bar button item on iOS 26.

> [!NOTE]
>
> Please note that this will also change positioning of bar button items with `hidesSharedBackground: true` on iOS 26.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d188be5c-48bf-4dee-97e2-599eac487af0" /> | <video src="https://github.com/user-attachments/assets/82d5ca33-8ef2-40bb-8d4e-030b0b53054c" /> |

Closes https://github.com/software-mansion/react-native-screens/issues/2990.

### Explanation

Starting from iOS 26, custom view inside `UIBarButtonItem` is stretched to at least 36 width. This causes our `RNSScreenStackHeaderSubview` to stretch if its width is smaller than 36, leaving subviews in the same origin (for one subview, it's usually `(0,0)`; that's why it is aligned to the left, visible in "before" recording).

In order to mitigate this, we add `wrapperView` which will be stretched by UIKit to required minimum size. `RNSScreenStackHeaderSubview` will be centered inside of it. Additional constraints and properties needed to be added to make sure that `wrapperView` is not stretched to all available space in `UINavigationBar` (this would happen in `headerRight` if we used only `wrapperView.width >= RNSScreenStackHeaderSubview.width` constraint):

- `wrapperView.width == RNSScreenStackHeaderSubview.width` - makes sure that wrapper matches content. By using lower priority than default, we allow UIKit to "take over" with its minimum width, while maintaining "fit-content"/"content hugging" behavior,
- `[self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal]` - prevents stretching to all available width in `UINavigationBar`.

`RNSScreenStackHeaderSubview` needs to use `intrinsicContentSize` in order to bridge auto-layout centering and frame size from Yoga.

## Changes

- on iOS 26, add wrapper view between `UIBarButtonItem` and `RNSScreenStackHeaderSubview`
- center `RNSScreenStackHeaderSubview` inside `wrapperView` while maintaining correct sizing via auto layout
  - use `intrinsicContentSize` to bridge between auto-layout and frames calculated by Yoga
- fix frame passed to shadow tree (now, `RNSScreenStackHeaderSubview` can have non-zero offset (which was not the case previously); without change to `self.bounds`, this offset would be accounted for 2 times when using `[self convertRect:frame toView:ancestorView]`)

## Test code and steps to reproduce

Run `Test3446`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
