### PR TITLE
chore(e2e): semver replaced

### DIFF
--- a/FabricExample/e2e/component-objects/back-button.ts
+++ b/FabricExample/e2e/component-objects/back-button.ts
@@ -1,7 +1,6 @@
 import { device, element, by } from 'detox';
 import { getIOSVersion } from '../../../scripts/e2e/ios-devices.js';
-import semverSatisfies from 'semver/functions/satisfies';
-import semverCoerce from 'semver/functions/coerce';
+import { isVersion } from '../helpers/versionComparator.js';
 
 const IOS_BAR_BUTTON_TYPE = '_UIButtonBarButton';
 const backButtonElement = element(by.id('BackButton'));
@@ -15,8 +14,8 @@ export async function tapBarBackButton() {
   } else throw new Error(`Platform "${platform}" not supported`);
 }
 async function getIOSBackButton() {
-  const iosVersion = semverCoerce(getIOSVersion().replace('iOS', ''))!;
-  if (semverSatisfies(iosVersion, '>=26.0')) {
+  const iosVersion = getIOSVersion().replace('iOS', '').trim();
+  if (isVersion(iosVersion).equalOrHigherThan('26.0')) {
     const elementsByAttributes =
       (await backButtonElement.getAttributes()) as unknown as {
         elements: { className: string }[];

--- a/FabricExample/e2e/helpers/versionComparator.ts
+++ b/FabricExample/e2e/helpers/versionComparator.ts
@@ -1,0 +1,36 @@
+function assertSupportedVersionString(version: string): asserts version is MajorVersion | MajorMinorVersion {
+    if (Number(version) === parseInt(version, 10)) {
+        return;
+    }
+    const parts = version.split('.');
+    if (parts.length === 2) {
+        const [major, minor] = parts;
+        if (Number(major) === parseInt(major, 10) && Number(minor) === parseInt(minor, 10)) {
+            return;
+        }
+    }
+    throw new Error(`Version string "${version}" is not a valid MAJOR or MAJOR.MINOR version.`);
+}
+
+export function isVersion(version: string) {
+    assertSupportedVersionString(version);
+    return {
+        equalOrHigherThan(versionToCompare: string) {
+            assertSupportedVersionString(versionToCompare);
+            return compareVersions(version, versionToCompare) >= 0;
+        },
+    }
+}
+
+function compareVersions(version: MajorVersion | MajorMinorVersion, versionToCompare: MajorVersion | MajorMinorVersion) {
+    const [majorA, minorA = '0'] = version.split('.').map(Number);
+    const [majorB, minorB = '0'] = versionToCompare.split('.').map(Number);
+    if (majorA !== majorB) {
+        return majorA - majorB;
+    } else {
+        return Number(minorA) - Number(minorB);
+    }
+}
+
+type MajorVersion = `${number}`;
+type MajorMinorVersion = `${number}.${number}`;

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -51,7 +51,6 @@
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.1",
     "@types/react-test-renderer": "^19.1.0",
-    "@types/semver": "^7",
     "babel-jest": "^29.6.3",
     "detox": "^20.45.1",
     "eslint": "^8.19.0",
@@ -59,7 +58,6 @@
     "patch-package": "^8.0.0",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.1",
-    "semver": "^7.7.3",
     "ts-jest": "^29.0.3",
     "typescript": "5.0.4"
   },

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -3076,13 +3076,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7":
-  version: 7.7.1
-  resolution: "@types/semver@npm:7.7.1"
-  checksum: 10c0/c938aef3bf79a73f0f3f6037c16e2e759ff40c54122ddf0b2583703393d8d3127130823facb880e694caa324eb6845628186aac1997ee8b31dc2d18fafe26268
-  languageName: node
-  linkType: hard
-
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -3323,7 +3316,6 @@ __metadata:
     "@types/jest": "npm:^29.5.13"
     "@types/react": "npm:^19.1.1"
     "@types/react-test-renderer": "npm:^19.1.0"
-    "@types/semver": "npm:^7"
     babel-jest: "npm:^29.6.3"
     detox: "npm:^20.45.1"
     eslint: "npm:^8.19.0"
@@ -3341,7 +3333,6 @@ __metadata:
     react-native-screens: "link:../"
     react-native-worklets: "npm:~0.6.0"
     react-test-renderer: "npm:19.1.1"
-    semver: "npm:^7.7.3"
     ts-jest: "npm:^29.0.3"
     typescript: "npm:5.0.4"
   languageName: unknown
@@ -9470,15 +9461,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.3":
-  version: 7.7.3
-  resolution: "semver@npm:7.7.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Applied optional suggestion (SemVer replaced with in-house impl)

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation: <!-- For adding new props to native-stack -->
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [ ] Ensured that CI passes
