### PR TITLE
chore: Bump material components version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'com.google.android.material:material:1.13.0'
     implementation "androidx.core:core-ktx:1.8.0"
 
     constraints {


### PR DESCRIPTION
## Description

This PR bumps the version of material components (com.google.android.material:material) to version 1.13.

## Test code and steps to reproduce

Tested FormShets, BottomTabs, Stack and Search component.