### PR TITLE
chore: Update docs about dropping the support for RN 0.79 since 4.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Here's a table with summary of supported `react-native` versions:
 
 | library version | react-native version |
 | --------------- | -------------------- |
-| 4.19.0+         | 0.80.0+              |
+| 4.19.0+         | 0.81.0+              |
 | 4.14.0+         | 0.79.0+              |
 | 4.5.0+          | 0.77.0+              |
 | 4.0.0+          | 0.76.0+              |


### PR DESCRIPTION
## Description

According to the policy of supporting 3 past versions of React Native, I'm adding a note that starting from `react-native-screens@4.19.0`, we are dropping support for `react-native@0.79.x`. I reviewed the code and did not find any specific version checks related to 0.79 that we need to remove (I only checked for 0.79, not earlier versions).

Fixes https://github.com/software-mansion/react-native-screens-labs/issues/702

## Changes

- Updated `README.md` docs

## Test code and steps to reproduce

N/A

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
