### PR TITLE
fix(iOS): Fix memory leaks in RNSScreen for brownfield environments

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -104,7 +104,7 @@ namespace react = facebook::react;
 @property (nonatomic) BOOL hideKeyboardOnSwipe;
 @property (nonatomic) BOOL customAnimationOnSwipe;
 @property (nonatomic) BOOL preventNativeDismiss;
-@property (nonatomic, retain) RNSScreen *controller;
+@property (nonatomic, weak) RNSScreen *controller;
 @property (nonatomic, copy) NSDictionary *gestureResponseDistance;
 @property (nonatomic) int activityState;
 @property (nonatomic, nullable) NSString *screenId;
@@ -212,6 +212,11 @@ namespace react = facebook::react;
  * tree.
  */
 - (BOOL)registerContentWrapper:(nonnull RNSScreenContentWrapper *)contentWrapper contentHeightErrata:(float)errata;
+
+/**
+ * Sets the retained controller to break the retain cycle.
+ */
+- (void)setRetainedController:(RNSScreen *_Nullable)controller;
 
 @end
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -53,6 +53,36 @@ struct ContentWrapperBox {
   float contentHeightErrata{0.f};
 };
 
+@interface RNSWeakProxy : NSProxy
+
+@property (nonatomic, weak, readonly) id target;
+
+- (instancetype)initWithTarget:(id)target;
+
+@end
+
+@implementation RNSWeakProxy
+
+- (instancetype)initWithTarget:(id)target
+{
+  _target = target;
+  return self;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
+{
+  return [_target methodSignatureForSelector:selector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  if (_target) {
+    [invocation invokeWithTarget:_target];
+  }
+}
+
+@end
+
 @interface RNSScreenView () <
     UIAdaptivePresentationControllerDelegate,
 #if !TARGET_OS_TV
@@ -69,6 +99,7 @@ struct ContentWrapperBox {
 
 @implementation RNSScreenView {
   __weak RNS_REACT_SCROLL_VIEW_COMPONENT *_sheetsScrollView;
+  RNSScreen *_retainedController;
 
   /// Up-to-date only when sheet is in `fitToContents` mode.
   CGFloat _sheetContentHeight;
@@ -121,7 +152,9 @@ struct ContentWrapperBox {
 
 - (void)initCommonProps
 {
-  _controller = [[RNSScreen alloc] initWithView:self];
+  RNSScreen *controller = [[RNSScreen alloc] initWithView:self];
+  _controller = controller;
+  _retainedController = controller;
   _stackPresentation = RNSScreenStackPresentationPush;
   _stackAnimation = RNSScreenStackAnimationDefault;
   _gestureEnabled = YES;
@@ -950,7 +983,13 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)invalidateImpl
 {
   _controller = nil;
+  _retainedController = nil;
   [_sheetsScrollView removeObserver:self forKeyPath:@"bounds" context:nil];
+}
+
+- (void)setRetainedController:(RNSScreen *)controller
+{
+  _retainedController = controller;
 }
 
 #ifndef RCT_NEW_ARCH_ENABLED
@@ -1861,6 +1900,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
       _previousFirstResponder = responder;
     }
   } else {
+    // When moving to a parent controller, release the retained controller
+    // The parent will now hold a strong reference to this controller
+    [self.screenView setRetainedController:nil];
     [self.screenView overrideScrollViewBehaviorInFirstDescendantChainIfNeeded];
     [self.screenView updateContentScrollViewEdgeEffectsIfExists];
   }
@@ -1884,6 +1926,11 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (void)setupProgressNotification
 {
+  // Clean up any existing animation timer before setting up a new one
+  // This prevents memory leaks when viewWillDisappear is called multiple times
+  [_animationTimer invalidate];
+  _animationTimer = nil;
+
   if (self.transitionCoordinator != nil) {
     if (!self.transitionCoordinator.isAnimated) {
       // If the transition is not animated, there is no point to set up animation
@@ -1898,7 +1945,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     auto animation = ^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
       [[context containerView] addSubview:self->_fakeView];
       self->_fakeView.alpha = 1.0;
-      self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
+      // Use weak proxy to prevent retain cycle between CADisplayLink and RNSScreen
+      RNSWeakProxy *weakProxy = [[RNSWeakProxy alloc] initWithTarget:self];
+      self->_animationTimer = [CADisplayLink displayLinkWithTarget:weakProxy selector:@selector(handleAnimation)];
       [self->_animationTimer addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     };
 
@@ -1907,6 +1956,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
                         completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
                           [self->_animationTimer setPaused:YES];
                           [self->_animationTimer invalidate];
+                          self->_animationTimer = nil;
                           [self->_fakeView removeFromSuperview];
                         }];
   }
@@ -2186,6 +2236,13 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 }
 
 #endif // RCT_NEW_ARCH_ENABLED
+
+- (void)dealloc
+{
+  // Clean up animation timer to prevent memory leaks
+  [_animationTimer invalidate];
+  _animationTimer = nil;
+}
 
 @end
 


### PR DESCRIPTION
## Description

This PR fixes critical memory leaks in `RNSScreen` that occur when React Native is completely dismissed in brownfield applications. In brownfield environments, when RN views and the Hermes engine are fully torn down, `RNSScreen` and related objects were not being deallocated, causing significant memory leaks.

**Root causes identified:**
1. **Retain cycle between RNSScreen ↔ RNSScreenView**: UIViewController holds a strong reference to its view, and RNSScreenView holds a strong reference back to controller
2. **CADisplayLink retain cycle**: CADisplayLink holds a strong reference to its target (self)
3. **Missing cleanup**: No `dealloc` method and incomplete timer cleanup in `setupProgressNotification`
4. **Lifecycle management**: Controller needs temporary strong reference until parent takes ownership

Fixes memory leaks in brownfield React Native environments.

## Changes

- Changed `RNSScreenView.controller` property from `strong` to `weak` reference
- Added `_retainedController` internal property to temporarily hold strong reference until parentViewController takes ownership
- Implemented `RNSWeakProxy` class using NSProxy pattern to break CADisplayLink retain cycle
- Added cleanup logic at the start of `setupProgressNotification` to handle multiple `viewWillDisappear` calls
- Added `dealloc` method to `RNSScreen` to properly clean up `_animationTimer`
- Added nil assignment after `invalidate` in completion block
- Release `_retainedController` in `willMoveToParentViewController` when parent takes ownership

## Test code and steps to reproduce

### Testing for memory leaks in brownfield environment:

**Prerequisites**: Brownfield iOS app with React Native integration

**Steps**:
1. Integrate this version of react-native-screens in your brownfield app
2. Present a React Native screen
3. Completely dismiss the React Native screen (tear down entire RN instance)
4. Use Xcode Instruments with "Leaks" template or check Allocations

**Verification**:
You can add a temporary log to verify dealloc is called:

```objc
// In RNSScreen.mm
- (void)dealloc
{
  NSLog(@"✅ RNSScreen dealloc called - memory leak fixed!");
  [_animationTimer invalidate];
  _animationTimer = nil;
}
```

When you completely dismiss RN, you should see the log message in console.

**Expected behavior**: 
- Before fix: RNSScreen remains in memory, dealloc never called
- After fix: RNSScreen is properly deallocated, log appears in console

### Testing in FabricExample:

```bash
cd FabricExample
yarn install
cd ios && pod install && cd ..
yarn ios
# Navigate through screens and observe memory behavior
```

## Checklist

- [ ] Included code example that can be used to test this change ✅ (Testing instructions above)
- [ ] Updated TS types ❌ (Not applicable - iOS-only memory management fix)
- [ ] Updated documentation: ❌ (Not applicable - internal implementation fix, no API changes)
  - [ ] GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] native-stack/README.md
  - [ ] src/types.tsx
  - [ ] src/native-stack/types.tsx
- [ ] Ensured that CI passes ⏳ (Will verify after PR submission)

---

**Note**: This is an iOS-only internal implementation fix with no API changes, so TypeScript types and documentation updates are not required.