### PR TITLE
refactor: Rename style to absoluteWithNoBottom in ScreenStackItem

### DIFF
--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -214,7 +214,7 @@ function getPositioningStyle(
   }
 
   if (isIOS) {
-    return styles.absolute;
+    return styles.absoluteWithNoBottom;
   }
 
   // Other platforms, tested reliably only on Android
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  absolute: {
+  absoluteWithNoBottom: {
     position: 'absolute',
     top: 0,
     start: 0,


### PR DESCRIPTION
## Description

As discussed in https://github.com/software-mansion/react-native-screens/pull/3454#discussion_r2598282283 , this name more precisely describes the style.

## Changes

- Rename

## Test code and steps to reproduce

N/A

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
