### PR TITLE
fix: Handle enabling interactions for RNSScreenStack that is moved to window

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -367,10 +367,16 @@ RNS_IGNORE_SUPER_CALL_END
     [self maybeAddToParentAndUpdateContainer];
   }
 #endif
-  if (self.window == nil) {
-    // When hot reload happens that would remove the whole stack, disabling the interaction on a screen out transition
-    // will not be matched with enabling the interactions on another screen's in transition. We need to make sure
-    // that the subtree is interactive again
+  if (@available(iOS 26, *)) {
+    // Re-enable interactions that have been disabled by screen transition
+    //
+    // There are some cases where stack screens cannot reenable the interactivity on their own.
+    // 1) When hot reload happens that would remove the whole stack, disabling the interaction on a screen out
+    // transition will not be matched with enabling the interactions on another screen's in transition. 2) In
+    // UIPageViewController, you can make a whole ScreenStack appear by switching pages. In this case we found out that
+    // the screen.viewDidAppear is called and enables interactions before willMoveToWindow that disables them.
+    //
+    // For these cases, we need ScreenStack to help making sure that the subtree is interactive again.
     [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
   }
 }


### PR DESCRIPTION
## Description

This fix handles the case where the whole nested ScreenStack is moved to window with UIPageViewController. The logic worked under the assumption that the nested stack is put inside outer stack's screen, but this is not the case here.

We had a similar case when the hierarchy changed on JS reload. The same fix can be used here by just removing a condition.

## Changes

Modified RNSScreenStack.didMoveToWindow

## Test code and steps to reproduce

Install `react-native-pager-view` and paste the following code into `App.tsx`:

```ts
import React, { useState } from 'react';
import PagerView from 'react-native-pager-view';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import { Button, ScrollView, Text, View } from 'react-native';
import { NavigationContainer, NavigationIndependentTree, NavigationProp } from '@react-navigation/native';

const OuterStack = createNativeStackNavigator();
const InnerStack = createNativeStackNavigator();

function Screen(props: { navigation: NavigationProp<any> }) {
  const [click, setClick] = useState(false);

  return (<>
    <Button title='click' onPress={() => setClick(c => !c)}/>
    <Button title='push' onPress={() => props.navigation.navigate('inner2')}/>
    { click && <Text>clicked</Text>}
  </>)
}

function Inner() {
    return (<NavigationIndependentTree>
      <PagerView style={{ flex: 1 }} initialPage={0} scrollEnabled={true}>
        <View key="0" style={{ backgroundColor: 'blue' }}>
          <Text>This Works</Text>
        </View>
        <View key="1" style={{ backgroundColor: 'red' }}>
          <NavigationContainer>
              <InnerStack.Navigator>
                <InnerStack.Screen name='inner' component={Screen} options={{ headerBackButtonDisplayMode: 'minimal' }} />
                <InnerStack.Screen name='inner2' component={Screen} options={{ headerBackButtonDisplayMode: 'minimal' }} />
              </InnerStack.Navigator>
          </NavigationContainer>
        </View>
        <View key="2" style={{ backgroundColor: 'red' }}>
          <NavigationContainer>
              <InnerStack.Navigator>
                <InnerStack.Screen name='inner' component={Screen} />
                <InnerStack.Screen name='inner2' component={Screen} />
              </InnerStack.Navigator>
          </NavigationContainer>
        </View>
      </PagerView>
    </NavigationIndependentTree>)
}

export default function App() {
  return (
    <NavigationContainer>
      <OuterStack.Navigator>
        <OuterStack.Screen name='outer' component={Inner} />
      </OuterStack.Navigator>
    </NavigationContainer>
  )
}
```