### PR TITLE
fix(iOS, Stack): Fix enum conversion for landscape right

### DIFF
--- a/ios/conversion/RNSConversions.mm
+++ b/ios/conversion/RNSConversions.mm
@@ -43,7 +43,7 @@ RNSOrientation RNSOrientationFromUIInterfaceOrientationMask(UIInterfaceOrientati
       return RNSOrientationLandscape;
     case UIInterfaceOrientationMaskLandscapeLeft:
       return RNSOrientationLandscapeLeft;
-    case UIInterfaceOrientationLandscapeRight:
+    case UIInterfaceOrientationMaskLandscapeRight:
       return RNSOrientationLandscapeRight;
     case UIInterfaceOrientationMaskPortraitUpsideDown:
       return RNSOrientationPortraitDown;


### PR DESCRIPTION
## Description

There was a typo, mask should be used instead of UIDeviceOrientation value.

Fixes: https://github.com/software-mansion/react-native-screens/issues/3473

## Test code and steps to reproduce

`Orientation.tsx`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
