### PR TITLE
fix(Android): crash on hot reload when FabricUIManagerBinding is null

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp
@@ -7,16 +7,19 @@ namespace facebook {
 namespace react {
 
 RNSScreenShadowNodeCommitHook::RNSScreenShadowNodeCommitHook(
-    std::shared_ptr<const ContextContainer> contextContainer)
-    : contextContainer_(contextContainer) {
-  getUIManagerFromSharedContext(contextContainer)->registerCommitHook(*this);
+    const std::shared_ptr<const ContextContainer> &contextContainer) {
+  if (auto uiManager = getUIManagerFromSharedContext(contextContainer)) {
+    uiManager->registerCommitHook(*this);
+  }
 }
 
 RNSScreenShadowNodeCommitHook::~RNSScreenShadowNodeCommitHook() noexcept {
-  // Note: We intentionally don't unregister the commit hook here.
+  // We intentionally don't unregister the commit hook here.
   // During hot reload, the FabricUIManagerBinding may already be destroyed
   // when this destructor is called, causing a JNI crash when trying to
-  // access the binding. The UIManager will clean up hooks when it's destroyed.
+  // access the binding. The UIManager will clean up hooks when it's destroyed
+  // In case the lifecycle of the commit hook should be shorter than
+  // that of the UIManager consider unregistering the hook manually.
 }
 
 RootShadowNode::Unshared RNSScreenShadowNodeCommitHook::shadowTreeWillCommit(
@@ -29,8 +32,8 @@ RootShadowNode::Unshared RNSScreenShadowNodeCommitHook::shadowTreeWillCommit(
   auto newRootProps =
       std::static_pointer_cast<const RootProps>(newRootShadowNode->getProps());
 
-  const bool wasHorizontal = isHorizontal_(*oldRootProps.get());
-  const bool willBeHorizontal = isHorizontal_(*newRootProps.get());
+  const bool wasHorizontal = isHorizontal_(*oldRootProps);
+  const bool willBeHorizontal = isHorizontal_(*newRootProps);
 
   if (wasHorizontal != willBeHorizontal) {
     return newRootShadowNodeWithScreenFrameSizesReset(newRootShadowNode);
@@ -86,14 +89,37 @@ void RNSScreenShadowNodeCommitHook::findScreenNodes(
   }
 }
 
+/**
+ * This method might return nullptr. See its implementation for details.
+ */
 std::shared_ptr<UIManager>
 RNSScreenShadowNodeCommitHook::getUIManagerFromSharedContext(
-    std::shared_ptr<const ContextContainer> sharedContext) {
+    const std::shared_ptr<const ContextContainer> &sharedContext) {
+  if (sharedContext == nullptr) {
+    return nullptr;
+  }
+
   auto fabricUIManager =
       sharedContext
           ->at<jni::alias_ref<facebook::react::JFabricUIManager::javaobject>>(
               "FabricUIManager");
-  return fabricUIManager->getBinding()->getScheduler()->getUIManager();
+  if (fabricUIManager == nullptr) {
+    return nullptr;
+  }
+
+  // This line might still crash in case the FabricUIManager.mBinding (Java
+  // class) is at this moment `null`.
+  auto *fabricUiManagerBinding = fabricUIManager->getBinding();
+  if (fabricUiManagerBinding == nullptr) {
+    return nullptr;
+  }
+
+  auto scheduler = fabricUiManagerBinding->getScheduler();
+  if (scheduler == nullptr) {
+    return nullptr;
+  }
+
+  return scheduler->getUIManager();
 }
 
 } // namespace react

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
@@ -13,7 +13,8 @@ class RNSScreenComponentDescriptor;
 
 class RNSScreenShadowNodeCommitHook : public UIManagerCommitHook {
  public:
-  RNSScreenShadowNodeCommitHook(std::shared_ptr<const ContextContainer>);
+  RNSScreenShadowNodeCommitHook(
+      const std::shared_ptr<const ContextContainer> &);
 
   virtual ~RNSScreenShadowNodeCommitHook() noexcept override;
 
@@ -28,8 +29,6 @@ class RNSScreenShadowNodeCommitHook : public UIManagerCommitHook {
       const ShadowTreeCommitOptions & /*commitOptions*/) noexcept override;
 
  private:
-  std::weak_ptr<const ContextContainer> contextContainer_;
-
   static inline bool isHorizontal_(const RootProps &props) {
     const auto &layoutConstraints = props.layoutConstraints;
     const float width = layoutConstraints.maximumSize.width;
@@ -46,7 +45,7 @@ class RNSScreenShadowNodeCommitHook : public UIManagerCommitHook {
       std::vector<const RNSScreenShadowNode *> &screenNodes);
 
   static std::shared_ptr<UIManager> getUIManagerFromSharedContext(
-      std::shared_ptr<const ContextContainer> sharedContext);
+      const std::shared_ptr<const ContextContainer> &sharedContext);
 };
 
 } // namespace react


### PR DESCRIPTION
Fixes #3476

## Description

The destructor of `RNSScreenShadowNodeCommitHook` crashes during hot reload because it tries to access `FabricUIManagerBinding` after the React instance has been destroyed.

## Root Cause

The crash occurs because:
1. Hot reload destroys the React instance
2. `FabricUIManagerBinding` becomes null
3. The `CommitHook` destructor tries to unregister itself
4. `getUIManagerFromSharedContext()` calls `getBinding()` which accesses null
5. JNI crashes when accessing the null object's field

This bug was introduced in #3295 (commit 91b17d555).

## Changes

Remove the unregister call from the destructor. This is safe because the `UIManager` automatically cleans up all registered hooks when it's destroyed, so manual unregistration is unnecessary.

## Test Code and Steps to Reproduce

1. Create any app with `@react-navigation/native-stack`
2. Enable New Architecture on Android
3. Run the app in development mode
4. Press `r` to hot reload
5. **Before fix**: App crashes with SIGABRT
6. **After fix**: App reloads successfully

## Crash Log (Before Fix)

```
F libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE)
JNI DETECTED ERROR IN APPLICATION: field operation on NULL object: 0x0
  in call to GetObjectField
  from void com.facebook.jni.HybridData$Destructor.deleteNative(long)
```

## Stack Trace

```
#16 facebook::react::JFabricUIManager::getBinding()
#17 facebook::react::RNSScreenShadowNodeCommitHook::getUIManagerFromSharedContext
#18 facebook::react::RNSScreenShadowNodeCommitHook::~RNSScreenShadowNodeCommitHook
```

## Environment

- React Native: 0.83.0-rc.3 / 0.83.0-rc.5
- react-native-screens: 4.19.0-nightly-20251203
- Architecture: New Architecture (Fabric + Bridgeless)
- Platform: Android