### PR TITLE
fix(iOS, Tabs): use clearColor background to prevent flash during tab transitions

### DIFF
--- a/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.mm
@@ -70,10 +70,10 @@ namespace react = facebook::react;
   _scrollEdgeEffectsNeedUpdate = NO;
 #endif
 
-  // Prevents incorrect tab bar appearance after tab change on iOS 26.0
-  // TODO: verify if it's still necessary on iOS 26.1
+  // Use clearColor to prevent any background flash during tab transitions.
+  // This ensures compatibility with both light and dark themes.
 #if !TARGET_OS_TV
-  self.backgroundColor = [UIColor systemBackgroundColor];
+  self.backgroundColor = [UIColor clearColor];
 #endif // !TARGET_OS_TV
 
   [self resetProps];


### PR DESCRIPTION
Previously using systemBackgroundColor, which could cause a visible flash of white or black background during tab transitions in apps with custom themes. Using clearColor ensures the background is transparent, preventing any visual artifacts regardless of the app's color scheme.

Fixes #3472 

## Description

When using NativeTabs with custom app themes (especially dark themes), there can be a brief flash of the system background color during tab transitions. Using `clearColor` makes the background fully transparent, preventing any flash regardless of the app's color scheme.

## Changes

- Changed `self.backgroundColor` from `[UIColor systemBackgroundColor]` to `[UIColor clearColor]` in `RNSBottomTabsScreenComponentView.mm`

## Test code and steps to reproduce

```tsx
import { Tabs } from 'expo-router/tabs';

export default function TabLayout() {
  return (
    <Tabs
      screenOptions={{
        tabBarStyle: { backgroundColor: '#1a1a2e' },
      }}
    >
      <Tabs.Screen name="index" options={{ title: 'Home' }} />
      <Tabs.Screen name="settings" options={{ title: 'Settings' }} />
    </Tabs>
  );
}
```

1. Create app with dark theme
2. Switch between screens rapidly
3. **Before:** Brief flash of system background color visible around edges
4. **After:** No flash, smooth transitions

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation:
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/native-stack/README.md
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx
  - [ ] https://github.com/software-mansion/react-native-screens/blob/main/src/native-stack/types.tsx
- [x] Ensured that CI passes