### PR TITLE
chore(Stack): rename components related to new stack

### DIFF
--- a/apps/src/shared/gamma/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
-  ScreenStackHost,
-  StackScreen,
+  Stack,
   StackScreenLifecycleState,
 } from 'react-native-screens/experimental';
 import type { StackScreenProps } from 'react-native-screens/experimental';
@@ -148,9 +147,9 @@ export function StackContainer({ pathConfigs }: StackContainerProps) {
   console.log('StackContainer render', stack);
 
   return (
-    <ScreenStackHost>
+    <Stack.Host>
       {stack.map(({ component: Component, ...screenProps }) => (
-        <StackScreen
+        <Stack.Screen
           key={screenProps.screenKey}
           {...screenProps}
           onPop={handlePop}>
@@ -162,8 +161,8 @@ export function StackContainer({ pathConfigs }: StackContainerProps) {
             }}>
             <Component />
           </StackNavigationContext.Provider>
-        </StackScreen>
+        </Stack.Screen>
       ))}
-    </ScreenStackHost>
+    </Stack.Host>
   );
 }

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -1,0 +1,14 @@
+import ScreenStackHost from './ScreenStackHost';
+import StackScreen from './StackScreen';
+
+export { StackScreenLifecycleState } from './StackScreen';
+
+export * from './ScreenStackHost.types';
+export * from './StackScreen.types';
+
+const Stack = {
+  Host: ScreenStackHost,
+  Screen: StackScreen,
+};
+
+export default Stack;

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -8,11 +8,11 @@ export * from './types';
 
 // Components
 
-export { default as ScreenStackHost } from '../components/gamma/stack/ScreenStackHost';
 export {
-  default as StackScreen,
+  default as Stack,
   StackScreenLifecycleState,
-} from '../components/gamma/stack/StackScreen';
+} from '../components/gamma/stack';
+
 export { default as SplitViewHost } from '../components/gamma/split-view/SplitViewHost';
 export { default as SplitViewScreen } from '../components/gamma/split-view/SplitViewScreen';
 export { default as SafeAreaView } from '../components/safe-area/SafeAreaView';


### PR DESCRIPTION

Closes https://github.com/software-mansion/react-native-screens-labs/issues/734

This PR renames `ScreenStackHost` and `StackScreen` components.

They are now grouped under `Stack` "namespace object" and can be used as follows:

```tsx
    <Stack.Host>
      {stack.map(({ component: Component, ...screenProps }) => (
        <Stack.Screen
          key={screenProps.screenKey}
          {...screenProps}
          onPop={handlePop}>
          <StackNavigationContext.Provider
            value={{
              ...screenProps,
              pop,
              push,
            }}>
            <Component />
          </StackNavigationContext.Provider>
        </Stack.Screen>
      ))}
    </Stack.Host>
```

I've also updated relevant test examples.
