### PR TITLE
fix(iOS, Stack): center subview not visible/misaligned in header

### DIFF
--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -174,12 +174,7 @@ RNS_IGNORE_SUPER_CALL_BEGIN
         self);
   } else {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-    BOOL needsAutoLayout = NO;
-    if (@available(iOS 26.0, *)) {
-      needsAutoLayout = _type == RNSScreenStackHeaderSubviewTypeLeft || _type == RNSScreenStackHeaderSubviewTypeRight;
-    }
-
-    if (needsAutoLayout) {
+    if (self.needsAutoLayout) {
       BOOL sizeHasChanged = _layoutMetrics.frame.size != layoutMetrics.frame.size;
       _layoutMetrics = layoutMetrics;
       if (sizeHasChanged) {
@@ -214,12 +209,7 @@ RNS_IGNORE_SUPER_CALL_END
   // makes UINavigationBar the only one to control the position of header content.
   if (!CGSizeEqualToSize(frame.size, self.frame.size)) {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-    BOOL needsAutoLayout = NO;
-    if (@available(iOS 26.0, *)) {
-      needsAutoLayout = _type == RNSScreenStackHeaderSubviewTypeLeft || _type == RNSScreenStackHeaderSubviewTypeRight;
-    }
-
-    if (needsAutoLayout) {
+    if (self.needsAutoLayout) {
       _lastReactFrameSize = frame.size;
       [self invalidateIntrinsicContentSize];
     } else
@@ -232,6 +222,22 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 #endif // RCT_NEW_ARCH_ENABLED
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
+// Starting from iOS 26, to center left and right subviews inside liquid glass backdrop,
+// we need to use auto layout. To make Yoga's layout work with auto layout, we pass information
+// from Yoga via `intrinsicContentSize`.
+- (BOOL)needsAutoLayout
+{
+  BOOL needsAutoLayout = NO;
+  if (@available(iOS 26.0, *)) {
+    needsAutoLayout = _type == RNSScreenStackHeaderSubviewTypeLeft || _type == RNSScreenStackHeaderSubviewTypeRight;
+  }
+  return needsAutoLayout;
+}
+
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 
 #pragma mark - UIBarButtonItem specific
 


### PR DESCRIPTION
## Description

Fixes missing/misaligned center subview in header on iOS.

| before | after |
| --- | --- |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/b38a076e-3d80-42f5-8bd3-12a649e856f1" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/81ddc53d-f6a2-46fc-9a5b-566c42828408" /> |

Fixes https://github.com/software-mansion/react-native-screens/issues/3482.

## Changes

- limit wrapping subviews and related logic to left and right subviews only on iOS 26+ (previously, there was only an SDK macro, without runtime check)

## Test code and steps to reproduce

Run `Test3446` to verify that pressables are still working. To test center subview, use:

<details>
<summary>Test example</summary>

```tsx
import React from 'react';
import { View, Text } from 'react-native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import Colors from '../shared/styling/Colors';

function MainScreen() {
  return <View style={{ backgroundColor: 'moccasin' }} />;
}

const Stack = createNativeStackNavigator();

export default function App() {
  return (
    <Stack.Navigator>
      <Stack.Screen
        name="Main"
        component={MainScreen}
        options={{
          headerLeft: () => <Text>a</Text>,
          headerTitle: () => <Text>b</Text>,
          headerRight: () => <Text>c</Text>,
          headerBackground: () => (
            <View
              style={{
                backgroundColor: Colors.PurpleLight80,
                width: '100%',
                height: 120,
              }}
            />
          ),
        }}
      />
    </Stack.Navigator>
  );
}
```
</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
