### PR TITLE
chore(JS): use new platform specific icon syntax in tests

### DIFF
--- a/apps/src/tests/Test3168.tsx
+++ b/apps/src/tests/Test3168.tsx
@@ -205,7 +205,10 @@ function TabsStackComponent() {
         tabKey: 'main',
         title: 'Main',
         icon: {
-          sfSymbolName: 'house',
+          ios: {
+            type: 'sfSymbol',
+            name: 'house',
+          },
         },
       },
       component: () => Menu({ tabsMode: true }),
@@ -215,7 +218,10 @@ function TabsStackComponent() {
         tabKey: 'another',
         title: 'Another',
         icon: {
-          sfSymbolName: 'ellipsis',
+          ios: {
+            type: 'sfSymbol',
+            name: 'ellipsis',
+          },
         },
       },
       component: AnotherTab,
@@ -225,7 +231,10 @@ function TabsStackComponent() {
         tabKey: 'examples',
         title: 'Search',
         icon: {
-          sfSymbolName: 'magnifyingglass',
+          ios: {
+            type: 'sfSymbol',
+            name: 'magnifyingglass',
+          },
         },
         systemItem: searchBarConfig.useSystemItem ? 'search' : undefined,
       },

--- a/apps/src/tests/Test3236.tsx
+++ b/apps/src/tests/Test3236.tsx
@@ -58,7 +58,10 @@ function App() {
         title: 'Tab 1',
         freezeContents: false,
         icon: {
-          sfSymbolName: 'sun.max',
+          ios: {
+            type: 'sfSymbol',
+            name: 'sun.max',
+          },
         },
         iconResourceName: 'sunny',
       },
@@ -69,7 +72,10 @@ function App() {
         tabKey: 'Tab2',
         title: 'Tab 2',
         icon: {
-          sfSymbolName: 'snow',
+          ios: {
+            type: 'sfSymbol',
+            name: 'snow',
+          },
         },
         iconResourceName: 'mode_cool',
       },

--- a/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
@@ -21,7 +21,10 @@ export default function BottomTabsComponent() {
         tabKey: 'config',
         title: 'Config',
         icon: {
-          sfSymbolName: 'gear',
+          ios: {
+            type: 'sfSymbol',
+            name: 'gear',
+          },
         },
       },
       component: ConfigTab,
@@ -31,7 +34,10 @@ export default function BottomTabsComponent() {
         tabKey: 'test',
         title: 'Test',
         icon: {
-          sfSymbolName: 'uiwindow.split.2x1',
+          ios: {
+            type: 'sfSymbol',
+            name: 'uiwindow.split.2x1',
+          },
         },
         systemItem:
           config.tabBarItemSystemItem !== 'disabled'
@@ -60,7 +66,10 @@ export default function BottomTabsComponent() {
         config: tabsConfig,
         setConfig: setTabsConfig,
       }}>
-      <BottomTabsContainer tabConfigs={TAB_CONFIGS} tabBarMinimizeBehavior={config.tabBarMinimizeBehavior} />
+      <BottomTabsContainer
+        tabConfigs={TAB_CONFIGS}
+        tabBarMinimizeBehavior={config.tabBarMinimizeBehavior}
+      />
     </ConfigWrapperContext.Provider>
   );
 }

--- a/apps/src/tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
+++ b/apps/src/tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
@@ -23,7 +23,10 @@ export default function ConfigColumn({
           tabKey: 'column' + index,
           title: 'Column ' + index,
           icon: {
-            sfSymbolName: index + '.circle',
+            ios: {
+              type: 'sfSymbol',
+              name: index + '.circle',
+            },
           },
         },
         component: () => ConfigColumnTab({ index, configColumnIndex }),


### PR DESCRIPTION
## Description

Updates test screens to use new platform specific icon API (introduced in https://github.com/software-mansion/react-native-screens/pull/3214).

Closes https://github.com/software-mansion/react-native-screens-labs/issues/738.

## Changes

- use new icon API in test screens

## Test code and steps to reproduce

Run example app with affected tests.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
