### PR TITLE
feat(Tabs): allow full tabs background color styling

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.WindowInsets
 import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import com.facebook.react.modules.core.ReactChoreographer
@@ -226,6 +227,12 @@ class TabsHost(
         if (newValue != oldValue) {
             updateInterfaceInsets()
             updateNavigationMenuIfNeeded(oldValue, newValue)
+        }
+    }
+
+    var nativeContainerBackgroundColor: Int? by Delegates.observable(null) { _, oldValue, newValue ->
+        if (newValue != oldValue) {
+            background = newValue?.toDrawable()
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -150,6 +150,14 @@ class TabsHostViewManager :
         view.tabBarHidden = value
     }
 
+    @ReactProp(name = "nativeContainerBackgroundColor", customType = "Color")
+    override fun setNativeContainerBackgroundColor(
+        view: TabsHost,
+        value: Int?,
+    ) {
+        view.nativeContainerBackgroundColor = value
+    }
+
     // Android additional
 
     @ReactProp(name = "tabBarItemTitleFontColorActive", customType = "Color")

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerDelegate.java
@@ -24,6 +24,12 @@ public class RNSBottomTabsManagerDelegate<T extends View, U extends BaseViewMana
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
+      case "tabBarHidden":
+        mViewManager.setTabBarHidden(view, value == null ? false : (boolean) value);
+        break;
+      case "nativeContainerBackgroundColor":
+        mViewManager.setNativeContainerBackgroundColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
       case "tabBarBackgroundColor":
         mViewManager.setTabBarBackgroundColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
@@ -74,9 +80,6 @@ public class RNSBottomTabsManagerDelegate<T extends View, U extends BaseViewMana
         break;
       case "tabBarControllerMode":
         mViewManager.setTabBarControllerMode(view, (String) value);
-        break;
-      case "tabBarHidden":
-        mViewManager.setTabBarHidden(view, value == null ? false : (boolean) value);
         break;
       case "controlNavigationStateInJS":
         mViewManager.setControlNavigationStateInJS(view, value == null ? false : (boolean) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSBottomTabsManagerInterface.java
@@ -14,6 +14,8 @@ import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
 public interface RNSBottomTabsManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+  void setTabBarHidden(T view, boolean value);
+  void setNativeContainerBackgroundColor(T view, @Nullable Integer value);
   void setTabBarBackgroundColor(T view, @Nullable Integer value);
   void setTabBarItemTitleFontFamily(T view, @Nullable String value);
   void setTabBarItemTitleFontSize(T view, float value);
@@ -31,6 +33,5 @@ public interface RNSBottomTabsManagerInterface<T extends View> extends ViewManag
   void setTabBarTintColor(T view, @Nullable Integer value);
   void setTabBarMinimizeBehavior(T view, @Nullable String value);
   void setTabBarControllerMode(T view, @Nullable String value);
-  void setTabBarHidden(T view, boolean value);
   void setControlNavigationStateInJS(T view, boolean value);
 }

--- a/apps/src/tests/Test3492.tsx
+++ b/apps/src/tests/Test3492.tsx
@@ -1,0 +1,479 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  useWindowDimensions,
+  ColorValue,
+} from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+
+import {
+  BottomTabsContainer,
+  type TabConfiguration,
+} from '../shared/gamma/containers/bottom-tabs/BottomTabsContainer';
+import Colors from '../shared/styling/Colors';
+import ConfigWrapperContext, {
+  Configuration,
+  DEFAULT_GLOBAL_CONFIGURATION,
+} from '../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
+import LongText from '../shared/LongText';
+
+type TabKey = 'Tab2' | 'Tab3' | 'Tab4';
+
+type ContentType = 'view' | 'scrollViewWithText' | 'scrollViewWithRects';
+
+type RectConfig = {
+  height: number;
+  gap: number;
+};
+
+type SingleTabConfig = {
+  navBackground: string;
+  reactBackground: string;
+  contentType: ContentType;
+  rectConfig: RectConfig;
+};
+
+type AppConfig = {
+  containerBackground: string;
+  tabs: Record<TabKey, SingleTabConfig>;
+};
+
+type BackgroundContextType = {
+  config: AppConfig;
+  setConfig: Dispatch<SetStateAction<AppConfig>>;
+  applyPreset: (preset: AppConfig) => void;
+};
+
+const DEFAULT_RECT_CONFIG: RectConfig = {
+  height: 100,
+  gap: 20,
+};
+
+const DEFAULT_TAB_CONFIG: SingleTabConfig = {
+  navBackground: Colors.White,
+  reactBackground: 'transparent',
+  contentType: 'view',
+  rectConfig: DEFAULT_RECT_CONFIG,
+};
+
+const INITIAL_CONFIG: AppConfig = {
+  containerBackground: Colors.White,
+  tabs: {
+    Tab2: { ...DEFAULT_TAB_CONFIG, contentType: 'view' },
+    Tab3: { ...DEFAULT_TAB_CONFIG, contentType: 'scrollViewWithText' },
+    Tab4: { ...DEFAULT_TAB_CONFIG, contentType: 'scrollViewWithRects' },
+  },
+};
+
+const PRESETS: Record<string, AppConfig> = {
+  Default: INITIAL_CONFIG,
+};
+
+const BackgroundTestContext = createContext<BackgroundContextType | null>(null);
+
+const useBackgroundTestContext = () => {
+  const context = useContext(BackgroundTestContext);
+  if (!context)
+    throw new Error('useBackgroundTestContext must be used within provider');
+  return context;
+};
+
+const ConfigSection = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <View
+    style={{
+      marginBottom: 20,
+      padding: 10,
+      backgroundColor: '#f0f0f0',
+      borderRadius: 8,
+    }}>
+    <Text style={{ fontWeight: 'bold', marginBottom: 10, fontSize: 16 }}>
+      {title}
+    </Text>
+    {children}
+  </View>
+);
+
+const SimplePicker = ({
+  label,
+  value,
+  options,
+  onChange,
+  type = 'normal',
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (option: string) => void;
+  type?: 'normal' | 'color';
+}) => (
+  <View style={{ marginBottom: 10 }}>
+    <Text style={{ fontSize: 12, color: 'gray' }}>
+      {label}: {value}
+    </Text>
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{
+        gap: 12,
+        paddingVertical: 10,
+        paddingHorizontal: 5,
+      }}>
+      {options.map((opt: string) => (
+        <Pressable
+          key={opt}
+          onPress={() => onChange(opt)}
+          style={{
+            padding: 8,
+            backgroundColor: 'white',
+            borderRadius: 6,
+            borderWidth: 2,
+            borderColor: type === 'color' ? opt : '#ddd',
+            shadowColor: '#000',
+            shadowOffset: {
+              width: 0,
+              height: 1,
+            },
+            shadowOpacity: 0.22,
+            shadowRadius: 2.22,
+
+            elevation: 3,
+            transform: [{ scale: value === opt ? 1.2 : 1 }],
+          }}>
+          <Text
+            style={{
+              color: 'black',
+              fontSize: 12,
+            }}>
+            {opt}
+          </Text>
+        </Pressable>
+      ))}
+    </ScrollView>
+  </View>
+);
+
+const RectsGenerator = ({ config }: { config: RectConfig }) => {
+  const { width } = useWindowDimensions();
+  const sidePadding = 30;
+
+  return (
+    <View
+      style={{
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: config.gap,
+        paddingVertical: config.gap,
+      }}>
+      {[...Array(20).keys()].map(i => (
+        <View
+          key={i}
+          style={{
+            width: width - sidePadding * 2,
+            height: config.height,
+            backgroundColor: Colors.PurpleLight80,
+            justifyContent: 'center',
+            alignItems: 'center',
+            borderRadius: 4,
+          }}>
+          <Text style={{ color: 'white', fontWeight: 'bold' }}>{i + 1}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const TestScreenRenderer = ({ tabKey }: { tabKey: TabKey }) => {
+  const { config } = useBackgroundTestContext();
+  const tabConfig = config.tabs[tabKey];
+
+  const Container = tabConfig.contentType === 'view' ? View : ScrollView;
+
+  return (
+    <Container
+      style={{ flex: 1, backgroundColor: tabConfig.reactBackground }}
+      contentContainerStyle={
+        tabConfig.contentType !== 'view' ? { flexGrow: 1 } : undefined
+      }>
+      {tabConfig.contentType === 'view' && (
+        <View
+          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <Text style={{ fontSize: 24, fontWeight: 'bold' }}>
+            Hello {tabKey}
+          </Text>
+          <Text>Bg: {tabConfig.reactBackground}</Text>
+        </View>
+      )}
+
+      {tabConfig.contentType === 'scrollViewWithText' && <LongText size="xl" />}
+
+      {tabConfig.contentType === 'scrollViewWithRects' && (
+        <RectsGenerator config={tabConfig.rectConfig} />
+      )}
+    </Container>
+  );
+};
+
+function ConfigScreen() {
+  const { config, setConfig, applyPreset } = useBackgroundTestContext();
+
+  const updateTab = (key: TabKey, update: Partial<SingleTabConfig>) => {
+    setConfig(prev => ({
+      ...prev,
+      tabs: {
+        ...prev.tabs,
+        [key]: { ...prev.tabs[key], ...update },
+      },
+    }));
+  };
+
+  const updateRects = (key: TabKey, update: Partial<RectConfig>) => {
+    setConfig(prev => ({
+      ...prev,
+      tabs: {
+        ...prev.tabs,
+        [key]: {
+          ...prev.tabs[key],
+          rectConfig: { ...prev.tabs[key].rectConfig, ...update },
+        },
+      },
+    }));
+  };
+
+  const colors = [
+    Colors.White,
+    Colors.PurpleLight40,
+    Colors.BlueLight40,
+    Colors.NavyDark140,
+    'transparent',
+  ];
+  const contentTypes = ['view', 'scrollViewWithText', 'scrollViewWithRects'];
+
+  return (
+    <ScrollView
+      contentContainerStyle={{
+        padding: 16,
+        paddingTop: 60,
+        paddingBottom: 100,
+      }}>
+      <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 20 }}>
+        Background Tester
+      </Text>
+
+      <ConfigSection title="Presets">
+        <ScrollView horizontal contentContainerStyle={{ gap: 10 }}>
+          {Object.keys(PRESETS).map(name => (
+            <Pressable
+              key={name}
+              style={{
+                padding: 8,
+                backgroundColor: 'white',
+                borderRadius: 6,
+                borderWidth: 1,
+                borderColor: '#ddd',
+              }}
+              onPress={() => applyPreset(PRESETS[name])}>
+              <Text>{name}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </ConfigSection>
+
+      <ConfigSection title="Global Container">
+        <SimplePicker
+          type="color"
+          label="Native Container Style BG"
+          value={config.containerBackground}
+          options={colors}
+          onChange={(c: string) =>
+            setConfig(p => ({ ...p, containerBackground: c }))
+          }
+        />
+      </ConfigSection>
+
+      {(Object.keys(config.tabs) as TabKey[]).map(key => {
+        const tConfig = config.tabs[key];
+        return (
+          <ConfigSection key={key} title={`Config: ${key}`}>
+            <SimplePicker
+              type="color"
+              label="Tab Props Style BG"
+              value={tConfig.navBackground}
+              options={colors}
+              onChange={(c: string) => updateTab(key, { navBackground: c })}
+            />
+            <SimplePicker
+              type="color"
+              label="React View BG"
+              value={tConfig.reactBackground}
+              options={colors}
+              onChange={(c: string) => updateTab(key, { reactBackground: c })}
+            />
+            <SimplePicker
+              label="Content Type"
+              value={tConfig.contentType}
+              options={contentTypes}
+              onChange={(c: any) => updateTab(key, { contentType: c })}
+            />
+
+            {tConfig.contentType === 'scrollViewWithRects' && (
+              <View
+                style={{
+                  marginTop: 10,
+                  padding: 10,
+                  backgroundColor: '#fff',
+                  borderRadius: 4,
+                }}>
+                <Text style={{ fontWeight: 'bold' }}>Rect Configs:</Text>
+                <SimplePicker
+                  label="Item Height"
+                  value={String(tConfig.rectConfig.height)}
+                  options={['50', '100', '200', '400']}
+                  onChange={(v: string) =>
+                    updateRects(key, { height: parseFloat(v) })
+                  }
+                />
+                <SimplePicker
+                  label="Gap Size"
+                  value={String(tConfig.rectConfig.gap)}
+                  options={['0', '10', '20', '50', '100']}
+                  onChange={(v: string) =>
+                    updateRects(key, { gap: parseFloat(v) })
+                  }
+                />
+              </View>
+            )}
+          </ConfigSection>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function ScreenTab2() {
+  return <TestScreenRenderer tabKey="Tab2" />;
+}
+function ScreenTab3() {
+  return <TestScreenRenderer tabKey="Tab3" />;
+}
+function ScreenTab4() {
+  return <TestScreenRenderer tabKey="Tab4" />;
+}
+
+function Tabs() {
+  const [tabsConfig, setTabsConfig] = React.useState<Configuration>(
+    DEFAULT_GLOBAL_CONFIGURATION,
+  );
+  const { config } = useBackgroundTestContext();
+
+  const dynamicTabConfigs = useMemo<TabConfiguration[]>(
+    () => [
+      {
+        tabScreenProps: {
+          tabKey: 'Tab1',
+          title: 'Config',
+          icon: {
+            ios: { type: 'sfSymbol', name: 'gear' },
+          },
+          style: { backgroundColor: Colors.White },
+        },
+        safeAreaConfiguration: {
+          edges: {
+            bottom: true,
+          },
+        },
+        component: ConfigScreen,
+      },
+      {
+        tabScreenProps: {
+          tabKey: 'Tab2',
+          title: 'Tab 2',
+          icon: { ios: { type: 'sfSymbol', name: 'square' } },
+          style: { backgroundColor: config.tabs.Tab2.navBackground },
+        },
+        safeAreaConfiguration: {
+          edges: {
+            bottom: true,
+          },
+        },
+        component: ScreenTab2,
+      },
+      {
+        tabScreenProps: {
+          tabKey: 'Tab3',
+          title: 'Tab 3',
+          icon: { ios: { type: 'sfSymbol', name: 'triangle' } },
+          style: { backgroundColor: config.tabs.Tab3.navBackground },
+        },
+        safeAreaConfiguration: {
+          edges: {
+            bottom: true,
+          },
+        },
+        component: ScreenTab3,
+      },
+      {
+        tabScreenProps: {
+          tabKey: 'Tab4',
+          title: 'Tab 4',
+          icon: { ios: { type: 'sfSymbol', name: 'circle' } },
+          style: { backgroundColor: config.tabs.Tab4.navBackground },
+        },
+        safeAreaConfiguration: {
+          edges: {
+            bottom: true,
+          },
+        },
+        component: ScreenTab4,
+      },
+    ],
+    [config],
+  );
+
+  return (
+    <ConfigWrapperContext.Provider
+      value={{
+        config: tabsConfig,
+        setConfig: setTabsConfig,
+      }}>
+      <BottomTabsContainer
+        tabConfigs={dynamicTabConfigs}
+        nativeContainerStyle={{ backgroundColor: config.containerBackground }}
+      />
+    </ConfigWrapperContext.Provider>
+  );
+}
+
+function App() {
+  const [config, setConfig] = useState<AppConfig>(INITIAL_CONFIG);
+
+  return (
+    <NavigationContainer>
+      <BackgroundTestContext.Provider
+        value={{
+          config,
+          setConfig,
+          applyPreset: newConfig => setConfig(newConfig),
+        }}>
+        <Tabs />
+      </BackgroundTestContext.Provider>
+    </NavigationContainer>
+  );
+}
+
+export default App;

--- a/apps/src/tests/Test3492.tsx
+++ b/apps/src/tests/Test3492.tsx
@@ -12,7 +12,6 @@ import {
   ScrollView,
   Pressable,
   useWindowDimensions,
-  ColorValue,
 } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 
@@ -26,6 +25,7 @@ import ConfigWrapperContext, {
   DEFAULT_GLOBAL_CONFIGURATION,
 } from '../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
 import LongText from '../shared/LongText';
+import { someExtensiveComputation } from './TestBottomTabs/utils';
 
 type TabKey = 'Tab2' | 'Tab3' | 'Tab4';
 
@@ -39,6 +39,7 @@ type RectConfig = {
 type SingleTabConfig = {
   navBackground: string;
   reactBackground: string;
+  isHeavy: 'true' | 'false';
   contentType: ContentType;
   rectConfig: RectConfig;
 };
@@ -62,6 +63,7 @@ const DEFAULT_RECT_CONFIG: RectConfig = {
 const DEFAULT_TAB_CONFIG: SingleTabConfig = {
   navBackground: Colors.White,
   reactBackground: 'transparent',
+  isHeavy: 'false',
   contentType: 'view',
   rectConfig: DEFAULT_RECT_CONFIG,
 };
@@ -77,6 +79,78 @@ const INITIAL_CONFIG: AppConfig = {
 
 const PRESETS: Record<string, AppConfig> = {
   Default: INITIAL_CONFIG,
+  ColorfulTab: {
+    containerBackground: Colors.White,
+    tabs: {
+      Tab2: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'view',
+        navBackground: Colors.PurpleLight40,
+        reactBackground: 'transparent',
+      },
+      Tab3: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithText',
+        navBackground: Colors.BlueLight40,
+        reactBackground: 'transparent',
+      },
+      Tab4: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithRects',
+        navBackground: Colors.NavyDark140,
+        reactBackground: 'transparent',
+        rectConfig: { height: 80, gap: 15 },
+      },
+    },
+  },
+  ColorfulReact: {
+    containerBackground: Colors.White,
+    tabs: {
+      Tab2: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'view',
+        navBackground: 'transparent',
+        reactBackground: Colors.PurpleLight40,
+      },
+      Tab3: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithText',
+        navBackground: 'transparent',
+        reactBackground: Colors.BlueLight40,
+      },
+      Tab4: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithRects',
+        navBackground: 'transparent',
+        reactBackground: Colors.NavyDark140,
+        rectConfig: { height: 80, gap: 15 },
+      },
+    },
+  },
+  ColorfulTabReact: {
+    containerBackground: Colors.White,
+    tabs: {
+      Tab2: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'view',
+        navBackground: Colors.White,
+        reactBackground: Colors.PurpleLight40,
+      },
+      Tab3: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithText',
+        navBackground: Colors.White,
+        reactBackground: Colors.BlueLight40,
+      },
+      Tab4: {
+        ...DEFAULT_TAB_CONFIG,
+        contentType: 'scrollViewWithRects',
+        navBackground: Colors.White,
+        reactBackground: Colors.NavyDark140,
+        rectConfig: { height: 80, gap: 15 },
+      },
+    },
+  },
 };
 
 const BackgroundTestContext = createContext<BackgroundContextType | null>(null);
@@ -131,8 +205,7 @@ const SimplePicker = ({
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{
         gap: 12,
-        paddingVertical: 10,
-        paddingHorizontal: 5,
+        padding: 5,
       }}>
       {options.map((opt: string) => (
         <Pressable
@@ -151,14 +224,13 @@ const SimplePicker = ({
             },
             shadowOpacity: 0.22,
             shadowRadius: 2.22,
-
             elevation: 3,
-            transform: [{ scale: value === opt ? 1.2 : 1 }],
           }}>
           <Text
             style={{
               color: 'black',
               fontSize: 12,
+              fontWeight: opt === value ? 'bold' : undefined,
             }}>
             {opt}
           </Text>
@@ -203,6 +275,10 @@ const TestScreenRenderer = ({ tabKey }: { tabKey: TabKey }) => {
   const tabConfig = config.tabs[tabKey];
 
   const Container = tabConfig.contentType === 'view' ? View : ScrollView;
+
+  if (tabConfig.isHeavy === 'true') {
+    someExtensiveComputation();
+  }
 
   return (
     <Container
@@ -325,12 +401,19 @@ function ConfigScreen() {
               onChange={(c: string) => updateTab(key, { reactBackground: c })}
             />
             <SimplePicker
+              label="Heavy Render"
+              value={String(tConfig.isHeavy)}
+              options={['true', 'false']}
+              onChange={(c: string) =>
+                updateTab(key, { isHeavy: c === 'true' ? 'true' : 'false' })
+              }
+            />
+            <SimplePicker
               label="Content Type"
               value={tConfig.contentType}
               options={contentTypes}
               onChange={(c: any) => updateTab(key, { contentType: c })}
             />
-
             {tConfig.contentType === 'scrollViewWithRects' && (
               <View
                 style={{
@@ -343,7 +426,7 @@ function ConfigScreen() {
                 <SimplePicker
                   label="Item Height"
                   value={String(tConfig.rectConfig.height)}
-                  options={['50', '100', '200', '400']}
+                  options={['50', '100', '200']}
                   onChange={(v: string) =>
                     updateRects(key, { height: parseFloat(v) })
                   }
@@ -351,7 +434,7 @@ function ConfigScreen() {
                 <SimplePicker
                   label="Gap Size"
                   value={String(tConfig.rectConfig.gap)}
-                  options={['0', '10', '20', '50', '100']}
+                  options={['20', '50', '100']}
                   onChange={(v: string) =>
                     updateRects(key, { gap: parseFloat(v) })
                   }
@@ -392,11 +475,6 @@ function Tabs() {
           },
           style: { backgroundColor: Colors.White },
         },
-        safeAreaConfiguration: {
-          edges: {
-            bottom: true,
-          },
-        },
         component: ConfigScreen,
       },
       {
@@ -405,11 +483,6 @@ function Tabs() {
           title: 'Tab 2',
           icon: { ios: { type: 'sfSymbol', name: 'square' } },
           style: { backgroundColor: config.tabs.Tab2.navBackground },
-        },
-        safeAreaConfiguration: {
-          edges: {
-            bottom: true,
-          },
         },
         component: ScreenTab2,
       },
@@ -420,11 +493,6 @@ function Tabs() {
           icon: { ios: { type: 'sfSymbol', name: 'triangle' } },
           style: { backgroundColor: config.tabs.Tab3.navBackground },
         },
-        safeAreaConfiguration: {
-          edges: {
-            bottom: true,
-          },
-        },
         component: ScreenTab3,
       },
       {
@@ -433,11 +501,6 @@ function Tabs() {
           title: 'Tab 4',
           icon: { ios: { type: 'sfSymbol', name: 'circle' } },
           style: { backgroundColor: config.tabs.Tab4.navBackground },
-        },
-        safeAreaConfiguration: {
-          edges: {
-            bottom: true,
-          },
         },
         component: ScreenTab4,
       },

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -135,9 +135,6 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      style: {
-        backgroundColor: Colors.YellowLight40,
-      },
       tabKey: 'Tab3',
       badgeValue: '2137',
       testID: 'tab-screen-3-id',
@@ -223,9 +220,6 @@ function App() {
       }}>
       <BottomTabsContainer
         tabConfigs={TAB_CONFIGS}
-        nativeContainerStyle={{
-          backgroundColor: Colors.GreenLight80,
-        }}
         tabBarBackgroundColor={Colors.NavyLight100}
         tabBarItemActiveIndicatorColor={Colors.GreenLight40}
         tabBarItemActiveIndicatorEnabled={true}

--- a/apps/src/tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/TestBottomTabs/index.tsx
@@ -135,6 +135,9 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
+      style: {
+        backgroundColor: Colors.YellowLight40,
+      },
       tabKey: 'Tab3',
       badgeValue: '2137',
       testID: 'tab-screen-3-id',
@@ -220,6 +223,9 @@ function App() {
       }}>
       <BottomTabsContainer
         tabConfigs={TAB_CONFIGS}
+        nativeContainerStyle={{
+          backgroundColor: Colors.GreenLight80,
+        }}
         tabBarBackgroundColor={Colors.NavyLight100}
         tabBarItemActiveIndicatorColor={Colors.GreenLight40}
         tabBarItemActiveIndicatorEnabled={true}

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -168,6 +168,7 @@ export { default as Test3422 } from './Test3422';
 export { default as Test3425 } from './Test3425';
 export { default as Test3446 } from './Test3446';
 export { default as Test3450 } from './Test3450';
+export { default as Test3492 } from './Test3492';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL tabBarHidden;
 
+@property (nonatomic, strong, readonly, nullable) UIColor *nativeContainerBackgroundColor;
+
 @property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
@@ -113,6 +113,7 @@ namespace react = facebook::react;
   _props = defaultProps;
 #endif
   _tabBarTintColor = nil;
+  _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
 }
 
 #pragma mark - UIView methods
@@ -308,6 +309,11 @@ namespace react = facebook::react;
     {
       _controller.tabBar.hidden = _tabBarHidden;
     }
+  }
+
+  if (newComponentProps.nativeContainerBackgroundColor != oldComponentProps.nativeContainerBackgroundColor) {
+    _nativeContainerBackgroundColor = RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor);
+    _controller.view.backgroundColor = _nativeContainerBackgroundColor;
   }
 
   if (newComponentProps.tabBarMinimizeBehavior != oldComponentProps.tabBarMinimizeBehavior) {

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
@@ -113,7 +113,11 @@ namespace react = facebook::react;
   _props = defaultProps;
 #endif
   _tabBarTintColor = nil;
+#if !TARGET_OS_TV
   _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
+#else // !TARGET_OS_TV
+  _nativeContainerBackgroundColor = nil;
+#endif // !TARGET_OS_TV
 }
 
 #pragma mark - UIView methods
@@ -312,8 +316,13 @@ namespace react = facebook::react;
   }
 
   if (newComponentProps.nativeContainerBackgroundColor != oldComponentProps.nativeContainerBackgroundColor) {
-    _nativeContainerBackgroundColor =
-        RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor) ?: [UIColor systemBackgroundColor];
+    _nativeContainerBackgroundColor = RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor);
+#if !TARGET_OS_TV
+    if (_nativeContainerBackgroundColor == nil) {
+      _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
+    }
+#endif // !TARGET_OS_TV
+
     _controller.view.backgroundColor = _nativeContainerBackgroundColor;
   }
 
@@ -495,7 +504,13 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)setNativeContainerBackgroundColor:(UIColor *_Nullable)nativeContainerBackgroundColor
 {
-  _nativeContainerBackgroundColor = nativeContainerBackgroundColor ?: [UIColor systemBackgroundColor];
+  _nativeContainerBackgroundColor = nativeContainerBackgroundColor;
+#if !TARGET_OS_TV
+  if (_nativeContainerBackgroundColor == nil) {
+    _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
+  }
+#endif // !TARGET_OS_TV
+
   _controller.view.backgroundColor = _nativeContainerBackgroundColor;
 }
 

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
@@ -312,7 +312,8 @@ namespace react = facebook::react;
   }
 
   if (newComponentProps.nativeContainerBackgroundColor != oldComponentProps.nativeContainerBackgroundColor) {
-    _nativeContainerBackgroundColor = RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor);
+    _nativeContainerBackgroundColor =
+        RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor) ?: [UIColor systemBackgroundColor];
     _controller.view.backgroundColor = _nativeContainerBackgroundColor;
   }
 
@@ -490,6 +491,12 @@ RNS_IGNORE_SUPER_CALL_END
   {
     _controller.tabBar.hidden = _tabBarHidden;
   }
+}
+
+- (void)setNativeContainerBackgroundColor:(UIColor *_Nullable)nativeContainerBackgroundColor
+{
+  _nativeContainerBackgroundColor = nativeContainerBackgroundColor ?: [UIColor systemBackgroundColor];
+  _controller.view.backgroundColor = _nativeContainerBackgroundColor;
 }
 
 // This is a Paper-only setter method that will be called by the mounting code.

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentViewManager.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentViewManager.mm
@@ -24,6 +24,7 @@ RCT_EXPORT_MODULE(RNSBottomTabsManager)
 
 RCT_EXPORT_VIEW_PROPERTY(tabBarTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(tabBarHidden, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(nativeContainerBackgroundColor, UIColor);
 // This remapping allows us to store UITabBarMinimizeBehavior in the component while accepting a custom enum as input
 // from JS.
 RCT_REMAP_VIEW_PROPERTY(

--- a/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.mm
+++ b/ios/bottom-tabs/screen/RNSBottomTabsScreenComponentView.mm
@@ -70,12 +70,6 @@ namespace react = facebook::react;
   _scrollEdgeEffectsNeedUpdate = NO;
 #endif
 
-  // Prevents incorrect tab bar appearance after tab change on iOS 26.0
-  // TODO: verify if it's still necessary on iOS 26.1
-#if !TARGET_OS_TV
-  self.backgroundColor = [UIColor systemBackgroundColor];
-#endif // !TARGET_OS_TV
-
   [self resetProps];
 }
 

--- a/src/components/tabs/TabsHost.tsx
+++ b/src/components/tabs/TabsHost.tsx
@@ -28,6 +28,7 @@ function TabsHost(props: TabsHostProps) {
     experimentalControlNavigationStateInJS = featureFlags.experiment
       .controlledBottomTabs,
     bottomAccessory,
+    nativeContainerStyle,
     ...filteredProps
   } = props;
 
@@ -64,6 +65,7 @@ function TabsHost(props: TabsHostProps) {
       style={styles.fillParent}
       onNativeFocusChange={onNativeFocusChangeCallback}
       controlNavigationStateInJS={experimentalControlNavigationStateInJS}
+      nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
       // @ts-ignore suppress ref - debug only
       ref={componentNodeRef}
       {...filteredProps}>

--- a/src/components/tabs/TabsHost.types.ts
+++ b/src/components/tabs/TabsHost.types.ts
@@ -33,7 +33,16 @@ export type TabBarMinimizeBehavior =
 // iOS-specific
 export type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
-export interface TabsHostProps extends ViewProps {
+export type TabsHostNativeContainerStyleProps = {
+  /**
+   * @summary Specifies the background color of the native container.
+   *
+   * @platform android, ios
+   */
+  backgroundColor?: ColorValue;
+};
+
+export interface TabsHostProps {
   // #region Events
   /**
    * A callback that gets invoked when user requests change of focused tab screen.
@@ -46,6 +55,7 @@ export interface TabsHostProps extends ViewProps {
   // #endregion Events
 
   // #region General
+  children?: ViewProps['children'];
   /**
    * @summary Hides the tab bar.
    *
@@ -54,6 +64,16 @@ export interface TabsHostProps extends ViewProps {
    * @platform android, ios
    */
   tabBarHidden?: boolean;
+  /**
+   * @summary Allows for native container view customization.
+   *
+   * On Android, style is applied to `FrameLayout` that wraps currently focused screen
+   * and `BottomNavigationView`. On iOS, style is applied to `UITabBarController`'s
+   * view.
+   *
+   * @platform android, ios
+   */
+  nativeContainerStyle?: TabsHostNativeContainerStyleProps;
   // #endregion General
 
   // #region Android-only

--- a/src/components/tabs/TabsScreen.tsx
+++ b/src/components/tabs/TabsScreen.tsx
@@ -67,6 +67,7 @@ function TabsScreen(props: TabsScreenProps) {
     scrollEdgeEffects,
     // eslint-disable-next-line camelcase -- we use sneak case experimental prefix
     experimental_userInterfaceStyle,
+    style,
     ...rest
   } = props;
 
@@ -129,7 +130,7 @@ function TabsScreen(props: TabsScreenProps) {
   return (
     <BottomTabsScreenNativeComponent
       collapsable={false}
-      style={styles.fillParent}
+      style={[style, styles.fillParent]}
       onWillAppear={onWillAppearCallback}
       onDidAppear={onDidAppearCallback}
       onWillDisappear={onWillDisappearCallback}

--- a/src/components/tabs/TabsScreen.types.ts
+++ b/src/components/tabs/TabsScreen.types.ts
@@ -1,8 +1,10 @@
 import type {
   ColorValue,
   NativeSyntheticEvent,
+  StyleProp,
   TextStyle,
   ViewProps,
+  ViewStyle,
 } from 'react-native';
 import type {
   PlatformIcon,
@@ -280,6 +282,7 @@ export interface TabsScreenProps {
 
   // #region General
   children?: ViewProps['children'];
+  style?: StyleProp<Pick<ViewStyle, 'backgroundColor'>>;
   /**
    * @summary Defines what should be rendered when tab screen is frozen.
    *

--- a/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
@@ -33,6 +33,10 @@ export interface NativeProps extends ViewProps {
   // Events
   onNativeFocusChange?: CT.DirectEventHandler<NativeFocusChangeEvent>;
 
+  // General
+  tabBarHidden?: CT.WithDefault<boolean, false>;
+  nativeContainerBackgroundColor?: ColorValue;
+
   // Appearance
   // tabBarAppearance?: TabBarAppearance; // Does not work due to codegen issue.
 
@@ -59,7 +63,6 @@ export interface NativeProps extends ViewProps {
   tabBarTintColor?: ColorValue;
   tabBarMinimizeBehavior?: CT.WithDefault<TabBarMinimizeBehavior, 'automatic'>;
   tabBarControllerMode?: CT.WithDefault<TabBarControllerMode, 'automatic'>;
-  tabBarHidden?: CT.WithDefault<boolean, false>;
 
   // Control
 


### PR DESCRIPTION
## Description

Adds customization of `backgroundColor` for native tabs container (`UITabBarController.view` on iOS, `TabsHost` on Android) and tab screen (`RNSBottomTabsScreenComponentView` on iOS, `TabScreen` on Android).

| Android | iOS |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/6dfb2628-560c-42d3-a380-6a858e7a8534" /> | <video src="https://github.com/user-attachments/assets/545dfcf3-7924-4c2d-ad7f-2ca00d369cb8" /> |

Closes https://github.com/software-mansion/react-native-screens-labs/issues/721.
Supersedes https://github.com/software-mansion/react-native-screens/pull/3478.

### Comparison of different approaches to setting background color on iOS

This PR allows for (at least) 3 kinds of setting background color in tabs. Due to asynchronous nature, different approaches result in different effect.

#### Tab screen + React View has background color

This is similar to current approach where tab screen uses `systemBackgroundColor` and user defines background color via View inside components passed to tab screen. This approach was used to mitigate problems with liquid glass tab bar appearance adaptation (more details: https://github.com/software-mansion/react-native-screens/pull/3279).

https://github.com/user-attachments/assets/49397de6-77d2-4d70-8412-6681fb361ee1

First, background color of tab screen is visible before tab's content is rendered by React and correct color appears.

#### Only React View has background color

This is similar to approach suggested in https://github.com/software-mansion/react-native-screens/pull/3478 (transparent screen). While this seems to work better on first tab renders, switching between similar tabs after they are rendered causes a flash.

https://github.com/user-attachments/assets/816e59ad-6265-4c84-97c5-4ca64ca8341b

This is reproducible in bare UIKit app when child VC's view has clear background color and its subview has different background color.

#### Only Tab screen has background color

This approach is possible thanks to this PR and it is closes to native platform but tab's content still appears after a delay because it needs to be rendered by React - this causes a flash on first render.

https://github.com/user-attachments/assets/8883acfe-d353-4f8c-90f7-462b46f4bf79

## Changes

- add `nativeContainerStyle` prop to `BottomTabs` component with `backgroundColor` field
- add `style` prop to `BottomTabsScreen` component with `backgroundColor` field
- add `Test3492`

## Test code and steps to reproduce

Run `Test3492`.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
