### PR TITLE
feat: Remove componentProvider from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,28 +163,6 @@
       "javaPackageName": "com.swmansion.rnscreens"
     },
     "ios": {
-      "componentProvider": {
-        "RNSStackScreen": "RNSStackScreenComponentView",
-        "RNSStackHost": "RNSStackHostComponentView",
-        "RNSBottomTabsScreen": "RNSBottomTabsScreenComponentView",
-        "RNSBottomTabs": "RNSBottomTabsHostComponentView",
-        "RNSBottomTabsAccessory": "RNSBottomTabsAccessoryComponentView",
-        "RNSBottomTabsAccessoryContent": "RNSBottomTabsAccessoryContentComponentView",
-        "RNSFullWindowOverlay": "RNSFullWindowOverlay",
-        "RNSModalScreen": "RNSModalScreen",
-        "RNSScreenContainer": "RNSScreenContainerView",
-        "RNSScreenContentWrapper": "RNSScreenContentWrapper",
-        "RNSScreenFooter": "RNSScreenFooter",
-        "RNSScreen": "RNSScreenView",
-        "RNSScreenNavigationContainer": "RNSScreenNavigationContainerView",
-        "RNSScreenStackHeaderConfig": "RNSScreenStackHeaderConfig",
-        "RNSScreenStackHeaderSubview": "RNSScreenStackHeaderSubview",
-        "RNSScreenStack": "RNSScreenStackView",
-        "RNSSearchBar": "RNSSearchBar",
-        "RNSSplitViewHost": "RNSSplitViewHostComponentView",
-        "RNSSplitViewScreen": "RNSSplitViewScreenComponentView",
-        "RNSSafeAreaView": "RNSSafeAreaViewComponentView"
-      },
       "components": {
         "RNSFullWindowOverlay": {
           "className": "RNSFullWindowOverlay"


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/580

## Description

This PR removes legacy field `codegenConfig.ios.componentProvider` from `package.json` replaced by `codegenConfig.ios.components` since RN 0.80 (current minimum version supported by screens on Fabric is 0.81).

## Changes

Removed obsolete field.

## Test code and steps to reproduce

The project should still build normally and register the native components.