### PR TITLE
feat(Android): Make commit hook condition for resetting screen size more general

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.cpp
@@ -32,10 +32,9 @@ RootShadowNode::Unshared RNSScreenShadowNodeCommitHook::shadowTreeWillCommit(
   auto newRootProps =
       std::static_pointer_cast<const RootProps>(newRootShadowNode->getProps());
 
-  const bool wasHorizontal = isHorizontal_(*oldRootProps);
-  const bool willBeHorizontal = isHorizontal_(*newRootProps);
-
-  if (wasHorizontal != willBeHorizontal) {
+  // Check if screen area has changed size (either because of orientation
+  // change, or application resize with floating window / split screen)
+  if (_screenSizeChanged(*oldRootProps, *newRootProps)) {
     return newRootShadowNodeWithScreenFrameSizesReset(newRootShadowNode);
   }
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
@@ -29,13 +29,18 @@ class RNSScreenShadowNodeCommitHook : public UIManagerCommitHook {
       const ShadowTreeCommitOptions & /*commitOptions*/) noexcept override;
 
  private:
-  static inline bool isHorizontal_(const RootProps &props) {
-    const auto &layoutConstraints = props.layoutConstraints;
-    const float width = layoutConstraints.maximumSize.width;
-    const float height = layoutConstraints.maximumSize.height;
+  static inline bool _screenSizeChanged(
+      const RootProps &oldProps,
+      const RootProps &newProps) {
+    const auto &newLayoutConstraints = newProps.layoutConstraints;
+    const auto &oldLayoutConstraints = oldProps.layoutConstraints;
 
-    return width > height;
-  };
+    return (
+        newLayoutConstraints.maximumSize.width !=
+            oldLayoutConstraints.maximumSize.width ||
+        newLayoutConstraints.maximumSize.height !=
+            oldLayoutConstraints.maximumSize.width);
+  }
 
   static RootShadowNode::Unshared newRootShadowNodeWithScreenFrameSizesReset(
       RootShadowNode::Unshared rootShadowNode);


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/598

## Description

This PR aims to generalize the condition in RNSScreenShadowNodeCommitHook to also include the screen resize, without orientation change. Let's discuss the change & decide how "general" should it be.

Even when triggering the mechanism on every screen resize, this shouldn't be a problem, since the change is still rare.

## Changes

Modified the screen size reset condition in RNSScreenShadowNodeCommitHook

## Before & After

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4f4f562c-dafb-4881-9d27-9439d1375d34" /> | <video src="https://github.com/user-attachments/assets/d136bf0b-b87f-4ff9-866d-e5a4199be39c" /> |


## Test code and steps to reproduce

Use Test2933 & try split screen, floating window.