### PR TITLE
feat(ios): post willDisappear notification

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -626,6 +626,8 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)notifyWillDisappear
 {
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"RNSScreenViewWillDisappear" object:self userInfo:nil];
+
   if (_hideKeyboardOnSwipe) {
     [self endEditing:YES];
   }


### PR DESCRIPTION
## Description

This PR adds a new `RNSScreenViewWillDisappear` notification that is posted when a screen is about to disappear. This allows third-party libraries (like bottom sheet implementations) to detect when their presenting screen is being popped from the navigation stack and respond accordingly (e.g., dismiss themselves).

When a modal or bottom sheet is presented from a screen within a native stack navigator, and that screen is popped (via back button or gesture), the presented modal/sheet needs to be dismissed. Currently there's no reliable way for external libraries to detect this scenario.

This notification provides a simple integration point for third-party libraries to observe screen disappearance events without needing to subclass or modify RNSScreen.

## Changes

- Posts `RNSScreenViewWillDisappear` notification from `RNSScreenView` when `notifyWillDisappear` is called
- The notification object is the `RNSScreenView` instance

## Before & after - visual documentation

### Before

https://github.com/user-attachments/assets/6df19221-57ba-4866-ad8c-1a0e1f299432

### After

https://github.com/user-attachments/assets/e969e02b-1746-439a-a04b-67bcc0bb18fe

## Test plan

1. Present a third-party modal from a screen in a native stack
2. Pop the screen (back button or swipe gesture)
3. Verify the notification is received before the screen disappears

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
