### PR TITLE
feat(ios): add RNSLifecycleListenerProtocol for screen lifecycle events

### DIFF
--- a/ios/integrations/RNSLifecycleListenerProtocol.h
+++ b/ios/integrations/RNSLifecycleListenerProtocol.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSLifecycleListenerProtocol <NSObject>
+
+// Called when a screen in the presenting hierarchy is about to disappear.
+// @param screen The screen controller that is disappearing
+// @param isPresenterUnmounting YES if the presenter (modal) itself is being unmounted
+- (void)screenWillDisappear:(UIViewController *)screen isPresenterUnmounting:(BOOL)isPresenterUnmounting;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Add `RNSLifecycleListenerProtocol` to allow external view controllers (such as third-party bottom sheets) to receive screen lifecycle events when a screen in the presenting hierarchy is about to disappear.

This is useful for external modal implementations that need to know when the presenting screen is being unmounted (e.g., when navigating back) so they can dismiss themselves appropriately.

## Changes

- Added new `RNSLifecycleListenerProtocol` in `ios/integrations/`
- Modified `RNSScreen.mm`:
  - Added `_controllerBeforeInvalidate` ivar to preserve controller reference before invalidation
  - Updated `notifyWillDisappear` to notify conforming presented view controllers
  - Updated `invalidateImpl` to store controller before nulling
- The protocol method `screenWillDisappear:isPresenterUnmounting:` provides:
  - The screen controller that is disappearing
  - A flag indicating if the presenter (modal) itself is being unmounted

## Before & after - visual documentation

### Before

https://github.com/user-attachments/assets/6df19221-57ba-4866-ad8c-1a0e1f299432

### After

https://github.com/user-attachments/assets/3a6039c8-87be-4cef-8880-7ccd78bd9fb7

## Test plan

1. Present a third-party modal (e.g., TrueSheet) that conforms to `RNSLifecycleListenerProtocol`
2. Navigate back (pop the screen) while the modal is open
3. The modal should receive `screenWillDisappear:isPresenterUnmounting:` callback
4. The modal can use this to dismiss itself when the presenting screen is popped

Example conformance:
```objc
@interface MyModalController : UIViewController <RNSLifecycleListenerProtocol>
@end

@implementation MyModalController

- (void)screenWillDisappear:(UIViewController *)screen isPresenterUnmounting:(BOOL)isPresenterUnmounting {
  if (!isPresenterUnmounting) {
    // Screen is being popped, dismiss ourselves
    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
  }
}

@end
```

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes