### PR TITLE
fix(iOS, FullWindowOverlay): FullWindowOverlay shown behind fullScreenModal 

### DIFF
--- a/apps/src/tests/Test3380.tsx
+++ b/apps/src/tests/Test3380.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FullWindowOverlay } from 'react-native-screens';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+/**
+ * REPRODUCTION: "Sibling Structure"
+ * Root
+ * ├── NavigationContainer (contains the Modal)
+ * └── FullWindowOverlay (Sibling, outside the Modal)
+ */
+
+const Stack = createNativeStackNavigator();
+
+// 1. The Screen Inside the Modal
+//    It has a button to trigger the "Global" Overlay
+function ModalScreen({ onTriggerOverlay }: { onTriggerOverlay: () => void }) {
+  return (
+    <View style={styles.modalContainer}>
+      <Text style={styles.modalText}>I am a Native Stack Modal</Text>
+      <Text style={styles.modalSubText}>
+        I am inside the NavigationContainer.
+        The Overlay is outside.
+      </Text>
+      
+      <View style={styles.spacer} />
+      
+      <Button 
+        title="FIRE SIBLING OVERLAY" 
+        color="red"
+        onPress={onTriggerOverlay} 
+      />
+    </View>
+  );
+}
+
+// 2. The Home Screen (just to open the modal)
+function HomeScreen({ navigation }: any) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Test 3380: Sibling Structure</Text>
+      <Button title="Open Full Screen Modal" onPress={() => navigation.navigate('MyModal')} />
+    </View>
+  );
+}
+
+// 3. The Root Component (The Mini-App)
+export default function Test3380() {
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  return (
+    <View style={{ flex: 1 }}>
+      {/* PART A: The Navigation Stack (Where the Modal lives) */}
+      <NavigationContainer independent={true}>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Group screenOptions={{ presentation: 'fullScreenModal', headerShown: false }}>
+            <Stack.Screen name="MyModal">
+              {() => <ModalScreen onTriggerOverlay={() => setOverlayVisible(true)} />}
+            </Stack.Screen>
+          </Stack.Group>
+        </Stack.Navigator>
+      </NavigationContainer>
+
+      {/* This sits physically AFTER the Navigation in the render tree */}
+      {overlayVisible && (
+        <FullWindowOverlay>
+          <View style={styles.overlayContainer}>
+            <View style={styles.overlayBox}>
+              <Text style={styles.overlayText}>✅ VISIBLE</Text>
+              <Text style={styles.overlaySubText}>
+                I am a Sibling Overlay.
+                I successfully covered the Modal.
+              </Text>
+              <Button 
+                title="Close Overlay" 
+                color="white" 
+                onPress={() => setOverlayVisible(false)} 
+              />
+            </View>
+          </View>
+        </FullWindowOverlay>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  modalContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#222', 
+  },
+  modalText: {
+    color: 'white',
+    fontSize: 22,
+    fontWeight: 'bold',
+  },
+  modalSubText: {
+    color: '#ccc',
+    textAlign: 'center',
+    marginTop: 10,
+    maxWidth: 300,
+  },
+  hint: {
+    color: '#888',
+    marginTop: 20,
+    fontStyle: 'italic',
+  },
+  spacer: {
+    height: 40,
+  },
+  // Overlay Styles
+  overlayContainer: {
+    flex: 1,
+    justifyContent: 'flex-end', 
+    alignItems: 'center',
+    paddingBottom: 50,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  overlayBox: {
+    width: '90%',
+    height: 150,
+    backgroundColor: '#00C853', 
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    elevation: 8,
+  },
+  overlayText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+    marginBottom: 5,
+  },
+  overlaySubText: {
+    color: 'white',
+    marginBottom: 15,
+  }
+});

--- a/apps/src/tests/index.ts
+++ b/apps/src/tests/index.ts
@@ -165,6 +165,7 @@ export { default as Test3342 } from './Test3342';
 export { default as Test3346 } from './Test3346';
 export { default as Test3369 } from './Test3369';
 export { default as Test3379 } from './Test3379';
+export { default as Test3380 } from './Test3380';
 export { default as Test3422 } from './Test3422';
 export { default as Test3425 } from './Test3425';
 export { default as Test3446 } from './Test3446';

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -166,22 +166,29 @@
 
 - (void)didMoveToWindow
 {
-  // Detaching FullWindowOverlay is handled by `didMoveToSuperview`
-  if (self.window != nil) {
-    [self maybeShow];
-  }
+    [super didMoveToWindow];
+    [self show];
 }
 
-- (void)maybeShow
-{
-  UIWindow *window = [self window];
-  if (![[window subviews] containsObject:self]) {
-    [window addSubview:_container];
-  }
+- (void)show
+{    UIWindow *targetWindow = self.window;
+    
+    if (!targetWindow) {
+        targetWindow = RCTKeyWindow();
+    }
+    
+    if (targetWindow && _container) {
+        [targetWindow addSubview:_container];
+    }
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - Fabric Specific
+
+- (void)maybeShow
+{
+    [self show];
+}
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
@@ -200,6 +207,7 @@
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
+  [self maybeShow];
   [self addSubview:childComponentView];
 }
 


### PR DESCRIPTION
Fixes #3521

**Description**

The solution restores the original z-index behavior by unconditionally calling addSubview when showing the overlay. In UIKit, this forces the view to the front of the visual stack, ensuring it covers the modal.

Crucially, this change maintains the fix for Multi-Window applications introduced in #3372. We continue to rely on didMoveToWindow to resolve the correct UIWindowScene context, ensuring the overlay attaches to the correct window in split-screen or multi-scene environments.

**Changes**

- Restored Z-Index Promotion: Removed the containsObject check. This allows addSubview to move the overlay to the top of the window stack if it is already attached.

- Preserved Context Logic: Kept the logic prioritizing self.window to ensure Multi-Window stability.

- Added Safety Fallback: Added a fallback to RCTKeyWindow in case self.window is nil, improving robustness for edge cases.

**Before**

https://github.com/user-attachments/assets/bfa34ec8-32a4-48bb-ad83-757754e5714a

**After**

https://github.com/user-attachments/assets/163799b4-4927-4c74-a41a-203c929f8e0f

**Steps to reproduce**
1. Open FabricExample.
2. Trigger FullWindowOverlay in Test3380.

I have tried to verify that this solution wont break the fix recently added for multiple screen applications by enabling multiple screens in FabricExample, and tested the test3379 before #3372 was introduced and after this solution to confirm that solution keeps working after this change.
**Before**

https://github.com/user-attachments/assets/2d5aa8d7-b417-4a7e-9864-9a9e35152f91

**After**

https://github.com/user-attachments/assets/e98f776d-d14b-4efb-9326-34950796088a

**Checklist**
- [x]  Included code example that can be used to test this change