### PR TITLE
fix(iOS, Stack): Add compression resistance to button item

### DIFF
--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -278,6 +278,10 @@ RNS_IGNORE_SUPER_CALL_END
       // 2. Set content hugging priority for RNSScreenStackHeaderSubview.
       [self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
       [self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+      
+      // 3. Set compression resistance to prevent UIKit from shrinking the subview below its intrinsic size.
+      [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+      [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
       _barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:wrapperView];
     } else


### PR DESCRIPTION
## Description

Closes #3547, after debugging it appears that auto layout was shrinking the view even though the intrinsic size from RN didn't change. Content hugging is already configured there so simply add compression resistance in the same vein to prevent shrinkage.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bed74a64-361d-46de-8cfd-75c29ceda69a" /> | <video src="https://github.com/user-attachments/assets/b7a809b3-980a-4ccd-ac3a-28ea8a3c3f23" /> |


## Test plan

Tested reproduction case (https://github.com/LeviWilliams/screens-repo-ios26) with patch on simulator and physical device.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
