### PR TITLE
fix: Correct screen size change comparison

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNodeCommitHook.h
@@ -39,7 +39,7 @@ class RNSScreenShadowNodeCommitHook : public UIManagerCommitHook {
         newLayoutConstraints.maximumSize.width !=
             oldLayoutConstraints.maximumSize.width ||
         newLayoutConstraints.maximumSize.height !=
-            oldLayoutConstraints.maximumSize.width);
+            oldLayoutConstraints.maximumSize.height);
   }
 
   static RootShadowNode::Unshared newRootShadowNodeWithScreenFrameSizesReset(


### PR DESCRIPTION
## Description

...

## Changes

Changed width to height in _screenSizeChanged() comparison

## Test plan

Use Test2933 to check if the screen adapts to the orientation change correctly. Use the same test on android tablet to see that screen resize without orientation change also works.

## Checklist

- [ ] Ensured that CI passes
