### PR TITLE
refactor: sheetDefaultResizeAnimationEnabled -> sheetResizeAnimationEnabled

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -94,7 +94,7 @@ class Screen(
     var sheetClosesOnTouchOutside = true
     var sheetElevation: Float = 24F
     var sheetShouldOverflowTopInset = false
-    var sheetDefaultResizeAnimationEnabled = true
+    var sheetResizeAnimationEnabled = true
 
     /**
      * On Paper, when using form sheet presentation we want to delay enter transition in order
@@ -163,7 +163,7 @@ class Screen(
 
                 if (isInitial) {
                     setupInitialSheetContentHeight(sheetBehavior, height)
-                } else if (sheetDefaultResizeAnimationEnabled) {
+                } else if (sheetResizeAnimationEnabled) {
                     updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
                 } else {
                     updateSheetContentHeightWithoutAnimation(sheetBehavior, height)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -277,12 +277,12 @@ open class ScreenViewManager :
         view?.sheetShouldOverflowTopInset = sheetShouldOverflowTopInset
     }
 
-    @ReactProp(name = "sheetDefaultResizeAnimationEnabled")
-    override fun setSheetDefaultResizeAnimationEnabled(
+    @ReactProp(name = "sheetResizeAnimationEnabled")
+    override fun setSheetResizeAnimationEnabled(
         view: Screen?,
-        sheetDefaultResizeAnimationEnabled: Boolean,
+        sheetResizeAnimationEnabled: Boolean,
     ) {
-        view?.sheetDefaultResizeAnimationEnabled = sheetDefaultResizeAnimationEnabled
+        view?.sheetResizeAnimationEnabled = sheetResizeAnimationEnabled
     }
 
     // mark: iOS-only

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -53,8 +53,8 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManager<
       case "sheetShouldOverflowTopInset":
         mViewManager.setSheetShouldOverflowTopInset(view, value == null ? false : (boolean) value);
         break;
-      case "sheetDefaultResizeAnimationEnabled":
-        mViewManager.setSheetDefaultResizeAnimationEnabled(view, value == null ? true : (boolean) value);
+      case "sheetResizeAnimationEnabled":
+        mViewManager.setSheetResizeAnimationEnabled(view, value == null ? true : (boolean) value);
         break;
       case "customAnimationOnSwipe":
         mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -25,7 +25,7 @@ public interface RNSScreenManagerInterface<T extends View> extends ViewManagerWi
   void setSheetInitialDetent(T view, int value);
   void setSheetElevation(T view, int value);
   void setSheetShouldOverflowTopInset(T view, boolean value);
-  void setSheetDefaultResizeAnimationEnabled(T view, boolean value);
+  void setSheetResizeAnimationEnabled(T view, boolean value);
   void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, @Nullable String value);
   void setFullScreenSwipeShadowEnabled(T view, boolean value);

--- a/apps/src/tests/Test2560.tsx
+++ b/apps/src/tests/Test2560.tsx
@@ -124,7 +124,7 @@ export default function App() {
             contentStyle: {
               backgroundColor: Colors.YellowLight40,
             },
-            // TODO(@t0maboro) - add `sheetDefaultResizeAnimationEnabled` prop here when possible
+            // TODO(@t0maboro) - add `sheetResizeAnimationEnabled` prop here when possible
           }}
         />
       </Stack.Navigator>

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -260,7 +260,7 @@ When set to `false`, the sheet's layout will be constrained by the inset from th
 
 Defaults to `false`.
 
-### `sheetDefaultResizeAnimationEnabled` (Android only)
+### `sheetResizeAnimationEnabled` (Android only)
 
 Whether the default native animation should be used when the sheet's with `fitToContents` content size changes.
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -99,7 +99,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       sheetElevation = 24,
       sheetInitialDetentIndex = 0,
       sheetShouldOverflowTopInset = false,
-      sheetDefaultResizeAnimationEnabled = true,
+      sheetResizeAnimationEnabled = true,
       // Other
       screenId,
       stackPresentation,
@@ -232,9 +232,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             sheetLargestUndimmedDetent={resolvedSheetLargestUndimmedDetent}
             sheetElevation={sheetElevation}
             sheetShouldOverflowTopInset={sheetShouldOverflowTopInset}
-            sheetDefaultResizeAnimationEnabled={
-              sheetDefaultResizeAnimationEnabled
-            }
+            sheetResizeAnimationEnabled={sheetResizeAnimationEnabled}
             sheetGrabberVisible={sheetGrabberVisible}
             sheetCornerRadius={sheetCornerRadius}
             sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -82,7 +82,7 @@ export interface NativeProps extends ViewProps {
   sheetInitialDetent?: CT.WithDefault<CT.Int32, 0>;
   sheetElevation?: CT.WithDefault<CT.Int32, 24>;
   sheetShouldOverflowTopInset?: CT.WithDefault<boolean, false>;
-  sheetDefaultResizeAnimationEnabled?: CT.WithDefault<boolean, true>;
+  sheetResizeAnimationEnabled?: CT.WithDefault<boolean, true>;
   customAnimationOnSwipe?: boolean;
   fullScreenSwipeEnabled?: CT.WithDefault<OptionalBoolean, 'undefined'>;
   fullScreenSwipeShadowEnabled?: CT.WithDefault<boolean, true>;

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -84,7 +84,7 @@ export interface NativeProps extends ViewProps {
   sheetInitialDetent?: CT.WithDefault<CT.Int32, 0>;
   sheetElevation?: CT.WithDefault<CT.Int32, 24>;
   sheetShouldOverflowTopInset?: CT.WithDefault<boolean, false>;
-  sheetDefaultResizeAnimationEnabled?: CT.WithDefault<boolean, true>;
+  sheetResizeAnimationEnabled?: CT.WithDefault<boolean, true>;
   customAnimationOnSwipe?: boolean;
   fullScreenSwipeEnabled?: CT.WithDefault<OptionalBoolean, 'undefined'>;
   fullScreenSwipeShadowEnabled?: CT.WithDefault<boolean, true>;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -525,7 +525,7 @@ export interface ScreenProps extends ViewProps {
    *
    * @platform android
    */
-  sheetDefaultResizeAnimationEnabled?: boolean;
+  sheetResizeAnimationEnabled?: boolean;
   /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:


### PR DESCRIPTION
## Description

Just renaming prop, the "Default" doesn't add any value to it.

> [!NOTE]  
> I'm intentionally omitting the deprecation path, assuming that no one has consumed this prop so far, as it was released recently.

## Changes

- Rename prop

## Before & after - visual documentation

N/A

## Test plan

Just renaming prop, I believe that green CI is enough,

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
