### PR TITLE
feat: Add support for managing sheet detents with imperative API

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1743,6 +1743,27 @@ PODS:
     - React-utils (= 0.84.0-rc.1)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.84.0-rc.1)
+  - ReactNavigation (8.0.0-alpha.3):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - RNGestureHandler (2.29.1):
     - hermes-engine
     - RCTRequired
@@ -2025,6 +2046,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeDependencies (from `../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)
+  - "ReactNavigation (from `../node_modules/@react-navigation/native`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -2179,6 +2201,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeDependencies:
     :podspec: "../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec"
+  ReactNavigation:
+    :path: "../node_modules/@react-navigation/native"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -2192,7 +2216,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 338ed69636904cd70e9d5105526467c7b929c1d4
-  hermes-engine: c3fade8ae5ce23f29a01372acdcce8e0437e9984
+  hermes-engine: f6455302f94b29e87ff2ab5f0bb0c3b7b7d2a8df
   RCTDeprecation: 33a05e66fc1a11e2951bd16136e2ce94f311efe2
   RCTRequired: 0674ae0bedf47acb16062d9e1a6ba29394c022ba
   RCTSwiftUI: bf8adc14f68efd97fc40efd52b2d7ae223877c44
@@ -2263,10 +2287,11 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 9c1667bc43d8a73352d85a469679bb36a4b2a8a7
   ReactCodegen: 1768a327a5d7c186ac95936c1e49bf5af540fc17
   ReactCommon: 20c9e7fdb2957c694e8d3471430e3eaa86567f66
-  ReactNativeDependencies: dcff10826a4c394a5f452ffc88e3dbf95a03207a
+  ReactNativeDependencies: 50ac6a8be5c681f39feb4570f4c0ebd9c342f6a0
+  ReactNavigation: 08b0bfdd2c6055326fabf5810998790f956acd75
   RNGestureHandler: f080747d181c86d346827ba389209e1afb528628
   RNReanimated: ecef5a2762be20bc8090045a0fe574da9d5d6f8e
-  RNScreens: cf790008c91f78f3d2d8f04ec8daa561b8fa1d97
+  RNScreens: aae08713cce5fdfd76f5d089553ca1ea9e5f15e9
   RNWorklets: 67500a3686a9402d2352b65447729bf25fa1282b
   Yoga: b424d5df74684853feaf06fdbc368c37364ed2e4
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -15,6 +15,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNSScreenManagerDelegate
 import com.facebook.react.viewmanagers.RNSScreenManagerInterface
 import com.swmansion.rnscreens.bottomsheet.SheetDetents
+import com.swmansion.rnscreens.bottomsheet.SheetUtils
 import com.swmansion.rnscreens.events.HeaderBackButtonClickedEvent
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.ScreenAppearEvent
@@ -441,6 +442,15 @@ open class ScreenViewManager :
         )
 
     protected override fun getDelegate(): ViewManagerDelegate<Screen> = delegate
+
+    override fun setDetent(
+        view: Screen?,
+        index: Int,
+    ) {
+        view?.sheetBehavior?.apply {
+            state = SheetUtils.sheetStateFromDetentIndex(index, view.sheetDetents.count)
+        }
+    }
 
     companion object {
         const val REACT_CLASS = "RNSScreen"

--- a/apps/src/tests/TestFormSheet.tsx
+++ b/apps/src/tests/TestFormSheet.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Button, FlatList, ScrollView, Text, TextInput, View } from 'react-native';
 import PressableWithFeedback from '../shared/PressableWithFeedback';
 import { Spacer } from '../shared';
+import { type SheetCommands } from '../../../src/types';
 
 type ItemData = {
   id: number,
@@ -57,12 +58,20 @@ function Second({ navigation }: RouteProps<'Second'>) {
 }
 
 function FormSheet({ navigation }: RouteProps<'FormSheet'>) {
+  const sheetRef = React.useRef<SheetCommands>(null);
+
+  React.useEffect(() => {
+    navigation.setOptions({ sheetRef });
+  }, [navigation]);
+
   return (
     // When using `fitToContents` you can't use flex: 1. It is you who must provide
     // the content size - you can't rely on parent size here.
     <View style={{ backgroundColor: 'lightgreen', flex: 1 }}>
       <View style={{ paddingTop: 20 }}>
         <Button title="Go back" onPress={() => navigation.goBack()} />
+        <Button title="Set Detent 0" onPress={() => sheetRef.current?.setDetent(0)} />
+        <Button title="Set Detent 1" onPress={() => sheetRef.current?.setDetent(1)} />
         <Button title="Open Second" onPress={() => navigation.navigate('Second')} />
         <Button title="Open SecondFormSheet" onPress={() => navigation.navigate('SecondFormSheet')} />
         <PressableWithFeedback>

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1218,6 +1218,13 @@ RNS_IGNORE_SUPER_CALL_END
 #endif // RCT_NEW_ARCH_ENABLED
 }
 
+- (void)setDetent:(NSInteger)index
+{
+  UISheetPresentationControllerDetentIdentifier nextIdent = [[NSNumber numberWithInteger:index] stringValue];
+
+  [self setSelectedDetentForSheet:_controller.sheetPresentationController to:nextIdent animate:YES];
+}
+
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
 
 /**
@@ -1533,6 +1540,11 @@ RNS_IGNORE_SUPER_CALL_END
     [self updateFormSheetPresentationStyle];
   }
 #endif // !TARGET_OS_TV && !TARGET_OS_VISION
+}
+
+- (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
+{
+  RCTRNSScreenHandleCommand(self, commandName, args);
 }
 
 #pragma mark - Paper specific
@@ -2280,6 +2292,13 @@ RCT_EXPORT_VIEW_PROPERTY(sheetExpandsWhenScrolledToEdge, BOOL);
 - (UIView *)view
 {
   return [[RNSScreenView alloc] initWithBridge:self.bridge];
+}
+RCT_EXPORT_METHOD(setDetent : (NSNumber *_Nonnull)reactTag index : (NSNumber *)index)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry) {
+    RNSScreenView *screen = viewRegistry[reactTag];
+    [screen setDetent:index];
+  }];
 }
 #endif
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -16,6 +16,7 @@ import {
 // Native components
 import ScreenNativeComponent, {
   NativeProps as ScreenNativeComponentProps,
+  Commands as ScreenNativeCommands,
 } from '../fabric/ScreenNativeComponent';
 import ModalScreenNativeComponent, {
   NativeProps as ModalScreenNativeComponentProps,
@@ -38,6 +39,8 @@ const AnimatedNativeScreen = Animated.createAnimatedComponent(
 const AnimatedNativeModalScreen = Animated.createAnimatedComponent(
   ModalScreenNativeComponent,
 );
+const NativeScreenCommands: SheetCommandsType =
+  ScreenNativeCommands as SheetCommandsType;
 
 // Incomplete type, all accessible properties available at:
 // react-native/Libraries/Components/View/ReactNativeViewViewConfig.js
@@ -64,6 +67,10 @@ interface ViewConfig extends View {
     };
   };
 }
+
+type SheetCommandsType = {
+  setDetent: (viewRef: ViewConfig, index: number) => void;
+};
 
 export const InnerScreen = React.forwardRef<View, ScreenProps>(
   function InnerScreen(props, ref) {
@@ -100,6 +107,7 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       sheetInitialDetentIndex = 0,
       sheetShouldOverflowTopInset = false,
       sheetDefaultResizeAnimationEnabled = true,
+      sheetRef,
       // Other
       screenId,
       stackPresentation,
@@ -109,6 +117,28 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
       onWillAppear,
       onWillDisappear,
     } = rest;
+
+    React.useImperativeHandle(sheetRef, () => ({
+      setDetent: index => {
+        _callMethodWithRef(viewRef =>
+          NativeScreenCommands.setDetent(viewRef, index),
+        );
+      },
+    }));
+
+    const _callMethodWithRef = React.useCallback(
+      (method: (ref: ViewConfig) => void) => {
+        const viewRef = innerRef.current;
+        if (viewRef) {
+          method(viewRef);
+        } else {
+          console.warn(
+            'Reference to native screen component has not been updated yet',
+          );
+        }
+      },
+      [innerRef],
+    );
 
     if (enabled && isNativePlatformSupported) {
       const resolvedSheetAllowedDetents =

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -1,7 +1,10 @@
 'use client';
 
-import { codegenNativeComponent } from 'react-native';
-import type { CodegenTypes as CT, ViewProps, ColorValue } from 'react-native';
+import {
+  codegenNativeCommands,
+  codegenNativeComponent,
+  type HostComponent,
+ CodegenTypes as CT, ViewProps, ColorValue } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ScreenEvent = Readonly<{}>;
@@ -119,6 +122,19 @@ export interface NativeProps extends ViewProps {
     true
   >;
 }
+
+type ComponentType = HostComponent<NativeProps>;
+
+interface NativeCommands {
+  setDetent: (
+    viewRef: React.ComponentRef<ComponentType>,
+    index: CT.Int32,
+  ) => void;
+}
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['setDetent'],
+});
 
 export default codegenNativeComponent<NativeProps>('RNSScreen', {
   interfaceOnly: true,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -22,6 +22,9 @@ export type SearchBarCommands = {
   setText: (text: string) => void;
   cancelSearch: () => void;
 };
+export type SheetCommands = {
+  setDetent: (index: number) => void;
+};
 
 export type BackButtonDisplayMode = 'default' | 'generic' | 'minimal';
 export type StackPresentationTypes =
@@ -526,6 +529,14 @@ export interface ScreenProps extends ViewProps {
    * @platform android
    */
   sheetDefaultResizeAnimationEnabled?: boolean;
+  /**
+   * Reference to imperatively modify screen with presentation `formSheet`.
+   *
+   * Currently supported operations are:
+   *
+   * * `setDetent` - set the current detent index for the sheet
+   */
+  sheetRef?: React.RefObject<SheetCommands>;
   /**
    * How the screen should appear/disappear when pushed or popped at the top of the stack.
    * The following values are currently supported:


### PR DESCRIPTION
Introduced a `sheetRef` prop and associated commands for controlling sheet detents on `formSheet` presentations. This includes native methods and type definitions to set the detent index programmatically, improving customization and flexibility.

## Description

This feature allows to control active detent of opened `formSheet`. Sometimes it is really useful to set detent programmatically

## Changes

- Screens handles UI commands via react reference (like `SearchBar`)

## Demonstration

| iOS | Android |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/775ccb96-0a2b-44b6-88b6-770f4e663771"> | <video src="https://github.com/user-attachments/assets/9dc11075-4032-4c3f-b29b-1eac11198e5c"> |

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
