### PR TITLE
fix(Android, Fabric): Fix crash when sending key event for opening dev menu

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -431,10 +431,17 @@ class ScreenStackHeaderConfig(
         config: ScreenStackHeaderConfig,
     ) : CustomToolbar(context, config) {
         override fun showOverflowMenu(): Boolean {
-            (context.applicationContext as ReactApplication)
-                .reactNativeHost
-                .reactInstanceManager
-                .showDevOptionsDialog()
+            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+                (context.applicationContext as ReactApplication)
+                    .reactHost
+                    ?.devSupportManager
+                    ?.showDevOptionsDialog()
+            } else {
+                (context.applicationContext as ReactApplication)
+                    .reactNativeHost
+                    .reactInstanceManager
+                    .showDevOptionsDialog()
+            }
             return true
         }
     }


### PR DESCRIPTION
## Description

Fixes the crash when opening the dev menu by key event on Fabric

Please take a look at for the context why it's needed https://github.com/software-mansion/react-native-screens/pull/602#issue-679057388 

Looks like this was added before the new architecture and forgotten during the migration: https://github.com/software-mansion/react-native-screens/pull/602 .

## Changes

- Fixed opening dev menu from key event on Fabric

## Before & after - visual documentation

Before

```
java.lang.RuntimeException: You should not use ReactNativeHost directly in the New Architecture
at com.facebook.react.ReactApplication.getReactNativeHost(ReactApplication.kt:20)
at com.swmansion.rnscreens.ScreenStackHeaderConfig$DebugMenuToolbar.showOverflowMenu(ScreenStackHeaderConfig.kt:435)
at androidx.appcompat.widget.ToolbarWidgetWrapper.showOverflowMenu(ToolbarWidgetWrapper.java:352)
at androidx.appcompat.app.ToolbarActionBar.openOptionsMenu(ToolbarActionBar.java:426)
at androidx.appcompat.app.ToolbarActionBar.onMenuKeyEvent(ToolbarActionBar.java:472)
at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:588)
at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3393)
at expo.modules.devmenu.detectors.TouchInterceptingWindowCallback.dispatchKeyEvent(Unknown Source:2)
at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.bypassDispatchKeyEvent(AppCompatDelegateImpl.java:3583)
at androidx.appcompat.app.AppCompatDelegateImpl.dispatchKeyEvent(AppCompatDelegateImpl.java:1564)
at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3396)
at expo.modules.devmenu.detectors.TouchInterceptingWindowCallback.dispatchKeyEvent(Unknown Source:2)
at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:377)
at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:8144)
at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:7983)
at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7369)
at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7426)
at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7392)
at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7558)
at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7400)
at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:7615)
at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7373)
at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7426)
at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7392)
at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7400)
at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7373)
at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7426)
at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7392)
at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7591)
at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:7831)
at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:5190)
at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:4553)
at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:4544)
at android.view.inputmethod.InputMethodManager.-$$Nest$mfinishedInputEvent(Unknown Source:0)
at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:5167)
at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:181)
at android.os.MessageQueue.nativePollOnce(Native Method)
at android.os.MessageQueue.nextLegacy(MessageQueue.java:913)
at android.os.MessageQueue.next(MessageQueue.java:1025)
at android.os.Looper.loopOnce(Looper.java:196)
at android.os.Looper.loop(Looper.java:338)
at android.app.ActivityThread.main(ActivityThread.java:9067)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```

After

https://github.com/user-attachments/assets/e80734df-ab0c-4c89-a90c-1837b8d8944a

## Test plan

Launch FabricExample on android & send `adb shell input keyevent 82` via console

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
