### PR TITLE
fix(Android, Examples): Fix crashes in examples below API level 29

### DIFF
--- a/Example/android/app/src/main/java/com/swmansion/rnscreens/example/MainActivity.kt
+++ b/Example/android/app/src/main/java/com/swmansion/rnscreens/example/MainActivity.kt
@@ -30,6 +30,9 @@ class MainActivity : ReactActivity() {
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     // opt out of having 80% opacity over 3-button navigation
-    getWindow().setNavigationBarContrastEnforced(false)
+    // supported for API level 29 or higher
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+      getWindow().setNavigationBarContrastEnforced(false)
+    }
   }
 }

--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
@@ -30,6 +30,9 @@ class MainActivity : ReactActivity() {
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     // opt out of having 80% opacity over 3-button navigation
-    getWindow().setNavigationBarContrastEnforced(false)
+    // supported for API level 29 or higher
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+      getWindow().setNavigationBarContrastEnforced(false)
+    }
   }
 }


### PR DESCRIPTION
## Description

<img width="1121" height="175" alt="Screenshot 2026-01-29 at 15 41 29" src="https://github.com/user-attachments/assets/4d19fff5-ca98-40bf-b605-69aa1f9204d1" />

## Changes

- Wrapper problematic code with the API-level check

## Before & after - visual documentation

### Before

Crash (on API level 28)

### After

No crash (on API level 28)

## Test plan

Launch both apps on device with API lvl < 29

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
