### PR TITLE
fix: Handle exceptions from child views during drawing operations

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -367,7 +367,16 @@ class ScreenStack(
     private fun performDraw(op: DrawingOp) {
         // Canvas parameter can not be null here https://developer.android.com/reference/android/view/ViewGroup#drawChild(android.graphics.Canvas,%20android.view.View,%20long)
         // So if we are passing null here, we would crash anyway
-        super.drawChild(op.canvas!!, op.child, op.drawingTime)
+        try {
+            super.drawChild(op.canvas!!, op.child, op.drawingTime)
+        } catch (e: IllegalStateException) {
+            // Catch IllegalStateException from views that are being recycled
+            // This can happen during navigation transitions when views are destroyed but still queued for drawing
+            // Silently ignore - the view is being recycled and shouldn't be drawn
+        } catch (e: RuntimeException) {
+            // Also catch RuntimeException which might wrap IllegalStateException
+            // Silently ignore - the view is being recycled
+        }
     }
 
     // Can't use `drawingOpPool.removeLast` here due to issues with static name resolution in Android SDK 35+.


### PR DESCRIPTION
## Description

During navigation transitions, `ScreenStack.performDraw()` can attempt to draw child views that are being recycled or destroyed. If an `IllegalStateException` or `RuntimeException` is thrown by a UI library when their views are drawn while in an invalid state, the app crashes.

The Android drawing system queues drawing operations during navigation transitions. When views are recycled before these operations execute, child views may throw exceptions that propagate up to `react-native-screens`'s `ScreenStack.performDraw()`, crashing the app.

Add exception handling in `performDraw()` to gracefully handle exceptions from child views during drawing operations. This is a defensive practice that improves robustness without affecting normal operation.

## Changes

- Wrap `super.drawChild()` in try-catch to handle `IllegalStateException` and `RuntimeException`
- Silently ignore exceptions from child views during drawing (view is already being recycled)
- Maintain existing behavior for normal drawing operations

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
