### PR TITLE
fix(iOS): fix possible build issues on Mac Catalyst due to implicit conversions

### DIFF
--- a/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.mm
@@ -39,7 +39,8 @@ namespace react = facebook::react;
   if (_reactEventEmitter != nullptr) {
     _reactEventEmitter->onNativeFocusChange(
         {.tabKey = RCTStringFromNSString(payload.tabKey),
-         .repeatedSelectionHandledBySpecialEffect = payload.repeatedSelectionHandledBySpecialEffect});
+         .repeatedSelectionHandledBySpecialEffect =
+             static_cast<bool>(payload.repeatedSelectionHandledBySpecialEffect)});
     return YES;
   } else {
     RCTLogWarn(@"[RNScreens] Skipped OnNativeFocusChange event emission due to nullish emitter");


### PR DESCRIPTION

## Description

Closes <https://github.com/software-mansion/react-native-screens/issues/3592>

The fix relies on adding an explicit cast from `BOOL` to `bool`.
Currently, I am not aware of any scenario where described cast could
fail, therefore I determine it to be safe.

This change reportedly fixes an issue with build on Mac Catalyst.
The fix is analogous to the one I did in <https://github.com/software-mansion/react-native-screens/pull/3202>.

## Before & after - visual documentation

N/A

## Test plan

This diff does not change behavior on our end. For us sufficient testing plan would be
for out CIs to pass. I'm relying here on user confirmation that the PR indeed fixes the issue.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
