### PR TITLE
fix(Android, Stack v5): update stack model after native pop

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackOperation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackOperation.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.host
 
 import com.swmansion.rnscreens.gamma.stack.screen.StackScreen
 
-internal sealed class StackOperation()
+internal sealed class StackOperation
 
 internal class PushOperation(
     val screen: StackScreen,


### PR DESCRIPTION
## Description

Currently when doing native pop, the `stackModel` stored in `StackContainer`
is never updated, therefore leading to an incorrect state held (natively
dismissed fragments are never removed from the state).

This PR changes that.

## Changes

Currently I remove them from the state in `onFragmentDestroyView`,
and it seems to work, however I'm not sure, this is the perfect
place timing-wise. This callback is called only after fragment's
view is destroyed, which might be pretty late in component
lifecycle, and we might execute container operations still taking
into consideration possibly removed screens. We need to look into
that later.

## Before & after - visual documentation

N/A

## Test plan

Only sensible way to test this is to add logging in `StackContainer`
and dismiss few screens natively, and see that the state is updated (with this fix).

## Checklist

- [x] Ensured that CI passes

