### PR TITLE
chore(examples): fix import path for tests in apps/App.tsx

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 import Example from './Example';
-// import * as Test from './src/tests';
+// import * as Test from './src/tests/issue-tests';
 
 enableFreeze(true);
 


### PR DESCRIPTION

After <https://github.com/software-mansion/react-native-screens/pull/3528>
The commented import is no longer up to date. This PR fixes it.
