### PR TITLE
fix: `updateSelectedTab` removing unowned fragments

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
@@ -382,8 +382,9 @@ class TabsHost(
     private fun updateSelectedTab() {
         val newFocusedTab = currentFocusedTab
 
-        check(requireFragmentManager.fragments.size <= 1) { "[RNScreens] There can be only a single focused tab" }
-        val oldFocusedTab = requireFragmentManager.fragments.firstOrNull()
+        val tabFragments = requireFragmentManager.fragments.filterIsInstance<TabScreenFragment>()
+        check(tabFragments.size <= 1) { "[RNScreens] There can be only a single focused tab" }
+        val oldFocusedTab = tabFragments.firstOrNull()
 
         if (newFocusedTab === oldFocusedTab) {
             return


### PR DESCRIPTION
## Description

Fixes `updateSelectedTab` removing unowned fragments (fragments that were created by other libraries) 

## Changes

- Made sure that the code will only remove `TabScreenFragment` 

## Test plan

This change was tested using the new Expo template in the preview version of Expo Go. 
Before, the `react-native-screens` removed the fragment created by `expo-dev-menu`. With this fix, everything seems to work. 