### PR TITLE
chore(examples): add patch to `MainActivity` to enable predictive back gesture

### DIFF
--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
@@ -26,6 +26,10 @@ class MainActivity : ReactActivity() {
     supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
     super.onCreate(savedInstanceState)
 
+    // Remove this once we have sensible workaround to disable the react callback.
+    // Currently it prevents fragment manager's callback from triggering, blocking
+    // native-pop & predictive back gesture.
+    // See: https://github.com/software-mansion/react-native-screens/pull/3630
     try {
       val field = ReactActivity::class.java.getDeclaredField("mBackPressedCallback")
       field.isAccessible = true


### PR DESCRIPTION

## Description

Add patch to MainActivity to enable predictive back gesture

This is needed, because for some reason, currently the
`OnBackPressedCallback` from `ReactActivity` is added after the one from
fragment manager, effectively preventing native dismiss & navigation
from working properly.

This should be either fixed directly on RN side or we'll need to make it
into an installation step / alternatively we can create a hacky
workaround & handle this on our end.

This is added only to FabricExample because we do plan to support
predictive back gesture only on new architecture with new stack
implementation.

## Changes

This patch uses reflection to disable the `ReactAcctivity`'s `OnBackPressedCallback`.

It effectively disables `BackPressed` API from `react-native`. We should be
fine with it for now.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
