### PR TITLE
feat(tabs): add useBottomTabBarHeight for native bottom tabs

### DIFF
--- a/FabricExample/e2e/examplesTests/nativeBottomTabs.e2e.ts
+++ b/FabricExample/e2e/examplesTests/nativeBottomTabs.e2e.ts
@@ -14,6 +14,9 @@ describe('Native BottomTabs', () => {
     await expect(
       element(by.id('tab-screen-1-id')),
     ).toBeVisible();
+    await expect(
+      element(by.id('tab-bar-height-state-Tab1')),
+    ).toHaveText('ready');
   });
 
   it('should use tab id to navigate to third tab screen', async () => {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -7,6 +7,7 @@ import android.text.TextUtils
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.View.OnClickListener
+import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostEventEmitter.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens.gamma.tabs
 import com.facebook.react.bridge.ReactContext
 import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
 import com.swmansion.rnscreens.gamma.tabs.event.TabsHostNativeFocusChangeEvent
+import com.swmansion.rnscreens.gamma.tabs.event.TabsHostTabBarHeightChangeEvent
 
 internal class TabsHostEventEmitter(
     reactContext: ReactContext,
@@ -20,6 +21,16 @@ internal class TabsHostEventEmitter(
                 tabKey,
                 tabNumber,
                 repeatedSelectionHandledBySpecialEffect,
+            ),
+        )
+    }
+
+    fun emitOnTabBarHeightChange(tabBarHeight: Double) {
+        reactEventDispatcher.dispatchEvent(
+            TabsHostTabBarHeightChangeEvent(
+                surfaceId,
+                viewTag,
+                tabBarHeight,
             ),
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHostViewManager.kt
@@ -10,6 +10,7 @@ import com.facebook.react.viewmanagers.RNSBottomTabsManagerDelegate
 import com.facebook.react.viewmanagers.RNSBottomTabsManagerInterface
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
 import com.swmansion.rnscreens.gamma.tabs.event.TabsHostNativeFocusChangeEvent
+import com.swmansion.rnscreens.gamma.tabs.event.TabsHostTabBarHeightChangeEvent
 
 @ReactModule(name = TabsHostViewManager.REACT_CLASS)
 class TabsHostViewManager :
@@ -54,6 +55,7 @@ class TabsHostViewManager :
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
         mutableMapOf(
             makeEventRegistrationInfo(TabsHostNativeFocusChangeEvent),
+            makeEventRegistrationInfo(TabsHostTabBarHeightChangeEvent),
         )
 
     override fun addEventEmitters(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/event/TabsHostTabBarHeightChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/event/TabsHostTabBarHeightChangeEvent.kt
@@ -1,0 +1,35 @@
+package com.swmansion.rnscreens.gamma.tabs.event
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
+
+class TabsHostTabBarHeightChangeEvent(
+    surfaceId: Int,
+    viewId: Int,
+    private val tabBarHeightInDp: Double,
+) : Event<TabsHostTabBarHeightChangeEvent>(surfaceId, viewId),
+    NamingAwareEventType {
+    override fun getEventName() = EVENT_NAME
+
+    override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+
+    override fun getCoalescingKey(): Short = tabBarHeightInDp.toInt().toShort()
+
+    override fun getEventData(): WritableMap? =
+        Arguments.createMap().apply {
+            putDouble(EVENT_KEY_HEIGHT, tabBarHeightInDp)
+        }
+
+    companion object : NamingAwareEventType {
+        const val EVENT_NAME = "topTabBarHeightChange"
+        const val EVENT_REGISTRATION_NAME = "onTabBarHeightChange"
+
+        private const val EVENT_KEY_HEIGHT = "height"
+
+        override fun getEventName() = EVENT_NAME
+
+        override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+    }
+}

--- a/apps/src/tests/issue-tests/TestBottomTabs/components/TabContentView.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/components/TabContentView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { type ViewProps, View, Text, Button } from 'react-native';
+import { useBottomTabBarHeight } from 'react-native-screens';
 import ConfigWrapperContext from '../../../../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
 import { someExtensiveComputation } from '../utils';
 import { TabConfigurationSummary } from './TabConfigurationSummary';
@@ -14,12 +15,7 @@ export function TabContentView(props: TabContentViewProps) {
   const { selectNextTab, tabKey, message, ...viewProps } = props;
 
   const configWrapper = React.useContext(ConfigWrapperContext);
-
-  console.log(
-    `TabContentView render with config: ${JSON.stringify(
-      configWrapper.config,
-    )}`,
-  );
+  const tabBarHeight = useBottomTabBarHeight();
 
   if (configWrapper.config.heavyTabRender) {
     someExtensiveComputation();
@@ -28,6 +24,13 @@ export function TabContentView(props: TabContentViewProps) {
   return (
     <View {...viewProps}>
       {message !== undefined && <Text>{message}</Text>}
+      <Text testID={`tab-bar-height-label-${tabKey}`}>
+        Tab bar height: {tabBarHeight.toFixed(2)}
+      </Text>
+      <Text testID={`tab-bar-height-state-${tabKey}`}>
+        {tabBarHeight > 0 ? 'ready' : 'pending'}
+      </Text>
+      <Text testID={`tab-bar-height-value-${tabKey}`}>{tabBarHeight}</Text>
       <TabConfigurationSummary tabKey={tabKey} />
       <Button title="Next tab" onPress={selectNextTab} />
       <Button

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab3.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab3.tsx
@@ -1,8 +1,14 @@
 import PressableWithFeedback from '../../../../shared/PressableWithFeedback';
 import React from 'react';
-import { ScrollView, Text } from 'react-native';
+import { Platform, ScrollView, Text } from 'react-native';
+import { useBottomTabBarHeight } from 'react-native-screens';
 
 export function Tab3() {
+  const tabBarHeight = useBottomTabBarHeight();
+  // Android native tabs are drawn above content, so we offset the list bottom
+  // by the reported tab bar height to keep the last item reachable.
+  const bottomOffset = Platform.OS === 'android' ? Math.max(tabBarHeight, 0) : 0;
+
   return (
     <ScrollView
       contentContainerStyle={{
@@ -10,6 +16,7 @@ export function Tab3() {
         height: 'auto',
         gap: 15,
         paddingHorizontal: 30,
+        paddingBottom: bottomOffset,
       }}>
       {[...Array(30).keys()].map(index => (
         <PressableWithFeedback

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.h
@@ -76,11 +76,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)emitOnNativeFocusChangeRequestSelectedTabScreen:(nonnull RNSBottomTabsScreenComponentView *)tabScreen
                 repeatedSelectionHandledBySpecialEffect:(BOOL)repeatedSelectionHandledBySpecialEffect;
+- (BOOL)emitOnTabBarHeightChangeWithHeight:(CGFloat)height;
 
 #if !RCT_NEW_ARCH_ENABLED
 #pragma mark - LEGACY Event blocks
 
 @property (nonatomic, copy) RCTDirectEventBlock onNativeFocusChange;
+@property (nonatomic, copy) RCTDirectEventBlock onTabBarHeightChange;
 
 #endif
 

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentView.mm
@@ -275,6 +275,13 @@ namespace react = facebook::react;
                                   .repeatedSelectionHandledBySpecialEffect = repeatedSelectionHandledBySpecialEffect}];
 }
 
+- (BOOL)emitOnTabBarHeightChangeWithHeight:(CGFloat)height
+{
+  return [_reactEventEmitter
+      emitOnTabBarHeightChange:OnTabBarHeightChangePayload{
+                                   .height = height}];
+}
+
 #pragma mark - RCTComponentViewProtocol
 #if RCT_NEW_ARCH_ENABLED
 
@@ -313,6 +320,7 @@ namespace react = facebook::react;
     {
       _controller.tabBar.hidden = _tabBarHidden;
     }
+    [self emitOnTabBarHeightChangeWithHeight:_tabBarHidden ? 0 : _controller.tabBar.frame.size.height];
   }
 
   if (newComponentProps.nativeContainerBackgroundColor != oldComponentProps.nativeContainerBackgroundColor) {
@@ -500,6 +508,7 @@ RNS_IGNORE_SUPER_CALL_END
   {
     _controller.tabBar.hidden = _tabBarHidden;
   }
+  [self emitOnTabBarHeightChangeWithHeight:_tabBarHidden ? 0 : _controller.tabBar.frame.size.height];
 }
 
 - (void)setNativeContainerBackgroundColor:(UIColor *_Nullable)nativeContainerBackgroundColor
@@ -547,6 +556,11 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)setOnNativeFocusChange:(RCTDirectEventBlock)onNativeFocusChange
 {
   [self.reactEventEmitter setOnNativeFocusChange:onNativeFocusChange];
+}
+
+- (void)setOnTabBarHeightChange:(RCTDirectEventBlock)onTabBarHeightChange
+{
+  [self.reactEventEmitter setOnTabBarHeightChange:onTabBarHeightChange];
 }
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/bottom-tabs/host/RNSBottomTabsHostComponentViewManager.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostComponentViewManager.mm
@@ -41,6 +41,7 @@ RCT_REMAP_VIEW_PROPERTY(tabBarControllerMode, tabBarControllerModeFromRNSTabBarC
 #pragma mark - LEGACY Events
 
 RCT_EXPORT_VIEW_PROPERTY(onNativeFocusChange, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTabBarHeightChange, RCTDirectEventBlock);
 
 #endif
 

--- a/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.h
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 // Hide C++ symbols from C compiler used when building Swift module
 #if defined(__cplusplus) && RCT_NEW_ARCH_ENABLED
@@ -20,16 +21,25 @@ struct OnNativeFocusChangePayload {
   NSString *_Nonnull tabKey;
   BOOL repeatedSelectionHandledBySpecialEffect;
 };
+
+struct OnTabBarHeightChangePayload {
+  CGFloat height;
+};
 #else
 typedef struct {
   NSString *_Nonnull tabKey;
   BOOL repeatedSelectionHandledBySpecialEffect;
 } OnNativeFocusChangePayload;
+
+typedef struct {
+  CGFloat height;
+} OnTabBarHeightChangePayload;
 #endif
 
 @interface RNSBottomTabsHostEventEmitter : NSObject
 
 - (BOOL)emitOnNativeFocusChange:(OnNativeFocusChangePayload)payload;
+- (BOOL)emitOnTabBarHeightChange:(OnTabBarHeightChangePayload)payload;
 
 @end
 
@@ -47,6 +57,7 @@ typedef struct {
 #pragma mark - LEGACY Event emitter blocks
 
 @property (nonatomic, copy) RCTDirectEventBlock onNativeFocusChange;
+@property (nonatomic, copy) RCTDirectEventBlock onTabBarHeightChange;
 
 #endif // RCT_NEW_ARCH_ENABLED
 

--- a/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.mm
+++ b/ios/bottom-tabs/host/RNSBottomTabsHostEventEmitter.mm
@@ -60,4 +60,28 @@ namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 }
 
+- (BOOL)emitOnTabBarHeightChange:(OnTabBarHeightChangePayload)payload
+{
+#if RCT_NEW_ARCH_ENABLED
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onTabBarHeightChange(
+        {.height = static_cast<double>(payload.height)});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnTabBarHeightChange event emission due to nullish emitter");
+    return NO;
+  }
+#else
+  if (self.onTabBarHeightChange) {
+    self.onTabBarHeightChange(@{
+      @"height" : @(payload.height),
+    });
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnTabBarHeightChange event emission due to nullish emitter");
+    return NO;
+  }
+#endif // RCT_NEW_ARCH_ENABLED
+}
+
 @end

--- a/ios/bottom-tabs/host/RNSTabBarController.h
+++ b/ios/bottom-tabs/host/RNSTabBarController.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Might return null in cases where the controller view hierararchy is not attached to parent.
  */
-@property (nonatomic, readonly, nullable) RNSBottomTabsHostComponentView *tabsHostComponentView;
+@property (nonatomic, weak, readonly, nullable) RNSBottomTabsHostComponentView *tabsHostComponentView;
 
 /**
  * Tab bar appearance coordinator. If you need to update tab bar appearance avoid using this one directly. Send the

--- a/ios/bottom-tabs/host/RNSTabBarController.mm
+++ b/ios/bottom-tabs/host/RNSTabBarController.mm
@@ -6,6 +6,7 @@
 
 @implementation RNSTabBarController {
   NSArray<RNSTabsScreenViewController *> *_Nullable _tabScreenControllers;
+  CGFloat _lastEmittedTabBarHeight;
 
 #if !RCT_NEW_ARCH_ENABLED
   BOOL _isControllerFlushBlockScheduled;
@@ -18,6 +19,7 @@
     _tabScreenControllers = nil;
     _tabBarAppearanceCoordinator = [RNSTabBarAppearanceCoordinator new];
     _tabsHostComponentView = nil;
+    _lastEmittedTabBarHeight = -1;
 
 #if !RCT_NEW_ARCH_ENABLED
     _isControllerFlushBlockScheduled = NO;
@@ -37,6 +39,29 @@
 - (void)tabBar:(UITabBar *)tabBar didSelectItem:(UITabBarItem *)item
 {
   RNSLog(@"TabBar: %@ didSelectItem: %@", tabBar, item);
+}
+
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+  [self emitTabBarHeightChangeIfNeeded];
+}
+
+- (void)emitTabBarHeightChangeIfNeeded
+{
+  RNSBottomTabsHostComponentView *tabsHostComponentView = self.tabsHostComponentView;
+  if (tabsHostComponentView == nil || tabsHostComponentView.window == nil || self.view.window == nil) {
+    return;
+  }
+
+  CGFloat height = tabsHostComponentView.tabBarHidden ? 0 : self.tabBar.frame.size.height;
+
+  if (_lastEmittedTabBarHeight == height) {
+    return;
+  }
+
+  _lastEmittedTabBarHeight = height;
+  [tabsHostComponentView emitOnTabBarHeightChangeWithHeight:height];
 }
 
 #pragma mark-- Signals

--- a/scripts/swift-format-helper.sh
+++ b/scripts/swift-format-helper.sh
@@ -1,4 +1,6 @@
-changed=$(find ios Example/ios FabricExample/ios -type f -name '*.swift' | tr '\n' ' ')
+changed=$(find ios Example/ios FabricExample/ios \
+  -type d -name build -prune -o \
+  -type f -name '*.swift' -print | tr '\n' ' ')
 
 case "$1" in
     "format") swift-format format --in-place --parallel --configuration=.swift-format $changed;;

--- a/src/components/tabs/BottomTabBarHeightContext.ts
+++ b/src/components/tabs/BottomTabBarHeightContext.ts
@@ -1,0 +1,7 @@
+'use client';
+
+import * as React from 'react';
+
+export const BottomTabBarHeightContext = React.createContext<
+  number | undefined
+>(undefined);

--- a/src/components/tabs/TabsHost.tsx
+++ b/src/components/tabs/TabsHost.tsx
@@ -8,6 +8,7 @@ import {
   type NativeSyntheticEvent,
 } from 'react-native';
 import BottomTabsNativeComponent, {
+  type NativeTabBarHeightChangeEvent,
   type NativeProps as BottomTabsNativeComponentProps,
 } from '../../fabric/bottom-tabs/BottomTabsNativeComponent';
 import featureFlags from '../../flags';
@@ -16,6 +17,7 @@ import { bottomTabsDebugLog } from '../../private/logging';
 import TabsAccessory from './TabsAccessory';
 import { TabsAccessoryEnvironment } from './TabsAccessory.types';
 import TabsAccessoryContent from './TabsAccessoryContent';
+import { BottomTabBarHeightContext } from './BottomTabBarHeightContext';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -59,38 +61,52 @@ function TabsHost(props: TabsHostProps) {
 
   const [bottomAccessoryEnvironment, setBottomAccessoryEnvironment] =
     useState<TabsAccessoryEnvironment>('regular');
+  const [tabBarHeight, setTabBarHeight] = useState(0);
+
+  const onTabBarHeightChangeCallback = React.useCallback(
+    (event: NativeSyntheticEvent<NativeTabBarHeightChangeEvent>) => {
+      const nextHeight = event.nativeEvent.height;
+      setTabBarHeight(prevHeight =>
+        prevHeight === nextHeight ? prevHeight : nextHeight,
+      );
+    },
+    [],
+  );
 
   return (
-    <BottomTabsNativeComponent
-      style={styles.fillParent}
-      onNativeFocusChange={onNativeFocusChangeCallback}
-      controlNavigationStateInJS={experimentalControlNavigationStateInJS}
-      nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
-      // @ts-ignore suppress ref - debug only
-      ref={componentNodeRef}
-      {...filteredProps}>
-      {filteredProps.children}
-      {bottomAccessory &&
-        Platform.OS === 'ios' &&
-        parseInt(Platform.Version, 10) >= 26 &&
-        (Platform.constants.reactNativeVersion.minor >= 82 ? (
-          <TabsAccessory>
-            <TabsAccessoryContent environment="regular">
-              {bottomAccessory('regular')}
-            </TabsAccessoryContent>
-            <TabsAccessoryContent environment="inline">
-              {bottomAccessory('inline')}
-            </TabsAccessoryContent>
-          </TabsAccessory>
-        ) : (
-          <TabsAccessory
-            onEnvironmentChange={event => {
-              setBottomAccessoryEnvironment(event.nativeEvent.environment);
-            }}>
-            {bottomAccessory(bottomAccessoryEnvironment)}
-          </TabsAccessory>
-        ))}
-    </BottomTabsNativeComponent>
+    <BottomTabBarHeightContext.Provider value={tabBarHeight}>
+      <BottomTabsNativeComponent
+        style={styles.fillParent}
+        onNativeFocusChange={onNativeFocusChangeCallback}
+        onTabBarHeightChange={onTabBarHeightChangeCallback}
+        controlNavigationStateInJS={experimentalControlNavigationStateInJS}
+        nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
+        // @ts-ignore suppress ref - debug only
+        ref={componentNodeRef}
+        {...filteredProps}>
+        {filteredProps.children}
+        {bottomAccessory &&
+          Platform.OS === 'ios' &&
+          parseInt(Platform.Version, 10) >= 26 &&
+          (Platform.constants.reactNativeVersion.minor >= 82 ? (
+            <TabsAccessory>
+              <TabsAccessoryContent environment="regular">
+                {bottomAccessory('regular')}
+              </TabsAccessoryContent>
+              <TabsAccessoryContent environment="inline">
+                {bottomAccessory('inline')}
+              </TabsAccessoryContent>
+            </TabsAccessory>
+          ) : (
+            <TabsAccessory
+              onEnvironmentChange={event => {
+                setBottomAccessoryEnvironment(event.nativeEvent.environment);
+              }}>
+              {bottomAccessory(bottomAccessoryEnvironment)}
+            </TabsAccessory>
+          ))}
+      </BottomTabsNativeComponent>
+    </BottomTabBarHeightContext.Provider>
   );
 }
 

--- a/src/components/tabs/TabsHost.web.tsx
+++ b/src/components/tabs/TabsHost.web.tsx
@@ -1,5 +1,14 @@
+import React from 'react';
 import { View } from 'react-native';
 
-const TabsHost = View;
+import { BottomTabBarHeightContext } from './BottomTabBarHeightContext';
+
+function TabsHost(props: React.ComponentProps<typeof View>) {
+  return (
+    <BottomTabBarHeightContext.Provider value={0}>
+      <View {...props} />
+    </BottomTabBarHeightContext.Provider>
+  );
+}
 
 export default TabsHost;

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -1,9 +1,12 @@
 import TabsHost from './TabsHost';
 import TabsScreen from './TabsScreen';
+import { BottomTabBarHeightContext } from './BottomTabBarHeightContext';
+import { useBottomTabBarHeight } from './useBottomTabBarHeight';
 
 export type * from './TabsHost.types';
 export type * from './TabsScreen.types';
 export type { TabsAccessoryEnvironment } from './TabsAccessory.types';
+export { BottomTabBarHeightContext, useBottomTabBarHeight };
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE

--- a/src/components/tabs/useBottomTabBarHeight.ts
+++ b/src/components/tabs/useBottomTabBarHeight.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+
+import { BottomTabBarHeightContext } from './BottomTabBarHeightContext';
+
+/**
+ * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
+ */
+export function useBottomTabBarHeight() {
+  const height = React.useContext(BottomTabBarHeightContext);
+
+  if (height === undefined) {
+    throw new Error(
+      "Couldn't find the bottom tab bar height. Are you inside a screen in Native Bottom Tab Navigator?",
+    );
+  }
+
+  return height;
+}

--- a/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsNativeComponent.ts
@@ -15,6 +15,10 @@ type NativeFocusChangeEvent = {
   repeatedSelectionHandledBySpecialEffect: boolean;
 };
 
+export type NativeTabBarHeightChangeEvent = {
+  height: CT.Double;
+};
+
 type TabBarItemLabelVisibilityMode =
   | 'auto'
   | 'selected'
@@ -32,6 +36,7 @@ type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 export interface NativeProps extends ViewProps {
   // Events
   onNativeFocusChange?: CT.DirectEventHandler<NativeFocusChangeEvent>;
+  onTabBarHeightChange?: CT.DirectEventHandler<NativeTabBarHeightChangeEvent>;
 
   // General
   tabBarHidden?: CT.WithDefault<boolean, false>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,4 +62,8 @@ export { default as useTransitionProgress } from './useTransitionProgress';
 /**
  * EXPERIMENTAL API BELOW. MIGHT CHANGE W/O ANY NOTICE
  */
-export { default as Tabs } from './components/tabs';
+export {
+  default as Tabs,
+  BottomTabBarHeightContext,
+  useBottomTabBarHeight,
+} from './components/tabs';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1317,5 +1317,7 @@ export interface GestureProviderProps extends GestureProps {
   gestureDetectorBridge: React.MutableRefObject<GestureDetectorBridge>;
 }
 
-export type * from './components/tabs';
+export type * from './components/tabs/TabsHost.types';
+export type * from './components/tabs/TabsScreen.types';
+export type { TabsAccessoryEnvironment } from './components/tabs/TabsAccessory.types';
 export type * from './components/shared/types';


### PR DESCRIPTION
## Description

  This PR introduces an experimental API to read native bottom tab bar height from JS in react-native-screens.
  ### What

  - Adds useBottomTabBarHeight and BottomTabBarHeightContext for native bottom tabs.
  - Adds native event plumbing (onTabBarHeightChange) on both Android and iOS.

  ### Why

  - Native bottom tabs render outside the JS layout tree, so tab bar height wasn’t accessible in screen layout
    code.
  - This enables reliable content offset/layout behavior and aligns with common migration expectations.

  Relates to #3616 and for react-navigation: https://github.com/react-navigation/react-navigation/discussions/12949

  ## Changes

  - Added onTabBarHeightChange to BottomTabsNativeComponent spec.
  - Added Android tab bar height event emission:
      - TabsHost
      - TabsHostEventEmitter
      - TabsHostViewManager
      - new event type TabsHostTabBarHeightChangeEvent
      - RNSBottomTabsHostEventEmitter
      - RNSBottomTabsHostComponentView / manager event exposure
  - Exported new API:
      - useBottomTabBarHeight
      - updated public exports in src/index.tsx and src/types.tsx
  - Added verification updates in FabricExample:
      - e2e assertion for ready tab bar height state
      - visible test UI showing height/state
      - Android-only Tab3 content bottom offset using the new hook
  - Fixed Android compile regression:
      - added missing ViewGroup import in ScreenStackHeaderConfig.kt
  - Updated Swift lint helper:
      - excludes generated iOS build directories to avoid formatting noise

  ## Before & after - visual documentation

<img width="300" height="600" alt="Screenshot_1770746164" src="https://github.com/user-attachments/assets/e87df49f-a828-4e51-a84c-2285069a5abe" />
<img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 09 56 11" src="https://github.com/user-attachments/assets/a7bd5a91-b26e-438a-953b-aebd8bf80210" />

**without reading tab bar height, content is covered**
<img width="300" height="600" alt="Screenshot_1770746213" src="https://github.com/user-attachments/assets/7eaed6cc-225d-4b9f-86d1-12c8fa88b476" />

**after reading tab bar height, we can offset content **
<img width="300" height="600" alt="Screenshot_1770746287" src="https://github.com/user-attachments/assets/502c53bd-dbbb-4331-b2f0-157473ed789b" />


  ## Test plan

  Tested files:

  - apps/src/tests/issue-tests/TestBottomTabs/components/TabContentView.tsx
  - apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab3.tsx

  Commands run:
  - npm run lint
  - ./gradlew :react-native-screens:compileDebugKotlin (from FabricExample/android)

  Manual verification:

  1. Launch FabricExample.
  2. Go to Issue Tests -> TestBottomTabs.
  3. Confirm first tab shows ready and a non-zero tab bar height.
  4. On Android, open Tab3 and verify bottom content is offset above tab bar using hook value.

  Minimal usage example:

  import { Platform } from 'react-native';
  import { useBottomTabBarHeight } from 'react-native-screens';

  function ScreenContent() {
    const tabBarHeight = useBottomTabBarHeight();
    const bottomPadding = Platform.OS === 'android' ? tabBarHeight : 0;
    // apply bottomPadding to content container
  }

  ## Checklist

  - [x] Included code example that can be used to test this change.
  - [x] Updated / created local changelog entries in relevant test files.
  - [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
  - [x] For API changes, updated relevant public types.
  - [ ] Ensured that CI passes