### PR TITLE
feat: add xcassetTinted and xcassetOriginal icon types

### DIFF
--- a/apps/src/screens/BarButtonItems.tsx
+++ b/apps/src/screens/BarButtonItems.tsx
@@ -17,6 +17,11 @@ const demoScreens = [
   { name: 'PlainButtonDemo', title: 'Plain Button' },
   { name: 'IconButtonDemo', title: 'Icon Button' },
   { name: 'XcassetIconButtonDemo', title: 'Xcasset Icon Button' },
+  { name: 'XcassetTintedIconButtonDemo', title: 'Xcasset Tinted Icon Button' },
+  {
+    name: 'XcassetOriginalIconButtonDemo',
+    title: 'Xcasset Original Icon Button',
+  },
   { name: 'SystemIconButtonDemo', title: 'System Icon Button' },
   { name: 'MenuButtonDemo', title: 'Menu Button' },
   { name: 'BadgeButtonDemo', title: 'Badge Button' },
@@ -65,6 +70,8 @@ const DemoScreenContent = () => (
 const PlainButtonDemo = DemoScreenContent;
 const IconButtonDemo = DemoScreenContent;
 const XcassetIconButtonDemo = DemoScreenContent;
+const XcassetTintedIconButtonDemo = DemoScreenContent;
+const XcassetOriginalIconButtonDemo = DemoScreenContent;
 const MenuButtonDemo = DemoScreenContent;
 const BadgeButtonDemo = DemoScreenContent;
 const DisabledButtonDemo = DemoScreenContent;
@@ -143,7 +150,46 @@ export default function BarButtonItemsExample() {
                 name: 'custom-icon-fill',
               },
               label: 'Xcasset',
+              tintColor: 'red',
               onPress: () => Alert.alert('Icon Xcasset pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="XcassetTintedIconButtonDemo"
+        component={XcassetTintedIconButtonDemo}
+        options={{
+          title: 'Xcasset Tinted Icon',
+          unstable_headerRightItems: () => [
+            {
+              type: 'button',
+              icon: {
+                type: 'xcassetTinted',
+                name: 'custom-icon-fill',
+              },
+              label: 'Tinted',
+              tintColor: 'red',
+              onPress: () => Alert.alert('Xcasset Tinted pressed'),
+            },
+          ],
+        }}
+      />
+      <Stack.Screen
+        name="XcassetOriginalIconButtonDemo"
+        component={XcassetOriginalIconButtonDemo}
+        options={{
+          title: 'Xcasset Original Icon',
+          unstable_headerRightItems: () => [
+            {
+              type: 'button',
+              icon: {
+                type: 'xcassetOriginal',
+                name: 'custom-icon-fill',
+              },
+              label: 'Original',
+              tintColor: 'red',
+              onPress: () => Alert.alert('Xcasset Original pressed'),
             },
           ],
         }}
@@ -445,6 +491,18 @@ export default function BarButtonItemsExample() {
                     destructive: true,
                     discoverabilityLabel: 'Favorite',
                     onPress: () => Alert.alert('Action 1 pressed'),
+                  },
+                  {
+                    label: 'Tinted Xcasset',
+                    icon: { type: 'xcassetTinted', name: 'custom-icon-fill' },
+                    type: 'action',
+                    onPress: () => Alert.alert('Tinted Xcasset pressed'),
+                  },
+                  {
+                    label: 'Original Xcasset',
+                    icon: { type: 'xcassetOriginal', name: 'custom-icon-fill' },
+                    type: 'action',
+                    onPress: () => Alert.alert('Original Xcasset pressed'),
                   },
                   {
                     label: 'Action 2',

--- a/apps/src/tests/issue-tests/TestXcassetRenderingModes.tsx
+++ b/apps/src/tests/issue-tests/TestXcassetRenderingModes.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import {
+  BottomTabsContainer,
+  type TabConfiguration,
+} from '../../shared/gamma/containers/bottom-tabs/BottomTabsContainer';
+import { CenteredLayoutView } from '../../shared/CenteredLayoutView';
+import { Text } from 'react-native';
+
+function makeTab(title: string, description: string) {
+  return () => (
+    <CenteredLayoutView>
+      <Text style={{ fontWeight: 'bold' }}>{title}</Text>
+      <Text style={{ textAlign: 'center' }}>{description}</Text>
+    </CenteredLayoutView>
+  );
+}
+
+const TAB_CONFIGS: TabConfiguration[] = [
+  {
+    tabScreenProps: {
+      tabKey: 'Tab1',
+      title: 'xcasset',
+      icon: {
+        ios: {
+          type: 'xcasset',
+          name: 'custom-icon-fill',
+        },
+      },
+    },
+    component: makeTab(
+      'xcasset',
+      'Uses default rendering mode from asset catalog.\nIcon color depends on asset catalog settings.',
+    ),
+  },
+  {
+    tabScreenProps: {
+      tabKey: 'Tab2',
+      title: 'Tinted',
+      icon: {
+        ios: {
+          type: 'xcassetTinted',
+          name: 'custom-icon-fill',
+        },
+      },
+    },
+    component: makeTab(
+      'xcassetTinted',
+      'Uses UIImageRenderingModeAlwaysTemplate.\nIcon should respect the tab bar tint color.',
+    ),
+  },
+  {
+    tabScreenProps: {
+      tabKey: 'Tab3',
+      title: 'Original',
+      icon: {
+        ios: {
+          type: 'xcassetOriginal',
+          name: 'custom-icon-fill',
+        },
+      },
+    },
+    component: makeTab(
+      'xcassetOriginal',
+      'Uses UIImageRenderingModeAlwaysOriginal.\nIcon should render with its original asset colors.',
+    ),
+  },
+];
+
+function App() {
+  return (
+    <BottomTabsContainer tabBarTintColor={'red'} tabConfigs={TAB_CONFIGS} />
+  );
+}
+
+export default App;

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -187,6 +187,7 @@ export { default as TestScreenAnimation } from './TestScreenAnimation';
 // export { default as TestScreenAnimationV5 } from './TestScreenAnimationV5';
 export { default as TestHeader } from './TestHeader';
 export { default as TestPreload } from './TestPreload';
+export { default as TestXcassetRenderingModes } from './TestXcassetRenderingModes';
 export { default as TestActivityStateProgression } from './TestActivityStateProgression';
 export { default as TestHeaderTitle } from './TestHeaderTitle';
 export { default as TestHeaderHeight } from './TestHeaderHeight';

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -26,6 +26,8 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
   NSDictionary *templateSourceObj = dict[@"templateSource"];
   NSString *sfSymbolName = dict[@"sfSymbolName"];
   NSString *xcassetName = dict[@"xcassetName"];
+  NSString *xcassetTintedName = dict[@"xcassetTintedName"];
+  NSString *xcassetOriginalName = dict[@"xcassetOriginalName"];
 
   if (imageSourceObj != nil || templateSourceObj != nil) {
     BOOL isTemplate = imageSourceObj != nil ? NO : YES;
@@ -41,6 +43,10 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
     self.image = [UIImage systemImageNamed:sfSymbolName];
   } else if (xcassetName != nil) {
     self.image = [UIImage imageNamed:xcassetName];
+  } else if (xcassetTintedName != nil) {
+    self.image = [[UIImage imageNamed:xcassetTintedName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  } else if (xcassetOriginalName != nil) {
+    self.image = [[UIImage imageNamed:xcassetOriginalName] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
   }
 
   if (title != nil) {
@@ -166,12 +172,18 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
   NSString *title = dict[@"title"];
   NSString *sfSymbolName = dict[@"sfSymbolName"];
   NSString *xcassetName = dict[@"xcassetName"];
+  NSString *xcassetTintedName = dict[@"xcassetTintedName"];
+  NSString *xcassetOriginalName = dict[@"xcassetOriginalName"];
 
-  UIImage* image = nil;
+  UIImage *image = nil;
   if (sfSymbolName != nil) {
     image = [UIImage systemImageNamed:sfSymbolName];
   } else if (xcassetName != nil) {
     image = [UIImage imageNamed:xcassetName];
+  } else if (xcassetTintedName != nil) {
+    image = [[UIImage imageNamed:xcassetTintedName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  } else if (xcassetOriginalName != nil) {
+    image = [[UIImage imageNamed:xcassetOriginalName] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
   }
 
   return [UIMenu menuWithTitle:title
@@ -187,12 +199,18 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
   NSString *title = dict[@"title"];
   NSString *sfSymbolName = dict[@"sfSymbolName"];
   NSString *xcassetName = dict[@"xcassetName"];
+  NSString *xcassetTintedName = dict[@"xcassetTintedName"];
+  NSString *xcassetOriginalName = dict[@"xcassetOriginalName"];
 
   UIImage *image = nil;
   if (sfSymbolName != nil) {
     image = [UIImage systemImageNamed:sfSymbolName];
   } else if (xcassetName != nil) {
     image = [UIImage imageNamed:xcassetName];
+  } else if (xcassetTintedName != nil) {
+    image = [[UIImage imageNamed:xcassetTintedName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  } else if (xcassetOriginalName != nil) {
+    image = [[UIImage imageNamed:xcassetOriginalName] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
   }
 
   UIAction *actionElement = [UIAction actionWithTitle:title

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -130,6 +130,8 @@ typedef NS_ENUM(NSInteger, RNSBottomTabsIconType) {
   RNSBottomTabsIconTypeTemplate,
   RNSBottomTabsIconTypeSfSymbol,
   RNSBottomTabsIconTypeXcasset,
+  RNSBottomTabsIconTypeXcassetTinted,
+  RNSBottomTabsIconTypeXcassetOriginal,
 };
 
 #if !RCT_NEW_ARCH_ENABLED

--- a/ios/bottom-tabs/RCTConvert+RNSBottomTabs.mm
+++ b/ios/bottom-tabs/RCTConvert+RNSBottomTabs.mm
@@ -16,6 +16,8 @@ RCT_ENUM_CONVERTER(
       @"template" : @(RNSBottomTabsIconTypeTemplate),
       @"sfSymbol" : @(RNSBottomTabsIconTypeSfSymbol),
       @"xcasset" : @(RNSBottomTabsIconTypeXcasset),
+      @"xcassetTinted" : @(RNSBottomTabsIconTypeXcassetTinted),
+      @"xcassetOriginal" : @(RNSBottomTabsIconTypeXcassetOriginal),
     }),
     RNSBottomTabsIconTypeSfSymbol,
     integerValue)

--- a/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/bottom-tabs/RNSTabBarAppearanceCoordinator.mm
@@ -58,12 +58,20 @@
                fromScreenView:(RNSBottomTabsScreenComponentView *)screenView
               withImageLoader:(RCTImageLoader *_Nullable)imageLoader
 {
-  if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol || screenView.iconType == RNSBottomTabsIconTypeXcasset) {
+  if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol || screenView.iconType == RNSBottomTabsIconTypeXcasset ||
+      screenView.iconType == RNSBottomTabsIconTypeXcassetTinted ||
+      screenView.iconType == RNSBottomTabsIconTypeXcassetOriginal) {
     if (screenView.iconResourceName != nil) {
       if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol) {
         tabBarItem.image = [UIImage systemImageNamed:screenView.iconResourceName];
       } else {
-        tabBarItem.image = [UIImage imageNamed:screenView.iconResourceName];
+        UIImage *image = [UIImage imageNamed:screenView.iconResourceName];
+        if (screenView.iconType == RNSBottomTabsIconTypeXcassetTinted) {
+          image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        } else if (screenView.iconType == RNSBottomTabsIconTypeXcassetOriginal) {
+          image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        }
+        tabBarItem.image = image;
       }
     } else if (screenView.systemItem != RNSBottomTabsScreenSystemItemNone) {
       // Restore default system item icon
@@ -78,7 +86,13 @@
       if (screenView.iconType == RNSBottomTabsIconTypeSfSymbol) {
         tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconResourceName];
       } else {
-        tabBarItem.selectedImage = [UIImage imageNamed:screenView.selectedIconResourceName];
+        UIImage *image = [UIImage imageNamed:screenView.selectedIconResourceName];
+        if (screenView.iconType == RNSBottomTabsIconTypeXcassetTinted) {
+          image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        } else if (screenView.iconType == RNSBottomTabsIconTypeXcassetOriginal) {
+          image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        }
+        tabBarItem.selectedImage = image;
       }
     } else if (screenView.systemItem != RNSBottomTabsScreenSystemItemNone) {
       // Restore default system item icon
@@ -138,8 +152,8 @@
 
   // A layout pass is required because the image might be loaded asynchronously,
   // after the tab bar has already been attached to the window.
-  // This code handles case where image passed by the user is not 
-  // of appropriate size & needs to be readjusted. W/o additional 
+  // This code handles case where image passed by the user is not
+  // of appropriate size & needs to be readjusted. W/o additional
   // layout here the icon would be displayed with original dimensions.
   UIViewController *parent = screenView.controller.parentViewController;
   if ([parent isKindOfClass:[UITabBarController class]]) {

--- a/ios/conversion/RNSConversions-BottomTabs.mm
+++ b/ios/conversion/RNSConversions-BottomTabs.mm
@@ -230,6 +230,10 @@ RNSBottomTabsIconType RNSBottomTabsIconTypeFromIcon(react::RNSBottomTabsScreenIc
       return RNSBottomTabsIconTypeSfSymbol;
     case Xcasset:
       return RNSBottomTabsIconTypeXcasset;
+    case XcassetTinted:
+      return RNSBottomTabsIconTypeXcassetTinted;
+    case XcassetOriginal:
+      return RNSBottomTabsIconTypeXcassetOriginal;
   }
 }
 
@@ -241,6 +245,9 @@ RCTImageSource *RCTImageSourceFromImageSourceAndIconType(
 
   switch (iconType) {
     case RNSBottomTabsIconTypeSfSymbol:
+    case RNSBottomTabsIconTypeXcasset:
+    case RNSBottomTabsIconTypeXcassetTinted:
+    case RNSBottomTabsIconTypeXcassetOriginal:
       iconImageSource = nil;
       break;
 

--- a/src/components/helpers/prepareHeaderBarButtonItems.ts
+++ b/src/components/helpers/prepareHeaderBarButtonItems.ts
@@ -17,12 +17,18 @@ const prepareMenu = (
         iconType === 'sfSymbol' ? menuItem.icon?.name : undefined;
       const xcassetName =
         iconType === 'xcasset' ? menuItem.icon?.name : undefined;
+      const xcassetTintedName =
+        iconType === 'xcassetTinted' ? menuItem.icon?.name : undefined;
+      const xcassetOriginalName =
+        iconType === 'xcassetOriginal' ? menuItem.icon?.name : undefined;
 
       if (menuItem.type === 'submenu') {
         return {
           ...menuItem,
           sfSymbolName,
           xcassetName,
+          xcassetTintedName,
+          xcassetOriginalName,
           ...prepareMenu(menuItem, menuIndex, side),
         };
       }
@@ -30,6 +36,8 @@ const prepareMenu = (
         ...menuItem,
         sfSymbolName,
         xcassetName,
+        xcassetTintedName,
+        xcassetOriginalName,
         menuId: `${menuIndex}-${index}-${side}`,
       };
     }),
@@ -71,6 +79,10 @@ export const prepareHeaderBarButtonItems = (
       templateSource,
       sfSymbolName: item.icon?.type === 'sfSymbol' ? item.icon.name : undefined,
       xcassetName: item.icon?.type === 'xcasset' ? item.icon.name : undefined,
+      xcassetTintedName:
+        item.icon?.type === 'xcassetTinted' ? item.icon.name : undefined,
+      xcassetOriginalName:
+        item.icon?.type === 'xcassetOriginal' ? item.icon.name : undefined,
       titleStyle,
       tintColor,
       badge,

--- a/src/components/tabs/TabsScreen.tsx
+++ b/src/components/tabs/TabsScreen.tsx
@@ -306,9 +306,19 @@ function parseIOSIconToNativeProps(icon: PlatformIconIOS | undefined): {
       iconType: 'xcasset',
       iconResourceName: icon.name,
     };
+  } else if (icon.type === 'xcassetTinted') {
+    return {
+      iconType: 'xcassetTinted',
+      iconResourceName: icon.name,
+    };
+  } else if (icon.type === 'xcassetOriginal') {
+    return {
+      iconType: 'xcassetOriginal',
+      iconResourceName: icon.name,
+    };
   } else {
     throw new Error(
-      '[RNScreens] Incorrect icon format for iOS. You must provide `sfSymbol`, `imageSource`, `templateSource` or `xcasset`.',
+      '[RNScreens] Incorrect icon format for iOS. You must provide `sfSymbol`, `imageSource`, `templateSource`, `xcasset`, `xcassetTinted` or `xcassetOriginal`.',
     );
   }
 }

--- a/src/components/tabs/TabsScreen.types.ts
+++ b/src/components/tabs/TabsScreen.types.ts
@@ -332,6 +332,12 @@ export interface TabsScreenProps {
    *   Uses an SF Symbol with the specified name.
    * - `{ type: 'xcasset', name }`
    *   Uses asset from Xcassets.
+   * - `{ type: 'xcassetTinted', name }`
+   *   Uses asset from Xcassets with `UIImageRenderingModeAlwaysTemplate`
+   *   (icon respects tint color).
+   * - `{ type: 'xcassetOriginal', name }`
+   *   Uses asset from Xcassets with `UIImageRenderingModeAlwaysOriginal`
+   *   (icon renders with its original colors).
    * - `{ type: 'templateSource', templateSource }`
    *   Uses the provided image as a template image.
    *   The icon color will depend on the current state

--- a/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
+++ b/src/fabric/bottom-tabs/BottomTabsScreenNativeComponent.ts
@@ -12,7 +12,13 @@ import type {
 import { UnsafeMixed } from './codegenUtils';
 
 // iOS-specific: SFSymbol, image as a template usage
-export type IconType = 'image' | 'template' | 'sfSymbol' | 'xcasset';
+export type IconType =
+  | 'image'
+  | 'template'
+  | 'sfSymbol'
+  | 'xcasset'
+  | 'xcassetTinted'
+  | 'xcassetOriginal';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -125,9 +125,21 @@ export type PlatformIconIOSXcasset = {
   name: string;
 };
 
+export type PlatformIconIOSXcassetTinted = {
+  type: 'xcassetTinted';
+  name: string;
+};
+
+export type PlatformIconIOSXcassetOriginal = {
+  type: 'xcassetOriginal';
+  name: string;
+};
+
 export type PlatformIconIOS =
   | PlatformIconIOSSfSymbol
   | PlatformIconIOSXcasset
+  | PlatformIconIOSXcassetTinted
+  | PlatformIconIOSXcassetOriginal
   | {
       type: 'templateSource';
       templateSource: ImageSourcePropType;
@@ -1175,7 +1187,11 @@ export interface HeaderBarButtonItemMenuAction {
   title?: string;
   subtitle?: string;
   onPress: () => void;
-  icon?: PlatformIconIOSSfSymbol | PlatformIconIOSXcasset;
+  icon?:
+    | PlatformIconIOSSfSymbol
+    | PlatformIconIOSXcasset
+    | PlatformIconIOSXcassetTinted
+    | PlatformIconIOSXcassetOriginal;
   /**
    * State of the item.
    *
@@ -1201,7 +1217,7 @@ export interface HeaderBarButtonItemMenuAction {
    */
   hidden?: boolean;
   /**
-   * Indicates whether to keep the menu presented after firing the element’s action.
+   * Indicates whether to keep the menu presented after firing the element's action.
    *
    * Read more: https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented
    */
@@ -1217,7 +1233,11 @@ export interface HeaderBarButtonItemMenuAction {
 export interface HeaderBarButtonItemSubmenu {
   type: 'submenu';
   title?: string;
-  icon?: PlatformIconIOSSfSymbol | PlatformIconIOSXcasset;
+  icon?:
+    | PlatformIconIOSSfSymbol
+    | PlatformIconIOSXcasset
+    | PlatformIconIOSXcassetTinted
+    | PlatformIconIOSXcassetOriginal;
   items: HeaderBarButtonItemWithMenu['menu']['items'];
   displayInline?: boolean;
   destructive?: boolean;


### PR DESCRIPTION
Add two new icon types that give explicit control over the rendering mode of xcasset icons:
- xcassetTinted forces UIImageRenderingModeAlwaysTemplate (icon respects tint color)
- xcassetOriginal forces UIImageRenderingModeAlwaysOriginal (icon keeps original colors)

I intentionally kept the base `xcasset` to allow customization in xcode as well. If you think it is redundant, I can remove this icon type.

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

### Tabs

Three examples: default, tinted and original

https://github.com/user-attachments/assets/014d03b3-354e-4c07-8282-b8c80f2a80cf

### Header items

Three examples: default, tinted and original

https://github.com/user-attachments/assets/06d10bdf-3050-4328-be30-0a7379026a45

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
