### PR TITLE
chore: Change constexpr to obj-c NSNumber

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -38,8 +38,8 @@
 namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
-static constexpr auto DEFAULT_TITLE_FONT_SIZE = @17;
-static constexpr auto DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
+static NSNumber *const DEFAULT_TITLE_FONT_SIZE = @17;
+static NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
 
 #if !defined(RCT_NEW_ARCH_ENABLED)
 // Some RN private method hacking below. Couldn't figure out better way to access image data


### PR DESCRIPTION
Fixes https://github.com/software-mansion/react-native-screens/issues/3549

## Description

This PR replaces constexpr declaration with equivalent NSNumber declaration for default font sizes. We weren't able to reproduce the compilation error, but the change doesn't have a negative impact.

## Changes

Replaced the default font size declarations.

## Test plan

Have a header (regular, large) with some non-default font family (this triggers the font size check). Set a breakpoint in `RNSScreenStackHeaderConfig.mm:491` and `:519` and verify the constants are correct.

## Checklist

- [x] Ensured that CI passes
