### PR TITLE
fix(iOS, Stack v4): prevent header subview memory leak

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -932,7 +932,6 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 - (void)removeReactSubview:(RNSScreenStackHeaderSubview *)subview
 {
   [_reactSubviews removeObject:subview];
-  [subview invalidateUIBarButtonItem];
 }
 RNS_IGNORE_SUPER_CALL_END
 
@@ -972,7 +971,6 @@ RNS_IGNORE_SUPER_CALL_END
 
   [_reactSubviews removeObject:(RNSScreenStackHeaderSubview *)childComponentView];
   [childComponentView removeFromSuperview];
-  [(RNSScreenStackHeaderSubview *)childComponentView invalidateUIBarButtonItem];
 
   if (!isGoingToBeRemoved) {
     [self updateViewControllerIfNeeded];

--- a/ios/RNSScreenStackHeaderSubview.h
+++ b/ios/RNSScreenStackHeaderSubview.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 #ifdef RCT_NEW_ARCH_ENABLED
     RCTViewComponentView
 #else
-    UIView
+    UIView <RCTInvalidating>
 #endif
 
 @property (nonatomic) RNSScreenStackHeaderSubviewType type;
@@ -51,16 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Returns UIBarButtonItem associated with this subview. If it doesn't exist, UIBarButtonItem is created.
- * UIBarButtonItem is strongly retained by RNSScreenStackHeaderSubview. It must be cleared via
- * `invalidateUIBarButtonItem` to prevent memory leak.
  */
 - (UIBarButtonItem *)getUIBarButtonItem;
-
-/**
- * Clears reference to UIBarButtonItem. It must be called when UIBarButtonItem is no longer needed to prevent memory
- * leak.
- */
-- (void)invalidateUIBarButtonItem;
 
 @end
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -28,7 +28,7 @@ namespace react = facebook::react;
   CGSize _lastReactFrameSize;
 #endif // !RCT_NEW_ARCH_ENABLED && RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   // This is a strong reference to UIBarButtonItem which creates a retain cycle.
-  // It must be cleared via `invalidateUIBarButtonItem` method.
+  // The cycle is cleared via `invalidateUIBarButtonItem` method, called by `invalidate` callback.
   UIBarButtonItem *_barButtonItem;
   BOOL _hidesSharedBackground;
 }
@@ -223,6 +223,12 @@ RNS_IGNORE_SUPER_CALL_END
 
 #endif // RCT_NEW_ARCH_ENABLED
 
+// Used by both Fabric & Paper
+- (void)invalidate
+{
+  [self invalidateUIBarButtonItem];
+}
+
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 
 // Starting from iOS 26, to center left and right subviews inside liquid glass backdrop,
@@ -283,12 +289,10 @@ RNS_IGNORE_SUPER_CALL_END
       [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
       [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
-      // This creates a retain cycle. The reference must be later cleared via `invalidateUIBarButtonItem` method.
       _barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:wrapperView];
     } else
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
     {
-      // This creates a retain cycle. The reference must be later cleared via `invalidateUIBarButtonItem` method.
       _barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:self];
     }
     [self configureBarButtonItem];


### PR DESCRIPTION
## Description

Prevents header subview memory leak.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/696.

### Details

When header items were introduced, potential memory leak was spotted: https://github.com/software-mansion/react-native-screens/pull/2987#discussion_r2426222553.

From my testing, it seems that after introducing a wrapper view on iOS 26+ (https://github.com/software-mansion/react-native-screens/pull/3449), UIKit manages to deallocate all necessary views. On iOS 18 however I managed to create a memory leak (see video "before").

There is one thing that confuses me a little bit - it seems like on iOS 26, UIKit retains the reference to bar button item & wrapper view a little bit longer than expected (e.g. via `_UINavigationBarContentView`). When we push a screen with bar button item, pop it, it seems like the reference remains but when we push a new screen, it is deallocated.

Also, when first screen uses `headerShown: false`, the behavior seems similar also on iOS 18 but this time with header subview reference. It is also deallocated after pushing another screen.

I don't think that we need to worry about this for now but I wanted to point that out in PR description.

### Solution

I decided to keep the reference to `UIBarButtonItem` inside `RNSScreenStackHeaderSubview` to maintain prop update logic (https://github.com/software-mansion/react-native-screens/pull/2987#discussion_r2426318215). I don't think that we can make it a weak reference because in header config we clear left/rightBarButtonItems from navigation item - I guess that the button might be deallocated before we attempt to re-use it (correct me if I'm wrong).

Because of the above, I needed a place to clear the reference. I thought about willMoveToWindow/Superview callbacks but:
1. `willMoveToWindow` is called multiple times so it's not reliable
2. `willMoveToSuperview` is better but when we push another screen over a screen with bar button item, we will move to nil. I think that we don't want to clear the bar button then to maintain any (internal) state inside the button.

At first, I wanted to use already existing logic in header config's `unmountChildComponentView` but this callback's Paper counterpart isn't called when entire screen is popped instead of only subview. That's why I used `invalidate` callback. On Paper, it's available via `RCTInvalidating`. On Fabric, this is available on RCTViewComponentView starting from RN 0.82. As next release will require RN 0.82 for Fabric, we can comfortably use this callback.

## Changes

- add method to clear bar button reference
- use it in `invalidate` callback

## Before & after - visual documentation

### Before

https://github.com/user-attachments/assets/fb07fd55-8462-4fec-9791-85733c78e606

### After

https://github.com/user-attachments/assets/42ab5c6c-4a97-4db1-a098-60d08d39adc8

## Test plan

Run `Test3422`. Remove `headerShown: false` from `Screen1`. Push a screen and then pop it. Check memory graph for `HeaderSubview`. You can also override `dealloc` for header subview.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
