### PR TITLE
feat: add new impl for header and toolbar items

### DIFF
--- a/FabricExample/Gemfile.lock
+++ b/FabricExample/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+    ffi (1.17.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2156,7 +2156,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: dfb9ab6ee2eac316f7869edf6ec27b9e872329f0
-  hermes-engine: 2f2ffe03fec9edfd45418f6e7701497449e8e918
+  hermes-engine: c995f5923796713b131782bb344dd6df48c8daa6
   RCTDeprecation: df7412cdad525035c3adeb14c1dc35b344e98187
   RCTRequired: 28a4bf1ef190650fcd6973d8a6a8f8beb30ef807
   RCTSwiftUI: 3003f1af83c332be5946ec0433fedcf0ada06551
@@ -2227,13 +2227,13 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 706b65371b90b5cc797b6639e8979f2e5cecd6da
   ReactCodegen: 3b63446e22acfdafa14e48a23c4a34b3ec99215e
   ReactCommon: d588ff8119315f4d3341e06f954e60789b050710
-  ReactNativeDependencies: c52d241ee664599a6b536f2bd4576a2c2a26a9b5
+  ReactNativeDependencies: e253e147767f576f51d4ec9f34f3a7510c6b79a6
   RNGestureHandler: 6c55d44ca01fff875b82ee7a9dee86a7aa9fa563
   RNReanimated: 371d8a67ea2cf7a2608d97fd990c3ac1b6994cfb
-  RNScreens: 60f2260949e6f9cc35cd76c506a3475bec919ca6
+  RNScreens: 8eeca9124e5974cec3fa5be2a6cbc6e4158ffbaf
   RNWorklets: babdff0047f276ae0e194e0750cf956db2fd3c86
   Yoga: 7549f28c2f55a71280f339554f8980f4a1414b0f
 
-PODFILE CHECKSUM: a0cbdc24376755a35e5c6ea1e2e0d8052d5a39f3
+PODFILE CHECKSUM: cefb89ad1353fbc6d55f4c209bb4f2ff268c95e0
 
 COCOAPODS: 1.15.2

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -5,6 +5,7 @@ import AnimationAndroid from './test-animation-android';
 import TestStackSimpleNav from './test-stack-simple-nav';
 import TestStackSubviews from './test-stack-subviews-android';
 import TestStackBackButton from './test-stack-back-button-android';
+import TestBarIOS from './test-bar-ios';
 
 const scenarios = {
   PreventNativeDismissSingleStack,
@@ -13,6 +14,7 @@ const scenarios = {
   TestStackSimpleNav,
   TestStackSubviews,
   TestStackBackButton,
+  TestBarIOS,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-bar-ios.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-bar-ios.tsx
@@ -1,0 +1,232 @@
+import React, { useState } from 'react';
+import { Alert, Button, StyleSheet, Text, View } from 'react-native';
+import { Bar } from 'react-native-screens';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Bar items iOS',
+  key: 'test-bar-ios',
+  details:
+    'Exercises the new Bar component with header and toolbar placements, including items, spacers, menus and submenus.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  return <StackSetup />;
+}
+
+function StackSetup() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Inbox',
+          Component: InboxScreen,
+          options: {},
+        },
+        {
+          name: 'Profile',
+          Component: ProfileScreen,
+          options: {},
+        },
+      ]}
+    />
+  );
+}
+
+function InboxScreen() {
+  const navigation = useStackNavigationContext();
+
+  const [selectedActionId, setSelectedActionId] = useState('read');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([
+    'profile',
+  ]);
+
+  return (
+    <View style={styles.container}>
+      <Bar placement="header">
+        <Bar.Item
+          title="Menu"
+          icon={{ type: 'sfSymbol', name: 'line.3.horizontal' }}
+          onPress={() => Alert.alert('Menu opened')}
+        />
+        <Bar.Spacer />
+        <Bar.Item title="Inbox" />
+        <Bar.Spacer size={16} />
+        <Bar.Item
+          title="Notifications"
+          icon={{ type: 'sfSymbol', name: 'bell' }}
+          badge={{ value: 5 }}
+          onPress={() => Alert.alert('Notifications')}
+        />
+        <Bar.Menu
+          title="Actions"
+          icon={{ type: 'sfSymbol', name: 'ellipsis.circle' }}
+          menuTitle="Inbox Actions"
+          selectedId={selectedActionId}
+          onSelectionChange={({ id }) => setSelectedActionId(id)}>
+          <Bar.MenuAction
+            identifier="read"
+            title="Mark as Read"
+            icon={{ type: 'sfSymbol', name: 'envelope.open' }}
+            keepsMenuPresented
+          />
+          <Bar.MenuAction
+            identifier="archive"
+            title="Archive"
+            icon={{ type: 'sfSymbol', name: 'archivebox' }}
+            onPress={() => Alert.alert('Archived')}
+          />
+          <Bar.MenuAction
+            identifier="delete"
+            title="Delete"
+            destructive
+            icon={{ type: 'sfSymbol', name: 'trash' }}
+            onPress={() => Alert.alert('Deleted')}
+          />
+          <Bar.MenuAction
+            identifier="disabled"
+            title="Disabled"
+            disabled
+            icon={{ type: 'sfSymbol', name: 'slash.circle' }}
+          />
+          <Bar.MenuSubmenu
+            identifier="sort"
+            title="Sort"
+            icon={{ type: 'sfSymbol', name: 'arrow.up.arrow.down' }}
+            layout="palette">
+            <Bar.MenuAction
+              identifier="sort-sender"
+              title="By Sender"
+              onPress={() => Alert.alert('Sorted by sender')}
+            />
+            <Bar.MenuAction
+              identifier="sort-date"
+              title="By Date"
+              onPress={() => Alert.alert('Sorted by date')}
+            />
+          </Bar.MenuSubmenu>
+        </Bar.Menu>
+      </Bar>
+      <View style={styles.content}>
+        <Text style={styles.title}>Inbox</Text>
+        <Button
+          title="Go to Profile"
+          onPress={() => navigation.push('Profile')}
+        />
+      </View>
+      <Bar placement="toolbar">
+        <Bar.Item
+          title="Home"
+          icon={{ type: 'sfSymbol', name: 'house' }}
+          onPress={() => Alert.alert('Home')}
+        />
+        <Bar.Item
+          title="Search"
+          icon={{ type: 'sfSymbol', name: 'magnifyingglass' }}
+          onPress={() => Alert.alert('Search')}
+        />
+        <Bar.Spacer />
+        <Bar.Menu
+          title="Account"
+          icon={{ type: 'sfSymbol', name: 'person.crop.circle' }}
+          menuTitle="Account"
+          menuLayout="palette"
+          menuMultiselectable
+          selectedIds={selectedAccountIds}
+          onSelectionChange={({ ids }) => setSelectedAccountIds(ids)}>
+          <Bar.MenuAction
+            identifier="profile"
+            title="Profile"
+            subtitle="View details"
+            icon={{ type: 'sfSymbol', name: 'person' }}
+            onPress={() => navigation.push('Profile')}
+          />
+          <Bar.MenuAction
+            identifier="settings"
+            title="Settings"
+            icon={{ type: 'sfSymbol', name: 'gearshape' }}
+            onPress={() => Alert.alert('Settings')}
+          />
+          <Bar.MenuAction
+            identifier="logout"
+            title="Logout"
+            destructive
+            icon={{
+              type: 'sfSymbol',
+              name: 'rectangle.portrait.and.arrow.right',
+            }}
+            onPress={() => Alert.alert('Logged out')}
+          />
+          <Bar.MenuSubmenu
+            title="Preferences"
+            icon={{ type: 'sfSymbol', name: 'slider.horizontal.3' }}
+            layout="palette">
+            <Bar.MenuAction
+              title="Notifications"
+              onPress={() => Alert.alert('Notifications preferences')}
+            />
+            <Bar.MenuAction
+              title="Privacy"
+              onPress={() => Alert.alert('Privacy preferences')}
+            />
+          </Bar.MenuSubmenu>
+        </Bar.Menu>
+      </Bar>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <View style={styles.container}>
+      <Bar placement="header">
+        <Bar.Item
+          title="Back"
+          icon={{ type: 'sfSymbol', name: 'chevron.backward' }}
+          onPress={() => navigation.pop(navigation.routeKey)}
+        />
+        <Bar.Spacer />
+        <Bar.Item title="Profile" />
+        <Bar.Spacer size={16} />
+        <Bar.Item
+          title="Edit"
+          icon={{ type: 'sfSymbol', name: 'pencil' }}
+          onPress={() => Alert.alert('Edit Profile')}
+        />
+      </Bar>
+      <View style={styles.content}>
+        <Text style={styles.title}>Profile</Text>
+        <Button
+          title="Edit Profile"
+          onPress={() => Alert.alert('Edit Profile')}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f2f2f2',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 16,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/ios/bar/BarMenuContainer.h
+++ b/ios/bar/BarMenuContainer.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol BarMenuContainer <NSObject>
+- (void)updateMenu;
+- (void)menuItemSelected:(NSString *)identifier;
+- (BOOL)hasSelectedItem;
+- (NSArray<NSString *> *)selectedItemIDs;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/BarPropHelpers.hpp
+++ b/ios/bar/BarPropHelpers.hpp
@@ -1,0 +1,78 @@
+#import <React/RCTConversions.h>
+
+#include <string>
+#include <vector>
+
+static inline NSString * _Nullable ToolbarNSStringFromStringProp(const std::string &value)
+{
+  if (value.empty()) {
+    return nil;
+  }
+
+  return RCTNSStringFromString(value);
+}
+
+static inline NSArray<NSString *> * _Nonnull ToolbarNSStringArrayFromStringArrayProp(
+  const std::vector<std::string> &value
+)
+{
+  if (value.empty()) {
+    return @[];
+  }
+
+  NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:value.size()];
+  for (const auto &item : value) {
+    if (!item.empty()) {
+      [result addObject:RCTNSStringFromString(item)];
+    }
+  }
+
+  return result;
+}
+
+static inline std::vector<std::string> ToolbarStringVectorFromNSStringArray(NSArray<NSString *> * _Nonnull value)
+{
+  std::vector<std::string> result;
+  result.reserve(value.count);
+
+  for (NSString *item in value) {
+    if (item.length == 0) {
+      continue;
+    }
+    result.emplace_back(item.UTF8String);
+  }
+
+  return result;
+}
+
+#define APPLY_STRING_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    target.prop = ToolbarNSStringFromStringProp(newProps.prop); \
+  }
+
+#define APPLY_STRING_ARRAY_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    target.prop = ToolbarNSStringArrayFromStringArrayProp(newProps.prop); \
+  }
+
+#define APPLY_BOOL_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    target.prop = newProps.prop; \
+  }
+
+// Codegen non-optional doubles default to 0, so we use negative as a sentinel for "unset".
+#define APPLY_OPTIONAL_DOUBLE_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    double value = newProps.prop; \
+    target.prop = value >= 0 ? @(value) : nil; \
+  }
+
+#define APPLY_COLOR_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    target.prop = RCTUIColorFromSharedColor(newProps.prop); \
+  }
+
+#define APPLY_NUMBER_PROP(target, oldProps, newProps, prop) \
+  if (oldProps.prop != newProps.prop) { \
+    target.prop = @(newProps.prop); \
+  }

--- a/ios/bar/RNSBarItemView.h
+++ b/ios/bar/RNSBarItemView.h
@@ -1,0 +1,42 @@
+#import <UIKit/UIKit.h>
+
+#import "RNSReactBaseView.h"
+
+@class RNSBarView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarItemView : RNSReactBaseView
+
+@property (nonatomic, weak, nullable) RNSBarView *barParent;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *icon;
+@property (nonatomic, copy, nullable) NSString *placement;
+@property (nonatomic, copy, nullable) NSString *variant;
+@property (nonatomic, strong, nullable) UIColor *tintColor;
+@property (nonatomic, strong, nullable) NSNumber *width;
+@property (nonatomic, assign) BOOL disabled;
+@property (nonatomic, assign) BOOL selected;
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, assign) BOOL hidesSharedBackground;
+@property (nonatomic, assign) BOOL hasSharesBackground;
+@property (nonatomic, assign) BOOL sharesBackground;
+@property (nonatomic, assign) BOOL hasBadge;
+@property (nonatomic, strong, nullable) NSNumber *badgeCount;
+@property (nonatomic, copy, nullable) NSString *badgeValue;
+@property (nonatomic, strong, nullable) UIColor *badgeForegroundColor;
+@property (nonatomic, strong, nullable) UIColor *badgeBackgroundColor;
+@property (nonatomic, copy, nullable) NSString *badgeFontFamily;
+@property (nonatomic, copy, nullable) NSString *badgeFontWeight;
+@property (nonatomic, strong, nullable) NSNumber *badgeFontSize;
+@property (nonatomic, copy, nullable) NSString *titleFontFamily;
+@property (nonatomic, copy, nullable) NSString *titleFontWeight;
+@property (nonatomic, strong, nullable) NSNumber *titleFontSize;
+@property (nonatomic, strong, nullable) UIColor *titleColor;
+@property (nonatomic, copy, nullable) NSString *testID;
+
+- (void)emitPress;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarItemView.mm
+++ b/ios/bar/RNSBarItemView.mm
@@ -1,0 +1,99 @@
+#import "RNSBarItemView.h"
+
+#import <React/RCTConversions.h>
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import "BarPropHelpers.hpp"
+#import "RNSBarView.h"
+
+using namespace facebook::react;
+
+@interface RNSBarView (BarInternal)
+- (void)updateBarItems;
+- (void)updateBarItem:(RNSBarItemView *)itemView;
+@end
+
+@implementation RNSBarItemView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarItemComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarItemProps>();
+    _props = defaultProps;
+
+    self.hidden = YES;
+    self.userInteractionEnabled = NO;
+  }
+
+  return self;
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldItemProps = *std::static_pointer_cast<RNSBarItemProps const>(_props);
+  const auto &newItemProps = *std::static_pointer_cast<RNSBarItemProps const>(props);
+
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, title);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, icon);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, placement);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, variant);
+
+  APPLY_COLOR_PROP(self, oldItemProps, newItemProps, tintColor);
+
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldItemProps, newItemProps, width);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, disabled);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, selected);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, accessibilityLabel);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, accessibilityHint);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, testID);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, titleFontFamily);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, titleFontWeight);
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldItemProps, newItemProps, titleFontSize);
+
+  APPLY_COLOR_PROP(self, oldItemProps, newItemProps, titleColor);
+
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, identifier);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, hidesSharedBackground);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, sharesBackground);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, hasSharesBackground);
+  APPLY_BOOL_PROP(self, oldItemProps, newItemProps, hasBadge);
+
+  APPLY_NUMBER_PROP(self, oldItemProps, newItemProps, badgeCount);
+
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, badgeValue);
+
+  APPLY_COLOR_PROP(self, oldItemProps, newItemProps, badgeForegroundColor);
+  APPLY_COLOR_PROP(self, oldItemProps, newItemProps, badgeBackgroundColor);
+
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, badgeFontFamily);
+  APPLY_STRING_PROP(self, oldItemProps, newItemProps, badgeFontWeight);
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldItemProps, newItemProps, badgeFontSize);
+
+  [super updateProps:props oldProps:oldProps];
+
+  if (self.barParent != nil) {
+    [self.barParent updateBarItem:self];
+  }
+}
+
+- (void)emitPress
+{
+  if (self.disabled) {
+    return;
+  }
+
+  if (auto eventEmitter = std::static_pointer_cast<RNSBarItemEventEmitter const>(_eventEmitter)) {
+    eventEmitter->onItemPress({});
+  }
+}
+
+@end

--- a/ios/bar/RNSBarMenuActionView.h
+++ b/ios/bar/RNSBarMenuActionView.h
@@ -1,0 +1,29 @@
+#import <UIKit/UIKit.h>
+
+#import "BarMenuContainer.h"
+#import "RNSReactBaseView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarMenuActionView : RNSReactBaseView
+
+@property (nonatomic, weak, nullable) id<BarMenuContainer> menuParent;
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *subtitle;
+@property (nonatomic, copy, nullable) NSString *icon;
+@property (nonatomic, assign) BOOL disabled;
+@property (nonatomic, assign) BOOL destructive;
+@property (nonatomic, assign) BOOL keepsMenuPresented;
+@property (nonatomic, copy, nullable) NSString *discoverabilityLabel;
+@property (nonatomic, assign) UIMenuElementState state;
+
+- (void)emitPress;
+- (UIAction *)uiAction;
+- (void)applySelectionState:(UIMenuElementState)state;
+- (void)clearSelectionState;
+- (UIMenuElementState)effectiveState;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarMenuActionView.mm
+++ b/ios/bar/RNSBarMenuActionView.mm
@@ -1,0 +1,163 @@
+#import "RNSBarMenuActionView.h"
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import "BarPropHelpers.hpp"
+
+using namespace facebook::react;
+
+@implementation RNSBarMenuActionView {
+  BOOL _hasSelectionOverride;
+  UIMenuElementState _selectionState;
+  BOOL _menuHidden;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarMenuActionComponentDescriptor>();
+}
+
+static UIImage * _Nullable ToolbarSystemImage(NSString * _Nullable icon)
+{
+  if (icon.length > 0) {
+    if (@available(iOS 13.0, *)) {
+      return [UIImage systemImageNamed:icon];
+    }
+  }
+
+  return nil;
+}
+
+static UIMenuElementState ToolbarMenuStateFromString(const std::string &value)
+{
+  if (value == "on") {
+    return UIMenuElementStateOn;
+  }
+  if (value == "mixed") {
+    return UIMenuElementStateMixed;
+  }
+  return UIMenuElementStateOff;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarMenuActionProps>();
+    _props = defaultProps;
+
+    self.hidden = YES;
+    self.userInteractionEnabled = NO;
+    self.state = UIMenuElementStateOff;
+    _menuHidden = NO;
+  }
+
+  return self;
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldActionProps = *std::static_pointer_cast<RNSBarMenuActionProps const>(_props);
+  const auto &newActionProps = *std::static_pointer_cast<RNSBarMenuActionProps const>(props);
+
+  APPLY_STRING_PROP(self, oldActionProps, newActionProps, identifier);
+
+  APPLY_STRING_PROP(self, oldActionProps, newActionProps, title);
+  APPLY_STRING_PROP(self, oldActionProps, newActionProps, subtitle);
+  APPLY_STRING_PROP(self, oldActionProps, newActionProps, icon);
+
+  if (oldActionProps.state != newActionProps.state) {
+    self.state = ToolbarMenuStateFromString(newActionProps.state);
+  }
+
+  APPLY_BOOL_PROP(self, oldActionProps, newActionProps, disabled);
+  APPLY_BOOL_PROP(self, oldActionProps, newActionProps, destructive);
+  if (oldActionProps.hidden != newActionProps.hidden) {
+    _menuHidden = newActionProps.hidden;
+  }
+  APPLY_BOOL_PROP(self, oldActionProps, newActionProps, keepsMenuPresented);
+  APPLY_STRING_PROP(self, oldActionProps, newActionProps, discoverabilityLabel);
+
+  [super updateProps:props oldProps:oldProps];
+
+  [self.menuParent updateMenu];
+}
+
+- (void)emitPress
+{
+  if (self.disabled) {
+    return;
+  }
+
+  NSString *selectionID = self.identifier ?: @"";
+  [self.menuParent menuItemSelected:selectionID];
+
+  if (auto eventEmitter = std::static_pointer_cast<RNSBarMenuActionEventEmitter const>(_eventEmitter)) {
+    eventEmitter->onMenuActionPress({});
+  }
+}
+
+- (UIAction *)uiAction
+{
+  NSString *title = self.title ?: @"";
+  UIImage *image = ToolbarSystemImage(self.icon);
+
+  __weak RNSBarMenuActionView *weakSelf = self;
+  UIAction *action = [UIAction actionWithTitle:title
+                                         image:image
+                                    identifier:self.identifier
+                                       handler:^(__kindof UIAction * _Nonnull) {
+    [weakSelf emitPress];
+  }];
+
+  if (@available(iOS 15.0, *)) {
+    if (self.subtitle.length > 0) {
+      action.subtitle = self.subtitle;
+    }
+  }
+
+  if (self.discoverabilityLabel.length > 0) {
+    action.discoverabilityTitle = self.discoverabilityLabel;
+  }
+
+  UIMenuElementAttributes attributes = 0;
+  if (self.disabled) {
+    attributes |= UIMenuElementAttributesDisabled;
+  }
+  if (self.destructive) {
+    attributes |= UIMenuElementAttributesDestructive;
+  }
+  if (_menuHidden) {
+    attributes |= UIMenuElementAttributesHidden;
+  }
+  if (self.keepsMenuPresented) {
+    if (@available(iOS 16.0, *)) {
+      attributes |= UIMenuElementAttributesKeepsMenuPresented;
+    }
+  }
+
+  action.attributes = attributes;
+  action.state = [self effectiveState];
+
+  return action;
+}
+
+- (void)applySelectionState:(UIMenuElementState)state
+{
+  _hasSelectionOverride = YES;
+  _selectionState = state;
+}
+
+- (void)clearSelectionState
+{
+  _hasSelectionOverride = NO;
+}
+
+- (UIMenuElementState)effectiveState
+{
+  return _hasSelectionOverride ? _selectionState : self.state;
+}
+
+@end

--- a/ios/bar/RNSBarMenuSubmenuView.h
+++ b/ios/bar/RNSBarMenuSubmenuView.h
@@ -1,0 +1,30 @@
+#import <UIKit/UIKit.h>
+
+#import "BarMenuContainer.h"
+#import "RNSReactBaseView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarMenuSubmenuView : RNSReactBaseView <BarMenuContainer>
+
+@property (nonatomic, weak, nullable) id<BarMenuContainer> menuParent;
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *subtitle;
+@property (nonatomic, copy, nullable) NSString *icon;
+@property (nonatomic, assign) BOOL inlinePresentation;
+@property (nonatomic, copy, nullable) NSString *layout;
+@property (nonatomic, assign) BOOL destructive;
+@property (nonatomic, assign) BOOL multiselectable;
+@property (nonatomic, copy, nullable) NSString *selectedId;
+@property (nonatomic, copy, nullable) NSString *defaultSelectedId;
+@property (nonatomic, copy) NSArray<NSString *> *selectedIds;
+@property (nonatomic, copy) NSArray<NSString *> *defaultSelectedIds;
+@property (nonatomic, assign) BOOL hasSelectedId;
+@property (nonatomic, assign) BOOL hasSelectedIds;
+
+- (UIMenu *)menuRepresentation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarMenuSubmenuView.mm
+++ b/ios/bar/RNSBarMenuSubmenuView.mm
@@ -1,0 +1,432 @@
+#import "RNSBarMenuSubmenuView.h"
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import "RNSBarMenuActionView.h"
+#import "BarPropHelpers.hpp"
+
+using namespace facebook::react;
+
+@implementation RNSBarMenuSubmenuView {
+  NSMutableArray<UIView<RCTComponentViewProtocol> *> * _menuChildren;
+  NSMutableOrderedSet<NSString *> * _uncontrolledSelectedIDs;
+  NSString * _uncontrolledSelectedID;
+  BOOL _hasAppliedInitialSelection;
+  BOOL _hasAppliedInitialMultiSelection;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarMenuSubmenuComponentDescriptor>();
+}
+
+static UIImage * _Nullable ToolbarSystemImage(NSString * _Nullable icon)
+{
+  if (icon.length > 0) {
+    if (@available(iOS 13.0, *)) {
+      return [UIImage systemImageNamed:icon];
+    }
+  }
+
+  return nil;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarMenuSubmenuProps>();
+    _props = defaultProps;
+
+    self.hidden = YES;
+    self.userInteractionEnabled = NO;
+    _menuChildren = [NSMutableArray new];
+    _uncontrolledSelectedIDs = [NSMutableOrderedSet new];
+    self.selectedIds = @[];
+    self.defaultSelectedIds = @[];
+  }
+
+  return self;
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super mountChildComponentView:childComponentView index:index];
+
+  childComponentView.hidden = YES;
+  childComponentView.userInteractionEnabled = NO;
+
+  if ([childComponentView isKindOfClass:[RNSBarMenuActionView class]]) {
+    ((RNSBarMenuActionView *)childComponentView).menuParent = self;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+    ((RNSBarMenuSubmenuView *)childComponentView).menuParent = self;
+  }
+
+  if (index <= (NSInteger)_menuChildren.count) {
+    [_menuChildren insertObject:childComponentView atIndex:index];
+  } else {
+    [_menuChildren addObject:childComponentView];
+  }
+
+  [self updateMenu];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super unmountChildComponentView:childComponentView index:index];
+
+  if ([childComponentView isKindOfClass:[RNSBarMenuActionView class]]) {
+    ((RNSBarMenuActionView *)childComponentView).menuParent = nil;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+    ((RNSBarMenuSubmenuView *)childComponentView).menuParent = nil;
+  }
+
+  if (index < (NSInteger)_menuChildren.count && _menuChildren[index] == childComponentView) {
+    [_menuChildren removeObjectAtIndex:index];
+  } else {
+    [_menuChildren removeObject:childComponentView];
+  }
+
+  [self updateMenu];
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldSubmenuProps = *std::static_pointer_cast<RNSBarMenuSubmenuProps const>(_props);
+  const auto &newSubmenuProps = *std::static_pointer_cast<RNSBarMenuSubmenuProps const>(props);
+
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, identifier);
+
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, title);
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, subtitle);
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, icon);
+  APPLY_BOOL_PROP(self, oldSubmenuProps, newSubmenuProps, inlinePresentation);
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, layout);
+  APPLY_BOOL_PROP(self, oldSubmenuProps, newSubmenuProps, destructive);
+  APPLY_BOOL_PROP(self, oldSubmenuProps, newSubmenuProps, multiselectable);
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, selectedId);
+  APPLY_STRING_PROP(self, oldSubmenuProps, newSubmenuProps, defaultSelectedId);
+  APPLY_STRING_ARRAY_PROP(self, oldSubmenuProps, newSubmenuProps, selectedIds);
+  APPLY_STRING_ARRAY_PROP(self, oldSubmenuProps, newSubmenuProps, defaultSelectedIds);
+  APPLY_BOOL_PROP(self, oldSubmenuProps, newSubmenuProps, hasSelectedId);
+  APPLY_BOOL_PROP(self, oldSubmenuProps, newSubmenuProps, hasSelectedIds);
+
+  [super updateProps:props oldProps:oldProps];
+
+  [self updateMenu];
+}
+
+
+- (void)updateMenu
+{
+  [self.menuParent updateMenu];
+}
+
+- (NSArray<RNSBarMenuActionView *> *)actionChildren
+{
+  NSMutableArray<RNSBarMenuActionView *> *actions = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuActionView class]]) {
+      [actions addObject:(RNSBarMenuActionView *)child];
+    }
+  }
+
+  return actions;
+}
+
+- (NSArray<RNSBarMenuSubmenuView *> *)submenuChildren
+{
+  NSMutableArray<RNSBarMenuSubmenuView *> *submenus = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+      [submenus addObject:(RNSBarMenuSubmenuView *)child];
+    }
+  }
+
+  return submenus;
+}
+
+- (NSSet<NSString *> *)actionIDSet
+{
+  NSMutableSet<NSString *> *ids = [NSMutableSet new];
+
+  for (RNSBarMenuActionView *action in [self actionChildren]) {
+    if (action.identifier.length > 0) {
+      [ids addObject:action.identifier];
+    }
+  }
+
+  return ids;
+}
+
+- (BOOL)isMultiSelectionMode
+{
+  if (self.multiselectable) {
+    return YES;
+  }
+
+  if (self.hasSelectedIds || self.defaultSelectedIds.count > 0) {
+    return YES;
+  }
+
+  return NO;
+}
+
+- (BOOL)isSingleSelectionMode
+{
+  if ([self isMultiSelectionMode]) {
+    return NO;
+  }
+
+  if (self.hasSelectedId || self.defaultSelectedId.length > 0) {
+    return YES;
+  }
+
+  return NO;
+}
+
+- (NSString *)resolvedSingleSelectionID
+{
+  if (self.hasSelectedId) {
+    NSString *selectedID = self.selectedId ?: @"";
+    if (selectedID.length == 0) {
+      return @"";
+    }
+
+    NSSet<NSString *> *availableIDs = [self actionIDSet];
+    return [availableIDs containsObject:selectedID] ? selectedID : @"";
+  }
+
+  if (!_hasAppliedInitialSelection) {
+    if (self.defaultSelectedId.length > 0) {
+      _uncontrolledSelectedID = self.defaultSelectedId;
+    }
+    _hasAppliedInitialSelection = YES;
+  }
+
+  NSSet<NSString *> *availableIDs = [self actionIDSet];
+  if (_uncontrolledSelectedID.length > 0 && [availableIDs containsObject:_uncontrolledSelectedID]) {
+    return _uncontrolledSelectedID;
+  }
+
+  return @"";
+}
+
+- (NSArray<NSString *> *)resolvedMultiSelectionIDs
+{
+  if (self.hasSelectedIds) {
+    return self.selectedIds;
+  }
+
+  if (!_hasAppliedInitialMultiSelection) {
+    [_uncontrolledSelectedIDs removeAllObjects];
+    for (NSString *item in self.defaultSelectedIds) {
+      if (item.length > 0) {
+        [_uncontrolledSelectedIDs addObject:item];
+      }
+    }
+    _hasAppliedInitialMultiSelection = YES;
+  }
+
+  NSSet<NSString *> *availableIDs = [self actionIDSet];
+  if (availableIDs.count == 0) {
+    [_uncontrolledSelectedIDs removeAllObjects];
+    return @[];
+  }
+
+  for (NSString *item in _uncontrolledSelectedIDs.array) {
+    if (![availableIDs containsObject:item]) {
+      [_uncontrolledSelectedIDs removeObject:item];
+    }
+  }
+
+  return _uncontrolledSelectedIDs.array;
+}
+
+- (BOOL)applySelectionStateToActions
+{
+  NSArray<RNSBarMenuActionView *> *actions = [self actionChildren];
+  if (actions.count == 0) {
+    return NO;
+  }
+
+  BOOL singleSelection = [self isSingleSelectionMode];
+  BOOL multiSelection = [self isMultiSelectionMode];
+
+  if (!singleSelection && !multiSelection) {
+    for (RNSBarMenuActionView *action in actions) {
+      [action clearSelectionState];
+    }
+    return NO;
+  }
+
+  if (singleSelection) {
+    NSString *selectedID = [self resolvedSingleSelectionID];
+    BOOL hasSelection = NO;
+
+    for (RNSBarMenuActionView *action in actions) {
+      if (action.identifier.length > 0 && [action.identifier isEqualToString:selectedID]) {
+        [action applySelectionState:UIMenuElementStateOn];
+        hasSelection = YES;
+      } else {
+        [action applySelectionState:UIMenuElementStateOff];
+      }
+    }
+
+    return hasSelection;
+  }
+
+  NSArray<NSString *> *selectedIDs = [self resolvedMultiSelectionIDs];
+  NSSet<NSString *> *selectedSet = [NSSet setWithArray:selectedIDs];
+  BOOL hasSelection = selectedIDs.count > 0;
+
+  for (RNSBarMenuActionView *action in actions) {
+    if (action.identifier.length > 0 && [selectedSet containsObject:action.identifier]) {
+      [action applySelectionState:UIMenuElementStateOn];
+    } else {
+      [action applySelectionState:UIMenuElementStateOff];
+    }
+  }
+
+  return hasSelection;
+}
+
+- (void)menuItemSelected:(NSString *)identifier
+{
+  if (identifier.length == 0) {
+    return;
+  }
+
+  BOOL singleSelection = [self isSingleSelectionMode];
+  BOOL multiSelection = [self isMultiSelectionMode];
+
+  if (singleSelection || multiSelection) {
+    BOOL isControlled = singleSelection ? self.hasSelectedId : self.hasSelectedIds;
+    NSArray<NSString *> *currentSelection = @[];
+
+    if (multiSelection) {
+      currentSelection = self.hasSelectedIds ? self.selectedIds : [self resolvedMultiSelectionIDs];
+    }
+
+    if (singleSelection) {
+      if (!isControlled) {
+        _uncontrolledSelectedID = identifier;
+        _hasAppliedInitialSelection = YES;
+      }
+    } else if (multiSelection) {
+      NSMutableOrderedSet<NSString *> *mutableSelection =
+        [NSMutableOrderedSet orderedSetWithArray:currentSelection];
+      if ([mutableSelection containsObject:identifier]) {
+        [mutableSelection removeObject:identifier];
+      } else {
+        [mutableSelection addObject:identifier];
+      }
+      if (!isControlled) {
+        [_uncontrolledSelectedIDs removeAllObjects];
+        [_uncontrolledSelectedIDs addObjectsFromArray:mutableSelection.array];
+        _hasAppliedInitialMultiSelection = YES;
+      }
+    }
+
+    if (!isControlled) {
+      [self updateMenu];
+    }
+  }
+
+  [self.menuParent menuItemSelected:identifier];
+}
+
+- (BOOL)hasSelectedItem
+{
+  return [self applySelectionStateToActions];
+}
+
+- (NSArray<NSString *> *)selectedItemIDs
+{
+  [self applySelectionStateToActions];
+
+  NSMutableOrderedSet<NSString *> *ids = [NSMutableOrderedSet new];
+  for (RNSBarMenuActionView *action in [self actionChildren]) {
+    if ([action effectiveState] == UIMenuElementStateOn && action.identifier.length > 0) {
+      [ids addObject:action.identifier];
+    }
+  }
+
+  for (RNSBarMenuSubmenuView *submenu in [self submenuChildren]) {
+    [ids addObjectsFromArray:[submenu selectedItemIDs]];
+  }
+
+  return ids.array;
+}
+
+- (NSArray<UIMenuElement *> *)menuElementsFromChildren
+{
+  NSMutableArray<UIMenuElement *> *elements = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuActionView class]]) {
+      UIAction *action = [(RNSBarMenuActionView *)child uiAction];
+      if (action != nil) {
+        [elements addObject:action];
+      }
+      continue;
+    }
+
+    if ([child isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+      UIMenu *submenu = [(RNSBarMenuSubmenuView *)child menuRepresentation];
+      if (submenu != nil) {
+        [elements addObject:submenu];
+      }
+      continue;
+    }
+  }
+
+  return elements;
+}
+
+- (UIMenu *)menuRepresentation
+{
+  NSString *title = self.title ?: @"";
+  UIImage *image = ToolbarSystemImage(self.icon);
+
+  BOOL hasSelection = [self applySelectionStateToActions];
+  BOOL singleSelection = [self isSingleSelectionMode];
+
+  UIMenuOptions options = 0;
+  if (self.inlinePresentation) {
+    options |= UIMenuOptionsDisplayInline;
+  }
+  if (self.destructive) {
+    options |= UIMenuOptionsDestructive;
+  }
+  if (singleSelection && hasSelection) {
+    if (@available(iOS 15.0, *)) {
+      options |= UIMenuOptionsSingleSelection;
+    }
+  }
+  if ([self.layout isEqualToString:@"palette"]) {
+    if (@available(iOS 17.0, *)) {
+      options |= UIMenuOptionsDisplayAsPalette;
+    }
+  }
+
+  NSArray<UIMenuElement *> *children = [self menuElementsFromChildren];
+  UIMenu *menu = [UIMenu menuWithTitle:title
+                                 image:image
+                            identifier:self.identifier
+                               options:options
+                              children:children];
+
+  if (@available(iOS 15.0, *)) {
+    if (self.subtitle.length > 0) {
+      menu.subtitle = self.subtitle;
+    }
+  }
+
+  return menu;
+}
+
+@end

--- a/ios/bar/RNSBarMenuView.h
+++ b/ios/bar/RNSBarMenuView.h
@@ -1,0 +1,54 @@
+#import <UIKit/UIKit.h>
+
+#import "BarMenuContainer.h"
+#import "RNSReactBaseView.h"
+
+@class RNSBarView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarMenuView : RNSReactBaseView <BarMenuContainer>
+
+@property (nonatomic, weak, nullable) RNSBarView *barParent;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *icon;
+@property (nonatomic, copy, nullable) NSString *placement;
+@property (nonatomic, copy, nullable) NSString *variant;
+@property (nonatomic, strong, nullable) UIColor *tintColor;
+@property (nonatomic, strong, nullable) NSNumber *width;
+@property (nonatomic, assign) BOOL disabled;
+@property (nonatomic, assign) BOOL selected;
+@property (nonatomic, assign) BOOL changesSelectionAsPrimaryAction;
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, assign) BOOL hidesSharedBackground;
+@property (nonatomic, assign) BOOL hasSharesBackground;
+@property (nonatomic, assign) BOOL sharesBackground;
+@property (nonatomic, assign) BOOL hasBadge;
+@property (nonatomic, strong, nullable) NSNumber *badgeCount;
+@property (nonatomic, copy, nullable) NSString *badgeValue;
+@property (nonatomic, strong, nullable) UIColor *badgeForegroundColor;
+@property (nonatomic, strong, nullable) UIColor *badgeBackgroundColor;
+@property (nonatomic, copy, nullable) NSString *badgeFontFamily;
+@property (nonatomic, copy, nullable) NSString *badgeFontWeight;
+@property (nonatomic, strong, nullable) NSNumber *badgeFontSize;
+@property (nonatomic, copy, nullable) NSString *titleFontFamily;
+@property (nonatomic, copy, nullable) NSString *titleFontWeight;
+@property (nonatomic, strong, nullable) NSNumber *titleFontSize;
+@property (nonatomic, strong, nullable) UIColor *titleColor;
+@property (nonatomic, copy, nullable) NSString *menuTitle;
+@property (nonatomic, copy, nullable) NSString *menuLayout;
+@property (nonatomic, assign) BOOL menuMultiselectable;
+@property (nonatomic, copy, nullable) NSString *selectedId;
+@property (nonatomic, copy, nullable) NSString *defaultSelectedId;
+@property (nonatomic, copy) NSArray<NSString *> *selectedIds;
+@property (nonatomic, copy) NSArray<NSString *> *defaultSelectedIds;
+@property (nonatomic, assign) BOOL hasSelectedId;
+@property (nonatomic, assign) BOOL hasSelectedIds;
+@property (nonatomic, copy, nullable) NSString *testID;
+
+- (UIMenu *)menuRepresentation;
+- (BOOL)canApplySelectionAsPrimaryAction;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarMenuView.mm
+++ b/ios/bar/RNSBarMenuView.mm
@@ -1,0 +1,493 @@
+#import "RNSBarMenuView.h"
+
+#import <React/RCTConversions.h>
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import "RNSBarMenuActionView.h"
+#import "RNSBarMenuSubmenuView.h"
+#import "BarPropHelpers.hpp"
+#import "RNSBarView.h"
+
+using namespace facebook::react;
+
+@interface RNSBarView (BarInternal)
+- (void)updateBarItems;
+- (void)updateBarMenu:(RNSBarMenuView *)menuView;
+@end
+
+@implementation RNSBarMenuView {
+  NSMutableArray<UIView<RCTComponentViewProtocol> *> * _menuChildren;
+  NSMutableOrderedSet<NSString *> * _uncontrolledSelectedIDs;
+  NSString * _uncontrolledSelectedID;
+  BOOL _hasAppliedInitialSelection;
+  BOOL _hasAppliedInitialMultiSelection;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarMenuComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarMenuProps>();
+    _props = defaultProps;
+
+    self.hidden = YES;
+    self.userInteractionEnabled = NO;
+    _menuChildren = [NSMutableArray new];
+    _uncontrolledSelectedIDs = [NSMutableOrderedSet new];
+    self.selectedIds = @[];
+    self.defaultSelectedIds = @[];
+  }
+
+  return self;
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super mountChildComponentView:childComponentView index:index];
+
+  childComponentView.hidden = YES;
+  childComponentView.userInteractionEnabled = NO;
+
+  if ([childComponentView isKindOfClass:[RNSBarMenuActionView class]]) {
+    ((RNSBarMenuActionView *)childComponentView).menuParent = self;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+    ((RNSBarMenuSubmenuView *)childComponentView).menuParent = self;
+  }
+
+  if (index <= (NSInteger)_menuChildren.count) {
+    [_menuChildren insertObject:childComponentView atIndex:index];
+  } else {
+    [_menuChildren addObject:childComponentView];
+  }
+
+  [self updateMenu];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super unmountChildComponentView:childComponentView index:index];
+
+  if ([childComponentView isKindOfClass:[RNSBarMenuActionView class]]) {
+    ((RNSBarMenuActionView *)childComponentView).menuParent = nil;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+    ((RNSBarMenuSubmenuView *)childComponentView).menuParent = nil;
+  }
+
+  if (index < (NSInteger)_menuChildren.count && _menuChildren[index] == childComponentView) {
+    [_menuChildren removeObjectAtIndex:index];
+  } else {
+    [_menuChildren removeObject:childComponentView];
+  }
+
+  [self updateMenu];
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldMenuProps = *std::static_pointer_cast<RNSBarMenuProps const>(_props);
+  const auto &newMenuProps = *std::static_pointer_cast<RNSBarMenuProps const>(props);
+
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, title);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, icon);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, placement);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, variant);
+
+  APPLY_COLOR_PROP(self, oldMenuProps, newMenuProps, tintColor);
+
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldMenuProps, newMenuProps, width);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, disabled);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, selected);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, changesSelectionAsPrimaryAction);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, accessibilityLabel);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, accessibilityHint);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, testID);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, titleFontFamily);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, titleFontWeight);
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldMenuProps, newMenuProps, titleFontSize);
+
+  APPLY_COLOR_PROP(self, oldMenuProps, newMenuProps, titleColor);
+
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, identifier);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, hidesSharedBackground);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, sharesBackground);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, hasSharesBackground);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, hasBadge);
+
+  APPLY_NUMBER_PROP(self, oldMenuProps, newMenuProps, badgeCount);
+
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, badgeValue);
+
+  APPLY_COLOR_PROP(self, oldMenuProps, newMenuProps, badgeForegroundColor);
+  APPLY_COLOR_PROP(self, oldMenuProps, newMenuProps, badgeBackgroundColor);
+
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, badgeFontFamily);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, badgeFontWeight);
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldMenuProps, newMenuProps, badgeFontSize);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, menuTitle);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, menuLayout);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, menuMultiselectable);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, selectedId);
+  APPLY_STRING_PROP(self, oldMenuProps, newMenuProps, defaultSelectedId);
+  APPLY_STRING_ARRAY_PROP(self, oldMenuProps, newMenuProps, selectedIds);
+  APPLY_STRING_ARRAY_PROP(self, oldMenuProps, newMenuProps, defaultSelectedIds);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, hasSelectedId);
+  APPLY_BOOL_PROP(self, oldMenuProps, newMenuProps, hasSelectedIds);
+
+  [super updateProps:props oldProps:oldProps];
+
+  [self updateMenu];
+}
+
+- (void)updateMenu
+{
+  if (self.barParent != nil) {
+    [self.barParent updateBarMenu:self];
+  }
+}
+
+- (NSArray<RNSBarMenuActionView *> *)actionChildren
+{
+  NSMutableArray<RNSBarMenuActionView *> *actions = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuActionView class]]) {
+      [actions addObject:(RNSBarMenuActionView *)child];
+    }
+  }
+
+  return actions;
+}
+
+- (NSArray<RNSBarMenuSubmenuView *> *)submenuChildren
+{
+  NSMutableArray<RNSBarMenuSubmenuView *> *submenus = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+      [submenus addObject:(RNSBarMenuSubmenuView *)child];
+    }
+  }
+
+  return submenus;
+}
+
+- (NSSet<NSString *> *)actionIDSet
+{
+  NSMutableSet<NSString *> *ids = [NSMutableSet new];
+
+  for (RNSBarMenuActionView *action in [self actionChildren]) {
+    if (action.identifier.length > 0) {
+      [ids addObject:action.identifier];
+    }
+  }
+
+  return ids;
+}
+
+- (NSString *)firstActionID
+{
+  for (RNSBarMenuActionView *action in [self actionChildren]) {
+    if (action.identifier.length > 0) {
+      return action.identifier;
+    }
+  }
+
+  return nil;
+}
+
+- (BOOL)isMultiSelectionMode
+{
+  if (self.changesSelectionAsPrimaryAction) {
+    return NO;
+  }
+
+  if (self.menuMultiselectable) {
+    return YES;
+  }
+
+  if (self.hasSelectedIds || self.defaultSelectedIds.count > 0) {
+    return YES;
+  }
+
+  return NO;
+}
+
+- (BOOL)isSingleSelectionMode
+{
+  if (self.changesSelectionAsPrimaryAction) {
+    return YES;
+  }
+
+  if ([self isMultiSelectionMode]) {
+    return NO;
+  }
+
+  if (self.hasSelectedId || self.defaultSelectedId.length > 0) {
+    return YES;
+  }
+
+  return NO;
+}
+
+- (NSString *)resolvedSingleSelectionID
+{
+  if (self.hasSelectedId) {
+    NSString *selectedID = self.selectedId ?: @"";
+    if (selectedID.length == 0) {
+      return @"";
+    }
+
+    NSSet<NSString *> *availableIDs = [self actionIDSet];
+    return [availableIDs containsObject:selectedID] ? selectedID : @"";
+  }
+
+  if (!_hasAppliedInitialSelection) {
+    if (self.defaultSelectedId.length > 0) {
+      _uncontrolledSelectedID = self.defaultSelectedId;
+    } else {
+      _uncontrolledSelectedID = [self firstActionID];
+    }
+    _hasAppliedInitialSelection = YES;
+  }
+
+  NSSet<NSString *> *availableIDs = [self actionIDSet];
+  if (_uncontrolledSelectedID.length > 0 && [availableIDs containsObject:_uncontrolledSelectedID]) {
+    return _uncontrolledSelectedID;
+  }
+
+  _uncontrolledSelectedID = [self firstActionID];
+  return _uncontrolledSelectedID ?: @"";
+}
+
+- (NSArray<NSString *> *)resolvedMultiSelectionIDs
+{
+  if (self.hasSelectedIds) {
+    return self.selectedIds;
+  }
+
+  if (!_hasAppliedInitialMultiSelection) {
+    [_uncontrolledSelectedIDs removeAllObjects];
+    for (NSString *item in self.defaultSelectedIds) {
+      if (item.length > 0) {
+        [_uncontrolledSelectedIDs addObject:item];
+      }
+    }
+    _hasAppliedInitialMultiSelection = YES;
+  }
+
+  NSSet<NSString *> *availableIDs = [self actionIDSet];
+  if (availableIDs.count == 0) {
+    [_uncontrolledSelectedIDs removeAllObjects];
+    return @[];
+  }
+
+  for (NSString *item in _uncontrolledSelectedIDs.array) {
+    if (![availableIDs containsObject:item]) {
+      [_uncontrolledSelectedIDs removeObject:item];
+    }
+  }
+
+  return _uncontrolledSelectedIDs.array;
+}
+
+- (BOOL)applySelectionStateToActions
+{
+  NSArray<RNSBarMenuActionView *> *actions = [self actionChildren];
+  if (actions.count == 0) {
+    return NO;
+  }
+
+  BOOL singleSelection = [self isSingleSelectionMode];
+  BOOL multiSelection = [self isMultiSelectionMode];
+
+  if (!singleSelection && !multiSelection) {
+    for (RNSBarMenuActionView *action in actions) {
+      [action clearSelectionState];
+    }
+    return NO;
+  }
+
+  if (singleSelection) {
+    NSString *selectedID = [self resolvedSingleSelectionID];
+    BOOL hasSelection = NO;
+
+    for (RNSBarMenuActionView *action in actions) {
+      if (action.identifier.length > 0 && [action.identifier isEqualToString:selectedID]) {
+        [action applySelectionState:UIMenuElementStateOn];
+        hasSelection = YES;
+      } else {
+        [action applySelectionState:UIMenuElementStateOff];
+      }
+    }
+
+    return hasSelection;
+  }
+
+  NSArray<NSString *> *selectedIDs = [self resolvedMultiSelectionIDs];
+  NSSet<NSString *> *selectedSet = [NSSet setWithArray:selectedIDs];
+  BOOL hasSelection = selectedIDs.count > 0;
+
+  for (RNSBarMenuActionView *action in actions) {
+    if (action.identifier.length > 0 && [selectedSet containsObject:action.identifier]) {
+      [action applySelectionState:UIMenuElementStateOn];
+    } else {
+      [action applySelectionState:UIMenuElementStateOff];
+    }
+  }
+
+  return hasSelection;
+}
+
+- (void)menuItemSelected:(NSString *)identifier
+{
+  if (identifier.length == 0) {
+    return;
+  }
+
+  BOOL singleSelection = [self isSingleSelectionMode];
+  BOOL multiSelection = [self isMultiSelectionMode];
+
+  if (!singleSelection && !multiSelection) {
+    return;
+  }
+
+  BOOL isDirectAction = [[self actionIDSet] containsObject:identifier];
+  BOOL isControlled = singleSelection ? self.hasSelectedId : self.hasSelectedIds;
+  NSArray<NSString *> *currentSelection = @[];
+
+  if (multiSelection) {
+    currentSelection = self.hasSelectedIds ? self.selectedIds : [self resolvedMultiSelectionIDs];
+  }
+
+  NSArray<NSString *> *nextSelection = @[];
+
+  if (isDirectAction) {
+    if (singleSelection) {
+      nextSelection = @[identifier];
+      if (!isControlled) {
+        _uncontrolledSelectedID = identifier;
+        _hasAppliedInitialSelection = YES;
+      }
+    } else if (multiSelection) {
+      NSMutableOrderedSet<NSString *> *mutableSelection =
+        [NSMutableOrderedSet orderedSetWithArray:currentSelection];
+      if ([mutableSelection containsObject:identifier]) {
+        [mutableSelection removeObject:identifier];
+      } else {
+        [mutableSelection addObject:identifier];
+      }
+      nextSelection = mutableSelection.array;
+      if (!isControlled) {
+        [_uncontrolledSelectedIDs removeAllObjects];
+        [_uncontrolledSelectedIDs addObjectsFromArray:mutableSelection.array];
+        _hasAppliedInitialMultiSelection = YES;
+      }
+    }
+  } else {
+    nextSelection = [self selectedItemIDs];
+  }
+
+  if (isDirectAction && !isControlled) {
+    [self updateMenu];
+  }
+
+  if (auto eventEmitter = std::static_pointer_cast<RNSBarMenuEventEmitter const>(_eventEmitter)) {
+    std::string selectionID = std::string(identifier.UTF8String);
+    std::vector<std::string> selectionIDs = ToolbarStringVectorFromNSStringArray(nextSelection);
+    RNSBarMenuEventEmitter::OnSelectionChange payload{selectionID, selectionIDs};
+    eventEmitter->onSelectionChange(payload);
+  }
+}
+
+- (BOOL)hasSelectedItem
+{
+  return [self applySelectionStateToActions];
+}
+
+- (NSArray<NSString *> *)selectedItemIDs
+{
+  [self applySelectionStateToActions];
+
+  NSMutableOrderedSet<NSString *> *ids = [NSMutableOrderedSet new];
+  for (RNSBarMenuActionView *action in [self actionChildren]) {
+    if ([action effectiveState] == UIMenuElementStateOn && action.identifier.length > 0) {
+      [ids addObject:action.identifier];
+    }
+  }
+
+  for (RNSBarMenuSubmenuView *submenu in [self submenuChildren]) {
+    [ids addObjectsFromArray:[submenu selectedItemIDs]];
+  }
+
+  return ids.array;
+}
+
+- (BOOL)canApplySelectionAsPrimaryAction
+{
+  if (!self.changesSelectionAsPrimaryAction) {
+    return NO;
+  }
+
+  return [self applySelectionStateToActions];
+}
+
+- (NSArray<UIMenuElement *> *)menuElementsFromChildren
+{
+  NSMutableArray<UIMenuElement *> *elements = [NSMutableArray new];
+
+  for (UIView *child in _menuChildren) {
+    if ([child isKindOfClass:[RNSBarMenuActionView class]]) {
+      UIAction *action = [(RNSBarMenuActionView *)child uiAction];
+      if (action != nil) {
+        [elements addObject:action];
+      }
+      continue;
+    }
+
+    if ([child isKindOfClass:[RNSBarMenuSubmenuView class]]) {
+      UIMenu *submenu = [(RNSBarMenuSubmenuView *)child menuRepresentation];
+      if (submenu != nil) {
+        [elements addObject:submenu];
+      }
+      continue;
+    }
+  }
+
+  return elements;
+}
+
+- (UIMenu *)menuRepresentation
+{
+  NSString *title = self.menuTitle ?: @"";
+  BOOL hasSelection = [self applySelectionStateToActions];
+  BOOL singleSelection = [self isSingleSelectionMode];
+
+  UIMenuOptions options = 0;
+  if (singleSelection && hasSelection) {
+    if (@available(iOS 15.0, *)) {
+      options |= UIMenuOptionsSingleSelection;
+    }
+  }
+  if ([self.menuLayout isEqualToString:@"palette"]) {
+    if (@available(iOS 17.0, *)) {
+      options |= UIMenuOptionsDisplayAsPalette;
+    }
+  }
+
+  NSArray<UIMenuElement *> *children = [self menuElementsFromChildren];
+  UIMenu *menu = [UIMenu menuWithTitle:title
+                                 image:nil
+                            identifier:nil
+                               options:options
+                              children:children];
+  return menu;
+}
+
+@end

--- a/ios/bar/RNSBarSpacerView.h
+++ b/ios/bar/RNSBarSpacerView.h
@@ -1,0 +1,16 @@
+#import <UIKit/UIKit.h>
+
+#import "RNSReactBaseView.h"
+
+@class RNSBarView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarSpacerView : RNSReactBaseView
+
+@property (nonatomic, weak, nullable) RNSBarView *barParent;
+@property (nonatomic, strong, nullable) NSNumber *size;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarSpacerView.mm
+++ b/ios/bar/RNSBarSpacerView.mm
@@ -1,0 +1,49 @@
+#import "RNSBarSpacerView.h"
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import "BarPropHelpers.hpp"
+
+#import "RNSBarView.h"
+
+using namespace facebook::react;
+
+@interface RNSBarView (BarInternal)
+- (void)updateBarItems;
+@end
+
+@implementation RNSBarSpacerView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarSpacerComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarSpacerProps>();
+    _props = defaultProps;
+
+    self.hidden = YES;
+    self.userInteractionEnabled = NO;
+  }
+
+  return self;
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldSpacerProps = *std::static_pointer_cast<RNSBarSpacerProps const>(_props);
+  const auto &newSpacerProps = *std::static_pointer_cast<RNSBarSpacerProps const>(props);
+
+  APPLY_OPTIONAL_DOUBLE_PROP(self, oldSpacerProps, newSpacerProps, size);
+
+  [super updateProps:props oldProps:oldProps];
+
+  [self.barParent updateBarItems];
+}
+
+@end

--- a/ios/bar/RNSBarView+Header.mm
+++ b/ios/bar/RNSBarView+Header.mm
@@ -1,0 +1,63 @@
+#import "RNSBarView+Internal.hpp"
+#import <React/UIView+React.h>
+
+@implementation RNSBarView (Header)
+
+- (BOOL)replaceBarButtonItem:(UIBarButtonItem *)barButton
+                    withItem:(UIBarButtonItem *)replacement
+            inNavigationItem:(UINavigationItem *)navigationItem
+                     segment:(ToolbarSegment)segment
+{
+  NSArray<UIBarButtonItem *> *items = segment == ToolbarSegmentLeft
+    ? navigationItem.leftBarButtonItems
+    : navigationItem.rightBarButtonItems;
+  NSUInteger index = [items indexOfObjectIdenticalTo:barButton];
+  if (index == NSNotFound) {
+    return NO;
+  }
+
+  NSMutableArray<UIBarButtonItem *> *mutableItems = [items mutableCopy];
+  mutableItems[index] = replacement;
+
+  if (segment == ToolbarSegmentLeft) {
+    [navigationItem setLeftBarButtonItems:mutableItems animated:YES];
+    _appliedLeftItems = [mutableItems copy];
+  } else {
+    [navigationItem setRightBarButtonItems:mutableItems animated:YES];
+    _appliedRightItems = [mutableItems copy];
+  }
+
+  return YES;
+}
+
+- (void)clearNavigationItemsIfNeeded
+{
+  if (!_appliedNavigationItems) {
+    return;
+  }
+
+  UIViewController *viewController = self.reactViewController;
+  if (viewController == nil) {
+    return;
+  }
+
+  UINavigationItem *navigationItem = viewController.navigationItem;
+  if (navigationItem == nil) {
+    return;
+  }
+
+  if (_appliedLeftItems != nil &&
+      [navigationItem.leftBarButtonItems isEqualToArray:_appliedLeftItems]) {
+    navigationItem.leftBarButtonItems = nil;
+  }
+  if (_appliedRightItems != nil &&
+      [navigationItem.rightBarButtonItems isEqualToArray:_appliedRightItems]) {
+    navigationItem.rightBarButtonItems = nil;
+  }
+
+  _appliedNavigationItems = NO;
+  _appliedLeftItems = nil;
+  _appliedRightItems = nil;
+}
+
+@end

--- a/ios/bar/RNSBarView+Internal.hpp
+++ b/ios/bar/RNSBarView+Internal.hpp
@@ -1,0 +1,53 @@
+#import "RNSBarView.h"
+
+#import "RNSBarItemView.h"
+#import "RNSBarMenuView.h"
+#import "RNSBarSpacerView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ToolbarSegment) {
+  ToolbarSegmentNone,
+  ToolbarSegmentLeft,
+  ToolbarSegmentRight,
+};
+
+@interface RNSBarView () {
+@package
+  UIView * _view;
+  NSMutableArray<UIView<RCTComponentViewProtocol> *> * _toolbarChildren;
+  NSMapTable<UIBarButtonItem *, RNSBarItemView *> * _barButtonMap;
+  NSMapTable<RNSBarItemView *, UIBarButtonItem *> * _itemBarButtonMap;
+  NSMapTable<RNSBarMenuView *, UIBarButtonItem *> * _menuBarButtonMap;
+  BOOL _appliedToolbarItems;
+  BOOL _originalToolbarHiddenKnown;
+  BOOL _originalToolbarHidden;
+  BOOL _appliedNavigationItems;
+  BOOL _placementIsToolbar;
+  NSArray<UIBarButtonItem *> * _Nullable _appliedLeftItems;
+  NSArray<UIBarButtonItem *> * _Nullable _appliedRightItems;
+  NSArray<UIBarButtonItem *> * _Nullable _appliedToolbarItemArray;
+}
+
+@end
+
+@interface RNSBarView (InternalMethods)
+
+- (NSArray<UIBarButtonItem *> *)barItemsForChildren;
+- (void)resetBarMappings;
+
+- (BOOL)replaceBarButtonItem:(UIBarButtonItem *)barButton
+                    withItem:(UIBarButtonItem *)replacement
+            inNavigationItem:(UINavigationItem *)navigationItem
+                     segment:(ToolbarSegment)segment;
+- (void)clearNavigationItemsIfNeeded;
+
+- (BOOL)replaceBottomBarButtonItem:(UIBarButtonItem *)barButton
+                          withItem:(UIBarButtonItem *)replacement
+                    viewController:(UIViewController *)viewController;
+- (void)updateBottomBarItemsWithViewController:(UIViewController *)viewController;
+- (void)clearBottomBarIfNeeded;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bar/RNSBarView+Toolbar.mm
+++ b/ios/bar/RNSBarView+Toolbar.mm
@@ -1,0 +1,70 @@
+#import "RNSBarView+Internal.hpp"
+#import <React/UIView+React.h>
+
+@implementation RNSBarView (Toolbar)
+
+- (BOOL)replaceBottomBarButtonItem:(UIBarButtonItem *)barButton
+                          withItem:(UIBarButtonItem *)replacement
+                    viewController:(UIViewController *)viewController
+{
+  NSArray<UIBarButtonItem *> *items = viewController.toolbarItems;
+  NSUInteger index = [items indexOfObjectIdenticalTo:barButton];
+  if (index == NSNotFound) {
+    return NO;
+  }
+
+  NSMutableArray<UIBarButtonItem *> *mutableItems = [items mutableCopy];
+  mutableItems[index] = replacement;
+  [viewController setToolbarItems:mutableItems animated:YES];
+  _appliedToolbarItemArray = [mutableItems copy];
+  return YES;
+}
+
+- (void)updateBottomBarItemsWithViewController:(UIViewController *)viewController
+{
+  UINavigationController *navigationController = viewController.navigationController;
+  if (navigationController == nil) {
+    return;
+  }
+
+  [self resetBarMappings];
+
+  NSArray<UIBarButtonItem *> *items = [self barItemsForChildren];
+  [viewController setToolbarItems:items animated:YES];
+  _appliedToolbarItemArray = items;
+  if (!_originalToolbarHiddenKnown) {
+    _originalToolbarHidden = navigationController.isToolbarHidden;
+    _originalToolbarHiddenKnown = YES;
+  }
+  [navigationController setToolbarHidden:NO animated:NO];
+
+  _appliedToolbarItems = YES;
+}
+
+- (void)clearBottomBarIfNeeded
+{
+  if (!_appliedToolbarItems) {
+    return;
+  }
+
+  UIViewController *viewController = self.reactViewController;
+  if (viewController == nil) {
+    return;
+  }
+
+  if (_appliedToolbarItemArray != nil &&
+      [viewController.toolbarItems isEqualToArray:_appliedToolbarItemArray]) {
+    viewController.toolbarItems = nil;
+  }
+
+  UINavigationController *navigationController = viewController.navigationController;
+  if (navigationController != nil && _originalToolbarHiddenKnown) {
+    [navigationController setToolbarHidden:_originalToolbarHidden animated:NO];
+    _originalToolbarHiddenKnown = NO;
+  }
+
+  _appliedToolbarItems = NO;
+  _appliedToolbarItemArray = nil;
+}
+
+@end

--- a/ios/bar/RNSBarView.h
+++ b/ios/bar/RNSBarView.h
@@ -1,0 +1,15 @@
+#import <UIKit/UIKit.h>
+
+#import "RNSReactBaseView.h"
+
+#ifndef RNSBarViewNativeComponent_h
+#define RNSBarViewNativeComponent_h
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSBarView : RNSReactBaseView
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* RNSBarViewNativeComponent_h */

--- a/ios/bar/RNSBarView.mm
+++ b/ios/bar/RNSBarView.mm
@@ -1,0 +1,961 @@
+#import "RNSBarView+Internal.hpp"
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+#import <React/UIView+React.h>
+#import <React/RCTLog.h>
+
+#import "RCTFabricComponentsPlugins.h"
+using namespace facebook::react;
+
+static UIFontWeight ToolbarFontWeightFromString(NSString *weight)
+{
+  if (weight.length == 0) {
+    return UIFontWeightRegular;
+  }
+
+  NSString *lowered = weight.lowercaseString;
+  if ([lowered isEqualToString:@"bold"]) {
+    return UIFontWeightBold;
+  }
+  if ([lowered isEqualToString:@"normal"]) {
+    return UIFontWeightRegular;
+  }
+
+  double numericWeight = weight.doubleValue;
+  if (numericWeight >= 900) {
+    return UIFontWeightBlack;
+  }
+  if (numericWeight >= 800) {
+    return UIFontWeightHeavy;
+  }
+  if (numericWeight >= 700) {
+    return UIFontWeightBold;
+  }
+  if (numericWeight >= 600) {
+    return UIFontWeightSemibold;
+  }
+  if (numericWeight >= 500) {
+    return UIFontWeightMedium;
+  }
+  if (numericWeight >= 400) {
+    return UIFontWeightRegular;
+  }
+  if (numericWeight >= 300) {
+    return UIFontWeightLight;
+  }
+  if (numericWeight >= 200) {
+    return UIFontWeightThin;
+  }
+
+  return UIFontWeightUltraLight;
+}
+
+static UIFont * _Nullable ToolbarFontFromStyle(
+  NSString * _Nullable family,
+  NSNumber * _Nullable sizeNumber,
+  NSString * _Nullable weight
+) {
+  if (family.length == 0 && sizeNumber == nil && weight.length == 0) {
+    return nil;
+  }
+
+  CGFloat size = sizeNumber != nil ? sizeNumber.doubleValue : [UIFont systemFontSize];
+  UIFont *font = nil;
+
+  if (family.length > 0) {
+    font = [UIFont fontWithName:family size:size];
+  }
+
+  if (font == nil) {
+    UIFontWeight fontWeight = ToolbarFontWeightFromString(weight);
+    font = [UIFont systemFontOfSize:size weight:fontWeight];
+  }
+
+  return font;
+}
+
+static void ToolbarApplyTitleStyleToBarButtonItem(
+  UIBarButtonItem *barButton,
+  NSString * _Nullable fontFamily,
+  NSNumber * _Nullable fontSize,
+  NSString * _Nullable fontWeight,
+  UIColor * _Nullable titleColor
+) {
+  UIFont *font = ToolbarFontFromStyle(fontFamily, fontSize, fontWeight);
+  if (font == nil && titleColor == nil) {
+    return;
+  }
+
+  NSMutableDictionary<NSAttributedStringKey, id> *attributes = [NSMutableDictionary new];
+  if (font != nil) {
+    attributes[NSFontAttributeName] = font;
+  }
+  if (titleColor != nil) {
+    attributes[NSForegroundColorAttributeName] = titleColor;
+  }
+
+  [barButton setTitleTextAttributes:attributes forState:UIControlStateNormal];
+}
+
+static void ToolbarApplyBadgeToBarButtonItem(
+  UIBarButtonItem *barButton,
+  BOOL hasBadge,
+  NSNumber * _Nullable badgeCount,
+  NSString * _Nullable badgeValue,
+  UIColor * _Nullable badgeForegroundColor,
+  UIColor * _Nullable badgeBackgroundColor,
+  NSString * _Nullable badgeFontFamily,
+  NSNumber * _Nullable badgeFontSize,
+  NSString * _Nullable badgeFontWeight
+);
+
+static void ToolbarApplyBarButtonCommon(
+  UIBarButtonItem *barButton,
+  BOOL enabled,
+  BOOL selected,
+  UIColor * _Nullable tintColor,
+  NSNumber * _Nullable width,
+  NSString * _Nullable accessibilityLabel,
+  NSString * _Nullable accessibilityHint,
+  NSString * _Nullable testID,
+  NSString * _Nullable titleFontFamily,
+  NSNumber * _Nullable titleFontSize,
+  NSString * _Nullable titleFontWeight,
+  UIColor * _Nullable titleColor,
+  NSString * _Nullable identifier,
+  BOOL hidesSharedBackground,
+  BOOL hasSharesBackground,
+  BOOL sharesBackground,
+  BOOL hasBadge,
+  NSNumber * _Nullable badgeCount,
+  NSString * _Nullable badgeValue,
+  UIColor * _Nullable badgeForegroundColor,
+  UIColor * _Nullable badgeBackgroundColor,
+  NSString * _Nullable badgeFontFamily,
+  NSNumber * _Nullable badgeFontSize,
+  NSString * _Nullable badgeFontWeight
+) {
+  barButton.enabled = enabled;
+  if (@available(iOS 15.0, *)) {
+    barButton.selected = selected;
+  }
+
+  if (tintColor != nil) {
+    barButton.tintColor = tintColor;
+  }
+
+  if (width != nil) {
+    barButton.width = width.doubleValue;
+  }
+
+  if (accessibilityLabel.length > 0) {
+    barButton.accessibilityLabel = accessibilityLabel;
+  }
+  if (accessibilityHint.length > 0) {
+    barButton.accessibilityHint = accessibilityHint;
+  }
+  if (testID.length > 0) {
+    [barButton setValue:testID forKey:@"accessibilityIdentifier"];
+  }
+
+  ToolbarApplyTitleStyleToBarButtonItem(
+    barButton,
+    titleFontFamily,
+    titleFontSize,
+    titleFontWeight,
+    titleColor
+  );
+
+  if (@available(iOS 26.0, *)) {
+    if (identifier.length > 0) {
+      barButton.identifier = identifier;
+    }
+    barButton.hidesSharedBackground = hidesSharedBackground;
+    if (hasSharesBackground) {
+      barButton.sharesBackground = sharesBackground;
+    }
+  }
+
+  ToolbarApplyBadgeToBarButtonItem(
+    barButton,
+    hasBadge,
+    badgeCount,
+    badgeValue,
+    badgeForegroundColor,
+    badgeBackgroundColor,
+    badgeFontFamily,
+    badgeFontSize,
+    badgeFontWeight
+  );
+}
+
+static void ToolbarApplyBadgeToBarButtonItem(
+  UIBarButtonItem *barButton,
+  BOOL hasBadge,
+  NSNumber * _Nullable badgeCount,
+  NSString * _Nullable badgeValue,
+  UIColor * _Nullable badgeForegroundColor,
+  UIColor * _Nullable badgeBackgroundColor,
+  NSString * _Nullable badgeFontFamily,
+  NSNumber * _Nullable badgeFontSize,
+  NSString * _Nullable badgeFontWeight
+) {
+  if (@available(iOS 26.0, *)) {
+    if (!hasBadge) {
+      barButton.badge = nil;
+      return;
+    }
+
+    UIBarButtonItemBadge *badge = nil;
+    if (badgeValue.length > 0) {
+      badge = [UIBarButtonItemBadge badgeWithString:badgeValue];
+    } else if (badgeCount != nil) {
+      badge = [UIBarButtonItemBadge badgeWithCount:badgeCount.unsignedIntegerValue];
+    } else {
+      badge = [UIBarButtonItemBadge indicatorBadge];
+    }
+
+    badge.backgroundColor = badgeBackgroundColor;
+    badge.foregroundColor = badgeForegroundColor;
+
+    UIFont *font = ToolbarFontFromStyle(badgeFontFamily, badgeFontSize, badgeFontWeight);
+    if (font != nil) {
+      badge.font = font;
+    }
+
+    barButton.badge = badge;
+  }
+}
+
+static UIImage * _Nullable ToolbarSystemImage(NSString * _Nullable icon)
+{
+  if (icon.length == 0) {
+    return nil;
+  }
+
+  if (@available(iOS 13.0, *)) {
+    return [UIImage systemImageNamed:icon];
+  }
+
+  return nil;
+}
+
+static UIImage * _Nullable ToolbarImageFromProps(
+  NSString * _Nullable icon
+) {
+  return ToolbarSystemImage(icon);
+}
+
+static void ToolbarApplyBarButtonContent(
+  UIBarButtonItem *barButton,
+  NSString * _Nullable title,
+  NSString * _Nullable icon
+)
+{
+  UIImage *image = ToolbarImageFromProps(icon);
+  if (image != nil) {
+    barButton.image = image;
+    barButton.title = nil;
+  } else {
+    barButton.image = nil;
+    barButton.title = title ?: @"";
+  }
+}
+
+@implementation RNSBarView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNSBarViewComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNSBarViewProps>();
+    _props = defaultProps;
+
+    _view = [[UIView alloc] init];
+    self.contentView = _view;
+
+    _toolbarChildren = [NSMutableArray new];
+    [self resetBarMappings];
+    _placementIsToolbar = NO;
+  }
+
+  return self;
+}
+
+- (void)resetBarMappings
+{
+  _barButtonMap = [NSMapTable strongToWeakObjectsMapTable];
+  _itemBarButtonMap = [NSMapTable weakToWeakObjectsMapTable];
+  _menuBarButtonMap = [NSMapTable weakToWeakObjectsMapTable];
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super mountChildComponentView:childComponentView index:index];
+
+  childComponentView.hidden = YES;
+  childComponentView.userInteractionEnabled = NO;
+
+  if ([childComponentView isKindOfClass:[RNSBarItemView class]]) {
+    ((RNSBarItemView *)childComponentView).barParent = self;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuView class]]) {
+    ((RNSBarMenuView *)childComponentView).barParent = self;
+  } else if ([childComponentView isKindOfClass:[RNSBarSpacerView class]]) {
+    ((RNSBarSpacerView *)childComponentView).barParent = self;
+  }
+
+  if (index <= (NSInteger)_toolbarChildren.count) {
+    [_toolbarChildren insertObject:childComponentView atIndex:index];
+  } else {
+    [_toolbarChildren addObject:childComponentView];
+  }
+
+  [self updateBarItems];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super unmountChildComponentView:childComponentView index:index];
+
+  if ([childComponentView isKindOfClass:[RNSBarItemView class]]) {
+    ((RNSBarItemView *)childComponentView).barParent = nil;
+  } else if ([childComponentView isKindOfClass:[RNSBarMenuView class]]) {
+    ((RNSBarMenuView *)childComponentView).barParent = nil;
+  } else if ([childComponentView isKindOfClass:[RNSBarSpacerView class]]) {
+    ((RNSBarSpacerView *)childComponentView).barParent = nil;
+  }
+
+  if (index < (NSInteger)_toolbarChildren.count && _toolbarChildren[index] == childComponentView) {
+    [_toolbarChildren removeObjectAtIndex:index];
+  } else {
+    [_toolbarChildren removeObject:childComponentView];
+  }
+
+  [self updateBarItems];
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldViewProps = *std::static_pointer_cast<RNSBarViewProps const>(_props);
+  const auto &newViewProps = *std::static_pointer_cast<RNSBarViewProps const>(props);
+
+  if (oldViewProps.placement != newViewProps.placement) {
+    _placementIsToolbar = (newViewProps.placement == RNSBarViewPlacement::Toolbar);
+    [self updateBarItems];
+  }
+
+  [super updateProps:props oldProps:oldProps];
+}
+
+- (ToolbarSegment)segmentForChild:(UIView *)child
+{
+  NSInteger index = [_toolbarChildren indexOfObjectIdenticalTo:child];
+  if (index == NSNotFound) {
+    return ToolbarSegmentNone;
+  }
+
+  if ([child isKindOfClass:[RNSBarItemView class]]) {
+    RNSBarItemView *itemView = (RNSBarItemView *)child;
+    return [itemView.placement isEqualToString:@"left"] ? ToolbarSegmentLeft : ToolbarSegmentRight;
+  }
+
+  if ([child isKindOfClass:[RNSBarMenuView class]]) {
+    RNSBarMenuView *menuView = (RNSBarMenuView *)child;
+    return [menuView.placement isEqualToString:@"left"] ? ToolbarSegmentLeft : ToolbarSegmentRight;
+  }
+
+  return ToolbarSegmentRight;
+}
+
+- (void)updateBarItems
+{
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self updateBarItems];
+    });
+    return;
+  }
+
+  UIViewController *viewController = self.reactViewController;
+  if (viewController == nil) {
+    return;
+  }
+
+  if (_placementIsToolbar) {
+    [self clearNavigationItemsIfNeeded];
+    [self updateBottomBarItemsWithViewController:viewController];
+    return;
+  }
+
+  [self clearBottomBarIfNeeded];
+
+  NSMutableArray *leftSegment = [NSMutableArray new];
+  NSMutableArray *rightSegment = [NSMutableArray new];
+
+  for (NSInteger i = 0; i < (NSInteger)_toolbarChildren.count; i++) {
+    UIView *child = _toolbarChildren[i];
+
+    if ([child isKindOfClass:[RNSBarSpacerView class]]) {
+      continue;
+    }
+
+    BOOL isLeft = NO;
+    if ([child isKindOfClass:[RNSBarItemView class]]) {
+      RNSBarItemView *itemView = (RNSBarItemView *)child;
+      isLeft = [itemView.placement isEqualToString:@"left"];
+    } else if ([child isKindOfClass:[RNSBarMenuView class]]) {
+      RNSBarMenuView *menuView = (RNSBarMenuView *)child;
+      isLeft = [menuView.placement isEqualToString:@"left"];
+    }
+
+    if (isLeft) {
+      [leftSegment addObject:child];
+    } else {
+      [rightSegment addObject:child];
+    }
+  }
+
+  [self resetBarMappings];
+
+  UINavigationItem *navigationItem = viewController.navigationItem;
+  NSArray<UIBarButtonItem *> *leftItems = [self barButtonItemsForSegment:leftSegment];
+  NSArray<UIBarButtonItem *> *rightItems = [self barButtonItemsForSegment:rightSegment];
+  [navigationItem setLeftBarButtonItems:leftItems animated:YES];
+  [navigationItem setRightBarButtonItems:rightItems animated:YES];
+  _appliedLeftItems = leftItems;
+  _appliedRightItems = rightItems;
+
+  _appliedNavigationItems = YES;
+}
+
+- (NSArray<UIBarButtonItem *> *)barButtonItemsForSegment:(NSArray *)segment
+{
+  return [self barButtonItemsForChildren:segment includeFlexibleSpacers:NO];
+}
+
+- (NSArray<UIBarButtonItem *> *)barItemsForChildren
+{
+  return [self barButtonItemsForChildren:_toolbarChildren includeFlexibleSpacers:YES];
+}
+
+- (NSArray<UIBarButtonItem *> *)barButtonItemsForChildren:(NSArray *)children includeFlexibleSpacers:(BOOL)includeFlexibleSpacers
+{
+  NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray new];
+
+  for (UIView *child in children) {
+    if ([child isKindOfClass:[RNSBarSpacerView class]]) {
+      RNSBarSpacerView *spacer = (RNSBarSpacerView *)child;
+      if (spacer.size != nil) {
+        UIBarButtonItem *space = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
+                                                                               target:nil
+                                                                               action:nil];
+        space.width = spacer.size.doubleValue;
+        [items addObject:space];
+      } else if (includeFlexibleSpacers) {
+        UIBarButtonItem *space = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
+                                                                               target:nil
+                                                                               action:nil];
+        [items addObject:space];
+      }
+      continue;
+    }
+
+    if ([child isKindOfClass:[RNSBarItemView class]]) {
+      RNSBarItemView *itemView = (RNSBarItemView *)child;
+      UIBarButtonItem *barButton = [self barButtonItemForItem:itemView];
+      if (barButton != nil) {
+        [items addObject:barButton];
+        [_barButtonMap setObject:itemView forKey:barButton];
+        [_itemBarButtonMap setObject:barButton forKey:itemView];
+      }
+      continue;
+    }
+
+    if ([child isKindOfClass:[RNSBarMenuView class]]) {
+      RNSBarMenuView *menuView = (RNSBarMenuView *)child;
+      UIBarButtonItem *barButton = [self barButtonItemForMenu:menuView];
+      if (barButton != nil) {
+        [items addObject:barButton];
+        [_menuBarButtonMap setObject:barButton forKey:menuView];
+      }
+      continue;
+    }
+
+  }
+
+  return items;
+}
+
+- (UIBarButtonItemStyle)barButtonItemStyleForVariant:(NSString *)variant
+{
+  if ([variant isEqualToString:@"done"]) {
+    return UIBarButtonItemStyleDone;
+  }
+
+  if ([variant isEqualToString:@"prominent"]) {
+    if (@available(iOS 26.0, *)) {
+      return UIBarButtonItemStyleProminent;
+    }
+    return UIBarButtonItemStyleDone;
+  }
+
+  return UIBarButtonItemStylePlain;
+}
+
+- (UIBarButtonItem *)barButtonItemForItem:(RNSBarItemView *)itemView
+{
+  UIBarButtonItemStyle style = [self barButtonItemStyleForVariant:itemView.variant];
+  UIBarButtonItem *barButton = nil;
+
+  UIImage *image = ToolbarImageFromProps(itemView.icon);
+  NSString *title = itemView.title ?: @"";
+  if (image != nil) {
+    barButton = [[UIBarButtonItem alloc] initWithImage:image
+                                                 style:style
+                                                target:self
+                                                action:@selector(handleBarButtonItem:)];
+  }
+
+  if (barButton == nil) {
+    barButton = [[UIBarButtonItem alloc] initWithTitle:title
+                                                 style:style
+                                                target:self
+                                                action:@selector(handleBarButtonItem:)];
+  }
+
+  barButton.target = self;
+  barButton.action = @selector(handleBarButtonItem:);
+
+  ToolbarApplyBarButtonContent(
+    barButton,
+    itemView.title,
+    itemView.icon
+  );
+
+  ToolbarApplyBarButtonCommon(
+    barButton,
+    !itemView.disabled,
+    itemView.selected,
+    itemView.tintColor,
+    itemView.width,
+    itemView.accessibilityLabel,
+    itemView.accessibilityHint,
+    itemView.testID,
+    itemView.titleFontFamily,
+    itemView.titleFontSize,
+    itemView.titleFontWeight,
+    itemView.titleColor,
+    itemView.identifier,
+    itemView.hidesSharedBackground,
+    itemView.hasSharesBackground,
+    itemView.sharesBackground,
+    itemView.hasBadge,
+    itemView.badgeCount,
+    itemView.badgeValue,
+    itemView.badgeForegroundColor,
+    itemView.badgeBackgroundColor,
+    itemView.badgeFontFamily,
+    itemView.badgeFontSize,
+    itemView.badgeFontWeight
+  );
+
+  return barButton;
+}
+
+- (UIBarButtonItem *)barButtonItemForMenu:(RNSBarMenuView *)menuView
+{
+  UIBarButtonItemStyle style = [self barButtonItemStyleForVariant:menuView.variant];
+  UIBarButtonItem *barButton = nil;
+
+  UIImage *image = ToolbarImageFromProps(menuView.icon);
+  NSString *title = menuView.title ?: @"";
+  if (image != nil) {
+    barButton = [[UIBarButtonItem alloc] initWithImage:image
+                                                 style:style
+                                                target:nil
+                                                action:nil];
+  }
+
+  if (barButton == nil) {
+    barButton = [[UIBarButtonItem alloc] initWithTitle:title
+                                                 style:style
+                                                target:nil
+                                                action:nil];
+  }
+
+  BOOL canApplySelectionAsPrimaryAction = NO;
+  if (@available(iOS 15.0, *)) {
+    canApplySelectionAsPrimaryAction = [menuView canApplySelectionAsPrimaryAction];
+    barButton.changesSelectionAsPrimaryAction = NO;
+  }
+  if (@available(iOS 14.0, *)) {
+    barButton.menu = [menuView menuRepresentation];
+  }
+  if (@available(iOS 15.0, *)) {
+    barButton.changesSelectionAsPrimaryAction = canApplySelectionAsPrimaryAction;
+  }
+
+  ToolbarApplyBarButtonContent(
+    barButton,
+    menuView.title,
+    menuView.icon
+  );
+
+  ToolbarApplyBarButtonCommon(
+    barButton,
+    !menuView.disabled,
+    menuView.selected,
+    menuView.tintColor,
+    menuView.width,
+    menuView.accessibilityLabel,
+    menuView.accessibilityHint,
+    menuView.testID,
+    menuView.titleFontFamily,
+    menuView.titleFontSize,
+    menuView.titleFontWeight,
+    menuView.titleColor,
+    menuView.identifier,
+    menuView.hidesSharedBackground,
+    menuView.hasSharesBackground,
+    menuView.sharesBackground,
+    menuView.hasBadge,
+    menuView.badgeCount,
+    menuView.badgeValue,
+    menuView.badgeForegroundColor,
+    menuView.badgeBackgroundColor,
+    menuView.badgeFontFamily,
+    menuView.badgeFontSize,
+    menuView.badgeFontWeight
+  );
+
+  return barButton;
+}
+
+
+- (BOOL)updateExistingBarButton:(UIBarButtonItem *)barButton forItemView:(RNSBarItemView *)itemView
+{
+  UIBarButtonItemStyle desiredStyle = [self barButtonItemStyleForVariant:itemView.variant];
+  if (barButton.style != desiredStyle) {
+    return NO;
+  }
+
+  ToolbarApplyBarButtonContent(
+    barButton,
+    itemView.title,
+    itemView.icon
+  );
+  barButton.target = self;
+  barButton.action = @selector(handleBarButtonItem:);
+
+  ToolbarApplyBarButtonCommon(
+    barButton,
+    !itemView.disabled,
+    itemView.selected,
+    itemView.tintColor,
+    itemView.width,
+    itemView.accessibilityLabel,
+    itemView.accessibilityHint,
+    itemView.testID,
+    itemView.titleFontFamily,
+    itemView.titleFontSize,
+    itemView.titleFontWeight,
+    itemView.titleColor,
+    itemView.identifier,
+    itemView.hidesSharedBackground,
+    itemView.hasSharesBackground,
+    itemView.sharesBackground,
+    itemView.hasBadge,
+    itemView.badgeCount,
+    itemView.badgeValue,
+    itemView.badgeForegroundColor,
+    itemView.badgeBackgroundColor,
+    itemView.badgeFontFamily,
+    itemView.badgeFontSize,
+    itemView.badgeFontWeight
+  );
+
+  return YES;
+}
+
+- (BOOL)updateExistingBarButton:(UIBarButtonItem *)barButton forMenuView:(RNSBarMenuView *)menuView
+{
+  UIBarButtonItemStyle desiredStyle = [self barButtonItemStyleForVariant:menuView.variant];
+  if (barButton.style != desiredStyle) {
+    return NO;
+  }
+
+  ToolbarApplyBarButtonContent(
+    barButton,
+    menuView.title,
+    menuView.icon
+  );
+
+  BOOL canApplySelectionAsPrimaryAction = NO;
+  if (@available(iOS 15.0, *)) {
+    canApplySelectionAsPrimaryAction = [menuView canApplySelectionAsPrimaryAction];
+    barButton.changesSelectionAsPrimaryAction = NO;
+  }
+  if (@available(iOS 14.0, *)) {
+    barButton.menu = [menuView menuRepresentation];
+  }
+  if (@available(iOS 15.0, *)) {
+    barButton.changesSelectionAsPrimaryAction = canApplySelectionAsPrimaryAction;
+  }
+
+  ToolbarApplyBarButtonCommon(
+    barButton,
+    !menuView.disabled,
+    menuView.selected,
+    menuView.tintColor,
+    menuView.width,
+    menuView.accessibilityLabel,
+    menuView.accessibilityHint,
+    menuView.testID,
+    menuView.titleFontFamily,
+    menuView.titleFontSize,
+    menuView.titleFontWeight,
+    menuView.titleColor,
+    menuView.identifier,
+    menuView.hidesSharedBackground,
+    menuView.hasSharesBackground,
+    menuView.sharesBackground,
+    menuView.hasBadge,
+    menuView.badgeCount,
+    menuView.badgeValue,
+    menuView.badgeForegroundColor,
+    menuView.badgeBackgroundColor,
+    menuView.badgeFontFamily,
+    menuView.badgeFontSize,
+    menuView.badgeFontWeight
+  );
+
+  return YES;
+}
+
+- (BOOL)updateBarButtonForItemView:(RNSBarItemView *)itemView
+                    viewController:(UIViewController *)viewController
+                           segment:(ToolbarSegment)segment
+{
+  UIBarButtonItem *barButton = [_itemBarButtonMap objectForKey:itemView];
+  if (barButton == nil) {
+    return NO;
+  }
+
+  if (segment == ToolbarSegmentLeft || segment == ToolbarSegmentRight) {
+    UINavigationItem *navigationItem = viewController.navigationItem;
+    NSArray<UIBarButtonItem *> *items = segment == ToolbarSegmentLeft
+      ? navigationItem.leftBarButtonItems
+      : navigationItem.rightBarButtonItems;
+    if ([items indexOfObjectIdenticalTo:barButton] == NSNotFound) {
+      return NO;
+    }
+
+    if ([self updateExistingBarButton:barButton forItemView:itemView]) {
+      return YES;
+    }
+
+    UIBarButtonItem *replacement = [self barButtonItemForItem:itemView];
+    if (replacement == nil) {
+      return NO;
+    }
+
+    BOOL replaced = [self replaceBarButtonItem:barButton
+                                      withItem:replacement
+                                inNavigationItem:navigationItem
+                                        segment:segment];
+    if (replaced) {
+      [_barButtonMap setObject:itemView forKey:replacement];
+      [_itemBarButtonMap setObject:replacement forKey:itemView];
+    }
+    return replaced;
+  }
+
+  NSArray<UIBarButtonItem *> *items = viewController.toolbarItems;
+  if ([items indexOfObjectIdenticalTo:barButton] == NSNotFound) {
+    return NO;
+  }
+
+  if ([self updateExistingBarButton:barButton forItemView:itemView]) {
+    return YES;
+  }
+
+  UIBarButtonItem *replacement = [self barButtonItemForItem:itemView];
+  if (replacement == nil) {
+    return NO;
+  }
+
+  BOOL replaced = [self replaceBottomBarButtonItem:barButton
+                                           withItem:replacement
+                                     viewController:viewController];
+  if (replaced) {
+    [_barButtonMap setObject:itemView forKey:replacement];
+    [_itemBarButtonMap setObject:replacement forKey:itemView];
+  }
+  return replaced;
+}
+
+- (BOOL)updateBarButtonForMenuView:(RNSBarMenuView *)menuView
+                    viewController:(UIViewController *)viewController
+                           segment:(ToolbarSegment)segment
+{
+  UIBarButtonItem *barButton = [_menuBarButtonMap objectForKey:menuView];
+  if (barButton == nil) {
+    return NO;
+  }
+
+  if (segment == ToolbarSegmentLeft || segment == ToolbarSegmentRight) {
+    UINavigationItem *navigationItem = viewController.navigationItem;
+    NSArray<UIBarButtonItem *> *items = segment == ToolbarSegmentLeft
+      ? navigationItem.leftBarButtonItems
+      : navigationItem.rightBarButtonItems;
+    if ([items indexOfObjectIdenticalTo:barButton] == NSNotFound) {
+      return NO;
+    }
+
+    if ([self updateExistingBarButton:barButton forMenuView:menuView]) {
+      return YES;
+    }
+
+    UIBarButtonItem *replacement = [self barButtonItemForMenu:menuView];
+    if (replacement == nil) {
+      return NO;
+    }
+
+    BOOL replaced = [self replaceBarButtonItem:barButton
+                                      withItem:replacement
+                                inNavigationItem:navigationItem
+                                        segment:segment];
+    if (replaced) {
+      [_menuBarButtonMap setObject:replacement forKey:menuView];
+    }
+    return replaced;
+  }
+
+  NSArray<UIBarButtonItem *> *items = viewController.toolbarItems;
+  if ([items indexOfObjectIdenticalTo:barButton] == NSNotFound) {
+    return NO;
+  }
+
+  if ([self updateExistingBarButton:barButton forMenuView:menuView]) {
+    return YES;
+  }
+
+  UIBarButtonItem *replacement = [self barButtonItemForMenu:menuView];
+  if (replacement == nil) {
+    return NO;
+  }
+
+  BOOL replaced = [self replaceBottomBarButtonItem:barButton
+                                           withItem:replacement
+                                     viewController:viewController];
+  if (replaced) {
+    [_menuBarButtonMap setObject:replacement forKey:menuView];
+  }
+  return replaced;
+}
+
+- (void)updateBarItem:(RNSBarItemView *)itemView
+{
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self updateBarItem:itemView];
+    });
+    return;
+  }
+
+  UIViewController *viewController = self.reactViewController;
+  if (viewController == nil || itemView == nil) {
+    return;
+  }
+
+  if (_placementIsToolbar) {
+    if (![self updateBarButtonForItemView:itemView
+                           viewController:viewController
+                                  segment:ToolbarSegmentNone]) {
+      [self updateBarItems];
+    }
+    return;
+  }
+
+  ToolbarSegment segment = [self segmentForChild:itemView];
+  if (segment == ToolbarSegmentLeft || segment == ToolbarSegmentRight) {
+    if (![self updateBarButtonForItemView:itemView
+                           viewController:viewController
+                                  segment:segment]) {
+      [self updateBarItems];
+    }
+    return;
+  }
+
+  [self updateBarItems];
+}
+
+- (void)updateBarMenu:(RNSBarMenuView *)menuView
+{
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self updateBarMenu:menuView];
+    });
+    return;
+  }
+
+  UIViewController *viewController = self.reactViewController;
+  if (viewController == nil || menuView == nil) {
+    return;
+  }
+
+  if (_placementIsToolbar) {
+    if (![self updateBarButtonForMenuView:menuView
+                           viewController:viewController
+                                  segment:ToolbarSegmentNone]) {
+      [self updateBarItems];
+    }
+    return;
+  }
+
+  ToolbarSegment segment = [self segmentForChild:menuView];
+  if (segment == ToolbarSegmentLeft || segment == ToolbarSegmentRight) {
+    if (![self updateBarButtonForMenuView:menuView
+                           viewController:viewController
+                                  segment:segment]) {
+      [self updateBarItems];
+    }
+    return;
+  }
+
+  [self updateBarItems];
+}
+
+- (void)handleBarButtonItem:(UIBarButtonItem *)sender
+{
+  RNSBarItemView *itemView = [_barButtonMap objectForKey:sender];
+  [itemView emitPress];
+}
+
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{
+  if (newSuperview == nil) {
+    [self clearNavigationItemsIfNeeded];
+    [self clearBottomBarIfNeeded];
+  }
+
+  [super willMoveToSuperview:newSuperview];
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window != nil) {
+    [self updateBarItems];
+  }
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -220,6 +220,24 @@
         },
         "RNSScrollViewMarker": {
           "className": "RNSScrollViewMarkerComponentView"
+        },
+        "RNSBarView": {
+          "className": "RNSBarView"
+        },
+        "RNSBarItem": {
+          "className": "RNSBarItemView"
+        },
+        "RNSBarMenu": {
+          "className": "RNSBarMenuView"
+        },
+        "RNSBarMenuAction": {
+          "className": "RNSBarMenuActionView"
+        },
+        "RNSBarMenuSubmenu": {
+          "className": "RNSBarMenuSubmenuView"
+        },
+        "RNSBarSpacer": {
+          "className": "RNSBarSpacerView"
         }
       }
     }

--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { type ColorValue, type ViewProps } from 'react-native';
+import BarView from '../fabric/bar/BarViewNativeComponent';
+import BarItemNative, {
+  type NativeBarItemProps,
+} from '../fabric/bar/BarItemNativeComponent';
+import BarMenuNative, {
+  type NativeBarMenuProps,
+} from '../fabric/bar/BarMenuNativeComponent';
+import BarMenuActionNative, {
+  type NativeBarMenuActionProps,
+} from '../fabric/bar/BarMenuActionNativeComponent';
+import BarMenuSubmenuNative, {
+  type NativeBarMenuSubmenuProps,
+} from '../fabric/bar/BarMenuSubmenuNativeComponent';
+import BarSpacerNative, {
+  type BarSpacerProps,
+} from '../fabric/bar/BarSpacerNativeComponent';
+
+export type BarPlacement = 'header' | 'toolbar';
+
+export type BarProps = ViewProps & {
+  placement?: BarPlacement;
+  children?: React.ReactNode;
+};
+
+export type BarIcon = {
+  type: 'sfSymbol';
+  name: string;
+};
+
+export type BarTitleStyle = {
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: string;
+  color?: ColorValue;
+};
+
+export type BarBadgeStyle = {
+  color?: ColorValue;
+  backgroundColor?: ColorValue;
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: string;
+};
+
+export type BarBadge = {
+  value: number | string;
+  style?: BarBadgeStyle;
+};
+
+export type BarItemVariant = 'plain' | 'done' | 'prominent';
+export type BarItemPlacement = 'left' | 'right';
+
+type SharedBarItemProps = {
+  title?: string;
+  titleStyle?: BarTitleStyle;
+  icon?: BarIcon;
+  placement?: BarItemPlacement;
+  variant?: BarItemVariant;
+  tintColor?: ColorValue;
+  disabled?: boolean;
+  width?: number;
+  identifier?: string;
+  hidesSharedBackground?: boolean;
+  sharesBackground?: boolean;
+  badge?: BarBadge;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  testID?: string;
+};
+
+export function Bar(props: BarProps) {
+  return <BarView {...props} style={{ height: 0, width: 0 }} />;
+}
+
+export type BarItemProps = SharedBarItemProps & {
+  selected?: boolean;
+  onPress?: () => void;
+};
+
+export type BarMenuProps = SharedBarItemProps & {
+  selected?: boolean;
+  menuTitle?: string;
+  menuLayout?: 'default' | 'palette';
+  menuMultiselectable?: boolean;
+  selectedId?: string;
+  defaultSelectedId?: string;
+  selectedIds?: string[];
+  defaultSelectedIds?: string[];
+  onSelectionChange?: (selection: { id: string; ids: string[] }) => void;
+  children?: React.ReactNode;
+};
+
+export type BarMenuActionProps = {
+  identifier?: string;
+  title: string;
+  subtitle?: string;
+  icon?: BarIcon;
+  onPress?: () => void;
+  state?: 'on' | 'off' | 'mixed';
+  disabled?: boolean;
+  destructive?: boolean;
+  hidden?: boolean;
+  keepsMenuPresented?: boolean;
+  discoverabilityLabel?: string;
+};
+
+export type BarMenuSubmenuProps = {
+  identifier?: string;
+  title: string;
+  subtitle?: string;
+  icon?: BarIcon;
+  inline?: boolean;
+  layout?: 'default' | 'palette';
+  destructive?: boolean;
+  multiselectable?: boolean;
+  selectedId?: string;
+  defaultSelectedId?: string;
+  selectedIds?: string[];
+  defaultSelectedIds?: string[];
+  children?: React.ReactNode;
+};
+
+const resolveIconProps = (icon?: BarIcon) => {
+  if (!icon) {
+    return {};
+  }
+
+  return {
+    icon: icon.name,
+  };
+};
+
+const mapTitleStyle = (style?: BarTitleStyle) => {
+  if (!style) {
+    return {};
+  }
+
+  return {
+    titleFontFamily: style.fontFamily,
+    titleFontSize: style.fontSize,
+    titleFontWeight: style.fontWeight,
+    titleColor: style.color,
+  };
+};
+
+const mapBadge = (badge?: BarBadge) => {
+  if (!badge) {
+    return {
+      hasBadge: false,
+    };
+  }
+
+  const value = badge.value;
+
+  return {
+    hasBadge: true,
+    badgeCount: typeof value === 'number' ? value : undefined,
+    badgeValue: typeof value === 'string' ? value : undefined,
+    badgeForegroundColor: badge.style?.color,
+    badgeBackgroundColor: badge.style?.backgroundColor,
+    badgeFontFamily: badge.style?.fontFamily,
+    badgeFontSize: badge.style?.fontSize,
+    badgeFontWeight: badge.style?.fontWeight,
+  };
+};
+
+const applySharedProps = (
+  props: SharedBarItemProps & {
+    selected?: boolean;
+  }
+) => {
+  const { icon, badge, titleStyle, sharesBackground, selected, ...rest } =
+    props;
+
+  const iconProps = resolveIconProps(icon);
+  const badgeProps = mapBadge(badge);
+  const titleStyleProps = mapTitleStyle(titleStyle);
+  const hasSharesBackground = sharesBackground !== undefined;
+
+  return {
+    ...rest,
+    ...badgeProps,
+    ...titleStyleProps,
+    ...iconProps,
+    selected,
+    hasSharesBackground,
+    sharesBackground: sharesBackground ?? false,
+  };
+};
+
+Bar.Item = function BarItem({ onPress, ...rest }: BarItemProps) {
+  const nativeProps: NativeBarItemProps = {
+    ...applySharedProps(rest),
+  };
+
+  return <BarItemNative {...nativeProps} onItemPress={onPress} />;
+};
+
+Bar.Menu = function BarMenu({ children, ...rest }: BarMenuProps) {
+  const changesSelectionAsPrimaryAction = rest.onSelectionChange !== undefined;
+  const hasSelectedId = rest.selectedId !== undefined;
+  const hasSelectedIds = rest.selectedIds !== undefined;
+
+  const nativeProps: NativeBarMenuProps = {
+    ...applySharedProps(rest),
+    changesSelectionAsPrimaryAction,
+    menuTitle: rest.menuTitle,
+    menuLayout: rest.menuLayout,
+    menuMultiselectable: rest.menuMultiselectable,
+    selectedId: rest.selectedId,
+    defaultSelectedId: rest.defaultSelectedId,
+    selectedIds: rest.selectedIds,
+    defaultSelectedIds: rest.defaultSelectedIds,
+    hasSelectedId,
+    hasSelectedIds,
+    onSelectionChange: rest.onSelectionChange
+      ? (event) => {
+          rest.onSelectionChange?.({
+            id: event.nativeEvent.id,
+            ids: event.nativeEvent.ids,
+          });
+        }
+      : undefined,
+  };
+
+  return <BarMenuNative {...nativeProps}>{children}</BarMenuNative>;
+};
+
+Bar.MenuAction = function BarMenuAction({
+  onPress,
+  icon,
+  ...rest
+}: BarMenuActionProps) {
+  const nativeProps: NativeBarMenuActionProps = {
+    ...rest,
+    ...resolveIconProps(icon),
+  };
+
+  return <BarMenuActionNative {...nativeProps} onMenuActionPress={onPress} />;
+};
+
+Bar.MenuSubmenu = function BarMenuSubmenu({
+  icon,
+  children,
+  inline,
+  ...rest
+}: BarMenuSubmenuProps) {
+  const hasSelectedId = rest.selectedId !== undefined;
+  const hasSelectedIds = rest.selectedIds !== undefined;
+
+  const nativeProps: NativeBarMenuSubmenuProps = {
+    ...rest,
+    ...resolveIconProps(icon),
+    inlinePresentation: inline,
+    selectedId: rest.selectedId,
+    defaultSelectedId: rest.defaultSelectedId,
+    selectedIds: rest.selectedIds,
+    defaultSelectedIds: rest.defaultSelectedIds,
+    hasSelectedId,
+    hasSelectedIds,
+  };
+
+  return (
+    <BarMenuSubmenuNative {...nativeProps}>{children}</BarMenuSubmenuNative>
+  );
+};
+
+Bar.Spacer = function BarSpacer(props: BarSpacerProps) {
+  return <BarSpacerNative {...props} />;
+};

--- a/src/fabric/bar/BarItemNativeComponent.ts
+++ b/src/fabric/bar/BarItemNativeComponent.ts
@@ -1,0 +1,41 @@
+import {
+  codegenNativeComponent,
+  type ColorValue,
+  type CodegenTypes,
+  type ViewProps,
+} from 'react-native';
+
+export interface NativeBarItemProps extends ViewProps {
+  title?: string;
+  icon?: string;
+  placement?: string;
+  variant?: string;
+  tintColor?: ColorValue;
+  width?: CodegenTypes.Double;
+  disabled?: boolean;
+  selected?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  testID?: string;
+  titleFontFamily?: string;
+  titleFontSize?: CodegenTypes.Double;
+  titleFontWeight?: string;
+  titleColor?: ColorValue;
+  identifier?: string;
+  hidesSharedBackground?: boolean;
+  sharesBackground?: boolean;
+  hasSharesBackground?: boolean;
+  badgeCount?: CodegenTypes.Int32;
+  badgeValue?: string;
+  badgeForegroundColor?: ColorValue;
+  badgeBackgroundColor?: ColorValue;
+  badgeFontFamily?: string;
+  badgeFontSize?: CodegenTypes.Double;
+  badgeFontWeight?: string;
+  hasBadge?: boolean;
+  // TODO: something in the event type
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onItemPress?: CodegenTypes.DirectEventHandler<{}>;
+}
+
+export default codegenNativeComponent<NativeBarItemProps>('RNSBarItem');

--- a/src/fabric/bar/BarMenuActionNativeComponent.ts
+++ b/src/fabric/bar/BarMenuActionNativeComponent.ts
@@ -1,0 +1,25 @@
+import {
+  codegenNativeComponent,
+  type CodegenTypes,
+  type ViewProps,
+} from 'react-native';
+
+export interface NativeBarMenuActionProps extends ViewProps {
+  identifier?: string;
+  title?: string;
+  subtitle?: string;
+  icon?: string;
+  state?: string;
+  disabled?: boolean;
+  destructive?: boolean;
+  hidden?: boolean;
+  keepsMenuPresented?: boolean;
+  discoverabilityLabel?: string;
+  // TODO: something in the event type
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onMenuActionPress?: CodegenTypes.DirectEventHandler<{}>;
+}
+
+export default codegenNativeComponent<NativeBarMenuActionProps>(
+  'RNSBarMenuAction'
+);

--- a/src/fabric/bar/BarMenuNativeComponent.ts
+++ b/src/fabric/bar/BarMenuNativeComponent.ts
@@ -1,0 +1,52 @@
+import {
+  codegenNativeComponent,
+  type ColorValue,
+  type CodegenTypes,
+  type ViewProps,
+} from 'react-native';
+
+export interface NativeBarMenuProps extends ViewProps {
+  title?: string;
+  icon?: string;
+  placement?: string;
+  variant?: string;
+  tintColor?: ColorValue;
+  width?: CodegenTypes.Double;
+  disabled?: boolean;
+  selected?: boolean;
+  changesSelectionAsPrimaryAction?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  testID?: string;
+  titleFontFamily?: string;
+  titleFontSize?: CodegenTypes.Double;
+  titleFontWeight?: string;
+  titleColor?: ColorValue;
+  identifier?: string;
+  hidesSharedBackground?: boolean;
+  sharesBackground?: boolean;
+  hasSharesBackground?: boolean;
+  badgeCount?: CodegenTypes.Int32;
+  badgeValue?: string;
+  badgeForegroundColor?: ColorValue;
+  badgeBackgroundColor?: ColorValue;
+  badgeFontFamily?: string;
+  badgeFontSize?: CodegenTypes.Double;
+  badgeFontWeight?: string;
+  hasBadge?: boolean;
+  menuTitle?: string;
+  menuLayout?: string;
+  menuMultiselectable?: boolean;
+  selectedId?: string;
+  defaultSelectedId?: string;
+  selectedIds?: string[];
+  defaultSelectedIds?: string[];
+  hasSelectedId?: boolean;
+  hasSelectedIds?: boolean;
+  onSelectionChange?: CodegenTypes.DirectEventHandler<{
+    id: string;
+    ids: string[];
+  }>;
+}
+
+export default codegenNativeComponent<NativeBarMenuProps>('RNSBarMenu');

--- a/src/fabric/bar/BarMenuSubmenuNativeComponent.ts
+++ b/src/fabric/bar/BarMenuSubmenuNativeComponent.ts
@@ -1,0 +1,22 @@
+import { codegenNativeComponent, type ViewProps } from 'react-native';
+
+export interface NativeBarMenuSubmenuProps extends ViewProps {
+  identifier?: string;
+  title?: string;
+  subtitle?: string;
+  icon?: string;
+  inlinePresentation?: boolean;
+  layout?: string;
+  destructive?: boolean;
+  multiselectable?: boolean;
+  selectedId?: string;
+  defaultSelectedId?: string;
+  selectedIds?: string[];
+  defaultSelectedIds?: string[];
+  hasSelectedId?: boolean;
+  hasSelectedIds?: boolean;
+}
+
+export default codegenNativeComponent<NativeBarMenuSubmenuProps>(
+  'RNSBarMenuSubmenu'
+);

--- a/src/fabric/bar/BarSpacerNativeComponent.ts
+++ b/src/fabric/bar/BarSpacerNativeComponent.ts
@@ -1,0 +1,11 @@
+import {
+  codegenNativeComponent,
+  type CodegenTypes,
+  type ViewProps,
+} from 'react-native';
+
+export interface BarSpacerProps extends ViewProps {
+  size?: CodegenTypes.Double;
+}
+
+export default codegenNativeComponent<BarSpacerProps>('RNSBarSpacer');

--- a/src/fabric/bar/BarViewNativeComponent.ts
+++ b/src/fabric/bar/BarViewNativeComponent.ts
@@ -1,0 +1,11 @@
+import {
+  codegenNativeComponent,
+  type ViewProps,
+  type CodegenTypes,
+} from 'react-native';
+
+export interface NativeBarViewProps extends ViewProps {
+  placement?: CodegenTypes.WithDefault<'header' | 'toolbar', 'header'>;
+}
+
+export default codegenNativeComponent<NativeBarViewProps>('RNSBarView');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,21 @@ export {
   ScreenStackHeaderSearchBarView,
 } from './components/ScreenStackHeaderConfig';
 
+export {
+  Bar,
+  type BarBadge,
+  type BarBadgeStyle,
+  type BarIcon,
+  type BarItemPlacement,
+  type BarItemProps,
+  type BarItemVariant,
+  type BarMenuActionProps,
+  type BarMenuProps,
+  type BarMenuSubmenuProps,
+  type BarProps,
+  type BarTitleStyle,
+} from './components/Bar';
+
 export { default as SearchBar } from './components/SearchBar';
 export { default as ScreenContainer } from './components/ScreenContainer';
 export { default as ScreenStack } from './components/ScreenStack';


### PR DESCRIPTION
## Description

This adds a new component based API and implementation for a unified header and toolbar API. It looks like following:

```jsx
<Bar placement="header">
  <Bar.Item
    placement="left"
    title="Menu"
    icon={{ type: 'sfSymbol', name: 'line.3.horizontal' }}
    onPress={() => Alert.alert('Menu opened')}
  />
</Bar>
```

The `placement: 'header' | 'toolbar'` controls where the items are placed.

**This is primarily done by Codex, so it needs proper review from someone familiar with iOS.**

It also doesn't implement many things currently present in the header items API, and has missing things:

- No support for images
- No support for custom views
- Toolbar has some warnings related to layout
- iOS renders right items in reverse which will be confusing looking at component order, need a way to reverse the render order
- Anything else I have overlooked

## Changes

- Added the codegen references to `package.json`
- Added JS files in `src/bar`
- Added the native files in `ios/bar`

## Visual documentation


https://github.com/user-attachments/assets/1f13169a-0ecc-40b7-9000-1d3f08ebf80d



## Test plan

I added an example in the example app to test this.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
