### PR TITLE
fix(Tabs): remove width/height 100% from TabsHost fillParent style

### DIFF
--- a/src/components/tabs/TabsHost.tsx
+++ b/src/components/tabs/TabsHost.tsx
@@ -99,7 +99,5 @@ export default TabsHost;
 const styles = StyleSheet.create({
   fillParent: {
     flex: 1,
-    width: '100%',
-    height: '100%',
   },
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/software-mansion/react-native-screens/issues/3662

- Remove `width: '100%'` and `height: '100%'` from `TabsHost`'s `fillParent` style
- Keep only `flex: 1`, which is sufficient for the native layout constraints on both iOS and Android

## Problem

`TabsHost` cannot be used as a flex child alongside sibling views. The explicit `width/height: '100%'` forces it to take the full parent size, making patterns like a persistent banner above tabs impossible.

## Why this is safe

- **iOS**: `RNSBottomTabsHostComponentView.mm` pins `controller.view` to the host view's 4 edges via `NSLayoutConstraint` — it fills whatever bounds the JS view provides
- **Android**: `TabsHost.kt` uses `MATCH_PARENT` — same behavior, fills the parent view's bounds
- **`TabsScreen`** is not affected — it uses `position: 'absolute'` (correct for stacking tab content)

## Test plan

- Wrap `NativeTabs` in a `<View style={{ flex: 1 }}>` with a sibling `<View>` above it
- Verify the sibling renders above and NativeTabs fills remaining space
- Verify tabs render correctly when used standalone (no siblings) — `flex: 1` still fills parent