### PR TITLE
chore: Setup run configurations for v4 and v5

### DIFF
--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -72,6 +72,10 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def isGammaEnabled() {
+    return project.hasProperty("rnsGammaEnabled") && project.rnsGammaEnabled == "true"
+}
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -84,6 +88,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        buildConfigField "boolean", "RNS_GAMMA_ENABLED", isGammaEnabled().toString()
         testBuildType System.getProperty('testBuildType', 'release') // Detox
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner' // Detox
     }

--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainActivity.kt
@@ -26,17 +26,15 @@ class MainActivity : ReactActivity() {
     supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
     super.onCreate(savedInstanceState)
 
-    // Remove this once we have sensible workaround to disable the react callback.
-    // Currently it prevents fragment manager's callback from triggering, blocking
-    // native-pop & predictive back gesture.
-    // See: https://github.com/software-mansion/react-native-screens/pull/3630
-    try {
-      val field = ReactActivity::class.java.getDeclaredField("mBackPressedCallback")
-      field.isAccessible = true
-      val callback = field.get(this) as androidx.activity.OnBackPressedCallback
-      callback.isEnabled = false // <--- KILL SWITCH
-    } catch (e: Exception) {
-      e.printStackTrace()
+    if (BuildConfig.RNS_GAMMA_ENABLED) {
+      try {
+        val field = ReactActivity::class.java.getDeclaredField("mBackPressedCallback")
+        field.isAccessible = true
+        val callback = field.get(this) as androidx.activity.OnBackPressedCallback
+        callback.isEnabled = false
+      } catch (e: Exception) {
+        e.printStackTrace()
+      }
     }
   }
 

--- a/FabricExample/android/gradle.properties
+++ b/FabricExample/android/gradle.properties
@@ -45,3 +45,6 @@ edgeToEdgeEnabled=true
 
 # Use this property to enable or disable debug logging
 rnsDebugLogsEnabled=true
+
+# Use this property to enable V5-specific code
+rnsGammaEnabled=true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,10 @@ def areDebugLogsEnabled() {
     return project.hasProperty("rnsDebugLogsEnabled") && project.rnsDebugLogsEnabled == "true"
 }
 
+def isGammaEnabled() {
+    return project.hasProperty("rnsGammaEnabled") && project.rnsGammaEnabled == "true"
+}
+
 def resolveReactNativeDirectory() {
     def userDefinedRnDirPath = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
     if (userDefinedRnDirPath != null) {
@@ -132,6 +136,7 @@ android {
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", IS_NEW_ARCHITECTURE_ENABLED.toString()
         buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabled().toString()
+        buildConfigField "boolean", "RNS_GAMMA_ENABLED", isGammaEnabled().toString()
         ndk {
             abiFilters (*reactNativeArchitectures())
         }


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/960

## Description

This PR adds run configuration for building FabricExample with or w/o Stack v5-specific logic. It adds a new `buildConfigField "rnsGammaEnabled"` to both screens lib and FabricExample that can be enabled either by passing `-PrnsGammaEnabled=true` to gradle or in `gradle.properties` (for expo, etc).

## Changes

- Added `rnsGammaEnabled` build config to react-native-screens and FabricExample that can be set in gradle.properties or as a flag.

## Test plan

Build the app (preferably both debug and release). For FabricExample-level config, check predictive back & whether the run config makes the difference. For `react-native-screens`-level config, you can paste the following in native code (for instance, `Screen.onLayout()`)

```kotlin
        if (com.swmansion.rnscreens.BuildConfig.RNS_GAMMA_ENABLED) {
            Log.d("SCREENS", "gamma enabled")
        }
```

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
