### PR TITLE
chore: Readd landscape orientations to FabricExample plist

### DIFF
--- a/FabricExample/ios/FabricExample/Info.plist
+++ b/FabricExample/ios/FabricExample/Info.plist
@@ -46,6 +46,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
## Description

This PR adds allowed screen orientations to iPhone that were removed https://github.com/react-native-community/template/pull/183. The fix has been submitted in https://github.com/react-native-community/template/pull/207, but it won't be available for some time.

## Changes

Updated Info.plist for FabricExample.

## Test plan

Build the app; see if rotating the screen works.

## Checklist

- [ ] Ensured that CI passes
