### PR TITLE
feat(iOS, Tabs): add userInterfaceStyle prop to enforce native tabs color scheme

### DIFF
--- a/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
@@ -236,6 +236,7 @@ function App() {
         tabBarItemTitleFontWeight="700"
         tabBarItemLabelVisibilityMode="auto"
         tabBarMinimizeBehavior="onScrollDown"
+        userInterfaceStyle="light"
       />
     </ConfigWrapperContext.Provider>
   );

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab1.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab1.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { CenteredLayoutView } from '../../../../shared/CenteredLayoutView';
 import { TabContentView } from '../components/TabContentView';
-import Colors from '../../../../shared/styling/Colors';
 
 export function Tab1() {
   return (
-    <CenteredLayoutView style={{ backgroundColor: Colors.OffWhite }}>
+    <CenteredLayoutView style={{ backgroundColor: 'white' }}>
       <TabContentView selectNextTab={undefined} tabKey={'Tab1'} />
     </CenteredLayoutView>
   );

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab2.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab2.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { CenteredLayoutView } from '../../../../shared/CenteredLayoutView';
 import { TabContentView } from '../components/TabContentView';
-import Colors from '../../../../shared/styling/Colors';
 
 export function Tab2() {
   return (
-    <CenteredLayoutView style={{ backgroundColor: Colors.PurpleLight100 }}>
+    <CenteredLayoutView style={{ backgroundColor: 'white' }}>
       <TabContentView selectNextTab={undefined} tabKey={'Tab2'} />
     </CenteredLayoutView>
   );

--- a/apps/src/tests/single-feature-tests/tabs/index.ts
+++ b/apps/src/tests/single-feature-tests/tabs/index.ts
@@ -4,6 +4,7 @@ import BottomAccessoryScenario from './bottom-accessory-layout';
 import OverrideScrollViewContentInsetScenario from './override-scroll-view-content-inset';
 import TabBarHiddenScenario from './tab-bar-hidden';
 import TabsScreenOrientationScenario from './tabs-screen-orientation';
+import UserInterfaceStyleScenario from './user-interface-style';
 
 const TabsScenarioGroup: ScenarioGroup = {
   name: 'Tabs',
@@ -13,6 +14,7 @@ const TabsScenarioGroup: ScenarioGroup = {
     OverrideScrollViewContentInsetScenario,
     TabBarHiddenScenario,
     TabsScreenOrientationScenario,
+    UserInterfaceStyleScenario,
   ],
 };
 

--- a/apps/src/tests/single-feature-tests/tabs/user-interface-style.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/user-interface-style.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Tabs, type TabsHostProps } from 'react-native-screens';
+
+type UserInterfaceStyle = NonNullable<TabsHostProps['userInterfaceStyle']>;
+
+const SCENARIO = {
+  name: 'User Interface Style',
+  key: 'user-interface-style',
+  details:
+    'Tests userInterfaceStyle on TabsHost. Forces light style even in dark mode to prevent tab bar flash.',
+  platforms: ['ios'] as const,
+  AppComponent: App,
+};
+
+export default SCENARIO;
+
+const STYLE_OPTIONS: { label: string; value: UserInterfaceStyle }[] = [
+  { label: 'Unspecified (system)', value: 'unspecified' },
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+];
+
+function Tab1() {
+  return (
+    <ScrollView
+      style={styles.tab}
+      contentInsetAdjustmentBehavior="automatic">
+      <Text style={styles.title}>Tab 1</Text>
+      <Text style={styles.description}>
+        This test verifies that userInterfaceStyle on TabsHost forces the tab
+        bar appearance. Set your device to dark mode, then select "Light" — the
+        tab bar should stay light without any flash.
+      </Text>
+    </ScrollView>
+  );
+}
+
+function Tab2() {
+  return (
+    <ScrollView
+      style={styles.tab}
+      contentInsetAdjustmentBehavior="automatic">
+      <Text style={styles.title}>Tab 2</Text>
+      <Text style={styles.description}>
+        Navigate between tabs and verify no dark mode flash occurs on the tab
+        bar when userInterfaceStyle is set to "light".
+      </Text>
+    </ScrollView>
+  );
+}
+
+function App() {
+  const [style, setStyle] = useState<UserInterfaceStyle>('light');
+  const [focusedTab, setFocusedTab] = useState('Tab1');
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.pickerContainer, { paddingTop: insets.top + 8 }]}>
+        {STYLE_OPTIONS.map(option => (
+          <Pressable
+            key={option.value}
+            onPress={() => setStyle(option.value)}
+            style={[
+              styles.option,
+              style === option.value && styles.optionSelected,
+            ]}>
+            <Text
+              style={[
+                styles.optionText,
+                style === option.value && styles.optionTextSelected,
+              ]}>
+              {option.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+      <Tabs.Host
+        userInterfaceStyle={style}
+        onNativeFocusChange={e => setFocusedTab(e.nativeEvent.tabKey)}
+        nativeContainerStyle={{ backgroundColor: 'white' }}>
+        <Tabs.Screen
+          tabKey="Tab1"
+          title="Tab 1"
+          isFocused={focusedTab === 'Tab1'}
+          icon={{ ios: { type: 'sfSymbol', name: 'house.fill' } }}>
+          <Tab1 />
+        </Tabs.Screen>
+        <Tabs.Screen
+          tabKey="Tab2"
+          title="Tab 2"
+          isFocused={focusedTab === 'Tab2'}
+          icon={{ ios: { type: 'sfSymbol', name: 'gear' } }}>
+          <Tab2 />
+        </Tabs.Screen>
+      </Tabs.Host>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  pickerContainer: {
+    flexDirection: 'row',
+    padding: 8,
+    gap: 8,
+    backgroundColor: 'white',
+    zIndex: 1,
+  },
+  option: {
+    flex: 1,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    alignItems: 'center',
+  },
+  optionSelected: {
+    backgroundColor: '#007AFF',
+    borderColor: '#007AFF',
+  },
+  optionText: {
+    fontSize: 13,
+    color: '#333',
+  },
+  optionTextSelected: {
+    color: 'white',
+    fontWeight: '600',
+  },
+  tab: {
+    flex: 1,
+    backgroundColor: 'white',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#333',
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#555',
+  },
+});

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -484,4 +484,20 @@ UIUserInterfaceStyle UIUserInterfaceStyleFromTabsScreenCppEquivalent(
   }
 }
 
+UIUserInterfaceStyle UIUserInterfaceStyleFromTabsHostCppEquivalent(
+    react::RNSTabsHostUserInterfaceStyle userInterfaceStyle)
+{
+  using enum facebook::react::RNSTabsHostUserInterfaceStyle;
+  switch (userInterfaceStyle) {
+    case Unspecified:
+      return UIUserInterfaceStyleUnspecified;
+    case Light:
+      return UIUserInterfaceStyleLight;
+    case Dark:
+      return UIUserInterfaceStyleDark;
+    default:
+      RCTLogError(@"[RNScreens] unsupported user interface style");
+  }
+}
+
 }; // namespace rnscreens::conversion

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -96,6 +96,9 @@ NSString *_Nullable RNSTabsBottomAccessoryOnEnvironmentChangePayloadFromUITabAcc
 UIUserInterfaceStyle UIUserInterfaceStyleFromTabsScreenCppEquivalent(
     react::RNSTabsScreenUserInterfaceStyle userInterfaceStyle);
 
+UIUserInterfaceStyle UIUserInterfaceStyleFromTabsHostCppEquivalent(
+    react::RNSTabsHostUserInterfaceStyle userInterfaceStyle);
+
 RCTImageSource *RCTImageSourceFromImageSourceAndIconType(
     const facebook::react::ImageSource *imageSource,
     RNSTabsIconType iconType);

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -63,6 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(18_0)
 @property (nonatomic, readonly) UITabBarControllerMode tabBarControllerMode API_AVAILABLE(ios(18.0));
 #endif // Check for iOS >= 18
+
+@property (nonatomic, readonly) UIUserInterfaceStyle userInterfaceStyle;
 @end
 
 #pragma mark - React Events

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -113,6 +113,7 @@ namespace react = facebook::react;
   _props = defaultProps;
 #endif
   _tabBarTintColor = nil;
+  _userInterfaceStyle = UIUserInterfaceStyleUnspecified;
 #if !TARGET_OS_TV
   _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
 #else // !TARGET_OS_TV
@@ -352,6 +353,12 @@ namespace react = facebook::react;
       }
   }
 
+  if (newComponentProps.userInterfaceStyle != oldComponentProps.userInterfaceStyle) {
+    _userInterfaceStyle =
+        rnscreens::conversion::UIUserInterfaceStyleFromTabsHostCppEquivalent(newComponentProps.userInterfaceStyle);
+    _controller.overrideUserInterfaceStyle = _userInterfaceStyle;
+  }
+
   // Super call updates _props pointer. We should NOT update it before calling super.
   [super updateProps:props oldProps:oldProps];
 }
@@ -542,6 +549,12 @@ RNS_IGNORE_SUPER_CALL_END
     if (tabBarControllerMode != RNSTabBarControllerModeAutomatic) {
       RCTLogWarn(@"[RNScreens] tabBarControllerMode is supported for iOS >= 18");
     }
+}
+
+- (void)setUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
+{
+  _userInterfaceStyle = userInterfaceStyle;
+  _controller.overrideUserInterfaceStyle = _userInterfaceStyle;
 }
 
 - (void)setOnNativeFocusChange:(RCTDirectEventBlock)onNativeFocusChange

--- a/ios/tabs/host/RNSTabsHostComponentViewManager.mm
+++ b/ios/tabs/host/RNSTabsHostComponentViewManager.mm
@@ -34,6 +34,7 @@ RCT_REMAP_VIEW_PROPERTY(
 // This remapping allows us to store UITabBarControllerMode in the component while accepting a custom enum as input
 // from JS.
 RCT_REMAP_VIEW_PROPERTY(tabBarControllerMode, tabBarControllerModeFromRNSTabBarControllerMode, RNSTabBarControllerMode);
+RCT_EXPORT_VIEW_PROPERTY(userInterfaceStyle, UIUserInterfaceStyle);
 
 // TODO: Missing prop
 //@property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;

--- a/src/components/tabs/TabsHost.types.ts
+++ b/src/components/tabs/TabsHost.types.ts
@@ -6,6 +6,7 @@ import type {
   ViewProps,
 } from 'react-native';
 import type { TabsAccessoryEnvironment } from './TabsAccessory.types';
+import type { UserInterfaceStyle } from '../shared/types';
 
 export type TabAccessoryComponentFactory = (
   environment: TabsAccessoryEnvironment,
@@ -273,6 +274,27 @@ export interface TabsHostProps {
    * @supported iOS 18 or higher
    */
   tabBarControllerMode?: TabBarControllerMode;
+  /**
+   * @summary Overrides the user interface style for the tab bar controller.
+   *
+   * This allows enforcing a specific appearance (light or dark) for the tab bar
+   * regardless of the system setting. Useful when the app uses a light background
+   * in dark mode (or vice versa) to prevent the tab bar from briefly flashing
+   * with the wrong style during navigation.
+   *
+   * The following values are currently supported:
+   *
+   * - `unspecified` - inherits the system user interface style (default)
+   * - `light` - forces the light interface style
+   * - `dark` - forces the dark interface style
+   *
+   * @see {@link https://developer.apple.com/documentation/uikit/uiuserinterfacestyle|UIUserInterfaceStyle}
+   *
+   * @default unspecified
+   *
+   * @platform ios
+   */
+  userInterfaceStyle?: UserInterfaceStyle;
   // #endregion iOS-only
 
   // #region Experimental support

--- a/src/fabric/tabs/TabsHostNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostNativeComponent.ts
@@ -29,6 +29,8 @@ type TabBarMinimizeBehavior =
 
 type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
+type UserInterfaceStyle = 'unspecified' | 'light' | 'dark';
+
 export interface NativeProps extends ViewProps {
   // Events
   onNativeFocusChange?: CT.DirectEventHandler<NativeFocusChangeEvent>;
@@ -63,6 +65,7 @@ export interface NativeProps extends ViewProps {
   tabBarTintColor?: ColorValue;
   tabBarMinimizeBehavior?: CT.WithDefault<TabBarMinimizeBehavior, 'automatic'>;
   tabBarControllerMode?: CT.WithDefault<TabBarControllerMode, 'automatic'>;
+  userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;
 
   // Control
 


### PR DESCRIPTION
## Description

Adds a `userInterfaceStyle` prop to `Tabs.Host` that forces the tab bar appearance regardless of the system color scheme.

Many apps intentionally use light-only layouts even when the device is in dark mode. Without this prop, the native tab bar briefly flashes with dark mode colors on every navigation before settling to the correct appearance (sometimes needing user input/scroll to settle correctly), since `overrideUserInterfaceStyle` was previously only applied per-screen after the mounting transaction.

This prop gives developers the high control: lock the tab bar to a specific appearance so it never fights the app's intended design, regardless of the system setting.

## Changes

- Added `userInterfaceStyle` prop to `TabsHostProps` TypeScript types (`'unspecified' | 'light' | 'dark'`)
- Added prop to codegen native component spec
- Added iOS conversion function for the new enum
- Set `overrideUserInterfaceStyle` on the controller in `updateProps` (Fabric) and Paper setter
- Added test scario: Tabs > User Interface Style

https://github.com/user-attachments/assets/8ee558ce-4892-420d-a0cf-b8f3e88751de



## Test code and steps to reproduce

1. Set device/simulator to **dark mode**
2. Open the test app → Tabs → **User Interface Style**
3. Select **Light** — the tab bar should stay light with no flash
4. Navigate between tabs — no dark mode flash should occur
5. Select **Dark** — tab bar forces dark appearance
6. Select **Unspecified** — tab bar follows system setting

## Platforms

| Platform | Supported |
|----------|-----------|
| iOS      | ✅        |
| Android  | ❌ (N/A)  |