### PR TITLE
chore: define min. required `react-native` version in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "^0.82.0"
+    "react-native": ">=0.82.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13577,7 +13577,7 @@ __metadata:
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
-    react-native: ^0.82.0
+    react-native: ">=0.82.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Define version of required `react-native` version in `peerDependencies`
Until now, we've updated the "compatibility table" in project readme.
From now on, to enable compatibility with tools such as RNRepo we want
to define the required RN version also explicitly in library
`package.json`.

This is now possible, because since 4.25.0 we plan to drop support
for legacy architecture, which would sometimes require different minimal
supported RN version (*MSRNV*) than the new architecture.

We should keep updating this field every time we change *MSRNV* along
with the table in readme. The table should not be removed!

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1000
