### PR TITLE
chore: Update lockfiles after 4.24 release

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -2434,7 +2434,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2780,7 +2780,7 @@ SPEC CHECKSUMS:
   ReactCommon: e897f9a1b4afab370cfefaaf5fb3c80371bc3937
   RNGestureHandler: 4e01eefc427d3af22b877fdb4f7bc826132daab6
   RNReanimated: 1d9e9249c9e4222881b7107e52b52f4a9ee879b6
-  RNScreens: a5d9faf7291f407fc866db537a65518b0cc1844a
+  RNScreens: 67a126c21af12b5b309df90994d31b881775ca44
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
 

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1835,7 +1835,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1856,9 +1856,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.23.0)
+    - RNScreens/common (= 4.24.0)
     - Yoga
-  - RNScreens/common (4.23.0):
+  - RNScreens/common (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2192,7 +2192,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 974207232af1c5372a56239516ccc450a6420bfd
-  hermes-engine: ea345dc52e1a9b901a2b2e66be524a973154ff61
+  hermes-engine: 83fbd293b074bd63933c39ddfa88ffb390a0f6c4
   RCTDeprecation: 8ae59687fd548d481aa5ce8014ac7cd9b47e7316
   RCTRequired: d711b3887891fab6a77c6b9cdc49a3d8b171e36a
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2263,10 +2263,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
   ReactCodegen: 7cc1904b7db3c7b68dfd4b5424175a013051874f
   ReactCommon: ac616b2f169c57d56bd4b1a02f8a2dbb0b395722
-  ReactNativeDependencies: 8b4dd00142a189920d68b5bb85c46506eff6d39b
+  ReactNativeDependencies: a79f93bdc7f0de496dbc2aa051e665dad1763ab0
   RNGestureHandler: f080747d181c86d346827ba389209e1afb528628
   RNReanimated: 72296a949b2e629ed59666d445fa7ac9ab066571
-  RNScreens: 3a7ff46e00609d263758d646c1e6baad39921a53
+  RNScreens: 8c846783cda52889bbf9c69e71ff0f2ed1187743
   RNWorklets: ec060e76f9d7b7786d83a233e310b2ec778fb3eb
   Yoga: b8206e6746bd28c028572774cece66d5348240c1
 


### PR DESCRIPTION
it hasn't been covered in: https://github.com/software-mansion/react-native-screens/pull/3680 