### PR TITLE
fix(iOS): fix `tabBar` respecting RTL

### DIFF
--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -1,5 +1,6 @@
 #import "RNSTabBarAppearanceCoordinator.h"
 #import <React/RCTFont.h>
+#import <React/RCTI18nUtil.h>
 #import <React/RCTImageLoader.h>
 #import "RCTConvert+RNSTabs.h"
 #import "RNSConversions.h"
@@ -20,6 +21,13 @@
 
   // Step 1 - configure host-specific appearance
   tabBar.tintColor = hostComponentView.tabBarTintColor;
+
+  // Apply RTL semantic attribute so tab items render right-to-left when the app is in RTL mode
+  if ([[RCTI18nUtil sharedInstance] isRTL]) {
+    tabBar.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+  } else {
+    tabBar.semanticContentAttribute = UISemanticContentAttributeUnspecified;
+  }
 
   // Set tint color for iPadOS tab bar. This is the official way recommended by Apple:
   // https://developer.apple.com/forums/thread/761056?answerId=798245022#798245022


### PR DESCRIPTION
## Description

Currently `tabBar` doesn't respect RTL on iOS(Android is correct). This PR fixes it.

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
