### PR TITLE
fix(examples): Convert object to array for props.scenarioGroup and props.scenario

### DIFF
--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -11,7 +11,7 @@ import {
 function ScenarioSelect(props: { scenarios: Scenario[] }) {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {props.scenarios.map(({ name, key, details, platforms }) => (
+      {Object.values(props.scenarios).map(({ name, key, details, platforms }) => (
         <ScenarioButton
           title={name}
           details={details}
@@ -43,7 +43,7 @@ export default function ScenarioSelectionScreen(props: {
             }}>
             {() => <ScenarioSelect scenarios={props.scenarioGroup.scenarios} />}
           </Stack.Screen>
-          {props.scenarioGroup.scenarios.map(({ key, AppComponent }) => (
+          {Object.values(props.scenarioGroup.scenarios).map(({ key, AppComponent }) => (
             <Stack.Screen name={key} key={key} component={AppComponent} />
           ))}
         </Stack.Navigator>


### PR DESCRIPTION
## Description

related to this PR: https://github.com/software-mansion/react-native-screens/pull/3678 .

Now both are objects, so `map` function won't work properly, converting to array.

Note: typechecks aren't satisfied, but:
- weren't satisfied before my fix
- it potentially blocks SFT for Appearance

## Changes

- object => array

## Before & after - visual documentation

N/A

## Test plan

Try launching any SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
