### PR TITLE
chore(Android): disable default RNSLog activation in debug mode

### DIFF
--- a/TVOSExample/android/gradle.properties
+++ b/TVOSExample/android/gradle.properties
@@ -42,3 +42,6 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
+
+# Use this property to enable or disable debug logging
+rnsDebugLogsEnabled=true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,11 +38,7 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-def areDebugLogsEnabledDebugMode() {
-    return !project.hasProperty("rnsDebugLogsEnabled") || project.rnsDebugLogsEnabled == "true"
-}
-
-def areDebugLogsEnabledReleaseMode() {
+def areDebugLogsEnabled() {
     return project.hasProperty("rnsDebugLogsEnabled") && project.rnsDebugLogsEnabled == "true"
 }
 
@@ -140,6 +136,7 @@ android {
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", IS_NEW_ARCHITECTURE_ENABLED.toString()
         buildConfigField "boolean", "RNS_GAMMA_ENABLED", isGammaEnabled().toString()
+        buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabled().toString()
         ndk {
             abiFilters (*reactNativeArchitectures())
         }
@@ -149,14 +146,6 @@ android {
                         "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
-        }
-    }
-    buildTypes {
-        debug {
-            buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabledDebugMode().toString()
-        }
-        release {
-            buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabledReleaseMode().toString()
         }
     }
     buildFeatures {


### PR DESCRIPTION
## Description

This PR changes `RNSLog` activating/deactivating depending on debug/release mode mechanism introduced in https://github.com/software-mansion/react-native-screens/pull/3718

To activate `RNSLog`, set flag `rnsDebugLogsEnabled` to true.

## Changes

- update `gradle.properties` in `TVOSExample`
- update `build.gradle`

## Before & after - visual documentation

N/A

## Test plan

Run app with set flag and check if logs work properly.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
