### PR TITLE
chore(JS): Deduplicate `FeatureFlags` exports

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -29,7 +29,7 @@ import {
   resolveSheetLargestUndimmedDetent,
 } from './helpers/sheet';
 import { parseBooleanToOptionalBooleanNativeProp } from '../utils';
-import featureFlags from '../flags';
+import { featureFlags } from '../flags';
 import warnOnce from 'warn-once';
 
 type NativeProps = ScreenNativeComponentProps | ModalScreenNativeComponentProps;

--- a/src/components/ScreenStack.tsx
+++ b/src/components/ScreenStack.tsx
@@ -15,7 +15,7 @@ import warnOnce from 'warn-once';
 import ScreenStackNativeComponent, {
   NativeProps,
 } from '../fabric/ScreenStackNativeComponent';
-import featureFlags from '../flags';
+import { featureFlags } from '../flags';
 
 const assertGHProvider = (
   ScreenGestureDetector: (

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -16,7 +16,7 @@ import {
   View,
   ViewProps,
 } from 'react-native';
-import featureFlags from '../flags';
+import { featureFlags } from '../flags';
 
 // Native components
 import ScreenStackHeaderConfigNativeComponent from '../fabric/ScreenStackHeaderConfigNativeComponent';

--- a/src/components/tabs/TabsHost.tsx
+++ b/src/components/tabs/TabsHost.tsx
@@ -10,7 +10,7 @@ import {
 import TabsHostNativeComponent, {
   type NativeProps as TabsHostNativeComponentProps,
 } from '../../fabric/tabs/TabsHostNativeComponent';
-import featureFlags from '../../flags';
+import { featureFlags } from '../../flags';
 import type { TabsHostProps, NativeFocusChangeEvent } from './TabsHost.types';
 import { bottomTabsDebugLog } from '../../private/logging';
 import TabsBottomAccessory from './TabsBottomAccessory';

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -230,5 +230,3 @@ export const featureFlags = {
     },
   },
 };
-
-export default featureFlags;


### PR DESCRIPTION
## Description

This PR deduplicates `featureFlags` exports.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/699

## Changes

- remove default export from `flags.ts`
- update `featureFlags` imports

## Before & after - visual documentation

N/A

## Test plan


## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
