### PR TITLE
fix(Examples): Fix default icon provider

### DIFF
--- a/apps/src/tests/shared/components/tabs/TabsConfigProvider.tsx
+++ b/apps/src/tests/shared/components/tabs/TabsConfigProvider.tsx
@@ -61,8 +61,14 @@ function makeInitialConfig(
       tabScreenProps: {
         tabKey: k,
         title: k,
-        icon: {
-          shared: {
+        android: {
+          icon: {
+            type: 'imageSource',
+            imageSource: require('../../../../../assets/variableIcons/icon.png'),
+          },
+        },
+        ios: {
+          icon: {
             type: 'imageSource',
             imageSource: require('../../../../../assets/variableIcons/icon.png'),
           },


### PR DESCRIPTION
## Description

Typecheck didn't catch that.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1046

## Changes

- Updated icon props in provider

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <img width="583" height="1298" alt="Screenshot 2026-03-10 at 11 26 54" src="https://github.com/user-attachments/assets/9b81fc2c-6c58-420e-8d4d-222e615fe621" /> | <img width="593" height="1294" alt="Screenshot 2026-03-10 at 11 23 58" src="https://github.com/user-attachments/assets/e8d27559-57dd-495e-9a08-bccfa7a9d5b1" /> |


## Test plan

Check SFT color scheme example for Tabs

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
