### PR TITLE
chore: Remove Paper related code & annotation from Tabs

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -16,7 +16,6 @@ import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.ThemedReactContext
 import com.google.android.material.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeCoordinator
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeListener
@@ -241,12 +240,9 @@ class TabsHost(
             applyDayNightUiMode(uiNightMode)
         }
 
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // On Paper the children are not yet attached here.
-            containerUpdateCoordinator.let {
-                it.invalidateAll()
-                it.runContainerUpdate()
-            }
+        containerUpdateCoordinator.let {
+            it.invalidateAll()
+            it.runContainerUpdate()
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
@@ -6,7 +6,6 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
-import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNSTabsHostAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSTabsHostAndroidManagerInterface
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
@@ -67,7 +66,6 @@ class TabsHostViewManager :
         view.onViewManagerAddEventEmitters()
     }
 
-    @ReactProp(name = "tabBarHidden")
     override fun setTabBarHidden(
         view: TabsHost,
         value: Boolean,
@@ -75,7 +73,6 @@ class TabsHostViewManager :
         view.tabBarHidden = value
     }
 
-    @ReactProp(name = "nativeContainerBackgroundColor", customType = "Color")
     override fun setNativeContainerBackgroundColor(
         view: TabsHost,
         value: Int?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -8,7 +8,6 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
-import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNSTabsScreenAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSTabsScreenAndroidManagerInterface
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
@@ -55,8 +54,6 @@ class TabsScreenViewManager :
         view.onViewManagerAddEventEmitters()
     }
 
-    // Annotation is Paper only
-    @ReactProp(name = "isFocused")
     override fun setIsFocused(
         view: TabsScreen,
         value: Boolean,
@@ -65,7 +62,6 @@ class TabsScreenViewManager :
         view.isFocusedTab = value
     }
 
-    @ReactProp(name = "tabKey")
     override fun setTabKey(
         view: TabsScreen,
         value: String?,
@@ -73,7 +69,6 @@ class TabsScreenViewManager :
         view.tabKey = value
     }
 
-    @ReactProp(name = "badgeValue")
     override fun setBadgeValue(
         view: TabsScreen,
         value: String?,
@@ -81,7 +76,6 @@ class TabsScreenViewManager :
         view.badgeValue = value
     }
 
-    @ReactProp(name = "title")
     override fun setTitle(
         view: TabsScreen,
         value: String?,
@@ -89,7 +83,6 @@ class TabsScreenViewManager :
         view.tabTitle = value
     }
 
-    @ReactProp(name = "specialEffects")
     override fun setSpecialEffects(
         view: TabsScreen,
         value: ReadableMap?,
@@ -112,7 +105,6 @@ class TabsScreenViewManager :
         view.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect = scrollToTop
     }
 
-    @ReactProp(name = "tabBarItemTestID")
     override fun setTabBarItemTestID(
         view: TabsScreen,
         value: String?,
@@ -120,7 +112,6 @@ class TabsScreenViewManager :
         view.tabBarItemTestID = value
     }
 
-    @ReactProp(name = "tabBarItemAccessibilityLabel")
     override fun setTabBarItemAccessibilityLabel(
         view: TabsScreen,
         value: String?,
@@ -130,7 +121,6 @@ class TabsScreenViewManager :
 
     // Android specific
 
-    @ReactProp(name = "drawableIconResourceName")
     override fun setDrawableIconResourceName(
         view: TabsScreen,
         value: String?,
@@ -138,7 +128,6 @@ class TabsScreenViewManager :
         view.drawableIconResourceName = value
     }
 
-    @ReactProp(name = "selectedDrawableIconResourceName")
     override fun setSelectedDrawableIconResourceName(
         view: TabsScreen,
         value: String?,
@@ -146,7 +135,6 @@ class TabsScreenViewManager :
         view.selectedDrawableIconResourceName = value
     }
 
-    @ReactProp(name = "imageIconResource")
     override fun setImageIconResource(
         view: TabsScreen,
         value: ReadableMap?,
@@ -157,7 +145,6 @@ class TabsScreenViewManager :
         }
     }
 
-    @ReactProp(name = "selectedImageIconResource")
     override fun setSelectedImageIconResource(
         view: TabsScreen,
         value: ReadableMap?,
@@ -168,7 +155,6 @@ class TabsScreenViewManager :
         }
     }
 
-    @ReactProp(name = "standardAppearance")
     override fun setStandardAppearance(
         view: TabsScreen,
         value: ReadableMap?,


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1030

## Description

This PR removes code related to Paper from Tabs implementation on Android

## Changes

Removed:
- architecture check
- ReactProp annotations

## Before & after - visual documentation

n/a

## Test plan

Try to compile the app. See if it runs correctly on Fabric.

## Checklist

- [ ] Ensured that CI passes
