### PR TITLE
refactor(Tabs): Rename `tabKey` to `screenKey`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -218,9 +218,9 @@ class TabsHost(
             val fragment = getFragmentForMenuItemId(item.itemId)
             val repeatedSelectionHandledBySpecialEffect =
                 if (fragment == currentFocusedTab) specialEffectsHandler.handleRepeatedTabSelection() else false
-            val tabKey = fragment?.tabsScreen?.tabKey ?: "undefined"
+            val screenKey = fragment?.tabsScreen?.screenKey ?: "undefined"
             eventEmitter.emitOnNativeFocusChange(
-                tabKey,
+                screenKey,
                 item.itemId,
                 repeatedSelectionHandledBySpecialEffect,
             )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
@@ -9,7 +9,7 @@ internal class TabsHostEventEmitter(
     viewTag: Int,
 ) : BaseEventEmitter(reactContext, viewTag) {
     fun emitOnNativeFocusChange(
-        tabKey: String,
+        screenKey: String,
         tabNumber: Int,
         repeatedSelectionHandledBySpecialEffect: Boolean,
     ) {
@@ -17,7 +17,7 @@ internal class TabsHostEventEmitter(
             TabsHostNativeFocusChangeEvent(
                 surfaceId,
                 viewTag,
-                tabKey,
+                screenKey,
                 tabNumber,
                 repeatedSelectionHandledBySpecialEffect,
             ),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostNativeFocusChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostNativeFocusChangeEvent.kt
@@ -9,7 +9,7 @@ import com.swmansion.rnscreens.gamma.tabs.screen.event.TabsScreenDidAppearEvent
 class TabsHostNativeFocusChangeEvent(
     surfaceId: Int,
     viewId: Int,
-    val tabKey: String,
+    val screenKey: String,
     val tabNumber: Int,
     val repeatedSelectionHandledBySpecialEffect: Boolean,
 ) : Event<TabsScreenDidAppearEvent>(surfaceId, viewId),
@@ -19,14 +19,14 @@ class TabsHostNativeFocusChangeEvent(
     override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
 
     // If the user taps currently selected tab 2 times and e.g. scroll to top effect can run,
-    // we should send 2 events [(tabKey, true), (tabKey, false)]. We don't want them to be coalesced
+    // we should send 2 events [(screenKey, true), (screenKey, false)]. We don't want them to be coalesced
     // as we would lose information about activation of special effect. That's why we take into
     // account `repeatedSelectionHandledBySpecialEffect` for coalescingKey.
     override fun getCoalescingKey(): Short = (tabNumber * 10 + if (repeatedSelectionHandledBySpecialEffect) 1 else 0).toShort()
 
     override fun getEventData(): WritableMap? =
         Arguments.createMap().apply {
-            putString(EVENT_KEY_TAB_KEY, tabKey)
+            putString(EVENT_KEY_SCREEN_KEY, screenKey)
             putBoolean(
                 EVENT_KEY_REPEATED_SELECTION_HANDLED_BY_SPECIAL_EFFECT,
                 repeatedSelectionHandledBySpecialEffect,
@@ -37,7 +37,7 @@ class TabsHostNativeFocusChangeEvent(
         const val EVENT_NAME = "topNativeFocusChange"
         const val EVENT_REGISTRATION_NAME = "onNativeFocusChange"
 
-        private const val EVENT_KEY_TAB_KEY = "tabKey"
+        private const val EVENT_KEY_SCREEN_KEY = "screenKey"
         private const val EVENT_KEY_REPEATED_SELECTION_HANDLED_BY_SPECIAL_EFFECT =
             "repeatedSelectionHandledBySpecialEffect"
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -31,7 +31,7 @@ class TabsScreen(
 
     internal lateinit var eventEmitter: TabsScreenEventEmitter
 
-    var tabKey: String? = null
+    var screenKey: String? = null
         set(value) {
             field =
                 if (value?.isBlank() == true) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -62,11 +62,11 @@ class TabsScreenViewManager :
         view.isFocusedTab = value
     }
 
-    override fun setTabKey(
+    override fun setScreenKey(
         view: TabsScreen,
         value: String?,
     ) {
-        view.tabKey = value
+        view.screenKey = value
     }
 
     override fun setBadgeValue(

--- a/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/bottom-tabs/BottomTabsContainer.tsx
@@ -25,7 +25,7 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
 
   const { tabConfigs, ...restProps } = props;
 
-  const [focusedTabKey, setFocusedTabKey] = React.useState<string>(() => {
+  const [focusedScreenKey, setFocusedScreenKey] = React.useState<string>(() => {
     console.log('BottomTabsContainer focusedStateKey initial state computed');
 
     if (props.tabConfigs.length === 0) {
@@ -34,21 +34,21 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
 
     const maybeUserRequestedFocusedTab = tabConfigs.find(
       tabConfig => tabConfig.tabScreenProps.isFocused === true,
-    )?.tabScreenProps.tabKey;
+    )?.tabScreenProps.screenKey;
 
     if (maybeUserRequestedFocusedTab != null) {
       return maybeUserRequestedFocusedTab;
     }
 
     // Default to first tab
-    return tabConfigs[0].tabScreenProps.tabKey;
+    return tabConfigs[0].tabScreenProps.screenKey;
   });
 
   const configWrapper = React.useContext(ConfigWrapperContext);
 
   const onNativeFocusChangeCallback = React.useCallback(
     (event: NativeSyntheticEvent<NativeFocusChangeEvent>) => {
-      const tabKey = event.nativeEvent.tabKey;
+      const screenKey = event.nativeEvent.screenKey;
 
       // Use `startTransition` only if the state is controlled in JS
       // const transitionFn = !configWrapper.config.controlledBottomTabs
@@ -67,8 +67,8 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
       // };
 
       transitionFn(() => {
-        console.info(`Starting transition to ${tabKey}`);
-        setFocusedTabKey(tabKey);
+        console.info(`Starting transition to ${screenKey}`);
+        setFocusedScreenKey(screenKey);
       });
     },
     [],
@@ -84,17 +84,17 @@ export function BottomTabsContainer(props: BottomTabsContainerProps) {
       direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
       {...restProps}>
       {tabConfigs.map(tabConfig => {
-        const tabKey = tabConfig.tabScreenProps.tabKey;
-        const isFocused = tabConfig.tabScreenProps.tabKey === focusedTabKey;
+        const screenKey = tabConfig.tabScreenProps.screenKey;
+        const isFocused = tabConfig.tabScreenProps.screenKey === focusedScreenKey;
         console.info(
-          `BottomTabsContainer map to component -> ${tabKey} ${
+          `BottomTabsContainer map to component -> ${screenKey} ${
             isFocused ? '(focused)' : ''
           }`,
         );
 
         return (
           <Tabs.Screen
-            key={tabKey}
+            key={screenKey}
             {...tabConfig.tabScreenProps}
             isFocused={isFocused} // notice that the value passed by user is overriden here!
           >

--- a/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs.tsx
@@ -51,7 +51,7 @@ function ConfigScreen() {
         onValueChange={value =>
           tabsDispatch({
             type: 'tabScreen',
-            tabKey: 'Tab1',
+            screenKey: 'Tab1',
             config: {
               tabScreenProps: {
                 orientation: value === 'undefined' ? undefined : value,

--- a/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack.tsx
@@ -65,7 +65,7 @@ function ConfigScreen() {
         onValueChange={value =>
           tabsDispatch({
             type: 'tabScreen',
-            tabKey: 'Tab1',
+            screenKey: 'Tab1',
             config: {
               tabScreenProps: {
                 orientation: value === 'undefined' ? undefined : value,

--- a/apps/src/tests/issue-tests/Test3168.tsx
+++ b/apps/src/tests/issue-tests/Test3168.tsx
@@ -202,7 +202,7 @@ function TabsStackComponent() {
   const TAB_CONFIGS: TabConfiguration[] = [
     {
       tabScreenProps: {
-        tabKey: 'main',
+        screenKey: 'main',
         title: 'Main',
         ios: {
           icon: {
@@ -215,7 +215,7 @@ function TabsStackComponent() {
     },
     {
       tabScreenProps: {
-        tabKey: 'another',
+        screenKey: 'another',
         title: 'Another',
         ios: {
           icon: {
@@ -228,7 +228,7 @@ function TabsStackComponent() {
     },
     {
       tabScreenProps: {
-        tabKey: 'examples',
+        screenKey: 'examples',
         title: 'Search',
         ios: {
           icon: {

--- a/apps/src/tests/issue-tests/Test3212/BottomTabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/BottomTabsScenario.tsx
@@ -35,12 +35,12 @@ export function BottomTabsScenario() {
             tabConfigs={[
               {
                 component: ConfigComponent,
-                tabScreenProps: { tabKey: 'config', title: 'Config' },
+                tabScreenProps: { screenKey: 'config', title: 'Config' },
               },
               {
                 component: ScrollViewTemplate,
                 tabScreenProps: {
-                  tabKey: 'stack',
+                  screenKey: 'stack',
                   title: 'Scroll',
                   ios: {
                     scrollEdgeEffects: config,

--- a/apps/src/tests/issue-tests/Test3212/StackInBottomTabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/StackInBottomTabsScenario.tsx
@@ -32,12 +32,12 @@ export function StackInBottomTabsScenario() {
           tabConfigs={[
             {
               component: ConfigComponent,
-              tabScreenProps: { tabKey: 'config', title: 'Config' },
+              tabScreenProps: { screenKey: 'config', title: 'Config' },
             },
             {
               component: StackScenario,
               tabScreenProps: {
-                tabKey: 'stack',
+                screenKey: 'stack',
                 title: 'Stack',
                 ios: {
                   scrollEdgeEffects: config,

--- a/apps/src/tests/issue-tests/Test3236.tsx
+++ b/apps/src/tests/issue-tests/Test3236.tsx
@@ -54,7 +54,7 @@ function App() {
   const TAB_CONFIGS: TabConfiguration[] = [
     {
       tabScreenProps: {
-        tabKey: 'Tab1',
+        screenKey: 'Tab1',
         title: 'Tab 1',
         ios: {
           icon: {
@@ -73,7 +73,7 @@ function App() {
     },
     {
       tabScreenProps: {
-        tabKey: 'Tab2',
+        screenKey: 'Tab2',
         title: 'Tab 2',
         ios: {
           icon: {

--- a/apps/src/tests/issue-tests/Test3288.tsx
+++ b/apps/src/tests/issue-tests/Test3288.tsx
@@ -136,7 +136,7 @@ function TestScreen() {
 const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
-      tabKey: 'Tab1',
+      screenKey: 'Tab1',
       title: 'Config',
       ios: {
         icon: {
@@ -149,7 +149,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab2',
+      screenKey: 'Tab2',
       title: 'Test',
       ios: {
         icon: {

--- a/apps/src/tests/issue-tests/Test3342.tsx
+++ b/apps/src/tests/issue-tests/Test3342.tsx
@@ -69,7 +69,7 @@ function Screen2(stackNavProp: StackNavigationProp) {
   const TAB_CONFIGS: TabConfiguration[] = [
     {
       tabScreenProps: {
-        tabKey: 'Tab1',
+        screenKey: 'Tab1',
         title: 'Tab 1',
         ios: {
           icon: {
@@ -83,7 +83,7 @@ function Screen2(stackNavProp: StackNavigationProp) {
     },
     {
       tabScreenProps: {
-        tabKey: 'Tab2',
+        screenKey: 'Tab2',
         title: 'Tab 2',
         ios: {
           icon: {

--- a/apps/src/tests/issue-tests/Test3443.tsx
+++ b/apps/src/tests/issue-tests/Test3443.tsx
@@ -19,7 +19,7 @@ function makeTab(title: string, description: string) {
 const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
-      tabKey: 'Tab1',
+      screenKey: 'Tab1',
       title: 'Tab 1',
       ios: {
         icon: {
@@ -35,7 +35,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab2',
+      screenKey: 'Tab2',
       title: 'Tab 2',
       ios: {
         icon: {

--- a/apps/src/tests/issue-tests/Test3492.tsx
+++ b/apps/src/tests/issue-tests/Test3492.tsx
@@ -27,7 +27,7 @@ import ConfigWrapperContext, {
 import LongText from '../../shared/LongText';
 import { someExtensiveComputation } from './TestBottomTabs/utils';
 
-type TabKey = 'Tab2' | 'Tab3' | 'Tab4';
+type ScreenKey = 'Tab2' | 'Tab3' | 'Tab4';
 
 type ContentType = 'view' | 'scrollViewWithText' | 'scrollViewWithRects';
 
@@ -46,7 +46,7 @@ type SingleTabConfig = {
 
 type AppConfig = {
   containerBackground: string;
-  tabs: Record<TabKey, SingleTabConfig>;
+  tabs: Record<ScreenKey, SingleTabConfig>;
 };
 
 type BackgroundContextType = {
@@ -270,9 +270,9 @@ const RectsGenerator = ({ config }: { config: RectConfig }) => {
   );
 };
 
-const TestScreenRenderer = ({ tabKey }: { tabKey: TabKey }) => {
+const TestScreenRenderer = ({ screenKey }: { screenKey: ScreenKey }) => {
   const { config } = useBackgroundTestContext();
-  const tabConfig = config.tabs[tabKey];
+  const tabConfig = config.tabs[screenKey];
 
   const Container = tabConfig.contentType === 'view' ? View : ScrollView;
 
@@ -290,7 +290,7 @@ const TestScreenRenderer = ({ tabKey }: { tabKey: TabKey }) => {
         <View
           style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <Text style={{ fontSize: 24, fontWeight: 'bold' }}>
-            Hello {tabKey}
+            Hello {screenKey}
           </Text>
           <Text>Bg: {tabConfig.reactBackground}</Text>
         </View>
@@ -308,7 +308,7 @@ const TestScreenRenderer = ({ tabKey }: { tabKey: TabKey }) => {
 function ConfigScreen() {
   const { config, setConfig, applyPreset } = useBackgroundTestContext();
 
-  const updateTab = (key: TabKey, update: Partial<SingleTabConfig>) => {
+  const updateTab = (key: ScreenKey, update: Partial<SingleTabConfig>) => {
     setConfig(prev => ({
       ...prev,
       tabs: {
@@ -318,7 +318,7 @@ function ConfigScreen() {
     }));
   };
 
-  const updateRects = (key: TabKey, update: Partial<RectConfig>) => {
+  const updateRects = (key: ScreenKey, update: Partial<RectConfig>) => {
     setConfig(prev => ({
       ...prev,
       tabs: {
@@ -382,7 +382,7 @@ function ConfigScreen() {
         />
       </ConfigSection>
 
-      {(Object.keys(config.tabs) as TabKey[]).map(key => {
+      {(Object.keys(config.tabs) as ScreenKey[]).map(key => {
         const tConfig = config.tabs[key];
         return (
           <ConfigSection key={key} title={`Config: ${key}`}>
@@ -449,13 +449,13 @@ function ConfigScreen() {
 }
 
 function ScreenTab2() {
-  return <TestScreenRenderer tabKey="Tab2" />;
+  return <TestScreenRenderer screenKey="Tab2" />;
 }
 function ScreenTab3() {
-  return <TestScreenRenderer tabKey="Tab3" />;
+  return <TestScreenRenderer screenKey="Tab3" />;
 }
 function ScreenTab4() {
-  return <TestScreenRenderer tabKey="Tab4" />;
+  return <TestScreenRenderer screenKey="Tab4" />;
 }
 
 function Tabs() {
@@ -468,7 +468,7 @@ function Tabs() {
     () => [
       {
         tabScreenProps: {
-          tabKey: 'Tab1',
+          screenKey: 'Tab1',
           title: 'Config',
           icon: {
             ios: { type: 'sfSymbol', name: 'gear' },
@@ -479,7 +479,7 @@ function Tabs() {
       },
       {
         tabScreenProps: {
-          tabKey: 'Tab2',
+          screenKey: 'Tab2',
           title: 'Tab 2',
           icon: { ios: { type: 'sfSymbol', name: 'square' } },
           style: { backgroundColor: config.tabs.Tab2.navBackground },
@@ -488,7 +488,7 @@ function Tabs() {
       },
       {
         tabScreenProps: {
-          tabKey: 'Tab3',
+          screenKey: 'Tab3',
           title: 'Tab 3',
           icon: { ios: { type: 'sfSymbol', name: 'triangle' } },
           style: { backgroundColor: config.tabs.Tab3.navBackground },
@@ -497,7 +497,7 @@ function Tabs() {
       },
       {
         tabScreenProps: {
-          tabKey: 'Tab4',
+          screenKey: 'Tab4',
           title: 'Tab 4',
           icon: { ios: { type: 'sfSymbol', name: 'circle' } },
           style: { backgroundColor: config.tabs.Tab4.navBackground },

--- a/apps/src/tests/issue-tests/Test3596.tsx
+++ b/apps/src/tests/issue-tests/Test3596.tsx
@@ -30,7 +30,7 @@ function makeTab(title: string) {
 const TAB_CONFIGS: TabConfiguration[] = [
   {
     tabScreenProps: {
-      tabKey: 'Tab1',
+      screenKey: 'Tab1',
       title: 'Tab 1',
       ios: {
         icon: {
@@ -49,7 +49,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab2',
+      screenKey: 'Tab2',
       title: 'Tab 2',
       ios: {
         icon: {
@@ -68,7 +68,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab3',
+      screenKey: 'Tab3',
       title: 'Tab 3',
       ios: {
         systemItem: 'search',

--- a/apps/src/tests/issue-tests/TestBottomTabs/components/TabConfigurationSummary.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/components/TabConfigurationSummary.tsx
@@ -3,7 +3,7 @@ import { Text } from 'react-native';
 import ConfigWrapperContext from '../../../../shared/gamma/containers/bottom-tabs/ConfigWrapperContext';
 
 export interface TabConfigurationSummaryProps {
-  tabKey: string;
+  screenKey: string;
 }
 
 export function TabConfigurationSummary(props: TabConfigurationSummaryProps) {
@@ -11,7 +11,7 @@ export function TabConfigurationSummary(props: TabConfigurationSummaryProps) {
 
   return (
     <>
-      <Text>tabKey: {props.tabKey}</Text>
+      <Text>screenKey: {props.screenKey}</Text>
       <Text>
         heavyTabRender: {configWrapper.config.heavyTabRender ? 'true' : 'false'}
       </Text>

--- a/apps/src/tests/issue-tests/TestBottomTabs/components/TabContentView.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/components/TabContentView.tsx
@@ -6,12 +6,12 @@ import { TabConfigurationSummary } from './TabConfigurationSummary';
 
 export interface TabContentViewProps extends ViewProps {
   selectNextTab?: (() => void) | undefined;
-  tabKey: string;
+  screenKey: string;
   message?: string;
 }
 
 export function TabContentView(props: TabContentViewProps) {
-  const { selectNextTab, tabKey, message, ...viewProps } = props;
+  const { selectNextTab, screenKey, message, ...viewProps } = props;
 
   const configWrapper = React.useContext(ConfigWrapperContext);
 
@@ -28,7 +28,7 @@ export function TabContentView(props: TabContentViewProps) {
   return (
     <View {...viewProps}>
       {message !== undefined && <Text>{message}</Text>}
-      <TabConfigurationSummary tabKey={tabKey} />
+      <TabConfigurationSummary screenKey={screenKey} />
       <Button title="Next tab" onPress={selectNextTab} />
       <Button
         title="Toggle heavy render"

--- a/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
@@ -87,7 +87,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
       accessibilityLabel: 'First Tab Screen',
       tabBarItemTestID: 'tab-item-1-id',
       tabBarItemAccessibilityLabel: 'First Tab Item',
-      tabKey: 'Tab1',
+      screenKey: 'Tab1',
       title: 'Tab1',
       isFocused: true,
     },
@@ -95,7 +95,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab2',
+      screenKey: 'Tab2',
       badgeValue: 'NEW',
       testID: 'tab-screen-2-id',
       accessibilityLabel: 'Second Tab Screen',
@@ -179,7 +179,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab3',
+      screenKey: 'Tab3',
       badgeValue: '2137',
       testID: 'tab-screen-3-id',
       accessibilityLabel: 'Third Tab Screen',
@@ -228,7 +228,7 @@ const TAB_CONFIGS: TabConfiguration[] = [
   },
   {
     tabScreenProps: {
-      tabKey: 'Tab4',
+      screenKey: 'Tab4',
       testID: 'tab-screen-4-id',
       accessibilityLabel: 'Fourth Tab Screen',
       tabBarItemTestID: 'tab-item-4-id',

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab1.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab1.tsx
@@ -6,7 +6,7 @@ import Colors from '../../../../shared/styling/Colors';
 export function Tab1() {
   return (
     <CenteredLayoutView style={{ backgroundColor: Colors.OffWhite }}>
-      <TabContentView selectNextTab={undefined} tabKey={'Tab1'} />
+      <TabContentView selectNextTab={undefined} screenKey={'Tab1'} />
     </CenteredLayoutView>
   );
 }

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab2.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab2.tsx
@@ -6,7 +6,7 @@ import Colors from '../../../../shared/styling/Colors';
 export function Tab2() {
   return (
     <CenteredLayoutView style={{ backgroundColor: Colors.PurpleLight100 }}>
-      <TabContentView selectNextTab={undefined} tabKey={'Tab2'} />
+      <TabContentView selectNextTab={undefined} screenKey={'Tab2'} />
     </CenteredLayoutView>
   );
 }

--- a/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
@@ -78,7 +78,7 @@ function makeTabConfigs(
   return [
     {
       tabScreenProps: {
-        tabKey: 'Auto',
+        screenKey: 'Auto',
         title: 'Auto',
         isFocused: true,
         orientation: tabsOrientations.home.tabScreen,
@@ -109,7 +109,7 @@ function makeTabConfigs(
     },
     {
       tabScreenProps: {
-        tabKey: 'Portrait',
+        screenKey: 'Portrait',
         title: 'Portrait',
         tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
         icon: {
@@ -140,7 +140,7 @@ function makeTabConfigs(
     },
     {
       tabScreenProps: {
-        tabKey: 'Landscape',
+        screenKey: 'Landscape',
         title: 'Landscape',
         orientation: tabsOrientations.landscape.tabScreen,
         ios: {

--- a/apps/src/tests/issue-tests/TestHeaderHeight.tsx
+++ b/apps/src/tests/issue-tests/TestHeaderHeight.tsx
@@ -464,7 +464,7 @@ function HeaderHeightTabsWrapper() {
   const TAB_CONFIGS: TabConfiguration[] = [
     {
       tabScreenProps: {
-        tabKey: 'Tab1',
+        screenKey: 'Tab1',
         title: 'Tab 1',
         ios: {
           icon: {
@@ -483,7 +483,7 @@ function HeaderHeightTabsWrapper() {
     },
     {
       tabScreenProps: {
-        tabKey: 'Tab2',
+        screenKey: 'Tab2',
         title: 'Tab 2',
         ios: {
           icon: {

--- a/apps/src/tests/issue-tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
+++ b/apps/src/tests/issue-tests/TestSafeAreaViewIOS/bottom-tabs/BottomTabsComponent.tsx
@@ -18,7 +18,7 @@ export default function BottomTabsComponent() {
   const TAB_CONFIGS: TabConfiguration[] = [
     {
       tabScreenProps: {
-        tabKey: 'config',
+        screenKey: 'config',
         title: 'Config',
         ios: {
           icon: {
@@ -31,7 +31,7 @@ export default function BottomTabsComponent() {
     },
     {
       tabScreenProps: {
-        tabKey: 'test',
+        screenKey: 'test',
         title: 'Test',
         ios: {
           icon: {

--- a/apps/src/tests/issue-tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
+++ b/apps/src/tests/issue-tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
@@ -20,7 +20,7 @@ export default function ConfigColumn({
     .map(index => {
       const configuration: TabConfiguration = {
         tabScreenProps: {
-          tabKey: 'column' + index,
+          screenKey: 'column' + index,
           title: 'Column ' + index,
           ios: {
             icon: {

--- a/apps/src/tests/shared/components/tabs/TabsConfigProvider.tsx
+++ b/apps/src/tests/shared/components/tabs/TabsConfigProvider.tsx
@@ -34,7 +34,7 @@ function reduce(
       break;
     case 'tabScreen':
       const tabIndex = config.tabConfigs.findIndex(
-        c => c.tabScreenProps.tabKey === action.tabKey,
+        c => c.tabScreenProps.screenKey === action.screenKey,
       );
       if (tabIndex >= 0) {
         config.tabConfigs[tabIndex] = {
@@ -59,7 +59,7 @@ function makeInitialConfig(
   return {
     tabConfigs: Object.entries(tabs).map(([k, C]) => ({
       tabScreenProps: {
-        tabKey: k,
+        screenKey: k,
         title: k,
         android: {
           icon: {

--- a/apps/src/tests/shared/tabs-config.types.tsx
+++ b/apps/src/tests/shared/tabs-config.types.tsx
@@ -4,8 +4,8 @@ import { TabsHostProps } from 'react-native-screens';
 
 type StaticTabScreenProps<S extends KeyList> = Omit<
   TabConfiguration['tabScreenProps'],
-  'tabKey'
-> & { tabKey: Extract<keyof S, string> };
+  'screenKey'
+> & { screenKey: Extract<keyof S, string> };
 
 export type StaticTabConfiguration<S extends KeyList> = Omit<
   TabConfiguration,
@@ -21,7 +21,7 @@ export type StaticTabsContainerProps<S extends KeyList> = TabsHostProps & {
 export type TabConfigUpdate<S extends KeyList> =
   | {
       type: 'tabScreen';
-      tabKey: Extract<keyof S, string>;
+      screenKey: Extract<keyof S, string>;
       config: Partial<
         Omit<StaticTabConfiguration<S>, 'tabScreenProps'> & {
           tabScreenProps: Partial<StaticTabScreenProps<S>>;

--- a/apps/src/tests/shared/tabs.tsx
+++ b/apps/src/tests/shared/tabs.tsx
@@ -29,5 +29,5 @@ export function findTabScreenOptions<S extends KeyList>(
   config: StaticTabsContainerProps<S>,
   key: Extract<keyof S, string>,
 ): StaticTabConfiguration<S> | undefined {
-  return config.tabConfigs.find(c => c.tabScreenProps.tabKey === key);
+  return config.tabConfigs.find(c => c.tabScreenProps.screenKey === key);
 }

--- a/apps/src/tests/single-feature-tests/tabs/override-scroll-view-content-inset.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/override-scroll-view-content-inset.tsx
@@ -59,7 +59,7 @@ function App() {
             {
               component: FalseTab,
               tabScreenProps: {
-                tabKey: 'False',
+                screenKey: 'False',
                 title: 'False',
                 ios: {
                   overrideScrollViewContentInsetAdjustmentBehavior: false,
@@ -70,7 +70,7 @@ function App() {
             {
               component: TrueTab,
               tabScreenProps: {
-                tabKey: 'True',
+                screenKey: 'True',
                 title: 'True',
                 ios: {
                   overrideScrollViewContentInsetAdjustmentBehavior: true,
@@ -81,7 +81,7 @@ function App() {
             {
               component: DefaultTab,
               tabScreenProps: {
-                tabKey: 'Default',
+                screenKey: 'Default',
                 title: 'Default',
                 ios: { icon: { type: 'sfSymbol', name: 'circle.dashed' } },
               },

--- a/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation.tsx
@@ -38,7 +38,7 @@ function ConfigScreen() {
         onValueChange={value =>
           dispatch({
             type: 'tabScreen',
-            tabKey: 'Tab1',
+            screenKey: 'Tab1',
             config: {
               tabScreenProps: {
                 orientation: value === 'undefined' ? undefined : value,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab.tsx
@@ -83,7 +83,7 @@ export function App() {
         {
           component: TabScreen,
           tabScreenProps: {
-            tabKey: 'Tab1',
+            screenKey: 'Tab1',
             title: 'Tab1',
             ios: {
               icon: {
@@ -113,7 +113,7 @@ export function App() {
         {
           component: TabScreen,
           tabScreenProps: {
-            tabKey: 'Tab2',
+            screenKey: 'Tab2',
             title: 'Tab2',
             ios: {
               icon: {
@@ -194,7 +194,7 @@ export function App() {
         {
           component: TabScreen,
           tabScreenProps: {
-            tabKey: 'Tab3',
+            screenKey: 'Tab3',
             title: 'Tab3',
             ios: {
               icon: {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-color-scheme.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-color-scheme.tsx
@@ -39,7 +39,7 @@ function ConfigScreen() {
   useEffect(() => {
     dispatch({
       type: 'tabScreen',
-      tabKey: 'Config',
+      screenKey: 'Config',
       config: {
         safeAreaConfiguration: {
           edges: {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-direction.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-direction.tsx
@@ -39,7 +39,7 @@ function ConfigScreen() {
   useEffect(() => {
     dispatch({
       type: 'tabScreen',
-      tabKey: 'Config',
+      screenKey: 'Config',
       config: {
         safeAreaConfiguration: {
           edges: {

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -254,7 +254,7 @@ namespace react = facebook::react;
 {
   return [_reactEventEmitter
       emitOnNativeFocusChange:OnNativeFocusChangePayload{
-                                  .tabKey = tabScreen.tabKey,
+                                  .screenKey = tabScreen.screenKey,
                                   .repeatedSelectionHandledBySpecialEffect = repeatedSelectionHandledBySpecialEffect}];
 }
 

--- a/ios/tabs/host/RNSTabsHostEventEmitter.h
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.h
@@ -17,12 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if defined(__cplusplus)
 struct OnNativeFocusChangePayload {
-  NSString *_Nonnull tabKey;
+  NSString *_Nonnull screenKey;
   BOOL repeatedSelectionHandledBySpecialEffect;
 };
 #else
 typedef struct {
-  NSString *_Nonnull tabKey;
+  NSString *_Nonnull screenKey;
   BOOL repeatedSelectionHandledBySpecialEffect;
 } OnNativeFocusChangePayload;
 #endif

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -38,7 +38,7 @@ namespace react = facebook::react;
 #if RCT_NEW_ARCH_ENABLED
   if (_reactEventEmitter != nullptr) {
     _reactEventEmitter->onNativeFocusChange(
-        {.tabKey = RCTStringFromNSString(payload.tabKey),
+        {.screenKey = RCTStringFromNSString(payload.screenKey),
          .repeatedSelectionHandledBySpecialEffect =
              static_cast<bool>(payload.repeatedSelectionHandledBySpecialEffect)});
     return YES;
@@ -49,7 +49,7 @@ namespace react = facebook::react;
 #else
   if (self.onNativeFocusChange) {
     self.onNativeFocusChange(@{
-      @"tabKey" : payload.tabKey,
+      @"screenKey" : payload.screenKey,
       @"repeatedSelectionHandledBySpecialEffect" : @(payload.repeatedSelectionHandledBySpecialEffect)
     });
     return YES;

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 // architecture is dropped.
 
 @property (nonatomic) BOOL isSelectedScreen;
-@property (nonatomic, nullable) NSString *tabKey;
+@property (nonatomic, nullable) NSString *screenKey;
 @property (nonatomic, nullable) NSString *badgeValue;
 
 @property (nonatomic, nullable) NSString *tabBarItemTestID;

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -270,9 +270,9 @@ RNS_IGNORE_SUPER_CALL_END
     tabScreenOrientationNeedsUpdate = YES;
   }
 
-  if (newComponentProps.tabKey != oldComponentProps.tabKey) {
-    RCTAssert(!newComponentProps.tabKey.empty(), @"[RNScreens] tabKey must not be empty!");
-    _tabKey = RCTNSStringFromString(newComponentProps.tabKey);
+  if (newComponentProps.screenKey != oldComponentProps.screenKey) {
+    RCTAssert(!newComponentProps.screenKey.empty(), @"[RNScreens] screenKey must not be empty!");
+    _screenKey = RCTNSStringFromString(newComponentProps.screenKey);
   }
 
   if (newComponentProps.isFocused != oldComponentProps.isFocused) {
@@ -514,7 +514,7 @@ RNS_IGNORE_SUPER_CALL_END
   // enabling us to warn users that dynamic changes are not supported.
   // On Paper, setter for the prop may not be called (when it is undefined in JS).
   // Therefore we set the flag in didSetProps to make sure to handle this case as well.
-  // didSetProps will always be called because tabKey prop is required.
+  // didSetProps will always be called because screenKey prop is required.
   _isOverrideScrollViewContentInsetAdjustmentBehaviorSet = YES;
 
   if (_tabBarItemNeedsRecreation) {
@@ -559,10 +559,10 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
-- (void)setTabKey:(NSString *)tabKey
+- (void)setScreenKey:(NSString *)screenKey
 {
-  RCTAssert([NSString rnscreens_isBlankOrNull:tabKey] == NO, @"[RNScreens] tabKey must not be empty");
-  _tabKey = tabKey;
+  RCTAssert([NSString rnscreens_isBlankOrNull:screenKey] == NO, @"[RNScreens] screenKey must not be empty");
+  _screenKey = screenKey;
 }
 
 - (void)setTitle:(NSString *)title

--- a/ios/tabs/screen/RNSTabsScreenComponentViewManager.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentViewManager.mm
@@ -17,7 +17,7 @@ RCT_EXPORT_MODULE(RNSTabsScreenManager)
   return [[RNSTabsScreenComponentView alloc] initWithFrame:CGRectZero];
 }
 
-RCT_EXPORT_VIEW_PROPERTY(tabKey, NSString);
+RCT_EXPORT_VIEW_PROPERTY(screenKey, NSString);
 
 RCT_REMAP_VIEW_PROPERTY(isFocused, isSelectedScreen, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(title, NSString);

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -5,7 +5,7 @@ import type { TabsHostPropsIOS } from './TabsHost.ios.types';
 // #region General helpers
 
 export type NativeFocusChangeEvent = {
-  tabKey: string;
+  screenKey: string;
   repeatedSelectionHandledBySpecialEffect: boolean;
 };
 

--- a/src/components/tabs/screen/TabsScreen.android.tsx
+++ b/src/components/tabs/screen/TabsScreen.android.tsx
@@ -50,7 +50,7 @@ function TabsScreen(props: TabsScreenProps) {
       onWillAppear,
       onWillDisappear,
       isFocused,
-      tabKey: filteredBaseProps.tabKey,
+      screenKey: filteredBaseProps.screenKey,
     });
 
   const iconProps = parseIconsToNativeProps(

--- a/src/components/tabs/screen/TabsScreen.ios.tsx
+++ b/src/components/tabs/screen/TabsScreen.ios.tsx
@@ -53,7 +53,7 @@ function TabsScreen(props: TabsScreenProps) {
       onWillAppear,
       onWillDisappear,
       isFocused,
-      tabKey: filteredBaseProps.tabKey,
+      screenKey: filteredBaseProps.screenKey,
     });
 
   const iconProps = parseIconsToNativeProps(ios?.icon, ios?.selectedIcon);

--- a/src/components/tabs/screen/TabsScreen.types.ts
+++ b/src/components/tabs/screen/TabsScreen.types.ts
@@ -55,7 +55,7 @@ export interface TabsScreenPropsBase {
    *
    * @platform android, ios
    */
-  tabKey: string;
+  screenKey: string;
 
   // General
   children?: ViewProps['children'];

--- a/src/components/tabs/screen/useTabsScreen.ts
+++ b/src/components/tabs/screen/useTabsScreen.ts
@@ -16,7 +16,7 @@ interface TabsScreenConfig<T> {
   onWillAppear?: TabsScreenEventHandler<EmptyObject>;
   onWillDisappear?: TabsScreenEventHandler<EmptyObject>;
   isFocused?: boolean;
-  tabKey: string;
+  screenKey: string;
 }
 
 export function useTabsScreen<
@@ -28,7 +28,7 @@ export function useTabsScreen<
   onWillAppear,
   onWillDisappear,
   isFocused = false,
-  tabKey,
+  screenKey,
 }: TabsScreenConfig<T>) {
   const componentNodeHandle = React.useRef<number>(-1);
 
@@ -84,7 +84,7 @@ export function useTabsScreen<
   bottomTabsDebugLog(
     `TabsScreen [${
       componentNodeHandle.current ?? -1
-    }] render; tabKey: ${tabKey}, isFocused: ${isFocused}`,
+    }] render; screenKey: ${screenKey}, isFocused: ${isFocused}`,
   );
 
   return {

--- a/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
@@ -6,7 +6,7 @@ import type { CodegenTypes as CT, ColorValue, ViewProps } from 'react-native';
 // #region General helpers
 
 type NativeFocusChangeEvent = {
-  tabKey: string;
+  screenKey: string;
   repeatedSelectionHandledBySpecialEffect: boolean;
 };
 

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -6,7 +6,7 @@ import type { CodegenTypes as CT, ColorValue, ViewProps } from 'react-native';
 // #region General helpers
 
 type NativeFocusChangeEvent = {
-  tabKey: string;
+  screenKey: string;
   repeatedSelectionHandledBySpecialEffect: boolean;
 };
 

--- a/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
@@ -80,7 +80,7 @@ export interface NativeProps extends ViewProps {
 
   // Control
   isFocused?: boolean;
-  tabKey: string;
+  screenKey: string;
 
   // General
   title?: string | undefined | null;

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -124,7 +124,7 @@ export interface NativeProps extends ViewProps {
 
   // Control
   isFocused?: boolean;
-  tabKey: string;
+  screenKey: string;
 
   // General
   title?: string | undefined | null;


### PR DESCRIPTION
## Description

As discussed in the RFC: https://github.com/software-mansion/react-native-screens-labs/pull/1023 we're renaming `tabKey` to `screenKey` to make it consistent with other components.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1047

## Changes

- `tabKey` -> `screenKey`

## Before & after - visual documentation

N/A - refactor

## Test plan

I went through some examples in SFT and TestBottomTabs and confirmed that these work.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
