### PR TITLE
chore(Android): Remove BottomSheet-related Paper-specific code

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -38,7 +38,6 @@ import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
 import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 import com.swmansion.rnscreens.ext.asScreenStackFragment
-import com.swmansion.rnscreens.ext.parentAsViewGroup
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
 import com.swmansion.rnscreens.utils.getDecorViewTopInset
 import kotlin.math.max
@@ -99,10 +98,6 @@ class Screen(
     var sheetDefaultResizeAnimationEnabled = true
 
     /**
-     * On Paper, when using form sheet presentation we want to delay enter transition in order
-     * to wait for initial layout from React, otherwise the animator-based animation will look
-     * glitchy.
-     *
      * On Fabric, the view layout is completed before window insets are applied.
      * To ensure the BottomSheet correctly respects insets during its enter transition,
      * we delay the transition until both layout and insets have been applied.
@@ -169,17 +164,6 @@ class Screen(
                     updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
                 } else {
                     updateSheetContentHeightWithoutAnimation(sheetBehavior, height)
-                }
-            }
-
-            if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-                // On old architecture we delay enter transition in order to wait for initial frame.
-                shouldTriggerPostponedTransitionAfterLayout = true
-                val parent = parentAsViewGroup()
-                if (parent != null && !parent.isInLayout) {
-                    // There are reported cases (irreproducible) when Screen is not laid out after
-                    // maxHeight is set on behaviour.
-                    parent.requestLayout()
                 }
             }
         }
@@ -300,9 +284,7 @@ class Screen(
         // internal offsets with the new maxHeight. This prevents the sheet from snapping back
         // to its old position when the user starts a gesture.
         parent.requestLayout()
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            updateScreenSizeFabric(width, clampedHeight, top + translationY.toInt())
-        }
+        updateScreenSizeFabric(width, clampedHeight, top + translationY.toInt())
     }
 
     private fun setupInitialSheetContentHeight(
@@ -391,20 +373,13 @@ class Screen(
         }
 
         footer?.onParentLayout(coordinatorLayoutDidChange, left, top, right, bottom, container!!.height)
-
-        if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // When using form sheet presentation we want to delay enter transition **on Paper** in order
-            // to wait for initial layout from React, otherwise the animator-based animation will look
-            // glitchy. *This seems to not be needed on Fabric*.
-            triggerPostponedEnterTransitionIfNeeded()
-        }
     }
 
     // On Fabric, the view layout is completed before window insets are applied.
     // To ensure the BottomSheet correctly respects insets during its enter transition,
     // we delay the transition until both layout and insets have been applied.
     internal fun requestTriggeringPostponedEnterTransition() {
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && !sheetShouldOverflowTopInset) {
+        if (!sheetShouldOverflowTopInset) {
             shouldTriggerPostponedTransitionAfterLayout = true
         }
     }
@@ -705,7 +680,7 @@ class Screen(
         dispatchSheetDetentChanged(detentIndex, isStable)
         // There is no need to update shadow state for transient sheet states -
         // we are unsure of the exact sheet position anyway.
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && isStable) {
+        if (isStable) {
             onSheetYTranslationChanged()
         }
 
@@ -718,10 +693,8 @@ class Screen(
     }
 
     internal fun onSheetYTranslationChanged() {
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // Translation is relative to the bottom edge, therefore it returns negative values.
-            updateScreenSizeFabric(width, height, top + translationY.toInt())
-        }
+        // Translation is relative to the bottom edge, therefore it returns negative values.
+        updateScreenSizeFabric(width, height, top + translationY.toInt())
     }
 
     override fun onApplyWindowInsets(insets: WindowInsets?): WindowInsets? {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
@@ -6,7 +6,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPS
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
-import com.swmansion.rnscreens.BuildConfig
 import com.swmansion.rnscreens.Screen
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 
@@ -138,28 +137,13 @@ fun Screen.isSheetFitToContents(): Boolean =
 fun Screen.usesFormSheetPresentation(): Boolean = stackPresentation === Screen.StackPresentation.FORM_SHEET
 
 fun Screen.requiresEnterTransitionPostponing(): Boolean {
-    // On old architecture the content wrapper might not have received its frame yet,
-    // which is required to determine height of the sheet after animation. Therefore
-    // we delay the transition and trigger it after views receive the layout.
-    // This is used only for formSheet presentation, because we use value animators
-    // there. Tween animations have some magic way to make this work (maybe they
-    // postpone the transition internally, dunno).
-    //
     // On Fabric, system insets are applied after the initial layout pass. However,
     // the BottomSheet height might be measured earlier due to internal BottomSheet logic
     // or layout callbacks, before those insets are applied.
     // To ensure the BottomSheet height respects the top inset we delay starting the enter
     // transition until both layout and insets are fully applied.
 
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && !this.sheetShouldOverflowTopInset && this.usesFormSheetPresentation()) {
-        return true
-    }
-
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED || !this.usesFormSheetPresentation()) {
-        return false
-    }
-    // Assumes that formSheet uses content wrapper
-    return !this.isLaidOutOrHasCachedLayout() || this.contentWrapper?.isLaidOutOrHasCachedLayout() != true
+    return !this.sheetShouldOverflowTopInset && this.usesFormSheetPresentation()
 }
 
 fun Screen.sheetShouldUseDimmingView(): Boolean {


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1031

## Description

This PR removes Paper-specific code from BottomSheet implementation on android.

> [!note]
> I was 50/50 about changing `Screen.kt` here, but I figured it's better for testing to have most of the changes in one place. I only touched things that directly relate to formSheet presentation. The `dispatchShadowStateUpdate()` remains Fabric/Paper, though it should use Fabric (new arch guard).

## Changes

Removed new arch guards and related code for BottomSheet from `SheetUtils.kt` and `Screen.kt`.

## Before & after - visual documentation

n/a

## Test plan

> [!note]
> Please DO test the runtime.

Compile & run the app. See if various bottomsheet presentation options work same as before.

## Checklist

- [ ] Ensured that CI passes
