### PR TITLE
chore(JS, Tabs): Remove dead code around `onLifecycleStateChange` event

### DIFF
--- a/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
@@ -13,11 +13,6 @@ import type {
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;
 
-type LifecycleStateChangeEvent = Readonly<{
-  previousState: CT.Int32;
-  newState: CT.Int32;
-}>;
-
 // #endregion General helpers
 
 // #region Android-specific helpers
@@ -72,7 +67,6 @@ export type Appearance = {
 
 export interface NativeProps extends ViewProps {
   // Events
-  onLifecycleStateChange?: CT.DirectEventHandler<LifecycleStateChangeEvent>;
   onWillAppear?: CT.DirectEventHandler<GenericEmptyEvent>;
   onDidAppear?: CT.DirectEventHandler<GenericEmptyEvent>;
   onWillDisappear?: CT.DirectEventHandler<GenericEmptyEvent>;

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -15,11 +15,6 @@ import { UnsafeMixed } from './codegenUtils';
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;
 
-type LifecycleStateChangeEvent = Readonly<{
-  previousState: CT.Int32;
-  newState: CT.Int32;
-}>;
-
 // #endregion General helpers
 
 // #region iOS-specific helpers
@@ -116,7 +111,6 @@ type UserInterfaceStyle = 'unspecified' | 'light' | 'dark';
 
 export interface NativeProps extends ViewProps {
   // Events
-  onLifecycleStateChange?: CT.DirectEventHandler<LifecycleStateChangeEvent>;
   onWillAppear?: CT.DirectEventHandler<GenericEmptyEvent>;
   onDidAppear?: CT.DirectEventHandler<GenericEmptyEvent>;
   onWillDisappear?: CT.DirectEventHandler<GenericEmptyEvent>;


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1018

## Changes

- removed unused callbacks from spec

## Before & after - visual documentation

N/A

## Test plan

App builds, BottomTabs example is working in the runtime

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
