### PR TITLE
fix(Examples): Fix TestBottomTabsOrientation

### DIFF
--- a/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
@@ -109,23 +109,22 @@ function makeTabConfigs(
       tabScreenProps: {
         screenKey: 'Portrait',
         title: 'Portrait',
-        tabBarItemBadgeBackgroundColor: Colors.GreenDark100,
-        icon: {
-          ios: {
+        ios: {
+          icon: {
             type: 'templateSource',
             templateSource: require('../../../assets/variableIcons/icon.png'),
           },
-          android: {
-            type: 'drawableResource',
-            name: 'sym_call_missed',
-          },
-        },
-        selectedIcon: {
-          ios: {
+          selectedIcon: {
             type: 'templateSource',
             templateSource: require('../../../assets/variableIcons/icon_fill.png'),
           },
-          android: {
+        },
+        android: {
+          icon: {
+            type: 'drawableResource',
+            name: 'sym_call_missed',
+          },
+          selectedIcon: {
             type: 'drawableResource',
             name: 'sym_call_missed',
           },


### PR DESCRIPTION
## Description

Omission from https://github.com/software-mansion/react-native-screens/pull/3722#discussion_r2924931375

## Changes

- fixed icon
- removed badge, as no badges are displayed

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
