### PR TITLE
feat: shared element transition POC using native Fragment API

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt
@@ -13,6 +13,7 @@ import com.swmansion.rnscreens.gamma.stack.screen.StackScreenViewManager
 import com.swmansion.rnscreens.gamma.tabs.host.TabsHostViewManager
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreenViewManager
 import com.swmansion.rnscreens.safearea.SafeAreaViewManager
+import com.swmansion.rnscreens.sharedtransition.SharedTransitionViewManager
 import com.swmansion.rnscreens.utils.ScreenDummyLayoutHelper
 
 // Fool autolinking for older versions that do not support BaseReactPackage.
@@ -57,6 +58,7 @@ class RNScreensPackage : BaseReactPackage() {
             StackHostViewManager(),
             StackScreenViewManager(),
             ScrollViewMarkerViewManager(),
+            SharedTransitionViewManager(),
         )
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -15,6 +15,7 @@ import com.swmansion.rnscreens.stack.views.ChildrenDrawingOrderStrategy
 import com.swmansion.rnscreens.stack.views.ReverseFromIndex
 import com.swmansion.rnscreens.stack.views.ReverseOrder
 import com.swmansion.rnscreens.stack.views.ScreensCoordinatorLayout
+import com.swmansion.rnscreens.sharedtransition.SharedTransitionHelper
 import com.swmansion.rnscreens.utils.setTweenAnimations
 import kotlin.collections.ArrayList
 import kotlin.math.max
@@ -241,7 +242,20 @@ class ScreenStack(
         }
 
         createTransaction().let { transaction ->
-            if (stackAnimation != null) {
+            // Try to set up shared element transition between outgoing and incoming fragments.
+            // Works for both forward (push) and backward (pop) navigation.
+            val hasSharedElements = if (newTop != null && topScreenWrapper != null && topScreenWillChange) {
+                SharedTransitionHelper.setupSharedElementTransition(
+                    transaction,
+                    topScreenWrapper?.fragment,
+                    newTop.fragment,
+                    isForward = shouldUseOpenAnimation,
+                )
+            } else {
+                false
+            }
+
+            if (stackAnimation != null && !hasSharedElements) {
                 transaction.setTweenAnimations(stackAnimation, shouldUseOpenAnimation)
             }
 

--- a/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionHelper.kt
@@ -1,0 +1,118 @@
+package com.swmansion.rnscreens.sharedtransition
+
+import android.transition.ChangeBounds
+import android.transition.ChangeClipBounds
+import android.transition.ChangeTransform
+import android.transition.Fade
+import android.transition.TransitionSet
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+
+/**
+ * Helper that wires up Android's native Fragment shared element transitions.
+ *
+ * It walks the view trees of the outgoing and incoming Fragments, collects
+ * every [SharedTransitionView] whose `transitionName` is non-null, then
+ * matches them by tag and calls [FragmentTransaction.addSharedElement].
+ */
+object SharedTransitionHelper {
+
+    private const val TAG = "SharedTransitionHelper"
+    private const val TRANSITION_DURATION = 400L
+
+    /**
+     * Collect all SharedTransitionViews in the given view hierarchy.
+     */
+    fun findSharedTransitionViews(root: View?): List<SharedTransitionView> {
+        val result = mutableListOf<SharedTransitionView>()
+        if (root == null) return result
+        collectSharedViews(root, result)
+        return result
+    }
+
+    private fun collectSharedViews(view: View, out: MutableList<SharedTransitionView>) {
+        if (view is SharedTransitionView && ViewCompat.getTransitionName(view) != null) {
+            out.add(view)
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                collectSharedViews(view.getChildAt(i), out)
+            }
+        }
+    }
+
+    private fun createSharedElementTransitionSet(): TransitionSet {
+        return TransitionSet().apply {
+            addTransition(ChangeBounds())
+            addTransition(ChangeTransform())
+            addTransition(ChangeClipBounds())
+            duration = TRANSITION_DURATION
+            ordering = TransitionSet.ORDERING_TOGETHER
+        }
+    }
+
+    /**
+     * Creates a Fade transition for non-shared content.
+     * When fading in, delays until the shared element has mostly finished animating.
+     */
+    private fun createContentFadeTransition(fadeIn: Boolean): Fade {
+        return Fade(if (fadeIn) Fade.IN else Fade.OUT).apply {
+            duration = TRANSITION_DURATION / 2
+            if (fadeIn) {
+                startDelay = TRANSITION_DURATION / 2
+            }
+        }
+    }
+
+    /**
+     * Sets up shared element transitions between outgoing and incoming Fragments.
+     *
+     * @param isForward true for push, false for pop (back navigation)
+     * @return true if at least one shared element pair was found and added.
+     */
+    fun setupSharedElementTransition(
+        transaction: FragmentTransaction,
+        outgoingFragment: Fragment?,
+        incomingFragment: Fragment?,
+        isForward: Boolean = true,
+    ): Boolean {
+        if (outgoingFragment == null || incomingFragment == null) return false
+
+        val outgoingView = outgoingFragment.view ?: return false
+        val outgoingSharedViews = findSharedTransitionViews(outgoingView)
+
+        if (outgoingSharedViews.isEmpty()) {
+            return false
+        }
+
+        Log.d(TAG, "Found ${outgoingSharedViews.size} shared views in outgoing fragment (forward=$isForward)")
+
+        // Shared element transitions
+        incomingFragment.sharedElementEnterTransition = createSharedElementTransitionSet()
+        incomingFragment.sharedElementReturnTransition = createSharedElementTransitionSet()
+
+        // Non-shared content transitions — prevents destination content from
+        // bleeding through during the shared element animation
+        incomingFragment.enterTransition = createContentFadeTransition(fadeIn = true)
+        outgoingFragment.exitTransition = createContentFadeTransition(fadeIn = false)
+
+        // Return (pop) transitions
+        incomingFragment.returnTransition = createContentFadeTransition(fadeIn = false)
+        outgoingFragment.reenterTransition = createContentFadeTransition(fadeIn = true)
+
+        // Add each shared view to the transaction
+        var addedCount = 0
+        for (sharedView in outgoingSharedViews) {
+            val transitionName = ViewCompat.getTransitionName(sharedView) ?: continue
+            transaction.addSharedElement(sharedView, transitionName)
+            addedCount++
+            Log.d(TAG, "Added shared element: transitionName='$transitionName'")
+        }
+
+        return addedCount > 0
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionView.kt
@@ -1,0 +1,41 @@
+package com.swmansion.rnscreens.sharedtransition
+
+import android.content.Context
+import android.util.Log
+import androidx.core.view.ViewCompat
+import com.facebook.react.views.view.ReactViewGroup
+
+/**
+ * A custom native view that participates in shared element transitions.
+ *
+ * This view sets a `transitionName` on itself so that Android's Fragment
+ * shared element transition framework can match it with a corresponding
+ * view in the destination screen.
+ *
+ * When used as a source, this view's bounds animate to fill the destination
+ * screen's matching SharedTransitionView (or the screen itself).
+ */
+class SharedTransitionView(context: Context) : ReactViewGroup(context) {
+
+    var sharedTransitionTag: String? = null
+        set(value) {
+            field = value
+            if (value != null) {
+                ViewCompat.setTransitionName(this, value)
+                Log.d(TAG, "Set transitionName='$value' on view id=$id")
+            } else {
+                ViewCompat.setTransitionName(this, null)
+            }
+        }
+
+    init {
+        // Clip children to this view's bounds during transition so child views
+        // (text, icons) don't float outside the animating shared element rectangle.
+        clipChildren = true
+        clipToPadding = true
+    }
+
+    companion object {
+        const val TAG = "SharedTransitionView"
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/sharedtransition/SharedTransitionViewManager.kt
@@ -1,0 +1,26 @@
+package com.swmansion.rnscreens.sharedtransition
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+@ReactModule(name = SharedTransitionViewManager.REACT_CLASS)
+class SharedTransitionViewManager : ViewGroupManager<SharedTransitionView>() {
+
+    companion object {
+        const val REACT_CLASS = "RNSSharedTransitionView"
+    }
+
+    override fun getName(): String = REACT_CLASS
+
+    override fun createViewInstance(reactContext: ThemedReactContext): SharedTransitionView {
+        return SharedTransitionView(reactContext)
+    }
+
+    @ReactProp(name = "sharedTransitionTag")
+    fun setSharedTransitionTag(view: SharedTransitionView, tag: String?) {
+        view.sharedTransitionTag = tag
+    }
+}

--- a/apps/Example.tsx
+++ b/apps/Example.tsx
@@ -27,6 +27,7 @@ import SearchBar from './src/screens/SearchBar';
 import Events from './src/screens/Events';
 import Gestures from './src/screens/Gestures';
 import BarButtonItems from './src/screens/BarButtonItems';
+import SharedTransition from './src/screens/SharedTransition';
 
 import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -129,6 +130,11 @@ const SCREENS: Record<
   BarButtonItems: {
     title: 'Bar Button Items',
     component: BarButtonItems,
+    type: 'playground',
+  },
+  SharedTransition: {
+    title: 'Shared Element Transition',
+    component: SharedTransition,
     type: 'playground',
   },
 };

--- a/apps/src/screens/SharedTransition.tsx
+++ b/apps/src/screens/SharedTransition.tsx
@@ -1,0 +1,241 @@
+import React, { useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Pressable,
+  requireNativeComponent,
+  Platform,
+} from 'react-native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import { Button } from '../shared';
+
+// Native SharedTransitionView - wraps the Android native view
+const SharedTransitionView =
+  Platform.OS === 'android'
+    ? requireNativeComponent<any>('RNSSharedTransitionView')
+    : View;
+
+type StackParamList = {
+  List: undefined;
+  Detail: { color: string; title: string; emoji: string };
+};
+
+const ITEMS = [
+  { id: '1', color: '#FF6B6B', title: 'Sunset Red', emoji: '🌅' },
+  { id: '2', color: '#4ECDC4', title: 'Ocean Teal', emoji: '🌊' },
+  { id: '3', color: '#45B7D1', title: 'Sky Blue', emoji: '☁️' },
+  { id: '4', color: '#96CEB4', title: 'Mint Green', emoji: '🌿' },
+  { id: '5', color: '#FFEAA7', title: 'Sunny Yellow', emoji: '☀️' },
+  { id: '6', color: '#DDA0DD', title: 'Plum Purple', emoji: '🍇' },
+];
+
+interface ListScreenProps {
+  navigation: NativeStackNavigationProp<StackParamList, 'List'>;
+}
+
+const ListScreen = ({ navigation }: ListScreenProps): React.JSX.Element => {
+  const handlePress = useCallback(
+    (item: (typeof ITEMS)[0]) => {
+      navigation.navigate('Detail', {
+        color: item.color,
+        title: item.title,
+        emoji: item.emoji,
+      });
+    },
+    [navigation],
+  );
+
+  return (
+    <View style={styles.listContainer}>
+      <Text style={styles.heading}>Shared Element Transition Demo</Text>
+      <Text style={styles.subtitle}>
+        Tap a card to see it expand into the detail screen
+      </Text>
+      <View style={styles.grid}>
+        {ITEMS.map(item => (
+          <Pressable
+            key={item.id}
+            onPress={() => handlePress(item)}
+            style={styles.cardPressable}>
+            <View style={styles.cardWrapper}>
+              <SharedTransitionView
+                sharedTransitionTag={`card-${item.id}`}
+                style={[styles.cardBackground, { backgroundColor: item.color }]}
+              />
+              <View style={styles.cardContent} pointerEvents="none">
+                <Text style={styles.cardEmoji}>{item.emoji}</Text>
+                <Text style={styles.cardTitle}>{item.title}</Text>
+              </View>
+            </View>
+          </Pressable>
+        ))}
+      </View>
+      <Button onPress={() => navigation.pop()} title="🔙 Back to Examples" />
+    </View>
+  );
+};
+
+interface DetailScreenProps {
+  navigation: NativeStackNavigationProp<StackParamList, 'Detail'>;
+  route: { params: { color: string; title: string; emoji: string } };
+}
+
+const DetailScreen = ({
+  navigation,
+  route,
+}: DetailScreenProps): React.JSX.Element => {
+  const { color, title, emoji } = route.params;
+
+  return (
+    <View style={styles.detailContainer}>
+      <View style={styles.detailHeroWrapper}>
+        <SharedTransitionView
+          sharedTransitionTag={`card-${ITEMS.find(i => i.color === color)?.id}`}
+          style={[styles.detailHeroBackground, { backgroundColor: color }]}
+        />
+        <View style={styles.detailHeroContent} pointerEvents="none">
+          <Text style={styles.detailEmoji}>{emoji}</Text>
+          <Text style={styles.detailTitle}>{title}</Text>
+        </View>
+      </View>
+      <View style={styles.detailContent}>
+        <Text style={styles.detailDescription}>
+          This screen was reached via a shared element transition. The colored
+          card from the list animated and expanded to become the hero section of
+          this detail screen.
+        </Text>
+        <Text style={styles.detailDescription}>
+          On Android, this uses the native Fragment shared element transition
+          API with ChangeBounds, ChangeTransform, ChangeClipBounds, and Fade
+          transitions.
+        </Text>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+const SharedTransition = (): React.JSX.Element => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="List"
+        component={ListScreen}
+        options={{ title: 'Shared Transition' }}
+      />
+      <Stack.Screen
+        name="Detail"
+        options={{
+          headerShown: false,
+          animation: 'fade',
+        }}>
+        {(props: any) => <DetailScreen {...props} />}
+      </Stack.Screen>
+    </Stack.Navigator>
+  );
+};
+
+const styles = StyleSheet.create({
+  listContainer: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#f5f5f5',
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    marginBottom: 4,
+    color: '#333',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 16,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  cardPressable: {
+    width: '48%',
+    marginBottom: 12,
+  },
+  cardWrapper: {
+    height: 120,
+    borderRadius: 16,
+    overflow: 'hidden',
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  cardBackground: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 16,
+  },
+  cardContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  cardEmoji: {
+    fontSize: 32,
+    marginBottom: 8,
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#fff',
+    textShadowColor: 'rgba(0,0,0,0.3)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
+  detailContainer: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  detailHeroWrapper: {
+    height: 300,
+  },
+  detailHeroBackground: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  detailHeroContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  detailEmoji: {
+    fontSize: 72,
+    marginBottom: 16,
+  },
+  detailTitle: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#fff',
+    textShadowColor: 'rgba(0,0,0,0.3)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 3,
+  },
+  detailContent: {
+    padding: 24,
+  },
+  detailDescription: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#444',
+    marginBottom: 16,
+  },
+});
+
+export default SharedTransition;


### PR DESCRIPTION
## Summary

- Adds `SharedTransitionView`, a native Android view that participates in Fragment shared element transitions
- Hooks into `ScreenStack.onUpdate()` to detect shared elements and wire up `FragmentTransaction.addSharedElement()`
- Uses `ChangeBounds` + `ChangeTransform` + `ChangeClipBounds` for the shared element, with staggered `Fade` for non-shared content
- Includes example screen with card-to-hero transition demo

## Key Design Decision

Children (emoji, text) are placed **outside** `SharedTransitionView` — only the colored background is the shared element. This avoids a layout jump caused by React Native's Yoga engine re-laying out children at destination dimensions before the transition framework captures the start state (incompatible with `commitNowAllowingStateLoss()`). Follows the Material Design pattern: animate containers, cross-fade content.

## Test plan

- [ ] Open "Shared Element Transition" from the FabricExample app
- [ ] Tap any colored card — verify the background smoothly expands to fill the hero section
- [ ] Verify emoji/text fade in after the shared element animation settles (no jump)
- [ ] Press back — verify the hero smoothly shrinks back to the card position
- [ ] Verify other screen animations (slide, fade) still work normally when no shared elements are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)