### PR TITLE
fix(Android, Tabs): fix issue with badges being assigned to wrong menu items

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceApplicator.kt
@@ -200,11 +200,11 @@ internal class TabsAppearanceApplicator(
         tabsScreen: TabsScreen,
         appearance: TabsAppearance?,
     ) {
-        val menuItemIndex = bottomNavigationView.menu.children.indexOf(menuItem)
+        val menuItemId = menuItem.itemId
         val badgeValue = tabsScreen.badgeValue
 
         if (badgeValue == null) {
-            val badge = bottomNavigationView.getBadge(menuItemIndex)
+            val badge = bottomNavigationView.getBadge(menuItemId)
             badge?.isVisible = false
 
             return
@@ -212,7 +212,7 @@ internal class TabsAppearanceApplicator(
 
         val badgeValueNumber = badgeValue.toIntOrNull()
 
-        val badge = bottomNavigationView.getOrCreateBadge(menuItemIndex)
+        val badge = bottomNavigationView.getOrCreateBadge(menuItemId)
         badge.isVisible = true
 
         badge.clearText()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/appearance/TabsAppearanceCoordinator.kt
@@ -34,7 +34,7 @@ internal class TabsAppearanceCoordinator(
                 checkNotNull(bottomNavigationView.menu.findItem(menuItemId)) {
                     "[RNScreens] Missing MenuItem for id: $menuItemId"
                 }
-            check(menuItem.itemId == menuItemIdForFragmentAtIndex(index)) { "[RNScreens] Illegal state: menu items are shuffled" }
+            check(menuItem.itemId == menuItemId) { "[RNScreens] Illegal state: menu items are shuffled" }
             updateMenuItemAppearance(context, menuItem, fragment.tabsScreen, tabsAppearance)
         }
     }


### PR DESCRIPTION

## Description

Fix issue with badges being assigned to wrong menu items
For some reason the badge appearance update code used menuItemIndex
instead of menuItemId for associating badge with menu item.

I've fixed it & the code is more resistant to refactors right now.

The issue has been originally reported here: https://github.com/software-mansion/react-native-screens/pull/3776#issuecomment-4089134458

## Visual documentation

<img width="426" height="979" alt="image" src="https://github.com/user-attachments/assets/cc6ba0d9-499d-4f86-a450-79d35c358d7e" />


## Test plan

Run `TestBottomTabs` and make sure that the badges are displayed as defined in test code.
