### PR TITLE
fix(iOS, StackV5): Fix default props type

### DIFF
--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -47,7 +47,7 @@ namespace react = facebook::react;
 
 - (void)resetProps
 {
-  static const auto defaultProps = std::make_shared<const react::RNSScreenStackProps>();
+  static const auto defaultProps = std::make_shared<const react::RNSStackScreenProps>();
   _props = defaultProps;
 
   // container state


### PR DESCRIPTION
## Before & after - visual documentation

### Before

`TestScreenStack` isn't rendering content.

### After

`TestScreenStack` is rendering content.

## Test plan

`TestScreenStack`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
