### PR TITLE
feat(iOS, Tabs): support active nested content scroll view markers

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt
@@ -49,6 +49,11 @@ class ScrollViewMarkerViewManager :
         value: String?,
     ) = Unit
 
+    override fun setActive(
+        view: ScrollViewMarker?,
+        value: Boolean,
+    ) = Unit
+
     companion object {
         const val REACT_CLASS = "RNSScrollViewMarker"
     }

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/index.ts
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/index.ts
@@ -1,10 +1,11 @@
 import { ScenarioGroup } from '../../shared/helpers';
+import TestSvmActiveScrollViewForTabs from './test-svm-active-scroll-view-for-tabs';
 import TestSvmConfiguresScrollView from './test-svm-configures-scroll-view';
 
 const ScrollViewMarkerScenarioGroup: ScenarioGroup = {
   name: 'ScrollViewMarker scenarios',
   details: 'Scenarios related to ScrollViewMarker component',
-  scenarios: [TestSvmConfiguresScrollView],
+  scenarios: [TestSvmConfiguresScrollView, TestSvmActiveScrollViewForTabs],
 };
 
 export default ScrollViewMarkerScenarioGroup;

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-active-scroll-view-for-tabs.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-active-scroll-view-for-tabs.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { Scenario } from '../../shared/helpers';
+import { ScrollViewMarker } from 'react-native-screens/experimental';
+import { TabsContainer } from '../../../shared/gamma/containers/tabs';
+import { Rectangle } from '../../../shared/Rectangle';
+import Colors from '../../../shared/styling/Colors';
+import { generateNextColor } from '../../../shared/utils/color-generator';
+
+const SCENARIO: Scenario = {
+  name: 'Active marker for tabs',
+  key: 'test-svm-active-scroll-view-for-tabs',
+  details:
+    'Reproduces nested tab content where multiple descendant ScrollViews stay mounted under a non-scroll wrapper. ' +
+    'Switch pages with the buttons and verify that tab bar minimize behavior follows the active ScrollViewMarker ' +
+    'instead of remaining attached to the first registered ScrollView.',
+  platforms: ['ios'],
+  AppComponent: App,
+};
+
+export default SCENARIO;
+
+const ITEM_COUNT = 24;
+
+function App() {
+  return (
+    <TabsContainer
+      routeConfigs={[
+        {
+          name: 'Journal',
+          Component: JournalLikeScreen,
+          options: {
+            title: 'Journal',
+            ios: {
+              icon: { type: 'sfSymbol', name: 'book.closed' },
+            },
+          },
+        },
+        {
+          name: 'Other',
+          Component: PlaceholderTab,
+          options: {
+            title: 'Other',
+            ios: {
+              icon: { type: 'sfSymbol', name: 'square.grid.2x2' },
+            },
+          },
+        },
+      ]}
+      ios={{
+        tabBarMinimizeBehavior: 'onScrollDown',
+      }}
+    />
+  );
+}
+
+function JournalLikeScreen() {
+  const [activePage, setActivePage] = React.useState(0);
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Nested content with active marker</Text>
+        <View style={styles.controls}>
+          <PageButton
+            label="Day 1"
+            selected={activePage === 0}
+            onPress={() => setActivePage(0)}
+          />
+          <PageButton
+            label="Day 2"
+            selected={activePage === 1}
+            onPress={() => setActivePage(1)}
+          />
+        </View>
+      </View>
+
+      <View style={styles.pagerHost}>
+        <Page
+          active={activePage === 0}
+          label="Day 1"
+          accent={Colors.YellowLight100}
+        />
+        <Page
+          active={activePage === 1}
+          label="Day 2"
+          accent={Colors.GreenLight100}
+        />
+      </View>
+    </View>
+  );
+}
+
+function PlaceholderTab() {
+  return (
+    <ScrollView contentContainerStyle={styles.placeholderScrollContent}>
+      <Text style={styles.placeholderText}>Second tab placeholder</Text>
+      {Array.from({ length: 20 }, (_, index) => (
+        <Rectangle
+          key={index}
+          color={generateNextColor()}
+          width={'100%'}
+          height={88}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function Page(props: { active: boolean; label: string; accent: string }) {
+  const { active, label, accent } = props;
+
+  return (
+    <View
+      pointerEvents={active ? 'auto' : 'none'}
+      style={[
+        styles.pageContainer,
+        { opacity: active ? 1 : 0, zIndex: active ? 1 : 0 },
+      ]}>
+      <ScrollViewMarker active={active} style={styles.fillParent}>
+        <ScrollView
+          style={styles.fillParent}
+          contentContainerStyle={styles.scrollContent}>
+          <View style={[styles.pageIntro, { borderColor: accent }]}>
+            <Text style={styles.pageTitle}>{label}</Text>
+            <Text style={styles.pageSubtitle}>
+              Scroll this page after switching tabs. The tab bar should minimize
+              using the currently active marker.
+            </Text>
+          </View>
+          {Array.from({ length: ITEM_COUNT }, (_, index) => (
+            <Rectangle
+              key={`${label}-${index}`}
+              color={generateNextColor()}
+              width={'100%'}
+              height={96}
+            />
+          ))}
+        </ScrollView>
+      </ScrollViewMarker>
+    </View>
+  );
+}
+
+function PageButton(props: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const { label, onPress, selected } = props;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.button, selected ? styles.buttonSelected : undefined]}>
+      <Text style={styles.buttonText}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: Colors.White,
+  },
+  header: {
+    paddingTop: 16,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    gap: 12,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  controls: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  button: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    backgroundColor: '#E5E7EB',
+  },
+  buttonSelected: {
+    backgroundColor: '#CBD5E1',
+  },
+  buttonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  pagerHost: {
+    flex: 1,
+  },
+  pageContainer: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  fillParent: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+  },
+  scrollContent: {
+    padding: 16,
+    gap: 12,
+  },
+  pageIntro: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 2,
+    backgroundColor: '#F8FAFC',
+    gap: 6,
+  },
+  pageTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  pageSubtitle: {
+    fontSize: 14,
+    color: '#475569',
+  },
+  placeholderScrollContent: {
+    padding: 16,
+    gap: 12,
+  },
+  placeholderText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSScrollViewMarkerComponentView : RNSReactBaseView
 
+@property (nonatomic, readonly, getter=isActive) BOOL active;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
@@ -19,6 +19,7 @@ namespace react = facebook::react;
 
 @implementation RNSScrollViewMarkerComponentView {
   BOOL _hasAttemptedRegistration;
+  BOOL _isActive;
   BOOL _needsEdgeEffectUpdate;
 
   RNSScrollEdgeEffect _leftScrollEdgeEffect;
@@ -48,6 +49,7 @@ namespace react = facebook::react;
 {
   static const auto defaultProps = std::make_shared<const react::RNSScrollViewMarkerProps>();
   _props = defaultProps;
+  _isActive = NO;
   _leftScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
   _topScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
   _rightScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
@@ -109,6 +111,24 @@ namespace react = facebook::react;
   }
 
   [seekingAncestor registerDescendantScrollView:scrollView fromMarker:self];
+  [seekingAncestor updateDescendantScrollView:scrollView fromMarker:self isActive:self.isActive];
+}
+
+- (void)notifySeekingAncestorAboutActiveStateIfNeeded
+{
+  UIScrollView *scrollView = [self findScrollView];
+
+  if (scrollView == nil) {
+    return;
+  }
+
+  id<RNSScrollViewSeeking> seekingAncestor = [self findFirstSeekingAncestor];
+
+  if (seekingAncestor == nil) {
+    return;
+  }
+
+  [seekingAncestor updateDescendantScrollView:scrollView fromMarker:self isActive:self.isActive];
 }
 
 - (void)configureScrollView:(nullable UIScrollView *)scrollView
@@ -151,11 +171,22 @@ namespace react = facebook::react;
   [self maybeRegisterWithSeekingAncestor];
 }
 
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self registerWithSeekingAncestor];
+}
+
 #pragma mark - RNSScrollEdgeEffectProviding
 
 - (RNSScrollEdgeEffect)leftScrollEdgeEffect
 {
   return _leftScrollEdgeEffect;
+}
+
+- (BOOL)isActive
+{
+  return _isActive;
 }
 
 - (RNSScrollEdgeEffect)topScrollEdgeEffect
@@ -186,6 +217,11 @@ namespace react = facebook::react;
   if (oldComponentProps.leftScrollEdgeEffect != newComponentProps.leftScrollEdgeEffect) {
     _leftScrollEdgeEffect = RNSScrollEdgeEffectFromSVMLeftEdgeEffect(newComponentProps.leftScrollEdgeEffect);
     _needsEdgeEffectUpdate = true;
+  }
+
+  if (oldComponentProps.active != newComponentProps.active) {
+    _isActive = newComponentProps.active;
+    [self notifySeekingAncestorAboutActiveStateIfNeeded];
   }
 
   if (oldComponentProps.topScrollEdgeEffect != newComponentProps.topScrollEdgeEffect) {

--- a/ios/gamma/scroll-view-marker/RNSScrollViewSeeking.h
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewSeeking.h
@@ -12,4 +12,11 @@
 - (void)registerDescendantScrollView:(nonnull UIScrollView *)scrollView
                           fromMarker:(nonnull RNSScrollViewMarkerComponentView *)marker;
 
+/**
+ * Updates which of the registered marker-wrapped ScrollViews should be preferred by the seeking ancestor.
+ */
+- (void)updateDescendantScrollView:(nonnull UIScrollView *)scrollView
+                        fromMarker:(nonnull RNSScrollViewMarkerComponentView *)marker
+                          isActive:(BOOL)isActive;
+
 @end

--- a/ios/helpers/scroll-view/RNSScrollViewHelper.h
+++ b/ios/helpers/scroll-view/RNSScrollViewHelper.h
@@ -9,4 +9,9 @@
  */
 + (void)overrideScrollViewBehaviorInFirstDescendantChainFrom:(nullable UIView *)view;
 
+/**
+ * Overrides contentInsetAdjustmentBehavior for a specific ScrollView instance.
+ */
++ (void)overrideContentInsetAdjustmentBehaviorIfNeededForScrollView:(nullable UIScrollView *)scrollView;
+
 @end

--- a/ios/helpers/scroll-view/RNSScrollViewHelper.mm
+++ b/ios/helpers/scroll-view/RNSScrollViewHelper.mm
@@ -5,8 +5,12 @@
 
 + (void)overrideScrollViewBehaviorInFirstDescendantChainFrom:(nullable UIView *)view
 {
-  UIScrollView *scrollView = [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:view];
+  [self overrideContentInsetAdjustmentBehaviorIfNeededForScrollView:
+            [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:view]];
+}
 
++ (void)overrideContentInsetAdjustmentBehaviorIfNeededForScrollView:(nullable UIScrollView *)scrollView
+{
   if ([scrollView contentInsetAdjustmentBehavior] == UIScrollViewContentInsetAdjustmentNever) {
     [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentAutomatic];
   }

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -19,6 +19,13 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 @interface RNSTabBarController () <UINavigationControllerDelegate>
 @end
 
+static inline void RNSUpdateObservedContentScrollViewIfNeeded(UIViewController *_Nullable viewController)
+{
+  if ([viewController isKindOfClass:RNSTabsScreenViewController.class]) {
+    [(RNSTabsScreenViewController *)viewController updateTabBarObservedContentScrollViewIfNeeded];
+  }
+}
+
 @implementation RNSTabBarController {
   NSArray<RNSTabsScreenViewController *> *_Nullable _tabScreenControllers;
 
@@ -166,12 +173,12 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   [self progressNavigationState:screenKey];
 
   if (currSelectedViewController == nextSelectedViewController) {
-    [nextSelectedViewController updateTabBarObservedContentScrollViewIfNeeded];
+    RNSUpdateObservedContentScrollViewIfNeeded(nextSelectedViewController);
     return YES;
   }
 
   [self setSelectedViewController:nextSelectedViewController];
-  [nextSelectedViewController updateTabBarObservedContentScrollViewIfNeeded];
+  RNSUpdateObservedContentScrollViewIfNeeded(nextSelectedViewController);
   return YES;
 }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -166,10 +166,12 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   [self progressNavigationState:screenKey];
 
   if (currSelectedViewController == nextSelectedViewController) {
+    [nextSelectedViewController updateTabBarObservedContentScrollViewIfNeeded];
     return YES;
   }
 
   [self setSelectedViewController:nextSelectedViewController];
+  [nextSelectedViewController updateTabBarObservedContentScrollViewIfNeeded];
   return YES;
 }
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -2,10 +2,12 @@
 
 #import <React/RCTImageSource.h>
 #import "RNSEnums.h"
+#import "RNSContentScrollViewProviding.h"
 #import "RNSReactBaseView.h"
 #import "RNSSafeAreaProviding.h"
 #import "RNSScrollEdgeEffectApplicator.h"
 #import "RNSScrollViewBehaviorOverriding.h"
+#import "RNSScrollViewSeeking.h"
 #import "RNSTabsScreenEventEmitter.h"
 
 #if !RCT_NEW_ARCH_ENABLED
@@ -22,7 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
  * of a particular tab.
  */
 @interface RNSTabsScreenComponentView : RNSReactBaseView <
-                                            RNSSafeAreaProviding
+                                            RNSSafeAreaProviding,
+                                            RNSContentScrollViewProviding,
+                                            RNSScrollViewSeeking
 #if !RCT_NEW_ARCH_ENABLED
                                             ,
                                             RCTInvalidating
@@ -44,6 +48,8 @@ NS_ASSUME_NONNULL_BEGIN
  * on a content ScrollView inside the tab screen, if one exists. It uses ScrollViewFinder to find the ScrollView.
  */
 - (void)updateContentScrollViewEdgeEffectsIfExists;
+
+- (nullable UIScrollView *)findContentScrollView;
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -4,6 +4,7 @@
 #import "RNSDefines.h"
 #import "RNSLog.h"
 #import "RNSSafeAreaViewNotifications.h"
+#import "RNSScrollViewMarkerComponentView.h"
 #import "RNSScrollViewFinder.h"
 #import "RNSScrollViewHelper.h"
 #import "RNSTabBarAppearanceCoordinator.h"
@@ -29,6 +30,8 @@ namespace react = facebook::react;
   RNSTabsHostComponentView *__weak _Nullable _reactSuperview;
 
   RNSTabsScreenEventEmitter *_Nonnull _reactEventEmitter;
+  NSMapTable<RNSScrollViewMarkerComponentView *, UIScrollView *> *_registeredDescendantScrollViewsByMarker;
+  __weak UIScrollView *_activeRegisteredDescendantScrollView;
 
   // We need this information to warn users about dynamic changes to behavior being currently unsupported.
   BOOL _isOverrideScrollViewContentInsetAdjustmentBehaviorSet;
@@ -64,6 +67,8 @@ namespace react = facebook::react;
 
   _reactSuperview = nil;
   _reactEventEmitter = [RNSTabsScreenEventEmitter new];
+  _registeredDescendantScrollViewsByMarker = [NSMapTable weakToWeakObjectsMapTable];
+  _activeRegisteredDescendantScrollView = nil;
 
 #if !RCT_NEW_ARCH_ENABLED
   _tabItemNeedsAppearanceUpdate = NO;
@@ -159,14 +164,97 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)overrideScrollViewBehaviorInFirstDescendantChainIfNeeded
 {
   if ([self shouldOverrideScrollViewContentInsetAdjustmentBehavior]) {
-    [RNSScrollViewHelper overrideScrollViewBehaviorInFirstDescendantChainFrom:self];
+    [RNSScrollViewHelper overrideContentInsetAdjustmentBehaviorIfNeededForScrollView:[self findContentScrollView]];
   }
 }
 
 - (void)updateContentScrollViewEdgeEffectsIfExists
 {
-  [RNSScrollEdgeEffectApplicator applyToScrollView:[RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:self]
-                                      withProvider:self];
+  [RNSScrollEdgeEffectApplicator applyToScrollView:[self findContentScrollView] withProvider:self];
+}
+
+#pragma mark - RNSContentScrollViewProviding
+
+- (nullable UIScrollView *)findContentScrollView
+{
+  if (_activeRegisteredDescendantScrollView != nil && _activeRegisteredDescendantScrollView.window != nil) {
+    return _activeRegisteredDescendantScrollView;
+  }
+
+  UIScrollView *registeredDescendantScrollView = [self findMostVisibleRegisteredDescendantScrollView];
+  if (registeredDescendantScrollView != nil) {
+    return registeredDescendantScrollView;
+  }
+
+  UIView *firstSubview = self.subviews.firstObject;
+  UIScrollView *delegatedScrollView = [RNSScrollViewFinder findContentScrollViewWithDelegatingToProvider:firstSubview];
+  if (delegatedScrollView != nil) {
+    return delegatedScrollView;
+  }
+
+  return [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:self];
+}
+
+#pragma mark - RNSScrollViewSeeking
+
+- (void)registerDescendantScrollView:(nonnull UIScrollView *)scrollView
+                          fromMarker:(nonnull RNSScrollViewMarkerComponentView *)marker
+{
+  [_registeredDescendantScrollViewsByMarker setObject:scrollView forKey:marker];
+  if (marker.isActive) {
+    _activeRegisteredDescendantScrollView = scrollView;
+  }
+  [self updateObservedContentScrollViewIfNeeded];
+}
+
+- (void)updateDescendantScrollView:(nonnull UIScrollView *)scrollView
+                        fromMarker:(nonnull RNSScrollViewMarkerComponentView *)marker
+                          isActive:(BOOL)isActive
+{
+  UIScrollView *registeredScrollView = [_registeredDescendantScrollViewsByMarker objectForKey:marker];
+  UIScrollView *resolvedScrollView = registeredScrollView ?: scrollView;
+
+  if (isActive) {
+    _activeRegisteredDescendantScrollView = resolvedScrollView;
+  } else if (_activeRegisteredDescendantScrollView == resolvedScrollView) {
+    _activeRegisteredDescendantScrollView = nil;
+  }
+
+  [self updateObservedContentScrollViewIfNeeded];
+}
+
+#pragma mark - Private
+
+- (void)updateObservedContentScrollViewIfNeeded
+{
+  [_controller updateTabBarObservedContentScrollViewIfNeeded];
+}
+
+- (nullable UIScrollView *)findMostVisibleRegisteredDescendantScrollView
+{
+  NSArray<RNSScrollViewMarkerComponentView *> *markers = _registeredDescendantScrollViewsByMarker.keyEnumerator.allObjects;
+  UIScrollView *bestScrollView = nil;
+  CGFloat bestVisibilityScore = 0;
+
+  for (RNSScrollViewMarkerComponentView *marker in markers) {
+    UIScrollView *scrollView = [_registeredDescendantScrollViewsByMarker objectForKey:marker];
+    if (scrollView == nil || scrollView.window == nil) {
+      continue;
+    }
+
+    CGRect visibleRect = CGRectIntersection([scrollView convertRect:scrollView.bounds toView:self], self.bounds);
+    if (CGRectIsNull(visibleRect) || CGRectIsEmpty(visibleRect)) {
+      continue;
+    }
+
+    CGFloat visibilityScore = CGRectGetWidth(visibleRect) * CGRectGetHeight(visibleRect);
+    if (bestScrollView == nil || visibilityScore > bestVisibilityScore) {
+      bestScrollView = scrollView;
+      bestVisibilityScore = visibilityScore;
+    }
+  }
+
+  return bestScrollView;
 }
 
 #pragma mark - Prop update utils

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -37,6 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (bool)tabScreenSelectedRepeatedly;
 
 /**
+ * Updates the content ScrollView observed by UIKit for tab bar behavior.
+ */
+- (void)updateTabBarObservedContentScrollViewIfNeeded;
+
+/**
  * Set new special effects delegate.
  */
 - (void)setTabsSpecialEffectsDelegate:(nonnull id<RNSTabsSpecialEffectsSupporting>)delegate;

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -1,10 +1,11 @@
 #import "RNSTabsScreenViewController.h"
 #import "RNSLog.h"
-#import "RNSScrollViewFinder.h"
 #import "RNSTabBarController.h"
 #import "UIScrollView+RNScreens.h"
 
-@implementation RNSTabsScreenViewController
+@implementation RNSTabsScreenViewController {
+  __weak UIScrollView *_observedTabBarContentScrollView;
+}
 
 - (nullable NSString *)getScreenKeyOrNull
 {
@@ -39,6 +40,7 @@
 - (void)viewDidAppear:(BOOL)animated
 {
   [self.tabScreenComponentView.reactEventEmitter emitOnDidAppear];
+  [self updateTabBarObservedContentScrollViewIfNeeded];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -77,6 +79,7 @@
 
   [tabBarCtrl setNeedsUpdateOfTabBarAppearance:true];
   [tabBarCtrl updateTabBarAppearanceIfNeeded];
+  [self updateTabBarObservedContentScrollViewIfNeeded];
 }
 
 - (void)setTabsSpecialEffectsDelegate:(id<RNSTabsSpecialEffectsSupporting>)delegate
@@ -99,12 +102,26 @@
   if ([self tabsSpecialEffectsDelegate] != nil) {
     return [[self tabsSpecialEffectsDelegate] onRepeatedTabSelectionOfTabScreenController:self];
   } else if (self.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
-    UIScrollView *scrollView =
-        [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:[self tabScreenComponentView]];
+    UIScrollView *scrollView = [self.tabScreenComponentView findContentScrollView];
     return [scrollView rnscreens_scrollToTop];
   }
 
   return false;
+}
+
+- (void)updateTabBarObservedContentScrollViewIfNeeded
+{
+#if !TARGET_OS_TV && !TARGET_OS_VISION
+  if (@available(iOS 15.0, *)) {
+    UIScrollView *resolvedScrollView = [self.tabScreenComponentView findContentScrollView];
+    if (_observedTabBarContentScrollView == resolvedScrollView) {
+      return;
+    }
+
+    _observedTabBarContentScrollView = resolvedScrollView;
+    [self setContentScrollView:resolvedScrollView forEdge:NSDirectionalRectEdgeBottom];
+  }
+#endif // !TARGET_OS_TV && !TARGET_OS_VISION
 }
 
 #if !TARGET_OS_TV

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.tsx
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.tsx
@@ -3,10 +3,11 @@ import ScrollViewMarkerNativeComponent from '../../../fabric/gamma/ScrollViewMar
 import type { ScrollViewMarkerProps } from './ScrollViewMarker.types';
 
 export function ScrollViewMarker(props: ScrollViewMarkerProps) {
-  const { scrollEdgeEffects, ...rest } = props;
+  const { active, scrollEdgeEffects, ...rest } = props;
 
   return (
     <ScrollViewMarkerNativeComponent
+      active={active}
       leftScrollEdgeEffect={scrollEdgeEffects?.left}
       topScrollEdgeEffect={scrollEdgeEffects?.top}
       rightScrollEdgeEffect={scrollEdgeEffects?.right}

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
@@ -2,6 +2,7 @@ import type { ViewProps } from 'react-native';
 import type { ScrollEdgeEffect } from '../../shared/types';
 
 export interface ScrollViewMarkerProps {
+  active?: boolean;
   children: ViewProps['children'];
   style?: ViewProps['style'];
 

--- a/src/fabric/gamma/ScrollViewMarkerNativeComponent.ts
+++ b/src/fabric/gamma/ScrollViewMarkerNativeComponent.ts
@@ -6,6 +6,7 @@ import { codegenNativeComponent } from 'react-native';
 type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
 
 interface NativeProps extends ViewProps {
+  active?: CT.WithDefault<boolean, false>;
   leftScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;


### PR DESCRIPTION
## Summary

This extends `ScrollViewMarker` so Tabs can bind their content scroll view to an explicitly active nested descendant instead of relying only on first-descendant or visibility heuristics.

This is aimed at layouts where tab content is wrapped by non-scroll containers and multiple descendant `ScrollView`s stay mounted at once, for example paged day views. In those cases the tab bar can stay attached to the first registered scroll view, which breaks minimize behavior and repeated-selection scroll-to-top for the currently visible page.

## Changes

- add `active?: boolean` to `ScrollViewMarker`
- let `RNSScrollViewMarkerComponentView` notify seeking ancestors when active state changes
- teach `RNSTabsScreenComponentView` to track registered descendant scroll views by marker and prefer the active one in `findContentScrollView`
- use the resolved content scroll view for tab edge effects and content inset adjustment overrides
- call `setContentScrollView(_:forEdge:)` from `RNSTabsScreenViewController` so UIKit observes the resolved nested scroll view for the tab bar
- refresh the observed content scroll view when the selected tab controller updates
- add an iOS scenario that reproduces a nested, pager-like layout where multiple marked descendant scroll views remain mounted under a non-scroll wrapper
- add a no-op Android `active` setter to keep the prop surface aligned

## Context

This follows the direction discussed in software-mansion/react-native-screens#3463 and builds on the marker work from software-mansion/react-native-screens#3674.

## Validation

- `yarn check-types`
- manual downstream validation in a local Expo Router app using native tabs + nested paged scroll views: tab bar minimize behavior now follows the active page's vertical scroll view instead of staying attached to the first page
