### PR TITLE
fix(iOS, SplitView): Override the frame with HostView bounds in collapsed mode

### DIFF
--- a/ios/gamma/split/RNSSplitScreenController.swift
+++ b/ios/gamma/split/RNSSplitScreenController.swift
@@ -92,14 +92,42 @@ public class RNSSplitScreenController: UIViewController {
       return
     }
 
-    let ancestorView = findSplitHostController()?.view
-    assert(
-      ancestorView != nil,
-      "[RNScreens] Expected to find RNSSplitHost component for RNSSplitScreen component"
-    )
+    guard let splitHostController = findSplitHostController(),
+      let ancestorView = splitHostController.view
+    else {
+      assert(
+        false,
+        "[RNScreens] Expected to find RNSSplitHost component for RNSSplitScreen component"
+      )
+      return
+    }
+
+    var targetFrame = splitScreenComponentView.frame
+
+    /*
+     * When a UISplitViewController collapses into a single column, it hides columns and pushes
+     * them onto a UINavigationController stack. To optimize resources, UIKit
+     * does NOT update the frames of these off-screen views - they retain their old widths.
+     *
+     * When navigating back to a hidden column, UIKit performs the transition animation, but skips calling
+     * `setFrame:` on our actual component view, relying on AutoLayout to resize the content.
+     *
+     * However, Yoga is expecting absolute values. If we rely strictly on the component's current frame
+     * during this transition, Yoga will receive the stale width calculate the layout and break the UI.
+     *
+     * To fix this, if the SplitView is collapsed, we know the column must span the entire screen.
+     * We preemptively extract the host's bounds and send them as the target frame to the ShadowTree,
+     * ensuring the column renders at full width.
+     */
+    if splitHostController.isCollapsed {
+      targetFrame = ancestorView.bounds
+    }
 
     shadowStateProxy.updateShadowState(
-      ofComponent: splitScreenComponentView, inContextOfAncestorView: ancestorView)
+      ofComponent: splitScreenComponentView,
+      withFrame: targetFrame,
+      inContextOfAncestorView: ancestorView
+    )
   }
 
   ///

--- a/ios/gamma/split/RNSSplitScreenController.swift
+++ b/ios/gamma/split/RNSSplitScreenController.swift
@@ -95,14 +95,12 @@ public class RNSSplitScreenController: UIViewController {
     guard let splitHostController = findSplitHostController(),
       let ancestorView = splitHostController.view
     else {
-      assert(
-        false,
-        "[RNScreens] Expected to find RNSSplitHost component for RNSSplitScreen component"
-      )
+      assertionFailure(
+        "[RNScreens] Expected to find RNSSplitHost component for RNSSplitScreen component")
       return
     }
 
-    var targetFrame = splitScreenComponentView.frame
+    var targetFrame = splitScreenComponentView.bounds
 
     ///
     /// When a UISplitViewController collapses into a single column, it hides columns and pushes
@@ -113,14 +111,14 @@ public class RNSSplitScreenController: UIViewController {
     /// `setFrame:` on our actual component view, relying on AutoLayout to resize the content.
     ///
     /// However, Yoga is expecting absolute values. If we rely strictly on the component's current frame
-    /// during this transition, Yoga will receive the stale width calculate the layout and break the UI.
+    /// during this transition, Yoga will receive the stale width and then calculate the layout incorrectly, breaking the UI.
     ///
     /// To fix this, if the SplitView is collapsed, we know the column must span the entire screen.
     /// We preemptively extract the host's bounds and send them as the target frame to the ShadowTree,
     /// ensuring the column renders at full width.
     ///
     if splitHostController.isCollapsed {
-      targetFrame = ancestorView.bounds
+      targetFrame = ancestorView.convert(ancestorView.bounds, to: splitScreenComponentView)
     }
 
     shadowStateProxy.updateShadowState(

--- a/ios/gamma/split/RNSSplitScreenController.swift
+++ b/ios/gamma/split/RNSSplitScreenController.swift
@@ -104,21 +104,21 @@ public class RNSSplitScreenController: UIViewController {
 
     var targetFrame = splitScreenComponentView.frame
 
-    /*
-     * When a UISplitViewController collapses into a single column, it hides columns and pushes
-     * them onto a UINavigationController stack. To optimize resources, UIKit
-     * does NOT update the frames of these off-screen views - they retain their old widths.
-     *
-     * When navigating back to a hidden column, UIKit performs the transition animation, but skips calling
-     * `setFrame:` on our actual component view, relying on AutoLayout to resize the content.
-     *
-     * However, Yoga is expecting absolute values. If we rely strictly on the component's current frame
-     * during this transition, Yoga will receive the stale width calculate the layout and break the UI.
-     *
-     * To fix this, if the SplitView is collapsed, we know the column must span the entire screen.
-     * We preemptively extract the host's bounds and send them as the target frame to the ShadowTree,
-     * ensuring the column renders at full width.
-     */
+    ///
+    /// When a UISplitViewController collapses into a single column, it hides columns and pushes
+    /// them onto a UINavigationController stack. To optimize resources, UIKit
+    /// does NOT update the frames of these off-screen views - they retain their old widths.
+    ///
+    /// When navigating back to a hidden column, UIKit performs the transition animation, but skips calling
+    /// `setFrame:` on our actual component view, relying on AutoLayout to resize the content.
+    ///
+    /// However, Yoga is expecting absolute values. If we rely strictly on the component's current frame
+    /// during this transition, Yoga will receive the stale width calculate the layout and break the UI.
+    ///
+    /// To fix this, if the SplitView is collapsed, we know the column must span the entire screen.
+    /// We preemptively extract the host's bounds and send them as the target frame to the ShadowTree,
+    /// ensuring the column renders at full width.
+    ///
     if splitHostController.isCollapsed {
       targetFrame = ancestorView.bounds
     }


### PR DESCRIPTION
## Description

Navigating back to a supplementary column while the `UISplitViewController` was collapsed caused the column to render with an incorrect frame. When a `UISplitViewController` is collapsed, it pushes its columns onto a single `UINavigationController` stack, but `UIKit` does not update the frame of off-screen views immediately. Therefore, a hidden supplementary column retains its old width.
If the SplitView is currently collapsed, we know the column must eventually span the entire screen. We extract the Host's bounds and pass them as the target frame directly to the `ShadowStateProxy`.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1089

## Changes

- assigning Host's frame in collapsed mode on ShadowState update

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/00b32d45-180a-447a-bc47-5af04707957e" /> | <video src="https://github.com/user-attachments/assets/e19ffeed-1b66-4e8d-99b2-b8f473250939" /> |

## Test plan

No need to have a dedicated test, reproducible on any existing.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
