### PR TITLE
fix(iOS, Tabs): fix diverging behavior of JS updates requesting `moreNavigationController` on various Apple platforms

### DIFF
--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -605,11 +605,11 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 }
 
 /**
- * This method allows get the `moreNavigationController` instance under a couple of conditions.
+ * This method allows getting the `moreNavigationController` instance under a couple of conditions.
  *
  * First, it verifies whether we are on an appropriate platform, where the `moreNavigationController`
  * is available.
- * Second, it verifies whether the moreNavigationController can be even visible right now.
+ * Second, it verifies whether the `moreNavigationController` can even be in the interface right now.
  */
 - (nullable UINavigationController *)resolveMoreNavigationController
 {


### PR DESCRIPTION

Fix-up `moreNavigationController` handling on platforms where it is not available
I've introduced a bug in [#3785](https://github.com/software-mansion/react-native-screens/pull/3785/changes#diff-24866ece8ac586353673ecc0296de6ac8be5c1df28f12039774c9580bd5750d3).
If the code runs on a platform where `moreNavigationController` is not available,
the whole code for handling update requesting the
`moreNavigationController` won't execute - the update will not be rejected
as on other platforms, but rather the asserts will crash (in debug).
