### PR TITLE
feat(ios): add `largeTitleDisplayMode` prop to native stack header

### DIFF
--- a/ios/RNSConvert.h
+++ b/ios/RNSConvert.h
@@ -20,6 +20,9 @@ namespace react = facebook::react;
 + (UINavigationItemBackButtonDisplayMode)UINavigationItemBackButtonDisplayModeFromCppEquivalent:
     (react::RNSScreenStackHeaderConfigBackButtonDisplayMode)backButtonDisplayMode;
 
++ (RNSLargeTitleDisplayMode)RNSLargeTitleDisplayModeFromCppEquivalent:
+    (react::RNSScreenStackHeaderConfigLargeTitleDisplayMode)largeTitleDisplayMode;
+
 + (RNSOptionalBoolean)RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
     (react::RNSScreenFullScreenSwipeEnabled)fullScreenSwipeEnabled;
 

--- a/ios/RNSConvert.mm
+++ b/ios/RNSConvert.mm
@@ -36,6 +36,25 @@
   }
 }
 
++ (RNSLargeTitleDisplayMode)RNSLargeTitleDisplayModeFromCppEquivalent:
+    (react::RNSScreenStackHeaderConfigLargeTitleDisplayMode)largeTitleDisplayMode
+{
+  switch (largeTitleDisplayMode) {
+    using enum react::RNSScreenStackHeaderConfigLargeTitleDisplayMode;
+
+    case None:
+      return RNSLargeTitleDisplayModeNone;
+    case Automatic:
+      return RNSLargeTitleDisplayModeAutomatic;
+    case Always:
+      return RNSLargeTitleDisplayModeAlways;
+    case Never:
+      return RNSLargeTitleDisplayModeNever;
+    case InlineLarge:
+      return RNSLargeTitleDisplayModeInlineLarge;
+  }
+}
+
 + (RNSOptionalBoolean)RNSOptionalBooleanFromRNSFullScreenSwipeEnabledCppEquivalent:
     (react::RNSScreenFullScreenSwipeEnabled)fullScreenSwipeEnabled
 {

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -185,6 +185,19 @@ typedef NS_ENUM(NSInteger, RNSOptionalBoolean) {
   RNSOptionalBooleanFalse
 };
 
+typedef NS_ENUM(NSInteger, RNSLargeTitleDisplayMode) {
+  /// Falls back to the `largeTitle` boolean prop behaviour.
+  RNSLargeTitleDisplayModeNone,
+  /// Inherits the display mode from the navigation controller.
+  RNSLargeTitleDisplayModeAutomatic,
+  /// Always displays a large title.
+  RNSLargeTitleDisplayModeAlways,
+  /// Never displays a large title.
+  RNSLargeTitleDisplayModeNever,
+  /// Displays a large title in an inline (compact) position. Requires iOS 17+.
+  RNSLargeTitleDisplayModeInlineLarge,
+};
+
 typedef NS_ENUM(NSInteger, RNSTabsBottomAccessoryEnvironment) {
   RNSTabsBottomAccessoryEnvironmentRegular,
   RNSTabsBottomAccessoryEnvironmentInline

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, retain) UIColor *backgroundColor;
 @property (nonatomic, retain) UIColor *color;
 @property (nonatomic) BOOL largeTitle;
+@property (nonatomic) RNSLargeTitleDisplayMode largeTitleDisplayMode;
 @property (nonatomic, retain) NSString *largeTitleFontFamily;
 @property (nonatomic, retain) NSNumber *largeTitleFontSize;
 @property (nonatomic, retain) NSString *largeTitleFontWeight;
@@ -174,5 +175,6 @@ NS_ASSUME_NONNULL_END
 
 + (UISemanticContentAttribute)UISemanticContentAttribute:(nonnull id)json;
 + (UINavigationItemBackButtonDisplayMode)UINavigationItemBackButtonDisplayMode:(nonnull id)json;
++ (RNSLargeTitleDisplayMode)RNSLargeTitleDisplayMode:(nonnull id)json;
 
 @end

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -588,11 +588,41 @@ RNS_IGNORE_SUPER_CALL_END
 #if !TARGET_OS_TV
   [config configureBackItem:prevItem withPrevVC:prevVC];
 
-  if (config.largeTitle) {
-    navctr.navigationBar.prefersLargeTitles = YES;
+  if (config.largeTitleDisplayMode == RNSLargeTitleDisplayModeNone) {
+    // Legacy behaviour: driven by the boolean `largeTitle` prop.
+    if (config.largeTitle) {
+      navctr.navigationBar.prefersLargeTitles = YES;
+    }
+    navitem.largeTitleDisplayMode =
+        config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
+  } else {
+    // Explicit display-mode requested.
+    UINavigationItemLargeTitleDisplayMode displayMode;
+    switch (config.largeTitleDisplayMode) {
+      case RNSLargeTitleDisplayModeAutomatic:
+        displayMode = UINavigationItemLargeTitleDisplayModeAutomatic;
+        break;
+      case RNSLargeTitleDisplayModeAlways:
+        navctr.navigationBar.prefersLargeTitles = YES;
+        displayMode = UINavigationItemLargeTitleDisplayModeAlways;
+        break;
+      case RNSLargeTitleDisplayModeNever:
+        displayMode = UINavigationItemLargeTitleDisplayModeNever;
+        break;
+      case RNSLargeTitleDisplayModeInlineLarge:
+        navctr.navigationBar.prefersLargeTitles = YES;
+        if (@available(iOS 17.0, *)) {
+          displayMode = UINavigationItemLargeTitleDisplayModeInlineLarge;
+        } else {
+          displayMode = UINavigationItemLargeTitleDisplayModeAlways;
+        }
+        break;
+      default:
+        displayMode = UINavigationItemLargeTitleDisplayModeNever;
+        break;
+    }
+    navitem.largeTitleDisplayMode = displayMode;
   }
-  navitem.largeTitleDisplayMode =
-      config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
 #endif
 
   UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
@@ -1127,6 +1157,8 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
   _hideShadow = newScreenProps.hideShadow;
 
   _largeTitle = newScreenProps.largeTitle;
+  _largeTitleDisplayMode =
+      [RNSConvert RNSLargeTitleDisplayModeFromCppEquivalent:newScreenProps.largeTitleDisplayMode];
   if (newScreenProps.largeTitleFontFamily != oldScreenProps.largeTitleFontFamily) {
     _largeTitleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.largeTitleFontFamily);
   }
@@ -1286,6 +1318,7 @@ RCT_EXPORT_VIEW_PROPERTY(blurEffect, RNSBlurEffectStyle)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(direction, UISemanticContentAttribute)
 RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleDisplayMode, RNSLargeTitleDisplayMode)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleFontWeight, NSString)
@@ -1366,6 +1399,18 @@ RCT_ENUM_CONVERTER(
       @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
     }),
     UINavigationItemBackButtonDisplayModeDefault,
+    integerValue)
+
+RCT_ENUM_CONVERTER(
+    RNSLargeTitleDisplayMode,
+    (@{
+      @"none" : @(RNSLargeTitleDisplayModeNone),
+      @"automatic" : @(RNSLargeTitleDisplayModeAutomatic),
+      @"always" : @(RNSLargeTitleDisplayModeAlways),
+      @"never" : @(RNSLargeTitleDisplayModeNever),
+      @"inlineLarge" : @(RNSLargeTitleDisplayModeInlineLarge),
+    }),
+    RNSLargeTitleDisplayModeNone,
     integerValue)
 
 @end

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -15,6 +15,8 @@ type OnPressHeaderBarButtonMenuItemEvent = Readonly<{ menuId: string }>;
 
 type BackButtonDisplayMode = 'minimal' | 'default' | 'generic';
 
+type LargeTitleDisplayMode = 'none' | 'automatic' | 'always' | 'never' | 'inlineLarge';
+
 type BlurEffect =
   | 'none'
   | 'extraLight'
@@ -53,6 +55,7 @@ export interface NativeProps extends ViewProps {
   hidden?: boolean;
   hideShadow?: boolean;
   largeTitle?: boolean;
+  largeTitleDisplayMode?: CT.WithDefault<LargeTitleDisplayMode, 'none'>;
   largeTitleFontFamily?: string;
   largeTitleFontSize?: CT.Int32;
   largeTitleFontWeight?: string;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -26,6 +26,7 @@ export type SearchBarCommands = {
 };
 
 export type BackButtonDisplayMode = 'default' | 'generic' | 'minimal';
+export type LargeTitleDisplayMode = 'none' | 'automatic' | 'always' | 'never' | 'inlineLarge';
 export type StackPresentationTypes =
   | 'push'
   | 'modal'
@@ -761,6 +762,19 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
    * Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
    */
   largeTitleHideShadow?: boolean;
+  /**
+   * Controls how the navigation title is displayed. When set to a value other than `none`,
+   * this prop takes precedence over the `largeTitle` boolean prop.
+   *
+   * - `none` (default) — falls back to the `largeTitle` prop behaviour.
+   * - `automatic` — inherits the display mode from the navigation controller.
+   * - `always` — always displays a large title.
+   * - `never` — never displays a large title.
+   * - `inlineLarge` — displays a large title in an inline (compact) position (requires iOS 17+).
+   *
+   * @platform ios
+   */
+  largeTitleDisplayMode?: LargeTitleDisplayMode;
   /**
    * Callback which is executed when screen header is attached
    */


### PR DESCRIPTION
## Description

Exposes iOS's `UINavigationItemLargeTitleDisplayMode` to React Native via a new `largeTitleDisplayMode` prop on `ScreenStackHeaderConfig`. Previously, only a boolean `largeTitle` prop was available, mapping to `Always`/`Never`. This change provides granular control, including support for the iOS 17+ `inlineLarge` mode.

## Changes

- New `LargeTitleDisplayMode` type: `'none' | 'automatic' | 'always' | 'never' | 'inlineLarge'`
- `ScreenStackHeaderConfigProps` (`src/types.tsx`) — new optional `largeTitleDisplayMode` prop (iOS only)
- Fabric codegen (`ScreenStackHeaderConfigNativeComponent.ts`) — prop added with default `'none'`
- `RNSLargeTitleDisplayMode` enum (`RNSEnums.h`) — native enum with `None/Automatic/Always/Never/InlineLarge`
- Conversion layer — `RNSConvert` method for Fabric (C++ → ObjC); `RCTConvert` enum converter + `RCT_EXPORT_VIEW_PROPERTY` for Paper
- `updateViewController:withConfig:animated:` — `'none'` delegates to the existing `largeTitle` bool (fully backward-compatible); `inlineLarge` requires iOS 17+ with fallback to `Always` on older versions

## Test plan
```tsx
<ScreenStackHeaderConfig
  title="Settings"
  largeTitleDisplayMode="inlineLarge" // large title, compact inline layout (iOS 17+)
/>
```

`largeTitleDisplayMode` takes precedence over `largeTitle` when set to any value other than `'none'`.

Steps to reproduce / verify:
1. Set `largeTitleDisplayMode="automatic"` / `"always"` / `"never"` and confirm behavior matches `UINavigationItemLargeTitleDisplayMode`.
2. Set `largeTitleDisplayMode="inlineLarge"` on iOS 17+ and verify compact inline large title renders correctly.
3. Set `largeTitleDisplayMode="inlineLarge"` on iOS < 17 and confirm fallback to `Always`.
4. Leave `largeTitleDisplayMode` unset and confirm existing `largeTitle` prop behavior is unchanged.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes