### PR TITLE
chore: exclude AI agent config files from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,8 @@ android/.settings
 # e2e
 *Example/artifacts
 
-# not-yet-mature AI setup
-CLAUDE.md
-AGENTS.md
-.claude/
+# AI assistant configuration (local only)
+/CLAUDE.md
+/AGENTS.md
+/.claude/
 


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for `CLAUDE.md`, `AGENTS.md`, and `.claude/` directory
- These files are used for local AI assistant configuration and should not be committed to the repository

We don't have a mature setup yet. I will experiment a lot in upcoming
weeks and don't want to have that in the VCS yet.

We might consider checking these files in once we have some already
working & tested setup. For now, I believe we'll be better with everyone
using their own.

## Test plan
- [x] Verify `.gitignore` correctly excludes the listed files
- No functional code changes — no additional testing needed
