### PR TITLE
fix(Example): fix Test3492 after changes to TabsContainer

### DIFF
--- a/apps/src/tests/issue-tests/Test3492.tsx
+++ b/apps/src/tests/issue-tests/Test3492.tsx
@@ -2,7 +2,7 @@ import React, {
   createContext,
   useContext,
   useState,
-  useMemo,
+  useEffect,
   type Dispatch,
   type SetStateAction,
 } from 'react';
@@ -18,6 +18,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import {
   TabsContainer,
   type TabRouteConfig,
+  useTabsNavigationContext,
 } from '../../shared/gamma/containers/tabs';
 import Colors from '../../shared/styling/Colors';
 import ConfigWrapperContext, {
@@ -449,64 +450,101 @@ function ConfigScreen() {
 }
 
 function ScreenTab2() {
+  const { config } = useBackgroundTestContext();
+  const { setRouteOptions } = useTabsNavigationContext();
+
+  useEffect(() => {
+    setRouteOptions('Tab2', {
+      style: { backgroundColor: config.tabs.Tab2.navBackground },
+    });
+  }, [config.tabs.Tab2.navBackground, setRouteOptions]);
+
   return <TestScreenRenderer screenKey="Tab2" />;
 }
 function ScreenTab3() {
+  const { config } = useBackgroundTestContext();
+  const { setRouteOptions } = useTabsNavigationContext();
+
+  useEffect(() => {
+    setRouteOptions('Tab3', {
+      style: { backgroundColor: config.tabs.Tab3.navBackground },
+    });
+  }, [config.tabs.Tab3.navBackground, setRouteOptions]);
+
   return <TestScreenRenderer screenKey="Tab3" />;
 }
 function ScreenTab4() {
+  const { config } = useBackgroundTestContext();
+  const { setRouteOptions } = useTabsNavigationContext();
+
+  useEffect(() => {
+    setRouteOptions('Tab4', {
+      style: { backgroundColor: config.tabs.Tab4.navBackground },
+    });
+  }, [config.tabs.Tab4.navBackground, setRouteOptions]);
+
   return <TestScreenRenderer screenKey="Tab4" />;
 }
+
+const ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'Tab1',
+    Component: ConfigScreen,
+    options: {
+      title: 'Config',
+      ios: {
+        icon: {
+          type: 'sfSymbol',
+          name: 'gear',
+        },
+      },
+      style: { backgroundColor: Colors.White },
+    },
+  },
+  {
+    name: 'Tab2',
+    Component: ScreenTab2,
+    options: {
+      title: 'Tab 2',
+      ios: {
+        icon: {
+          type: 'sfSymbol',
+          name: 'square',
+        },
+      },
+      style: { backgroundColor: INITIAL_CONFIG.tabs.Tab2.navBackground },
+    },
+  },
+  {
+    name: 'Tab3',
+    Component: ScreenTab3,
+    options: {
+      title: 'Tab 3',
+      ios: { icon: { type: 'sfSymbol', name: 'triangle' } },
+      style: { backgroundColor: INITIAL_CONFIG.tabs.Tab3.navBackground },
+    },
+  },
+  {
+    name: 'Tab4',
+    Component: ScreenTab4,
+    options: {
+      title: 'Tab 4',
+      ios: {
+        icon: {
+          type: 'sfSymbol',
+          name: 'circle',
+        },
+      },
+      style: { backgroundColor: INITIAL_CONFIG.tabs.Tab4.navBackground },
+    },
+  },
+];
 
 function Tabs() {
   const [tabsConfig, setTabsConfig] = React.useState<Configuration>(
     DEFAULT_GLOBAL_CONFIGURATION,
   );
   const { config } = useBackgroundTestContext();
-
-  const dynamicRouteConfigs = useMemo<TabRouteConfig[]>(
-    () => [
-      {
-        name: 'Tab1',
-        Component: ConfigScreen,
-        options: {
-          title: 'Config',
-          icon: {
-            ios: { type: 'sfSymbol', name: 'gear' },
-          },
-          style: { backgroundColor: Colors.White },
-        },
-      },
-      {
-        name: 'Tab2',
-        Component: ScreenTab2,
-        options: {
-          title: 'Tab 2',
-          icon: { ios: { type: 'sfSymbol', name: 'square' } },
-          style: { backgroundColor: config.tabs.Tab2.navBackground },
-        },
-      },
-      {
-        name: 'Tab3',
-        Component: ScreenTab3,
-        options: {
-          title: 'Tab 3',
-          icon: { ios: { type: 'sfSymbol', name: 'triangle' } },
-          style: { backgroundColor: config.tabs.Tab3.navBackground },
-        },
-      },
-      {
-        name: 'Tab4',
-        Component: ScreenTab4,
-        options: {
-          title: 'Tab 4',
-          icon: { ios: { type: 'sfSymbol', name: 'circle' } },
-          style: { backgroundColor: config.tabs.Tab4.navBackground },
-        },
-      },
-    ],
-    [config],
-  );
 
   return (
     <ConfigWrapperContext.Provider
@@ -515,7 +553,7 @@ function Tabs() {
         setConfig: setTabsConfig,
       }}>
       <TabsContainer
-        routeConfigs={dynamicRouteConfigs}
+        routeConfigs={ROUTE_CONFIGS}
         nativeContainerStyle={{ backgroundColor: config.containerBackground }}
       />
     </ConfigWrapperContext.Provider>


### PR DESCRIPTION
## Description

Fixes `Test3492` after recent changes to `TabsContainer`.

## Changes

- use `setRouteOptions` to change tab screen background in runtime
- update API to set icon (`ios: { icon: {}}` instead of `icon: { ios: {}}`)

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/0e10eaa2-55f9-4d8a-9e07-379ba47ad98d" /> | <video src="https://github.com/user-attachments/assets/fe9543d0-2c45-4d01-889d-f0976facb6d0" /> |

## Test plan

Run `Test3492`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
