### PR TITLE
fix(ios): guard +load with #ifdef RCT_DYNAMIC_FRAMEWORKS

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -71,14 +71,6 @@
   RCTSurfaceTouchHandler *_touchHandler;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -228,6 +220,16 @@ RNS_IGNORE_SUPER_CALL_END
 
   [super updateProps:props oldProps:oldProps];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -77,7 +77,7 @@
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)init
 {

--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -72,10 +72,12 @@
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)init
 {

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -33,7 +33,7 @@
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -28,10 +28,12 @@
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/RNSModalScreen.mm
+++ b/ios/RNSModalScreen.mm
@@ -27,6 +27,13 @@
                   }];
 }
 
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return react::concreteComponentDescriptorProvider<react::RNSModalScreenComponentDescriptor>();
+}
+
+#pragma mark - Dynamic frameworks support
+
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
 #ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
@@ -34,11 +41,6 @@
   [super load];
 }
 #endif // RCT_DYNAMIC_FRAMEWORKS
-
-+ (react::ComponentDescriptorProvider)componentDescriptorProvider
-{
-  return react::concreteComponentDescriptorProvider<react::RNSModalScreenComponentDescriptor>();
-}
 
 @end
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -67,14 +67,6 @@ struct ContentWrapperBox {
   NSMutableArray<UIView *> *_reactSubviews;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -1433,6 +1425,16 @@ RNS_IGNORE_SUPER_CALL_END
   }
 #endif // !TARGET_OS_TV && !TARGET_OS_VISION
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -73,7 +73,7 @@ struct ContentWrapperBox {
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -68,10 +68,12 @@ struct ContentWrapperBox {
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -251,10 +251,12 @@ RNS_IGNORE_SUPER_CALL_END
 #pragma mark-- Fabric specific
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -256,7 +256,7 @@ RNS_IGNORE_SUPER_CALL_END
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -250,14 +250,6 @@ RNS_IGNORE_SUPER_CALL_END
 
 #pragma mark-- Fabric specific
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 #pragma mark - RCTComponentViewProtocol
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
@@ -318,6 +310,17 @@ RNS_IGNORE_SUPER_CALL_END
   [_controller willMoveToParentViewController:nil];
   [_controller removeFromParentViewController];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 @end
 
 Class<RCTComponentViewProtocol> RNSScreenContainerCls(void)

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -183,6 +183,8 @@ Class<RCTComponentViewProtocol> RNSScreenContentWrapperCls(void)
   return RNSScreenContentWrapper.class;
 }
 
+#pragma mark - Dynamic frameworks support
+
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
 #ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -184,10 +184,12 @@ Class<RCTComponentViewProtocol> RNSScreenContentWrapperCls(void)
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -91,10 +91,12 @@
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -90,14 +90,6 @@
   //  }
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSScreenFooterComponentDescriptor>();
@@ -107,6 +99,16 @@ Class<RCTComponentViewProtocol> RNSScreenFooterCls(void)
 {
   return RNSScreenFooter.class;
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -96,7 +96,7 @@
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -42,6 +42,8 @@ namespace react = facebook::react;
   return react::concreteComponentDescriptorProvider<react::RNSScreenNavigationContainerComponentDescriptor>();
 }
 
+#pragma mark - Dynamic frameworks support
+
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
 #ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -43,10 +43,12 @@ namespace react = facebook::react;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 @end
 

--- a/ios/RNSScreenNavigationContainer.mm
+++ b/ios/RNSScreenNavigationContainer.mm
@@ -48,7 +48,7 @@ namespace react = facebook::react;
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -181,14 +181,6 @@ namespace react = facebook::react;
   UIPanGestureRecognizer *_sinkEventsPanGestureRecognizer;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -1435,6 +1427,16 @@ RNS_IGNORE_SUPER_CALL_END
 {
   return react::concreteComponentDescriptorProvider<react::RNSScreenStackComponentDescriptor>();
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -182,10 +182,12 @@ namespace react = facebook::react;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -187,7 +187,7 @@ namespace react = facebook::react;
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -68,7 +68,7 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -62,14 +62,6 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   RCTImageLoader *_imageLoader;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -1114,6 +1106,16 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
     _imageLoader = react::unwrapManagedObject(imgLoaderPtr);
   }
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -63,10 +63,12 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -110,14 +110,6 @@ namespace react = facebook::react;
   [self updateShadowStateInContextOfAncestorView:[self findNavigationBar]];
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -300,6 +292,16 @@ RNS_IGNORE_SUPER_CALL_END
   _hidesSharedBackground = hidesSharedBackground;
   [self configureBarButtonItem];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -111,10 +111,12 @@ namespace react = facebook::react;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -116,7 +116,7 @@ namespace react = facebook::react;
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -50,7 +50,7 @@ namespace react = facebook::react;
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)init
 {

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -45,10 +45,12 @@ namespace react = facebook::react;
 #ifdef RCT_NEW_ARCH_ENABLED
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)init
 {

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -44,14 +44,6 @@ namespace react = facebook::react;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -468,6 +460,16 @@ namespace react = facebook::react;
 
 #else
 #endif // RCT_NEW_ARCH_ENABLED
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
@@ -241,6 +241,14 @@ namespace react = facebook::react;
   return NO;
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSScrollViewMarkerComponentDescriptor>();

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
@@ -241,14 +241,6 @@ namespace react = facebook::react;
   return NO;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSScrollViewMarkerComponentDescriptor>();
@@ -261,6 +253,16 @@ namespace react = facebook::react;
 {
   [self maybeRegisterWithSeekingAncestor];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -191,14 +191,6 @@ RNS_IGNORE_SUPER_CALL_END
   _hasModifiedReactSubviewsInCurrentTransaction = true;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSSplitHostComponentDescriptor>();
@@ -422,6 +414,16 @@ RNS_IGNORE_SUPER_CALL_END
   RCTAssert(_reactEventEmitter != nil, @"[RNScreens] Attempt to access uninitialized _reactEventEmitter");
   return _reactEventEmitter;
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -191,6 +191,14 @@ RNS_IGNORE_SUPER_CALL_END
   _hasModifiedReactSubviewsInCurrentTransaction = true;
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSSplitHostComponentDescriptor>();

--- a/ios/gamma/split/RNSSplitScreenComponentView.mm
+++ b/ios/gamma/split/RNSSplitScreenComponentView.mm
@@ -149,14 +149,6 @@ namespace react = facebook::react;
 
 #pragma mark - RCTComponentViewProtocol
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSSplitScreenComponentDescriptor>();
@@ -203,6 +195,16 @@ namespace react = facebook::react;
   // when we want to destroy the component.
   _controller = nil;
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/gamma/split/RNSSplitScreenComponentView.mm
+++ b/ios/gamma/split/RNSSplitScreenComponentView.mm
@@ -149,6 +149,14 @@ namespace react = facebook::react;
 
 #pragma mark - RCTComponentViewProtocol
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSSplitScreenComponentDescriptor>();

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -156,6 +156,16 @@ namespace react = facebook::react;
                                            withRenderedScreens:_renderedScreens];
 }
 
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 @end
 
 Class<RCTComponentViewProtocol> RNSStackHostCls(void)

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -122,14 +122,6 @@ namespace react = facebook::react;
       updateEventEmitter:std::static_pointer_cast<const react::RNSStackScreenEventEmitter>(eventEmitter)];
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSStackScreenComponentDescriptor>();
@@ -146,6 +138,16 @@ namespace react = facebook::react;
 {
   [self invalidateImpl];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -122,6 +122,14 @@ namespace react = facebook::react;
       updateEventEmitter:std::static_pointer_cast<const react::RNSStackScreenEventEmitter>(eventEmitter)];
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSStackScreenComponentDescriptor>();

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -26,10 +26,12 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -25,14 +25,6 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
   __weak UIView<RNSSafeAreaProviding> *_Nullable _providerView;
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -154,6 +146,16 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
   _providerView = nil;
   _currentSafeAreaInsets = UIEdgeInsetsZero;
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -31,7 +31,7 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 {
   [super load];
 }
-#endif
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
@@ -101,6 +101,14 @@ namespace react = facebook::react;
   [_reactEventEmitter updateEventEmitter:castedEventEmitter];
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsBottomAccessoryComponentDescriptor>();

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
@@ -101,14 +101,6 @@ namespace react = facebook::react;
   [_reactEventEmitter updateEventEmitter:castedEventEmitter];
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsBottomAccessoryComponentDescriptor>();
@@ -181,6 +173,16 @@ namespace react = facebook::react;
 }
 
 #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
@@ -93,14 +93,6 @@ namespace react = facebook::react;
 
 #endif // REACT_NATIVE_VERSION_MINOR >= 82
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsBottomAccessoryContentComponentDescriptor>();
@@ -116,6 +108,16 @@ namespace react = facebook::react;
 }
 
 #endif // RCT_NEW_ARCH_ENABLED
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
@@ -93,6 +93,14 @@ namespace react = facebook::react;
 
 #endif // REACT_NATIVE_VERSION_MINOR >= 82
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsBottomAccessoryContentComponentDescriptor>();

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -381,14 +381,6 @@ namespace react = facebook::react;
   [super finalizeUpdates:updateMask];
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsHostComponentDescriptor>();
@@ -664,6 +656,16 @@ RNS_IGNORE_SUPER_CALL_END
                                                     .currentNavState = currentNavState,
   }];
 }
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -381,6 +381,14 @@ namespace react = facebook::react;
   [super finalizeUpdates:updateMask];
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsHostComponentDescriptor>();

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -482,14 +482,6 @@ RNS_IGNORE_SUPER_CALL_END
   [super unmountChildComponentView:childComponentView index:index];
 }
 
-// Needed because of this: https://github.com/facebook/react-native/pull/37274
-#ifdef RCT_DYNAMIC_FRAMEWORKS
-+ (void)load
-{
-  [super load];
-}
-#endif // RCT_DYNAMIC_FRAMEWORKS
-
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsScreenIOSComponentDescriptor>();
@@ -758,6 +750,16 @@ RNS_FAILING_EVENT_GETTER(onDidDisappear);
 #undef RNS_FAILING_EVENT_GETTER
 
 #endif // RCT_NEW_ARCH_ENABLED
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -482,6 +482,14 @@ RNS_IGNORE_SUPER_CALL_END
   [super unmountChildComponentView:childComponentView index:index];
 }
 
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
   return react::concreteComponentDescriptorProvider<react::RNSTabsScreenIOSComponentDescriptor>();


### PR DESCRIPTION
## Summary

12 ComponentView files had unconditional `+load { [super load]; }` methods, but their parent `RCTViewComponentView` correctly guards its `+load` behind `#ifdef RCT_DYNAMIC_FRAMEWORKS`.

Without the guard, these `+load` methods run even when dynamic frameworks are not used, causing conflicts with third-party SDKs (e.g. Akamai BMP) that also use `+load` — particularly on x86_64 simulators where the load order differs from arm64.

This matches the pattern used by React Native core in `RCTViewComponentView.mm` (see facebook/react-native#37274).

**Note:** `UIViewController+RNScreens.mm` is intentionally NOT changed as its `+load` performs method swizzling that is functionally required.

### Changes

1. **Guarded existing `+load` methods** — wrapped 12 existing unconditional `+load` calls with `#ifdef RCT_DYNAMIC_FRAMEWORKS`.
2. **Added missing guarded `+load` methods** — 9 additional ComponentView files (gamma, tabs) were missing `+load` entirely, which would break component registration when using dynamic frameworks. Added guarded `+load` to these files.
3. **Relocated `+load` to end of `@implementation`** — moved all `+load` methods to a dedicated `#pragma mark - Dynamic frameworks support` section just before `@end` for consistency and readability.
4. **Normalized `#endif` comments** — ensured all `#endif` directives have consistent trailing comments (e.g. `#endif // RCT_DYNAMIC_FRAMEWORKS`).

### Affected files

**Existing `+load` guarded (12 files):**
- `RNSScreen.mm`
- `RNSScreenStack.mm`
- `RNSScreenContainer.mm`
- `RNSScreenNavigationContainer.mm`
- `RNSModalScreen.mm`
- `RNSFullWindowOverlay.mm`
- `RNSScreenFooter.mm`
- `RNSSafeAreaViewComponentView.mm`
- `RNSSearchBar.mm`
- `RNSScreenContentWrapper.mm`
- `RNSScreenStackHeaderConfig.mm`
- `RNSScreenStackHeaderSubview.mm`

**New guarded `+load` added (9 files):**
- `RNSScrollViewMarkerComponentView.mm`
- `RNSSplitHostComponentView.mm`
- `RNSSplitScreenComponentView.mm`
- `RNSStackHostComponentView.mm`
- `RNSStackScreenComponentView.mm`
- `RNSTabsHostComponentView.mm`
- `RNSTabsScreenComponentView.mm`
- `RNSTabsBottomAccessoryComponentView.mm`
- `RNSTabsBottomAccessoryContentComponentView.mm`

## Test plan

- Build xcframework with static linking (no `USE_FRAMEWORKS=dynamic`)
- Verify ComponentView `+load` methods are not in the binary (`nm` check)
- Run on x86_64 simulator alongside Akamai BMP — no crash at launch
- Run on arm64 simulator — screens navigation works normally