### PR TITLE
chore: remove local changelog requirement from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,6 @@ The reproduction code should be minimal & complete. Don't exclude exports or rem
 ## Checklist
 
 - [ ] Included code example that can be used to test this change.
-- [ ] Updated / created local changelog entries in relevant test files.
 - [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
 - [ ] For API changes, updated relevant public types.
 - [ ] Ensured that CI passes


### PR DESCRIPTION
## Description

Recently, we've experimented with the idea of local changelog per test screen in order to keep history of changes in the test file itself. However, [RFC-759](https://github.com/software-mansion/react-native-screens-labs/blob/main-issue-tracker/rfcs/0759-test-organisation.md) and [RFC-1076](https://github.com/software-mansion/react-native-screens-labs/blob/main-issue-tracker/rfcs/1076-test-re-organization-proposal.md) state that bug reproduction test screens should be immutable, therefore there is no need for separate checklist point in PR template for creating or updating any local changelog.

## Changes

- updated `PULL_REQUEST_TEMPLATE.md`

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

N/A
