### PR TITLE
fix(example): correct TabsHostConfig type to exclude navState

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -78,7 +78,9 @@ export type TabsNavigationAction =
 
 export type TabsHostConfig = Omit<
   TabsHostProps,
-  'children' | 'onNativeFocusChange' | 'experimentalControlNavigationStateInJS'
+  | 'children'
+  | 'navState'
+  | 'experimentalControlNavigationStateInJS'
 >;
 
 export type TabsContainerProps = Omit<


### PR DESCRIPTION
## Description

`TabsHostConfig` type was omitting `onNativeFocusChange` which is not a property of `TabsHostProps`. The correct property to exclude is `navState`, since it is managed internally by `TabsContainer`.

## Changes

- Replaced `onNativeFocusChange` with `navState` in the `Omit` list of `TabsHostConfig`.

## Test plan

Type-level change only — verified that the example app compiles without errors.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Updated / created local changelog entries in relevant test files.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes