### PR TITLE
chore(Android): remove legacy architecture related code

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.9.0)
 
 project(rnscreens)
 
-if(${RNS_NEW_ARCH_ENABLED})
 add_library(rnscreens
     SHARED
     ../cpp/RNScreensTurboModule.cpp
@@ -11,13 +10,6 @@ add_library(rnscreens
     ./src/main/cpp/NativeProxy.cpp
     ./src/main/cpp/OnLoad.cpp
 )
-else()
-add_library(rnscreens
-    SHARED
-    ../cpp/RNScreensTurboModule.cpp
-    ./src/main/cpp/jni-adapter.cpp
-)
-endif()
 
 include_directories(
     ../cpp
@@ -37,18 +29,11 @@ target_compile_definitions(
 )
 
 find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
 
-if(${RNS_NEW_ARCH_ENABLED})
-    find_package(fbjni REQUIRED CONFIG)
-    target_link_libraries(rnscreens
-        ReactAndroid::reactnative
-        ReactAndroid::jsi
-        fbjni::fbjni
-        android
-    )
-else()
-    target_link_libraries(rnscreens
-        ReactAndroid::jsi
-        android
-    )
-endif()
+target_link_libraries(rnscreens
+    ReactAndroid::reactnative
+    ReactAndroid::jsi
+    fbjni::fbjni
+    android
+)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,12 +77,14 @@ def resolveReactNativeDirectory() {
             "You should set project extension property (in `app/build.gradle`) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native.")
 }
 
-// spotless is only accessible within react-native-screens repo
+// spotless is only accessible within react-native-screens repo, while the RN Gradle
+// plugin is registered by the host app's settings.gradle — it's not on the classpath
+// in standalone repo context, so applying it here would fail during Gradle configuration.
 if (isRunningInContextOfScreensRepo()) {
     apply from: 'spotless.gradle'
+} else {
+    apply plugin: "com.facebook.react"
 }
-
-apply plugin: "com.facebook.react"
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,14 +30,6 @@ def isRunningInContextOfScreensRepo() {
     return project == rootProject
 }
 
-def isNewArchitectureEnabled() {
-    // To opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
-}
-
 def areDebugLogsEnabled() {
     return project.hasProperty("rnsDebugLogsEnabled") && project.rnsDebugLogsEnabled == "true"
 }
@@ -90,9 +82,7 @@ if (isRunningInContextOfScreensRepo()) {
     apply from: 'spotless.gradle'
 }
 
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+apply plugin: "com.facebook.react"
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -114,8 +104,6 @@ file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { rea
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
-def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
-
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', rnsDefaultCompileSdkVersion)
     namespace "com.swmansion.rnscreens"
@@ -134,7 +122,6 @@ android {
         targetSdkVersion safeExtGet(['targetSdkVersion', 'targetSdk'], rnsDefaultTargetSdkVersion)
         versionCode 1
         versionName "1.0"
-        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", IS_NEW_ARCHITECTURE_ENABLED.toString()
         buildConfigField "boolean", "RNS_GAMMA_ENABLED", isGammaEnabled().toString()
         buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabled().toString()
         ndk {
@@ -143,7 +130,6 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_STL=c++_shared",
-                        "-DRNS_NEW_ARCH_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }

--- a/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/SearchBarManager.kt
@@ -5,7 +5,6 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
-import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNSSearchBarManagerDelegate
 import com.facebook.react.viewmanagers.RNSSearchBarManagerInterface
 import com.swmansion.rnscreens.events.SearchBarBlurEvent
@@ -36,7 +35,6 @@ class SearchBarManager :
         view.onUpdate()
     }
 
-    @ReactProp(name = "autoCapitalize")
     override fun setAutoCapitalize(
         view: SearchBarView,
         autoCapitalize: String?,
@@ -53,7 +51,6 @@ class SearchBarManager :
             }
     }
 
-    @ReactProp(name = "autoFocus")
     override fun setAutoFocus(
         view: SearchBarView,
         autoFocus: Boolean,
@@ -61,7 +58,6 @@ class SearchBarManager :
         view.autoFocus = autoFocus
     }
 
-    @ReactProp(name = "barTintColor", customType = "Color")
     override fun setBarTintColor(
         view: SearchBarView,
         color: Int?,
@@ -69,7 +65,6 @@ class SearchBarManager :
         view.tintColor = color
     }
 
-    @ReactProp(name = "disableBackButtonOverride")
     override fun setDisableBackButtonOverride(
         view: SearchBarView,
         disableBackButtonOverride: Boolean,
@@ -77,7 +72,6 @@ class SearchBarManager :
         view.shouldOverrideBackButton = disableBackButtonOverride != true
     }
 
-    @ReactProp(name = "inputType")
     override fun setInputType(
         view: SearchBarView,
         inputType: String?,
@@ -94,7 +88,6 @@ class SearchBarManager :
             }
     }
 
-    @ReactProp(name = "placeholder")
     override fun setPlaceholder(
         view: SearchBarView,
         placeholder: String?,
@@ -104,7 +97,6 @@ class SearchBarManager :
         }
     }
 
-    @ReactProp(name = "textColor", customType = "Color")
     override fun setTextColor(
         view: SearchBarView,
         color: Int?,
@@ -112,7 +104,6 @@ class SearchBarManager :
         view.textColor = color
     }
 
-    @ReactProp(name = "headerIconColor", customType = "Color")
     override fun setHeaderIconColor(
         view: SearchBarView,
         color: Int?,
@@ -120,7 +111,6 @@ class SearchBarManager :
         view.headerIconColor = color
     }
 
-    @ReactProp(name = "hintTextColor", customType = "Color")
     override fun setHintTextColor(
         view: SearchBarView,
         color: Int?,
@@ -128,7 +118,6 @@ class SearchBarManager :
         view.hintTextColor = color
     }
 
-    @ReactProp(name = "shouldShowHintSearchIcon")
     override fun setShouldShowHintSearchIcon(
         view: SearchBarView,
         shouldShowHintSearchIcon: Boolean,


### PR DESCRIPTION
## Description

This PR removes all Paper-related code leftovers on Android.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1033

## Changes

- remove `ReactProp` annotations from `SearchBarManager.kt`
- remove new architecture guards from `build.gradle` and `CMakeLists.txt`

## Before & after - visual documentation

N/A


## Test plan

Build app.


## Checklist

- [ ] Ensured that CI passes
