### PR TITLE
feat(Tabs): add preventNativeSelection support

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -361,6 +361,12 @@ internal class TabsContainer(
 
         val isRepeated = nextSelectedFragment === currSelectedFragment
 
+        // If this is user action we test whether it should be prevented before we progress the state.
+        if (!isRepeated && !isInExternalOperationContext && nextSelectedFragment.isPreventNativeSelectionEnabled) {
+            delegate.onNavStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
+            return false
+        }
+
         val stateChanged = updateSelectedFragment(nextSelectedFragment)
 
         val hasTriggeredSpecialEffect =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
@@ -43,6 +43,6 @@ internal interface TabsContainerDelegate {
      */
     fun onNavStateUpdatePrevented(
         currentNavState: TabsNavState,
-        preventedScreenKey: String
+        preventedScreenKey: String,
     )
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
@@ -32,4 +32,17 @@ internal interface TabsContainerDelegate {
         rejectedNavState: TabsNavState,
         reason: TabsNavStateUpdateRejectionReason,
     )
+
+    /**
+     * Called when a native user action (tap) attempts to select a tab that has
+     * [com.swmansion.rnscreens.gamma.tabs.screen.TabsScreen.preventNativeSelection] enabled.
+     * The navigation state remains unchanged.
+     *
+     * @param currentNavState The currently active navigation state that was kept.
+     * @param preventedScreenKey The screen key of the tab whose selection was prevented.
+     */
+    fun onNavStateUpdatePrevented(
+        currentNavState: TabsNavState,
+        preventedScreenKey: String
+    )
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -184,7 +184,7 @@ class TabsHost(
 
     override fun onNavStateUpdatePrevented(
         currentNavState: TabsNavState,
-        preventedScreenKey: String
+        preventedScreenKey: String,
     ) {
         eventEmitter.emitOnTabSelectionPreventedEvent(currentNavState, preventedScreenKey)
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -182,6 +182,13 @@ class TabsHost(
         )
     }
 
+    override fun onNavStateUpdatePrevented(
+        currentNavState: TabsNavState,
+        preventedScreenKey: String
+    ) {
+        eventEmitter.emitOnTabSelectionPreventedEvent(currentNavState, preventedScreenKey)
+    }
+
     override fun didMountItems(uiManager: UIManager) {
         container.performContainerUpdateIfNeeded()
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
@@ -5,6 +5,7 @@ import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
+import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
 
 internal class TabsHostEventEmitter(
@@ -50,6 +51,24 @@ internal class TabsHostEventEmitter(
                 currentNavState,
                 rejectedNavState,
                 rejectionReason,
+            ),
+        )
+    }
+
+    /**
+     * Emits `onTabSelectionPrevented` event to JS when a tab selection is prevented
+     * because the target screen has `preventNativeSelection` enabled.
+     */
+    fun emitOnTabSelectionPreventedEvent(
+        currentNavState: TabsNavState,
+        preventedScreenKey: String,
+    ) {
+        reactEventDispatcher.dispatchEvent(
+            TabsHostTabSelectionPreventedEvent(
+                surfaceId,
+                viewTag,
+                currentNavState,
+                preventedScreenKey,
             ),
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
@@ -13,6 +13,7 @@ import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
+import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreen
 
@@ -59,6 +60,7 @@ class TabsHostViewManager :
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
         mutableMapOf(
             makeEventRegistrationInfo(TabsHostTabSelectedEvent),
+            makeEventRegistrationInfo(TabsHostTabSelectionPreventedEvent),
             makeEventRegistrationInfo(TabsHostTabSelectionRejectedEvent),
         )
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
@@ -1,0 +1,47 @@
+package com.swmansion.rnscreens.gamma.tabs.host.event
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
+
+/**
+ * React Native event dispatched to JS when a tab selection is prevented because the target
+ * screen has `preventNativeSelection` enabled.
+ *
+ * This event is never coalesced — every prevention is delivered individually.
+ */
+class TabsHostTabSelectionPreventedEvent(
+    surfaceId: Int,
+    viewId: Int,
+    val currentNavState: TabsNavState,
+    val preventedScreenKey: String,
+) : Event<TabsHostTabSelectionPreventedEvent>(surfaceId, viewId),
+    NamingAwareEventType {
+    override fun getEventName() = EVENT_NAME
+
+    override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+
+    override fun canCoalesce(): Boolean = false
+
+    override fun getEventData(): WritableMap? =
+        Arguments.createMap().apply {
+            putString(EK_SELECTED_KEY, currentNavState.selectedKey)
+            putInt(EK_PROVENANCE, currentNavState.provenance)
+            putString(EK_PREVENTED_KEY, preventedScreenKey)
+        }
+
+    companion object : NamingAwareEventType {
+        const val EVENT_NAME = "topTabSelectionPrevented"
+        const val EVENT_REGISTRATION_NAME = "onTabSelectionPrevented"
+
+        private const val EK_SELECTED_KEY = "selectedScreenKey"
+        private const val EK_PROVENANCE = "provenance"
+        private const val EK_PREVENTED_KEY = "preventedScreenKey"
+
+        override fun getEventName() = EVENT_NAME
+
+        override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -94,6 +94,8 @@ class TabsScreen(
     var shouldUseRepeatedTabSelectionScrollToTopSpecialEffect: Boolean = true
     var shouldUseRepeatedTabSelectionPopToRootSpecialEffect: Boolean = true
 
+    var preventNativeSelection: Boolean = false
+
     private fun <T> updateMenuItemAttributesIfNeeded(
         oldValue: T,
         newValue: T,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt
@@ -11,6 +11,7 @@ class TabsScreenFragment(
     internal val tabsScreen: TabsScreen,
 ) : Fragment() {
     internal val requireScreenKey: String by tabsScreen::requireScreenKey
+    internal val isPreventNativeSelectionEnabled: Boolean by tabsScreen::preventNativeSelection
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,4 +45,5 @@ class TabsScreenFragment(
         // Handle theme change through RN's Appearance.setColorScheme
         tabsScreen.onFragmentConfigurationChange(this, newConfig)
     }
+
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenFragment.kt
@@ -45,5 +45,4 @@ class TabsScreenFragment(
         // Handle theme change through RN's Appearance.setColorScheme
         tabsScreen.onFragmentConfigurationChange(this, newConfig)
     }
-
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -97,6 +97,13 @@ class TabsScreenViewManager :
         view.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect = scrollToTop
     }
 
+    override fun setPreventNativeSelection(
+        view: TabsScreen,
+        value: Boolean,
+    ) {
+        view.preventNativeSelection = value
+    }
+
     override fun setTabBarItemTestID(
         view: TabsScreen,
         value: String?,

--- a/apps/src/tests/single-feature-tests/tabs/index.ts
+++ b/apps/src/tests/single-feature-tests/tabs/index.ts
@@ -10,6 +10,7 @@ import TestTabsLayoutDirection from './test-tabs-layout-direction';
 import TestTabsIMEInsets from './test-tabs-ime-insets';
 import TestTabsSimpleNav from './test-tabs-simple-nav';
 import TestTabsMoreNavigationController from './test-tabs-more-navigation-controller';
+import TestTabsPreventNativeSelection from './test-tabs-prevent-native-selection';
 import TestTabsStaleStateUpdateRejection from './test-tabs-stale-update-rejection';
 
 const scenarios = {
@@ -23,6 +24,7 @@ const scenarios = {
   TestTabsIMEInsets,
   TestTabsSimpleNav,
   TestTabsMoreNavigationController,
+  TestTabsPreventNativeSelection,
   TestTabsStaleStateUpdateRejection,
 };
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
@@ -57,6 +57,8 @@ function TabsNavigationButtons() {
       <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
       <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
       <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
+      <Button title="Select Fifth" onPress={() => nav.selectTab('Fifth')} />
+      <Button title="Select Sixth" onPress={() => nav.selectTab('Sixth')} />
     </View>
   );
 }
@@ -81,6 +83,16 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
     name: 'Fourth',
     Component: ContentView,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
+  },
+  {
+    name: 'Fifth',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fifth' },
+  },
+  {
+    name: 'Sixth',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Sixth' },
   },
 ];
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import type { Scenario } from '../../shared/helpers';
+import { Button, Text, View } from 'react-native';
+import {
+  type TabRouteConfig,
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  useTabsNavigationContext,
+  TabsContainerWithHostConfigContext,
+} from '../../../shared/gamma/containers/tabs';
+import { CenteredLayoutView } from '../../../shared/CenteredLayoutView';
+import { ToastProvider, useToast } from '../../../shared/';
+import Colors from '../../../shared/styling/Colors';
+
+const SCENARIO: Scenario = {
+  name: 'Prevent native selection',
+  key: 'test-tabs-prevent-native-selection',
+  details: 'Test preventNativeSelection prop on TabsScreen',
+  platforms: ['android', 'ios'],
+  AppComponent: App,
+};
+
+export default SCENARIO;
+
+function ContentView() {
+  const nav = useTabsNavigationContext();
+
+  const preventNativeSelection =
+    nav.routeOptions.preventNativeSelection ?? false;
+
+  return (
+    <CenteredLayoutView>
+      <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
+        {nav.routeKey}
+      </Text>
+      <Text style={{ textAlign: 'center' }}>
+        preventNativeSelection: {JSON.stringify(preventNativeSelection)}
+      </Text>
+      <Button
+        title="Toggle preventNativeSelection"
+        onPress={() =>
+          nav.setRouteOptions(nav.routeKey, {
+            preventNativeSelection: !preventNativeSelection,
+          })
+        }
+      />
+      <TabsNavigationButtons />
+    </CenteredLayoutView>
+  );
+}
+
+function TabsNavigationButtons() {
+  const nav = useTabsNavigationContext();
+
+  return (
+    <View>
+      <Button title="Select First" onPress={() => nav.selectTab('First')} />
+      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
+      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
+      <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
+    </View>
+  );
+}
+
+const ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'First',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
+  },
+  {
+    name: 'Second',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
+  },
+  {
+    name: 'Third',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
+  },
+  {
+    name: 'Fourth',
+    Component: ContentView,
+    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
+  },
+];
+
+export function App() {
+  return (
+    <ToastProvider>
+      <AppContents />
+    </ToastProvider>
+  );
+}
+
+function AppContents() {
+  const toast = useToast();
+
+  return (
+    <TabsContainerWithHostConfigContext
+      routeConfigs={ROUTE_CONFIGS}
+      onTabSelectionPrevented={event => {
+        const message = `onTabSelectionPrevented: ${event.nativeEvent.preventedScreenKey}`;
+        console.warn(message);
+        toast.push({
+          message: message,
+          backgroundColor: Colors.GreenLight60,
+        });
+      }}
+    />
+  );
+}
+

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -39,7 +39,8 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 static void
 rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
 {
-  UITabBarController *rawTabBarController = ((UIViewController *)self).tabBarController;
+  UITabBarController *rawTabBarController = static_cast<UIViewController *>(self).tabBarController;
+
   RCTAssert(
       [rawTabBarController isKindOfClass:RNSTabBarController.class],
       @"[RNScreens] Expected tabBarController to be of class %@, got: %@",
@@ -52,8 +53,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
         .receiver = self,
         .super_class = class_getSuperclass(object_getClass(self)),
     };
-    ((void (*)(struct objc_super *, SEL, UIViewController *, BOOL))objc_msgSendSuper)(
-        &superInfo, _cmd, viewController, animated);
+    const auto msgSendSuperPushViewController =
+        reinterpret_cast<void (*)(struct objc_super *, SEL, UIViewController *, BOOL)>(objc_msgSendSuper);
+    msgSendSuperPushViewController(&superInfo, _cmd, viewController, animated);
   }
 }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -356,6 +356,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   if (shouldPreventTabSelection) {
     // Ideally we'd call this AFTER we prevent, but there is no appropriate callback.
+    // As long as we emit the event asynchronously this is rather fine.
     [self onDidPreventUserFromSelectingViewControllerWithKey:[self screenKeyForViewController:viewController]];
     return NO;
   }

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -830,27 +830,38 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 /// (e.g. `RNS_UIMoreNavigationController`), so if another library ISA-swizzles it first or Apple
 /// changes the private class, each distinct original class gets its own correct dynamic subclass.
 ///
-/// This method is idempotent — safe to call multiple times. The dynamic subclass is created once
-/// and reused; `object_setClass` and `objc_setAssociatedObject` are re-applied on each call.
-/// This is necessary because UIKit resets the isa pointer of `moreNavigationController` during
-/// tab bar reconfiguration (e.g. iPad app resize crossing the >5 tab threshold).
+/// This method is idempotent — safe to call multiple times regardless of whether UIKit has
+/// reset the ISA between calls. When the ISA already carries our `RNS_` prefix, only the
+/// associated-object back-reference is refreshed. When UIKit has reset the ISA (e.g. iPad
+/// app resize crossing the >5 tab threshold), the dynamic subclass is looked up (or created)
+/// and re-applied.
 - (void)ensurePushInterceptorOnMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  Class originalClass = object_getClass(self.moreNavigationController);
-  const char *originalClassName = class_getName(originalClass);
+  Class currentClass = object_getClass(self.moreNavigationController);
+  const char *currentClassName = class_getName(currentClass);
+
+  // If the ISA already points to our dynamic subclass, the interceptor is in place.
+  // Just refresh the associated object (it uses ASSIGN semantics, so it's cheap)
+  // and return early. Without this guard, repeated calls when UIKit has NOT reset
+  // the ISA would stack `RNS_RNS_...` subclasses, causing infinite recursion in
+  // rns_pushViewController's objc_msgSendSuper call.
+  if (strncmp(currentClassName, "RNS_", 4) == 0) {
+    [self installSelfAssociationWithMoreNavigationController];
+    return;
+  }
 
   // Build a unique subclass name per original runtime class: "RNS_<originalClassName>"
   char dynamicSubclassName[256];
-  snprintf(dynamicSubclassName, sizeof(dynamicSubclassName), "RNS_%s", originalClassName);
+  snprintf(dynamicSubclassName, sizeof(dynamicSubclassName), "RNS_%s", currentClassName);
 
   Class dynamicSubclass = objc_getClass(dynamicSubclassName);
 
   if (dynamicSubclass == nil) {
-    dynamicSubclass = objc_allocateClassPair(originalClass, dynamicSubclassName, 0);
-    RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %s", originalClassName);
+    dynamicSubclass = objc_allocateClassPair(currentClass, dynamicSubclassName, 0);
+    RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %s", currentClassName);
 
-    Method pushMethod = class_getInstanceMethod(originalClass, @selector(pushViewController:animated:));
+    Method pushMethod = class_getInstanceMethod(currentClass, @selector(pushViewController:animated:));
     class_addMethod(
         dynamicSubclass,
         @selector(pushViewController:animated:),
@@ -861,9 +872,15 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   }
 
   object_setClass(self.moreNavigationController, dynamicSubclass);
+  [self installSelfAssociationWithMoreNavigationController];
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
 
-  // Store a back-reference so the C function can reach this controller.
-  // OBJC_ASSOCIATION_ASSIGN: no retain cycle — self owns moreNavigationController and outlives it.
+/// Stores a weak (ASSIGN) back-reference from `moreNavigationController` to `self`
+/// so that `rns_pushViewController` can reach the owning `RNSTabBarController`.
+- (void)installSelfAssociationWithMoreNavigationController
+{
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   objc_setAssociatedObject(
       self.moreNavigationController, kRNSTabBarControllerAssociationKey, self, OBJC_ASSOCIATION_ASSIGN);
   _didAccessMoreNavigationController = YES;

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -278,6 +278,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   [self updateNavigationStateOnModelUpdate];
 
   if ([self isSelectedViewControllerTheMoreNavigationController]) {
+    [self disableNavigationBarInMoreNavigationController];
     [self setupMoreNavigationControllerDelegateIfNeeded];
   }
 
@@ -348,9 +349,23 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   if (shouldPreventTabSelection) {
     // Ideally we'd call this AFTER we prevent, but there is no appropriate callback.
     [self onDidPreventUserFromSelectingViewControllerWithKey:[self screenKeyForViewController:viewController]];
+    return NO;
   }
 
-  return !shouldPreventTabSelection;
+  // If we're gonna allow navigation to `moreNavigationController`, then we need to ensure
+  // that on top of its stack there is no controller with preventNativeSelection enabled.
+  // In such case, we want to pop to root.
+  // We do it here, because in `tabBarController:didSelectViewController:` we won't receive
+  // `moreNavigationController` in case there is already a tab pushed on the stack.
+  if ([self isViewControllerTheMoreNavigationController:viewController]) {
+    auto *poppedViewController = [self popToRootInMoreNavigationControllerRespectSelectionPrevention:YES animated:NO];
+    if (poppedViewController != nil) {
+      // We actually popped something -> let's notify JS realm of this fact.
+      [self onDidPreventUserFromSelectingViewControllerWithKey:[self screenKeyForViewController:poppedViewController]];
+    }
+  }
+
+  return YES;
 }
 
 - (void)tabBarController:(UITabBarController *)tabBarController
@@ -365,10 +380,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
       [viewController isKindOfClass:RNSTabsScreenViewController.class] || isNextViewControllerMoreNavigationController,
       @"[RNScreens] Unexpected type of controller: %@",
       viewController.class);
-
-  if (isNextViewControllerMoreNavigationController) {
-    [self disableNavigationBarInMoreNavigationController];
-  }
 
   [self userDidSelectViewController:viewController];
 }
@@ -513,7 +524,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
     // Animate only if we're currently in context of more view controller.
     BOOL shouldAnimate = [self isMoreNavigationControllerTabBarItemSelected];
-    [self popToRootInMoreNavigationControllerIfNeededAnimated:shouldAnimate];
+    [self popToRootInMoreNavigationControllerRespectSelectionPrevention:NO animated:shouldAnimate];
 
     // Also disable the header - we don't control it, but it impacts the layout
     // in ways Yoga is not aware of. The simplest option here is to disable it.
@@ -722,18 +733,56 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (void)disableNavigationBarInMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  [self.moreNavigationController setNavigationBarHidden:YES animated:NO];
+  if (!self.moreNavigationController.navigationBar.isHidden) {
+    [self.moreNavigationController setNavigationBarHidden:YES animated:NO];
+  }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
-- (void)popToRootInMoreNavigationControllerIfNeededAnimated:(BOOL)isAnimated
+- (nullable UIViewController *)popToRootInMoreNavigationControllerRespectSelectionPrevention:
+                                   (BOOL)shouldRespectSelectionPrevention
+                                                                                    animated:(BOOL)shouldAnimate
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   if ([self isMoreNavigationControllerPresentInTabBar] && self.moreNavigationController.viewControllers.count > 1) {
     // We quietly assume here, that the root view controller is the `UIMoreListViewController`.
-    [self.moreNavigationController popToRootViewControllerAnimated:isAnimated];
+    if (shouldRespectSelectionPrevention) {
+      UIViewController *topViewController = self.moreNavigationController.topViewController;
+      RCTAssert(
+          [topViewController isKindOfClass:RNSTabsScreenViewController.class],
+          @"[RNScreens] Unexpected type of view controller on moreNavigationControllerStack: %@",
+          topViewController.class);
+      RNSTabsScreenViewController *screenController = static_cast<RNSTabsScreenViewController *>(topViewController);
+      if (screenController.isPreventNativeSelectionEnabled) {
+        return [self popToRootMoreNavigationController:self.moreNavigationController animated:shouldAnimate];
+      }
+    } else {
+      return [self popToRootMoreNavigationController:self.moreNavigationController animated:shouldAnimate];
+    }
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  return nil;
+}
+
+/**
+ * Pops the top view controller from more navigation controller. We expect at most two controllers on the stack of more
+ * navigation controller. If this assumption ever becomes invalid, this method needs to be updated.
+ *
+ * @returns nil if there was nothing to pop, the topViewController otherwise.
+ */
+- (nullable UIViewController *)popToRootMoreNavigationController:
+                                   (nonnull UINavigationController *)moreNavigationController
+                                                        animated:(BOOL)animated
+{
+  if (moreNavigationController.viewControllers.count < 2) {
+    return nil;
+  }
+
+  auto *poppedViewControllers = [moreNavigationController popToRootViewControllerAnimated:animated];
+  RCTAssert(
+      poppedViewControllers != nil && poppedViewControllers.count == 1,
+      @"[RNScreens] Expected exactly one view controller to be popped");
+  return [poppedViewControllers firstObject];
 }
 
 - (void)setupMoreNavigationControllerDelegateIfNeeded

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -14,14 +14,10 @@
  */
 static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavigationController";
 
-@interface RNSTabBarController () <UITabBarControllerDelegate>
+// We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
+@interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
 
-// We need this to handle navigation within `moreNavigationController`
-@interface RNSTabBarController () <UINavigationControllerDelegate>
-@end
-
-// We need this to handle navigation within `moreNavigationController`
 @interface RNSTabBarController ()
 
 /// Consulted by the ISA-swizzled `pushViewController:animated:` on `moreNavigationController`
@@ -275,6 +271,27 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
 }
 
+- (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
+{
+  [self.tabsHostComponentView tabBarController:self preventedSelectionOf:screenKey currentState:_navigationState];
+}
+
+- (BOOL)shouldPreventNativeTabSelection:(nonnull UIViewController *)nextViewController
+{
+  // This handles the tabsHostComponentView nullability
+  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
+    return YES;
+  }
+
+  if (![nextViewController isKindOfClass:RNSTabsScreenViewController.class]) {
+    // Allow for more view controller selection
+    return NO;
+  }
+
+  auto *screenViewController = static_cast<RNSTabsScreenViewController *>(nextViewController);
+  return screenViewController.isPreventNativeSelectionEnabled;
+}
+
 #pragma mark - UITabBarControllerDelegate
 
 // These methods are not called on programatic selection!
@@ -354,27 +371,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     [self userDidSelectViewController:viewController];
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-}
-
-- (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
-{
-  [self.tabsHostComponentView tabBarController:self preventedSelectionOf:screenKey currentState:_navigationState];
-}
-
-- (BOOL)shouldPreventNativeTabSelection:(nonnull UIViewController *)nextViewController
-{
-  // This handles the tabsHostComponentView nullability
-  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
-    return YES;
-  }
-
-  if (![nextViewController isKindOfClass:RNSTabsScreenViewController.class]) {
-    // Allow for more view controller selection
-    return NO;
-  }
-
-  auto *screenViewController = static_cast<RNSTabsScreenViewController *>(nextViewController);
-  return screenViewController.isPreventNativeSelectionEnabled;
 }
 
 #pragma mark - Signals related

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -265,7 +265,14 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
     return NO;
   }
 
-  return ![self shouldPreventNativeTabSelection];
+  BOOL shouldPreventTabSelection = [self shouldPreventNativeTabSelection:viewController];
+
+  if (shouldPreventTabSelection) {
+    // Ideally we'd call this AFTER we prevent, but there is no appropriate callback.
+    [self onDidPreventUserFromSelectingViewControllerWithKey:[self screenKeyForViewController:viewController]];
+  }
+
+  return !shouldPreventTabSelection;
 }
 
 - (void)tabBarController:(UITabBarController *)tabBarController
@@ -307,10 +314,25 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
-- (BOOL)shouldPreventNativeTabSelection
+- (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
+{
+  [self.tabsHostComponentView tabBarController:self preventedSelectionOf:screenKey currentState:_navigationState];
+}
+
+- (BOOL)shouldPreventNativeTabSelection:(nonnull UIViewController *)nextViewController
 {
   // This handles the tabsHostComponentView nullability
-  return [self.tabsHostComponentView experimental_controlNavigationStateInJS] ?: NO;
+  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
+    return YES;
+  }
+
+  if (![nextViewController isKindOfClass:RNSTabsScreenViewController.class]) {
+    // Allow for more view controller selection
+    return NO;
+  }
+
+  auto *screenViewController = static_cast<RNSTabsScreenViewController *>(nextViewController);
+  return screenViewController.isPreventNativeSelectionEnabled;
 }
 
 #pragma mark - Signals related
@@ -540,9 +562,9 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   return static_cast<RNSTabsScreenViewController *>(self.selectedViewController);
 }
 
-- (nonnull NSString *)screenKeyForSelectedViewController
+- (nonnull NSString *)screenKeyForViewController:(nonnull UIViewController *)viewController
 {
-  if ([self isSelectedViewControllerTheMoreNavigationController]) {
+  if ([self isViewControllerTheMoreNavigationController:viewController]) {
     return kMoreNavigationControllerScreenKey;
   }
 
@@ -555,6 +577,11 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   auto *screenKey = static_cast<RNSTabsScreenViewController *>(self.selectedViewController).getScreenKeyOrNull;
   RCTAssert(screenKey != nil, @"[RNScreens] screenKey MUST NOT be nil");
   return screenKey;
+}
+
+- (nonnull NSString *)screenKeyForSelectedViewController
+{
+  return [self screenKeyForViewController:self.selectedViewController];
 }
 
 /**
@@ -593,13 +620,18 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   return [screenKey isEqualToString:kMoreNavigationControllerScreenKey];
 }
 
-- (BOOL)isSelectedViewControllerTheMoreNavigationController
+- (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  return [self canHaveMoreNavigationController] && self.selectedViewController == self.moreNavigationController;
+  return [self canHaveMoreNavigationController] && viewController == self.moreNavigationController;
 #else
   return NO;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+- (BOOL)isSelectedViewControllerTheMoreNavigationController
+{
+  return [self isViewControllerTheMoreNavigationController:self.selectedViewController];
 }
 
 - (BOOL)isMoreNavigationControllerRequestedByOperation:(nullable RNSTabsNavigationState *)navState

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -70,6 +70,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   RNSTabsNavigationState *_Nullable _pendingOperation;
 
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  BOOL _didInstallPushInterceptor;
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+
 #if !RCT_NEW_ARCH_ENABLED
   BOOL _isControllerFlushBlockScheduled;
 #endif // !RCT_NEW_ARCH_ENABLED
@@ -100,6 +104,19 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     _tabsHostComponentView = tabsHostComponentView;
   }
   return self;
+}
+
+- (void)dealloc
+{
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  // Clear the OBJC_ASSOCIATION_ASSIGN back-reference to self stored on moreNavigationController.
+  // This is a safety measure — moreNavigationController should never outlive us, but if it ever does
+  // (e.g. due to UIKit lifecycle changes), we avoid leaving a dangling pointer behind.
+  if (_didInstallPushInterceptor) {
+    objc_setAssociatedObject(
+        self.moreNavigationController, kRNSTabBarControllerAssociationKey, nil, OBJC_ASSOCIATION_ASSIGN);
+  }
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
 #pragma mark - UIKit callbacks
@@ -278,11 +295,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 - (BOOL)shouldPreventNativeTabSelection:(nonnull UIViewController *)nextViewController
 {
-  // This handles the tabsHostComponentView nullability
-  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
-    return YES;
-  }
-
   if (![nextViewController isKindOfClass:RNSTabsScreenViewController.class]) {
     // Allow for more view controller selection
     return NO;
@@ -321,6 +333,13 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     // We trigger the state update from here, because `tabBarController:didSelectViewController:` won't be called.
     [self userDidRepeatViewControllerSelection:viewController];
 
+    return NO;
+  }
+
+  // This handles the tabsHostComponentView nullability
+  // TODO: This if is likely to be removed, since we want to roll back the support
+  // for "controlled mode", at least initially.
+  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
     return NO;
   }
 
@@ -729,17 +748,30 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 /// Creates a dynamic subclass of the runtime class of `moreNavigationController`
 /// (which is the private `UIMoreNavigationController`) and overrides `pushViewController:animated:`
-/// with our gating implementation. The dynamic subclass is created once and reused.
+/// with our gating implementation.
+///
+/// The subclass name is derived from the actual runtime class of `moreNavigationController`
+/// (e.g. `RNS_UIMoreNavigationController`), so if another library ISA-swizzles it first or Apple
+/// changes the private class, each distinct original class gets its own correct dynamic subclass.
 - (void)installPushInterceptorOnMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  static const char *kDynamicSubclassName = "RNS_UIMoreNavigationController";
-  Class dynamicSubclass = objc_getClass(kDynamicSubclassName);
+  RCTAssert(
+      _didInstallPushInterceptor == NO,
+      @"[RNScreens] installPushInterceptorOnMoreNavigationController MUST NOT be called twice");
+
+  Class originalClass = object_getClass(self.moreNavigationController);
+  const char *originalClassName = class_getName(originalClass);
+
+  // Build a unique subclass name per original runtime class: "RNS_<originalClassName>"
+  char dynamicSubclassName[256];
+  snprintf(dynamicSubclassName, sizeof(dynamicSubclassName), "RNS_%s", originalClassName);
+
+  Class dynamicSubclass = objc_getClass(dynamicSubclassName);
 
   if (dynamicSubclass == nil) {
-    Class originalClass = object_getClass(self.moreNavigationController);
-    dynamicSubclass = objc_allocateClassPair(originalClass, kDynamicSubclassName, 0);
-    RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %@", originalClass);
+    dynamicSubclass = objc_allocateClassPair(originalClass, dynamicSubclassName, 0);
+    RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %s", originalClassName);
 
     Method pushMethod = class_getInstanceMethod(originalClass, @selector(pushViewController:animated:));
     class_addMethod(
@@ -757,6 +789,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   // OBJC_ASSOCIATION_ASSIGN: no retain cycle — self owns moreNavigationController and outlives it.
   objc_setAssociatedObject(
       self.moreNavigationController, kRNSTabBarControllerAssociationKey, self, OBJC_ASSOCIATION_ASSIGN);
+  _didInstallPushInterceptor = YES;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -44,7 +44,6 @@ static const void *kRNSTabBarControllerAssociationKey = &kRNSTabBarControllerAss
 static void
 rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
 {
-  NSLog(@"MoreNavigationController pushViewController");
   RNSTabBarController *tabBarController = objc_getAssociatedObject(self, kRNSTabBarControllerAssociationKey);
 
   if ([tabBarController moreNavigationController:self shouldPushViewController:viewController]) {
@@ -278,18 +277,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
 }
 
-- (void)setSelectedViewController:(__kindof UIViewController *)selectedViewController
-{
-  NSLog(@"setSelectedViewController:%@", selectedViewController);
-  [super setSelectedViewController:selectedViewController];
-}
-
-- (void)setSelectedIndex:(NSUInteger)selectedIndex
-{
-  NSLog(@"setSelectedIndex:%ld", selectedIndex);
-  [super setSelectedIndex:selectedIndex];
-}
-
 - (void)userDidSelectViewController:(nonnull UIViewController *)viewController
 {
   // At this moment the `UITabBarController` model is already updated.
@@ -334,7 +321,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
     shouldSelectViewController:(UIViewController *)viewController
 {
-  NSLog(@"shouldSelectViewController:%@", viewController);
   RCTAssert(tabBarController == self, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   // Can be UINavigationController in case of MoreNavigationController
@@ -393,7 +379,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (void)tabBarController:(UITabBarController *)tabBarController
     didSelectViewController:(UIViewController *)viewController
 {
-  NSLog(@"didSelectViewController:%@", viewController);
   RCTAssert(self == tabBarController, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   BOOL isNextViewControllerMoreNavigationController = [viewController isKindOfClass:UINavigationController.class];

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -900,10 +900,16 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     if (selectedIndexPath != nil) {
       [tableView deselectRowAtIndexPath:selectedIndexPath animated:YES];
     }
+  } else {
+    RCTLogWarn(@"[RNScreens] Failed to find a table view to clear focus!");
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
+/**
+ * Unbounded DFS looking for ANY `UITableView` in the subtree rooted at view.
+ * The `view` parameter is included in the search.
+ */
 - (nullable UITableView *)findTableViewInView:(UIView *)view
 {
   if ([view isKindOfClass:UITableView.class]) {

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -278,6 +278,18 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
 }
 
+- (void)setSelectedViewController:(__kindof UIViewController *)selectedViewController
+{
+  NSLog(@"setSelectedViewController:%@", selectedViewController);
+  [super setSelectedViewController:selectedViewController];
+}
+
+- (void)setSelectedIndex:(NSUInteger)selectedIndex
+{
+  NSLog(@"setSelectedIndex:%ld", selectedIndex);
+  [super setSelectedIndex:selectedIndex];
+}
+
 - (void)userDidSelectViewController:(nonnull UIViewController *)viewController
 {
   // At this moment the `UITabBarController` model is already updated.
@@ -322,6 +334,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
     shouldSelectViewController:(UIViewController *)viewController
 {
+  NSLog(@"shouldSelectViewController:%@", viewController);
   RCTAssert(tabBarController == self, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   // Can be UINavigationController in case of MoreNavigationController
@@ -380,6 +393,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (void)tabBarController:(UITabBarController *)tabBarController
     didSelectViewController:(UIViewController *)viewController
 {
+  NSLog(@"didSelectViewController:%@", viewController);
   RCTAssert(self == tabBarController, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   BOOL isNextViewControllerMoreNavigationController = [viewController isKindOfClass:UINavigationController.class];

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -29,22 +29,23 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 /**
- * Key used to store a weak (ASSIGN) reference back to the owning RNSTabBarController
- * as an associated object on the moreNavigationController instance.
- */
-static const void *kRNSTabBarControllerAssociationKey = &kRNSTabBarControllerAssociationKey;
-
-/**
  * Replacement implementation for `pushViewController:animated:` injected into
  * a dynamic subclass of `UIMoreNavigationController` via ISA-swizzle.
  *
  * Before allowing the push, this function consults the owning `RNSTabBarController`
+ * (reached via UIKit's `tabBarController` property on the parent chain)
  * to check whether the push should be prevented (e.g. due to `preventNativeSelection`).
  */
 static void
 rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
 {
-  RNSTabBarController *tabBarController = objc_getAssociatedObject(self, kRNSTabBarControllerAssociationKey);
+  UITabBarController *rawTabBarController = ((UIViewController *)self).tabBarController;
+  RCTAssert(
+      [rawTabBarController isKindOfClass:RNSTabBarController.class],
+      @"[RNScreens] Expected tabBarController to be of class %@, got: %@",
+      RNSTabBarController.class,
+      rawTabBarController.class);
+  RNSTabBarController *tabBarController = static_cast<RNSTabBarController *>(rawTabBarController);
 
   if ([tabBarController moreNavigationController:self shouldPushViewController:viewController]) {
     struct objc_super superInfo = {
@@ -69,10 +70,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RNSTabsNavigationState *_Nullable _lastUINavigationState;
 
   RNSTabsNavigationState *_Nullable _pendingOperation;
-
-#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  BOOL _didAccessMoreNavigationController;
-#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 
 #if !RCT_NEW_ARCH_ENABLED
   BOOL _isControllerFlushBlockScheduled;
@@ -104,27 +101,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     _tabsHostComponentView = tabsHostComponentView;
   }
   return self;
-}
-
-- (void)dealloc
-{
-#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  // Clear the OBJC_ASSOCIATION_ASSIGN back-reference to self stored on moreNavigationController.
-  // This is a safety measure — moreNavigationController should never outlive us, but if it ever does
-  // (e.g. due to UIKit lifecycle changes), we avoid leaving a dangling pointer behind.
-  //
-  // We guard with _didAccessMoreNavigationController to avoid lazy creation of
-  // moreNavigationController during teardown. We also check the isa prefix because UIKit may have
-  // already reset it (e.g. iPad resize), in which case there's no associated object to clean up.
-  if (_didAccessMoreNavigationController) {
-    Class currentClass = object_getClass(self.moreNavigationController);
-    const char *className = class_getName(currentClass);
-    if (strncmp(className, "RNS_", 4) == 0) {
-      objc_setAssociatedObject(
-          self.moreNavigationController, kRNSTabBarControllerAssociationKey, nil, OBJC_ASSOCIATION_ASSIGN);
-    }
-  }
-#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
 #pragma mark - UIKit callbacks
@@ -817,10 +793,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 /// changes the private class, each distinct original class gets its own correct dynamic subclass.
 ///
 /// This method is idempotent — safe to call multiple times regardless of whether UIKit has
-/// reset the ISA between calls. When the ISA already carries our `RNS_` prefix, only the
-/// associated-object back-reference is refreshed. When UIKit has reset the ISA (e.g. iPad
-/// app resize crossing the >5 tab threshold), the dynamic subclass is looked up (or created)
-/// and re-applied.
+/// reset the ISA between calls. When the ISA already carries our `RNS_` prefix, we return
+/// early. When UIKit has reset the ISA (e.g. iPad app resize crossing the >5 tab threshold),
+/// the dynamic subclass is looked up (or created) and re-applied.
 - (void)ensurePushInterceptorOnMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
@@ -828,12 +803,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   const char *currentClassName = class_getName(currentClass);
 
   // If the ISA already points to our dynamic subclass, the interceptor is in place.
-  // Just refresh the associated object (it uses ASSIGN semantics, so it's cheap)
-  // and return early. Without this guard, repeated calls when UIKit has NOT reset
-  // the ISA would stack `RNS_RNS_...` subclasses, causing infinite recursion in
-  // rns_pushViewController's objc_msgSendSuper call.
+  // Without this guard, repeated calls when UIKit has NOT reset the ISA would stack
+  // `RNS_RNS_...` subclasses, causing infinite recursion in rns_pushViewController's
+  // objc_msgSendSuper call.
   if (strncmp(currentClassName, "RNS_", 4) == 0) {
-    [self installSelfAssociationWithMoreNavigationController];
     return;
   }
 
@@ -858,18 +831,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   }
 
   object_setClass(self.moreNavigationController, dynamicSubclass);
-  [self installSelfAssociationWithMoreNavigationController];
-#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-}
-
-/// Stores a weak (ASSIGN) back-reference from `moreNavigationController` to `self`
-/// so that `rns_pushViewController` can reach the owning `RNSTabBarController`.
-- (void)installSelfAssociationWithMoreNavigationController
-{
-#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  objc_setAssociatedObject(
-      self.moreNavigationController, kRNSTabBarControllerAssociationKey, self, OBJC_ASSOCIATION_ASSIGN);
-  _didAccessMoreNavigationController = YES;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -1,6 +1,8 @@
 #import "RNSTabBarController.h"
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
 #import "NSString+RNSUtility.h"
 #import "RNSLog.h"
 #import "RNSScreenWindowTraits.h"
@@ -18,6 +20,46 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 // We need this to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UINavigationControllerDelegate>
 @end
+
+// We need this to handle navigation within `moreNavigationController`
+@interface RNSTabBarController ()
+
+/// Consulted by the ISA-swizzled `pushViewController:animated:` on `moreNavigationController`
+/// to decide whether a push should proceed.
+- (BOOL)moreNavigationController:(UINavigationController *)navigationController
+        shouldPushViewController:(UIViewController *)viewController;
+
+@end
+
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+/**
+ * Key used to store a weak (ASSIGN) reference back to the owning RNSTabBarController
+ * as an associated object on the moreNavigationController instance.
+ */
+static const void *kRNSTabBarControllerAssociationKey = &kRNSTabBarControllerAssociationKey;
+
+/**
+ * Replacement implementation for `pushViewController:animated:` injected into
+ * a dynamic subclass of `UIMoreNavigationController` via ISA-swizzle.
+ *
+ * Before allowing the push, this function consults the owning `RNSTabBarController`
+ * to check whether the push should be prevented (e.g. due to `preventNativeSelection`).
+ */
+static void
+rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
+{
+  RNSTabBarController *tabBarController = objc_getAssociatedObject(self, kRNSTabBarControllerAssociationKey);
+
+  if ([tabBarController moreNavigationController:self shouldPushViewController:viewController]) {
+    struct objc_super superInfo = {
+        .receiver = self,
+        .super_class = class_getSuperclass(object_getClass(self)),
+    };
+    ((void (*)(struct objc_super *, SEL, UIViewController *, BOOL))objc_msgSendSuper)(
+        &superInfo, _cmd, viewController, animated);
+  }
+}
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 
 @implementation RNSTabBarController {
   NSArray<RNSTabsScreenViewController *> *_Nullable _tabScreenControllers;
@@ -569,12 +611,12 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
   }
 
   RCTAssert(
-      [self.selectedViewController isKindOfClass:RNSTabsScreenViewController.class],
+      [viewController isKindOfClass:RNSTabsScreenViewController.class],
       @"[RNScreens] Expected selected view controller to be of class %@, got: %@",
       RNSTabsScreenViewController.class,
-      self.selectedViewController.class);
+      viewController.class);
 
-  auto *screenKey = static_cast<RNSTabsScreenViewController *>(self.selectedViewController).getScreenKeyOrNull;
+  auto *screenKey = static_cast<RNSTabsScreenViewController *>(viewController).getScreenKeyOrNull;
   RCTAssert(screenKey != nil, @"[RNScreens] screenKey MUST NOT be nil");
   return screenKey;
 }
@@ -684,8 +726,88 @@ static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavi
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   if (self.moreNavigationController.delegate == nil) {
     self.moreNavigationController.delegate = self;
+    [self installPushInterceptorOnMoreNavigationController];
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+/// Creates a dynamic subclass of the runtime class of `moreNavigationController`
+/// (which is the private `UIMoreNavigationController`) and overrides `pushViewController:animated:`
+/// with our gating implementation. The dynamic subclass is created once and reused.
+- (void)installPushInterceptorOnMoreNavigationController
+{
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  static const char *kDynamicSubclassName = "RNS_UIMoreNavigationController";
+  Class dynamicSubclass = objc_getClass(kDynamicSubclassName);
+
+  if (dynamicSubclass == nil) {
+    Class originalClass = object_getClass(self.moreNavigationController);
+    dynamicSubclass = objc_allocateClassPair(originalClass, kDynamicSubclassName, 0);
+    RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %@", originalClass);
+
+    Method pushMethod = class_getInstanceMethod(originalClass, @selector(pushViewController:animated:));
+    class_addMethod(
+        dynamicSubclass,
+        @selector(pushViewController:animated:),
+        (IMP)rns_pushViewController,
+        method_getTypeEncoding(pushMethod));
+
+    objc_registerClassPair(dynamicSubclass);
+  }
+
+  object_setClass(self.moreNavigationController, dynamicSubclass);
+
+  // Store a back-reference so the C function can reach this controller.
+  // OBJC_ASSOCIATION_ASSIGN: no retain cycle — self owns moreNavigationController and outlives it.
+  objc_setAssociatedObject(
+      self.moreNavigationController, kRNSTabBarControllerAssociationKey, self, OBJC_ASSOCIATION_ASSIGN);
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+/// Decides whether `moreNavigationController` should be allowed to push `viewController`.
+/// This mirrors the logic in `shouldPreventNativeTabSelection:` for the More list context.
+- (BOOL)moreNavigationController:(UINavigationController *)navigationController
+        shouldPushViewController:(UIViewController *)viewController
+{
+  BOOL shouldPrevent = [self shouldPreventNativeTabSelection:viewController];
+
+  if (shouldPrevent) {
+    [self onDidPreventUserFromSelectingViewControllerWithKey:[self screenKeyForViewController:viewController]];
+    [self deselectMoreListSelectionInNavigationController:navigationController];
+  }
+
+  return !shouldPrevent;
+}
+
+/// When we prevent a push from the More list, the tapped table view cell stays highlighted
+/// because UIKit expects the push to handle deselection on return. We deselect it manually.
+- (void)deselectMoreListSelectionInNavigationController:(UINavigationController *)navigationController
+{
+#if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  UIViewController *topVC = navigationController.topViewController;
+  UITableView *tableView = [self findTableViewInView:topVC.view];
+
+  if (tableView != nil) {
+    NSIndexPath *selectedIndexPath = tableView.indexPathForSelectedRow;
+    if (selectedIndexPath != nil) {
+      [tableView deselectRowAtIndexPath:selectedIndexPath animated:YES];
+    }
+  }
+#endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+- (nullable UITableView *)findTableViewInView:(UIView *)view
+{
+  if ([view isKindOfClass:UITableView.class]) {
+    return (UITableView *)view;
+  }
+  for (UIView *subview in view.subviews) {
+    UITableView *result = [self findTableViewInView:subview];
+    if (result != nil) {
+      return result;
+    }
+  }
+  return nil;
 }
 
 /**

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -44,6 +44,7 @@ static const void *kRNSTabBarControllerAssociationKey = &kRNSTabBarControllerAss
 static void
 rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
 {
+  NSLog(@"MoreNavigationController pushViewController");
   RNSTabBarController *tabBarController = objc_getAssociatedObject(self, kRNSTabBarControllerAssociationKey);
 
   if ([tabBarController moreNavigationController:self shouldPushViewController:viewController]) {
@@ -71,7 +72,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RNSTabsNavigationState *_Nullable _pendingOperation;
 
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  BOOL _didInstallPushInterceptor;
+  BOOL _didAccessMoreNavigationController;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 
 #if !RCT_NEW_ARCH_ENABLED
@@ -112,9 +113,17 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   // Clear the OBJC_ASSOCIATION_ASSIGN back-reference to self stored on moreNavigationController.
   // This is a safety measure — moreNavigationController should never outlive us, but if it ever does
   // (e.g. due to UIKit lifecycle changes), we avoid leaving a dangling pointer behind.
-  if (_didInstallPushInterceptor) {
-    objc_setAssociatedObject(
-        self.moreNavigationController, kRNSTabBarControllerAssociationKey, nil, OBJC_ASSOCIATION_ASSIGN);
+  //
+  // We guard with _didAccessMoreNavigationController to avoid lazy creation of
+  // moreNavigationController during teardown. We also check the isa prefix because UIKit may have
+  // already reset it (e.g. iPad resize), in which case there's no associated object to clean up.
+  if (_didAccessMoreNavigationController) {
+    Class currentClass = object_getClass(self.moreNavigationController);
+    const char *className = class_getName(currentClass);
+    if (strncmp(className, "RNS_", 4) == 0) {
+      objc_setAssociatedObject(
+          self.moreNavigationController, kRNSTabBarControllerAssociationKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    }
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
@@ -279,7 +288,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   if ([self isSelectedViewControllerTheMoreNavigationController]) {
     [self disableNavigationBarInMoreNavigationController];
-    [self setupMoreNavigationControllerDelegateIfNeeded];
+    [self prepareForMoreNavigationControllerHandlingIfNeeded];
   }
 
   auto *updateContext = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
@@ -530,7 +539,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     // in ways Yoga is not aware of. The simplest option here is to disable it.
     [self disableNavigationBarInMoreNavigationController];
 
-    [self setupMoreNavigationControllerDelegateIfNeeded];
+    [self prepareForMoreNavigationControllerHandlingIfNeeded];
   }
 
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
@@ -785,13 +794,17 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   return [poppedViewControllers firstObject];
 }
 
-- (void)setupMoreNavigationControllerDelegateIfNeeded
+- (void)prepareForMoreNavigationControllerHandlingIfNeeded
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+  // This can be called multiple times in lifetime of `RNSTabBarController`.
+  // UIKit reuses the same `UIMoreNavigationController` instance, but resets both
+  // the delegate and the isa pointer when the More controller disappears from the
+  // tab bar (e.g. user resizing the app on iPad). We re-apply both unconditionally.
   if (self.moreNavigationController.delegate == nil) {
     self.moreNavigationController.delegate = self;
-    [self installPushInterceptorOnMoreNavigationController];
   }
+  [self ensurePushInterceptorOnMoreNavigationController];
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
@@ -802,13 +815,14 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 /// The subclass name is derived from the actual runtime class of `moreNavigationController`
 /// (e.g. `RNS_UIMoreNavigationController`), so if another library ISA-swizzles it first or Apple
 /// changes the private class, each distinct original class gets its own correct dynamic subclass.
-- (void)installPushInterceptorOnMoreNavigationController
+///
+/// This method is idempotent — safe to call multiple times. The dynamic subclass is created once
+/// and reused; `object_setClass` and `objc_setAssociatedObject` are re-applied on each call.
+/// This is necessary because UIKit resets the isa pointer of `moreNavigationController` during
+/// tab bar reconfiguration (e.g. iPad app resize crossing the >5 tab threshold).
+- (void)ensurePushInterceptorOnMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  RCTAssert(
-      _didInstallPushInterceptor == NO,
-      @"[RNScreens] installPushInterceptorOnMoreNavigationController MUST NOT be called twice");
-
   Class originalClass = object_getClass(self.moreNavigationController);
   const char *originalClassName = class_getName(originalClass);
 
@@ -838,7 +852,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   // OBJC_ASSOCIATION_ASSIGN: no retain cycle — self owns moreNavigationController and outlives it.
   objc_setAssociatedObject(
       self.moreNavigationController, kRNSTabBarControllerAssociationKey, self, OBJC_ASSOCIATION_ASSIGN);
-  _didInstallPushInterceptor = YES;
+  _didAccessMoreNavigationController = YES;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -112,6 +112,10 @@ NS_ASSUME_NONNULL_BEGIN
              currentState:(nonnull RNSTabsNavigationState *)currentNavState
                withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
 
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    preventedSelectionOf:(nonnull NSString *)screenKey
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -628,6 +628,22 @@ RNS_IGNORE_SUPER_CALL_END
                                                       .rejectionReason = reasonCode}];
 }
 
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    preventedSelectionOf:(nonnull NSString *)screenKey
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState
+{
+  RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
+  RCTAssert(screenKey != nil, @"[RNScreens] Expected NON NIL screenKey");
+  RCTAssert(
+      currentNavState != nil && currentNavState.selectedScreenKey != nil,
+      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+
+  [self.reactEventEmitter emitOnTabSelectionPrevented:{
+                                                          .currentNavState = currentNavState,
+                                                          .preventedScreenKey = screenKey,
+  }];
+}
+
 @end
 
 #pragma mark - Modified React Subviews implementation

--- a/ios/tabs/host/RNSTabsHostEventEmitter.h
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.h
@@ -40,6 +40,14 @@ typedef struct {
   RNSTabsNavigationStateRejectionReason rejectionReason;
 } OnTabSelectionRejectedPayload;
 
+/** Payload for the `onTabSelectionPrevented` event emitted when a tab selection is prevented. */
+typedef struct {
+  /** The currently active navigation state that was kept. */
+  RNSTabsNavigationState *_Nonnull currentNavState;
+  /** Screen key of the tab whose selection was prevented. */
+  NSString *_Nonnull preventedScreenKey;
+} OnTabSelectionPreventedPayload;
+
 @interface RNSTabsHostEventEmitter : NSObject
 
 /** Emits `onTabSelected` event to JS. Returns YES if the event was dispatched successfully. */
@@ -47,6 +55,9 @@ typedef struct {
 
 /** Emits `onTabSelectionRejected` event to JS. Returns YES if the event was dispatched successfully. */
 - (BOOL)emitOnTabSelectionRejected:(OnTabSelectionRejectedPayload)payload;
+
+/** Emits `onTabSelectionPrevented` event to JS. Returns YES if the event was dispatched successfully. */
+- (BOOL)emitOnTabSelectionPrevented:(OnTabSelectionPreventedPayload)payload;
 
 @end
 

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -69,4 +69,18 @@ namespace react = facebook::react;
   }
 }
 
+- (BOOL)emitOnTabSelectionPrevented:(OnTabSelectionPreventedPayload)payload
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onTabSelectionPrevented(
+        {.selectedScreenKey = RCTStringFromNSString(payload.currentNavState.selectedScreenKey),
+         .provenance = payload.currentNavState.provenance,
+         .preventedScreenKey = RCTStringFromNSString(payload.preventedScreenKey)});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnTabSelectionPrevented event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 @end

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -81,6 +81,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL shouldUseRepeatedTabSelectionPopToRootSpecialEffect;
 @property (nonatomic) BOOL shouldUseRepeatedTabSelectionScrollToTopSpecialEffect;
 
+@property (nonatomic) BOOL preventNativeSelection;
+
 @property (nonatomic, readonly) BOOL overrideScrollViewContentInsetAdjustmentBehavior;
 
 @property (nonatomic, nullable) NSString *tabItemTestID;

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -348,6 +348,10 @@ RNS_IGNORE_SUPER_CALL_END
         newComponentProps.specialEffects.repeatedTabSelection.scrollToTop;
   }
 
+  if (newComponentProps.preventNativeSelection != oldComponentProps.preventNativeSelection) {
+    _preventNativeSelection = newComponentProps.preventNativeSelection;
+  }
+
   if (newComponentProps.overrideScrollViewContentInsetAdjustmentBehavior !=
       oldComponentProps.overrideScrollViewContentInsetAdjustmentBehavior) {
     _overrideScrollViewContentInsetAdjustmentBehavior =

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RNSTabBarController;
+
 @interface RNSTabsScreenViewController : UIViewController
 #if !TARGET_OS_TV
                                          <RNSOrientationProviding>
@@ -17,8 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly, nullable) RNSTabsScreenComponentView *tabScreenComponentView;
 @property (nonatomic, weak, readonly, nullable) id<RNSTabsSpecialEffectsSupporting> tabsSpecialEffectsDelegate;
-
-- (nullable NSString *)getScreenKeyOrNull;
 
 /**
  * Tell the controller that the tab screen it owns has got its react-props related to appearance changed.
@@ -47,6 +47,14 @@ NS_ASSUME_NONNULL_BEGIN
  * already changed (to other delegate or nil), this method does nothing.
  */
 - (void)clearTabsSpecialEffectsDelegateIfNeeded:(nonnull id<RNSTabsSpecialEffectsSupporting>)delegate;
+
+@end
+
+@interface RNSTabsScreenViewController (ScreenPropsForwarding)
+
+- (nullable NSString *)getScreenKeyOrNull;
+
+- (BOOL)isPreventNativeSelectionEnabled;
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface RNSTabsScreenViewController (ScreenPropsForwarding)
+@interface RNSTabsScreenViewController (TabsScreenPropsForwarding)
 
 - (nullable NSString *)getScreenKeyOrNull;
 

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -10,8 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RNSTabBarController;
-
 @interface RNSTabsScreenViewController : UIViewController
 #if !TARGET_OS_TV
                                          <RNSOrientationProviding>

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -126,7 +126,7 @@
 
 @end
 
-@implementation RNSTabsScreenViewController (ScreenPropsForwarding)
+@implementation RNSTabsScreenViewController (TabsScreenPropsForwarding)
 
 - (nullable NSString *)getScreenKeyOrNull
 {

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -28,21 +28,25 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
+  [super viewWillAppear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnWillAppear];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
+  [super viewDidAppear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnDidAppear];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
+  [super viewWillDisappear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnWillDisappear];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+  [super viewDidDisappear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnDidDisappear];
 }
 

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -6,11 +6,6 @@
 
 @implementation RNSTabsScreenViewController
 
-- (nullable NSString *)getScreenKeyOrNull
-{
-  return self.tabScreenComponentView.screenKey;
-}
-
 - (nullable RNSTabBarController *)findTabBarController
 {
   return static_cast<RNSTabBarController *_Nullable>(self.tabBarController);
@@ -124,5 +119,19 @@
 }
 
 #endif // !TARGET_OS_TV
+
+@end
+
+@implementation RNSTabsScreenViewController (ScreenPropsForwarding)
+
+- (nullable NSString *)getScreenKeyOrNull
+{
+  return self.tabScreenComponentView.screenKey;
+}
+
+- (BOOL)isPreventNativeSelectionEnabled
+{
+  return self.tabScreenComponentView.preventNativeSelection;
+}
 
 @end

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -105,6 +105,19 @@ export type TabSelectionRejectedEvent = {
   rejectionReason: TabSelectionRejectionReason;
 };
 
+/**
+ * @summary Payload of the event emitted when the native side prevents a tab selection
+ * because the target screen has `preventNativeSelection` enabled.
+ */
+export type TabSelectionPreventedEvent = {
+  /** Screen key of the currently selected (active) tab. */
+  selectedScreenKey: string;
+  /** Provenance of the currently active navigation state. */
+  provenance: number;
+  /** Screen key of the tab whose selection was prevented. */
+  preventedScreenKey: string;
+};
+
 export type TabsHostColorScheme = ColorScheme | 'inherit';
 
 export type TabsHostDirection = Direction | 'inherit';
@@ -257,6 +270,17 @@ export interface TabsHostPropsBase {
    */
   onTabSelectionRejected?: (
     event: NativeSyntheticEvent<TabSelectionRejectedEvent>,
+  ) => void;
+
+  /**
+   * @summary
+   * A callback that gets invoked when the native side prevents a tab selection
+   * because the target screen has `preventNativeSelection` enabled.
+   *
+   * @see {@link TabSelectionPreventedEvent}
+   */
+  onTabSelectionPrevented?: (
+    event: NativeSyntheticEvent<TabSelectionPreventedEvent>,
   ) => void;
 }
 

--- a/src/components/tabs/screen/TabsScreen.types.ts
+++ b/src/components/tabs/screen/TabsScreen.types.ts
@@ -30,6 +30,14 @@ export interface TabsScreenPropsBase {
    * @platform android, ios
    */
   screenKey: string;
+  /**
+   * @summary When set to `true`, prevents native tab selection for this screen.
+   *
+   * @default false
+   *
+   * @platform android, ios
+   */
+  preventNativeSelection?: boolean;
 
   // General
   children?: ViewProps['children'];

--- a/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
@@ -26,6 +26,12 @@ type TabSelectionRejectedEvent = Readonly<{
   rejectionReason: 'stale' | 'repeated' | 'more-nav-ctrl-not-available';
 }>;
 
+type TabSelectionPreventedEvent = Readonly<{
+  selectedScreenKey: string;
+  provenance: CT.Int32;
+  preventedScreenKey: string;
+}>;
+
 type TabsHostColorScheme = 'inherit' | 'light' | 'dark';
 
 // #endregion General helpers
@@ -42,6 +48,7 @@ export interface NativeProps extends ViewProps {
   // Events
   onTabSelected?: CT.DirectEventHandler<TabSelectedEvent>;
   onTabSelectionRejected?: CT.DirectEventHandler<TabSelectionRejectedEvent>;
+  onTabSelectionPrevented?: CT.DirectEventHandler<TabSelectionPreventedEvent>;
 
   // General
   tabBarHidden?: CT.WithDefault<boolean, false>;

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -26,6 +26,12 @@ type TabSelectionRejectedEvent = Readonly<{
   rejectionReason: 'stale' | 'repeated' | 'more-nav-ctrl-not-available';
 }>;
 
+type TabSelectionPreventedEvent = Readonly<{
+  selectedScreenKey: string;
+  provenance: CT.Int32;
+  preventedScreenKey: string;
+}>;
+
 type TabsHostColorScheme = 'inherit' | 'light' | 'dark';
 
 type LayoutDirection = 'inherit' | 'ltr' | 'rtl';
@@ -52,6 +58,7 @@ export interface NativeProps extends ViewProps {
   // Events
   onTabSelected?: CT.DirectEventHandler<TabSelectedEvent>;
   onTabSelectionRejected?: CT.DirectEventHandler<TabSelectionRejectedEvent>;
+  onTabSelectionPrevented?: CT.DirectEventHandler<TabSelectionPreventedEvent>;
 
   // General
   tabBarHidden?: CT.WithDefault<boolean, false>;

--- a/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenAndroidNativeComponent.ts
@@ -74,6 +74,7 @@ export interface NativeProps extends ViewProps {
 
   // Control
   screenKey: string;
+  preventNativeSelection?: CT.WithDefault<boolean, false>;
 
   // General
   title?: string | undefined | null;

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -119,6 +119,7 @@ export interface NativeProps extends ViewProps {
   // Control
   isFocused?: boolean;
   screenKey: string;
+  preventNativeSelection?: CT.WithDefault<boolean, false>;
 
   // General
   title?: string | undefined | null;


### PR DESCRIPTION
## Description

Adds the ability to prevent native tab selection on a per-screen basis. When `preventNativeSelection` is set to `true` on a `TabsScreen`, tapping that tab in the tab bar (or selecting it from the "More" list on iOS) will be blocked. The `TabsHost` receives an `onTabSelectionPrevented` callback with the key of the prevented screen and the current navigation state, allowing JS to decide how to handle the attempt (e.g. show a confirmation dialog, redirect elsewhere).

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1078

## Changes

- **`TabsScreen`**: New `preventNativeSelection` boolean prop plumbed from JS → codegen specs → native on both Android and iOS.
- **`TabsHost`**: New `onTabSelectionPrevented` event (type + codegen spec + native emitter) fired when selection is blocked.
- **iOS (`RNSTabBarController`)**:
  - `tabBarController:shouldSelectViewController:` now checks per-screen `preventNativeSelection` and emits the prevented event.
  - ISA-swizzles `UIMoreNavigationController` to intercept `pushViewController:animated:` so screens behind the "More" list are also subject to prevention. Includes table-view deselection cleanup when a push is blocked.
  - Dynamic subclass name is derived from the actual runtime class (e.g. `RNS_UIMoreNavigationController`), so each distinct original class gets its own correct subclass — safe even if another library ISA-swizzles first.
  - Clears the `OBJC_ASSOCIATION_ASSIGN` back-reference in `dealloc` as a safety measure against potential dangling pointers.
  - Refactored `screenKeyForSelectedViewController` → `screenKeyForViewController:` and `isSelectedViewControllerTheMoreNavigationController` → `isViewControllerTheMoreNavigationController:` to support querying arbitrary view controllers (not just the selected one).
- **iOS (`RNSTabsScreenViewController`)**: Added `ScreenPropsForwarding` category exposing `isPreventNativeSelectionEnabled`.
- **Android**: Prevention logic in `TabsContainer.onMenuItemSelected` — checks `isPreventNativeSelectionEnabled` before progressing state, delegates to `TabsContainerDelegate.onNavStateUpdatePrevented` which emits the event via `TabsHost`.
- **Example app**: New test scenario (`TestTabsPreventNativeSelection`) with 6 tabs, per-tab toggle, and toast on prevention.

## Known issues

- **`experimental_controlNavigationStateInJS` is not respected in the "More" navigation controller flow on iOS.** When the experimental controlled-mode flag is enabled and the user is already on the "More" tab, tapping items in the More list will not be blocked by the controlled-mode gate (only by `preventNativeSelection`). This is acceptable since the controlled-mode feature is planned for removal before release.

## Visual documentation

### Rudimentary scenarios

We navigate to a "third" tab natively, toggle `preventNativeSelection`, go back, and navigate again. That attempt is blocked (prevented) and an event is emitted, as it can be observed by appearance of toast. We navigate to the "third" tab via JS - this is allowed, as we only prevent native selection - toggle the option and repeat the experiment. This time navigation to "third" tab is allowed.

| iOS | Android | 
| -- | -- |
| <video src="https://github.com/user-attachments/assets/fed8b101-265e-469a-8e18-ad4cc6148618" alt="s-1-ios" /> | <video src="https://github.com/user-attachments/assets/523b0fbd-9366-4943-95bc-c4f7059a62e3" alt="s-1-android" /> |

### More navigation controller scenarios

In the video on the left I showcase that the navigation from "more list" is correctly prevented.

In the video on the right I cover a edge case, where a user / programmer navigates first the the "fifth" tab, then navigates away, e.g. to "third" and then comes back. W/o prevention mechanism, the "fifth" tab would be shown, as it is pushed onto *more navigation controller stack*. I've implemented logic to cover this case. Now, the "more list" will be displayed. *I've decided that in such case we will emit the `OnTabSelectionPrevented` event*, as we effectively prevent s user from navigating to that tab, even if this is not fully intentional. See [more details here](https://github.com/software-mansion/react-native-screens/pull/3838/commits/610a4df4679d4c70db802fc1890b51a57f217f51).

| Block from more list | Forced pop on navigation | 
| -- | -- |
| <video src="https://github.com/user-attachments/assets/67fb3e0e-b3bf-4ad8-8834-67e9cf8b439e" alt="block-from-more-list" /> | <video src="https://github.com/user-attachments/assets/d7302f29-dc27-4d9e-a335-6af5dcdbf2fc" alt="forced-pop-on-navigation" /> |



## Test plan

- Run `TestTabsPreventNativeSelection` scenario from the example app.
- Tap a tab → verify it switches normally.
- Toggle `preventNativeSelection` on a tab → tap it → verify it does **not** switch and the `onTabSelectionPrevented` toast appears.
- On iOS with 6 tabs: verify prevention also works for tabs listed under the "More" navigation controller.
- Toggle the flag back off → verify the tab becomes selectable again.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes