### PR TITLE
fix(ios): add missing super calls in RNSTabsScreenViewController

### DIFF
--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -33,21 +33,25 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
+  [super viewWillAppear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnWillAppear];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
+  [super viewDidAppear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnDidAppear];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
+  [super viewWillDisappear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnWillDisappear];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+  [super viewDidDisappear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnDidDisappear];
 }
 


### PR DESCRIPTION
## Description

`RNSTabsScreenViewController` overrides `viewWillAppear:`, `viewDidAppear:`, `viewWillDisappear:`, and `viewDidDisappear:` to emit React Native lifecycle events but none of them call their `super` implementation. Apple's documentation requires calling super in these methods — skipping it can break UIKit's internal bookkeeping for appearance transitions, trait collection propagation, and child container callbacks.

## Changes

- Added `[super viewWillAppear:animated]`, `[super viewDidAppear:animated]`, `[super viewWillDisappear:animated]`, and `[super viewDidDisappear:animated]` calls before the event emission in each method.

## Test plan

- Run any Tabs test scenario from the example app.
- Verify tab switching, appearance/disappearance events, and orientation changes still work correctly.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes