### PR TITLE
chore(Tabs): remove isFocused prop from TabsScreen codegen spec

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -10,7 +10,7 @@ import type { SafeAreaViewProps } from '../../../../../../src/components/safe-ar
 
 export type TabRouteOptions = Omit<
   TabsScreenProps,
-  'children' | 'screenKey' | 'isFocused'
+  'children' | 'screenKey'
 > & {
   safeAreaConfiguration?: SafeAreaViewProps;
 };

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -117,7 +117,6 @@ export interface NativeProps extends ViewProps {
   onDidDisappear?: CT.DirectEventHandler<GenericEmptyEvent>;
 
   // Control
-  isFocused?: boolean;
   screenKey: string;
   preventNativeSelection?: CT.WithDefault<boolean, false>;
 


### PR DESCRIPTION
## Description

Remove the `isFocused` prop from the `TabsScreen` iOS codegen spec. Tab focus is managed natively by the platform — the JS-driven `isFocused` prop is no longer needed.

I believe strongly I've already removed it once, but it returned, likely as some merge / rebase artifact. 

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1128

## Changes

- Removed `isFocused?: boolean` from `NativeProps` in the codegen spec (`TabsScreenIOSNativeComponent.ts`).
- Removed the now-unnecessary `'isFocused'` entry from the `Omit` in `TabRouteOptions` (example app types).

> [!note]
> The legacy (Paper) arch property remap in `RNSTabsScreenComponentViewManager.mm` is intentionally left untouched — old arch code removal is tracked separately.

## Test plan

No new tests — this is a prop removal. Existing Tabs tests should continue to pass as the prop was not actively consumed.

## Checklist

- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes