### PR TITLE
refactor(test): defining testID for ScenarioButton an assign scenario key property value to it

### DIFF
--- a/apps/src/tests/shared/ScenarioButton.tsx
+++ b/apps/src/tests/shared/ScenarioButton.tsx
@@ -7,6 +7,7 @@ export function ScenarioButton(props: {
   title: string;
   details?: string;
   platformsHint?: ('ios' | 'android')[];
+  testID?: string;
 }) {
   const navigation = useNavigation<any>();
   const hasAndroid =
@@ -17,6 +18,7 @@ export function ScenarioButton(props: {
 
   return (
     <TouchableOpacity
+      testID={props.testID}
       style={styles.button}
       onPress={() => navigation.navigate(props.route)}>
       <View style={styles.descriptionContainer}>

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -11,13 +11,14 @@ import {
 function ScenarioSelect(props: { scenarios: Scenario[] }) {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {Object.values(props.scenarios).map(({ name, key, details, platforms }) => (
+      {Object.values(props.scenarios).map(({ name, key, details, platforms, testID }) => (
         <ScenarioButton
           title={name}
           details={details}
           route={key}
           key={key}
           platformsHint={platforms}
+          testID={testID}
         />
       ))}
     </ScrollView>

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -11,14 +11,14 @@ import {
 function ScenarioSelect(props: { scenarios: Scenario[] }) {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {Object.values(props.scenarios).map(({ name, key, details, platforms, testID }) => (
+      {Object.values(props.scenarios).map(({ name, key, details, platforms }) => (
         <ScenarioButton
           title={name}
           details={details}
           route={key}
           key={key}
           platformsHint={platforms}
-          testID={testID}
+          testID={key}
         />
       ))}
     </ScrollView>

--- a/apps/src/tests/shared/helpers.ts
+++ b/apps/src/tests/shared/helpers.ts
@@ -21,6 +21,10 @@ export interface Scenario {
    */
   platforms?: ('android' | 'ios')[];
   /**
+   * Test ID for the scenario
+   */
+  testID?: string;
+  /**
    * Component that will render the test scenario. It should be standalone!
    * That means it should be possible to render this w/o any additional harness
    * as top-level application component & it should remain functional.

--- a/apps/src/tests/shared/helpers.ts
+++ b/apps/src/tests/shared/helpers.ts
@@ -10,6 +10,7 @@ export interface Scenario {
    * Globally unique key identifying this scenario.
    * Must be in kebab-case.
    * Should match the filename of the scenario file.
+   * This is also used as a testID in scenario.
    */
   key: string;
   /**
@@ -20,10 +21,6 @@ export interface Scenario {
    * What platforms does this test cover.
    */
   platforms?: ('android' | 'ios')[];
-  /**
-   * testID for the scenario
-   */
-  testID?: string;
   /**
    * Component that will render the test scenario. It should be standalone!
    * That means it should be possible to render this w/o any additional harness

--- a/apps/src/tests/shared/helpers.ts
+++ b/apps/src/tests/shared/helpers.ts
@@ -10,7 +10,7 @@ export interface Scenario {
    * Globally unique key identifying this scenario.
    * Must be in kebab-case.
    * Should match the filename of the scenario file.
-   * This is also used as a testID in scenario.
+   * This is also used as the testID for the scenario.
    */
   key: string;
   /**

--- a/apps/src/tests/shared/helpers.ts
+++ b/apps/src/tests/shared/helpers.ts
@@ -21,7 +21,7 @@ export interface Scenario {
    */
   platforms?: ('android' | 'ios')[];
   /**
-   * Test ID for the scenario
+   * testID for the scenario
    */
   testID?: string;
   /**


### PR DESCRIPTION
## Description

Defined testID for ScenarioButton. 
This testID is mapped in the ScenarioSelect function (found in ScenarioScreen.tsx) to the scenario's key property. This change is required for single-feature tests to allow Detox to select a specific scenario from the domain-specific list (e.g., Tabs).

Fixes: https://github.com/software-mansion/react-native-screens-labs/issues/1125 

### Changes
- testID was added to ScenarioButton function to make it accessible by detox 
- Updated the ScenarioSelect function (in ScenarioScreen.tsx) to pass the scenario's **key property** as the testID to each ScenarioButton.