### PR TITLE
fix(Android, Stack v4): fall back to rootWindowInsets for status bar top when ancestor consumed insets

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -168,10 +168,20 @@ open class CustomToolbar(
         // We want to handle display cutout always, no matter the HeaderConfig prop values.
         // If there are no cutout displays, we want to apply the additional padding to
         // respect the status bar.
+        //
+        // Use rootWindowInsets as a fallback for status bar top height when unhandledInsets
+        // reports 0. This can happen when an ancestor view (e.g. SafeAreaProvider from
+        // react-native-safe-area-context) has already consumed the top systemBars inset, causing
+        // unhandledInsets.top == 0 and the toolbar title to render behind the status bar.
+        // rootWindowInsets always contains the raw window insets regardless of consumption by ancestors.
+        val statusBarTop = if (shouldApplyTopInset) {
+            val fromUnhandled = systemBarInsets.top
+            if (fromUnhandled > 0) fromUnhandled else resolveInsetsOrZero(WindowInsetsCompat.Type.systemBars()).top
+        } else 0
         val verticalInsets =
             InsetsCompat.of(
                 0,
-                max(cutoutInsets.top, if (shouldApplyTopInset) systemBarInsets.top else 0),
+                max(cutoutInsets.top, statusBarTop),
                 0,
                 max(cutoutInsets.bottom, 0),
             )


### PR DESCRIPTION
## Description

Fixes a regression introduced in #3240 where the native stack header title renders **behind the status bar** on Android 15 (SDK 35) with edge-to-edge enabled.

### Root cause

PR #3240 changed `CustomToolbar.onApplyWindowInsets` to read `systemBars` insets from `unhandledInsets` (received from ancestor views) instead of `rootWindowInsets`. 

When `SafeAreaProvider` from `react-native-safe-area-context` wraps the app (standard setup), it **consumes the `systemBars.top` inset** before it reaches `CustomToolbar`. As a result:

```
unhandledInsets.getInsets(Type.systemBars()).top == 0  // consumed by ancestor
```

So `CustomToolbar` computes `paddingTop = 0` and the toolbar title renders at y=0, visually behind the status bar.

Before #3240, `rootWindowInsets` was used with `ignoreVisibility = true`, which always provided a stable, non-zero status bar height regardless of what ancestors consumed.

### Fix

For the status bar **top** height specifically, fall back to `rootWindowInsets` when `unhandledInsets.top == 0`. `rootWindowInsets` always contains the raw window insets that no ancestor can consume:

```kotlin
val statusBarTop = if (shouldApplyTopInset) {
    val fromUnhandled = systemBarInsets.top
    if (fromUnhandled > 0) fromUnhandled
    else resolveInsetsOrZero(WindowInsetsCompat.Type.systemBars()).top // fallback to rootWindowInsets
} else 0
```

This preserves the intent of #3240 (use ancestor-received insets when available) while fixing the regression when an ancestor has already consumed the top inset.

### Affected versions

- **4.19.0 – 4.24.0** 🐞
- **4.18.0** ✅ (used `rootWindowInsets`, worked correctly)

## Changes

- `CustomToolbar.kt`: fall back to `rootWindowInsets` for `statusBarTop` when `unhandledInsets.top == 0`

## Test code and steps to reproduce

1. Enable edge-to-edge (`edgeToEdgeEnabled=true` in `gradle.properties`)
2. Wrap the app with `SafeAreaProvider` from `react-native-safe-area-context` (standard setup)
3. Push any screen with a native header using `createNativeStackNavigator`
4. Run on Android 15 physical device or emulator

**Expected:** Header title appears below the status bar  
**Actual (4.19.0+):** Header title renders behind/under the status bar

## Environment

- React Native: 0.85.0  
- Android: 15 (SDK 35), `edgeToEdgeEnabled=true`  
- Architecture: New Architecture (Fabric)  
- `@react-navigation/native-stack`: 7.6.1  
- `react-native-safe-area-context`: ^5.7.0

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation