### PR TITLE
feat(android): implement preventNativeDismiss / onNativeDismissCancelled for formSheet

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -80,12 +80,6 @@ class Screen(
      * Only takes effect when `stackPresentation` is `formSheet`.
      */
     var isPreventNativeDismiss: Boolean = false
-        set(value) {
-            field = value
-            // Keep BottomSheetBehavior in sync when the prop changes at runtime
-            // (e.g., when a form becomes dirty after initial mount).
-            sheetBehavior?.isHideable = !value
-        }
 
     var isSheetGrabberVisible: Boolean = false
 

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -69,6 +69,24 @@ class Screen(
     var isBeingRemoved = false
 
     // Props for controlling modal presentation
+
+    /**
+     * When `true`, the `formSheet` presentation will not be dismissed by a drag gesture.
+     * Instead, the gesture will bounce the sheet back to its last stable detent and fire the
+     * `onNativeDismissCancelled` event so the JS layer can respond (e.g., show a confirmation
+     * dialog).  Mirrors the iOS `preventNativeDismiss` behaviour powered by
+     * `UIAdaptivePresentationControllerDelegate.presentationControllerShouldDismiss`.
+     *
+     * Only takes effect when `stackPresentation` is `formSheet`.
+     */
+    var isPreventNativeDismiss: Boolean = false
+        set(value) {
+            field = value
+            // Keep BottomSheetBehavior in sync when the prop changes at runtime
+            // (e.g., when a form becomes dirty after initial mount).
+            sheetBehavior?.isHideable = !value
+        }
+
     var isSheetGrabberVisible: Boolean = false
 
     // corner radius must be updated after all props prop updates from a single transaction

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -21,6 +21,7 @@ import com.swmansion.rnscreens.events.ScreenDismissedEvent
 import com.swmansion.rnscreens.events.ScreenTransitionProgressEvent
 import com.swmansion.rnscreens.events.ScreenWillAppearEvent
 import com.swmansion.rnscreens.events.ScreenWillDisappearEvent
+import com.swmansion.rnscreens.events.ScreenNativeDismissCancelledEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
@@ -291,7 +292,9 @@ open class ScreenViewManager :
     override fun setPreventNativeDismiss(
         view: Screen?,
         value: Boolean,
-    ) = Unit
+    ) {
+        view?.isPreventNativeDismiss = value
+    }
 
     override fun setSwipeDirection(
         view: Screen?,
@@ -403,6 +406,7 @@ open class ScreenViewManager :
             HeaderBackButtonClickedEvent.EVENT_NAME to hashMapOf("registrationName" to "onHeaderBackButtonClicked"),
             ScreenTransitionProgressEvent.EVENT_NAME to hashMapOf("registrationName" to "onTransitionProgress"),
             SheetDetentChangedEvent.EVENT_NAME to hashMapOf("registrationName" to "onSheetDetentChanged"),
+            ScreenNativeDismissCancelledEvent.EVENT_NAME to hashMapOf("registrationName" to "onNativeDismissCancelled"),
         )
 
     protected override fun getDelegate(): ViewManagerDelegate<Screen> = delegate

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -197,8 +197,12 @@ class SheetDelegate(
         }
 
         behavior.apply {
-            isHideable = true
-            isDraggable = true
+            // When preventNativeDismiss is true the sheet must not be able to reach STATE_HIDDEN
+            // via a drag gesture.  BottomSheetBehavior will then snap back to the last stable
+            // detent, giving us a window to detect the attempt and notify JS via
+            // onNativeDismissCancelled (mirrors iOS presentationControllerShouldDismiss logic).
+            isHideable = !screen.isPreventNativeDismiss
+            isDraggable = screen.isGestureEnabled
         }
 
         // There is a guard internally that does not allow the callback to be duplicated.
@@ -627,17 +631,49 @@ class SheetDelegate(
     }
 
     private inner class SheetStateObserver : BottomSheetBehavior.BottomSheetCallback() {
-        override fun onStateChanged(
-            bottomSheet: View,
-            newState: Int,
-        ) {
-            this@SheetDelegate.onSheetStateChanged(newState)
-        }
+        // Tracks whether the user dragged the sheet past the lowest stable detent during
+        // the current gesture, which is the signal we use to detect a dismiss attempt when
+        // isHideable = false (i.e. preventNativeDismiss = true).
+        private var hasDraggedTowardDismiss = false
 
         override fun onSlide(
             bottomSheet: View,
             slideOffset: Float,
-        ) = Unit
+        ) {
+            // slideOffset == 0 corresponds to the lowest stable detent; negative means the
+            // sheet has been pulled below that point toward dismissal.  We use a small
+            // negative threshold rather than exactly 0 to avoid false positives from
+            // incidental micro-movements at the boundary.
+            if (slideOffset < DISMISS_ATTEMPT_SLIDE_THRESHOLD) {
+                hasDraggedTowardDismiss = true
+            }
+        }
+
+        override fun onStateChanged(
+            bottomSheet: View,
+            newState: Int,
+        ) {
+            val wasDraggingTowardDismiss = hasDraggedTowardDismiss
+
+            // Reset the flag whenever we land on any stable state (hidden or expanded).
+            if (SheetUtils.isStateStable(newState)) {
+                hasDraggedTowardDismiss = false
+            }
+
+            this@SheetDelegate.onSheetStateChanged(newState)
+
+            // A prevented dismiss looks like: user drags past the lowest detent, sheet
+            // settles back to a non-hidden stable state because isHideable = false.
+            // At that point we fire onNativeDismissCancelled so JS can respond
+            // (e.g. present a "discard changes?" confirmation).
+            if (screen.isPreventNativeDismiss &&
+                wasDraggingTowardDismiss &&
+                SheetUtils.isStateStable(newState) &&
+                !shouldDismissSheetInState(newState)
+            ) {
+                ScreenEventEmitter(screen).dispatchOnNativeDismissCancelled()
+            }
+        }
     }
 
     internal data class SheetAnimationContext(
@@ -649,5 +685,11 @@ class SheetDelegate(
 
     companion object {
         const val TAG = "SheetDelegate"
+
+        // The slideOffset value below which we consider the user to be attempting a dismiss
+        // gesture.  slideOffset == 0 is the lowest stable detent; values < 0 indicate the
+        // sheet has been pulled below that point.  A small negative threshold avoids false
+        // positives from micro-movements at the detent boundary.
+        private const val DISMISS_ATTEMPT_SLIDE_THRESHOLD = -0.05f
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -197,11 +197,7 @@ class SheetDelegate(
         }
 
         behavior.apply {
-            // When preventNativeDismiss is true the sheet must not be able to reach STATE_HIDDEN
-            // via a drag gesture.  BottomSheetBehavior will then snap back to the last stable
-            // detent, giving us a window to detect the attempt and notify JS via
-            // onNativeDismissCancelled (mirrors iOS presentationControllerShouldDismiss logic).
-            isHideable = !screen.isPreventNativeDismiss
+            isHideable = true
             isDraggable = true
         }
 
@@ -631,48 +627,28 @@ class SheetDelegate(
     }
 
     private inner class SheetStateObserver : BottomSheetBehavior.BottomSheetCallback() {
-        // Tracks whether the user dragged the sheet past the lowest stable detent during
-        // the current gesture, which is the signal we use to detect a dismiss attempt when
-        // isHideable = false (i.e. preventNativeDismiss = true).
-        private var hasDraggedTowardDismiss = false
-
         override fun onSlide(
             bottomSheet: View,
             slideOffset: Float,
-        ) {
-            // slideOffset == 0 corresponds to the lowest stable detent; negative means the
-            // sheet has been pulled below that point toward dismissal.  We use a small
-            // negative threshold rather than exactly 0 to avoid false positives from
-            // incidental micro-movements at the boundary.
-            if (slideOffset < DISMISS_ATTEMPT_SLIDE_THRESHOLD) {
-                hasDraggedTowardDismiss = true
-            }
-        }
+        ) = Unit
 
         override fun onStateChanged(
             bottomSheet: View,
             newState: Int,
         ) {
-            val wasDraggingTowardDismiss = hasDraggedTowardDismiss
-
-            // Reset the flag whenever we land on any stable state (hidden or expanded).
-            if (SheetUtils.isStateStable(newState)) {
-                hasDraggedTowardDismiss = false
-            }
-
-            this@SheetDelegate.onSheetStateChanged(newState)
-
-            // A prevented dismiss looks like: user drags past the lowest detent, sheet
-            // settles back to a non-hidden stable state because isHideable = false.
-            // At that point we fire onNativeDismissCancelled so JS can respond
-            // (e.g. present a "discard changes?" confirmation).
-            if (screen.isPreventNativeDismiss &&
-                wasDraggingTowardDismiss &&
-                SheetUtils.isStateStable(newState) &&
-                !shouldDismissSheetInState(newState)
-            ) {
+            // When preventNativeDismiss is enabled, intercept STATE_HIDDEN before it is
+            // processed further.  BottomSheetBehavior still reaches STATE_HIDDEN via the
+            // drag gesture (isHideable stays true so STATE_COLLAPSED is never reached),
+            // but we snap it back to the last stable state and notify JS instead of
+            // actually dismissing.  This mirrors the iOS
+            // UIAdaptivePresentationControllerDelegate.presentationControllerShouldDismiss
+            // synchronous hook.
+            if (screen.isPreventNativeDismiss && newState == BottomSheetBehavior.STATE_HIDDEN) {
+                sheetBehavior?.state = lastStableState
                 ScreenEventEmitter(screen).dispatchOnNativeDismissCancelled()
+                return
             }
+            this@SheetDelegate.onSheetStateChanged(newState)
         }
     }
 
@@ -685,11 +661,5 @@ class SheetDelegate(
 
     companion object {
         const val TAG = "SheetDelegate"
-
-        // The slideOffset value below which we consider the user to be attempting a dismiss
-        // gesture.  slideOffset == 0 is the lowest stable detent; values < 0 indicate the
-        // sheet has been pulled below that point.  A small negative threshold avoids false
-        // positives from micro-movements at the detent boundary.
-        private const val DISMISS_ATTEMPT_SLIDE_THRESHOLD = -0.05f
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -202,7 +202,7 @@ class SheetDelegate(
             // detent, giving us a window to detect the attempt and notify JS via
             // onNativeDismissCancelled (mirrors iOS presentationControllerShouldDismiss logic).
             isHideable = !screen.isPreventNativeDismiss
-            isDraggable = screen.isGestureEnabled
+            isDraggable = true
         }
 
         // There is a guard internally that does not allow the callback to be duplicated.

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenEventEmitter.kt
@@ -25,6 +25,8 @@ class ScreenEventEmitter(
 
     fun dispatchOnDismissed() = reactEventDispatcher?.dispatchEvent(ScreenDismissedEvent(reactSurfaceId, screen.id))
 
+    fun dispatchOnNativeDismissCancelled() = reactEventDispatcher?.dispatchEvent(ScreenNativeDismissCancelledEvent(reactSurfaceId, screen.id))
+
     fun dispatchTransitionProgress(
         progress: Float,
         isExitAnimation: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/events/ScreenNativeDismissCancelledEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/events/ScreenNativeDismissCancelledEvent.kt
@@ -1,0 +1,24 @@
+package com.swmansion.rnscreens.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class ScreenNativeDismissCancelledEvent(
+    surfaceId: Int,
+    viewId: Int,
+) : Event<ScreenNativeDismissCancelledEvent>(surfaceId, viewId) {
+    override fun getEventName() = EVENT_NAME
+
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
+
+    override fun getEventData(): WritableMap? =
+        Arguments.createMap().apply {
+            putInt("dismissCount", 1)
+        }
+
+    companion object {
+        const val EVENT_NAME = "topNativeDismissCancelled"
+    }
+}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -300,7 +300,10 @@ export interface ScreenProps extends ViewProps {
   /**
    * An internal callback called when screen is dismissed by gesture or by native header back button and `preventNativeDismiss` is set to `true`.
    *
-   * @platform ios
+   * On Android this fires after the sheet bounces back from a prevented drag-to-dismiss
+   * gesture (only applicable when `stackPresentation` is `"formSheet"`).
+   *
+   * @platform ios, android
    */
   onNativeDismissCancelled?: (
     e: NativeSyntheticEvent<{ dismissCount: number }>,
@@ -326,10 +329,20 @@ export interface ScreenProps extends ViewProps {
    */
   onWillDisappear?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
   /**
-   * Boolean indicating whether to prevent current screen from being dismissed.
-   * Defaults to `false`.
+   * Boolean indicating whether to prevent current screen from being dismissed by a drag
+   * gesture.  Defaults to `false`.
    *
-   * @platform ios
+   * On iOS this delegates to `UIAdaptivePresentationControllerDelegate
+   * .presentationControllerShouldDismiss`, which synchronously cancels the gesture before
+   * any visual motion occurs.
+   *
+   * On Android this is supported for `formSheet` presentation.  When `true`,
+   * `BottomSheetBehavior.isHideable` is set to `false` so the sheet bounces back to its
+   * last stable detent rather than reaching `STATE_HIDDEN`.  The
+   * `onNativeDismissCancelled` callback fires after the sheet settles, giving the JS layer
+   * a chance to respond (e.g. show a "Discard changes?" confirmation sheet).
+   *
+   * @platform ios, android (formSheet only)
    */
   preventNativeDismiss?: boolean;
   ref?: React.Ref<View>;


### PR DESCRIPTION
## Problem

`preventNativeDismiss` and `onNativeDismissCancelled` were no-ops on Android. Because of this, navigation libraries (e.g. React Navigation) that rely on `usePreventRemove` + `onNativeDismissCancelled` to implement "unsaved changes" guards work correctly on iOS but are completely bypassed on Android `formSheet` — the sheet dismisses natively before the JS layer can intercept it.

> **Note:** `gestureEnabled` / `isDraggable` support is tracked separately in #2937. This PR does not touch that prop.

## Root cause

iOS exposes `UIAdaptivePresentationControllerDelegate.presentationControllerShouldDismiss` — a **synchronous** hook that can return `NO` before any visual motion occurs. Android's `BottomSheetBehavior` has no equivalent. By the time any callback fires, the sheet has already moved.

## Solution

Implement the closest Android equivalent using `BottomSheetBehavior.isHideable`:

| Step | What happens |
|------|-------------|
| `preventNativeDismiss=true` set | `BottomSheetBehavior.isHideable = false` → sheet cannot reach `STATE_HIDDEN` via gesture |
| User drags sheet downward | `onSlide` fires; `slideOffset < -0.05f` flags a dismiss attempt |
| User releases | Behavior snaps sheet back to last stable detent |
| Stable state fires | `onNativeDismissCancelled` is dispatched to JS |
| JS receives event | App responds — e.g. shows a "Discard changes?" confirmation |

Runtime changes to `preventNativeDismiss` (e.g. a form going from clean → dirty) are reflected immediately via a property setter that updates `BottomSheetBehavior.isHideable` without requiring a re-mount.

The sheet moves slightly before bouncing back (unlike iOS where the gesture is cancelled before any visual motion), but the **JS contract is identical on both platforms**: `preventNativeDismiss` blocks the dismissal and `onNativeDismissCancelled` fires so the app can respond.

## Example usage

The following pattern works on iOS today. After this PR, it also works on Android `formSheet` with no changes required in application code:

```tsx
import { usePreventRemove } from '@react-navigation/native';
import { useState } from 'react';
import { Alert } from 'react-native';

function EditProfileScreen() {
  const [isDirty, setIsDirty] = useState(false);

  usePreventRemove(isDirty, ({ data }) => {
    // iOS:     fires because presentationControllerShouldDismiss returned NO
    // Android: fires via onNativeDismissCancelled after the sheet bounces back
    Alert.alert(
      'Discard changes?',
      'You have unsaved changes. Leave anyway?',
      [
        { text: 'Stay', style: 'cancel' },
        {
          text: 'Discard',
          style: 'destructive',
          onPress: () => navigation.dispatch(data.action),
        },
      ],
    );
  });

  return (
    <TextInput onChangeText={() => setIsDirty(true)} />
  );
}
```


## Demo of fix in action

https://github.com/user-attachments/assets/0d0ecd91-164a-483d-be19-fac1b3770711



## Files changed

| File | Change |
|------|--------|
| `Screen.kt` | Add `isPreventNativeDismiss` with a setter that keeps `BottomSheetBehavior.isHideable` in sync at runtime |
| `ScreenViewManager.kt` | Wire up `setPreventNativeDismiss` (was a no-op); register `onNativeDismissCancelled` event |
| `SheetDelegate.kt` | Apply `isHideable = !screen.isPreventNativeDismiss` during setup; `SheetStateObserver` tracks drag-toward-dismiss and dispatches event on bounce-back |
| `ScreenEventEmitter.kt` | Add `dispatchOnNativeDismissCancelled()` |
| `ScreenNativeDismissCancelledEvent.kt` | New event class (`topNativeDismissCancelled`) |
| `src/types.tsx` | Extend `@platform` annotations for `preventNativeDismiss` and `onNativeDismissCancelled` to include Android |

## Known differences from iOS

- The sheet moves slightly before bouncing back. iOS cancels the gesture before any visual motion via `presentationControllerShouldDismiss`. Android has no pre-gesture synchronous interception point.
- `DISMISS_ATTEMPT_SLIDE_THRESHOLD = -0.05f` is a heuristic. Open to feedback on whether this value needs tuning.
- Only `formSheet` presentation is affected. `pageSheet` falls back to `modal` on Android and is already JS-navigation-controlled.