### PR TITLE
refactor(Tabs, iOS): decouple moreNavigationController from navigation state

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavState.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavState.kt
@@ -1,6 +1,5 @@
 package com.swmansion.rnscreens.gamma.tabs.container
 
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason.MORE_NAV_CTRL_NOT_AVAILABLE
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason.REPEATED
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason.STALE
 
@@ -30,19 +29,15 @@ data class TabsNavState(
  *
  * - [STALE] — the update's provenance indicates that it is based on a stale state.
  * - [REPEATED] — the requested tab is already selected.
- * - [MORE_NAV_CTRL_NOT_AVAILABLE] — the iOS "More" navigation controller was requested but is not available.
- *   This should not happen on Android.
  */
 enum class TabsNavStateUpdateRejectionReason {
     STALE,
     REPEATED,
-    MORE_NAV_CTRL_NOT_AVAILABLE,
     ;
 
     override fun toString(): String =
         when (this) {
             STALE -> "stale"
             REPEATED -> "repeated"
-            MORE_NAV_CTRL_NOT_AVAILABLE -> "more-nav-ctrl-not-available"
         }
 }

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { I18nManager, type NativeSyntheticEvent } from 'react-native';
 import {
-  SCREEN_KEY_MORE_NAV_CTRL,
   type TabSelectedEvent,
   Tabs,
   type TabsHostNavState,
@@ -119,16 +118,8 @@ function useSanitizeRouteConfigs(routeConfigs: TabRouteConfig[]) {
     return names.length === new Set(names).size;
   }, [routeConfigs]);
 
-  const noNameUsesReservedRouteKey = React.useMemo(() => {
-    return routeConfigs.every(c => c.name !== SCREEN_KEY_MORE_NAV_CTRL);
-  }, [routeConfigs]);
-
   if (!areNamesUnique) {
     throw new Error('[Tabs] All tabs must have unique names');
-  }
-
-  if (!noNameUsesReservedRouteKey) {
-    throw new Error(`[Tabs] Tab name "${SCREEN_KEY_MORE_NAV_CTRL}" is reserved and can not be used`);
   }
 }
 

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -89,12 +89,9 @@ export type TabsContainerProps = Omit<
 > & {
   routeConfigs: TabRouteConfig[];
   /**
-   * @summary 
+   * @summary
    * Name of the tab that should be selected initially.
    * Defaults to the first tab if not provided.
-   *
-   * @description
-   * It MUST NOT be the `SCREEN_KEY_MORE_NAV_CTRL`.
    */
   defaultRouteName?: string;
   /**

--- a/apps/src/shared/gamma/containers/tabs/reducer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/reducer.tsx
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 import type {
   TabRoute,
   TabRouteConfig,
@@ -9,7 +8,6 @@ import type {
   TabsNavigationActionNativeSelectTab,
   TabsNavigationActionSetOptions,
 } from './TabsContainer.types';
-import { SCREEN_KEY_MORE_NAV_CTRL } from 'react-native-screens';
 
 const NOT_FOUND_INDEX = -1;
 
@@ -60,7 +58,7 @@ function tabsActionSelectTabHandler(
     r => r.routeKey === action.routeKey,
   );
 
-  if (routeIndex === NOT_FOUND_INDEX && !doesRouteKeyPointToMoreNavigationController(action.routeKey)) {
+  if (routeIndex === NOT_FOUND_INDEX) {
     console.error(
       `[Tabs] select-tab: route with key "${action.routeKey}" not found in state. Ignoring.`,
     );
@@ -85,7 +83,7 @@ function tabsActionNativeSelectTabHandler(
     r => r.routeKey === action.routeKey,
   );
 
-  if (routeIndex === NOT_FOUND_INDEX && !doesRouteKeyPointToMoreNavigationController(action.routeKey)) {
+  if (routeIndex === NOT_FOUND_INDEX) {
     console.error(
       `[Tabs] select-tab: route with key "${action.routeKey}" not found in state. Ignoring.`,
     );
@@ -206,9 +204,5 @@ function navStateWithConfirmedState(
     confirmedState: confirmedState,
     suggestedState: state.suggestedState,
   };
-}
-
-function doesRouteKeyPointToMoreNavigationController(routeKey: string): boolean {
-  return Platform.OS === 'ios' && routeKey === SCREEN_KEY_MORE_NAV_CTRL;
 }
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import type { Scenario } from '@apps/tests/shared/helpers';
-import { Button, Text, View } from 'react-native';
+import { Button, Text, View, type NativeSyntheticEvent } from 'react-native';
 import {
-  TabsContainer,
+  TabsContainerWithHostConfigContext,
   type TabRouteConfig,
   DEFAULT_TAB_ROUTE_OPTIONS,
   useTabsNavigationContext,
 } from '@apps/shared/gamma/containers/tabs';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
+import { ToastProvider, useToast } from '@apps/shared/';
+import Colors from '@apps/shared/styling/Colors';
+import type { MoreTabSelectedEvent } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'More navigation controller',
@@ -80,5 +83,26 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
 ];
 
 export function App() {
-  return <TabsContainer routeConfigs={ROUTE_CONFIGS} />;
+  return (
+    <ToastProvider>
+      <AppContents />
+    </ToastProvider>
+  );
+}
+
+function AppContents() {
+  const toast = useToast();
+
+  return (
+    <TabsContainerWithHostConfigContext
+      routeConfigs={ROUTE_CONFIGS}
+      ios={{
+        onMoreTabSelected: (event: NativeSyntheticEvent<MoreTabSelectedEvent>) => {
+          const message = `onMoreTabSelected: ${JSON.stringify(event.nativeEvent, undefined, 2)}`;
+          console.warn(message);
+          toast.push({ message, backgroundColor: Colors.GreenLight60 });
+        },
+      }}
+    />
+  );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
@@ -8,7 +8,6 @@ import {
   useTabsNavigationContext,
 } from '@apps/shared/gamma/containers/tabs';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
-import { SCREEN_KEY_MORE_NAV_CTRL } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'More navigation controller',
@@ -43,7 +42,6 @@ function TabsNavigationButtons() {
       <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
       <Button title="Select Fifth" onPress={() => nav.selectTab('Fifth')} />
       <Button title="Select Sixth" onPress={() => nav.selectTab('Sixth')} />
-      <Button title="Select MoreTab" onPress={() => nav.selectTab(SCREEN_KEY_MORE_NAV_CTRL)} />
     </View>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
@@ -15,7 +15,7 @@ import type { MoreTabSelectedEvent } from 'react-native-screens';
 const SCENARIO: Scenario = {
   name: 'More navigation controller',
   key: 'test-tabs-more-navigation-controller',
-  details: 'Test navigation and interactions with "More Naviagation Controller"',
+  details: 'Test navigation and interactions with "More Navigation Controller"',
   platforms: ['ios'],
   AppComponent: App,
 };

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -228,8 +228,6 @@ RNSOnTabSelectionRejectedRejectionReasonFromRNSTabsNavigationStateRejectionReaso
       return Stale;
     case RNSTabsNavigationStateRejectionReasonRepeated:
       return Repeated;
-    case RNSTabsNavigationStateRejectionReasonMoreNavCtrlNotAvailable:
-      return MoreNavCtrlNotAvailable;
     default:
       return Stale;
   }

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -232,7 +232,11 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(
       self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
 
-  [self updateNavigationStateOnModelUpdate];
+  BOOL isSelectedViewControllerTheMoreNavigationController = [self isSelectedViewControllerTheMoreNavigationController];
+
+  if (!isSelectedViewControllerTheMoreNavigationController) {
+    [self updateNavigationStateOnModelUpdate];
+  }
 
   // After state progression we trigger the special effect.
   BOOL repeatedSelectionHandledBySpecialEffect = NO;
@@ -256,9 +260,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(
       self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
 
-  BOOL isSelectedViewControllerTheMoreNavigationController = [self isSelectedViewControllerTheMoreNavigationController];
-
-  if (isSelectedViewControllerTheMoreNavigationController) {
+  if ([self isSelectedViewControllerTheMoreNavigationController]) {
     [self disableNavigationBarInMoreNavigationController];
     [self prepareForMoreNavigationControllerHandlingIfNeeded];
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -232,19 +232,15 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(
       self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
 
-  BOOL isSelectedViewControllerTheMoreNavigationController = [self isSelectedViewControllerTheMoreNavigationController];
-
-  if (!isSelectedViewControllerTheMoreNavigationController) {
-    [self updateNavigationStateOnModelUpdate];
+  if ([self isSelectedViewControllerTheMoreNavigationController]) {
+    // We don't want to run neither state update nor side effects.
+    return;
   }
+
+  [self updateNavigationStateOnModelUpdate];
 
   // After state progression we trigger the special effect.
-  BOOL repeatedSelectionHandledBySpecialEffect = NO;
-
-  if (![self isSelectedViewControllerTheMoreNavigationController]) {
-    // Do not perform special effects on `moreNavigationController`.
-    repeatedSelectionHandledBySpecialEffect = [[self selectedScreenViewController] tabScreenSelectedRepeatedly];
-  }
+  BOOL repeatedSelectionHandledBySpecialEffect = [[self selectedScreenViewController] tabScreenSelectedRepeatedly];
 
   auto *updateContext =
       [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -735,8 +735,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 ///
 /// This method is idempotent — safe to call multiple times regardless of whether UIKit has
 /// reset the ISA between calls. When the ISA already carries our `RNS_` prefix, we return
-/// early. When UIKit has reset the ISA (e.g. iPad app resize crossing the >5 tab threshold),
-/// the dynamic subclass is looked up (or created) and re-applied.
+/// early. When UIKit has reset the ISA (e.g. iPad app resize crossing the threshold at which UIKit introduces the More
+/// controller (currently >5 tabs)), the dynamic subclass is looked up (or created) and re-applied.
 - (void)ensurePushInterceptorOnMoreNavigationController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -9,11 +9,6 @@
 
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
-/**
- * This must be kept in sync with the constant we define in JS - `SCREEN_KEY_MORE_NAV_CTRL`.
- */
-static NSString *const kMoreNavigationControllerScreenKey = @"rnscreens_moreNavigationController";
-
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
@@ -261,18 +256,22 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(
       self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
 
-  [self updateNavigationStateOnModelUpdate];
+  BOOL isSelectedViewControllerTheMoreNavigationController = [self isSelectedViewControllerTheMoreNavigationController];
 
-  if ([self isSelectedViewControllerTheMoreNavigationController]) {
+  if (isSelectedViewControllerTheMoreNavigationController) {
     [self disableNavigationBarInMoreNavigationController];
     [self prepareForMoreNavigationControllerHandlingIfNeeded];
-  }
 
-  auto *updateContext = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
-                                                                           isRepeated:NO
-                                                            hasTriggeredSpecialEffect:NO
-                                                                       isNativeAction:YES];
-  [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
+    // We don't want to progress state in case a user selected the more navigation controller.
+    // TODO: Send an event, that the more navigation controller has been selected.
+  } else {
+    [self updateNavigationStateOnModelUpdate];
+    auto *updateContext = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
+                                                                             isRepeated:NO
+                                                              hasTriggeredSpecialEffect:NO
+                                                                         isNativeAction:YES];
+    [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
+  }
 }
 
 - (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
@@ -360,11 +359,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 {
   RCTAssert(self == tabBarController, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
-  BOOL isNextViewControllerMoreNavigationController = [viewController isKindOfClass:UINavigationController.class];
-
   // Can be UINavigationController in case of MoreNavigationController
   RCTAssert(
-      [viewController isKindOfClass:RNSTabsScreenViewController.class] || isNextViewControllerMoreNavigationController,
+      [viewController isKindOfClass:RNSTabsScreenViewController.class] ||
+          [viewController isKindOfClass:UINavigationController.class],
       @"[RNScreens] Unexpected type of controller: %@",
       viewController.class);
 
@@ -440,27 +438,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   UIViewController *_Nonnull currSelectedViewController = self.selectedViewController;
 
   NSString *_Nonnull nextSelectedViewControllerKey = _pendingOperation.selectedScreenKey;
-  UIViewController *nextSelectedViewController = nil;
-  BOOL isNextMoreNavigationController = NO;
-
-  if ([self isMoreNavigationControllerRequestedByOperation:_pendingOperation]) {
-    if (![self isMoreNavigationControllerPresentInTabBar]) {
-      // If the controller is not visible atm. we'll crash the app if we try to navigate to it.
-      RCTAssert(
-          _navigationState != nil,
-          @"[RNScreens] MoreNavigationController MUST NOT be used as an initially selected tab");
-      [self.tabsHostComponentView tabBarController:self
-                             rejectedStateUpdateTo:_pendingOperation
-                                      currentState:_navigationState
-                                        withReason:RNSTabsNavigationStateRejectionReasonMoreNavCtrlNotAvailable];
-      return;
-    }
-    nextSelectedViewController = [self resolveMoreNavigationController];
-    RCTAssert(nextSelectedViewController != nil, @"[RNScreens] Expected non-nil moreNavigationController");
-    isNextMoreNavigationController = YES;
-  } else {
-    nextSelectedViewController = [self findChildViewControllerForKey:nextSelectedViewControllerKey];
-  }
+  UIViewController *nextSelectedViewController = [self findChildViewControllerForKey:nextSelectedViewControllerKey];
 
   RCTAssert(
       nextSelectedViewController != nil,
@@ -468,8 +446,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
       nextSelectedViewControllerKey);
 
   RCTAssert(
-      isNextMoreNavigationController || [nextSelectedViewController isKindOfClass:RNSTabsScreenViewController.class],
-      @"[RNScreens] nextSelectedViewController MUST be either UINavigationController or %@, got: %@",
+      [nextSelectedViewController isKindOfClass:RNSTabsScreenViewController.class],
+      @"[RNScreens] nextSelectedViewController MUST be %@, got: %@",
       RNSTabsScreenViewController.class,
       nextSelectedViewController.class);
 
@@ -493,31 +471,14 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   // TODO: This code MUST be moved to some callback.
   // Should this be called only on JS updates?
-  if (!isNextMoreNavigationController) {
-    auto *screenViewController = static_cast<RNSTabsScreenViewController *>(nextSelectedViewController);
-    if (@available(iOS 26.0, *)) {
-      // On iOS 26, we need to set user interface style 2 parent views above the tab bar
-      // for this prop to take effect.
-      self.tabBar.superview.superview.overrideUserInterfaceStyle =
-          screenViewController.tabScreenComponentView.userInterfaceStyle;
-    } else {
-      self.tabBar.overrideUserInterfaceStyle = screenViewController.tabScreenComponentView.userInterfaceStyle;
-    }
-  }
-
-  if (isNextMoreNavigationController) {
-    // If we navigate explicitly to `moreNavigationController` we want to show the
-    // list of the available view controllers, not what's already on the stack there.
-
-    // Animate only if we're currently in context of more view controller.
-    BOOL shouldAnimate = [self isMoreNavigationControllerTabBarItemSelected];
-    [self popToRootInMoreNavigationControllerRespectSelectionPrevention:NO animated:shouldAnimate];
-
-    // Also disable the header - we don't control it, but it impacts the layout
-    // in ways Yoga is not aware of. The simplest option here is to disable it.
-    [self disableNavigationBarInMoreNavigationController];
-
-    [self prepareForMoreNavigationControllerHandlingIfNeeded];
+  auto *screenViewController = static_cast<RNSTabsScreenViewController *>(nextSelectedViewController);
+  if (@available(iOS 26.0, *)) {
+    // On iOS 26, we need to set user interface style 2 parent views above the tab bar
+    // for this prop to take effect.
+    self.tabBar.superview.superview.overrideUserInterfaceStyle =
+        screenViewController.tabScreenComponentView.userInterfaceStyle;
+  } else {
+    self.tabBar.overrideUserInterfaceStyle = screenViewController.tabScreenComponentView.userInterfaceStyle;
   }
 
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
@@ -619,10 +580,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 - (nonnull NSString *)screenKeyForViewController:(nonnull UIViewController *)viewController
 {
-  if ([self isViewControllerTheMoreNavigationController:viewController]) {
-    return kMoreNavigationControllerScreenKey;
-  }
-
   RCTAssert(
       [viewController isKindOfClass:RNSTabsScreenViewController.class],
       @"[RNScreens] Expected selected view controller to be of class %@, got: %@",
@@ -667,14 +624,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
-- (BOOL)isMoreNavigationControllerScreenKey:(nullable NSString *)screenKey
-{
-  if (screenKey == nil) {
-    return NO;
-  }
-  return [screenKey isEqualToString:kMoreNavigationControllerScreenKey];
-}
-
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
@@ -687,15 +636,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (BOOL)isSelectedViewControllerTheMoreNavigationController
 {
   return [self isViewControllerTheMoreNavigationController:self.selectedViewController];
-}
-
-- (BOOL)isMoreNavigationControllerRequestedByOperation:(nullable RNSTabsNavigationState *)navState
-{
-  if (navState == nil) {
-    return NO;
-  }
-
-  return [self isMoreNavigationControllerScreenKey:navState.selectedScreenKey];
 }
 
 - (BOOL)isMoreNavigationControllerPresentInTabBar

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -263,7 +263,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     [self prepareForMoreNavigationControllerHandlingIfNeeded];
 
     // We don't want to progress state in case a user selected the more navigation controller.
-    // TODO: Send an event, that the more navigation controller has been selected.
+    // Instead, we emit a dedicated event so JS knows the More tab was tapped.
+    [self.tabsHostComponentView tabBarController:self didSelectMoreTabWithCurrentState:_navigationState];
   } else {
     [self updateNavigationStateOnModelUpdate];
     auto *updateContext = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -116,6 +116,9 @@ NS_ASSUME_NONNULL_BEGIN
     preventedSelectionOf:(nonnull NSString *)screenKey
             currentState:(nonnull RNSTabsNavigationState *)currentNavState;
 
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -644,6 +644,19 @@ RNS_IGNORE_SUPER_CALL_END
   }];
 }
 
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
+{
+  RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
+  RCTAssert(
+      currentNavState != nil && currentNavState.selectedScreenKey != nil,
+      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+
+  [self.reactEventEmitter emitOnMoreTabSelected:{
+                                                    .currentNavState = currentNavState,
+  }];
+}
+
 @end
 
 #pragma mark - Modified React Subviews implementation

--- a/ios/tabs/host/RNSTabsHostEventEmitter.h
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.h
@@ -48,6 +48,12 @@ typedef struct {
   NSString *_Nonnull preventedScreenKey;
 } OnTabSelectionPreventedPayload;
 
+/** Payload for the `onMoreTabSelected` event emitted when the user taps the "More" tab bar item. */
+typedef struct {
+  /** The currently active navigation state when the "More" tab was tapped. */
+  RNSTabsNavigationState *_Nonnull currentNavState;
+} OnMoreTabSelectedPayload;
+
 @interface RNSTabsHostEventEmitter : NSObject
 
 /** Emits `onTabSelected` event to JS. Returns YES if the event was dispatched successfully. */
@@ -58,6 +64,9 @@ typedef struct {
 
 /** Emits `onTabSelectionPrevented` event to JS. Returns YES if the event was dispatched successfully. */
 - (BOOL)emitOnTabSelectionPrevented:(OnTabSelectionPreventedPayload)payload;
+
+/** Emits `onMoreTabSelected` event to JS. Returns YES if the event was dispatched successfully. */
+- (BOOL)emitOnMoreTabSelected:(OnMoreTabSelectedPayload)payload;
 
 @end
 

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -83,4 +83,17 @@ namespace react = facebook::react;
   }
 }
 
+- (BOOL)emitOnMoreTabSelected:(OnMoreTabSelectedPayload)payload
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onMoreTabSelected(
+        {.selectedScreenKey = RCTStringFromNSString(payload.currentNavState.selectedScreenKey),
+         .provenance = payload.currentNavState.provenance});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnMoreTabSelected event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 @end

--- a/ios/tabs/host/RNSTabsNavigationState.h
+++ b/ios/tabs/host/RNSTabsNavigationState.h
@@ -61,8 +61,6 @@ typedef NS_ENUM(NSInteger, RNSTabsNavigationStateRejectionReason) {
   RNSTabsNavigationStateRejectionReasonStale = 0,
   /** The requested tab is already selected. */
   RNSTabsNavigationStateRejectionReasonRepeated,
-  /** The iOS "More" navigation controller was requested but is not available. */
-  RNSTabsNavigationStateRejectionReasonMoreNavCtrlNotAvailable
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/components/tabs/host/TabsHost.ios.tsx
+++ b/src/components/tabs/host/TabsHost.ios.tsx
@@ -60,7 +60,8 @@ function TabsHost(props: TabsHostProps) {
       layoutDirection={direction}
       tabBarControllerMode={ios?.tabBarControllerMode}
       tabBarMinimizeBehavior={ios?.tabBarMinimizeBehavior}
-      tabBarTintColor={ios?.tabBarTintColor}>
+      tabBarTintColor={ios?.tabBarTintColor}
+      onMoreTabSelected={ios?.onMoreTabSelected}>
       {children}
       {ios?.bottomAccessory &&
         isIOS26OrHigher &&

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -6,9 +6,9 @@ import type { ColorValue, NativeSyntheticEvent } from 'react-native';
  * @summary Payload of the event emitted when the user taps the "More" tab bar item.
  *
  * @description
- * This event fires when there are more than 5 tabs and the user taps
- * the system-generated "More" tab bar item. It does NOT fire when a tab is selected
- * from within the More list — that triggers the normal `onTabSelected` event instead.
+ * This event fires when the user taps the system-generated "More" tab bar item.
+ * It does NOT fire when a tab is selected from within the More list — that triggers
+ * the normal `onTabSelected` event instead.
  *
  * The payload carries the navigation state that was active at the moment the "More" tab was tapped.
  *
@@ -125,10 +125,9 @@ export interface TabsHostPropsIOS {
    * A callback that gets invoked when the user taps the "More" tab bar item.
    *
    * @description
-   * This event fires when there are more than 5 tabs and the user taps
-   * the system-generated "More" tab bar item. It does NOT fire when a tab
-   * is selected from within the More list — that triggers the normal
-   * `onTabSelected` event instead.
+   * This event fires when the user taps the system-generated "More" tab bar item.
+   * It does NOT fire when a tab is selected from within the More list — that triggers
+   * the normal `onTabSelected` event instead.
    *
    * @see {@link MoreTabSelectedEvent}
    *

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -1,6 +1,25 @@
 import type { ReactNode } from 'react';
 import type { TabsBottomAccessoryEnvironment } from '../bottom-accessory/TabsBottomAccessory.types';
-import type { ColorValue } from 'react-native';
+import type { ColorValue, NativeSyntheticEvent } from 'react-native';
+
+/**
+ * @summary Payload of the event emitted when the user taps the "More" tab bar item.
+ *
+ * @description
+ * This event fires when there are more than 5 tabs and the user taps
+ * the system-generated "More" tab bar item. It does NOT fire when a tab is selected
+ * from within the More list — that triggers the normal `onTabSelected` event instead.
+ *
+ * The payload carries the navigation state that was active at the moment the "More" tab was tapped.
+ *
+ * @platform ios
+ */
+export type MoreTabSelectedEvent = {
+  /** Screen key of the tab that was active when "More" was tapped. */
+  selectedScreenKey: string;
+  /** Provenance of the navigation state when "More" was tapped. */
+  provenance: number;
+};
 
 export type TabsBottomAccessoryComponentFactory = (
   environment: TabsBottomAccessoryEnvironment,
@@ -101,4 +120,21 @@ export interface TabsHostPropsIOS {
    * @supported iOS 18 or higher
    */
   tabBarControllerMode?: TabBarControllerMode;
+  /**
+   * @summary
+   * A callback that gets invoked when the user taps the "More" tab bar item.
+   *
+   * @description
+   * This event fires when there are more than 5 tabs and the user taps
+   * the system-generated "More" tab bar item. It does NOT fire when a tab
+   * is selected from within the More list — that triggers the normal
+   * `onTabSelected` event instead.
+   *
+   * @see {@link MoreTabSelectedEvent}
+   *
+   * @platform ios
+   */
+  onMoreTabSelected?: (
+    event: NativeSyntheticEvent<MoreTabSelectedEvent>,
+  ) => void;
 }

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -11,10 +11,6 @@ export type TabsHostNavState = {
    *
    * @description
    * It must correspond to one of the keys you assign to the `TabsScreens`.
-   * There is one notable exception of `SCREEN_KEY_MORE_NAV_CTRL`, which can be
-   * used on iOS to select the {@link https://developer.apple.com/documentation/uikit/uitabbarcontroller/morenavigationcontroller?language=objc moreNavigationController}.
-   *
-   * @see `SCREEN_KEY_MORE_NAV_CTRL` in `./constants`.
    */
   selectedScreenKey: string;
   /**
@@ -144,9 +140,6 @@ export interface TabsHostPropsBase {
    * This prop can be thought of as a "next navigation state suggestion for the native side".
    * Depending on configuration and the provenance of the update
    * the update might get accepted or rejected.
-   *
-   * `SCREEN_KEY_MORE_NAV_CTRL` MUST NOT be used during initial render to indicate default
-   * selected tab.
    *
    * @see {@link TabsHostPropsBase#rejectStaleNavStateUpdates}
    * @see {@link TabsHostNavState} for description of the type model & accepted values.

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -70,13 +70,8 @@ export type TabSelectedEvent = {
  *   meaning a newer state has already been applied. Only reported when
  *   {@link TabsHostPropsBase#rejectStaleNavStateUpdates} is enabled.
  * - `repeated` — the requested tab is already selected.
- * - `more-nav-ctrl-not-available` — the iOS "More" navigation controller was requested
- *   but is not available in the current configuration.
  */
-export type TabSelectionRejectionReason =
-  | 'stale'
-  | 'repeated'
-  | 'more-nav-ctrl-not-available';
+export type TabSelectionRejectionReason = 'stale' | 'repeated';
 
 /**
  * @summary Payload of the event emitted when the native side rejects a tab selection request.

--- a/src/components/tabs/host/constants.ts
+++ b/src/components/tabs/host/constants.ts
@@ -1,9 +1,0 @@
-/**
- * @summary Special screen key used to identify `moreNavigationController` on iOS.
- *
- * This can be used to navigate to the special
- * {@link https://developer.apple.com/documentation/uikit/uitabbarcontroller/morenavigationcontroller?language=objc `moreNavigationController`}.
- *
- * @platform ios
- */
-export const SCREEN_KEY_MORE_NAV_CTRL = 'rnscreens_moreNavigationController';

--- a/src/components/tabs/host/index.ts
+++ b/src/components/tabs/host/index.ts
@@ -4,5 +4,3 @@ export type * from './TabsHost.types';
 
 export type * from './TabsHost.android.types';
 export type * from './TabsHost.ios.types';
-
-export { SCREEN_KEY_MORE_NAV_CTRL } from './constants';

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -41,8 +41,6 @@ export type {
 
 export type { TabsBottomAccessoryEnvironment } from './bottom-accessory';
 
-export { SCREEN_KEY_MORE_NAV_CTRL } from './host';
-
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -14,6 +14,7 @@ export type {
   // Android
   TabsHostPropsAndroid,
   // iOS
+  MoreTabSelectedEvent,
   TabsBottomAccessoryComponentFactory,
   TabBarMinimizeBehavior,
   TabBarControllerMode,

--- a/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
@@ -23,7 +23,7 @@ type TabSelectionRejectedEvent = Readonly<{
   provenance: CT.Int32;
   rejectedScreenKey: string;
   rejectedProvenance: CT.Int32;
-  rejectionReason: 'stale' | 'repeated' | 'more-nav-ctrl-not-available';
+  rejectionReason: 'stale' | 'repeated';
 }>;
 
 type TabSelectionPreventedEvent = Readonly<{

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -23,13 +23,18 @@ type TabSelectionRejectedEvent = Readonly<{
   provenance: CT.Int32;
   rejectedScreenKey: string;
   rejectedProvenance: CT.Int32;
-  rejectionReason: 'stale' | 'repeated' | 'more-nav-ctrl-not-available';
+  rejectionReason: 'stale' | 'repeated';
 }>;
 
 type TabSelectionPreventedEvent = Readonly<{
   selectedScreenKey: string;
   provenance: CT.Int32;
   preventedScreenKey: string;
+}>;
+
+type MoreTabSelectedEvent = Readonly<{
+  selectedScreenKey: string;
+  provenance: CT.Int32;
 }>;
 
 type TabsHostColorScheme = 'inherit' | 'light' | 'dark';
@@ -59,6 +64,7 @@ export interface NativeProps extends ViewProps {
   onTabSelected?: CT.DirectEventHandler<TabSelectedEvent>;
   onTabSelectionRejected?: CT.DirectEventHandler<TabSelectionRejectedEvent>;
   onTabSelectionPrevented?: CT.DirectEventHandler<TabSelectionPreventedEvent>;
+  onMoreTabSelected?: CT.DirectEventHandler<MoreTabSelectedEvent>;
 
   // General
   tabBarHidden?: CT.WithDefault<boolean, false>;


### PR DESCRIPTION
## Description

Refactors how the iOS `moreNavigationController` is handled in the Tabs component.

Previously, the "More" navigation controller (the overflow menu UIKit creates when there are >5 tabs) was treated as a first-class tab in the navigation state. This created several problems:
- State representation mismatch — `selectedScreenKey` pointed to a key that didn't correspond to any programmer-defined tab
- Cross-platform divergence — Android doesn't have this concept, yet the state model had to account for it
- Unnecessary complexity — reserved key constants, rejection/availability logic, special reducer handling

This PR treats the `moreNavigationController` as what it really is: UIKit chrome for tab overflow, not a navigation destination. A new iOS-only `onMoreTabSelected` event provides JS visibility into when the user taps "More".

Relates to #3785.

## Changes

- Stop emitting navigation state updates when the more controller is selected (both for initial and repeated selection)
- Add `onMoreTabSelected` iOS-only event (codegen spec, native event emitter, component view delegate, JS types)
- Remove `SCREEN_KEY_MORE_NAV_CTRL` constant and all references
- Remove programmatic navigation to the more list
- Remove dead `more-nav-ctrl-not-available` rejection reason from both platforms (codegen specs, TS types, ObjC, Kotlin)
- Expose `MoreTabSelectedEvent` type via `TabsHostPropsIOS` (iOS-specific types, following platform convention)
- Update test scenario with toast-based event visualization

## Test plan

- `apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx`
  1. Run the scenario (6 tabs trigger the "More" tab)
  2. Tap "More" tab → green toast appears with `selectedScreenKey` + `provenance`
  3. Tap a tab from within the More list → no toast, normal `onTabSelected` fires
  4. Programmatic `selectTab('Fifth')` / `selectTab('Sixth')` navigates correctly to tabs shown in More list
  5. Repeated "More" tab selection does not crash or progress state

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes