### PR TITLE
refactor(Tabs, iOS): extract RNSTabBarControllerDelegate into a formal protocol

### DIFF
--- a/ios/tabs/RNSTabBarAppearanceCoordinator.h
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
-#import "RNSTabsHostComponentView.h"
 #import "RNSTabsScreenViewController.h"
+
+@class RNSTabsHostComponentView;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -5,6 +5,7 @@
 #import "RNSConversions.h"
 #import "RNSImageLoadingHelper.h"
 #import "RNSTabBarController.h"
+#import "RNSTabsHostComponentView.h"
 #import "RNSTabsScreenViewController.h"
 
 @implementation RNSTabBarAppearanceCoordinator

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -11,6 +11,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RNSTabsHostComponentView;
+@class RNSTabBarController;
+
+@protocol RNSTabBarControllerDelegate <NSObject>
+
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+        didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
+             withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
+
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    rejectedStateUpdateTo:(nonnull RNSTabsNavigationState *)rejectedNavState
+             currentState:(nonnull RNSTabsNavigationState *)currentNavState
+               withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
+
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    preventedSelectionOf:(nonnull NSString *)screenKey
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState;
+
+- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState;
+
+@end
+
 @protocol RNSReactTransactionObserving
 
 - (void)reactMountingTransactionWillMount;

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -6,6 +6,7 @@
 #import "NSString+RNSUtility.h"
 #import "RNSLog.h"
 #import "RNSScreenWindowTraits.h"
+#import "RNSTabsHostComponentView.h"
 
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -12,9 +12,10 @@
 #import <React/RCTInvalidating.h>
 #endif
 
+#import "RNSTabBarController.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
-@class RNSTabBarController;
 @class RCTImageLoader;
 
 /**
@@ -26,7 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
  * 3. two way communication channel with React (commands & events)
  */
 @interface RNSTabsHostComponentView : RNSReactBaseView <
-                                          RNSScreenContainerDelegate
+                                          RNSScreenContainerDelegate,
+                                          RNSTabBarControllerDelegate
 #if !RCT_NEW_ARCH_ENABLED
                                           ,
                                           RCTInvalidating
@@ -96,28 +98,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSTabsHostComponentView ()
 
 - (nullable RCTImageLoader *)reactImageLoader;
-
-@end
-
-#pragma mark - RNSTabBarControllerDelegate
-
-@interface RNSTabsHostComponentView (RNSTabBarControllerDelegate)
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-        didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
-             withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    rejectedStateUpdateTo:(nonnull RNSTabsNavigationState *)rejectedNavState
-             currentState:(nonnull RNSTabsNavigationState *)currentNavState
-               withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    preventedSelectionOf:(nonnull NSString *)screenKey
-            currentState:(nonnull RNSTabsNavigationState *)currentNavState;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState;
 
 @end
 


### PR DESCRIPTION
## Description

Turns the informal `RNSTabBarControllerDelegate` category on `RNSTabsHostComponentView` into a proper `@protocol` defined in `RNSTabBarController.h`. This is a step toward fully decoupling `RNSTabBarController` from `RNSTabsHostComponentView` — a separate delegate property will follow once appearance configuration is also decoupled.

## Changes

- Defined `@protocol RNSTabBarControllerDelegate <NSObject>` in `RNSTabBarController.h` with the 4 existing callback methods
- Made `RNSTabsHostComponentView` conform to the new protocol
- Removed the `RNSTabsHostComponentView (RNSTabBarControllerDelegate)` category from the header
- Broke circular import chain (`RNSTabBarController.h` → `RNSTabBarAppearanceCoordinator.h` → `RNSTabsHostComponentView.h`) by downgrading the appearance coordinator's import to a forward declaration

## Test plan

Build FabricExample iOS app — this is a purely structural refactor with no behavioral changes.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes