### PR TITLE
fix(CI): fix nightly releases by bumping node version

### DIFF
--- a/.github/workflows/npm-screens-publish-nightly.yml
+++ b/.github/workflows/npm-screens-publish-nightly.yml
@@ -21,13 +21,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Ensure node version with npm 11.5.1 or later is installed for OIDC
+          node-version: '>=24.5.0 <25.0.0'
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
-      
-      # Ensure npm 11.5.1 or later is installed for OIDC
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh


### PR DESCRIPTION
## Description

Recently, CI releasing nightly versions stopped working. There seems to be a problem with bumping `npm` in runtime.

I set node version for publish workflow to `'>=24.5.0 <25.0.0'` (`npm@11.5.1` is preinstalled with `node` starting from `24.5.0`, source: click on `v24` on https://nodejs.org/en/about/previous-releases).

## Changes

- bump node version to `'>=24.5.0 <25.0.0'` in nightly release workflow
- remove manual npm bump

## Before & after - visual documentation

N/A

## Test plan

Nightly releases should start being published via CI.

## Checklist

- [ ] Ensured that CI passes
