### PR TITLE
chore(test): test-tabs-tab-bar-experimental-user-interface-style-ios with scenario

### DIFF
--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/ThemeScreen.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/ThemeScreen.tsx
@@ -1,0 +1,121 @@
+import {
+  TabsContainerWithHostConfigContext,
+  type TabRouteConfig,
+} from '@apps/shared/gamma/containers/tabs';
+import React from 'react';
+import { Button, View, Text, ScrollView, StyleSheet } from 'react-native';
+import { ThemedText } from '@apps/shared';
+
+type InterfaceStyle = 'dark' | 'light';
+
+export function DarkRootScreen({ onPush }: { onPush: () => void }) {
+  return <RootScreen style="dark" onPush={onPush} />;
+}
+
+export function LightRootScreen({ onPush }: { onPush: () => void }) {
+  return <RootScreen style="light" onPush={onPush} />;
+}
+
+function RootScreen({ style, onPush }: { style: InterfaceStyle; onPush: () => void }) {
+  const isDark = style === 'dark';
+  return (
+    <View style={{ flex: 1 }}>
+      <ScrollView style={{ padding: 40, backgroundColor: isDark ? 'black' : 'white' }}>
+        <View>
+          <Text style={styles.sectionHeader}>experimental_userInterfaceStyle</Text>
+          {isDark ? (
+            <Text style={styles.description}>
+              Enable system light mode and observe the tab bar and back button on the pushed screen.
+            </Text>
+          ) : (
+            <ThemedText>
+              Enable system dark mode and observe the tab bar and back button on the pushed screen.
+            </ThemedText>
+          )}
+          <Button title={`Push screen with style: ${style}`} onPress={onPush} />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function ThemedTabContent({ style }: { style: InterfaceStyle }) {
+  const isDark = style === 'dark';
+  const label = `experimental_userInterfaceStyle: ${style}`;
+  const description = `This screen forces ${style} interface style regardless of system setting. Observe the tab bar and navigation bar appearance.`;
+
+  return (
+    <View style={styles.centeredScreen}>
+      {isDark ? (
+        <>
+          <Text style={styles.sectionHeader}>{label}</Text>
+          <Text style={styles.description}>{description}</Text>
+        </>
+      ) : (
+        <>
+          <ThemedText>{label}</ThemedText>
+          <ThemedText style={{ textAlign: 'center' }}>{description}</ThemedText>
+        </>
+      )}
+    </View>
+  );
+}
+
+export function DarkInterfaceStyleScreen() {
+  return <InterfaceStyleScreen style="dark" />;
+}
+
+export function LightInterfaceStyleScreen() {
+  return <InterfaceStyleScreen style="light" />;
+}
+
+function InterfaceStyleScreen({ style }: { style: InterfaceStyle }) {
+  const isDark = style === 'dark';
+  const backgroundColor = isDark ? 'black' : 'white';
+  const icons = ['house', 'star'] as const;
+
+  const routeConfigs: TabRouteConfig[] = icons.map((icon, i) => ({
+    name: `Tab${i + 1}`,
+    Component: () => <ThemedTabContent style={style} />,
+    options: {
+      title: `Tab${i + 1}`,
+      ios: {
+        icon: { type: 'sfSymbol', name: icon },
+        experimental_userInterfaceStyle: style,
+      },
+      style: { backgroundColor },
+    },
+  }));
+
+  return (
+    <TabsContainerWithHostConfigContext
+      routeConfigs={routeConfigs}
+      nativeContainerStyle={{ backgroundColor }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    color: '#888',
+    letterSpacing: 0.5,
+    marginTop: 60,
+    marginBottom: 4,
+  },
+  description: {
+    fontSize: 13,
+    color: '#555',
+    marginBottom: 6,
+    marginTop: 12,
+  },
+  centeredScreen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 40,
+    gap: 12,
+  },
+});

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { StackContainer, StackRouteConfig, useStackNavigationContext } from '@apps/shared/gamma/containers/stack';
+import {  LightRootScreen, LightInterfaceStyleScreen, DarkRootScreen, DarkInterfaceStyleScreen } from './ThemeScreen';
+import { Scenario } from '@apps/tests/shared/helpers';
+
+const SCENARIO: Scenario = {
+  name: 'Tab Bar Experimental UIStyle',
+  key: 'test-tabs-tab-bar-experimental-user-interface-style-ios',
+  platforms: ['ios'],
+  AppComponent: App,
+};
+
+export default SCENARIO;
+
+function HomeScreen() {
+  const navigation = useStackNavigationContext();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>experimental_userInterfaceStyle</Text>
+      <Text style={styles.description}>
+        Select an interface style to preview how the tab bar and
+        navigation bar respond.
+      </Text>
+      <Button title="Dark" onPress={() => navigation.push('darkRoot')} />
+      <Button title="Light" onPress={() => navigation.push('lightRoot')} />
+    </View>
+  );
+}
+
+function DarkRootScreenContent() {
+  const navigation = useStackNavigationContext();
+  return <DarkRootScreen onPush={() => navigation.push('darkPushed')} />;
+}
+
+function LightRootScreenContent() {
+  const navigation = useStackNavigationContext();
+  return <LightRootScreen onPush={() => navigation.push('lightPushed')} />;
+}
+
+const ROUTE_CONFIGS: StackRouteConfig[] = [
+  { name: 'home', Component: HomeScreen, options: {} },
+  { name: 'darkRoot', Component: DarkRootScreenContent, options: {} },
+  { name: 'darkPushed', Component: DarkInterfaceStyleScreen, options: {} },
+  { name: 'lightRoot', Component: LightRootScreenContent, options: {} },
+  { name: 'lightPushed', Component: LightInterfaceStyleScreen, options: {} },
+];
+
+export function App() {
+  return (
+    <View style={{ flex: 1, width: '100%', height: '100%' }}>
+      <StackContainer routeConfigs={ROUTE_CONFIGS} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 40,
+    gap: 16,
+    backgroundColor: 'white',
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    color: '#5d5b5b',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  description: {
+    fontSize: 13,
+    color: '#555',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+});

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
@@ -1,0 +1,63 @@
+# Test Scenario: experimental_userInterfaceStyle
+
+## Details
+
+**Description:** This test validates the experimental_userInterfaceStyle prop by ensuring screens correctly override the system's global appearance. It specifically monitors tab bar UI behavior during pushes, pops, and tab switches to ensure that forced styles (e.g., Dark mode on a Light system) remain stable. The goal is to eliminate visual glitches like flickering, flashing, or momentary reverts to the system theme.
+
+**OS test creation version:** iOS 26.2
+
+## E2E test
+
+Not automated. Verification requires observing UI transitions (Tab Bar appearance and flicker detection) which are not reliably detectable by Detox snapshot or view-hierarchy testing.
+
+## Prerequisites
+
+- iOS device/simulator (use Cmd+Shift+A to toggle appearance on simulator)
+
+## Note
+
+Occasional flashes of the back button in the header are expected behavior and are unrelated to the experimental_userInterfaceStyle prop being tested in this scenario.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and set system appearance to **light**.
+
+- [ ] Expected: App is displayed in light mode.
+
+2. Navigate to the **Tab Bar Experimental UIStyle** screen.
+
+- [ ] Expected: `Home` screen is shown with two buttons `Dark` and `Light`.
+
+### Light system mode & dark screen style
+
+3. On `Home` screen click `Dark` button.
+
+  - [ ] Expected: Screen is shown with a black background. A single button to push the screen with dark style is visible.
+ 
+4. Tap **"Push screen with style: dark"** and observe tab bar.
+
+- [ ] Expected: The dark-styled tab screen is pushed, showing **Tab1** and **Tab2**. The tab bar reflects a **dark** style and appears without flash, flicker, or reversion to light style.
+
+5. Switch between **Tab1** and **Tab2** on the pushed screen.
+
+- [ ] Expected: Both tabs maintain the dark interface style. No flash, flicker, or reversion to light style on tab switch.
+
+1. Pop back to previous `Dark` screen and then pop back to the `Home` screen.
+
+- [ ] Expected: `Home` screen is shown with two buttons `Dark` and `Light`.
+
+### Dark system mode & light screen style
+
+7. Set system appearance to **dark**. Click `Light` button.
+
+  - [ ] Expected: Screen is shown with a white background. A single button to push the screen with light style is visible.
+
+8. Push **"Push screen with style: light"** and observe tab bar.
+
+- [ ] Expected: `LightScreen` is pushed. The tab bar reflects a **light** style and appears without flash, flicker, or reversion to light style.
+
+9. Switch between **Tab1** and **Tab2** on the pushed screen.
+
+- [ ] Expected: Both tabs maintain the light interface style. No flash, flicker, or reversion to dark style on tab switch.


### PR DESCRIPTION
## Description

New screen for experimental_userInterfaceStyle prop (iOS only) for dark and light value with corresponding manual scenario.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1116

## Changes

- Adding new screen and scenario in new directory to cover experimental_userInterfaceStyle prop set to dark and light 
- Screen added to tabs/index.ts to be displayed under SFT category