### PR TITLE
refactor(Tabs): remove controlledBottomTabs / controlNavigationStateInJS option

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -28,7 +28,6 @@ export function TabsContainer(props: TabsContainerProps) {
   const {
     routeConfigs,
     defaultRouteName,
-    experimentalControlNavigationStateInJS,
     onTabSelected,
     ...restProps
   } = props;
@@ -75,12 +74,8 @@ export function TabsContainer(props: TabsContainerProps) {
 
   return (
     <Tabs.Host
-      // Use controlled tabs by default, but allow to overwrite if user wants to
       navState={hostNavState}
       onTabSelected={onTabSelectedCallback}
-      experimentalControlNavigationStateInJS={
-        experimentalControlNavigationStateInJS
-      }
       direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
       {...restProps}>
       {tabsNavState.routes.map((route: TabRoute) => {

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -80,7 +80,6 @@ export type TabsHostConfig = Omit<
   TabsHostProps,
   | 'children'
   | 'navState'
-  | 'experimentalControlNavigationStateInJS'
 >;
 
 export type TabsContainerProps = Omit<
@@ -94,11 +93,6 @@ export type TabsContainerProps = Omit<
    * Defaults to the first tab if not provided.
    */
   defaultRouteName?: string;
-  /**
-   * Whether to control navigation state in JS.
-   * Passed to Tabs.Host as experimentalControlNavigationStateInJS.
-   */
-  experimentalControlNavigationStateInJS?: boolean;
 };
 
 export type SetTabOptionsMethod = (

--- a/apps/src/shared/gamma/containers/tabs/TabsContainerWithHostConfigContext.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainerWithHostConfigContext.tsx
@@ -20,7 +20,6 @@ export function TabsContainerWithHostConfigContext(props: TabsContainerProps) {
   const {
     routeConfigs,
     defaultRouteName,
-    experimentalControlNavigationStateInJS,
     ...hostProps
   } = props;
 
@@ -43,9 +42,6 @@ export function TabsContainerWithHostConfigContext(props: TabsContainerProps) {
       <TabsContainer
         routeConfigs={routeConfigs}
         defaultRouteName={defaultRouteName}
-        experimentalControlNavigationStateInJS={
-          experimentalControlNavigationStateInJS
-        }
         {...hostConfig}
       />
     </TabsHostConfigContext>

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -347,13 +347,6 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     return NO;
   }
 
-  // This handles the tabsHostComponentView nullability
-  // TODO: This if is likely to be removed, since we want to roll back the support
-  // for "controlled mode", at least initially.
-  if ([self.tabsHostComponentView experimental_controlNavigationStateInJS]) {
-    return NO;
-  }
-
   BOOL shouldPreventTabSelection = [self shouldPreventNativeTabSelection:viewController];
 
   if (shouldPreventTabSelection) {

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -62,8 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) UIUserInterfaceStyle colorScheme;
 
-@property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
-
 @property (nonatomic, readonly) UITraitEnvironmentLayoutDirection layoutDirection;
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -283,10 +283,6 @@ namespace react = facebook::react;
     [_controller setRejectStaleNavigationStateUpdates:_rejectStaleNavStateUpdates];
   }
 
-  if (newComponentProps.controlNavigationStateInJS != oldComponentProps.controlNavigationStateInJS) {
-    _experimental_controlNavigationStateInJS = newComponentProps.controlNavigationStateInJS;
-  }
-
   if (newComponentProps.tabBarTintColor != oldComponentProps.tabBarTintColor) {
     _needsTabBarAppearanceUpdate = YES;
     _tabBarTintColor = RCTUIColorFromSharedColor(newComponentProps.tabBarTintColor);

--- a/ios/tabs/host/RNSTabsHostComponentViewManager.mm
+++ b/ios/tabs/host/RNSTabsHostComponentViewManager.mm
@@ -35,9 +35,6 @@ RCT_REMAP_VIEW_PROPERTY(
 // from JS.
 RCT_REMAP_VIEW_PROPERTY(tabBarControllerMode, tabBarControllerModeFromRNSTabBarControllerMode, RNSTabBarControllerMode);
 
-// TODO: Missing prop
-//@property (nonatomic, readonly) BOOL experimental_controlNavigationStateInJS;
-
 #pragma mark - LEGACY Events
 
 RCT_EXPORT_VIEW_PROPERTY(onNativeFocusChange, RCTDirectEventBlock);

--- a/src/components/tabs/host/TabsHost.android.tsx
+++ b/src/components/tabs/host/TabsHost.android.tsx
@@ -23,7 +23,6 @@ function TabsHost(props: TabsHostProps) {
   const {
     children,
     direction,
-    experimentalControlNavigationStateInJS,
     nativeContainerStyle,
     onTabSelected,
     navState,
@@ -36,7 +35,6 @@ function TabsHost(props: TabsHostProps) {
   const { onTabSelected: onTabSelectedCallback } =
     useTabsHost<TabsHostAndroidNativeComponentProps>({
       componentNodeRef,
-      controlNavigationStateInJS: experimentalControlNavigationStateInJS,
       onTabSelected,
     });
 

--- a/src/components/tabs/host/TabsHost.ios.tsx
+++ b/src/components/tabs/host/TabsHost.ios.tsx
@@ -26,7 +26,6 @@ function TabsHost(props: TabsHostProps) {
   const {
     children,
     direction,
-    experimentalControlNavigationStateInJS,
     nativeContainerStyle,
     onTabSelected,
     navState,
@@ -36,10 +35,9 @@ function TabsHost(props: TabsHostProps) {
   const componentNodeRef =
     React.useRef<React.Component<TabsHostIOSNativeComponentProps>>(null);
 
-  const { controlNavigationStateInJS, onTabSelected: onTabSelectedCallback } =
+  const { onTabSelected: onTabSelectedCallback } =
     useTabsHost<TabsHostIOSNativeComponentProps>({
       componentNodeRef,
-      controlNavigationStateInJS: experimentalControlNavigationStateInJS,
       onTabSelected,
     });
 
@@ -56,7 +54,6 @@ function TabsHost(props: TabsHostProps) {
       ref={componentNodeRef}
       {...filteredBaseProps}
       // iOS-specific
-      controlNavigationStateInJS={controlNavigationStateInJS}
       layoutDirection={direction}
       tabBarControllerMode={ios?.tabBarControllerMode}
       tabBarMinimizeBehavior={ios?.tabBarMinimizeBehavior}

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -226,25 +226,6 @@ export interface TabsHostPropsBase {
    */
   colorScheme?: TabsHostColorScheme;
 
-  // Experimental support
-  /**
-   * @summary Experimental prop for changing container control.
-   *
-   * If set to true, tab screen changes need to be handled by JS using
-   * onNativeFocusChange callback (controlled/programatically-driven).
-   *
-   * If set to false, tab screen change will not be prevented by the
-   * native side (managed/natively-driven).
-   *
-   * On Android, only controlled tabs are currently supported and the
-   * value of this prop is ignored.
-   *
-   * @default Defaults to `false`.
-   *
-   * @platform android, ios
-   */
-  experimentalControlNavigationStateInJS?: boolean;
-
   // Events
   /**
    * @summary A callback that gets invoked when the selected tab changes.

--- a/src/components/tabs/host/useTabsHost.ts
+++ b/src/components/tabs/host/useTabsHost.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import { findNodeHandle, type NativeSyntheticEvent } from 'react-native';
 import type { NativeProps as TabsHostAndroidNativeComponentProps } from '../../../fabric/tabs/TabsHostAndroidNativeComponent';
 import type { NativeProps as TabsHostIOSNativeComponentProps } from '../../../fabric/tabs/TabsHostIOSNativeComponent';
-import featureFlags from '../../../flags';
 import { RNSLog } from '../../../private';
 import type { TabSelectedEvent } from './TabsHost.types';
 
@@ -12,13 +11,11 @@ type TabsHostPlatformNativeComponentProps =
 
 interface TabsHostConfig<T> {
   componentNodeRef: React.RefObject<React.Component<T> | null>;
-  controlNavigationStateInJS?: boolean;
   onTabSelected?: (event: NativeSyntheticEvent<TabSelectedEvent>) => void;
 }
 
 export function useTabsHost<T extends TabsHostPlatformNativeComponentProps>({
   componentNodeRef,
-  controlNavigationStateInJS,
   onTabSelected,
 }: TabsHostConfig<T>) {
   const componentNodeHandle = React.useRef<number>(-1);
@@ -45,9 +42,6 @@ export function useTabsHost<T extends TabsHostPlatformNativeComponentProps>({
   );
 
   return {
-    controlNavigationStateInJS:
-      controlNavigationStateInJS ??
-      featureFlags.experiment.controlledBottomTabs,
     onTabSelected: onTabSelectedCallback,
   };
 }

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -75,9 +75,6 @@ export interface NativeProps extends ViewProps {
   // direction style View prop.
   layoutDirection?: CT.WithDefault<LayoutDirection, 'inherit'>;
 
-  // Experimental support
-  controlNavigationStateInJS?: CT.WithDefault<boolean, false>;
-
   // iOS-specific props
   tabBarTintColor?: ColorValue;
   tabBarMinimizeBehavior?: CT.WithDefault<TabBarMinimizeBehavior, 'automatic'>;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,4 +1,3 @@
-const RNS_CONTROLLED_BOTTOM_TABS_DEFAULT = false;
 const RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT = false;
 const RNS_SYNCHRONOUS_HEADER_CONFIG_STATE_UPDATES_DEFAULT = false;
 const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = false;
@@ -50,7 +49,6 @@ export const compatibilityFlags = {
 
 const _featureFlags = {
   experiment: {
-    controlledBottomTabs: RNS_CONTROLLED_BOTTOM_TABS_DEFAULT,
     synchronousScreenUpdatesEnabled:
       RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT,
     synchronousHeaderConfigUpdatesEnabled:
@@ -120,10 +118,6 @@ const createStableFeatureFlagAccessor = <T extends STABLE_FF>(
   };
 };
 
-const controlledBottomTabsAccessor = createExperimentalFeatureFlagAccessor(
-  'controlledBottomTabs',
-  RNS_CONTROLLED_BOTTOM_TABS_DEFAULT,
-);
 const synchronousScreenUpdatesAccessor = createExperimentalFeatureFlagAccessor(
   'synchronousScreenUpdatesEnabled',
   RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT,
@@ -178,11 +172,16 @@ export const featureFlags = {
    *  Flags to enable experimental features. These might be removed w/o notice or moved to stable.
    */
   experiment: {
+    /**
+     * @deprecated This flag is a noop kept for backward compatibility.
+     * The "controlled bottom tabs" mode has been removed.
+     * The getter always returns `false`; the setter is a noop.
+     */
     get controlledBottomTabs() {
-      return controlledBottomTabsAccessor.get();
+      return false;
     },
-    set controlledBottomTabs(value: boolean) {
-      controlledBottomTabsAccessor.set(value);
+    set controlledBottomTabs(_value: boolean) {
+      // noop
     },
     get synchronousScreenUpdatesEnabled() {
       return synchronousScreenUpdatesAccessor.get();

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -172,17 +172,6 @@ export const featureFlags = {
    *  Flags to enable experimental features. These might be removed w/o notice or moved to stable.
    */
   experiment: {
-    /**
-     * @deprecated This flag is a noop kept for backward compatibility.
-     * The "controlled bottom tabs" mode has been removed.
-     * The getter always returns `false`; the setter is a noop.
-     */
-    get controlledBottomTabs() {
-      return false;
-    },
-    set controlledBottomTabs(_value: boolean) {
-      // noop
-    },
     get synchronousScreenUpdatesEnabled() {
       return synchronousScreenUpdatesAccessor.get();
     },


### PR DESCRIPTION
## Description

Removes the experimental `controlledBottomTabs` feature flag and its corresponding `experimentalControlNavigationStateInJS` prop from `TabsHost`. This mode — where native returns `NO` on tab selection to force JS-driven state management — was never graduated beyond `default: false` and is no longer needed.

The feature flag in `src/flags.ts` has been completely removed. Since this is pre-1.0 Tabs API surface and the flag was never enabled by default, a backward-compatible noop shim is not necessary.

**Note:** The `react-navigation` submodule (`packages/bottom-tabs/src/unstable/NativeBottomTabView.native.tsx`) still references `experimentalControlNavigationStateInJS={false}` — this needs a follow-up cleanup downstream.

Closes software-mansion/react-native-screens-labs#974.

## Changes

- Fully removed `featureFlags.experiment.controlledBottomTabs` from `src/flags.ts` (default constant, internal state, accessor, getter/setter)
- Removed `experimentalControlNavigationStateInJS` prop from `TabsHostPropsBase` type and both platform `TabsHost` components
- Removed `controlNavigationStateInJS` from the `useTabsHost` hook interface and return value
- Removed `controlNavigationStateInJS` from `TabsHostIOSNativeComponent` codegen spec
- Removed `experimental_controlNavigationStateInJS` property from iOS native (`RNSTabsHostComponentView`, `RNSTabBarController`)
- Cleaned up example app containers (`TabsContainer`, `TabsContainerWithHostConfigContext`, types)

## Test plan

- `npx tsc --noEmit` passes at repo root (no new type errors)
- Build FabricExample for iOS — codegen regenerates without the prop, tab switching works normally
- Build FabricExample for Android — no native changes on this platform, should be clean

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes