### PR TITLE
chore(Tabs): add usesStableTabsApi compatibility flag

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -48,9 +48,11 @@ export const compatibilityFlags = {
   usesNewAndroidHeaderHeightImplementation: true,
 
   /**
-   * There have been numerous "breaking changes" in the yet-experimental Tabs API. 
-   * This flag marks the shape of the API that's meant for stabilisation, and 
-   * can enable downstream to detect these changes.
+   * Numerous "breaking changes" in the yet-experimental Tabs API have been
+   * intoduced with version 4.25.0 of the library.
+   *
+   * This flag marks the shape of the API that's meant for stabilisation, and
+   * enables downstream to detect these changes.
    */
   usesStableTabsApi: true,
 } as const;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -46,6 +46,13 @@ export const compatibilityFlags = {
    * is in use or not.
    */
   usesNewAndroidHeaderHeightImplementation: true,
+
+  /**
+   * There have been numerous "breaking changes" in the yet-experimental Tabs API. 
+   * This flag marks the shape of the API that's meant for stabilisation, and 
+   * can enable downstream to detect these changes.
+   */
+  usesStableTabsApi: true,
 } as const;
 
 const _featureFlags = {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -49,10 +49,22 @@ export const compatibilityFlags = {
 
   /**
    * Numerous "breaking changes" in the yet-experimental Tabs API have been
-   * intoduced with version 4.25.0 of the library.
+   * introduced with version 4.25.0 of the library.
    *
    * This flag marks the shape of the API that's meant for stabilisation, and
    * enables downstream to detect these changes.
+   *
+   * See:
+   * * https://github.com/software-mansion/react-native-screens/pull/3888
+   * * https://github.com/software-mansion/react-native-screens/pull/3776
+   * * https://github.com/software-mansion/react-native-screens/pull/3781
+   * * https://github.com/software-mansion/react-native-screens/pull/3756
+   * * https://github.com/software-mansion/react-native-screens/pull/3808
+   * * https://github.com/software-mansion/react-native-screens/pull/3785
+   * * https://github.com/software-mansion/react-native-screens/pull/3789
+   * * https://github.com/software-mansion/react-native-screens/pull/3794
+   * * https://github.com/software-mansion/react-native-screens/pull/3863
+   * * https://github.com/software-mansion/react-native-screens/pull/3875
    */
   usesStableTabsApi: true,
 } as const;


### PR DESCRIPTION
## Summary
- Adds `usesStableTabsApi` compatibility flag to `compatibilityFlags` in `src/flags.ts`
- Allows downstream navigation libraries to detect the stable Tabs API shape at runtime, maintaining backward compatibility across breaking changes (e.g. `tabKey` → `screenKey`, removal of `experimentalControlNavigationStateInJS`, explicit exports)

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `compatibilityFlags.usesStableTabsApi === true` accessible from downstream

Closes https://github.com/software-mansion/react-native-screens-labs/issues/995

🤖 Generated with [Claude Code](https://claude.com/claude-code)