### PR TITLE
refactor(iOS, Tabs): Migrate scrollEdgeEffects from TabsScreen to ScrollViewMarker

### DIFF
--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       WORKING_DIRECTORY: FabricExample
       API_LEVEL: 34
+      RNS_GAMMA_ENABLED: 1
     concurrency:
       group: android-e2e-fabric-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/ios-e2e-test-fabric.yml
+++ b/.github/workflows/ios-e2e-test-fabric.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 90
     env:
       WORKING_DIRECTORY: FabricExample
+      RNS_GAMMA_ENABLED: 1
     concurrency:
       group: ios-e2e-fabric-${{ github.ref }}
       cancel-in-progress: true

--- a/apps/src/tests/issue-tests/Test3212/ScrollViewTemplate.tsx
+++ b/apps/src/tests/issue-tests/Test3212/ScrollViewTemplate.tsx
@@ -1,19 +1,22 @@
 import React from "react";
 import { Button, ScrollView, Text } from "react-native";
+import { ScrollViewMarker } from "react-native-screens/experimental";
 import { useScrollEdgeEffectsConfigContext } from "./context";
 
 export function ScrollViewTemplate() {
   const emoji = ['😎', '🍏', '👀', '🤖', '👾', '👨‍💻'];
-  const { setConfig }  = useScrollEdgeEffectsConfigContext();
+  const { config, setConfig } = useScrollEdgeEffectsConfigContext();
 
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      <Button title="Set effects to hidden" onPress={() => {
-        setConfig({ bottom: 'hidden', top: 'hidden', left: 'hidden', right: 'hidden' });
-      }}/>
-      <Text style={{ fontSize: 21 }}>
-        {Array.from({ length: 1000 }).map(_ => emoji[Math.floor(Math.random() * emoji.length)])}
-      </Text>
-    </ScrollView>
+    <ScrollViewMarker style={{ flex: 1 }} scrollEdgeEffects={config}>
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
+        <Button title="Set effects to hidden" onPress={() => {
+          setConfig({ bottom: 'hidden', top: 'hidden', left: 'hidden', right: 'hidden' });
+        }}/>
+        <Text style={{ fontSize: 21 }}>
+          {Array.from({ length: 1000 }).map(_ => emoji[Math.floor(Math.random() * emoji.length)])}
+        </Text>
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }

--- a/apps/src/tests/issue-tests/Test3212/StackInTabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/StackInTabsScenario.tsx
@@ -1,30 +1,34 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import {
   SCROLL_EDGE_EFFECT_DEFAULTS,
   ScrollEdgeEffects,
   ScrollEdgeEffectsConfigContext,
+  useScrollEdgeEffectsConfigContext,
 } from './context';
 import { NavigationContainer } from '@react-navigation/native';
 import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
 import { Config } from './Config';
 import { StackScenario } from './StackScenario';
 import { ScrollView } from 'react-native';
+import { ScrollViewMarker } from 'react-native-screens/experimental';
+
+function ConfigComponent() {
+  const { config } = useScrollEdgeEffectsConfigContext();
+
+  return (
+    <ScrollViewMarker style={{ flex: 1 }} scrollEdgeEffects={config}>
+      {/* Add ScrollView for automatic insets which are missing in TabsScreen */}
+      <ScrollView>
+        <Config title="Outer Tabs / scrollEdgeEffects:" />
+      </ScrollView>
+    </ScrollViewMarker>
+  );
+}
 
 export function StackInTabsScenario() {
   const [config, setConfig] = useState<ScrollEdgeEffects>({
     ...SCROLL_EDGE_EFFECT_DEFAULTS,
   });
-
-  // Add ScrollView for automatic insets which are missing in TabsScreen
-  const ConfigComponent = useCallback(
-    () => (
-      <ScrollView>
-        <Config title="Outer Tabs / scrollEdgeEffects:" />
-      </ScrollView>
-    ),
-    [],
-  );
-
   return (
     <ScrollEdgeEffectsConfigContext.Provider value={{ config, setConfig }}>
       <NavigationContainer>
@@ -40,9 +44,6 @@ export function StackInTabsScenario() {
               Component: StackScenario,
               options: {
                 title: 'Stack',
-                ios: {
-                  scrollEdgeEffects: config,
-                },
               },
             },
           ]}

--- a/apps/src/tests/issue-tests/Test3212/TabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/TabsScenario.tsx
@@ -43,9 +43,6 @@ export function TabsScenario() {
                 Component: ScrollViewTemplate,
                 options: {
                   title: 'Scroll',
-                  ios: {
-                    scrollEdgeEffects: config,
-                  },
                 },
               },
             ]}

--- a/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
@@ -184,7 +184,6 @@ const TAB_CONFIGS: TabRouteConfig[] = [
       tabBarItemTestID: 'tab-item-3-id',
       tabBarItemAccessibilityLabel: 'Third Tab Item',
       ios: {
-        scrollEdgeEffects: { bottom: 'hard' },
         standardAppearance: {
           stacked: {
             normal: {

--- a/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab3.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/tabs/Tab3.tsx
@@ -1,27 +1,30 @@
 import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
 import React from 'react';
 import { ScrollView, Text } from 'react-native';
+import { ScrollViewMarker } from 'react-native-screens/experimental';
 
 export function Tab3() {
   return (
-    <ScrollView
-      contentContainerStyle={{
-        width: '100%',
-        height: 'auto',
-        gap: 15,
-        paddingHorizontal: 30,
-      }}>
-      {[...Array(30).keys()].map(index => (
-        <PressableWithFeedback
-          key={index + 1}
-          onPress={() => console.log(`Pressed #${index + 1}`)}
-          style={{
-            paddingVertical: 10,
-            paddingHorizontal: 20,
-          }}>
-          <Text>Pressable #{index + 1}</Text>
-        </PressableWithFeedback>
-      ))}
-    </ScrollView>
+    <ScrollViewMarker style={{ flex: 1 }} scrollEdgeEffects={{ bottom: 'hard' }}>
+      <ScrollView
+        contentContainerStyle={{
+          width: '100%',
+          height: 'auto',
+          gap: 15,
+          paddingHorizontal: 30,
+        }}>
+        {[...Array(30).keys()].map(index => (
+          <PressableWithFeedback
+            key={index + 1}
+            onPress={() => console.log(`Pressed #${index + 1}`)}
+            style={{
+              paddingVertical: 10,
+              paddingHorizontal: 20,
+            }}>
+            <Text>Pressable #{index + 1}</Text>
+          </PressableWithFeedback>
+        ))}
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -375,48 +375,6 @@ UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSyst
   return UITabBarSystemItemSearch;
 }
 
-#define SWITCH_EDGE_EFFECT(X)                              \
-  switch (edgeEffect) {                                    \
-    using enum react::X;                                   \
-    case Automatic:                                        \
-      return RNSScrollEdgeEffectAutomatic;                 \
-    case Hard:                                             \
-      return RNSScrollEdgeEffectHard;                      \
-    case Soft:                                             \
-      return RNSScrollEdgeEffectSoft;                      \
-    case Hidden:                                           \
-      return RNSScrollEdgeEffectHidden;                    \
-    default:                                               \
-      RCTLogError(@"[RNScreens] unsupported edge effect"); \
-      return RNSScrollEdgeEffectAutomatic;                 \
-  }
-
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSBottomScrollEdgeEffect edgeEffect)
-{
-  SWITCH_EDGE_EFFECT(RNSTabsScreenIOSBottomScrollEdgeEffect);
-}
-
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSLeftScrollEdgeEffect edgeEffect)
-{
-  SWITCH_EDGE_EFFECT(RNSTabsScreenIOSLeftScrollEdgeEffect);
-}
-
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenRightScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSRightScrollEdgeEffect edgeEffect)
-{
-  SWITCH_EDGE_EFFECT(RNSTabsScreenIOSRightScrollEdgeEffect);
-}
-
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenTopScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSTopScrollEdgeEffect edgeEffect)
-{
-  SWITCH_EDGE_EFFECT(RNSTabsScreenIOSTopScrollEdgeEffect);
-}
-
-#undef SWITCH_EDGE_EFFECT
-
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 #if RCT_NEW_ARCH_ENABLED

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -70,15 +70,6 @@ RNSTabsScreenSystemItem RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(
 
 UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem);
 
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSBottomScrollEdgeEffect edgeEffect);
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSLeftScrollEdgeEffect edgeEffect);
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenRightScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSRightScrollEdgeEffect edgeEffect);
-RNSScrollEdgeEffect RNSTabsScrollEdgeEffectFromTabsScreenTopScrollEdgeEffectCppEquivalent(
-    react::RNSTabsScreenIOSTopScrollEdgeEffect edgeEffect);
-
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 #if RCT_NEW_ARCH_ENABLED

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -4,7 +4,6 @@
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"
 #import "RNSSafeAreaProviding.h"
-#import "RNSScrollEdgeEffectApplicator.h"
 #import "RNSScrollViewBehaviorOverriding.h"
 #import "RNSTabsScreenEventEmitter.h"
 
@@ -39,12 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, weak, nullable) RNSTabsHostComponentView *reactSuperview;
 
-/**
- * Updates [scroll edge effects](https://developer.apple.com/documentation/uikit/uiscrolledgeeffect)
- * on a content ScrollView inside the tab screen, if one exists. It uses ScrollViewFinder to find the ScrollView.
- */
-- (void)updateContentScrollViewEdgeEffectsIfExists;
-
 @end
 
 #pragma mark - Props
@@ -52,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Properties set on component in JavaScript.
  */
-@interface RNSTabsScreenComponentView () <RNSScrollViewBehaviorOverriding, RNSScrollEdgeEffectProviding>
+@interface RNSTabsScreenComponentView () <RNSScrollViewBehaviorOverriding>
 
 // TODO: All of these properties should be `readonly`. Do this when support for legacy
 // architecture is dropped.
@@ -88,11 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *tabItemTestID;
 @property (nonatomic, nullable) NSString *tabItemAccessibilityLabel;
 @property (nonatomic) BOOL tabBarItemNeedsA11yUpdate;
-
-@property (nonatomic) RNSScrollEdgeEffect bottomScrollEdgeEffect;
-@property (nonatomic) RNSScrollEdgeEffect leftScrollEdgeEffect;
-@property (nonatomic) RNSScrollEdgeEffect rightScrollEdgeEffect;
-@property (nonatomic) RNSScrollEdgeEffect topScrollEdgeEffect;
 
 @property (nonatomic) RNSTabsScreenSystemItem systemItem;
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -40,7 +40,6 @@ namespace react = facebook::react;
   BOOL _tabScreenOrientationNeedsUpdate;
   BOOL _tabBarItemNeedsRecreation;
   BOOL _tabBarItemNeedsUpdate;
-  BOOL _scrollEdgeEffectsNeedUpdate;
 #endif // !RCT_NEW_ARCH_ENABLED
 }
 
@@ -70,7 +69,6 @@ namespace react = facebook::react;
   _tabScreenOrientationNeedsUpdate = NO;
   _tabBarItemNeedsRecreation = NO;
   _tabBarItemNeedsUpdate = NO;
-  _scrollEdgeEffectsNeedUpdate = NO;
 #endif
 
   [self resetProps];
@@ -163,12 +161,6 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
-- (void)updateContentScrollViewEdgeEffectsIfExists
-{
-  [RNSScrollEdgeEffectApplicator applyToScrollView:[RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:self]
-                                      withProvider:self];
-}
-
 #pragma mark - Prop update utils
 
 - (void)createTabBarItem
@@ -249,7 +241,6 @@ RNS_IGNORE_SUPER_CALL_END
   bool tabScreenOrientationNeedsUpdate{false};
   bool tabBarItemNeedsRecreation{false};
   bool tabBarItemNeedsUpdate{false};
-  bool scrollEdgeEffectsNeedUpdate{false};
 
   if (newComponentProps.title != oldComponentProps.title ||
       newComponentProps.isTitleUndefined != oldComponentProps.isTitleUndefined) {
@@ -380,34 +371,6 @@ RNS_IGNORE_SUPER_CALL_END
     tabBarItemNeedsRecreation = YES;
   }
 
-  if (newComponentProps.bottomScrollEdgeEffect != oldComponentProps.bottomScrollEdgeEffect) {
-    [self setBottomScrollEdgeEffect:rnscreens::conversion::
-                                        RNSTabsScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffectCppEquivalent(
-                                            newComponentProps.bottomScrollEdgeEffect)];
-    scrollEdgeEffectsNeedUpdate = YES;
-  }
-
-  if (newComponentProps.leftScrollEdgeEffect != oldComponentProps.leftScrollEdgeEffect) {
-    [self setLeftScrollEdgeEffect:rnscreens::conversion::
-                                      RNSTabsScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffectCppEquivalent(
-                                          newComponentProps.leftScrollEdgeEffect)];
-    scrollEdgeEffectsNeedUpdate = YES;
-  }
-
-  if (newComponentProps.rightScrollEdgeEffect != oldComponentProps.rightScrollEdgeEffect) {
-    [self setRightScrollEdgeEffect:rnscreens::conversion::
-                                       RNSTabsScrollEdgeEffectFromTabsScreenRightScrollEdgeEffectCppEquivalent(
-                                           newComponentProps.rightScrollEdgeEffect)];
-    scrollEdgeEffectsNeedUpdate = YES;
-  }
-
-  if (newComponentProps.topScrollEdgeEffect != oldComponentProps.topScrollEdgeEffect) {
-    [self setTopScrollEdgeEffect:rnscreens::conversion::
-                                     RNSTabsScrollEdgeEffectFromTabsScreenTopScrollEdgeEffectCppEquivalent(
-                                         newComponentProps.topScrollEdgeEffect)];
-    scrollEdgeEffectsNeedUpdate = YES;
-  }
-
   if (newComponentProps.userInterfaceStyle != oldComponentProps.userInterfaceStyle) {
     _userInterfaceStyle =
         rnscreens::conversion::UIUserInterfaceStyleFromTabsScreenCppEquivalent(newComponentProps.userInterfaceStyle);
@@ -434,11 +397,6 @@ RNS_IGNORE_SUPER_CALL_END
     [_controller tabScreenOrientationHasChanged];
   }
 
-  if (scrollEdgeEffectsNeedUpdate) {
-    [self updateContentScrollViewEdgeEffectsIfExists];
-    scrollEdgeEffectsNeedUpdate = NO;
-  }
-
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -462,8 +420,8 @@ RNS_IGNORE_SUPER_CALL_END
   RNSLog(@"TabScreen [%ld] mount [%ld] at %ld", self.tag, childComponentView.tag, index);
   [super mountChildComponentView:childComponentView index:index];
 
-  // overrideScrollViewBehavior and updateContentScrollViewEdgeEffects use first descendant chain
-  // from screen to find ScrollView, that's why we're only interested in child mounted at index 0.
+  // overrideScrollViewBehavior uses first descendant chain from screen to find ScrollView,
+  // that's why we're only interested in child mounted at index 0.
   if (index == 0) {
     // Before the props are set (first render) defer acting to after
     // we receive props, as user might have decided to disable this feature.
@@ -472,7 +430,6 @@ RNS_IGNORE_SUPER_CALL_END
     } else {
       _needsScrollViewBehaviorOverride = YES;
     }
-    [self updateContentScrollViewEdgeEffectsIfExists];
   }
 }
 
@@ -539,11 +496,6 @@ RNS_IGNORE_SUPER_CALL_END
   if (_tabScreenOrientationNeedsUpdate) {
     [_controller tabScreenOrientationHasChanged];
     _tabScreenOrientationNeedsUpdate = NO;
-  }
-
-  if (_scrollEdgeEffectsNeedUpdate) {
-    [self updateContentScrollViewEdgeEffectsIfExists];
-    _scrollEdgeEffectsNeedUpdate = NO;
   }
 }
 
@@ -616,30 +568,6 @@ RNS_IGNORE_SUPER_CALL_END
 {
   _selectedIconResourceName = [NSString rnscreens_stringOrNilIfEmpty:selectedIconResourceName];
   _tabItemNeedsAppearanceUpdate = YES;
-}
-
-- (void)setBottomScrollEdgeEffect:(RNSScrollEdgeEffect)bottomScrollEdgeEffect
-{
-  _bottomScrollEdgeEffect = bottomScrollEdgeEffect;
-  _scrollEdgeEffectsNeedUpdate = YES;
-}
-
-- (void)setLeftScrollEdgeEffect:(RNSScrollEdgeEffect)leftScrollEdgeEffect
-{
-  _leftScrollEdgeEffect = leftScrollEdgeEffect;
-  _scrollEdgeEffectsNeedUpdate = YES;
-}
-
-- (void)setRightScrollEdgeEffect:(RNSScrollEdgeEffect)rightScrollEdgeEffect
-{
-  _rightScrollEdgeEffect = rightScrollEdgeEffect;
-  _scrollEdgeEffectsNeedUpdate = YES;
-}
-
-- (void)setTopScrollEdgeEffect:(RNSScrollEdgeEffect)topScrollEdgeEffect
-{
-  _topScrollEdgeEffect = topScrollEdgeEffect;
-  _scrollEdgeEffectsNeedUpdate = YES;
 }
 
 - (void)setOverrideScrollViewContentInsetAdjustmentBehavior:(BOOL)overrideScrollViewContentInsetAdjustmentBehavior

--- a/scripts/e2e/detox-utils.cjs
+++ b/scripts/e2e/detox-utils.cjs
@@ -66,12 +66,12 @@ function commonDetoxConfigFactory(applicationName) {
       'ios.debug': {
         type: 'ios.app',
         binaryPath: `ios/build/Build/Products/Debug-iphonesimulator/${applicationName}.app`,
-        build: `export RNS_GAMMA_ENABLED=1 && xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
+        build: `export && xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
       },
       'ios.release': {
         type: 'ios.app',
         binaryPath: `ios/build/Build/Products/Release-iphonesimulator/${applicationName}.app`,
-        build: `export RCT_NO_LAUNCH_PACKAGER=true RNS_GAMMA_ENABLED=1 && xcodebuild ONLY_ACTIVE_ARCH=YES -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
+        build: `export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild ONLY_ACTIVE_ARCH=YES -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
       },
       'android.debug': {
         type: 'android.apk',

--- a/scripts/e2e/detox-utils.cjs
+++ b/scripts/e2e/detox-utils.cjs
@@ -66,12 +66,12 @@ function commonDetoxConfigFactory(applicationName) {
       'ios.debug': {
         type: 'ios.app',
         binaryPath: `ios/build/Build/Products/Debug-iphonesimulator/${applicationName}.app`,
-        build: `xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
+        build: `export RNS_GAMMA_ENABLED=1 && xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
       },
       'ios.release': {
         type: 'ios.app',
         binaryPath: `ios/build/Build/Products/Release-iphonesimulator/${applicationName}.app`,
-        build: `export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild ONLY_ACTIVE_ARCH=YES -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
+        build: `export RCT_NO_LAUNCH_PACKAGER=true RNS_GAMMA_ENABLED=1 && xcodebuild ONLY_ACTIVE_ARCH=YES -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
       },
       'android.debug': {
         type: 'android.apk',

--- a/scripts/e2e/detox-utils.cjs
+++ b/scripts/e2e/detox-utils.cjs
@@ -66,7 +66,7 @@ function commonDetoxConfigFactory(applicationName) {
       'ios.debug': {
         type: 'ios.app',
         binaryPath: `ios/build/Build/Products/Debug-iphonesimulator/${applicationName}.app`,
-        build: `export && xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
+        build: `xcodebuild -workspace ios/${applicationName}.xcworkspace -UseNewBuildSystem=YES -scheme ${applicationName} -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty`,
       },
       'ios.release': {
         type: 'ios.app',

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
@@ -6,7 +6,7 @@ export interface ScrollViewMarkerProps {
   style?: ViewProps['style'];
 
   /**
-   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in the first descendant chain of the ScrollViewMarker).
+   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView resolved in direct subtree of the ScrollViewMarker).
    * Depending on values set, it will blur the scrolling content below certain UI elements (header items, search bar)
    * for the specified edge of the ScrollView.
    *

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
@@ -6,7 +6,7 @@ export interface ScrollViewMarkerProps {
   style?: ViewProps['style'];
 
   /**
-   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in first descendants chain of the ScrollViewMarker).
+   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in the first descendant chain of the ScrollViewMarker).
    * Depending on values set, it will blur the scrolling content below certain UI elements (header items, search bar)
    * for the specified edge of the ScrollView.
    *

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.types.ts
@@ -5,6 +5,32 @@ export interface ScrollViewMarkerProps {
   children: ViewProps['children'];
   style?: ViewProps['style'];
 
+  /**
+   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in first descendants chain of the ScrollViewMarker).
+   * Depending on values set, it will blur the scrolling content below certain UI elements (header items, search bar)
+   * for the specified edge of the ScrollView.
+   *
+   * When set in nested containers, i.e. Stack inside Tabs, or the other way around,
+   * the ScrollView will use only the innermost one's config.
+   *
+   * Edge effects can be configured for each edge separately. The following values are currently supported:
+   *
+   * - `automatic` - the automatic scroll edge effect style,
+   * - `hard` - a scroll edge effect with a hard cutoff and dividing line,
+   * - `soft` - a soft-edged scroll edge effect,
+   * - `hidden` - no scroll edge effect.
+   *
+   * The supported values correspond to the `UIScrollEdgeEffect`'s `style` and `isHidden` props
+   * in the official UIKit documentation:
+   *
+   * @see {@link https://developer.apple.com/documentation/uikit/uiscrolledgeeffect|UIScrollEdgeEffect}
+   *
+   * @default `automatic` for each edge
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 or higher
+   */
   scrollEdgeEffects?: {
     bottom?: ScrollEdgeEffect;
     left?: ScrollEdgeEffect;

--- a/src/components/tabs/screen/TabsScreen.ios.tsx
+++ b/src/components/tabs/screen/TabsScreen.ios.tsx
@@ -73,10 +73,6 @@ function TabsScreen(props: TabsScreenProps) {
       scrollEdgeAppearance={mapAppearanceToNativeProp(
         ios?.scrollEdgeAppearance,
       )}
-      bottomScrollEdgeEffect={ios?.scrollEdgeEffects?.bottom}
-      leftScrollEdgeEffect={ios?.scrollEdgeEffects?.left}
-      rightScrollEdgeEffect={ios?.scrollEdgeEffects?.right}
-      topScrollEdgeEffect={ios?.scrollEdgeEffects?.top}
       userInterfaceStyle={ios?.experimental_userInterfaceStyle}
       systemItem={ios?.systemItem}
       overrideScrollViewContentInsetAdjustmentBehavior={

--- a/src/components/tabs/screen/TabsScreen.ios.types.ts
+++ b/src/components/tabs/screen/TabsScreen.ios.types.ts
@@ -1,9 +1,5 @@
 import type { ColorValue, TextStyle } from 'react-native';
-import type {
-  UserInterfaceStyle,
-  ScrollEdgeEffect,
-  BlurEffect,
-} from '../../shared/types';
+import type { UserInterfaceStyle, BlurEffect } from '../../shared/types';
 import type { PlatformIconIOS } from '../../../types';
 
 export type TabsScreenBlurEffect = BlurEffect | 'systemDefault';
@@ -289,38 +285,6 @@ export interface TabsScreenPropsIOS {
    * @platform ios
    */
   overrideScrollViewContentInsetAdjustmentBehavior?: boolean;
-  /**
-   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in first descendants chain of the Screen).
-   * Depending on values set, it will blur the scrolling content below certain UI elements (header items, search bar)
-   * for the specified edge of the ScrollView.
-   *
-   * When set in nested containers, i.e. Stack inside Tabs, or the other way around,
-   * the ScrollView will use only the innermost one's config.
-   *
-   * Edge effects can be configured for each edge separately. The following values are currently supported:
-   *
-   * - `automatic` - the automatic scroll edge effect style,
-   * - `hard` - a scroll edge effect with a hard cutoff and dividing line,
-   * - `soft` - a soft-edged scroll edge effect,
-   * - `hidden` - no scroll edge effect.
-   *
-   * The supported values correspond to the `UIScrollEdgeEffect`'s `style` and `isHidden` props
-   * in the official UIKit documentation:
-   *
-   * @see {@link https://developer.apple.com/documentation/uikit/uiscrolledgeeffect|UIScrollEdgeEffect}
-   *
-   * @default `automatic` for each edge
-   *
-   * @platform ios
-   *
-   * @supported iOS 26 or higher
-   */
-  scrollEdgeEffects?: {
-    bottom?: ScrollEdgeEffect;
-    left?: ScrollEdgeEffect;
-    right?: ScrollEdgeEffect;
-    top?: ScrollEdgeEffect;
-  };
   /**
    * @summary Allows to override system appearance for the tab bar.
    *

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -103,8 +103,6 @@ type SystemItem =
   | 'search'
   | 'topRated';
 
-type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
-
 type UserInterfaceStyle = 'unspecified' | 'light' | 'dark';
 
 // #endregion iOS-specific helpers
@@ -158,11 +156,6 @@ export interface NativeProps extends ViewProps {
     boolean,
     true
   >;
-  bottomScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-  leftScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-  rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-  topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-
   // Experimental
   userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -64,6 +64,7 @@ export const compatibilityFlags = {
    * * https://github.com/software-mansion/react-native-screens/pull/3794
    * * https://github.com/software-mansion/react-native-screens/pull/3863
    * * https://github.com/software-mansion/react-native-screens/pull/3875
+   * * https://github.com/software-mansion/react-native-screens/pull/3895
    */
   usesStableTabsApi: true,
 } as const;


### PR DESCRIPTION
## Description

Removes `scrollEdgeEffects` from `TabsScreen` and moves the configuration to introduced in the other PR ScrollViewMarker.

> [!NOTE]  
> In this PR I'm adding RNS_GAMMA_ENABLED compilation flag to CI for e2e testing, because `TestBottomTabs` was failing on missing `ScrollViewMarker` symbols.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/980

## Changes

- Removed `scrollEdgeEffects` prop from `TabsScreen's` sources and codegen spec
- Removed the corresponding native iOS handling from `RNSTabsScreenComponentView`
- Updated example/test files to use `ScrollViewMarker` instead:
  - Test3212/ScrollViewTemplate.tsx — wraps ScrollView with ScrollViewMarker, reads effects from context
  - Test3212/TabsScenario.tsx — removed `ios.scrollEdgeEffects` from tab options
  - Test3212/StackInTabsScenario.tsx — removed ios.scrollEdgeEffects from tab options; Config tab now uses `ScrollViewMarker`
  - TestBottomTabs/tabs/Tab3.tsx — wraps ScrollView with ScrollViewMarker scrollEdgeEffects={{ bottom: 'hard' }}

## Visual documentation

Ensured that exsiting examples are working properly, after the migration

| Test3212 - TabsScenario | Test3213 - StackInTabsScenario | TestBottomTabs |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/e506f687-3082-47a0-b0c5-3c18b6b02415" /> | <video src="https://github.com/user-attachments/assets/6350a68b-3fed-4450-8ca3-e5173d2f7800" /> | <video src="https://github.com/user-attachments/assets/cc710498-c564-4a90-a753-95f562a9a114" /> |

## Test plan

Tests listed in changes section were retested.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
