### PR TITLE
docs(Android, Stack v5): add missing docs to StackHeaderConfig

### DIFF
--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -9,30 +9,125 @@ export type StackHeaderBackgroundSubviewCollapseModeAndroid =
   StackHeaderSubviewCollapseModeAndroid;
 
 export interface StackHeaderToolbarSubviewAndroid {
+  /**
+   * @summary The React component rendered in this toolbar slot.
+   *
+   * The subview is sized by Yoga but positioned by the native layout. Each
+   * subview is placed independently — subviews do not participate in a shared
+   * flex layout and cannot influence each other's sizing.
+   *
+   * Intrinsic sizing and explicit dimensions work as expected. Avoid
+   * parent-relative sizing (e.g. `flex: 1`) on the root element — it will
+   * produce incorrect dimensions. Flex layout within a root that has a known
+   * size works as expected.
+   *
+   * @platform android
+   */
   Component: ReactNode;
 }
 
 export interface StackHeaderBackgroundSubviewAndroid {
+  /**
+   * @summary Controls how the background subview behaves when the app bar
+   * collapses.
+   *
+   * The following values are available:
+   * - `off` - the subview scrolls away with the app bar,
+   * - `parallax` - the subview scrolls at a slower rate, creating a parallax
+   *   effect.
+   *
+   * `pin` is not currently supported because the background subview is
+   * stretched to match the entire `AppBarLayout`, which causes pinned content
+   * to move immediately rather than staying fixed. Support for `pin` collapse
+   * mode might be added in the future.
+   *
+   * @default off
+   *
+   * @platform android
+   */
   collapseMode?: StackHeaderSubviewCollapseModeAndroid | undefined;
+  /**
+   * @summary The React component rendered as the header background.
+   *
+   * The subview is stretched to match the header (`AppBarLayout`) dimensions,
+   * so parent-relative sizing (e.g. `flex: 1`) works correctly.
+   *
+   * @platform android
+   */
   Component: ReactNode;
 }
 
 export interface StackHeaderConfigPropsAndroid {
+  /**
+   * @summary Specifies the type of the Material 3 app bar.
+   *
+   * The following values are available:
+   * - `small` - small app bar with fixed title,
+   * - `medium` - medium app bar with collapsing title,
+   * - `large` - large app bar with collapsing title.
+   *
+   * M3 Expressive headers aren't currently supported (there is no stable
+   * `MDC-Android` version yet).
+   *
+   * @see {@link https://m3.material.io/components/app-bars/overview|Material Design 3: App bars}
+   *
+   * @default small
+   *
+   * @platform android
+   */
   type?: StackHeaderTypeAndroid | undefined;
+  /**
+   * @summary Custom view rendered behind the header content.
+   *
+   * @platform android
+   */
   backgroundSubview?: StackHeaderBackgroundSubviewAndroid | undefined;
+  /**
+   * @summary Custom view placed in the leading (start) slot of the toolbar.
+   *
+   * @platform android
+   */
   leadingSubview?: StackHeaderToolbarSubviewAndroid | undefined;
+  /**
+   * @summary Custom view placed in the center slot of the toolbar.
+   *
+   * @platform android
+   */
   centerSubview?: StackHeaderToolbarSubviewAndroid | undefined;
+  /**
+   * @summary Custom view placed in the trailing (end) slot of the toolbar.
+   *
+   * @platform android
+   */
   trailingSubview?: StackHeaderToolbarSubviewAndroid | undefined;
   /**
-   * Tint color for the back button icon.
-   * - `undefined` — use default tint (for custom images, no tint is applied)
-   * - `ColorValue` — apply a custom tint color
+   * @summary Tint color applied to the back button icon.
+   *
+   * When `undefined`, the default tint color is used. This applies to the
+   * native back arrow and `drawableResource` icons that have an associated
+   * tint. For `imageSource` icons, no tint is applied by default.
+   *
+   * @platform android
    */
   backButtonTintColor?: ColorValue | undefined;
   /**
-   * Custom icon for the back button.
-   * - `undefined` — use the native default back arrow
-   * - `PlatformIconAndroid` — use a custom icon (drawableResource or imageSource)
+   * @summary Custom icon for the back button.
+   *
+   * When `undefined`, the native back arrow (`homeAsUpIndicator`) is used.
+   *
+   * Supported values:
+   * - `{ type: 'imageSource', imageSource }`
+   *   Uses an image from the provided resource.
+   *
+   *   Remarks: `imageSource` type doesn't support SVGs on Android.
+   *   For loading SVGs use `drawableResource` type.
+   *
+   * - `{ type: 'drawableResource', name }`
+   *   Uses a drawable resource with the given name.
+   *
+   *   Remarks: Requires passing a drawable to resources via Android Studio.
+   *
+   * @platform android
    */
   backButtonIcon?: PlatformIconAndroid | undefined;
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -12,10 +12,13 @@ export interface StackHeaderToolbarSubviewAndroid {
   /**
    * @summary The React component rendered in this toolbar slot.
    *
-   * The subview is sized by Yoga but positioned by the native layout. Each
-   * subview is placed independently — subviews do not participate in a shared
-   * flex layout and cannot influence each other's sizing.
+   * The subview is sized by React Native's layout engine but positioned by the
+   * platform native layout. Each subview is placed independently — subviews do
+   * not participate in a shared flex layout and cannot influence each other's
+   * sizing.
    *
+   *
+   * @remarks
    * Intrinsic sizing and explicit dimensions work as expected. Avoid
    * parent-relative sizing (e.g. `flex: 1`) on the root element — it will
    * produce incorrect dimensions. Flex layout within a root that has a known
@@ -36,6 +39,7 @@ export interface StackHeaderBackgroundSubviewAndroid {
    * - `parallax` - the subview scrolls at a slower rate, creating a parallax
    *   effect.
    *
+   * @remarks
    * `pin` is not currently supported because the background subview is
    * stretched to match the entire `AppBarLayout`, which causes pinned content
    * to move immediately rather than staying fixed. Support for `pin` collapse
@@ -66,6 +70,7 @@ export interface StackHeaderConfigPropsAndroid {
    * - `medium` - medium app bar with collapsing title,
    * - `large` - large app bar with collapsing title.
    *
+   * @remarks
    * M3 Expressive headers aren't currently supported (there is no stable
    * `MDC-Android` version yet).
    *

--- a/src/components/gamma/stack/header/StackHeaderConfig.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.types.ts
@@ -2,9 +2,46 @@ import { StackHeaderConfigPropsAndroid } from './StackHeaderConfig.android.types
 import { StackHeaderConfigPropsIOS } from './StackHeaderConfig.ios.types';
 
 export interface StackHeaderConfigPropsBase {
+  /**
+   * @summary Title displayed in the header.
+   *
+   * @platform android, ios
+   */
   title?: string | undefined;
+  /**
+   * @summary Specifies if the header should be hidden.
+   *
+   * @default false
+   *
+   * @platform android, ios
+   */
   hidden?: boolean | undefined;
+  /**
+   * @summary Specifies if the content should be rendered behind the header.
+   *
+   * When `true`, content is rendered behind the header instead of starting
+   * below it.
+   *
+   * On Android:
+   * - The header background color is not affected by this prop.
+   * - Setting this prop to `true` is not supported when header scrolling is
+   *   enabled.
+   *
+   * @default false
+   *
+   * @platform android, ios
+   */
   transparent?: boolean | undefined;
+  /**
+   * @summary Specifies if the back button should be hidden.
+   *
+   * This prop does not apply to the root screen of the stack for which the back
+   * button is always hidden.
+   *
+   * @default false
+   *
+   * @platform android, ios
+   */
   backButtonHidden?: boolean | undefined;
 }
 


### PR DESCRIPTION
## Description

Adds missing docs to `StackHeaderConfig`.
