### PR TITLE
ci: add publish workflow using npm-package-publish action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,63 @@
+name: Publish release to npm
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: Type of release to publish.
+        type: choice
+        options:
+          - stable
+          - nightly
+          - beta
+          - rc
+        default: stable
+      version:
+        description: >-
+          Specific version to publish. For stable: usually inferred from
+          x.y-stable branch name. For nightly: leave empty to auto-infer
+          from npm latest tag.
+        type: string
+        required: false
+        default: ''
+      dry-run:
+        description: Whether to perform a dry run of the publish.
+        type: boolean
+        default: true
+
+jobs:
+  npm-publish:
+    if: github.repository == 'software-mansion/react-native-screens'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # for git operations on stable releases
+      id-token: write # for OIDC
+
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        shell: bash
+        run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'yarn'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Publish release
+        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
+        with:
+          package-name: 'react-native-screens'
+          package-json-path: 'package.json'
+          install-dependencies-command: 'yarn install --immutable'
+          release-type: ${{ inputs.release-type }}
+          version: ${{ inputs.version }}
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,7 @@
 name: Publish release to npm
 on:
+  schedule:
+    - cron: '27 23 * * *' # at 23:27 every day
   workflow_dispatch:
     inputs:
       release-type:
@@ -52,7 +54,8 @@ jobs:
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
 
-      - name: Publish release
+      - name: Publish manual release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
         with:
           package-name: 'react-native-screens'
@@ -61,3 +64,13 @@ jobs:
           release-type: ${{ inputs.release-type }}
           version: ${{ inputs.version }}
           dry-run: ${{ inputs.dry-run }}
+
+      - name: Publish automatic nightly release
+        if: ${{ github.event_name == 'schedule' }}
+        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
+        with:
+          package-name: 'react-native-screens'
+          package-json-path: 'package.json'
+          install-dependencies-command: 'yarn install --immutable'
+          release-type: 'nightly'
+          dry-run: true


### PR DESCRIPTION
## Description

Migrate the npm publishing flow to use the `software-mansion/npm-package-publish`
composite action, which provides unified version resolution, OIDC-based trusted
publishing, and `--provenance` builds.

This is Phase 1 — the new workflow is added **side-by-side** with the existing
nightly workflow. Automatic nightly runs are `dry-run: true` until verified.
Phase 2 (removing the old workflow, `release-it`, and custom version scripts)
will follow in a separate PR.

## Changes

- Added `.github/workflows/publish-npm.yml` using `software-mansion/npm-package-publish`
- Supports all release types via manual dispatch: `stable`, `nightly`, `beta`, `rc`
- Automatic nightly schedule (`23:27 UTC`) with dry-run enabled
- OIDC permissions (`id-token: write`) for provenance-based publishing
- Concurrency control to prevent parallel publishes

## Test plan

I'll first try to dry run publishing nightly and stable.
Then I'll release nightly.
Then I'll try to release 4.25.0-beta.1.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes