### PR TITLE
refactor(Example): replace TabsContainer with direct Tabs.Host approach in single-feature tests scenarios

### DIFF
--- a/apps/src/tests/single-feature-tests/tabs/bottom-accessory-layout.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/bottom-accessory-layout.tsx
@@ -69,7 +69,7 @@ function RGBView() {
     <View style={styles.fullView}>
       <View style={[styles.rgbStrip, { backgroundColor: '#ff4d4d' }]} />
       <View style={[styles.rgbStrip, { backgroundColor: '#4dff4d' }]} />
-      <View style={[styles.rgbStrip, { backgroundColor: '#4d4df0' }]} />
+      <View style={[styles.rgbStrip, { backgroundColor: '#4d4dff' }]} />
     </View>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/bottom-accessory-layout.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/bottom-accessory-layout.tsx
@@ -1,14 +1,9 @@
 import LongText from '@apps/shared/LongText';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, Pressable, ScrollView } from 'react-native';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
 import type { Scenario } from '@apps/tests/shared/helpers';
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Bottom Accessory',
@@ -19,6 +14,13 @@ const SCENARIO: Scenario = {
 };
 
 export default SCENARIO;
+
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
 function ShortViewUL() {
   return (
@@ -69,7 +71,7 @@ function RGBView() {
     <View style={styles.fullView}>
       <View style={[styles.rgbStrip, { backgroundColor: '#ff4d4d' }]} />
       <View style={[styles.rgbStrip, { backgroundColor: '#4dff4d' }]} />
-      <View style={[styles.rgbStrip, { backgroundColor: '#4d4dff' }]} />
+      <View style={[styles.rgbStrip, { backgroundColor: '#4d4df0' }]} />
     </View>
   );
 }
@@ -82,16 +84,13 @@ const ACCESSORY_VARIANTS = [
   { id: 4, content: RGBView },
 ];
 
-function ConfigScreen() {
-  const [selected, setSelected] = useState(0);
-  const { updateHostConfig } = useTabsHostConfig();
-
-  useEffect(() => {
-    updateHostConfig({
-      ios: { bottomAccessory: ACCESSORY_VARIANTS[selected].content },
-    });
-  }, [selected, updateHostConfig]);
-
+function ConfigScreen({
+  selected,
+  setSelected,
+}: {
+  selected: number;
+  setSelected: (id: number) => void;
+}) {
   return (
     <ScrollView style={styles.container}>
       {ACCESSORY_VARIANTS.map(item => (
@@ -109,27 +108,34 @@ function ConfigScreen() {
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Tab1',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab1',
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: DummyScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+  const [selected, setSelected] = useState(0);
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}
+      ios={{
+        bottomAccessory: () => {
+          const Content = ACCESSORY_VARIANTS[selected].content;
+          return <Content />;
+        },
+      }}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen selected={selected} setSelected={setSelected} />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <DummyScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/src/tests/single-feature-tests/tabs/override-scroll-view-content-inset.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/override-scroll-view-content-inset.tsx
@@ -4,7 +4,7 @@ import {
   NavigationContainer,
   NavigationIndependentTree,
 } from '@react-navigation/native';
-import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
+import { Tabs } from 'react-native-screens';
 import type { Scenario } from '@apps/tests/shared/helpers';
 
 const SCENARIO: Scenario = {
@@ -54,40 +54,32 @@ function App() {
   return (
     <NavigationIndependentTree>
       <NavigationContainer>
-        <TabsContainer
-          routeConfigs={[
-            {
-              name: 'False',
-              Component: FalseTab,
-              options: {
-                title: 'False',
-                ios: {
-                  overrideScrollViewContentInsetAdjustmentBehavior: false,
-                  icon: { type: 'sfSymbol', name: 'xmark.circle' },
-                },
-              },
-            },
-            {
-              name: 'True',
-              Component: TrueTab,
-              options: {
-                title: 'True',
-                ios: {
-                  overrideScrollViewContentInsetAdjustmentBehavior: true,
-                  icon: { type: 'sfSymbol', name: 'checkmark.circle' },
-                },
-              },
-            },
-            {
-              name: 'Default',
-              Component: DefaultTab,
-              options: {
-                title: 'Default',
-                ios: { icon: { type: 'sfSymbol', name: 'circle.dashed' } },
-              },
-            },
-          ]}
-        />
+        <Tabs.Host navState={{ selectedScreenKey: 'False', provenance: 0 }}>
+          <Tabs.Screen
+            screenKey="False"
+            title="False"
+            ios={{
+              overrideScrollViewContentInsetAdjustmentBehavior: false,
+              icon: { type: 'sfSymbol', name: 'xmark.circle' },
+            }}>
+            <FalseTab />
+          </Tabs.Screen>
+          <Tabs.Screen
+            screenKey="True"
+            title="True"
+            ios={{
+              overrideScrollViewContentInsetAdjustmentBehavior: true,
+              icon: { type: 'sfSymbol', name: 'checkmark.circle' },
+            }}>
+            <TrueTab />
+          </Tabs.Screen>
+          <Tabs.Screen
+            screenKey="Default"
+            title="Default"
+            ios={{ icon: { type: 'sfSymbol', name: 'circle.dashed' } }}>
+            <DefaultTab />
+          </Tabs.Screen>
+        </Tabs.Host>
       </NavigationContainer>
     </NavigationIndependentTree>
   );

--- a/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation.tsx
@@ -3,12 +3,7 @@ import React from 'react';
 import { ScrollView } from 'react-native';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
 import type { Scenario } from '@apps/tests/shared/helpers';
-import {
-  TabsContainer,
-  type TabRouteConfig,
-  useTabsNavigationContext,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs, type TabsScreenOrientation } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Tabs Screen Orientation',
@@ -19,44 +14,59 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { routeKey, routeOptions, setRouteOptions } = useTabsNavigationContext();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
+function ConfigScreen({
+  orientation,
+  setOrientation,
+}: {
+  orientation: TabsScreenOrientation | undefined;
+  setOrientation: (value: TabsScreenOrientation | undefined) => void;
+}) {
   return (
     <ScrollView style={{ padding: 40 }}>
       <SettingsPicker
         label="orientation"
         items={['portrait', 'landscape', 'undefined']}
-        value={routeOptions.orientation ?? 'undefined'}
+        value={orientation ?? 'undefined'}
         onValueChange={value =>
-          setRouteOptions(routeKey, {
-            orientation: value === 'undefined' ? undefined : value,
-          })
+          setOrientation(value === 'undefined' ? undefined : value)
         }
       />
     </ScrollView>
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Tab1',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab1',
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: DummyScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainer routeConfigs={ROUTE_CONFIGS} />;
+  const [orientation, setOrientation] = React.useState<
+    TabsScreenOrientation | undefined
+  >(undefined);
+
+  return (
+    <Tabs.Host navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        orientation={orientation}
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          orientation={orientation}
+          setOrientation={setOrientation}
+        />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <DummyScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
+import { Tabs } from 'react-native-screens';
 import type { Scenario } from '@apps/tests/shared/helpers';
 import {
   TabsScreenAppearanceAndroid,
@@ -78,164 +78,156 @@ function TabScreen() {
 
 export function App() {
   return (
-    <TabsContainer
-      routeConfigs={[
-        {
-          name: 'Tab1',
-          Component: TabScreen,
-          options: {
-            title: 'Tab1',
-            ios: {
-              icon: {
-                type: 'sfSymbol',
-                name: 'house.fill',
-              },
-              selectedIcon: {
-                type: 'sfSymbol',
-                name: 'house.fill',
-              },
-              standardAppearance: DEFAULT_APPEARANCE_IOS,
-              scrollEdgeAppearance: DEFAULT_APPEARANCE_IOS,
-            },
-            android: {
-              icon: {
-                type: 'imageSource',
-                imageSource: require('@assets/variableIcons/icon.png'),
-              },
-              selectedIcon: {
-                type: 'imageSource',
-                imageSource: require('@assets/variableIcons/icon_fill.png'),
-              },
-              standardAppearance: DEFAULT_APPEARANCE_ANDROID,
-            },
+    <Tabs.Host navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        ios={{
+          icon: {
+            type: 'sfSymbol',
+            name: 'house.fill',
           },
-        },
-        {
-          name: 'Tab2',
-          Component: TabScreen,
-          options: {
-            title: 'Tab2',
-            ios: {
-              icon: {
-                type: 'templateSource',
-                templateSource: require('@assets/variableIcons/icon.png'),
+          selectedIcon: {
+            type: 'sfSymbol',
+            name: 'house.fill',
+          },
+          standardAppearance: DEFAULT_APPEARANCE_IOS,
+          scrollEdgeAppearance: DEFAULT_APPEARANCE_IOS,
+        }}
+        android={{
+          icon: {
+            type: 'imageSource',
+            imageSource: require('@assets/variableIcons/icon.png'),
+          },
+          selectedIcon: {
+            type: 'imageSource',
+            imageSource: require('@assets/variableIcons/icon_fill.png'),
+          },
+          standardAppearance: DEFAULT_APPEARANCE_ANDROID,
+        }}>
+        <TabScreen />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={{
+          icon: {
+            type: 'templateSource',
+            templateSource: require('@assets/variableIcons/icon.png'),
+          },
+          standardAppearance: {
+            ...DEFAULT_APPEARANCE_IOS,
+            tabBarBackgroundColor: Colors.PurpleDark100,
+            stacked: {
+              ...DEFAULT_APPEARANCE_IOS.stacked,
+              normal: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
+                tabBarItemIconColor: Colors.YellowDark100,
+                tabBarItemTitleFontColor: Colors.YellowDark40,
               },
-              standardAppearance: {
-                ...DEFAULT_APPEARANCE_IOS,
-                tabBarBackgroundColor: Colors.PurpleDark100,
-                stacked: {
-                  ...DEFAULT_APPEARANCE_IOS.stacked,
-                  normal: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
-                    tabBarItemIconColor: Colors.YellowDark100,
-                    tabBarItemTitleFontColor: Colors.YellowDark40,
-                  },
-                  selected: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.selected,
-                    tabBarItemIconColor: Colors.RedDark100,
-                    tabBarItemTitleFontColor: Colors.RedDark40,
-                  },
-                  focused: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.focused,
-                    tabBarItemIconColor: Colors.RedLight100,
-                    tabBarItemTitleFontColor: Colors.RedLight40,
-                  },
-                },
+              selected: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.selected,
+                tabBarItemIconColor: Colors.RedDark100,
+                tabBarItemTitleFontColor: Colors.RedDark40,
               },
-              scrollEdgeAppearance: {
-                ...DEFAULT_APPEARANCE_IOS,
-                tabBarBackgroundColor: Colors.PurpleDark100,
-                stacked: {
-                  ...DEFAULT_APPEARANCE_IOS.stacked,
-                  normal: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
-                    tabBarItemIconColor: Colors.YellowDark100,
-                    tabBarItemTitleFontColor: Colors.YellowDark40,
-                  },
-                  selected: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.selected,
-                    tabBarItemIconColor: Colors.RedDark100,
-                    tabBarItemTitleFontColor: Colors.RedDark40,
-                  },
-                  focused: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.focused,
-                    tabBarItemIconColor: Colors.RedLight100,
-                    tabBarItemTitleFontColor: Colors.RedLight40,
-                  },
-                },
-              },
-            },
-            android: {
-              icon: {
-                type: 'drawableResource',
-                name: 'sym_call_missed',
-              },
-              standardAppearance: {
-                ...DEFAULT_APPEARANCE_ANDROID,
-                tabBarBackgroundColor: Colors.PurpleDark100,
-                tabBarItemRippleColor: Colors.PurpleDark40,
-                normal: {
-                  tabBarItemIconColor: Colors.YellowDark100,
-                  tabBarItemTitleFontColor: Colors.YellowDark40,
-                },
-                selected: {
-                  tabBarItemIconColor: Colors.RedDark100,
-                  tabBarItemTitleFontColor: Colors.RedDark40,
-                },
-                focused: {
-                  tabBarItemIconColor: Colors.RedLight100,
-                  tabBarItemTitleFontColor: Colors.RedLight40,
-                },
-                tabBarItemActiveIndicatorColor: Colors.PurpleDark120,
+              focused: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.focused,
+                tabBarItemIconColor: Colors.RedLight100,
+                tabBarItemTitleFontColor: Colors.RedLight40,
               },
             },
           },
-        },
-        {
-          name: 'Tab3',
-          Component: TabScreen,
-          options: {
-            title: 'Tab3',
-            ios: {
-              icon: {
-                type: 'templateSource',
-                templateSource: require('@assets/variableIcons/icon_fill.png'),
+          scrollEdgeAppearance: {
+            ...DEFAULT_APPEARANCE_IOS,
+            tabBarBackgroundColor: Colors.PurpleDark100,
+            stacked: {
+              ...DEFAULT_APPEARANCE_IOS.stacked,
+              normal: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
+                tabBarItemIconColor: Colors.YellowDark100,
+                tabBarItemTitleFontColor: Colors.YellowDark40,
               },
-              standardAppearance: {
-                ...DEFAULT_APPEARANCE_IOS,
-                stacked: {
-                  ...DEFAULT_APPEARANCE_IOS.stacked,
-                  normal: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
-                    tabBarItemBadgeBackgroundColor: Colors.GreenDark40,
-                  },
-                },
+              selected: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.selected,
+                tabBarItemIconColor: Colors.RedDark100,
+                tabBarItemTitleFontColor: Colors.RedDark40,
               },
-              scrollEdgeAppearance: {
-                ...DEFAULT_APPEARANCE_IOS,
-                stacked: {
-                  ...DEFAULT_APPEARANCE_IOS.stacked,
-                  normal: {
-                    ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
-                    tabBarItemBadgeBackgroundColor: Colors.GreenDark40,
-                  },
-                },
+              focused: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.focused,
+                tabBarItemIconColor: Colors.RedLight100,
+                tabBarItemTitleFontColor: Colors.RedLight40,
               },
             },
-            android: {
-              icon: {
-                type: 'imageSource',
-                imageSource: require('@assets/variableIcons/icon_fill.png'),
-              },
-              standardAppearance: {
-                ...DEFAULT_APPEARANCE_ANDROID,
-                tabBarItemBadgeTextColor: Colors.GreenDark120,
+          },
+        }}
+        android={{
+          icon: {
+            type: 'drawableResource',
+            name: 'sym_call_missed',
+          },
+          standardAppearance: {
+            ...DEFAULT_APPEARANCE_ANDROID,
+            tabBarBackgroundColor: Colors.PurpleDark100,
+            tabBarItemRippleColor: Colors.PurpleDark40,
+            normal: {
+              tabBarItemIconColor: Colors.YellowDark100,
+              tabBarItemTitleFontColor: Colors.YellowDark40,
+            },
+            selected: {
+              tabBarItemIconColor: Colors.RedDark100,
+              tabBarItemTitleFontColor: Colors.RedDark40,
+            },
+            focused: {
+              tabBarItemIconColor: Colors.RedLight100,
+              tabBarItemTitleFontColor: Colors.RedLight40,
+            },
+            tabBarItemActiveIndicatorColor: Colors.PurpleDark120,
+          },
+        }}>
+        <TabScreen />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab3"
+        title="Tab3"
+        ios={{
+          icon: {
+            type: 'templateSource',
+            templateSource: require('@assets/variableIcons/icon_fill.png'),
+          },
+          standardAppearance: {
+            ...DEFAULT_APPEARANCE_IOS,
+            stacked: {
+              ...DEFAULT_APPEARANCE_IOS.stacked,
+              normal: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
                 tabBarItemBadgeBackgroundColor: Colors.GreenDark40,
               },
             },
           },
-        },
-      ]}
-    />
+          scrollEdgeAppearance: {
+            ...DEFAULT_APPEARANCE_IOS,
+            stacked: {
+              ...DEFAULT_APPEARANCE_IOS.stacked,
+              normal: {
+                ...DEFAULT_APPEARANCE_IOS.stacked?.normal,
+                tabBarItemBadgeBackgroundColor: Colors.GreenDark40,
+              },
+            },
+          },
+        }}
+        android={{
+          icon: {
+            type: 'imageSource',
+            imageSource: require('@assets/variableIcons/icon_fill.png'),
+          },
+          standardAppearance: {
+            ...DEFAULT_APPEARANCE_ANDROID,
+            tabBarItemBadgeTextColor: Colors.GreenDark120,
+            tabBarItemBadgeBackgroundColor: Colors.GreenDark40,
+          },
+        }}>
+        <TabScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets.tsx
@@ -1,14 +1,9 @@
 import { Platform, StyleSheet, Text, TextInput, View } from 'react-native';
 import type { Scenario } from '@apps/tests/shared/helpers';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { SettingsSwitch } from '@apps/shared';
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsNavigationContext,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs } from 'react-native-screens';
+import { SafeAreaView } from 'react-native-screens/experimental';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
 
 const SCENARIO: Scenario = {
@@ -22,84 +17,87 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { routeKey, routeOptions, setRouteOptions } = useTabsNavigationContext();
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
-  const [safeAreaViewBottomEdgeEnabled, setSafeAreaViewBottomEdgeEnabled] =
-    useState(routeOptions.safeAreaConfiguration?.edges?.bottom ?? true);
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
-  useEffect(() => {
-    setRouteOptions(routeKey, {
-      safeAreaConfiguration: {
-        edges: {
-          bottom: safeAreaViewBottomEdgeEnabled,
-        },
-      },
-    });
-  }, [routeKey, setRouteOptions, safeAreaViewBottomEdgeEnabled]);
+function ConfigScreen({
+  tabBarRespectsIMEInsets,
+  setTabBarRespectsIMEInsets,
+}: {
+  tabBarRespectsIMEInsets: boolean;
+  setTabBarRespectsIMEInsets: (value: boolean) => void;
+}) {
+  const [safeAreaViewBottomEdgeEnabled, setSafeAreaViewBottomEdgeEnabled] =
+    useState(true);
 
   return (
-    <View style={[styles.container, styles.content]}>
-      <View style={styles.section}>
-        <Text style={styles.heading}>Safe Area – Bottom Edge</Text>
-        <SettingsSwitch
-          label={'safeAreaViewBottomEdgeEnabled'}
-          value={safeAreaViewBottomEdgeEnabled}
-          onValueChange={function (value: boolean): void {
-            setSafeAreaViewBottomEdgeEnabled(value);
-          }}
-        />
+    <SafeAreaView edges={{ bottom: safeAreaViewBottomEdgeEnabled }}>
+      <View style={[styles.container, styles.content]}>
+        <View style={styles.section}>
+          <Text style={styles.heading}>Safe Area – Bottom Edge</Text>
+          <SettingsSwitch
+            label={'safeAreaViewBottomEdgeEnabled'}
+            value={safeAreaViewBottomEdgeEnabled}
+            onValueChange={function (value: boolean): void {
+              setSafeAreaViewBottomEdgeEnabled(value);
+            }}
+          />
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.heading}>tabBarRespectsIMEInsets</Text>
+          <SettingsSwitch
+            label={'tabBarRespectsIMEInsets'}
+            value={tabBarRespectsIMEInsets}
+            onValueChange={function (value: boolean): void {
+              setTabBarRespectsIMEInsets(value);
+            }}
+          />
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.heading}>TextInput</Text>
+          <TextInput
+            placeholder="Focus TextInput to show IME..."
+            style={styles.textInput}
+          />
+        </View>
+        <View style={styles.end}>
+          <Text>TabsScreen bottom</Text>
+        </View>
       </View>
-      <View style={styles.section}>
-        <Text style={styles.heading}>tabBarRespectsIMEInsets</Text>
-        <SettingsSwitch
-          label={'tabBarRespectsIMEInsets'}
-          value={hostConfig.android?.tabBarRespectsIMEInsets ?? false}
-          onValueChange={function (value: boolean): void {
-            updateHostConfig({ android: { tabBarRespectsIMEInsets: value } });
-          }}
-        />
-      </View>
-      <View style={styles.section}>
-        <Text style={styles.heading}>TextInput</Text>
-        <TextInput
-          placeholder="Focus TextInput to show IME..."
-          style={styles.textInput}
-        />
-      </View>
-      <View style={styles.end}>
-        <Text>TabsScreen bottom</Text>
-      </View>
-    </View>
+    </SafeAreaView>
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Config',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Config',
-      safeAreaConfiguration: {
-        edges: {
-          bottom: true,
-        },
-      },
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: DummyScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+  const [tabBarRespectsIMEInsets, setTabBarRespectsIMEInsets] = useState(false);
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Config', provenance: 0 }}
+      android={{ tabBarRespectsIMEInsets }}>
+      <Tabs.Screen
+        screenKey="Config"
+        title="Config"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          tabBarRespectsIMEInsets={tabBarRespectsIMEInsets}
+          setTabBarRespectsIMEInsets={setTabBarRespectsIMEInsets}
+        />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <DummyScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx
@@ -2,32 +2,41 @@ import React from 'react';
 import type { Scenario } from '@apps/tests/shared/helpers';
 import { Button, Text, View, type NativeSyntheticEvent } from 'react-native';
 import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-  useTabsNavigationContext,
-} from '@apps/shared/gamma/containers/tabs';
+  Tabs,
+  type TabsHostNavState,
+  type MoreTabSelectedEvent,
+} from 'react-native-screens';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 import { ToastProvider, useToast } from '@apps/shared/';
 import { Colors } from '@apps/shared/styling';
-import type { MoreTabSelectedEvent } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'More navigation controller',
   key: 'test-tabs-more-navigation-controller',
-  details: 'Test navigation and interactions with "More Navigation Controller"',
+  details:
+    'Test navigation and interactions with "More Navigation Controller"',
   platforms: ['ios'],
   AppComponent: App,
 };
 
 export default SCENARIO;
 
-function ContentView() {
-  const { routeKey } = useTabsNavigationContext();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+const TAB_KEYS = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'];
+
+const SelectTabContext = React.createContext<(key: string) => void>(() => {});
+
+function ContentView({ screenKey }: { screenKey: string }) {
   return (
     <CenteredLayoutView>
       <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
-        {routeKey}
+        {screenKey}
       </Text>
       <TabsNavigationButtons />
     </CenteredLayoutView>
@@ -35,52 +44,20 @@ function ContentView() {
 }
 
 function TabsNavigationButtons() {
-  const nav = useTabsNavigationContext();
+  const selectTab = React.useContext(SelectTabContext);
 
   return (
     <View>
-      <Button title="Select First" onPress={() => nav.selectTab('First')} />
-      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
-      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
-      <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
-      <Button title="Select Fifth" onPress={() => nav.selectTab('Fifth')} />
-      <Button title="Select Sixth" onPress={() => nav.selectTab('Sixth')} />
+      {TAB_KEYS.map(key => (
+        <Button
+          key={key}
+          title={`Select ${key}`}
+          onPress={() => selectTab(key)}
+        />
+      ))}
     </View>
   );
 }
-
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'First',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
-  },
-  {
-    name: 'Second',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
-  },
-  {
-    name: 'Third',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
-  },
-  {
-    name: 'Fourth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
-  },
-  {
-    name: 'Fifth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fifth' },
-  },
-  {
-    name: 'Sixth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Sixth' },
-  },
-];
 
 export function App() {
   return (
@@ -93,16 +70,50 @@ export function App() {
 function AppContents() {
   const toast = useToast();
 
+  const [navState, setNavState] = React.useState<TabsHostNavState>({
+    selectedScreenKey: 'First',
+    provenance: 0,
+  });
+
+  const selectTab = React.useCallback((key: string) => {
+    setNavState(prev => ({
+      selectedScreenKey: key,
+      provenance: prev.provenance,
+    }));
+  }, []);
+
   return (
-    <TabsContainerWithHostConfigContext
-      routeConfigs={ROUTE_CONFIGS}
-      ios={{
-        onMoreTabSelected: (event: NativeSyntheticEvent<MoreTabSelectedEvent>) => {
-          const message = `onMoreTabSelected: ${JSON.stringify(event.nativeEvent, undefined, 2)}`;
-          console.warn(message);
-          toast.push({ message, backgroundColor: Colors.GreenLight60 });
-        },
-      }}
-    />
+    <SelectTabContext value={selectTab}>
+      <Tabs.Host
+        navState={navState}
+        onTabSelected={event => {
+          React.startTransition(() => {
+            setNavState({
+              selectedScreenKey: event.nativeEvent.selectedScreenKey,
+              provenance: event.nativeEvent.provenance,
+            });
+          });
+        }}
+        ios={{
+          onMoreTabSelected: (
+            event: NativeSyntheticEvent<MoreTabSelectedEvent>,
+          ) => {
+            const message = `onMoreTabSelected: ${JSON.stringify(event.nativeEvent, undefined, 2)}`;
+            console.warn(message);
+            toast.push({ message, backgroundColor: Colors.GreenLight60 });
+          },
+        }}>
+        {TAB_KEYS.map(key => (
+          <Tabs.Screen
+            key={key}
+            screenKey={key}
+            title={key}
+            ios={DEFAULT_ICON}
+            android={DEFAULT_ICON}>
+            <ContentView screenKey={key} />
+          </Tabs.Screen>
+        ))}
+      </Tabs.Host>
+    </SelectTabContext>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import type { Scenario } from '../../shared/helpers';
 import { Button, Text, View } from 'react-native';
-import {
-  type TabRouteConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-  useTabsNavigationContext,
-  TabsContainerWithHostConfigContext,
-} from '../../../shared/gamma/containers/tabs';
+import { Tabs, type TabsHostNavState } from 'react-native-screens';
 import { CenteredLayoutView } from '../../../shared/CenteredLayoutView';
 import { ToastProvider, useToast } from '../../../shared/';
 import { Colors } from '@apps/shared/styling';
@@ -21,27 +16,44 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ContentView() {
-  const nav = useTabsNavigationContext();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
-  const preventNativeSelection =
-    nav.routeOptions.preventNativeSelection ?? false;
+const TAB_KEYS = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'];
+
+type TabsContext = {
+  selectTab: (key: string) => void;
+  preventNativeSelection: Record<string, boolean>;
+  togglePreventNativeSelection: (key: string) => void;
+};
+
+const TabsCtx = React.createContext<TabsContext>({
+  selectTab: () => {},
+  preventNativeSelection: {},
+  togglePreventNativeSelection: () => {},
+});
+
+function ContentView({ screenKey }: { screenKey: string }) {
+  const { preventNativeSelection, togglePreventNativeSelection } =
+    React.useContext(TabsCtx);
+
+  const prevented = preventNativeSelection[screenKey] ?? false;
 
   return (
     <CenteredLayoutView>
       <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
-        {nav.routeKey}
+        {screenKey}
       </Text>
       <Text style={{ textAlign: 'center' }}>
-        preventNativeSelection: {JSON.stringify(preventNativeSelection)}
+        preventNativeSelection: {JSON.stringify(prevented)}
       </Text>
       <Button
         title="Toggle preventNativeSelection"
-        onPress={() =>
-          nav.setRouteOptions(nav.routeKey, {
-            preventNativeSelection: !preventNativeSelection,
-          })
-        }
+        onPress={() => togglePreventNativeSelection(screenKey)}
       />
       <TabsNavigationButtons />
     </CenteredLayoutView>
@@ -49,52 +61,20 @@ function ContentView() {
 }
 
 function TabsNavigationButtons() {
-  const nav = useTabsNavigationContext();
+  const { selectTab } = React.useContext(TabsCtx);
 
   return (
     <View>
-      <Button title="Select First" onPress={() => nav.selectTab('First')} />
-      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
-      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
-      <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
-      <Button title="Select Fifth" onPress={() => nav.selectTab('Fifth')} />
-      <Button title="Select Sixth" onPress={() => nav.selectTab('Sixth')} />
+      {TAB_KEYS.map(key => (
+        <Button
+          key={key}
+          title={`Select ${key}`}
+          onPress={() => selectTab(key)}
+        />
+      ))}
     </View>
   );
 }
-
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'First',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
-  },
-  {
-    name: 'Second',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
-  },
-  {
-    name: 'Third',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
-  },
-  {
-    name: 'Fourth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
-  },
-  {
-    name: 'Fifth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fifth' },
-  },
-  {
-    name: 'Sixth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Sixth' },
-  },
-];
 
 export function App() {
   return (
@@ -107,17 +87,66 @@ export function App() {
 function AppContents() {
   const toast = useToast();
 
+  const [navState, setNavState] = React.useState<TabsHostNavState>({
+    selectedScreenKey: 'First',
+    provenance: 0,
+  });
+
+  const [preventNativeSelection, setPreventNativeSelection] = React.useState<
+    Record<string, boolean>
+  >({});
+
+  const selectTab = React.useCallback((key: string) => {
+    setNavState(prev => ({
+      selectedScreenKey: key,
+      provenance: prev.provenance,
+    }));
+  }, []);
+
+  const togglePreventNativeSelection = React.useCallback((key: string) => {
+    setPreventNativeSelection(prev => ({
+      ...prev,
+      [key]: !(prev[key] ?? false),
+    }));
+  }, []);
+
+  const ctx = React.useMemo<TabsContext>(
+    () => ({ selectTab, preventNativeSelection, togglePreventNativeSelection }),
+    [selectTab, preventNativeSelection, togglePreventNativeSelection],
+  );
+
   return (
-    <TabsContainerWithHostConfigContext
-      routeConfigs={ROUTE_CONFIGS}
-      onTabSelectionPrevented={event => {
-        const message = `onTabSelectionPrevented: ${event.nativeEvent.preventedScreenKey}`;
-        console.warn(message);
-        toast.push({
-          message: message,
-          backgroundColor: Colors.GreenLight60,
-        });
-      }}
-    />
+    <TabsCtx value={ctx}>
+      <Tabs.Host
+        navState={navState}
+        onTabSelected={event => {
+          React.startTransition(() => {
+            setNavState({
+              selectedScreenKey: event.nativeEvent.selectedScreenKey,
+              provenance: event.nativeEvent.provenance,
+            });
+          });
+        }}
+        onTabSelectionPrevented={event => {
+          const message = `onTabSelectionPrevented: ${event.nativeEvent.preventedScreenKey}`;
+          console.warn(message);
+          toast.push({
+            message: message,
+            backgroundColor: Colors.GreenLight60,
+          });
+        }}>
+        {TAB_KEYS.map(key => (
+          <Tabs.Screen
+            key={key}
+            screenKey={key}
+            title={key}
+            preventNativeSelection={preventNativeSelection[key] ?? false}
+            ios={DEFAULT_ICON}
+            android={DEFAULT_ICON}>
+            <ContentView screenKey={key} />
+          </Tabs.Screen>
+        ))}
+      </Tabs.Host>
+    </TabsCtx>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import type { Scenario } from '@apps/tests/shared/helpers';
 import { Button, Text, View } from 'react-native';
-import {
-  TabsContainer,
-  type TabRouteConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-  useTabsNavigationContext,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs, type TabsHostNavState } from 'react-native-screens';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 
 const SCENARIO: Scenario = {
@@ -19,12 +14,20 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ContentView() {
-  const { routeKey } = useTabsNavigationContext();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+const SelectTabContext = React.createContext<(key: string) => void>(() => {});
+
+function ContentView({ screenKey }: { screenKey: string }) {
   return (
     <CenteredLayoutView>
       <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
-        {routeKey}
+        {screenKey}
       </Text>
       <TabsNavigationButtons />
     </CenteredLayoutView>
@@ -32,35 +35,64 @@ function ContentView() {
 }
 
 function TabsNavigationButtons() {
-  const nav = useTabsNavigationContext();
+  const selectTab = React.useContext(SelectTabContext);
 
   return (
     <View>
-      <Button title="Select First" onPress={() => nav.selectTab('First')} />
-      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
-      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
+      <Button title="Select First" onPress={() => selectTab('First')} />
+      <Button title="Select Second" onPress={() => selectTab('Second')} />
+      <Button title="Select Third" onPress={() => selectTab('Third')} />
     </View>
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'First',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
-  },
-  {
-    name: 'Second',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
-  },
-  {
-    name: 'Third',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
-  },
-];
-
 export function App() {
-  return <TabsContainer routeConfigs={ROUTE_CONFIGS} />;
+  const [navState, setNavState] = React.useState<TabsHostNavState>({
+    selectedScreenKey: 'First',
+    provenance: 0,
+  });
+
+  const selectTab = React.useCallback((key: string) => {
+    setNavState(prev => ({
+      selectedScreenKey: key,
+      provenance: prev.provenance,
+    }));
+  }, []);
+
+  return (
+    <SelectTabContext value={selectTab}>
+      <Tabs.Host
+        navState={navState}
+        onTabSelected={event => {
+          React.startTransition(() => {
+            setNavState({
+              selectedScreenKey: event.nativeEvent.selectedScreenKey,
+              provenance: event.nativeEvent.provenance,
+            });
+          });
+        }}>
+        <Tabs.Screen
+          screenKey="First"
+          title="First"
+          ios={DEFAULT_ICON}
+          android={DEFAULT_ICON}>
+          <ContentView screenKey="First" />
+        </Tabs.Screen>
+        <Tabs.Screen
+          screenKey="Second"
+          title="Second"
+          ios={DEFAULT_ICON}
+          android={DEFAULT_ICON}>
+          <ContentView screenKey="Second" />
+        </Tabs.Screen>
+        <Tabs.Screen
+          screenKey="Third"
+          title="Third"
+          ios={DEFAULT_ICON}
+          android={DEFAULT_ICON}>
+          <ContentView screenKey="Third" />
+        </Tabs.Screen>
+      </Tabs.Host>
+    </SelectTabContext>
+  );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import type { Scenario } from '../../shared/helpers';
 import { Button, Text, View } from 'react-native';
-import {
-  type TabRouteConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-  useTabsNavigationContext,
-  TabsContainerWithHostConfigContext,
-  useTabsHostConfig,
-} from '../../../shared/gamma/containers/tabs';
+import { Tabs, type TabsHostNavState } from 'react-native-screens';
 import { CenteredLayoutView } from '../../../shared/CenteredLayoutView';
 import { ToastProvider, useToast } from '../../../shared/';
 import { Colors } from '@apps/shared/styling';
@@ -22,25 +16,46 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ContentView() {
-  const { routeKey } = useTabsNavigationContext();
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
-  console.log(`ContentView - render for key ${routeKey}`);
+const TAB_KEYS = ['First', 'Second', 'Third', 'Fourth'];
+
+type TabsContext = {
+  selectTab: (key: string) => void;
+  rejectStaleNavStateUpdates: boolean;
+  toggleRejectStale: () => void;
+};
+
+const TabsCtx = React.createContext<TabsContext>({
+  selectTab: () => {},
+  rejectStaleNavStateUpdates: true,
+  toggleRejectStale: () => {},
+});
+
+function ContentView({ screenKey }: { screenKey: string }) {
+  const { rejectStaleNavStateUpdates, toggleRejectStale } =
+    React.useContext(TabsCtx);
+
+  console.log(`ContentView - render for key ${screenKey}`);
 
   const [heavyRenderEnabled, setHeavyRenderEnabled] = React.useState(false);
 
   return (
     <CenteredLayoutView>
       <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
-        {routeKey}
+        {screenKey}
       </Text>
       <Text style={{ textAlign: 'center' }}>
         heavyRender: {JSON.stringify(heavyRenderEnabled)}
       </Text>
       <Text style={{ textAlign: 'center' }}>
         rejectStaleNavStateUpdates:{' '}
-        {JSON.stringify(hostConfig.rejectStaleNavStateUpdates)}
+        {JSON.stringify(rejectStaleNavStateUpdates)}
       </Text>
       <HeavyRenderHierarchy enabled={heavyRenderEnabled} timeMs={3000} />
       <TabsNavigationButtons />
@@ -50,51 +65,27 @@ function ContentView() {
       />
       <Button
         title="Toggle rejectStaleNavStateUpdates"
-        onPress={() =>
-          updateHostConfig({
-            rejectStaleNavStateUpdates: !hostConfig.rejectStaleNavStateUpdates,
-          })
-        }
+        onPress={toggleRejectStale}
       />
     </CenteredLayoutView>
   );
 }
 
 function TabsNavigationButtons() {
-  const nav = useTabsNavigationContext();
+  const { selectTab } = React.useContext(TabsCtx);
 
   return (
     <View>
-      <Button title="Select First" onPress={() => nav.selectTab('First')} />
-      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
-      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
-      <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
+      {TAB_KEYS.map(key => (
+        <Button
+          key={key}
+          title={`Select ${key}`}
+          onPress={() => selectTab(key)}
+        />
+      ))}
     </View>
   );
 }
-
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'First',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
-  },
-  {
-    name: 'Second',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
-  },
-  {
-    name: 'Third',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
-  },
-  {
-    name: 'Fourth',
-    Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
-  },
-];
 
 export function App() {
   return (
@@ -107,20 +98,66 @@ export function App() {
 function AppContents() {
   const toast = useToast();
 
+  const [navState, setNavState] = React.useState<TabsHostNavState>({
+    selectedScreenKey: 'First',
+    provenance: 0,
+  });
+
+  const [rejectStaleNavStateUpdates, setRejectStale] = React.useState(true);
+
+  const selectTab = React.useCallback((key: string) => {
+    setNavState(prev => ({
+      selectedScreenKey: key,
+      provenance: prev.provenance,
+    }));
+  }, []);
+
+  const toggleRejectStale = React.useCallback(() => {
+    setRejectStale(prev => !prev);
+  }, []);
+
+  const ctx = React.useMemo<TabsContext>(
+    () => ({ selectTab, rejectStaleNavStateUpdates, toggleRejectStale }),
+    [selectTab, rejectStaleNavStateUpdates, toggleRejectStale],
+  );
+
   return (
-    <TabsContainerWithHostConfigContext
-      routeConfigs={ROUTE_CONFIGS}
-      rejectStaleNavStateUpdates={true}
-      onTabSelectionRejected={event => {
-        const message = `onTabSelectionRejected: ${JSON.stringify(
-          event.nativeEvent,
-          undefined,
-          2,
-        )}`;
-        console.warn(message);
-        toast.push({ message: message, backgroundColor: Colors.GreenLight60 });
-      }}
-    />
+    <TabsCtx value={ctx}>
+      <Tabs.Host
+        navState={navState}
+        rejectStaleNavStateUpdates={rejectStaleNavStateUpdates}
+        onTabSelected={event => {
+          React.startTransition(() => {
+            setNavState({
+              selectedScreenKey: event.nativeEvent.selectedScreenKey,
+              provenance: event.nativeEvent.provenance,
+            });
+          });
+        }}
+        onTabSelectionRejected={event => {
+          const message = `onTabSelectionRejected: ${JSON.stringify(
+            event.nativeEvent,
+            undefined,
+            2,
+          )}`;
+          console.warn(message);
+          toast.push({
+            message: message,
+            backgroundColor: Colors.GreenLight60,
+          });
+        }}>
+        {TAB_KEYS.map(key => (
+          <Tabs.Screen
+            key={key}
+            screenKey={key}
+            title={key}
+            ios={DEFAULT_ICON}
+            android={DEFAULT_ICON}>
+            <ContentView screenKey={key} />
+          </Tabs.Screen>
+        ))}
+      </Tabs.Host>
+    </TabsCtx>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
@@ -11,13 +11,7 @@ import {
 import type { Scenario } from '@apps/tests/shared/helpers';
 import React, { useEffect } from 'react';
 import { SettingsPicker } from '@apps/shared';
-import type { TabsHostColorScheme } from 'react-native-screens';
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs, type TabsHostColorScheme } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Tab Bar Color Scheme',
@@ -29,8 +23,20 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+function ConfigScreen({
+  colorScheme,
+  setColorScheme,
+}: {
+  colorScheme: TabsHostColorScheme;
+  setColorScheme: (value: TabsHostColorScheme) => void;
+}) {
   const [reactColorScheme, setReactColorScheme] =
     React.useState<ColorSchemeName>('unspecified');
 
@@ -71,8 +77,8 @@ function ConfigScreen() {
         <Text style={styles.heading}>TabsHost color scheme</Text>
         <SettingsPicker<NonNullable<TabsHostColorScheme>>
           label={'colorScheme'}
-          value={hostConfig.colorScheme ?? 'inherit'}
-          onValueChange={value => updateHostConfig({ colorScheme: value })}
+          value={colorScheme}
+          onValueChange={value => setColorScheme(value)}
           items={['inherit', 'light', 'dark']}
         />
       </View>
@@ -88,32 +94,33 @@ function TestScreen() {
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Config',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Config',
-      safeAreaConfiguration: {
-        edges: {
-          bottom: true,
-        },
-      },
-    },
-  },
-  {
-    name: 'Keyboard',
-    Component: TestScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Keyboard',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+  const [colorScheme, setColorScheme] =
+    React.useState<TabsHostColorScheme>('inherit');
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Config', provenance: 0 }}
+      colorScheme={colorScheme}>
+      <Tabs.Screen
+        screenKey="Config"
+        title="Config"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          colorScheme={colorScheme}
+          setColorScheme={setColorScheme}
+        />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Keyboard"
+        title="Keyboard"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <TestScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -139,6 +146,6 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   text: {
-    color: 'gray'
+    color: 'gray',
   },
 });

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
@@ -1,14 +1,8 @@
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
 import React from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { Scenario } from '@apps/tests/shared/helpers';
 import { SettingsPicker } from '@apps/shared';
-import { TabBarControllerMode } from 'react-native-screens';
+import { Tabs, TabBarControllerMode } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Tab Bar Controller Mode',
@@ -20,26 +14,36 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+function ConfigScreen({
+  tabBarControllerMode,
+  setTabBarControllerMode,
+}: {
+  tabBarControllerMode: TabBarControllerMode;
+  setTabBarControllerMode: (value: TabBarControllerMode) => void;
+}) {
   return (
     <ScrollView style={{ padding: 40 }}>
       <View>
         <Text style={styles.description}>
-          Controls whether the tab bar is displayed as a bar or
-          sidebar.{'\n'}Test tabSidebar on iPad — on iPhone it collapses
-          back to a tab bar automatically.
+          Controls whether the tab bar is displayed as a bar or sidebar.{'\n'}
+          Test tabSidebar on iPad — on iPhone it collapses back to a tab bar
+          automatically.
         </Text>
         <SettingsPicker<TabBarControllerMode>
           label="tabBarControllerMode"
-          value={hostConfig.ios?.tabBarControllerMode ?? 'automatic'}
-          onValueChange={value =>
-            updateHostConfig({ ios: { tabBarControllerMode: value } })
-          }
+          value={tabBarControllerMode}
+          onValueChange={value => setTabBarControllerMode(value)}
           items={['automatic', 'tabBar', 'tabSidebar']}
         />
       </View>
-    </ScrollView >
+    </ScrollView>
   );
 }
 
@@ -56,42 +60,38 @@ function TestScreen() {
       ))}
     </ScrollView>
   );
-};
-
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Tab1',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab1',
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: TestScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-
-    },
-  },
-];
+}
 
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
-};
+  const [tabBarControllerMode, setTabBarControllerMode] =
+    React.useState<TabBarControllerMode>('automatic');
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}
+      ios={{ tabBarControllerMode }}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          tabBarControllerMode={tabBarControllerMode}
+          setTabBarControllerMode={setTabBarControllerMode}
+        />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <TestScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
+}
 
 const styles = StyleSheet.create({
-  sectionHeader: {
-    fontSize: 13,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    color: '#888',
-    letterSpacing: 0.5,
-    marginTop: 24,
-    marginBottom: 4,
-  },
   description: {
     fontSize: 13,
     color: '#555',
@@ -103,23 +103,5 @@ const styles = StyleSheet.create({
     padding: 16,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#e0e0e0',
-  },
-  centeredScreen: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-    gap: 12,
-  },
-  screenLabel: {
-    fontSize: 17,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-  screenHint: {
-    fontSize: 14,
-    color: '#555',
-    textAlign: 'center',
-    lineHeight: 20,
   },
 });

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
@@ -2,12 +2,7 @@ import { SettingsSwitch } from '@apps/shared/SettingsSwitch';
 import React from 'react';
 import { ScrollView, Text } from 'react-native';
 import type { Scenario } from '@apps/tests/shared/helpers';
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Tab Bar Hidden',
@@ -18,38 +13,55 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
 
+function ConfigScreen({
+  tabBarHidden,
+  setTabBarHidden,
+}: {
+  tabBarHidden: boolean;
+  setTabBarHidden: (value: boolean) => void;
+}) {
   return (
-    <ScrollView style={{ padding: 40 }}
-      testID="tab-bar-hidden-scrollview">
+    <ScrollView style={{ padding: 40 }} testID="tab-bar-hidden-scrollview">
       <Text style={{ textAlign: 'center' }}>
-        Change flag value by clicking on button.</Text>
+        Change flag value by clicking on button.
+      </Text>
       <SettingsSwitch
         style={{ marginTop: 20, marginBottom: 15 }}
         label="tabBarHidden"
-        value={hostConfig.tabBarHidden ?? false}
-        onValueChange={value => updateHostConfig({ tabBarHidden: value })}
+        value={tabBarHidden}
+        onValueChange={value => setTabBarHidden(value)}
         testID="tab-bar-hidden-switch"
       />
     </ScrollView>
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Tab1',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      tabBarItemTestID: 'tab-bar-item-1-id',
-      tabBarItemAccessibilityLabel: 'First Tab Item',
-      title: 'Tab1',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+  const [tabBarHidden, setTabBarHidden] = React.useState(false);
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}
+      tabBarHidden={tabBarHidden}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        tabBarItemTestID="tab-bar-item-1-id"
+        tabBarItemAccessibilityLabel="First Tab Item"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          tabBarHidden={tabBarHidden}
+          setTabBarHidden={setTabBarHidden}
+        />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
@@ -9,13 +9,7 @@ import {
 import type { Scenario } from '@apps/tests/shared/helpers';
 import React, { useEffect, useState } from 'react';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
-import type { TabsHostProps } from 'react-native-screens';
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
+import { Tabs, type TabsHostProps } from 'react-native-screens';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
 
 const SCENARIO: Scenario = {
@@ -29,8 +23,20 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+function ConfigScreen({
+  direction,
+  setDirection,
+}: {
+  direction: NonNullable<TabsHostProps['direction']>;
+  setDirection: (value: NonNullable<TabsHostProps['direction']>) => void;
+}) {
   const [reactForceRtl, setReactForceRtl] = useState(false);
   const [reactAllowRtl, setReactAllowRtl] = useState(true);
 
@@ -103,8 +109,8 @@ function ConfigScreen() {
         <Text style={styles.heading}>TabsHost layout direction</Text>
         <SettingsPicker<NonNullable<TabsHostProps['direction']>>
           label={'direction'}
-          value={hostConfig.direction ?? 'inherit'}
-          onValueChange={value => updateHostConfig({ direction: value })}
+          value={direction}
+          onValueChange={value => setDirection(value)}
           items={['inherit', 'ltr', 'rtl']}
         />
       </View>
@@ -112,42 +118,36 @@ function ConfigScreen() {
   );
 }
 
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Config',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Config',
-      safeAreaConfiguration: {
-        edges: {
-          bottom: true,
-        },
-      },
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: DummyScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-    },
-  },
-];
-
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+  const [direction, setDirection] = React.useState<
+    NonNullable<TabsHostProps['direction']>
+  >('inherit');
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Config', provenance: 0 }}
+      direction={direction}>
+      <Tabs.Screen
+        screenKey="Config"
+        title="Config"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen direction={direction} setDirection={setDirection} />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <DummyScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  containerCenter: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   content: {
     padding: 20,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
@@ -1,14 +1,8 @@
-import {
-  TabsContainerWithHostConfigContext,
-  type TabRouteConfig,
-  useTabsHostConfig,
-  DEFAULT_TAB_ROUTE_OPTIONS,
-} from '@apps/shared/gamma/containers/tabs';
 import React from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { Scenario } from '@apps/tests/shared/helpers';
 import { SettingsPicker } from '@apps/shared';
-import { TabBarMinimizeBehavior } from 'react-native-screens';
+import { Tabs, TabBarMinimizeBehavior } from 'react-native-screens';
 
 const SCENARIO: Scenario = {
   name: 'Tab Bar Minimize Behavior',
@@ -20,25 +14,35 @@ const SCENARIO: Scenario = {
 
 export default SCENARIO;
 
-function ConfigScreen() {
-  const { hostConfig, updateHostConfig } = useTabsHostConfig();
+const DEFAULT_ICON = {
+  icon: {
+    type: 'imageSource' as const,
+    imageSource: require('@assets/variableIcons/icon.png'),
+  },
+};
+
+function ConfigScreen({
+  tabBarMinimizeBehavior,
+  setTabBarMinimizeBehavior,
+}: {
+  tabBarMinimizeBehavior: TabBarMinimizeBehavior;
+  setTabBarMinimizeBehavior: (value: TabBarMinimizeBehavior) => void;
+}) {
   return (
     <ScrollView style={{ padding: 40 }}>
       <View>
         <Text style={styles.description}>
-          Controls when the tab bar minimizes. Switch to Tab2 and
-          scroll up/down to observe the behaviour. Requires iOS 26+.
+          Controls when the tab bar minimizes. Switch to Tab2 and scroll up/down
+          to observe the behaviour. Requires iOS 26+.
         </Text>
         <SettingsPicker<TabBarMinimizeBehavior>
           label="tabBarMinimizeBehavior"
-          value={hostConfig.ios?.tabBarMinimizeBehavior ?? 'automatic'}
-          onValueChange={value =>
-            updateHostConfig({ ios: { tabBarMinimizeBehavior: value } })
-          }
+          value={tabBarMinimizeBehavior}
+          onValueChange={value => setTabBarMinimizeBehavior(value)}
           items={['automatic', 'onScrollDown', 'onScrollUp', 'never']}
         />
       </View>
-    </ScrollView >
+    </ScrollView>
   );
 }
 
@@ -55,42 +59,38 @@ function TestScreen() {
       ))}
     </ScrollView>
   );
-};
-
-const ROUTE_CONFIGS: TabRouteConfig[] = [
-  {
-    name: 'Tab1',
-    Component: ConfigScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab1',
-    },
-  },
-  {
-    name: 'Tab2',
-    Component: TestScreen,
-    options: {
-      ...DEFAULT_TAB_ROUTE_OPTIONS,
-      title: 'Tab2',
-
-    },
-  },
-];
+}
 
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
-};
+  const [tabBarMinimizeBehavior, setTabBarMinimizeBehavior] =
+    React.useState<TabBarMinimizeBehavior>('automatic');
+
+  return (
+    <Tabs.Host
+      navState={{ selectedScreenKey: 'Tab1', provenance: 0 }}
+      ios={{ tabBarMinimizeBehavior }}>
+      <Tabs.Screen
+        screenKey="Tab1"
+        title="Tab1"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <ConfigScreen
+          tabBarMinimizeBehavior={tabBarMinimizeBehavior}
+          setTabBarMinimizeBehavior={setTabBarMinimizeBehavior}
+        />
+      </Tabs.Screen>
+      <Tabs.Screen
+        screenKey="Tab2"
+        title="Tab2"
+        ios={DEFAULT_ICON}
+        android={DEFAULT_ICON}>
+        <TestScreen />
+      </Tabs.Screen>
+    </Tabs.Host>
+  );
+}
 
 const styles = StyleSheet.create({
-  sectionHeader: {
-    fontSize: 13,
-    fontWeight: '600' as const,
-    textTransform: 'uppercase' as const,
-    color: '#888',
-    letterSpacing: 0.5,
-    marginTop: 24,
-    marginBottom: 4,
-  },
   description: {
     fontSize: 13,
     color: '#555',
@@ -101,23 +101,5 @@ const styles = StyleSheet.create({
     padding: 16,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#e0e0e0',
-  },
-  centeredScreen: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-    gap: 12,
-  },
-  screenLabel: {
-    fontSize: 17,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-  screenHint: {
-    fontSize: 14,
-    color: '#555',
-    textAlign: 'center',
-    lineHeight: 20,
   },
 });


### PR DESCRIPTION
## Description

This PR replaces `TabsContainer` with `routeConfigs` prop with direct `Tabs.Host` + `Tabs.Screen` usage across 14 single-feature tabs test scenarios.

We hit what is likely a Metro bundler bug: Fast Refresh would fire but not actually update the screen when components were passed through `routeConfigs` objects rather than rendered directly in JSX. The refresh appeared to apply successfully (no full reload), yet the visible UI remained stale. By inlining `Tabs.Host` + `Tabs.Screen` directly in JSX, components are part of the regular React tree and Fast Refresh correctly reflects changes on screen. 

> **Note:**  This PR **does not** update issue tests.

## Changes

- update single-feature tabs tests as described above

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
