### PR TITLE
fix(iOS, Tabs): prevent double event on more tab navigation

### DIFF
--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -21,6 +21,8 @@
 - (BOOL)moreNavigationController:(UINavigationController *)navigationController
         shouldPushViewController:(UIViewController *)viewController;
 
+@property (nonatomic, readwrite) BOOL shouldProgressStateOnMoreNavigationControllerPush;
+
 @end
 
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
@@ -51,6 +53,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     };
     const auto msgSendSuperPushViewController =
         reinterpret_cast<void (*)(struct objc_super *, SEL, UIViewController *, BOOL)>(objc_msgSendSuper);
+
+    [tabBarController setShouldProgressStateOnMoreNavigationControllerPush:YES];
     msgSendSuperPushViewController(&superInfo, _cmd, viewController, animated);
   }
 }
@@ -88,6 +92,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     _tabsHostComponentView = nil;
     _navigationState = nil;
     _pendingOperation = nil;
+    _shouldProgressStateOnMoreNavigationControllerPush = NO;
 
     // Delegate field retains weakly, no risk of cycle.
     self.delegate = self;
@@ -392,7 +397,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 #pragma mark - UINavigationControllerDelegate
 
 - (void)navigationController:(UINavigationController *)navigationController
-       didShowViewController:(UIViewController *)viewController
+      willShowViewController:(UIViewController *)viewController
                     animated:(BOOL)animated
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
@@ -402,8 +407,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
       navigationController);
 
   // The root view controller is of different type.
-  if ([viewController isKindOfClass:RNSTabsScreenViewController.class]) {
+  if ([viewController isKindOfClass:RNSTabsScreenViewController.class] &&
+      [self shouldProgressStateOnMoreNavigationControllerPush]) {
     [self userDidSelectViewController:viewController];
+    [self setShouldProgressStateOnMoreNavigationControllerPush:NO];
   }
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }


### PR DESCRIPTION
## Description

When a user had something already pushed onto the stack inside the *more tab*, navigated away and then came back, the navigation state update event was dispatched **twice**:

1. First from `tabBarController:didSelectViewController:` delegate callback,
2. Second from `UINavigationControllerDelegate`'s `navigationController:didShowViewController:animated:`.

This PR fixes that by gating the second dispatch behind a new flag, so state only progresses when navigation was actually triggered via `pushViewController`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1140

### Known risk

The flag is set in the swizzled `pushViewController`, while what we truly want to detect is navigation originating from `UIMoreList`. This could break if `UIMoreNavigationController` calls `pushViewController` from other internal paths — I have not found such edge cases, but open to suggestions for a more precise detection.

### Considered alternative

Deduplication on the `eventemitter` / `TabsHost` layer was considered and rejected — it would mean tolerating incorrect `RNSTabBarController` behavior and working around it upstream. Fixing it at the source is preferred.

### Side effect worth noting

When the user is in tab `Sixth`, selects the more tab item (navigating to the *more list*), and then selects `Sixth` again from the list — this now triggers another `OnTabSelected` event with fresh provenance (native state progresses) and `OnTabSelected#isRepeated` set to **`false`**.

I consider this correct: we inform the programmer *where* the user navigated, and `isRepeated = false` signals "no way this should trigger a special effect", which is the intended purpose of that payload field. Open for discussion.

## Changes

- Added `shouldProgressStateOnMoreNavigationControllerPush` flag on `RNSTabBarController`.
- Flag set to `YES` inside the swizzled `rns_pushViewController`, reset in `init`.
- Renamed the `UINavigationControllerDelegate` callback override from `didShowViewController:` to `willShowViewController:` and guarded `userDidSelectViewController:` call behind the flag — clearing it after use.

## Test plan

Tested with:

- `apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller.tsx`

Reproduction steps (before the fix):

1. Build the `FabricExample` iOS app with more than 5 tabs configured (triggers the *More* tab).
2. Navigate into a tab accessible only via the *More* list (e.g. `Sixth`).
3. Push some screen onto its stack.
4. Switch to a different visible tab, then return to the *More* tab.
5. Observe that `onNativeStateChange` / `OnTabSelected` fires twice per return.

After the fix only a single event is dispatched.

Additional scenario to verify the intentional side effect:

1. Select tab `Sixth` via the *More* list.
2. Tap the *More* tab item again (goes back to *More* list).
3. Tap `Sixth` again from the list.
4. Expect a new `OnTabSelected` event with `isRepeated = false`.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes