### PR TITLE
chore(tests): allow forcing tab-select action when already selected

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -127,8 +127,9 @@ function useTabsNavigationMethods(dispatch: React.Dispatch<TabsNavigationAction>
   );
 
   const selectTab: SelectTabMethod = React.useCallback(
-    (routeKey: string) => {
-      dispatch({ type: 'tab-select', routeKey });
+    (routeKey: string, forceAction?: boolean) => {
+      const shouldForceAction = forceAction ?? false;
+      dispatch({ type: 'tab-select', routeKey, forceAction: shouldForceAction });
     },
     [dispatch],
   );

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -55,6 +55,7 @@ export type TabsContainerState = {
 export type TabsNavigationActionSelectTab = {
   type: 'tab-select';
   routeKey: string;
+  forceAction: boolean;
 };
 
 export type TabsNavigationActionNativeSelectTab = {
@@ -100,7 +101,7 @@ export type SetTabOptionsMethod = (
   options: Partial<TabRouteOptions>,
 ) => void;
 
-export type SelectTabMethod = (routeKey: string) => void;
+export type SelectTabMethod = (routeKey: string, forceAction?: boolean) => void;
 
 /// Navigation methods (user facing)
 

--- a/apps/src/shared/gamma/containers/tabs/reducer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/reducer.tsx
@@ -65,7 +65,7 @@ function tabsActionSelectTabHandler(
     return state;
   }
 
-  if (state.confirmedState.selectedRouteKey === action.routeKey) {
+  if (state.confirmedState.selectedRouteKey === action.routeKey && !action.forceAction) {
     return state;
   }
 


### PR DESCRIPTION
## Description

Extends the `selectTab` navigation method and the `tab-select` reducer action
with an optional `forceAction` flag. Previously, dispatching `tab-select` for
the currently selected route was a no-op (the reducer returned the existing
state). With `forceAction: true`, callers can bypass that short-circuit and
re-run the selection logic even when the target route is already active.

This is useful for scenarios where selecting the already-selected tab should
still produce a side effect (for example, to re-trigger an effect subscribed
to selection changes, or to reset internal state tied to a tab).

## Changes

- Added `forceAction: boolean` to `TabsNavigationActionSelectTab`.
- Extended `SelectTabMethod` signature with an optional `forceAction` flag.
- `selectTab` in `useTabsNavigationMethods` now forwards the flag (defaulting
  to `false`) to the dispatched action.
- Updated the reducer's early-return guard in `tabsActionSelectTabHandler` so
  it no longer short-circuits when `forceAction` is set.

## Test plan

Manual verification in `FabricExample`:

1. Open a tabs-based screen in the example app.
2. Call `selectTab(routeKey)` with the current route's key — confirm the state
   remains unchanged (existing behavior preserved).
3. Call `selectTab(routeKey, true)` with the current route's key — confirm the
   reducer proceeds past the early-return and emits a new state.

No new automated tests added; the change is a non-breaking API extension with
a default-off behavior.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes