### PR TITLE
feat(Android, Stack v5): add support for header scroll flags

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
@@ -18,7 +18,10 @@ internal sealed class StackHeaderAppBarLayout(
     abstract val toolbar: MaterialToolbar
 
     init {
-        layoutParams = CoordinatorLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+        layoutParams =
+            CoordinatorLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply {
+                behavior = StackHeaderAppBarLayoutBehavior()
+            }
 
         // TODO: this should be exposed in the future via prop. Also, it might not work correctly
         //       until we set liftOnScrollView manually. Also, we should disable it in transparent

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
@@ -7,9 +7,6 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
-import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
-import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_NO_SCROLL
-import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderType
@@ -39,11 +36,7 @@ internal sealed class StackHeaderAppBarLayout(
         override val toolbar =
             MaterialToolbar(context).apply {
                 elevation = 0f
-                layoutParams =
-                    LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply {
-                        // TODO: debug only for small header, must be moved to config
-                        scrollFlags = SCROLL_FLAG_NO_SCROLL
-                    }
+                layoutParams = LayoutParams(MATCH_PARENT, WRAP_CONTENT)
             }
 
         init {
@@ -85,10 +78,7 @@ internal sealed class StackHeaderAppBarLayout(
                         LayoutParams(
                             MATCH_PARENT,
                             resolveDimensionAttr(context, sizeAttr),
-                        ).apply {
-                            // TODO: debug only for medium/large header, must be moved to config
-                            scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
-                        }
+                        )
                     addView(toolbar)
                 }
             }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayout.kt
@@ -76,7 +76,6 @@ internal sealed class StackHeaderAppBarLayout(
                         else -> error("[RNScreens] Invalid header mode.")
                     }
                 CollapsingToolbarLayout(context, null, styleAttr).apply {
-                    fitsSystemWindows = false
                     layoutParams =
                         LayoutParams(
                             MATCH_PARENT,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt
@@ -13,9 +13,7 @@ import com.google.android.material.appbar.AppBarLayout
  * inset clamp in AppBarLayout only fires when topInset > minimumHeight, which is rarely true
  * (typical actionBarSize ~56dp vs status bar ~24dp).
  */
-internal class StackHeaderAppBarLayoutBehavior : AppBarLayout.Behavior {
-    constructor() : super()
-
+internal class StackHeaderAppBarLayoutBehavior : AppBarLayout.Behavior() {
     override fun onNestedPreScroll(
         coordinatorLayout: CoordinatorLayout,
         child: AppBarLayout,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderAppBarLayoutBehavior.kt
@@ -1,0 +1,31 @@
+package com.swmansion.rnscreens.gamma.stack.header
+
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.appbar.AppBarLayout
+
+/**
+ * Pre-clamps nested down-scroll so the AppBar offset cannot exceed 0 (its natural rest).
+ *
+ * Without this, AppBarLayout has a bug where SCROLL | ENTER_ALWAYS | EXIT_UNTIL_COLLAPSED
+ * combined with non-zero top window insets sets max = +topInset in onNestedPreScroll, allowing
+ * pull-down overshoot that snap-back animates away on release. The downNestedPreScrollRange
+ * inset clamp in AppBarLayout only fires when topInset > minimumHeight, which is rarely true
+ * (typical actionBarSize ~56dp vs status bar ~24dp).
+ */
+internal class StackHeaderAppBarLayoutBehavior : AppBarLayout.Behavior {
+    constructor() : super()
+
+    override fun onNestedPreScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: AppBarLayout,
+        target: View,
+        dx: Int,
+        dy: Int,
+        consumed: IntArray,
+        type: Int,
+    ) {
+        val adjustedDy = if (dy < 0) maxOf(dy, topAndBottomOffset) else dy
+        super.onNestedPreScroll(coordinatorLayout, child, target, dx, adjustedDy, consumed, type)
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -349,10 +349,12 @@ internal class StackHeaderCoordinator(
         appBar: StackHeaderAppBarLayout,
         config: StackHeaderConfigProviding,
     ) {
-        warnInvalidScrollFlagCombinations(config)
         val desired = computeScrollFlags(config)
+
         if (desired == lastScrollFlags) return
         lastScrollFlags = desired
+
+        warnInvalidScrollFlagCombinations(config)
 
         val target: View =
             when (appBar) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -16,6 +16,11 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.widget.TextViewCompat
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS_COLLAPSED
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.swmansion.rnscreens.ext.detachFromCurrentParent
@@ -55,6 +60,8 @@ internal class StackHeaderCoordinator(
     private var lastBackButtonVisible: Boolean? = null
     private var lastBackButtonTintColor: Int? = null
     private var lastBackButtonIcon: Drawable? = null
+
+    private var lastScrollFlags: Int? = null
 
     // For small header, we need to use custom title view in order to
     // render a subview to the leading side of the title.
@@ -154,6 +161,7 @@ internal class StackHeaderCoordinator(
         lastBackButtonVisible = null
         lastBackButtonTintColor = null
         lastBackButtonIcon = null
+        lastScrollFlags = null
         clearCachedRebuildTriggers()
     }
 
@@ -323,6 +331,7 @@ internal class StackHeaderCoordinator(
             }
         }
 
+        applyScrollFlags(appBar, config)
         applyBackButton(appBar.toolbar, config)
     }
 
@@ -333,6 +342,51 @@ internal class StackHeaderCoordinator(
         val desired = backgroundSubview.collapseMode.toNativeCollapseMode()
         if (params.collapseMode != desired) {
             params.collapseMode = desired
+        }
+    }
+
+    private fun applyScrollFlags(
+        appBar: StackHeaderAppBarLayout,
+        config: StackHeaderConfigProviding,
+    ) {
+        warnInvalidScrollFlagCombinations(config)
+        val desired = computeScrollFlags(config)
+        if (desired == lastScrollFlags) return
+        lastScrollFlags = desired
+
+        val target: View =
+            when (appBar) {
+                is StackHeaderAppBarLayout.Small -> appBar.toolbar
+                is StackHeaderAppBarLayout.Collapsing -> appBar.collapsingToolbarLayout
+            }
+        val params = target.layoutParams as AppBarLayout.LayoutParams
+        params.scrollFlags = desired
+        target.layoutParams = params
+        // Snap back to expanded so the visible state matches the new flags.
+        appBar.setExpanded(true, false)
+    }
+
+    private fun computeScrollFlags(config: StackHeaderConfigProviding): Int {
+        var flags = 0
+        if (config.scrollFlagScroll) flags = flags or SCROLL_FLAG_SCROLL
+        if (config.scrollFlagEnterAlways) flags = flags or SCROLL_FLAG_ENTER_ALWAYS
+        if (config.scrollFlagEnterAlwaysCollapsed) flags = flags or SCROLL_FLAG_ENTER_ALWAYS_COLLAPSED
+        if (config.scrollFlagExitUntilCollapsed) flags = flags or SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
+        if (config.scrollFlagSnap) flags = flags or SCROLL_FLAG_SNAP
+        return flags
+    }
+
+    private fun warnInvalidScrollFlagCombinations(config: StackHeaderConfigProviding) {
+        val anyDependentFlag =
+            config.scrollFlagEnterAlways ||
+                config.scrollFlagEnterAlwaysCollapsed ||
+                config.scrollFlagExitUntilCollapsed ||
+                config.scrollFlagSnap
+        if (anyDependentFlag && !config.scrollFlagScroll) {
+            Log.e(TAG, "[RNScreens] scrollFlag* requires scrollFlagScroll to take effect.")
+        }
+        if (config.scrollFlagEnterAlwaysCollapsed && !config.scrollFlagEnterAlways) {
+            Log.e(TAG, "[RNScreens] scrollFlagEnterAlwaysCollapsed requires scrollFlagEnterAlways to take effect.")
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -34,6 +34,17 @@ class StackHeaderConfig(
     override var backButtonIcon: Drawable? = null
         internal set
 
+    override var scrollFlagScroll: Boolean = false
+        internal set
+    override var scrollFlagEnterAlways: Boolean = false
+        internal set
+    override var scrollFlagEnterAlwaysCollapsed: Boolean = false
+        internal set
+    override var scrollFlagExitUntilCollapsed: Boolean = false
+        internal set
+    override var scrollFlagSnap: Boolean = false
+        internal set
+
     // Staging fields for back button icon resolution.
     // Both props may arrive in any order within a single update batch.
     // Resolution happens in resolveBackButtonIconIfNeeded(), called from onAfterUpdateTransaction.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
@@ -11,6 +11,11 @@ interface StackHeaderConfigProviding {
     val backButtonHidden: Boolean
     val backButtonTintColor: Int?
     val backButtonIcon: Drawable?
+    val scrollFlagScroll: Boolean
+    val scrollFlagEnterAlways: Boolean
+    val scrollFlagEnterAlwaysCollapsed: Boolean
+    val scrollFlagExitUntilCollapsed: Boolean
+    val scrollFlagSnap: Boolean
     val leadingSubview: StackHeaderSubviewProviding?
     val centerSubview: StackHeaderSubviewProviding?
     val trailingSubview: StackHeaderSubviewProviding?

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -151,6 +151,41 @@ open class StackHeaderConfigViewManager :
         view.backButtonImageIconUri = value?.getString("uri")
     }
 
+    override fun setScrollFlagScroll(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.scrollFlagScroll = value
+    }
+
+    override fun setScrollFlagEnterAlways(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.scrollFlagEnterAlways = value
+    }
+
+    override fun setScrollFlagEnterAlwaysCollapsed(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.scrollFlagEnterAlwaysCollapsed = value
+    }
+
+    override fun setScrollFlagExitUntilCollapsed(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.scrollFlagExitUntilCollapsed = value
+    }
+
+    override fun setScrollFlagSnap(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.scrollFlagSnap = value
+    }
+
     companion object {
         const val REACT_CLASS = "RNSStackHeaderConfigAndroid"
     }

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -42,6 +42,7 @@ type SubviewSize = 'none' | 'sm' | 'md' | 'lg';
 type HitSlopValue = '0' | '10' | '30';
 type PressRetentionValue = '0' | '20' | '50';
 type TitleOption = 'short' | 'long';
+type ScrollFlagValue = 'undefined' | 'true' | 'false';
 
 interface Config {
   enabled: boolean;
@@ -56,6 +57,11 @@ interface Config {
   backgroundCollapseMode: StackHeaderBackgroundSubviewCollapseModeAndroid;
   hitSlop: HitSlopValue;
   pressRetentionOffset: PressRetentionValue;
+  scrollFlagScroll: ScrollFlagValue;
+  scrollFlagEnterAlways: ScrollFlagValue;
+  scrollFlagEnterAlwaysCollapsed: ScrollFlagValue;
+  scrollFlagExitUntilCollapsed: ScrollFlagValue;
+  scrollFlagSnap: ScrollFlagValue;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -71,6 +77,11 @@ const DEFAULT_CONFIG: Config = {
   backgroundCollapseMode: 'parallax',
   hitSlop: '0',
   pressRetentionOffset: '0',
+  scrollFlagScroll: 'undefined',
+  scrollFlagEnterAlways: 'undefined',
+  scrollFlagEnterAlwaysCollapsed: 'undefined',
+  scrollFlagExitUntilCollapsed: 'undefined',
+  scrollFlagSnap: 'undefined',
 };
 
 const SUBVIEW_SIZES: SubviewSize[] = ['none', 'sm', 'md', 'lg'];
@@ -82,6 +93,18 @@ const COLLAPSE_MODES: StackHeaderBackgroundSubviewCollapseModeAndroid[] = [
 const HIT_SLOP_VALUES: HitSlopValue[] = ['0', '10', '30'];
 const PRESS_RETENTION_VALUES: PressRetentionValue[] = ['0', '20', '50'];
 const TITLE_OPTIONS: TitleOption[] = ['short', 'long'];
+const SCROLL_FLAG_VALUES: ScrollFlagValue[] = ['undefined', 'true', 'false'];
+
+function resolveScrollFlag(value: ScrollFlagValue): boolean | undefined {
+  switch (value) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return undefined;
+  }
+}
 
 function getSubviewDimensions(size: SubviewSize): {
   width: number;
@@ -156,6 +179,15 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       leadingSubview: makeToolbarSubview(config.leadingSize, 'L'),
       centerSubview: makeToolbarSubview(config.centerSize, 'C'),
       trailingSubview: makeToolbarSubview(config.trailingSize, 'T'),
+      scrollFlagScroll: resolveScrollFlag(config.scrollFlagScroll),
+      scrollFlagEnterAlways: resolveScrollFlag(config.scrollFlagEnterAlways),
+      scrollFlagEnterAlwaysCollapsed: resolveScrollFlag(
+        config.scrollFlagEnterAlwaysCollapsed,
+      ),
+      scrollFlagExitUntilCollapsed: resolveScrollFlag(
+        config.scrollFlagExitUntilCollapsed,
+      ),
+      scrollFlagSnap: resolveScrollFlag(config.scrollFlagSnap),
     },
   };
 }
@@ -261,6 +293,37 @@ function ConfigScreen() {
         value={config.backgroundCollapseMode}
         onValueChange={v => updateConfig('backgroundCollapseMode', v)}
         items={COLLAPSE_MODES}
+      />
+      <Text style={styles.heading}>Scroll Flags</Text>
+      <SettingsPicker<ScrollFlagValue>
+        label="scrollFlagScroll"
+        value={config.scrollFlagScroll}
+        onValueChange={v => updateConfig('scrollFlagScroll', v)}
+        items={SCROLL_FLAG_VALUES}
+      />
+      <SettingsPicker<ScrollFlagValue>
+        label="scrollFlagEnterAlways"
+        value={config.scrollFlagEnterAlways}
+        onValueChange={v => updateConfig('scrollFlagEnterAlways', v)}
+        items={SCROLL_FLAG_VALUES}
+      />
+      <SettingsPicker<ScrollFlagValue>
+        label="scrollFlagEnterAlwaysCollapsed"
+        value={config.scrollFlagEnterAlwaysCollapsed}
+        onValueChange={v => updateConfig('scrollFlagEnterAlwaysCollapsed', v)}
+        items={SCROLL_FLAG_VALUES}
+      />
+      <SettingsPicker<ScrollFlagValue>
+        label="scrollFlagExitUntilCollapsed"
+        value={config.scrollFlagExitUntilCollapsed}
+        onValueChange={v => updateConfig('scrollFlagExitUntilCollapsed', v)}
+        items={SCROLL_FLAG_VALUES}
+      />
+      <SettingsPicker<ScrollFlagValue>
+        label="scrollFlagSnap"
+        value={config.scrollFlagSnap}
+        onValueChange={v => updateConfig('scrollFlagSnap', v)}
+        items={SCROLL_FLAG_VALUES}
       />
       <Text style={styles.heading}>Pressable Settings</Text>
       <SettingsPicker<HitSlopValue>

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -4,7 +4,10 @@ import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
 import StackHeaderConfigAndroidNativeComponent from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import type { NativeProps as StackHeaderConfigAndroidNativeComponentProps } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
-import type { StackHeaderConfigPropsAndroid } from './StackHeaderConfig.android.types';
+import type {
+  StackHeaderConfigPropsAndroid,
+  StackHeaderTypeAndroid,
+} from './StackHeaderConfig.android.types';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -20,10 +23,22 @@ function StackHeaderConfig(props: StackHeaderConfigProps) {
     centerSubview,
     trailingSubview,
     backButtonIcon,
+    scrollFlagScroll,
+    scrollFlagEnterAlways,
+    scrollFlagEnterAlwaysCollapsed,
+    scrollFlagExitUntilCollapsed,
+    scrollFlagSnap,
     ...filteredAndroidProps
   } = android ?? {};
 
   const backButtonIconProps = parseBackButtonIconToNativeProps(backButtonIcon);
+  const scrollFlagProps = resolveScrollFlags(filteredAndroidProps.type, {
+    scrollFlagScroll,
+    scrollFlagEnterAlways,
+    scrollFlagEnterAlwaysCollapsed,
+    scrollFlagExitUntilCollapsed,
+    scrollFlagSnap,
+  });
 
   return (
     <StackHeaderConfigAndroidNativeComponent
@@ -31,7 +46,8 @@ function StackHeaderConfig(props: StackHeaderConfigProps) {
       style={StyleSheet.absoluteFill}
       {...baseProps}
       {...filteredAndroidProps}
-      {...backButtonIconProps}>
+      {...backButtonIconProps}
+      {...scrollFlagProps}>
       {/*
         Please note that the order of the subviews MUST match
         the order in native StackHeaderConfig.getConfigSubviewAt.
@@ -91,6 +107,63 @@ function parseBackButtonIconToNativeProps(
       '[RNScreens] Incorrect icon format for Android. You must provide `imageSource` or `drawableResource`.',
     );
   }
+}
+
+type ScrollFlagFields = Required<
+  Pick<
+    StackHeaderConfigPropsAndroid,
+    | 'scrollFlagScroll'
+    | 'scrollFlagEnterAlways'
+    | 'scrollFlagEnterAlwaysCollapsed'
+    | 'scrollFlagExitUntilCollapsed'
+    | 'scrollFlagSnap'
+  >
+>;
+
+const SCROLL_FLAG_DEFAULTS_BY_TYPE: Record<
+  StackHeaderTypeAndroid,
+  ScrollFlagFields
+> = {
+  small: {
+    scrollFlagScroll: false,
+    scrollFlagEnterAlways: false,
+    scrollFlagEnterAlwaysCollapsed: false,
+    scrollFlagExitUntilCollapsed: false,
+    scrollFlagSnap: false,
+  },
+  medium: {
+    scrollFlagScroll: true,
+    scrollFlagEnterAlways: false,
+    scrollFlagEnterAlwaysCollapsed: false,
+    scrollFlagExitUntilCollapsed: true,
+    scrollFlagSnap: true,
+  },
+  large: {
+    scrollFlagScroll: true,
+    scrollFlagEnterAlways: false,
+    scrollFlagEnterAlwaysCollapsed: false,
+    scrollFlagExitUntilCollapsed: true,
+    scrollFlagSnap: true,
+  },
+};
+
+function resolveScrollFlags(
+  type: StackHeaderTypeAndroid | undefined,
+  overrides: Partial<ScrollFlagFields>,
+): ScrollFlagFields {
+  const defaults = SCROLL_FLAG_DEFAULTS_BY_TYPE[type ?? 'small'];
+  return {
+    scrollFlagScroll: overrides.scrollFlagScroll ?? defaults.scrollFlagScroll,
+    scrollFlagEnterAlways:
+      overrides.scrollFlagEnterAlways ?? defaults.scrollFlagEnterAlways,
+    scrollFlagEnterAlwaysCollapsed:
+      overrides.scrollFlagEnterAlwaysCollapsed ??
+      defaults.scrollFlagEnterAlwaysCollapsed,
+    scrollFlagExitUntilCollapsed:
+      overrides.scrollFlagExitUntilCollapsed ??
+      defaults.scrollFlagExitUntilCollapsed,
+    scrollFlagSnap: overrides.scrollFlagSnap ?? defaults.scrollFlagSnap,
+  };
 }
 
 export default StackHeaderConfig;

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -109,16 +109,13 @@ function parseBackButtonIconToNativeProps(
   }
 }
 
-type ScrollFlagFields = Required<
-  Pick<
-    StackHeaderConfigPropsAndroid,
-    | 'scrollFlagScroll'
-    | 'scrollFlagEnterAlways'
-    | 'scrollFlagEnterAlwaysCollapsed'
-    | 'scrollFlagExitUntilCollapsed'
-    | 'scrollFlagSnap'
-  >
->;
+type ScrollFlagFields = {
+  scrollFlagScroll: boolean;
+  scrollFlagEnterAlways: boolean;
+  scrollFlagEnterAlwaysCollapsed: boolean;
+  scrollFlagExitUntilCollapsed: boolean;
+  scrollFlagSnap: boolean;
+};
 
 const SCROLL_FLAG_DEFAULTS_BY_TYPE: Record<
   StackHeaderTypeAndroid,
@@ -149,7 +146,7 @@ const SCROLL_FLAG_DEFAULTS_BY_TYPE: Record<
 
 function resolveScrollFlags(
   type: StackHeaderTypeAndroid | undefined,
-  overrides: Partial<ScrollFlagFields>,
+  overrides: Pick<StackHeaderConfigPropsAndroid, keyof ScrollFlagFields>,
 ): ScrollFlagFields {
   const defaults = SCROLL_FLAG_DEFAULTS_BY_TYPE[type ?? 'small'];
   return {

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -135,4 +135,65 @@ export interface StackHeaderConfigPropsAndroid {
    * @platform android
    */
   backButtonIcon?: PlatformIconAndroid | undefined;
+  /**
+   * @summary Whether the header reacts to nested scroll. Required for any
+   * other `scrollFlag*` prop to take effect.
+   *
+   * When `undefined`, falls back to the type-specific default:
+   * - `small` -> `false`
+   * - `medium` / `large` -> `true`
+   *
+   * Remarks: changing any `scrollFlag*` at runtime forces the header back to
+   * its fully expanded state, which produces a visible snap. Treat these
+   * props as a static configuration.
+   *
+   * @platform android
+   */
+  scrollFlagScroll?: boolean | undefined;
+  /**
+   * @summary When enabled, any upward scroll (even mid-content) brings the
+   * header back into view. Requires `scrollFlagScroll`.
+   *
+   * When `undefined`, falls back to the type-specific default (`false` for
+   * all types).
+   *
+   * @platform android
+   */
+  scrollFlagEnterAlways?: boolean | undefined;
+  /**
+   * @summary When combined with `scrollFlagEnterAlways`, an upward scroll
+   * first reveals only the collapsed portion of the header before fully
+   * expanding it once the content reaches its top. Requires
+   * `scrollFlagEnterAlways`.
+   *
+   * When `undefined`, falls back to the type-specific default (`false` for
+   * all types).
+   *
+   * @platform android
+   */
+  scrollFlagEnterAlwaysCollapsed?: boolean | undefined;
+  /**
+   * @summary When enabled, the header scrolls off completely — unless top
+   * inset padding (status bar / display cutout) is applied, in which case
+   * that inset region remains visible. Requires `scrollFlagScroll`.
+   *
+   * When `undefined`, falls back to the type-specific default:
+   * - `small` -> `false`
+   * - `medium` / `large` -> `true`
+   *
+   * @platform android
+   */
+  scrollFlagExitUntilCollapsed?: boolean | undefined;
+  /**
+   * @summary When enabled, after a scroll gesture ends the header snaps to
+   * either fully expanded or fully collapsed instead of resting partway.
+   * Requires `scrollFlagScroll`.
+   *
+   * When `undefined`, falls back to the type-specific default:
+   * - `small` -> `false`
+   * - `medium` / `large` -> `true`
+   *
+   * @platform android
+   */
+  scrollFlagSnap?: boolean | undefined;
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -152,8 +152,10 @@ export interface StackHeaderConfigPropsAndroid {
    */
   scrollFlagScroll?: boolean | undefined;
   /**
-   * @summary When enabled, any upward scroll (even mid-content) brings the
-   * header back into view. Requires `scrollFlagScroll`.
+   * @summary When enabled, the header re-expands as soon as the user scrolls
+   * back toward the top of the content, regardless of the ScrollView's current
+   * scroll position. Without this flag, the header only begins expanding once
+   * the list has reached the top of its content. Requires `scrollFlagScroll`.
    *
    * When `undefined`, falls back to the type-specific default (`false` for
    * all types).
@@ -162,33 +164,44 @@ export interface StackHeaderConfigPropsAndroid {
    */
   scrollFlagEnterAlways?: boolean | undefined;
   /**
-   * @summary When combined with `scrollFlagEnterAlways`, an upward scroll
-   * first reveals only the collapsed portion of the header before fully
-   * expanding it once the content reaches its top. Requires
+   * @summary Modifies `scrollFlagEnterAlways` so that the initial re-entry
+   * stops at the header's collapsed height (the toolbar); the remainder
+   * expands only after the ScrollView reaches the top of its content. Requires
    * `scrollFlagEnterAlways`.
    *
    * When `undefined`, falls back to the type-specific default (`false` for
    * all types).
    *
+   * @remarks
+   * This flag does not have any effect for `small` header.
+   *
    * @platform android
    */
   scrollFlagEnterAlwaysCollapsed?: boolean | undefined;
   /**
-   * @summary When enabled, the header scrolls off completely — unless top
-   * inset padding (status bar / display cutout) is applied, in which case
-   * that inset region remains visible. Requires `scrollFlagScroll`.
+   * @summary When enabled, the header collapses only until its minimum height
+   * (the toolbar) remains pinned at the top. Without this flag, the entire
+   * header scrolls off the screen. Requires `scrollFlagScroll`.
    *
    * When `undefined`, falls back to the type-specific default:
    * - `small` -> `false`
    * - `medium` / `large` -> `true`
    *
+   * @remarks
+   * Setting this flag for `small` header is equivalent to disabling
+   * `scrollFlagScroll`.
+   *
+   * Even when this flag is disabled, a strip the height of the system top
+   * inset (status bar and display cutout) remains visible at the top.
+   *
    * @platform android
    */
   scrollFlagExitUntilCollapsed?: boolean | undefined;
   /**
-   * @summary When enabled, after a scroll gesture ends the header snaps to
-   * either fully expanded or fully collapsed instead of resting partway.
-   * Requires `scrollFlagScroll`.
+   * @summary When enabled, the header snaps to its nearest edge (fully
+   * expanded, or fully collapsed as defined by `scrollFlagExitUntilCollapsed`)
+   * after a scroll gesture ends, instead of resting partway. Requires
+   * `scrollFlagScroll`.
    *
    * When `undefined`, falls back to the type-specific default:
    * - `small` -> `false`

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -143,7 +143,8 @@ export interface StackHeaderConfigPropsAndroid {
    * - `small` -> `false`
    * - `medium` / `large` -> `true`
    *
-   * Remarks: changing any `scrollFlag*` at runtime forces the header back to
+   * @remarks
+   * Changing any `scrollFlag*` at runtime forces the header back to
    * its fully expanded state, which produces a visible snap. Treat these
    * props as a static configuration.
    *

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -191,7 +191,7 @@ export interface StackHeaderConfigPropsAndroid {
    * Setting this flag for `small` header is equivalent to disabling
    * `scrollFlagScroll`.
    *
-   * Even when this flag is disabled, a strip the height of the system top
+   * Even when this flag is disabled, a strip with the height of the system top
    * inset (status bar and display cutout) remains visible at the top.
    *
    * @platform android

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -22,6 +22,12 @@ export interface NativeProps extends ViewProps {
   backButtonTintColor?: ColorValue | undefined;
   backButtonDrawableIconResourceName?: string | undefined;
   backButtonImageIconResource?: ImageSource | undefined;
+
+  scrollFlagScroll?: CT.WithDefault<boolean, false>;
+  scrollFlagEnterAlways?: CT.WithDefault<boolean, false>;
+  scrollFlagEnterAlwaysCollapsed?: CT.WithDefault<boolean, false>;
+  scrollFlagExitUntilCollapsed?: CT.WithDefault<boolean, false>;
+  scrollFlagSnap?: CT.WithDefault<boolean, false>;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Description

Adds support for customizing scroll flags for M3 App Bar header on Android.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/894.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/895.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/896.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/897.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/898.

### Details

After exposing scroll flags I noticed a bug - in `large` header if you use default flags (`SCROLL`, `EXIT_UNTIL_COLLAPSED`, `SNAP`) and `ENTER_ALWAYS`, the header would move down from expanded position by the height of top inset (the video describes it best).

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a44bcbe4-abb3-4a23-adbd-faee6a9f1a9b" /> | <video src="https://github.com/user-attachments/assets/1ec187b3-bbee-4928-b26f-7b8c99d06be9" /> |

After some investigation I found that this is most likely a native bug.

1. Setting `fitsSystemWindows = false` on `CollapsingToolbarLayout` was ignored because `CollapsingToolbarLayout` copies `fitsSystemWindows` from `AppBarLayout` when attached to window.
2. We want to rely on `fitsSystemWindows` for both `AppBarLayout` and `CollapsingToolbarLayout` to ensure correct scrolling behaviors. In the future PR, disabling inset should be done by disabling this flag on both components.

Here is the bug mechanism. I used Claude to investigate and later I confirmed the results with the debugger.

<details>
<summary>Investigation</summary>

#### How AppBarLayout scrolling works (the foundation)

**1. Coordinator wiring.** The `AppBarLayout` lives inside a `CoordinatorLayout` and has a `Behavior` attached via `CoordinatorLayout.LayoutParams.behavior`. The default is `AppBarLayout.Behavior` (extends `BaseBehavior`). That behavior implements the `NestedScrollingParent` callbacks — that's how it intercepts scroll events from a child like `RecyclerView`/`ScrollView`.

**2. The "offset" abstraction.** `AppBarLayout` doesn't really *scroll*. The `Behavior` translates the AppBar vertically using `setTopAndBottomOffset(int)` (inherited from `ViewOffsetBehavior`). Internally that calls `ViewCompat.offsetTopAndBottom(view, ...)`. The offset is:
- `0` = AppBar at its laid-out position (fully expanded, rest).
- Negative = AppBar shifted **up** off the top of CoordinatorLayout (collapsing).
- Positive = AppBar pushed **down** below its laid-out position. **This is the overshoot.** Should normally be impossible.

You can read the current value any time via `behavior.getTopAndBottomOffset()` (or `topAndBottomOffset` in Kotlin).

**3. Nested scroll path.** When you drag a list:
- RecyclerView calls `dispatchNestedPreScroll(dy, consumed, ...)` for each scroll delta. This bubbles up to `CoordinatorLayout`, which forwards to `AppBarLayout.Behavior.onNestedPreScroll(...)`.
- The Behavior decides how much of `dy` to consume (move the AppBar) and writes that into `consumed[1]`.
- RecyclerView then scrolls itself by `dy - consumed[1]`.
- If after that the list still has unconsumed delta (e.g. it's already at the top), it calls `dispatchNestedScroll(..., dyUnconsumed, ...)` → `Behavior.onNestedScroll(...)`. The AppBar gets a second chance.

**Sign convention reminder:** in nested scroll, `dy < 0` means the user is dragging *down* (revealing content above / expanding the AppBar). `dy > 0` means dragging *up* (collapsing).

##### The pre-scroll math (where the bug lives)

Look at `AppBarLayout.java:1664-1684` (`BaseBehavior.onNestedPreScroll`). The relevant block when `dy < 0`:

```java
min = -child.getTotalScrollRange();
max = min + child.getDownNestedPreScrollRange();
if (min != max) {
    consumed[1] = scroll(coordinatorLayout, child, dy, min, max);
}
```

`scroll(...)` computes `newOffset = clamp(currentOffset - dy, min, max)` and applies it via `setHeaderTopBottomOffset` → `setTopAndBottomOffset`.

**For the buggy flag combo `SCROLL | ENTER_ALWAYS | EXIT_UNTIL_COLLAPSED [| SNAP]`** with `T = topInset`, `H = CTL height`, `M = CTL.minimumHeight`:

- `getTotalScrollRange()` (`AppBarLayout.java:856`):
  - `range += childHeight = H`
  - first child has `fitsSystemWindows=true` → `range -= T` (line 879)
  - `EXIT_UNTIL_COLLAPSED` → `range -= M` (line 885), `break`
  - → **`H − T − M`**

- `getDownNestedPreScrollRange()` (line 907):
  - `FLAG_QUICK_RETURN = SCROLL | ENTER_ALWAYS` matches
  - `EXIT_UNTIL_COLLAPSED` branch (line 933): `childRange = H − M`
  - inset clamp at line 941: `childRange = min(H − M, H − T)`. Since `M > T`, `H − M < H − T`, the `min` keeps `H − M`. **Clamp is a no-op.**
  - → **`H − M`**

- Therefore `max = -(H − T − M) + (H − M) = +T`.

A positive `max` means the AppBar offset can be driven `T` pixels past `0`. That's the overshoot you see.

##### What the fix does

```kotlin
val adjustedDy = if (dy < 0) maxOf(dy, topAndBottomOffset) else dy
super.onNestedPreScroll(..., adjustedDy, ...)
```

We pre-clamp `dy` *before* super gets it. We want `newOffset = curOffset − adjustedDy ≤ 0`, i.e. `adjustedDy ≥ curOffset`. Since `curOffset ≤ 0` always (rest or partially collapsed), `maxOf(dy, curOffset)` is the smallest correction that satisfies it.

After our clamp, super's existing math runs unchanged but with a `dy` that can never produce a positive `newOffset`. `clamp(curOffset − adjustedDy, min, +T)` becomes `clamp(≤0, min, +T)` = some value `≤ 0`. No overshoot, no snap-back.

##### Explanation of the bug on the side of MDC

The bug in one sentence:** `AppBarLayout.getDownNestedPreScrollRange` and `AppBarLayout.getTotalScrollRange` apply the `topInset` adjustment asymmetrically, so for `SCROLL | ENTER_ALWAYS | EXIT_UNTIL_COLLAPSED` the pre-scroll range exceeds the total scroll range by exactly `topInset`, which shows up as a positive `max` in `onNestedPreScroll`.

###### The asymmetry

Both methods walk the same children and both purport to subtract `topInset` for a first child with `fitsSystemWindows=true`, but they do it differently:

- **`getTotalScrollRange`** (line 879) — unconditional subtraction:
  ```java
  if (i == 0 && child.getFitsSystemWindows()) {
      range -= getTopInset();
  }
  ```

- **`getDownNestedPreScrollRange`** (line 941) — a `min` clamp against a different reference point:
  ```java
  if (i == 0 && child.getFitsSystemWindows()) {
      childRange = Math.min(childRange, childHeight - getTopInset());
  }
  ```
  This clamp fires only when `childRange > childHeight − topInset`, i.e. only when `topInset > M` (CTL's minimumHeight). For any real device with a toolbar-sized `actionBarSize`, `M > T`, so the clamp is a **silent no-op**.

###### Why it matters

The contract of `onNestedPreScroll` in `BaseBehavior` (line 1670-1671) is:
```java
min = -child.getTotalScrollRange();
max = min + child.getDownNestedPreScrollRange();
```

For `max` to equal `0` (the rest position that is AppBarLayout's invariant), `downNestedPreScrollRange` must equal `totalScrollRange`. Any divergence between them leaks directly into `max` as allowed overshoot. The two methods need to agree on how they treat `topInset`; they don't.

</details>

### Known issues

#### Collapsed header is visible behind status bar

<img width="513" height="191" alt="obraz" src="https://github.com/user-attachments/assets/46c1ffb5-e98b-46d5-b683-c1d9d0513c1e" />

This will be fixed in a separate PR. `CollapsingToolbarLayout` allows for detailed scrim background customization. 

<img width="655" height="422" alt="obraz" src="https://github.com/user-attachments/assets/efd481fe-a088-4f30-88fd-2fe99520b21b" />

#### Small header flashes while scrolling

This will be fixed in separate PR with `ScrollViewMarker` integration. Setting explicit `liftOnScrollTargetView` fixes this issue.

| current | target view set |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/77885340-3069-4c30-9c2b-1eb294bebfd7" /> | <video src="https://github.com/user-attachments/assets/9f4d6b95-b92a-43d1-bc2b-a10193daa488" /> |

## Changes

- expose scroll flag configuration via props
- handle default values per-type in JS
- update `TestStackSubviews` to include scroll flags configuration
- create custom `AppBarLayout.Behavior` to fix native bug with `ENTER_ALWAYS` flag in collapsed header

## Visual documentation

| small | large |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d78eec8e-2960-4279-94a6-2b000aac0c3e" /> | <video src="https://github.com/user-attachments/assets/94fb0fe4-762b-40c3-9aba-5c3429bc86dc" /> |

## Test plan

Run `TestStackSubviews`. 

I did not additional test because currently it wouldn't add any value - it would be just a `TestStackSubviews` with less options. In the future, we should add a separate test with thorough test scenario to cover all possible flag combinations.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
