### PR TITLE
fix(iOS): fallback to `imageNamed` for custom SF symbols

### DIFF
--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -136,7 +136,11 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
 {
   NSString *sfSymbolName = dict[@"sfSymbolName"];
   if (sfSymbolName != nil) {
-    completionBlock([UIImage systemImageNamed:sfSymbolName]);
+    UIImage *image = [UIImage systemImageNamed:sfSymbolName];
+    if (!image) {
+      image = [UIImage imageNamed:sfSymbolName];
+    }
+    completionBlock(image);
     return;
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where custom SF Symbols fail to render in iOS components (e.g., stack menus).

Currently, `react-native-screens` uses `systemImageNamed` to resolve symbols but custom ones bundled into the app's asset catalogs are not loadable this way (reference [here](https://developer.apple.com/documentation/uikit/uiimage/init(systemname:)?language=objc#Discussion)).

The docs pointed me to use [`imageNamed`](https://developer.apple.com/documentation/uikit/uiimage/init(named:)?language=objc), instead.


## Changes

`ios/RNSBarButtonItem.mm`

- Updated `resolveImageFromConfig` to use `imageNamed` when `systemImageNamed` is nil

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/03ceaa69-4ffe-4830-9a05-c47fb233b6fc) | ![After](https://github.com/user-attachments/assets/1a661d0e-e05f-449b-b59b-f2fd9b92017a) |


## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

I did not add tests. The code change was simple enough to get done with linting and following the docs, but I am not familiar enough with objc to know best practices. I can try to spend more time on this area if needed, but mostly tested the fix via a patch applied to local dev builds. You can see that work [here](https://github.com/stumpapp/stump/commit/7be690d248d749c8aa10efcf46e9f40cb6a6d6c7), if interested or helpful at all

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
