### PR TITLE
fix(Android, FormSheet): Prevent BottomSheetBehavior override when using FormSheets

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -128,9 +128,12 @@ class ScreenStackFragment :
 
     override fun setToolbarTranslucent(translucent: Boolean) {
         if (isToolbarTranslucent != translucent) {
-            val params = screen.layoutParams
-            (params as CoordinatorLayout.LayoutParams).behavior =
-                if (translucent) null else ScrollingViewBehavior()
+            // FormSheet is using BottomSheetBehavior which shouldn't be overwritten.
+            if (!screen.usesFormSheetPresentation()) {
+                val params = screen.layoutParams
+                (params as CoordinatorLayout.LayoutParams).behavior =
+                    if (translucent) null else ScrollingViewBehavior()
+            }
             isToolbarTranslucent = translucent
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -37,6 +37,7 @@ import com.swmansion.rnscreens.events.ScreenDismissedEvent
 import com.swmansion.rnscreens.ext.recycle
 import com.swmansion.rnscreens.stack.views.ScreensCoordinatorLayout
 import com.swmansion.rnscreens.utils.DeviceUtils
+import com.swmansion.rnscreens.utils.RNSLog
 import com.swmansion.rnscreens.utils.resolveBackgroundColor
 import kotlin.math.max
 
@@ -133,6 +134,8 @@ class ScreenStackFragment :
                 val params = screen.layoutParams
                 (params as CoordinatorLayout.LayoutParams).behavior =
                     if (translucent) null else ScrollingViewBehavior()
+            } else {
+                RNSLog.w(TAG, "Skipping behavior update: Cannot override BottomSheetBehavior on a FormSheet.")
             }
             isToolbarTranslucent = translucent
         }
@@ -585,5 +588,9 @@ class ScreenStackFragment :
             bottomSheetWindowInsetListenerChain = BottomSheetWindowInsetListenerChain()
         }
         return bottomSheetWindowInsetListenerChain!!
+    }
+
+    companion object {
+        private const val TAG = "ScreenStackFragment"
     }
 }

--- a/apps/src/tests/issue-tests/Test3910.tsx
+++ b/apps/src/tests/issue-tests/Test3910.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Button, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+import { SafeAreaView } from 'react-native-screens/experimental';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Sheet: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const HomeScreen = ({
+  navigation,
+}: NativeStackScreenProps<RootStackParamList, 'Home'>) => (
+  <SafeAreaView edges={{ top: true, bottom: true }}>
+    <Button
+      title="Open form sheet"
+      onPress={() => navigation.navigate('Sheet')}
+    />
+  </SafeAreaView>
+);
+
+const SheetScreen = () => (
+  <View style={{ height: 250 }}>
+    <Text>This is a form sheet.</Text>
+  </View>
+);
+
+const App = () => (
+  <NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen
+        name="Sheet"
+        component={SheetScreen}
+        options={{
+          presentation: 'formSheet',
+          sheetAllowedDetents: 'fitToContents',
+          headerTransparent: true,
+        }}
+      />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+export default App;

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -191,6 +191,7 @@ export { default as Test3833 } from './Test3833';
 export { default as Test3835 } from './Test3835';
 export { default as Test3867 } from './Test3867';
 export { default as Test3885 } from './Test3885';
+export { default as Test3910 } from './Test3910';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
## Description

When `headerTransparent: true` is configured, `setToolbarTranslucent(true)` is invoked. Previously, this method overwrote the behavior with `null`. For FormSheet presentation, this unintentionally destroyed the BottomSheetBehavior. When `handleInsetsUpdateAndNotifyTransition` was invoked, the call to `screen.sheetBehavior!!` was crashing with `NullPointerException`.

> [!NOTE]
> Native header isn't supported on Android currently: https://reactnavigation.org/docs/native-stack-navigator/#android-specific-limitations - this issue aims only to resolve the crash, but for now we're not planning to add this feature for v4.

> [!NOTE]
> I deliberately removed SAV from the original repro, as it seems to be causing another issue: https://github.com/software-mansion/react-native-screens-labs/issues/968 - adding it to my queue

Closes https://github.com/software-mansion/react-native-screens/issues/3910

## Changes

- Guarded `setToolbarTranslucent` to only modify the layout behavior if we're not in the FormSheet presentation.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7ad82901-f3ca-4dbd-9f81-d117b46cfce3" /> | <video src="https://github.com/user-attachments/assets/03a630d1-2224-4788-8697-621c238d04f1" /> |

## Test plan

Added Test3910

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
