### PR TITLE
fix(Android, FormSheet): Create SheetAnimationCoordinator to synchronize animations coming from different sources

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -30,6 +30,7 @@ import com.swmansion.rnscreens.bottomsheet.SheetAnimationCoordinator
 import com.swmansion.rnscreens.bottomsheet.SheetDetents
 import com.swmansion.rnscreens.bottomsheet.fitToContentsSheetHeight
 import com.swmansion.rnscreens.bottomsheet.isSheetFitToContents
+import com.swmansion.rnscreens.bottomsheet.resolveClampedHeight
 import com.swmansion.rnscreens.bottomsheet.updateMetrics
 import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
@@ -183,7 +184,7 @@ class Screen(
          * This allows custom animators in RN to work, as we do not interfere with these animations
          * and we're just reacting to the sheet's content size changes.
          */
-        val clampedHeight = sheetAnimationCoordinator.resolveClampedHeight(height, this.translationY)
+        val clampedHeight = resolveClampedHeight(height, this.translationY)
         behavior.updateMetrics(clampedHeight)
         layout(this.left, this.bottom - clampedHeight, this.right, this.bottom)
 

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -26,6 +26,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.swmansion.rnscreens.bottomsheet.SheetAnimationCoordinator
 import com.swmansion.rnscreens.bottomsheet.SheetDetents
 import com.swmansion.rnscreens.bottomsheet.fitToContentsSheetHeight
 import com.swmansion.rnscreens.bottomsheet.isSheetFitToContents
@@ -49,6 +50,8 @@ class Screen(
 
     val sheetBehavior: BottomSheetBehavior<Screen>?
         get() = (layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<Screen>
+
+    internal val sheetAnimationCoordinator: SheetAnimationCoordinator by lazy { SheetAnimationCoordinator(this) }
 
     val reactEventDispatcher: EventDispatcher?
         get() = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
@@ -155,7 +158,7 @@ class Screen(
                 if (isInitial) {
                     setupInitialSheetContentHeight(sheetBehavior, height)
                 } else if (sheetDefaultResizeAnimationEnabled) {
-                    updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
+                    sheetAnimationCoordinator.onContentHeightChanged(sheetBehavior, oldHeight, height)
                 } else {
                     updateSheetContentHeightWithoutAnimation(sheetBehavior, height)
                 }
@@ -171,104 +174,6 @@ class Screen(
         updateState(width, height, headerHeight)
     }
 
-    /**
-     * This should be used only with sheet in `fitToContents` mode.
-     */
-    private fun updateSheetContentHeightWithAnimation(
-        behavior: BottomSheetBehavior<Screen>,
-        oldHeight: Int,
-        newHeight: Int,
-    ) {
-        val currentTranslationY = this.translationY
-
-        /*
-         * WHY OVERFLOW MATTERS:
-         * BottomSheetBehavior has a physical limit (maxHeight) defined by the parent container.
-         * If the new content height exceeds this limit (by its size or keyboard offset), simply
-         * animating translationY back to 'currentTranslationY' would attempt to render the sheet
-         * larger than the screen.
-         *
-         * We need to have constraint height inside the container's bounds.
-         * By including this overflow to our animation, we ensure the sheet stops
-         * expanding exactly at the maxHeight, preventing from being pushed
-         * off-screen or causing layout synchronization issues with the CoordinatorLayout.
-         */
-        val clampedOldHeight = resolveClampedHeight(oldHeight, currentTranslationY)
-        val clampedNewHeight = resolveClampedHeight(newHeight, currentTranslationY)
-        val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
-
-        if (visibleDelta == 0f) return
-
-        val isContentExpanding = visibleDelta > 0
-
-        if (isContentExpanding) {
-            /*
-             * Expanding content animation:
-             *
-             * Before animation, we're updating the SheetBehavior - the maximum height is the new
-             * content height, then we're forcing a layout pass. This ensures the view calculates
-             * with its new bounds when the animation starts.
-             *
-             * In the animation, we're translating the Screen back to it's (newly calculated) origin
-             * position, providing an impression that FormSheet expands. It already has the final size,
-             * but some content is not yet visible on the screen.
-             *
-             * After animation, we just need to send a notification that ShadowTree state should be updated,
-             * as the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            this.translationY += visibleDelta
-            this
-                .animate()
-                .translationY(currentTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                    layout(this.left, this.bottom - clampedNewHeight, this.right, this.bottom)
-                }.withEndAction {
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    parent.requestLayout()
-                    onSheetYTranslationChanged()
-                }.start()
-        } else {
-            /*
-             * Shrinking content animation:
-             *
-             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
-             *
-             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
-             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
-             * of shrink & expand animation is detected.
-             *
-             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
-             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
-             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
-             *
-             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
-             * another layout pass. Additionally, since the actual layout and the target position are equal,
-             * we can reset translationY to 0.
-             *
-             * After animation, we need to send a notification that ShadowTree state should be updated,
-             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            val targetTranslationY = currentTranslationY - visibleDelta
-            this
-                .animate()
-                .translationY(targetTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                }.withEndAction {
-                    layout(this.left, this.bottom - clampedNewHeight, this.right, this.bottom)
-                    this.translationY = currentTranslationY
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    parent.requestLayout()
-                    onSheetYTranslationChanged()
-                }.start()
-        }
-    }
-
     private fun updateSheetContentHeightWithoutAnimation(
         behavior: BottomSheetBehavior<Screen>,
         height: Int,
@@ -278,7 +183,7 @@ class Screen(
          * This allows custom animators in RN to work, as we do not interfere with these animations
          * and we're just reacting to the sheet's content size changes.
          */
-        val clampedHeight = resolveClampedHeight(height, this.translationY)
+        val clampedHeight = sheetAnimationCoordinator.resolveClampedHeight(height, this.translationY)
         behavior.updateMetrics(clampedHeight)
         layout(this.left, this.bottom - clampedHeight, this.right, this.bottom)
 
@@ -297,22 +202,6 @@ class Screen(
         // During the initial call in `onCreateView`, insets are not yet available,
         // so we need to request an additional layout pass later to account for them.
         requestLayout()
-    }
-
-    private fun resolveClampedHeight(
-        targetHeight: Int,
-        currentTranslationY: Float,
-    ): Int {
-        val maxAvailableVerticalSpace =
-            this.fragment
-                ?.asScreenStackFragment()
-                ?.sheetDelegate
-                ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
-
-        // Please note that currentTranslationY is rather < 0 here.
-        // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
-        // avoid the keyboard.
-        return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
     }
 
     fun registerLayoutCallbackForWrapper(wrapper: ScreenContentWrapper) {

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -159,7 +159,7 @@ class Screen(
                 if (isInitial) {
                     setupInitialSheetContentHeight(sheetBehavior, height)
                 } else if (sheetDefaultResizeAnimationEnabled) {
-                    sheetAnimationCoordinator.onContentHeightChanged(sheetBehavior, oldHeight, height)
+                    sheetAnimationCoordinator.updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
                 } else {
                     updateSheetContentHeightWithoutAnimation(sheetBehavior, height)
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -14,7 +14,9 @@ import com.swmansion.rnscreens.events.ScreenEventEmitter
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
 
-internal class SheetAnimationCoordinator(private val screen: Screen) {
+internal class SheetAnimationCoordinator(
+    private val screen: Screen,
+) {
     private var isSheetAnimationInProgress: Boolean = false
 
     private var lastKeyboardBottomOffset: Int = 0

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -95,6 +95,10 @@ internal class SheetAnimationCoordinator(
         if (isSheetAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
             screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+            // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+            // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+            // to its old position when the user starts a gesture.
+            screen.parent.requestLayout()
             return
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -84,8 +84,8 @@ internal class SheetAnimationCoordinator(private val screen: Screen) {
          * expanding exactly at the maxHeight, preventing from being pushed
          * off-screen or causing layout synchronization issues with the CoordinatorLayout.
          */
-        val clampedOldHeight = resolveClampedHeight(oldHeight, currentTranslationY)
-        val clampedNewHeight = resolveClampedHeight(newHeight, currentTranslationY)
+        val clampedOldHeight = screen.resolveClampedHeight(oldHeight, currentTranslationY)
+        val clampedNewHeight = screen.resolveClampedHeight(newHeight, currentTranslationY)
 
         // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
         // Silently update behavior metrics and re-layout so the ongoing slide animation
@@ -181,22 +181,6 @@ internal class SheetAnimationCoordinator(private val screen: Screen) {
         if (!isSheetAnimationInProgress) {
             updateSheetTranslationY(0f)
         }
-    }
-
-    internal fun resolveClampedHeight(
-        targetHeight: Int,
-        currentTranslationY: Float,
-    ): Int {
-        val maxAvailableVerticalSpace =
-            screen.fragment
-                ?.asScreenStackFragment()
-                ?.sheetDelegate
-                ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
-
-        // Please note that currentTranslationY is rather < 0 here.
-        // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
-        // avoid the keyboard.
-        return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
     }
 
     // This function calculates the Y offset to which the FormSheet should animate

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -65,7 +65,7 @@ internal class SheetAnimationCoordinator(private val screen: Screen) {
      * animation - this is the fix for the race condition between the slide-in
      * ValueAnimator and externally triggered layout pass (e.g. applying padding from SAV insets).
      */
-    internal fun onContentHeightChanged(
+    internal fun updateSheetContentHeightWithAnimation(
         behavior: BottomSheetBehavior<Screen>,
         oldHeight: Int,
         newHeight: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -13,10 +13,16 @@ import com.swmansion.rnscreens.events.ScreenAnimationDelegate
 import com.swmansion.rnscreens.events.ScreenEventEmitter
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
+import java.lang.ref.WeakReference
 
 internal class SheetAnimationCoordinator(
-    private val screen: Screen,
+    screen: Screen,
 ) {
+    private val screenRef = WeakReference(screen)
+    private val screen: Screen get() =
+        checkNotNull(screenRef.get()) {
+            "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
+        }
     private var isSheetAnimationInProgress: Boolean = false
 
     private var lastKeyboardBottomOffset: Int = 0

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -81,7 +81,7 @@ internal class SheetAnimationCoordinator(
          * animating translationY back to 'currentTranslationY' would attempt to render the sheet
          * larger than the screen.
          *
-         * We need to have constraint height inside the container's bounds.
+         * We need to constrain the height within the container's bounds.
          * By including this overflow to our animation, we ensure the sheet stops
          * expanding exactly at the maxHeight, preventing from being pushed
          * off-screen or causing layout synchronization issues with the CoordinatorLayout.

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -1,0 +1,306 @@
+package com.swmansion.rnscreens.bottomsheet
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ValueAnimator
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.swmansion.rnscreens.Screen
+import com.swmansion.rnscreens.ScreenStackFragment
+import com.swmansion.rnscreens.events.ScreenAnimationDelegate
+import com.swmansion.rnscreens.events.ScreenEventEmitter
+import com.swmansion.rnscreens.ext.asScreenStackFragment
+import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
+
+internal class SheetAnimationCoordinator(private val screen: Screen) {
+    private var isSheetAnimationInProgress: Boolean = false
+
+    private var lastKeyboardBottomOffset: Int = 0
+
+    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetDelegate.SheetAnimationContext): Animator {
+        val animatorSet = AnimatorSet()
+
+        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
+        val screenStackFragment = sheetAnimationContext.fragment
+
+        val alphaAnimator = createDimmingViewAlphaAnimator(0f, dimmingDelegate.maxAlpha, dimmingDelegate)
+        val slideAnimator = createSheetSlideInAnimator()
+
+        animatorSet
+            .play(slideAnimator)
+            .takeIf {
+                dimmingDelegate.willDimForDetentIndex(screen, screen.sheetInitialDetentIndex)
+            }?.with(alphaAnimator)
+
+        attachCommonListeners(animatorSet, isEnter = true, screenStackFragment)
+
+        return animatorSet
+    }
+
+    internal fun createSheetExitAnimator(sheetAnimationContext: SheetDelegate.SheetAnimationContext): Animator {
+        val animatorSet = AnimatorSet()
+
+        val coordinatorLayout = sheetAnimationContext.coordinatorLayout
+        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
+        val screenStackFragment = sheetAnimationContext.fragment
+
+        val alphaAnimator =
+            createDimmingViewAlphaAnimator(dimmingDelegate.dimmingView.alpha, 0f, dimmingDelegate)
+        val slideAnimator = createSheetSlideOutAnimator(coordinatorLayout)
+
+        animatorSet.play(alphaAnimator).with(slideAnimator)
+
+        attachCommonListeners(animatorSet, isEnter = false, screenStackFragment)
+
+        return animatorSet
+    }
+
+    /**
+     * This should be used only with sheet in `fitToContents` mode.
+     *
+     * If an entry/exit animation is already in progress, we silently update the
+     * behavior metrics and view layout without starting a competing translationY
+     * animation - this is the fix for the race condition between the slide-in
+     * ValueAnimator and externally triggered layout pass (e.g. applying padding from SAV insets).
+     */
+    internal fun onContentHeightChanged(
+        behavior: BottomSheetBehavior<Screen>,
+        oldHeight: Int,
+        newHeight: Int,
+    ) {
+        val currentTranslationY = screen.translationY
+
+        /*
+         * WHY OVERFLOW MATTERS:
+         * BottomSheetBehavior has a physical limit (maxHeight) defined by the parent container.
+         * If the new content height exceeds this limit (by its size or keyboard offset), simply
+         * animating translationY back to 'currentTranslationY' would attempt to render the sheet
+         * larger than the screen.
+         *
+         * We need to have constraint height inside the container's bounds.
+         * By including this overflow to our animation, we ensure the sheet stops
+         * expanding exactly at the maxHeight, preventing from being pushed
+         * off-screen or causing layout synchronization issues with the CoordinatorLayout.
+         */
+        val clampedOldHeight = resolveClampedHeight(oldHeight, currentTranslationY)
+        val clampedNewHeight = resolveClampedHeight(newHeight, currentTranslationY)
+
+        // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
+        // Silently update behavior metrics and re-layout so the ongoing slide animation
+        // lands at the correct final geometry, without firing a competing animation.
+        if (isSheetAnimationInProgress) {
+            behavior.updateMetrics(clampedNewHeight)
+            screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+            return
+        }
+
+        val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
+        if (visibleDelta == 0f) return
+
+        val isContentExpanding = visibleDelta > 0
+
+        if (isContentExpanding) {
+            /*
+             * Expanding content animation:
+             *
+             * Before animation, we're updating the SheetBehavior - the maximum height is the new
+             * content height, then we're forcing a layout pass. This ensures the view calculates
+             * with its new bounds when the animation starts.
+             *
+             * In the animation, we're translating the Screen back to it's (newly calculated) origin
+             * position, providing an impression that FormSheet expands. It already has the final size,
+             * but some content is not yet visible on the screen.
+             *
+             * After animation, we just need to send a notification that ShadowTree state should be updated,
+             * as the positioning of pressables has changed due to the Y translation manipulation.
+             */
+            screen.translationY += visibleDelta
+            screen
+                .animate()
+                .translationY(currentTranslationY)
+                .withStartAction {
+                    behavior.updateMetrics(clampedNewHeight)
+                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                }.withEndAction {
+                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                    // to its old position when the user starts a gesture.
+                    screen.parent.requestLayout()
+                    screen.onSheetYTranslationChanged()
+                }.start()
+        } else {
+            /*
+             * Shrinking content animation:
+             *
+             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
+             *
+             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
+             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
+             * of shrink & expand animation is detected.
+             *
+             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
+             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
+             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
+             *
+             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
+             * another layout pass. Additionally, since the actual layout and the target position are equal,
+             * we can reset translationY to 0.
+             *
+             * After animation, we need to send a notification that ShadowTree state should be updated,
+             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
+             */
+            val targetTranslationY = currentTranslationY - visibleDelta
+            screen
+                .animate()
+                .translationY(targetTranslationY)
+                .withStartAction {
+                    behavior.updateMetrics(clampedNewHeight)
+                }.withEndAction {
+                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                    screen.translationY = currentTranslationY
+                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                    // to its old position when the user starts a gesture.
+                    screen.parent.requestLayout()
+                    screen.onSheetYTranslationChanged()
+                }.start()
+        }
+    }
+
+    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
+        lastKeyboardBottomOffset = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+        // Prioritize enter/exit animations over direct keyboard inset reactions.
+        // We store the latest keyboard offset in `lastKeyboardBottomOffset`
+        // so that it can always be respected when applying translations in `updateSheetTranslationY`.
+        //
+        // This approach allows screen translation to be triggered from two sources, but without messing them together:
+        // - During enter/exit animations, while accounting for the keyboard height.
+        // - While interacting with a TextInput inside the bottom sheet, to handle keyboard show/hide events.
+        if (!isSheetAnimationInProgress) {
+            updateSheetTranslationY(0f)
+        }
+    }
+
+    internal fun resolveClampedHeight(
+        targetHeight: Int,
+        currentTranslationY: Float,
+    ): Int {
+        val maxAvailableVerticalSpace =
+            screen.fragment
+                ?.asScreenStackFragment()
+                ?.sheetDelegate
+                ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
+
+        // Please note that currentTranslationY is rather < 0 here.
+        // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
+        // avoid the keyboard.
+        return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
+    }
+
+    // This function calculates the Y offset to which the FormSheet should animate
+    // when appearing (entering) or disappearing (exiting) with the on-screen keyboard (IME) present.
+    // Its purpose is to ensure the FormSheet does not exceed the top edge of the screen.
+    // It tries to display the FormSheet fully above the keyboard when there's enough space.
+    // Otherwise, it shifts the sheet as high as possible, even if it means part of its content
+    // will remain hidden behind the keyboard.
+    private fun computeSheetOffsetYWithIMEPresent(keyboardHeight: Int): Int {
+        val containerHeight =
+            screen.fragment
+                ?.asScreenStackFragment()
+                ?.sheetDelegate
+                ?.tryResolveMaxFormSheetHeight()
+        check(containerHeight != null) {
+            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
+        }
+
+        if (screen.isSheetFitToContents()) {
+            val contentHeight = screen.contentWrapper?.height ?: 0
+            val offsetFromTop = maxOf(containerHeight - contentHeight, 0)
+            // If the content is higher than the Screen, offsetFromTop becomes negative.
+            // In such cases, we return 0 because a negative translation would shift the Screen
+            // to the bottom, which is not intended.
+            return minOf(offsetFromTop, keyboardHeight)
+        }
+
+        val detents = screen.sheetDetents
+
+        val detentValue = detents.highest().coerceIn(0.0, 1.0)
+        val sheetHeight = (detentValue * containerHeight).toInt()
+        val offsetFromTop = containerHeight - sheetHeight
+
+        return minOf(offsetFromTop, keyboardHeight)
+    }
+
+    private fun updateSheetTranslationY(baseTranslationY: Float) {
+        val keyboardCorrection = lastKeyboardBottomOffset
+        val bottomOffset = computeSheetOffsetYWithIMEPresent(keyboardCorrection).toFloat()
+
+        screen.translationY = baseTranslationY - bottomOffset
+    }
+
+    private fun createSheetSlideInAnimator(): ValueAnimator {
+        val startValueCallback = { _: Number? -> screen.height.toFloat() }
+        val evaluator = ExternalBoundaryValuesEvaluator(startValueCallback, { 0f })
+
+        return ValueAnimator.ofObject(evaluator, screen.height.toFloat(), 0f).apply {
+            addUpdateListener { updateSheetTranslationY(it.animatedValue as Float) }
+        }
+    }
+
+    private fun createSheetSlideOutAnimator(coordinatorLayout: CoordinatorLayout): ValueAnimator {
+        val endValue = (coordinatorLayout.bottom - screen.top - screen.translationY)
+
+        return ValueAnimator.ofFloat(0f, endValue).apply {
+            addUpdateListener {
+                updateSheetTranslationY(it.animatedValue as Float)
+            }
+        }
+    }
+
+    private fun createDimmingViewAlphaAnimator(
+        from: Float,
+        to: Float,
+        dimmingDelegate: DimmingViewManager,
+    ): ValueAnimator =
+        ValueAnimator.ofFloat(from, to).apply {
+            addUpdateListener { animator ->
+                (animator.animatedValue as? Float)?.let {
+                    dimmingDelegate.dimmingView.alpha = it
+                }
+            }
+        }
+
+    private fun attachCommonListeners(
+        animatorSet: AnimatorSet,
+        isEnter: Boolean,
+        screenStackFragment: ScreenStackFragment,
+    ) {
+        animatorSet.addListener(
+            ScreenAnimationDelegate(
+                screenStackFragment,
+                ScreenEventEmitter(screen),
+                if (isEnter) {
+                    ScreenAnimationDelegate.AnimationType.ENTER
+                } else {
+                    ScreenAnimationDelegate.AnimationType.EXIT
+                },
+            ),
+        )
+
+        animatorSet.addListener(
+            object : AnimatorListenerAdapter() {
+                override fun onAnimationStart(animation: Animator) {
+                    isSheetAnimationInProgress = true
+                }
+
+                override fun onAnimationEnd(animation: Animator) {
+                    isSheetAnimationInProgress = false
+
+                    screen.onSheetYTranslationChanged()
+                }
+            },
+        )
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -1,9 +1,6 @@
 package com.swmansion.rnscreens.bottomsheet
 
 import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
-import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Build
 import android.view.View
@@ -24,9 +21,6 @@ import com.swmansion.rnscreens.KeyboardState
 import com.swmansion.rnscreens.KeyboardVisible
 import com.swmansion.rnscreens.Screen
 import com.swmansion.rnscreens.ScreenStackFragment
-import com.swmansion.rnscreens.events.ScreenAnimationDelegate
-import com.swmansion.rnscreens.events.ScreenEventEmitter
-import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
 import com.swmansion.rnscreens.utils.isSoftKeyboardVisibleOrNull
 
 class SheetDelegate(
@@ -36,10 +30,7 @@ class SheetDelegate(
     private var isKeyboardVisible: Boolean = false
     private var keyboardState: KeyboardState = KeyboardNotVisible
 
-    private var isSheetAnimationInProgress: Boolean = false
-
     private var lastTopInset: Int = 0
-    private var lastKeyboardBottomOffset: Int = 0
 
     var lastStableDetentIndex: Int = screen.sheetInitialDetentIndex
         private set
@@ -348,36 +339,6 @@ class SheetDelegate(
         }
     }
 
-    // This function calculates the Y offset to which the FormSheet should animate
-    // when appearing (entering) or disappearing (exiting) with the on-screen keyboard (IME) present.
-    // Its purpose is to ensure the FormSheet does not exceed the top edge of the screen.
-    // It tries to display the FormSheet fully above the keyboard when there's enough space.
-    // Otherwise, it shifts the sheet as high as possible, even if it means part of its content
-    // will remain hidden behind the keyboard.
-    internal fun computeSheetOffsetYWithIMEPresent(keyboardHeight: Int): Int {
-        val containerHeight = tryResolveMaxFormSheetHeight()
-        check(containerHeight != null) {
-            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
-        }
-
-        if (screen.isSheetFitToContents()) {
-            val contentHeight = screen.contentWrapper?.height ?: 0
-            val offsetFromTop = maxOf(containerHeight - contentHeight, 0)
-            // If the content is higher than the Screen, offsetFromTop becomes negative.
-            // In such cases, we return 0 because a negative translation would shift the Screen
-            // to the bottom, which is not intended.
-            return minOf(offsetFromTop, keyboardHeight)
-        }
-
-        val detents = screen.sheetDetents
-
-        val detentValue = detents.highest().coerceIn(0.0, 1.0)
-        val sheetHeight = (detentValue * containerHeight).toInt()
-        val offsetFromTop = containerHeight - sheetHeight
-
-        return minOf(offsetFromTop, keyboardHeight)
-    }
-
     // This is listener function, not the view's.
     override fun onApplyWindowInsets(
         v: View,
@@ -473,128 +434,14 @@ class SheetDelegate(
 
     // Sheet entering/exiting animations
 
-    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetAnimationContext): Animator {
-        val animatorSet = AnimatorSet()
+    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetAnimationContext): Animator =
+        screen.sheetAnimationCoordinator.createSheetEnterAnimator(sheetAnimationContext)
 
-        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
-        val screenStackFragment = sheetAnimationContext.fragment
+    internal fun createSheetExitAnimator(sheetAnimationContext: SheetAnimationContext): Animator =
+        screen.sheetAnimationCoordinator.createSheetExitAnimator(sheetAnimationContext)
 
-        val alphaAnimator = createDimmingViewAlphaAnimator(0f, dimmingDelegate.maxAlpha, dimmingDelegate)
-        val slideAnimator = createSheetSlideInAnimator()
-
-        animatorSet
-            .play(slideAnimator)
-            .takeIf {
-                dimmingDelegate.willDimForDetentIndex(screen, screen.sheetInitialDetentIndex)
-            }?.with(alphaAnimator)
-
-        attachCommonListeners(animatorSet, isEnter = true, screenStackFragment)
-
-        return animatorSet
-    }
-
-    internal fun createSheetExitAnimator(sheetAnimationContext: SheetAnimationContext): Animator {
-        val animatorSet = AnimatorSet()
-
-        val coordinatorLayout = sheetAnimationContext.coordinatorLayout
-        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
-        val screenStackFragment = sheetAnimationContext.fragment
-
-        val alphaAnimator =
-            createDimmingViewAlphaAnimator(dimmingDelegate.dimmingView.alpha, 0f, dimmingDelegate)
-        val slideAnimator = createSheetSlideOutAnimator(coordinatorLayout)
-
-        animatorSet.play(alphaAnimator).with(slideAnimator)
-
-        attachCommonListeners(animatorSet, isEnter = false, screenStackFragment)
-
-        return animatorSet
-    }
-
-    private fun createDimmingViewAlphaAnimator(
-        from: Float,
-        to: Float,
-        dimmingDelegate: DimmingViewManager,
-    ): ValueAnimator =
-        ValueAnimator.ofFloat(from, to).apply {
-            addUpdateListener { animator ->
-                (animator.animatedValue as? Float)?.let {
-                    dimmingDelegate.dimmingView.alpha = it
-                }
-            }
-        }
-
-    private fun createSheetSlideInAnimator(): ValueAnimator {
-        val startValueCallback = { _: Number? -> screen.height.toFloat() }
-        val evaluator = ExternalBoundaryValuesEvaluator(startValueCallback, { 0f })
-
-        return ValueAnimator.ofObject(evaluator, screen.height.toFloat(), 0f).apply {
-            addUpdateListener { updateSheetTranslationY(it.animatedValue as Float) }
-        }
-    }
-
-    private fun createSheetSlideOutAnimator(coordinatorLayout: CoordinatorLayout): ValueAnimator {
-        val endValue = (coordinatorLayout.bottom - screen.top - screen.translationY)
-
-        return ValueAnimator.ofFloat(0f, endValue).apply {
-            addUpdateListener {
-                updateSheetTranslationY(it.animatedValue as Float)
-            }
-        }
-    }
-
-    private fun updateSheetTranslationY(baseTranslationY: Float) {
-        val keyboardCorrection = lastKeyboardBottomOffset
-        val bottomOffset = computeSheetOffsetYWithIMEPresent(keyboardCorrection).toFloat()
-
-        screen.translationY = baseTranslationY - bottomOffset
-    }
-
-    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
-        lastKeyboardBottomOffset = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-        // Prioritize enter/exit animations over direct keyboard inset reactions.
-        // We store the latest keyboard offset in `lastKeyboardBottomOffset`
-        // so that it can always be respected when applying translations in `updateSheetTranslationY`.
-        //
-        // This approach allows screen translation to be triggered from two sources, but without messing them together:
-        // - During enter/exit animations, while accounting for the keyboard height.
-        // - While interacting with a TextInput inside the bottom sheet, to handle keyboard show/hide events.
-        if (!isSheetAnimationInProgress) {
-            updateSheetTranslationY(0f)
-        }
-    }
-
-    private fun attachCommonListeners(
-        animatorSet: AnimatorSet,
-        isEnter: Boolean,
-        screenStackFragment: ScreenStackFragment,
-    ) {
-        animatorSet.addListener(
-            ScreenAnimationDelegate(
-                screenStackFragment,
-                ScreenEventEmitter(screen),
-                if (isEnter) {
-                    ScreenAnimationDelegate.AnimationType.ENTER
-                } else {
-                    ScreenAnimationDelegate.AnimationType.EXIT
-                },
-            ),
-        )
-
-        animatorSet.addListener(
-            object : AnimatorListenerAdapter() {
-                override fun onAnimationStart(animation: Animator) {
-                    isSheetAnimationInProgress = true
-                }
-
-                override fun onAnimationEnd(animation: Animator) {
-                    isSheetAnimationInProgress = false
-
-                    screen.onSheetYTranslationChanged()
-                }
-            },
-        )
-    }
+    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) =
+        screen.sheetAnimationCoordinator.handleKeyboardInsetsProgress(insets)
 
     private inner class KeyboardHandler : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
@@ -158,3 +158,19 @@ fun Screen.sheetShouldUseDimmingView(): Boolean {
  * is reattached to container.
  */
 fun View.isLaidOutOrHasCachedLayout() = this.isLaidOut || height > 0 || width > 0
+
+internal fun Screen.resolveClampedHeight(
+    targetHeight: Int,
+    currentTranslationY: Float,
+): Int {
+    val maxAvailableVerticalSpace =
+        fragment
+            ?.asScreenStackFragment()
+            ?.sheetDelegate
+            ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
+
+    // Please note that currentTranslationY is rather < 0 here.
+    // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
+    // avoid the keyboard.
+    return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
+}


### PR DESCRIPTION
## Description

FormSheet with `fitToContents` and `SafeAreaView` applies window insets during the entering transition, which triggers an extra `onLayout` pass on the ContentWrapper. This resulted in starting a concurrent ValueAnimator on translationY - conflicting with the slide-in animator already running, causing a race between them and wrong sheet positioning.

I'm introducing `SheetAnimationCoordinator`, which will be a single source of truth for the `FormSheet's` transitions. I'm adding a guard in `updateSheetContentHeightWithAnimation` - if an entry/exit animation is already running, the height performs an immediate metrics update and layout without touching translationY. The slide-in animator should have a priority over the sheet height change animation.

> [!WARNING]
> Fit to contents (TextInput) case from Test3336 is still not working - handling keyboard inset has its own animation which I'll synchronize in the followup PR. Ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1170

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/968

## Changes

- introduced `SheetAnimationCoordinator`, which should own all BottomSheet transitions
- replaced enter/exit animation and keyboard handling in `SheetDelegate` with the delegate methods to the coordiantor
- moved `Screen` animations to `SheetAnimationCoordinator`
- moved `resolveClampedHeight` to SheetUtils - needs to be accessible for both the screen and the coordinator.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/5fcf64ee-cf33-41d1-ad1e-80c8cde31db0" /> | <video src="https://github.com/user-attachments/assets/495ad0b9-0939-4f2f-ae9a-b208bded147b" /> |

## Test plan

Performed regression testing on Test3336 and TestFormSheet.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
