### PR TITLE
chore(CI): move dry-run input to top of publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,10 @@ on:
     - cron: "27 23 * * *" # at 23:27 every day
   workflow_dispatch:
     inputs:
+      dry-run:
+        description: Whether to perform a dry run of the publish. Uncheck it only if you want to publish artifacts to the NPM registry.
+        type: boolean
+        default: true
       release-type:
         description: Type of release to publish.
         type: choice
@@ -21,10 +25,6 @@ on:
         type: string
         required: false
         default: ""
-      dry-run:
-        description: Whether to perform a dry run of the publish.
-        type: boolean
-        default: true
 
 jobs:
   npm-publish:


### PR DESCRIPTION
## Description

Reorders the `workflow_dispatch` inputs in `publish-npm.yml` so the `dry-run` toggle appears first, and expands its description to make the intent explicit.

`dry-run` is the most consequential field on this workflow — leaving it checked is safe, unchecking it performs a real publish to npm. Surfacing it at the top of the inputs list makes it harder to miss, and the extended description spells out that it should be unchecked only for a real release.

The default remains `true` (dry-run on). Unlike Reanimated's equivalent workflow, we keep it as an opt-out rather than opt-in checkbox, because unchecking requires **in my mind** more effort. Dunno, I find it just as a better default atm. Open for suggestions here. 

## Changes

- Move the `dry-run` input to the top of the `workflow_dispatch` inputs in `.github/workflows/publish-npm.yml`.
- Extend the input description to clarify when it should be unchecked.

## Test plan

No functional change to the workflow logic — only input ordering and description text. Will verify via the GitHub Actions UI that the reordered inputs render correctly on the next manual `workflow_dispatch` invocation.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes