### PR TITLE
chore(release): bump version to 4.25.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "4.24.0",
+  "version": "4.25.0-beta.1",
   "description": "Native navigation primitives for your React Native app.",
   "scripts": {
     "submodules": "git submodule update --init --recursive && (cd react-navigation && yarn && yarn build && cd ../)",


### PR DESCRIPTION
## Description

Bumps `package.json` version from `4.24.0` to `4.25.0-beta.1` on the `4.25-stable` release branch, in preparation for the first beta of the 4.25 release line.

## Changes

- Updated `version` field in `package.json` to `4.25.0-beta.1`.

## Test plan

No code changes — version-only bump. Publishing will be validated by running the `Publish release to npm` workflow in `dry-run` mode against this branch before the actual beta publish.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes