### PR TITLE
chore(CI): refine dry-run description and disable action git ops

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: Whether to perform a dry run of the publish. Uncheck it only if you want to publish artifacts to the NPM registry.
+        description: >-
+          Whether to perform a dry run of the publish.
+          Uncheck only to publish artifacts to the npm registry.
         type: boolean
         default: true
       release-type:
@@ -64,6 +66,7 @@ jobs:
           release-type: ${{ inputs.release-type }}
           version: ${{ inputs.version }}
           dry-run: ${{ inputs.dry-run }}
+          perform-git-operations: false # We do it manually in more predictive manner
 
       - name: Publish automatic nightly release
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Description

Small follow-up cleanup to the npm publish workflow:

- The `dry-run` input description was long and awkwardly worded. Rewrite it into two short sentences using a YAML folded scalar for readability in the Actions UI.
- The reusable publish action was performing its own git operations (tag/push). We want these handled manually in the surrounding workflow so the sequencing is explicit and predictable. Disable `perform-git-operations` at the call site.

## Changes

- Reword the `dry-run` input description in `.github/workflows/publish-npm.yml`.
- Pass `perform-git-operations: false` to the reusable publish action so git tagging/pushing is driven from this workflow instead.

## Test plan

No runtime code changes. Verification:

- YAML lints cleanly (`actionlint` / GitHub's workflow parser).
- Manually trigger the workflow via `workflow_dispatch` with `dry-run: true` and confirm the action no longer performs git operations on its own.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes