### PR TITLE
chore(types): remove nullability from some `children` props in unstable/experimental components

### DIFF
--- a/src/components/gamma/split/SplitHost.types.ts
+++ b/src/components/gamma/split/SplitHost.types.ts
@@ -113,7 +113,7 @@ export type SplitHostCommands = {
 };
 
 export interface SplitHostProps extends ViewProps {
-  children?: React.ReactNode | undefined;
+  children: NonNullable<React.ReactNode>;
   ref?: React.Ref<SplitHostCommands> | undefined;
 
   /**

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -26,7 +26,7 @@ export interface StackHeaderToolbarSubviewAndroid {
    *
    * @platform android
    */
-  Component: ReactNode;
+  Component: NonNullable<ReactNode>;
 }
 
 export interface StackHeaderBackgroundSubviewAndroid {
@@ -58,7 +58,7 @@ export interface StackHeaderBackgroundSubviewAndroid {
    *
    * @platform android
    */
-  Component: ReactNode;
+  Component: NonNullable<ReactNode>;
 }
 
 export interface StackHeaderConfigPropsAndroid {

--- a/src/components/gamma/stack/header/android/StackHeaderSubview.android.types.ts
+++ b/src/components/gamma/stack/header/android/StackHeaderSubview.android.types.ts
@@ -9,7 +9,7 @@ export type StackHeaderSubviewTypeAndroid =
 export type StackHeaderSubviewCollapseModeAndroid = 'off' | 'parallax';
 
 export type StackHeaderSubviewProps = {
-  children?: ViewProps['children'] | undefined;
+  children: NonNullable<ViewProps['children']>;
 
   type?: StackHeaderSubviewTypeAndroid | undefined;
   collapseMode?: StackHeaderSubviewCollapseModeAndroid | undefined;

--- a/src/components/gamma/stack/host/StackHost.types.ts
+++ b/src/components/gamma/stack/host/StackHost.types.ts
@@ -3,7 +3,7 @@ import type { ReactNativeElement, ViewProps } from 'react-native';
 import { type NativeProps } from '../../../../fabric/gamma/stack/StackHostNativeComponent';
 
 export type StackHostProps = {
-  children: ViewProps['children'];
+  children: NonNullable<ViewProps['children']>;
   // TODO: Work on these types
   ref?:
     | React.RefObject<

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -167,7 +167,7 @@ export interface TabsHostPropsBase {
   rejectStaleNavStateUpdates?: boolean | undefined;
 
   // General
-  children?: ViewProps['children'] | undefined;
+  children: NonNullable<ViewProps['children']>;
   /**
    * @summary Hides the tab bar.
    *

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -65,6 +65,7 @@ export const compatibilityFlags = {
    * * https://github.com/software-mansion/react-native-screens/pull/3863
    * * https://github.com/software-mansion/react-native-screens/pull/3875
    * * https://github.com/software-mansion/react-native-screens/pull/3895
+   * * https://github.com/software-mansion/react-native-screens/pull/3918
    */
   usesStableTabsApi: true,
 } as const;


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/software-mansion/react-native-screens/pull/3719. We adjust `children` property to be not nullable for `Host` components (Tabs, Split and Stack v5) and subviews in Stack v5 implementation.

This change is applied only to unstable/experimental components so it shouldn't be considered a breaking change.

## Changes

- wrap `ReactNode`/`ViewProps['children']` in `NonNullable` for:
  - `StackHost`
  - `TabsHost`
  - `SplitHost`
  - `StackHeaderSubview` and related places in `StackHeaderConfig`

## Before & after - visual documentation

N/A

## Test plan

`yarn check-types`

## Checklist

- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
