### PR TITLE
refactor(Android, FormSheet): Minor cleanups in SheetAnimationCoordinator

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -101,10 +101,7 @@ internal class SheetAnimationCoordinator(
         if (isSheetAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
             screen.layoutBottomSheetAtHeight(clampedNewHeight)
-            // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-            // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-            // to its old position when the user starts a gesture.
-            screen.parent.requestLayout()
+            screen.synchronizeBottomSheetBehaviorWithLayout()
             return
         }
 
@@ -146,11 +143,7 @@ internal class SheetAnimationCoordinator(
                 behavior.updateMetrics(clampedNewHeight)
                 screen.layoutBottomSheetAtHeight(clampedNewHeight)
             }.withEndAction {
-                // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                // to its old position when the user starts a gesture.
-                screen.parent.requestLayout()
-                screen.onSheetYTranslationChanged()
+                screen.synchronizeBottomSheetBehaviorWithLayout()
             }.start()
     }
 
@@ -189,11 +182,7 @@ internal class SheetAnimationCoordinator(
             }.withEndAction {
                 screen.layoutBottomSheetAtHeight(clampedNewHeight)
                 screen.translationY = currentTranslationY
-                // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                // to its old position when the user starts a gesture.
-                screen.parent.requestLayout()
-                screen.onSheetYTranslationChanged()
+                screen.synchronizeBottomSheetBehaviorWithLayout()
             }.start()
     }
 
@@ -285,6 +274,14 @@ internal class SheetAnimationCoordinator(
         }
 
     private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
+
+    private fun Screen.synchronizeBottomSheetBehaviorWithLayout() {
+        // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+        // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+        // to its old position when the user starts a gesture.
+        parent.requestLayout()
+        onSheetYTranslationChanged()
+    }
 
     private fun attachCommonListeners(
         animatorSet: AnimatorSet,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -122,7 +122,7 @@ internal class SheetAnimationCoordinator(
      * content height, then we're forcing a layout pass. This ensures the view calculates
      * with its new bounds when the animation starts.
      *
-     * In the animation, we're translating the Screen back to it's (newly calculated) origin
+     * In the animation, we're translating the Screen back to its (newly calculated) origin
      * position, providing an impression that FormSheet expands. It already has the final size,
      * but some content is not yet visible on the screen.
      *

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -275,12 +275,20 @@ internal class SheetAnimationCoordinator(
 
     private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
 
-    private fun Screen.synchronizeBottomSheetBehaviorWithLayout() {
+    private fun Screen.synchronizeBottomSheetBehaviorOffsetsWithLayout() {
         // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
         // internal offsets with the new maxHeight. This prevents the sheet from snapping back
         // to its old position when the user starts a gesture.
         parent.requestLayout()
+    }
+
+    private fun Screen.notifyBottomSheetShadowStateChanged() {
         onSheetYTranslationChanged()
+    }
+
+    private fun Screen.synchronizeBottomSheetBehaviorWithLayout() {
+        synchronizeBottomSheetBehaviorOffsetsWithLayout()
+        notifyBottomSheetShadowStateChanged()
     }
 
     private fun attachCommonListeners(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -111,74 +111,90 @@ internal class SheetAnimationCoordinator(
         val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
         if (visibleDelta == 0f) return
 
-        val isContentExpanding = visibleDelta > 0
-
-        if (isContentExpanding) {
-            /*
-             * Expanding content animation:
-             *
-             * Before animation, we're updating the SheetBehavior - the maximum height is the new
-             * content height, then we're forcing a layout pass. This ensures the view calculates
-             * with its new bounds when the animation starts.
-             *
-             * In the animation, we're translating the Screen back to it's (newly calculated) origin
-             * position, providing an impression that FormSheet expands. It already has the final size,
-             * but some content is not yet visible on the screen.
-             *
-             * After animation, we just need to send a notification that ShadowTree state should be updated,
-             * as the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            screen.translationY += visibleDelta
-            screen
-                .animate()
-                .translationY(currentTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                    screen.layoutBottomSheetAtHeight(clampedNewHeight)
-                }.withEndAction {
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    screen.parent.requestLayout()
-                    screen.onSheetYTranslationChanged()
-                }.start()
+        if (visibleDelta > 0) {
+            animateContentExpanding(behavior, clampedNewHeight, currentTranslationY, visibleDelta)
         } else {
-            /*
-             * Shrinking content animation:
-             *
-             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
-             *
-             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
-             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
-             * of shrink & expand animation is detected.
-             *
-             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
-             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
-             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
-             *
-             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
-             * another layout pass. Additionally, since the actual layout and the target position are equal,
-             * we can reset translationY to 0.
-             *
-             * After animation, we need to send a notification that ShadowTree state should be updated,
-             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            val targetTranslationY = currentTranslationY - visibleDelta
-            screen
-                .animate()
-                .translationY(targetTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                }.withEndAction {
-                    screen.layoutBottomSheetAtHeight(clampedNewHeight)
-                    screen.translationY = currentTranslationY
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    screen.parent.requestLayout()
-                    screen.onSheetYTranslationChanged()
-                }.start()
+            animateContentShrinking(behavior, clampedNewHeight, currentTranslationY, visibleDelta)
         }
+    }
+
+    /*
+     * Expanding content animation:
+     *
+     * Before animation, we're updating the SheetBehavior - the maximum height is the new
+     * content height, then we're forcing a layout pass. This ensures the view calculates
+     * with its new bounds when the animation starts.
+     *
+     * In the animation, we're translating the Screen back to it's (newly calculated) origin
+     * position, providing an impression that FormSheet expands. It already has the final size,
+     * but some content is not yet visible on the screen.
+     *
+     * After animation, we just need to send a notification that ShadowTree state should be updated,
+     * as the positioning of pressables has changed due to the Y translation manipulation.
+     */
+    private fun animateContentExpanding(
+        behavior: BottomSheetBehavior<Screen>,
+        clampedNewHeight: Int,
+        currentTranslationY: Float,
+        visibleDelta: Float,
+    ) {
+        screen.translationY += visibleDelta
+        screen
+            .animate()
+            .translationY(currentTranslationY)
+            .withStartAction {
+                behavior.updateMetrics(clampedNewHeight)
+                screen.layoutBottomSheetAtHeight(clampedNewHeight)
+            }.withEndAction {
+                // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                // to its old position when the user starts a gesture.
+                screen.parent.requestLayout()
+                screen.onSheetYTranslationChanged()
+            }.start()
+    }
+
+    /*
+     * Shrinking content animation:
+     *
+     * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
+     *
+     * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
+     * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
+     * of shrink & expand animation is detected.
+     *
+     * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
+     * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
+     * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
+     *
+     * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
+     * another layout pass. Additionally, since the actual layout and the target position are equal,
+     * we can reset translationY to 0.
+     *
+     * After animation, we need to send a notification that ShadowTree state should be updated,
+     * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
+     */
+    private fun animateContentShrinking(
+        behavior: BottomSheetBehavior<Screen>,
+        clampedNewHeight: Int,
+        currentTranslationY: Float,
+        visibleDelta: Float,
+    ) {
+        val targetTranslationY = currentTranslationY - visibleDelta
+        screen
+            .animate()
+            .translationY(targetTranslationY)
+            .withStartAction {
+                behavior.updateMetrics(clampedNewHeight)
+            }.withEndAction {
+                screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                screen.translationY = currentTranslationY
+                // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                // to its old position when the user starts a gesture.
+                screen.parent.requestLayout()
+                screen.onSheetYTranslationChanged()
+            }.start()
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -101,7 +101,7 @@ internal class SheetAnimationCoordinator(
         if (isSheetAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
             screen.layoutBottomSheetAtHeight(clampedNewHeight)
-            screen.synchronizeBottomSheetBehaviorWithLayout()
+            screen.finalizeBottomSheetLayoutUpdates()
             return
         }
 
@@ -143,7 +143,7 @@ internal class SheetAnimationCoordinator(
                 behavior.updateMetrics(clampedNewHeight)
                 screen.layoutBottomSheetAtHeight(clampedNewHeight)
             }.withEndAction {
-                screen.synchronizeBottomSheetBehaviorWithLayout()
+                screen.finalizeBottomSheetLayoutUpdates()
             }.start()
     }
 
@@ -182,7 +182,7 @@ internal class SheetAnimationCoordinator(
             }.withEndAction {
                 screen.layoutBottomSheetAtHeight(clampedNewHeight)
                 screen.translationY = currentTranslationY
-                screen.synchronizeBottomSheetBehaviorWithLayout()
+                screen.finalizeBottomSheetLayoutUpdates()
             }.start()
     }
 
@@ -275,20 +275,15 @@ internal class SheetAnimationCoordinator(
 
     private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
 
-    private fun Screen.synchronizeBottomSheetBehaviorOffsetsWithLayout() {
+    private fun Screen.finalizeBottomSheetLayoutUpdates() {
         // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
         // internal offsets with the new maxHeight. This prevents the sheet from snapping back
         // to its old position when the user starts a gesture.
         parent.requestLayout()
-    }
 
-    private fun Screen.notifyBottomSheetShadowStateChanged() {
+        // Notify that ShadowTree state should be updated, as the positioning of pressables
+        // has changed due to the Y translation manipulation.
         onSheetYTranslationChanged()
-    }
-
-    private fun Screen.synchronizeBottomSheetBehaviorWithLayout() {
-        synchronizeBottomSheetBehaviorOffsetsWithLayout()
-        notifyBottomSheetShadowStateChanged()
     }
 
     private fun attachCommonListeners(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -100,7 +100,7 @@ internal class SheetAnimationCoordinator(
         // lands at the correct final geometry, without firing a competing animation.
         if (isSheetAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
-            screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+            screen.layoutBottomSheetAtHeight(clampedNewHeight)
             // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
             // internal offsets with the new maxHeight. This prevents the sheet from snapping back
             // to its old position when the user starts a gesture.
@@ -134,7 +134,7 @@ internal class SheetAnimationCoordinator(
                 .translationY(currentTranslationY)
                 .withStartAction {
                     behavior.updateMetrics(clampedNewHeight)
-                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                    screen.layoutBottomSheetAtHeight(clampedNewHeight)
                 }.withEndAction {
                     // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
                     // internal offsets with the new maxHeight. This prevents the sheet from snapping back
@@ -170,7 +170,7 @@ internal class SheetAnimationCoordinator(
                 .withStartAction {
                     behavior.updateMetrics(clampedNewHeight)
                 }.withEndAction {
-                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                    screen.layoutBottomSheetAtHeight(clampedNewHeight)
                     screen.translationY = currentTranslationY
                     // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
                     // internal offsets with the new maxHeight. This prevents the sheet from snapping back
@@ -267,6 +267,8 @@ internal class SheetAnimationCoordinator(
                 }
             }
         }
+
+    private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
 
     private fun attachCommonListeners(
         animatorSet: AnimatorSet,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -293,6 +293,10 @@ internal class SheetAnimationCoordinator(
                     isSheetAnimationInProgress = true
                 }
 
+                override fun onAnimationCancel(animation: Animator) {
+                    isSheetAnimationInProgress = false
+                }
+
                 override fun onAnimationEnd(animation: Animator) {
                     isSheetAnimationInProgress = false
 


### PR DESCRIPTION
## Description

Extracting long code blocks to separate functions, creating extension methods for repeated calls, fixing potential issues.

## Changes

- layoutBottomSheetAtHeight - relpacing 3 similar calls
- synchronizeBottomSheetBehaviorWithLayout - initially, I wanted to replace just calls inside content size change animations, but I decided to keep all 3 `parent.requestLayout` calls together, not sure if `onSheetYTranslationChanged` is needed in `updateSheetContentHeightWithAnimation`, but I think it won't hurt, because if layout metrics won't change, we'll early return and don't send update to yoga
- split content size change default animation into two separate helpers for expanding and shrinking - these long comments blocks started annoying me
- resetting `isSheetAnimationInProgress` flag in `onCancel` callback - might not be needed, because the enter/exit animation has a priority over any other animation, and when dismissing the sheet and showing it once again, we'll receive a new instance, but decided to add this override for safety, because I'm not sure whether the OS cannot cancel this animation in some specific case

## Before & after - visual documentation

N/A - refactor

## Test plan

Tested with TestFormSheet, Test3336, Test2560

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
