### PR TITLE
refactor(Android, FormSheet): Align animators implementation to use ValueAnimator

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -24,6 +24,7 @@ internal class SheetAnimationCoordinator(
             "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
         }
     private var isSheetAnimationInProgress: Boolean = false
+    private var currentContentAnimator: ValueAnimator? = null
 
     private var lastKeyboardBottomOffset: Int = 0
 
@@ -136,15 +137,24 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         screen.translationY += visibleDelta
-        screen
-            .animate()
-            .translationY(currentTranslationY)
-            .withStartAction {
-                behavior.updateMetrics(clampedNewHeight)
-                screen.layoutBottomSheetAtHeight(clampedNewHeight)
-            }.withEndAction {
-                screen.finalizeBottomSheetLayoutUpdates()
-            }.start()
+        currentContentAnimator?.cancel()
+        currentContentAnimator =
+            ValueAnimator.ofFloat(screen.translationY, currentTranslationY).apply {
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationStart(animation: Animator) {
+                            behavior.updateMetrics(clampedNewHeight)
+                            screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                        }
+
+                        override fun onAnimationEnd(animation: Animator) {
+                            screen.finalizeBottomSheetLayoutUpdates()
+                        }
+                    },
+                )
+                addUpdateListener { screen.translationY = it.animatedValue as Float }
+                start()
+            }
     }
 
     /*
@@ -174,16 +184,25 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         val targetTranslationY = currentTranslationY - visibleDelta
-        screen
-            .animate()
-            .translationY(targetTranslationY)
-            .withStartAction {
-                behavior.updateMetrics(clampedNewHeight)
-            }.withEndAction {
-                screen.layoutBottomSheetAtHeight(clampedNewHeight)
-                screen.translationY = currentTranslationY
-                screen.finalizeBottomSheetLayoutUpdates()
-            }.start()
+        currentContentAnimator?.cancel()
+        currentContentAnimator =
+            ValueAnimator.ofFloat(currentTranslationY, targetTranslationY).apply {
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationStart(animation: Animator) {
+                            behavior.updateMetrics(clampedNewHeight)
+                        }
+
+                        override fun onAnimationEnd(animation: Animator) {
+                            screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                            screen.translationY = currentTranslationY
+                            screen.finalizeBottomSheetLayoutUpdates()
+                        }
+                    },
+                )
+                addUpdateListener { screen.translationY = it.animatedValue as Float }
+                start()
+            }
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -296,6 +296,7 @@ internal class SheetAnimationCoordinator(
 
     private fun cancelCurrentContentAnimation() {
         currentContentAnimator?.removeAllListeners()
+        currentContentAnimator?.removeAllUpdateListeners()
         currentContentAnimator?.cancel()
         currentContentAnimator = null
     }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -137,7 +137,7 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         screen.translationY += visibleDelta
-        currentContentAnimator?.cancel()
+        cancelCurrentContentAnimation()
         currentContentAnimator =
             ValueAnimator.ofFloat(screen.translationY, currentTranslationY).apply {
                 addListener(
@@ -148,6 +148,7 @@ internal class SheetAnimationCoordinator(
                         }
 
                         override fun onAnimationEnd(animation: Animator) {
+                            currentContentAnimator = null
                             screen.finalizeBottomSheetLayoutUpdates()
                         }
                     },
@@ -184,7 +185,7 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         val targetTranslationY = currentTranslationY - visibleDelta
-        currentContentAnimator?.cancel()
+        cancelCurrentContentAnimation()
         currentContentAnimator =
             ValueAnimator.ofFloat(currentTranslationY, targetTranslationY).apply {
                 addListener(
@@ -194,6 +195,7 @@ internal class SheetAnimationCoordinator(
                         }
 
                         override fun onAnimationEnd(animation: Animator) {
+                            currentContentAnimator = null
                             screen.layoutBottomSheetAtHeight(clampedNewHeight)
                             screen.translationY = currentTranslationY
                             screen.finalizeBottomSheetLayoutUpdates()
@@ -291,6 +293,12 @@ internal class SheetAnimationCoordinator(
                 }
             }
         }
+
+    private fun cancelCurrentContentAnimation() {
+        currentContentAnimator?.removeAllListeners()
+        currentContentAnimator?.cancel()
+        currentContentAnimator = null
+    }
 
     private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
 


### PR DESCRIPTION
## Description

After moving everything to a single class, I think that it's reasonable to have a consistent system for all animations, therefore I'm aligning content size change animations with entering/exiting animations.

## Changes

- Replace `ViewPropertyAnimators` with `ValueAnimators`

## Before & after - visual documentation

N/A - refactor

## Test plan

Regression testing on Test2560 & Test3336

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
