### PR TITLE
chore(release): set main sentinel version and guard stable publishes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,7 +62,10 @@ jobs:
       - name: Validate publish target
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' }}
         shell: bash
-        run: ./scripts/validate-publish-target.sh "${{ github.ref_name }}" "${{ inputs.release-type }}"
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RELEASE_TYPE: ${{ inputs.release-type }}
+        run: ./scripts/validate-publish-target.sh "$BRANCH" "$RELEASE_TYPE"
 
       - name: Publish manual release
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -56,6 +56,14 @@ jobs:
           cache: "yarn"
           registry-url: https://registry.npmjs.org/
 
+      # Guards against publishing a stable / beta / rc release from an
+      # inappropriate target. Intentionally skipped for nightly releases,
+      # which are published from main by design.
+      - name: Validate publish target
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' }}
+        shell: bash
+        run: ./scripts/validate-publish-target.sh "${{ github.ref_name }}" "${{ inputs.release-type }}"
+
       - name: Publish manual release
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "4.24.0",
+  "version": "1000.0.0",
   "description": "Native navigation primitives for your React Native app.",
   "scripts": {
     "submodules": "git submodule update --init --recursive && (cd react-navigation && yarn && yarn build && cd ../)",

--- a/scripts/validate-publish-target.sh
+++ b/scripts/validate-publish-target.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Validates that the current branch and package.json version are appropriate
+# for publishing a non-nightly (stable / beta / rc) release.
+#
+# Exits 0 if the target is valid; non-zero (with one or more error messages)
+# otherwise. All failures are reported before exit so the operator sees every
+# problem in a single run.
+#
+# This script assumes it is run from the top level repo directory.
+#
+# Usage: scripts/validate-publish-target.sh <branch> <release-type>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <branch> <release-type>" >&2
+  exit 2
+fi
+
+BRANCH="$1"
+RELEASE_TYPE="$2"
+VERSION=$(jq -r .version package.json)
+
+echo "ref=$BRANCH version=$VERSION release-type=$RELEASE_TYPE"
+
+emit_error() {
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::error::$1"
+  else
+    echo "error: $1" >&2
+  fi
+}
+
+FAIL=0
+
+if [[ "$VERSION" == 1000.* ]]; then
+  emit_error "package.json version is '$VERSION' — this is the main-branch sentinel. Bump the version on a release branch before publishing a $RELEASE_TYPE release."
+  FAIL=1
+fi
+
+if [[ "$BRANCH" == "main" ]]; then
+  emit_error "Refusing to publish a $RELEASE_TYPE release from 'main'. Release from a *-stable or v*-main branch."
+  FAIL=1
+fi
+
+if ! [[ "$BRANCH" =~ ^(v[0-9]+-main|[0-9]+\.[0-9]+-stable)$ ]]; then
+  emit_error "Branch '$BRANCH' does not match an allowed release-branch pattern (v<major>-main or <major>.<minor>-stable). Publish from a dedicated release branch."
+  FAIL=1
+fi
+
+exit $FAIL

--- a/scripts/validate-publish-target.sh
+++ b/scripts/validate-publish-target.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
 # Validates that the current branch and package.json version are appropriate
-# for publishing a non-nightly (stable / beta / rc) release.
+# for publishing the requested release.
 #
-# Exits 0 if the target is valid; non-zero (with one or more error messages)
-# otherwise. All failures are reported before exit so the operator sees every
-# problem in a single run.
+# Handles all four release types:
+#   - nightly: always valid — nightly publishes are allowed from any branch
+#     per the release guide; the script returns success without running the
+#     branch/version checks.
+#   - stable / beta / rc: rejects the main-branch sentinel version, refuses
+#     publishes from `main`, and requires the branch to match a documented
+#     release-branch pattern.
+#
+# Exits 0 if the target is valid; 1 if a validation check fails (with one or
+# more error messages); 2 on usage error (missing arguments or unknown
+# release-type). For validation failures all checks are reported before exit
+# so the operator sees every problem in a single run.
 #
 # This script assumes it is run from the top level repo directory.
 #
+# Requires `jq` on PATH (pre-installed on GitHub-hosted ubuntu runners).
+#
 # Usage: scripts/validate-publish-target.sh <branch> <release-type>
+#   <release-type>: one of stable | beta | rc | nightly
 
 set -euo pipefail
 
@@ -20,9 +32,25 @@ fi
 
 BRANCH="$1"
 RELEASE_TYPE="$2"
+
+case "$RELEASE_TYPE" in
+  stable|beta|rc|nightly) ;;
+  *)
+    echo "error: unknown release-type '$RELEASE_TYPE' (expected: stable | beta | rc | nightly)" >&2
+    exit 2
+    ;;
+esac
+
 VERSION=$(jq -r .version package.json)
 
 echo "ref=$BRANCH version=$VERSION release-type=$RELEASE_TYPE"
+
+# Nightly publishes are the designed exception per the release guide: they are
+# allowed from any branch (scheduled cron runs from main; manual dispatch can
+# target a release branch). No further checks apply.
+if [[ "$RELEASE_TYPE" == "nightly" ]]; then
+  exit 0
+fi
 
 emit_error() {
   if [[ -n "${GITHUB_ACTIONS:-}" ]]; then


### PR DESCRIPTION
## Description

Adds two coupled changes for the release-branch workflow.

### 1. Pin `main` to a sentinel version (`1000.0.0`)

Bumps `package.json#version` on `main` to `1000.0.0`, per the release guide (see [labs#726](https://github.com/software-mansion/react-native-screens-labs/discussions/726)).

In the release-branch workflow, the version in `main/package.json` is not a real release version — releases are cut from dedicated `<major>.<minor>-stable` branches where the version is set independently. Keeping `main` pinned to a recently-released value (e.g. `4.24.0`) invites confusion and requires a bump on every release cut. Alternatives have their own trade-offs — `react-native-reanimated` uses a `<version>-main` suffix, which demands format discipline on every bump; `react-native-gesture-handler` does nothing, and the version on `main` silently drifts behind the real latest release. The sentinel `1000.0.0` is deliberately absurd so nobody mistakes it for a real release, requires no maintenance on release cuts, and still parses as valid semver for tooling.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1167.

### 2. Guard the publish workflow against non-nightly publishes from `main`

The sentinel is a clear *signal*, but without enforcement nothing prevents an operator from triggering **Publish release to npm** on `main` and pushing `react-native-screens@1000.0.0` to the registry. Adds a pre-publish validation step in `publish-npm.yml` that invokes `scripts/validate-publish-target.sh` whenever a non-nightly release is triggered via `workflow_dispatch`. The script rejects:

- the sentinel version (`1000.*`),
- runs targeting `main`,
- branches that do not match the documented release-branch patterns (`<major>.<minor>-stable` or `v<major>-main`).

All failures are surfaced in a single run so an operator sees every problem at once, not one at a time.

Nightly publishes from `main` remain intentionally untouched — they are the designed exception per the release guide.

## Changes

- `package.json`: version `4.24.0` → `1000.0.0`.
- `.github/workflows/publish-npm.yml`: new `Validate publish target` step, gated on `workflow_dispatch` with non-nightly `release-type`.
- `scripts/validate-publish-target.sh` (new): runs the three checks; exit `0` on success, `1` on validation failure, `2` on usage error.

## Test plan

- Locally: `./scripts/validate-publish-target.sh main stable` against current repo state → all three checks fail (sentinel + main + bad pattern), exit `1`.
- Locally: `./scripts/validate-publish-target.sh 4.25-stable stable` → sentinel check fires (`1000.0.0` on this branch), branch checks pass, exit `1`.
- Locally: invocation with missing args → usage error, exit `2`.
- Post-merge: run `publish-npm.yml` in dry-run against `main` with `release-type=stable` → expect the guard step to fail the workflow before the publish action runs.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes