### PR TITLE
fix(Android, FormSheet): Prioritize keyboard animation over content resize animation

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -279,7 +279,9 @@ class ScreenStackFragment :
                     override fun onPrepare(animation: WindowInsetsAnimationCompat) {
                         super.onPrepare(animation)
 
-                        sheetDelegate.notifyKeyboardAnimationStart()
+                        if ((animation.typeMask and WindowInsetsCompat.Type.ime()) != 0) {
+                            sheetDelegate.notifyKeyboardAnimationStart()
+                        }
                     }
 
                     // Replace InsetsAnimationCallback created by BottomSheetBehavior
@@ -300,7 +302,9 @@ class ScreenStackFragment :
                     override fun onEnd(animation: WindowInsetsAnimationCompat) {
                         super.onEnd(animation)
 
-                        sheetDelegate.notifyKeyboardAnimationEnd()
+                        if ((animation.typeMask and WindowInsetsCompat.Type.ime()) != 0) {
+                            sheetDelegate.notifyKeyboardAnimationEnd()
+                        }
 
                         screen.onSheetYTranslationChanged()
                     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -276,6 +276,12 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP,
                 ) {
+                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                        super.onPrepare(animation)
+
+                        sheetDelegate.notifyKeyboardAnimationStart()
+                    }
+
                     // Replace InsetsAnimationCallback created by BottomSheetBehavior
                     // to avoid interfering with custom animations.
                     // See: https://github.com/software-mansion/react-native-screens/pull/2909
@@ -293,6 +299,8 @@ class ScreenStackFragment :
 
                     override fun onEnd(animation: WindowInsetsAnimationCompat) {
                         super.onEnd(animation)
+
+                        sheetDelegate.notifyKeyboardAnimationEnd()
 
                         screen.onSheetYTranslationChanged()
                     }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -23,7 +23,9 @@ internal class SheetAnimationCoordinator(
         checkNotNull(screenRef.get()) {
             "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
         }
-    private var isKeyboardAnimationInProgress: Boolean = false
+    private var activeKeyboardAnimationsCount: Int = 0
+    private val isKeyboardAnimationInProgress: Boolean
+        get() = activeKeyboardAnimationsCount > 0
     private var isSheetAnimationInProgress: Boolean = false
     private var currentContentAnimator: ValueAnimator? = null
 
@@ -209,11 +211,11 @@ internal class SheetAnimationCoordinator(
     }
 
     internal fun notifyKeyboardAnimationStart() {
-        isKeyboardAnimationInProgress = true
+        activeKeyboardAnimationsCount++
     }
 
     internal fun notifyKeyboardAnimationEnd() {
-        isKeyboardAnimationInProgress = false
+        activeKeyboardAnimationsCount = maxOf(0, activeKeyboardAnimationsCount - 1)
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -23,6 +23,7 @@ internal class SheetAnimationCoordinator(
         checkNotNull(screenRef.get()) {
             "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
         }
+    private var isKeyboardAnimationInProgress: Boolean = false
     private var isSheetAnimationInProgress: Boolean = false
     private var currentContentAnimator: ValueAnimator? = null
 
@@ -99,7 +100,7 @@ internal class SheetAnimationCoordinator(
         // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
         // Silently update behavior metrics and re-layout so the ongoing slide animation
         // lands at the correct final geometry, without firing a competing animation.
-        if (isSheetAnimationInProgress) {
+        if (isSheetAnimationInProgress || isKeyboardAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
             screen.layoutBottomSheetAtHeight(clampedNewHeight)
             screen.finalizeBottomSheetLayoutUpdates()
@@ -205,6 +206,14 @@ internal class SheetAnimationCoordinator(
                 addUpdateListener { screen.translationY = it.animatedValue as Float }
                 start()
             }
+    }
+
+    internal fun notifyKeyboardAnimationStart() {
+        isKeyboardAnimationInProgress = true
+    }
+
+    internal fun notifyKeyboardAnimationEnd() {
+        isKeyboardAnimationInProgress = false
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -99,8 +99,9 @@ internal class SheetAnimationCoordinator(
         val clampedOldHeight = screen.resolveClampedHeight(oldHeight, currentTranslationY)
         val clampedNewHeight = screen.resolveClampedHeight(newHeight, currentTranslationY)
 
-        // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
-        // Silently update behavior metrics and re-layout so the ongoing slide animation
+        // If an entry/exit animation or a keyboard animation is in progress - it owns
+        // translationY writes. Then when the content size is changing, we silently
+        // update behavior metrics and re-layout so the ongoing slide animation
         // lands at the correct final geometry, without firing a competing animation.
         if (isSheetAnimationInProgress || isKeyboardAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -443,11 +443,9 @@ class SheetDelegate(
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) =
         screen.sheetAnimationCoordinator.handleKeyboardInsetsProgress(insets)
 
-    internal fun notifyKeyboardAnimationStart() =
-        screen.sheetAnimationCoordinator.notifyKeyboardAnimationStart()
+    internal fun notifyKeyboardAnimationStart() = screen.sheetAnimationCoordinator.notifyKeyboardAnimationStart()
 
-    internal fun notifyKeyboardAnimationEnd() =
-        screen.sheetAnimationCoordinator.notifyKeyboardAnimationEnd()
+    internal fun notifyKeyboardAnimationEnd() = screen.sheetAnimationCoordinator.notifyKeyboardAnimationEnd()
 
     private inner class KeyboardHandler : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -443,6 +443,12 @@ class SheetDelegate(
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) =
         screen.sheetAnimationCoordinator.handleKeyboardInsetsProgress(insets)
 
+    internal fun notifyKeyboardAnimationStart() =
+        screen.sheetAnimationCoordinator.notifyKeyboardAnimationStart()
+
+    internal fun notifyKeyboardAnimationEnd() =
+        screen.sheetAnimationCoordinator.notifyKeyboardAnimationEnd()
+
     private inner class KeyboardHandler : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(
             bottomSheet: View,


### PR DESCRIPTION
## Description

This PR fixes a snap back that occurs in FormSheet for the following combination:
- fitToContents
- TextInput
- SafeAreaView
- sheetResizeAnimationEnabled: true

There was a race condition between the keyboard insets animation (moving the FormSheet above the keyboard) and the sheet's content resize animation (caused by ignoring the bottom inset when the IME is present, because the FormSheet will be moved above the navigation bar). When the keyboard slides in, RN will recalculate the layout (sheet's height changed, because of the ignored bottom inset). This layout change triggers `updateSheetContentHeightWithAnimation` in the SheetAnimationCoordinator, and two animations try to update properties at the same time.

I think that the simplest solution is to let the keyboard animation set the sheet position without interference from the content resize animator by the time the keyboard slides in.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1170

## Changes

- Introduced an `isKeyboardAnimationInProgress` flag.
- Added `onPrepare` and `onEnd` overrides to notify the keyboard animation state.
- Updated `updateSheetContentHeightWithAnimation` - if a keyboard animation is in progress, it now silently updates the bottom sheet metrics and layout without firing a competing ValueAnimator.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/1adfe76c-ff68-4fd8-b97b-13da8488d4ff" /> | <video src="https://github.com/user-attachments/assets/c7c1b77b-085a-4d78-a68a-458def1ece6e" /> |

## Test plan

Test3336 - FormSheetWithFitToContentsWithTextInput case

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
