### PR TITLE
refactor(Example): TabsContainer and StackContainer refactor

### DIFF
--- a/apps/src/shared/gamma/containers/shared/use-components-by-name.ts
+++ b/apps/src/shared/gamma/containers/shared/use-components-by-name.ts
@@ -1,0 +1,17 @@
+import React, { useMemo } from 'react';
+import type { StackRouteConfig } from '../stack';
+import type { TabRouteConfig } from '../tabs';
+
+export const useComponentsByName = (
+  routeConfigs: StackRouteConfig[] | TabRouteConfig[],
+) => {
+  return useMemo(() => {
+    const map = new Map<string, React.ComponentType>();
+
+    for (const config of routeConfigs) {
+      map.set(config.name, config.Component);
+    }
+
+    return map;
+  }, [routeConfigs]);
+};

--- a/apps/src/shared/gamma/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.tsx
@@ -25,6 +25,14 @@ import { useParentNavigationEffect } from './hooks/useParentNavigationEffect';
 export function StackContainer({ routeConfigs }: StackContainerProps) {
   useSanitizeRouteConfigs(routeConfigs);
 
+  const componentsByName = React.useMemo(() => {
+    const map = new Map<string, StackRouteConfig['Component']>();
+    for (const config of routeConfigs) {
+      map.set(config.name, config.Component);
+    }
+    return map;
+  }, [routeConfigs]);
+
   const [stackNavState, navActionDispatch]: [
     StackNavigationState,
     React.Dispatch<NavigationAction>,
@@ -73,16 +81,12 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
             setRouteOptions: navMethods.setRouteOptions,
           };
 
-          const matchingConfig = routeConfigs.find(
-            config => config.name === name,
-          );
-          if (!matchingConfig) {
+          const Component = componentsByName.get(name);
+          if (!Component) {
             throw new Error(
               `[Stack] No config matches the "${name}" route name`,
             );
           }
-
-          const Component = matchingConfig.Component;
 
           return (
             <Stack.Screen

--- a/apps/src/shared/gamma/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.tsx
@@ -62,7 +62,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
   return (
     <Stack.Host ref={hostRef}>
       {stackNavState.stack.map(
-        ({ Component, options: { headerConfig, ...options }, activityMode, routeKey }) => {
+        ({ options: { headerConfig, ...options }, activityMode, routeKey, name }) => {
           const stackNavigationContext: StackNavigationContextPayload = {
             routeKey,
             routeOptions: { ...options },
@@ -72,6 +72,17 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
             batch: navMethods.batchAction,
             setRouteOptions: navMethods.setRouteOptions,
           };
+
+          const matchingConfig = routeConfigs.find(
+            config => config.name === name,
+          );
+          if (!matchingConfig) {
+            throw new Error(
+              `[Stack] No config matches the "${name}" route name`,
+            );
+          }
+
+          const Component = matchingConfig.Component;
 
           return (
             <Stack.Screen

--- a/apps/src/shared/gamma/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.tsx
@@ -21,17 +21,12 @@ import {
   useRenderDebugInfo,
 } from 'react-native-screens/private';
 import { useParentNavigationEffect } from './hooks/useParentNavigationEffect';
+import { useComponentsByName } from '../shared/use-components-by-name';
 
 export function StackContainer({ routeConfigs }: StackContainerProps) {
   useSanitizeRouteConfigs(routeConfigs);
 
-  const componentsByName = React.useMemo(() => {
-    const map = new Map<string, StackRouteConfig['Component']>();
-    for (const config of routeConfigs) {
-      map.set(config.name, config.Component);
-    }
-    return map;
-  }, [routeConfigs]);
+  const componentsByName = useComponentsByName(routeConfigs);
 
   const [stackNavState, navActionDispatch]: [
     StackNavigationState,

--- a/apps/src/shared/gamma/containers/stack/StackContainer.types.ts
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.types.ts
@@ -25,7 +25,7 @@ export type StackRouteConfig = {
 export type StackRoute = Omit<StackRouteConfig, 'Component'> & {
   activityMode: StackScreenProps['activityMode'];
   routeKey: StackScreenProps['screenKey'];
-  isMarkedForDismissal: Boolean; // whether this route is during or after dismissal process
+  isMarkedForDismissal: boolean; // whether this route is during or after dismissal process
 };
 
 /// StackContainer props

--- a/apps/src/shared/gamma/containers/stack/StackContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/stack/StackContainer.types.tsx
@@ -22,7 +22,7 @@ export type StackRouteConfig = {
   options: StackRouteOptions;
 };
 
-export type StackRoute = StackRouteConfig & {
+export type StackRoute = Omit<StackRouteConfig, 'Component'> & {
   activityMode: StackScreenProps['activityMode'];
   routeKey: StackScreenProps['screenKey'];
   isMarkedForDismissal: Boolean; // whether this route is during or after dismissal process

--- a/apps/src/shared/gamma/containers/stack/reducer.tsx
+++ b/apps/src/shared/gamma/containers/stack/reducer.tsx
@@ -270,8 +270,10 @@ function createRouteFromConfig(
   config: StackRouteConfig,
   activityMode: StackScreenActivityMode = 'detached',
 ): StackRoute {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { Component, ...rest } = config;
   return {
-    ...config,
+    ...rest,
     activityMode,
     routeKey: generateRouteKeyForRouteName(config.name),
     isMarkedForDismissal: false,

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -34,6 +34,14 @@ export function TabsContainer(props: TabsContainerProps) {
 
   useSanitizeRouteConfigs(routeConfigs);
 
+  const componentsByName = React.useMemo(() => {
+    const map = new Map<string, TabRouteConfig['Component']>();
+    for (const config of routeConfigs) {
+      map.set(config.name, config.Component);
+    }
+    return map;
+  }, [routeConfigs]);
+
   const [tabsNavState, dispatch]: [
     TabsContainerState,
     React.Dispatch<TabsNavigationAction>,
@@ -84,16 +92,12 @@ export function TabsContainer(props: TabsContainerProps) {
         const pendingForUpdate =
           route.routeKey === tabsNavState.suggestedState.selectedRouteKey;
 
-        const matchingConfig = routeConfigs.find(
-          config => config.name === route.name,
-        );
-        if (!matchingConfig) {
+        const Component = componentsByName.get(route.name);
+        if (!Component) {
           throw new Error(
             `[Tabs] None config matches the "${route.name}" route name`,
           );
         }
-
-        const Component = matchingConfig.Component;
 
         return (
           <TabsContainerItem

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -85,11 +85,11 @@ export function TabsContainer(props: TabsContainerProps) {
           route.routeKey === tabsNavState.suggestedState.selectedRouteKey;
 
         const matchingConfig = routeConfigs.find(
-          config => config.name === route.routeKey,
+          config => config.name === route.name,
         );
         if (!matchingConfig) {
           throw new Error(
-            `[Tabs] None config matches the "${route.routeKey}" routeKey`,
+            `[Tabs] None config matches the "${route.name}" route name`,
           );
         }
 

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -90,7 +90,7 @@ export function TabsContainer(props: TabsContainerProps) {
         const Component = componentsByName.get(route.name);
         if (!Component) {
           throw new Error(
-            `[Tabs] None config matches the "${route.name}" route name`,
+            `[Tabs] No route config matches the "${route.name}" route name`,
           );
         }
 

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -84,7 +84,27 @@ export function TabsContainer(props: TabsContainerProps) {
         const pendingForUpdate =
           route.routeKey === tabsNavState.suggestedState.selectedRouteKey;
 
-        return <TabsContainerItem key={route.routeKey} route={route} navMethods={navMethods} isSelected={isSelected} pendingForUpdate={pendingForUpdate} />
+        const matchingConfig = routeConfigs.find(
+          config => config.name === route.routeKey,
+        );
+        if (!matchingConfig) {
+          throw new Error(
+            `[Tabs] None config matches the "${route.routeKey}" routeKey`,
+          );
+        }
+
+        const Component = matchingConfig.Component;
+
+        return (
+          <TabsContainerItem
+            key={route.routeKey}
+            route={route}
+            navMethods={navMethods}
+            isSelected={isSelected}
+            pendingForUpdate={pendingForUpdate}
+            Component={Component}
+          />
+        );
       })}
     </Tabs.Host>
   );

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.tsx
@@ -21,6 +21,7 @@ import {
 } from './reducer';
 import { RNSLog } from 'react-native-screens/private';
 import { TabsContainerItem } from './TabsContainerItem';
+import { useComponentsByName } from '../shared/use-components-by-name';
 
 export function TabsContainer(props: TabsContainerProps) {
   RNSLog.info('TabsContainer render');
@@ -34,13 +35,7 @@ export function TabsContainer(props: TabsContainerProps) {
 
   useSanitizeRouteConfigs(routeConfigs);
 
-  const componentsByName = React.useMemo(() => {
-    const map = new Map<string, TabRouteConfig['Component']>();
-    for (const config of routeConfigs) {
-      map.set(config.name, config.Component);
-    }
-    return map;
-  }, [routeConfigs]);
+  const componentsByName = useComponentsByName(routeConfigs);
 
   const [tabsNavState, dispatch]: [
     TabsContainerState,

--- a/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainer.types.tsx
@@ -27,7 +27,7 @@ export type TabRouteConfig = {
 /**
  * Runtime instance of a tab route. Created from a TabRouteConfig blueprint.
  */
-export type TabRoute = TabRouteConfig & {
+export type TabRoute = Omit<TabRouteConfig, 'Component'> & {
   routeKey: string;
 };
 

--- a/apps/src/shared/gamma/containers/tabs/TabsContainerItem.tsx
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainerItem.tsx
@@ -37,7 +37,7 @@ function TabsContainerItemImpl(props: TabsContainerItemProps) {
       {...nativeOptions}
       screenKey={screenKey}>
       <TabsNavigationContext value={tabsNavigationContext}>
-        {getContent(props.route.Component, safeAreaConfiguration)}
+        {getContent(props.Component, safeAreaConfiguration)}
       </TabsNavigationContext>
     </Tabs.Screen>
   );

--- a/apps/src/shared/gamma/containers/tabs/TabsContainerItem.types.ts
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainerItem.types.ts
@@ -5,5 +5,6 @@ export type TabsContainerItemProps = {
   navMethods: TabsNavigationMethods;
   isSelected: boolean;
   pendingForUpdate: boolean;
+  Component: React.ComponentType;
 }
 

--- a/apps/src/shared/gamma/containers/tabs/TabsContainerItem.types.ts
+++ b/apps/src/shared/gamma/containers/tabs/TabsContainerItem.types.ts
@@ -1,4 +1,5 @@
 import type { TabRoute, TabsNavigationMethods } from './TabsContainer.types';
+import React from 'react';
 
 export type TabsContainerItemProps = {
   route: TabRoute;
@@ -6,5 +7,4 @@ export type TabsContainerItemProps = {
   isSelected: boolean;
   pendingForUpdate: boolean;
   Component: React.ComponentType;
-}
-
+};

--- a/apps/src/shared/gamma/containers/tabs/reducer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/reducer.tsx
@@ -135,8 +135,10 @@ function tabsActionSetOptionsHandler(
 }
 
 function createTabRouteFromConfig(config: TabRouteConfig): TabRoute {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { Component, ...rest } = config;
   return {
-    ...config,
+    ...rest,
     // Tab names are required to be unique (enforced by useSanitizeRouteConfigs),
     // so the name itself serves as a stable unique key.
     routeKey: config.name,
@@ -205,4 +207,3 @@ function navStateWithConfirmedState(
     suggestedState: state.suggestedState,
   };
 }
-


### PR DESCRIPTION
## Description

Previously, we were storing the actual React Component references directly inside the `useReducer` state (within `TabRoute` and `StackRoute` objects). This PR separates the navigation state from the Components. During the render phase, the containers dynamically resolve the correct Component by matching the route name from the state against a `componentsByName` Map (built via `useMemo` from the `routeConfigs` prop), rather than storing Component references in reducer state.

There is one issue related to `StackContainer`: often in our environment, we wrap `StackContainer` in an intermediate component (e.g. `StackSetup`) to consume contexts such as `useToast()`. If that wrapper is not explicitly exported from its file, Fast Refresh causes `useReducer` inside `StackContainer` to re-fire its initialization function, resetting the stack to the first screen. This issue will be solved in a separate PR.

## Changes

- Update `TabRoute` and `StackRoute` types to omit `Component` from the route state
- Update `TabsContainer` and `StackContainer` to resolve components via a `componentsByName` Map during render

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes