### PR TITLE
refactor(test): Changing android emulator for e2e workflow from pixel_2 to pixel_9 

### DIFF
--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_2
+          profile: pixel_9
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false
@@ -110,7 +110,7 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_2
+          profile: pixel_9
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false


### PR DESCRIPTION
## Description

Updated the Android E2E workflow emulator from Pixel 2 to Pixel 9.

The lower resolution of the Pixel 2 (1080x1920) appeared to be a likely source of test instability, as limited screen real estate often resulted in elements overlapping or being cut off. We believe that switching to the Pixel 9 (1080x2424) will improve E2E reliability by providing a larger, more modern viewport. However, we are still monitoring the results to confirm if this change fully addresses the flakiness of the tests.

## Changes

- android-e2e-test-fabric.yml: Changed profile from pixel_2 to pixel_9.