### PR TITLE
fix(Android, Stack v5): prevent crash when subview with (0, 0) size is added to small header

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt
@@ -68,13 +68,9 @@ class StackHeaderSubview(
             }
         }
 
-        if (yogaWidth > 0 && yogaHeight > 0) {
-            setMeasuredDimension(yogaWidth, yogaHeight)
-            if (invalidated && !isInLayout) {
-                requestLayout()
-            }
-        } else {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        setMeasuredDimension(yogaWidth, yogaHeight)
+        if (invalidated && !isInLayout) {
+            requestLayout()
         }
     }
 


### PR DESCRIPTION
## Description

Removes redundant `super.onMeasure` call to prevent crash when subview with `(0, 0)` size is added to `small` header.

### Reasoning

The super call is `ReactViewGroup.onMeasure` which basically does the same thing as the current implementation but without requesting layout:

```kotlin
  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
    assertExplicitMeasureSpec(widthMeasureSpec, heightMeasureSpec)

    setMeasuredDimension(
        MeasureSpec.getSize(widthMeasureSpec),
        MeasureSpec.getSize(heightMeasureSpec),
    )
```

If measure call from native platform goes to the React implementation, `assertExplicitMeasureSpec` causes a crash. By using our logic, we enforce sizing from Yoga which is the intended behavior.

## Changes

- remove `super.onMeasure` in `StackHeaderSubview.onMeasure`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/00588fa0-b6f2-4b1e-aee9-be13502bebc3" /> | <video src="https://github.com/user-attachments/assets/0b86cd28-9206-4aa1-86d9-2a94daff7344" /> |

## Test plan

Before running `TestStackSubviews` comment out the content of `PressableWithFeedback`:

<details>
<summary>Diff</summary>

```
diff --git a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
index 369eae025..5e3b74dfd 100644
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -140,9 +140,9 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
         <PressableWithFeedback
           hitSlop={hitSlop}
           pressRetentionOffset={pressRetentionOffset}>
-          <View style={{ width: dims.width, height: dims.height }}>
+          {/*<View style={{ width: dims.width, height: dims.height }}>
             <Text style={styles.subviewLabel}>{label}</Text>
-          </View>
+          </View>*/}
         </PressableWithFeedback>
       ),
     };
```

</details>

Change header to small and try to add any subview. The app should not crash.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
