### PR TITLE
feat(iOS): Enable synchronous screen shadow state updates by default

### DIFF
--- a/FabricExample/App.tsx
+++ b/FabricExample/App.tsx
@@ -1,7 +1,7 @@
 import App from '../apps';
 import { featureFlags } from 'react-native-screens';
 
-featureFlags.experiment.synchronousScreenUpdatesEnabled = false;
+featureFlags.experiment.synchronousScreenUpdatesEnabled = true;
 featureFlags.experiment.synchronousHeaderConfigUpdatesEnabled = true;
 featureFlags.experiment.synchronousHeaderSubviewUpdatesEnabled = true;
 featureFlags.experiment.androidResetScreenShadowStateOnOrientationChangeEnabled =

--- a/apps/src/tests/issue-tests/Test2543.tsx
+++ b/apps/src/tests/issue-tests/Test2543.tsx
@@ -89,7 +89,6 @@ function FormSheet({ route }: StackNavigationProp) {
       </Text>
       <View
         style={{
-          flex: 1,
           alignItems: 'center',
           justifyContent: 'center',
           height: 180,
@@ -100,7 +99,6 @@ function FormSheet({ route }: StackNavigationProp) {
       </View>
       <View
         style={{
-          flex: 1,
           alignItems: 'center',
           justifyContent: 'center',
           height: 180,
@@ -112,7 +110,6 @@ function FormSheet({ route }: StackNavigationProp) {
       </View>
       <View
         style={{
-          flex: 1,
           alignItems: 'center',
           justifyContent: 'center',
           height: 200,

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -103,6 +103,7 @@ struct ContentWrapperBox {
   _sheetsScrollView = nil;
   _sheetContentHeight = 0.0;
   _markedForUnmountInCurrentTransaction = NO;
+  _synchronousShadowStateUpdatesEnabled = YES;
 }
 
 + (RNSViewInteractionManager *)viewInteractionManagerInstance

--- a/src/fabric/ModalScreenNativeComponent.ts
+++ b/src/fabric/ModalScreenNativeComponent.ts
@@ -121,7 +121,7 @@ export interface NativeProps extends ViewProps {
   leftScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSModalScreen', {

--- a/src/fabric/ScreenNativeComponent.ts
+++ b/src/fabric/ScreenNativeComponent.ts
@@ -121,7 +121,7 @@ export interface NativeProps extends ViewProps {
   leftScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
-  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, true>;
   androidResetScreenShadowStateOnOrientationChangeEnabled?: CT.WithDefault<
     boolean,
     true

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,4 +1,4 @@
-const RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT = false;
+const RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT = true;
 const RNS_SYNCHRONOUS_HEADER_CONFIG_STATE_UPDATES_DEFAULT = true;
 const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = true;
 const RNS_ANDROID_LEGACY_TOP_INSET_BEHAVIOR_DEFAULT = false;
@@ -195,6 +195,11 @@ export const featureFlags = {
    *  Flags to enable experimental features. These might be removed w/o notice or moved to stable.
    */
   experiment: {
+    /**
+     * Enables synchronous shadow state updates for Screen components on iOS
+     * (Fabric, RN 0.82+). On by default.
+     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
+     */
     get synchronousScreenUpdatesEnabled() {
       return synchronousScreenUpdatesAccessor.get();
     },

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -195,11 +195,6 @@ export const featureFlags = {
    *  Flags to enable experimental features. These might be removed w/o notice or moved to stable.
    */
   experiment: {
-    /**
-     * Enables synchronous shadow state updates for Screen components on iOS
-     * (Fabric, RN 0.82+). On by default.
-     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
-     */
     get synchronousScreenUpdatesEnabled() {
       return synchronousScreenUpdatesAccessor.get();
     },


### PR DESCRIPTION
## Description

This PR changes the default value for `synchronousScreenUpdatesEnabled` flag to `true`

## Changes

Updated default values for the flag in native hierarchy & JS.

## Before & after - visual documentation

N/A

## Test plan

See https://github.com/software-mansion/react-native-screens/pull/3282

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
