### PR TITLE
feat(iOS): Enable synchronous header config shadow state updates by default

### DIFF
--- a/FabricExample/App.tsx
+++ b/FabricExample/App.tsx
@@ -2,7 +2,7 @@ import App from '../apps';
 import { featureFlags } from 'react-native-screens';
 
 featureFlags.experiment.synchronousScreenUpdatesEnabled = false;
-featureFlags.experiment.synchronousHeaderConfigUpdatesEnabled = false;
+featureFlags.experiment.synchronousHeaderConfigUpdatesEnabled = true;
 featureFlags.experiment.synchronousHeaderSubviewUpdatesEnabled = false;
 featureFlags.experiment.androidResetScreenShadowStateOnOrientationChangeEnabled =
   true;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -70,6 +70,7 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
     _show = YES;
     _translucent = NO;
     _addedReactSubviewsInCurrentTransaction = false;
+    _synchronousShadowStateUpdatesEnabled = YES;
     _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});
     [self initProps];
   }

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -70,7 +70,6 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
     _show = YES;
     _translucent = NO;
     _addedReactSubviewsInCurrentTransaction = false;
-    _synchronousShadowStateUpdatesEnabled = YES;
     _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});
     [self initProps];
   }
@@ -83,6 +82,7 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   _reactSubviews = [NSMutableArray new];
   _backTitleVisible = YES;
   _blurEffect = RNSBlurEffectStyleNone;
+  _synchronousShadowStateUpdatesEnabled = YES;
 }
 
 RNS_IGNORE_SUPER_CALL_BEGIN
@@ -282,11 +282,10 @@ RNS_IGNORE_SUPER_CALL_END
         // in the image attribute not being updated. We manually set frame to the size of an image
         // in order to trigger proper reload that'd update the image attribute.
         RCTImageSource *imageSource = [RNSScreenStackHeaderConfig imageSourceFromImageView:imageView];
-        [imageView reactSetFrame:CGRectMake(
-                                     imageView.frame.origin.x,
-                                     imageView.frame.origin.y,
-                                     imageSource.size.width,
-                                     imageSource.size.height)];
+        [imageView reactSetFrame:CGRectMake(imageView.frame.origin.x,
+                                            imageView.frame.origin.y,
+                                            imageSource.size.width,
+                                            imageSource.size.height)];
       }
 
       UIImage *image = imageView.image;
@@ -848,13 +847,12 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
-  RCTAssert(
-      childComponentView.superview == nil,
-      @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
-      self,
-      childComponentView,
-      @(index),
-      @([childComponentView.superview tag]));
+  RCTAssert(childComponentView.superview == nil,
+            @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
+            self,
+            childComponentView,
+            @(index),
+            @([childComponentView.superview tag]));
 
   //  [_reactSubviews insertObject:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
   [self insertReactSubview:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
@@ -1131,23 +1129,21 @@ Class<RCTComponentViewProtocol> RNSScreenStackHeaderConfigCls(void)
 
 @implementation RCTConvert (RNSScreenStackHeader)
 
-RCT_ENUM_CONVERTER(
-    UISemanticContentAttribute,
-    (@{
-      @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
-      @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
-    }),
-    UISemanticContentAttributeUnspecified,
-    integerValue)
+RCT_ENUM_CONVERTER(UISemanticContentAttribute,
+                   (@{
+                     @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
+                     @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
+                   }),
+                   UISemanticContentAttributeUnspecified,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    UINavigationItemBackButtonDisplayMode,
-    (@{
-      @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
-      @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
-      @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
-    }),
-    UINavigationItemBackButtonDisplayModeDefault,
-    integerValue)
+RCT_ENUM_CONVERTER(UINavigationItemBackButtonDisplayMode,
+                   (@{
+                     @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
+                     @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
+                     @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
+                   }),
+                   UINavigationItemBackButtonDisplayModeDefault,
+                   integerValue)
 
 @end

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -80,7 +80,7 @@ export interface NativeProps extends ViewProps {
   onPressHeaderBarButtonMenuItem?:
     | CT.DirectEventHandler<OnPressHeaderBarButtonMenuItemEvent>
     | undefined;
-  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, true>;
 
   // Experimental
   userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,5 +1,5 @@
 const RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT = false;
-const RNS_SYNCHRONOUS_HEADER_CONFIG_STATE_UPDATES_DEFAULT = false;
+const RNS_SYNCHRONOUS_HEADER_CONFIG_STATE_UPDATES_DEFAULT = true;
 const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = false;
 const RNS_ANDROID_LEGACY_TOP_INSET_BEHAVIOR_DEFAULT = false;
 const RNS_ANDROID_RESET_SCREEN_SHADOW_STATE_ON_ORIENTATION_CHANGE_DEFAULT =
@@ -201,6 +201,11 @@ export const featureFlags = {
     set synchronousScreenUpdatesEnabled(value: boolean) {
       synchronousScreenUpdatesAccessor.set(value);
     },
+    /**
+     * Enables synchronous shadow state updates for ScreenStackHeaderConfig
+     * on iOS (Fabric, RN 0.82+). On by default.
+     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
+     */
     get synchronousHeaderConfigUpdatesEnabled() {
       return synchronousHeaderConfigUpdatesAccessor.get();
     },

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -201,11 +201,6 @@ export const featureFlags = {
     set synchronousScreenUpdatesEnabled(value: boolean) {
       synchronousScreenUpdatesAccessor.set(value);
     },
-    /**
-     * Enables synchronous shadow state updates for ScreenStackHeaderConfig
-     * on iOS (Fabric, RN 0.82+). On by default.
-     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
-     */
     get synchronousHeaderConfigUpdatesEnabled() {
       return synchronousHeaderConfigUpdatesAccessor.get();
     },


### PR DESCRIPTION
## Description

This PR changes the default value for `synchronousHeaderConfigUpdatesEnabled` flag to true.

## Changes

Updated flag default, native and JS defaults

## Before & after - visual documentation

N/A

## Test plan

See #3282

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
