### PR TITLE
feat(iOS): Enable synchronous header subview shadow state updates by default

### DIFF
--- a/FabricExample/App.tsx
+++ b/FabricExample/App.tsx
@@ -3,7 +3,7 @@ import { featureFlags } from 'react-native-screens';
 
 featureFlags.experiment.synchronousScreenUpdatesEnabled = false;
 featureFlags.experiment.synchronousHeaderConfigUpdatesEnabled = true;
-featureFlags.experiment.synchronousHeaderSubviewUpdatesEnabled = false;
+featureFlags.experiment.synchronousHeaderSubviewUpdatesEnabled = true;
 featureFlags.experiment.androidResetScreenShadowStateOnOrientationChangeEnabled =
   true;
 featureFlags.experiment.iosPreventReattachmentOfDismissedScreens = true;

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2156,7 +2156,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: dfb9ab6ee2eac316f7869edf6ec27b9e872329f0
-  hermes-engine: 2f2ffe03fec9edfd45418f6e7701497449e8e918
+  hermes-engine: 525c2ec8932d29cc643fb67688830626b30a38df
   RCTDeprecation: df7412cdad525035c3adeb14c1dc35b344e98187
   RCTRequired: 28a4bf1ef190650fcd6973d8a6a8f8beb30ef807
   RCTSwiftUI: 3003f1af83c332be5946ec0433fedcf0ada06551
@@ -2227,7 +2227,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 706b65371b90b5cc797b6639e8979f2e5cecd6da
   ReactCodegen: 3b63446e22acfdafa14e48a23c4a34b3ec99215e
   ReactCommon: d588ff8119315f4d3341e06f954e60789b050710
-  ReactNativeDependencies: c52d241ee664599a6b536f2bd4576a2c2a26a9b5
+  ReactNativeDependencies: dca9d27cd6cae2415902174a647ab59dc8575e32
   RNGestureHandler: 6c55d44ca01fff875b82ee7a9dee86a7aa9fa563
   RNReanimated: 371d8a67ea2cf7a2608d97fd990c3ac1b6994cfb
   RNScreens: 60f2260949e6f9cc35cd76c506a3475bec919ca6

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2156,7 +2156,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: dfb9ab6ee2eac316f7869edf6ec27b9e872329f0
-  hermes-engine: 525c2ec8932d29cc643fb67688830626b30a38df
+  hermes-engine: 2f2ffe03fec9edfd45418f6e7701497449e8e918
   RCTDeprecation: df7412cdad525035c3adeb14c1dc35b344e98187
   RCTRequired: 28a4bf1ef190650fcd6973d8a6a8f8beb30ef807
   RCTSwiftUI: 3003f1af83c332be5946ec0433fedcf0ada06551
@@ -2227,7 +2227,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 706b65371b90b5cc797b6639e8979f2e5cecd6da
   ReactCodegen: 3b63446e22acfdafa14e48a23c4a34b3ec99215e
   ReactCommon: d588ff8119315f4d3341e06f954e60789b050710
-  ReactNativeDependencies: dca9d27cd6cae2415902174a647ab59dc8575e32
+  ReactNativeDependencies: c52d241ee664599a6b536f2bd4576a2c2a26a9b5
   RNGestureHandler: 6c55d44ca01fff875b82ee7a9dee86a7aa9fa563
   RNReanimated: 371d8a67ea2cf7a2608d97fd990c3ac1b6994cfb
   RNScreens: 60f2260949e6f9cc35cd76c506a3475bec919ca6

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -116,6 +116,7 @@ namespace react = facebook::react;
     static const auto defaultProps = std::make_shared<const react::RNSScreenStackHeaderSubviewProps>();
     _props = defaultProps;
     _lastScheduledFrame = CGRectZero;
+    _synchronousShadowStateUpdatesEnabled = YES;
   }
 
   return self;

--- a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
@@ -14,7 +14,7 @@ export type HeaderSubviewTypes =
 export interface NativeProps extends ViewProps {
   type?: CT.WithDefault<HeaderSubviewTypes, 'left'>;
   hidesSharedBackground?: boolean | undefined;
-  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+  synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,6 +1,6 @@
 const RNS_SYNCHRONOUS_SCREEN_STATE_UPDATES_DEFAULT = false;
 const RNS_SYNCHRONOUS_HEADER_CONFIG_STATE_UPDATES_DEFAULT = true;
-const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = false;
+const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = true;
 const RNS_ANDROID_LEGACY_TOP_INSET_BEHAVIOR_DEFAULT = false;
 const RNS_ANDROID_RESET_SCREEN_SHADOW_STATE_ON_ORIENTATION_CHANGE_DEFAULT =
   true;
@@ -207,6 +207,11 @@ export const featureFlags = {
     set synchronousHeaderConfigUpdatesEnabled(value: boolean) {
       synchronousHeaderConfigUpdatesAccessor.set(value);
     },
+    /**
+     * Enables synchronous shadow state updates for ScreenStackHeaderSubview
+     * on iOS (Fabric, RN 0.82+). On by default.
+     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
+     */
     get synchronousHeaderSubviewUpdatesEnabled() {
       return synchronousHeaderSubviewUpdatesAccessor.get();
     },

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -207,11 +207,6 @@ export const featureFlags = {
     set synchronousHeaderConfigUpdatesEnabled(value: boolean) {
       synchronousHeaderConfigUpdatesAccessor.set(value);
     },
-    /**
-     * Enables synchronous shadow state updates for ScreenStackHeaderSubview
-     * on iOS (Fabric, RN 0.82+). On by default.
-     * PR: https://github.com/software-mansion/react-native-screens/pull/3282
-     */
     get synchronousHeaderSubviewUpdatesEnabled() {
       return synchronousHeaderSubviewUpdatesAccessor.get();
     },


### PR DESCRIPTION
## Description

This PR changes the default value for `synchronousHeaderSubviewUpdatesEnabled` flag to `true`


## Changes

Updated flag defaults, native & JS initialization

## Before & after - visual documentation

N/A

## Test plan

See #3282 

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
