### PR TITLE
docs(agents): add build & run section, list TVOSExample

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,57 @@ such as stack, tabs, split.
 - `./FabricExample/` - contains an example application, we use it to showcase the library
   capabilities and test the library. It is not published as part of the package.
 
+- `./TVOSExample/` - tvOS example application, used to exercise the library on
+  Apple TV. Like `FabricExample`, it consumes the shared sources from `./apps/`
+  via path aliases. Not published as part of the package.
+
 - `./apps/` - extracted JS (react-native) code of the `FabricExample` application;
   this is done to share the code with other example applications in the repository.
 
 - `./react-navigation/` - this is a git submodule for a downstream library providing
   a complete navigation solution. It is not part of the library.
+
+## Build & run
+
+### Prerequisites
+
+- `yarn install` — installs JS dependencies. Triggers the `prepare` lifecycle
+  hook, which builds the library to `./lib/` (see below).
+- `yarn submodules` — initializes and builds the `react-navigation` git
+  submodule. Only needed when working against that downstream library; not
+  required to build or type-check the screens library itself.
+
+### Build the library
+
+```bash
+yarn prepare
+```
+
+Runs `bob build` (`react-native-builder-bob`) and `husky install`. Outputs:
+
+- `./lib/commonjs/` — CommonJS build
+- `./lib/module/` — ES module build
+- `./lib/typescript/` — `.d.ts` declarations (built via `tsconfig.build.json`)
+
+Source of truth is `./src/` (see `react-native-builder-bob` config in
+`package.json`).
+
+### Verify TypeScript
+
+Library:
+
+```bash
+yarn check-types
+```
+
+Runs `tsc --noEmit` against the root `tsconfig.json` (covers `./src/`).
+
+> Type-checking the example apps directly (`FabricExample/`, `TVOSExample/`,
+> `apps/`) is intentionally not documented here yet. Each app's `tsconfig.json`
+> currently surfaces a different set of pre-existing errors when run on its
+> own, and there are no `check-types` scripts in the example app
+> `package.json` files. This will be documented once the underlying issues
+> are resolved and a single entry point exists.
 
 ## Code conventions
 
@@ -37,7 +83,7 @@ such as stack, tabs, split.
 ## Imports
 
 - Use relative imports within library packages (`./src/`).
-- Use path aliases (`@apps/*`, `@assets/*`) only in example apps (`./apps/`, `./FabricExample/`).
+- Use path aliases (`@apps/*`, `@assets/*`) only in example apps (`./apps/`, `./FabricExample/`, `./TVOSExample/`).
 - Never use absolute paths from project root as import paths.
 
 ## Git & refactoring


### PR DESCRIPTION
## Description

Adds a `## Build & run` section to `AGENTS.md` covering prerequisites, the library build (`yarn prepare`), and library TypeScript verification (`yarn check-types`). Also fixes `## Repository layout tips` so that `./TVOSExample/` is listed alongside `./FabricExample/`, and updates the `## Imports` section so TVOSExample is included in the path-alias rule.

The `Verify TypeScript` subsection is intentionally library-only for now. Per-example tsconfig runs (`FabricExample/`, `TVOSExample/`, `apps/`) currently surface different sets of pre-existing errors when invoked directly, and there are no `check-types` scripts in the example app `package.json` files. Documenting them today would point agents at red baselines and teach them to ignore TS errors. A short caveat in the section records this; the example app surface will be documented once the underlying issues are resolved and a single entry point exists.

## Changes

- Added `## Build & run` section to `AGENTS.md` with three subsections:
  - **Prerequisites** — `yarn install`, `yarn submodules`.
  - **Build the library** — `yarn prepare` and the resulting outputs under `./lib/`.
  - **Verify TypeScript** — `yarn check-types` plus a caveat explaining why example-app TS verification is not documented yet.
- Added `./TVOSExample/` bullet to `## Repository layout tips`.
- Added `./TVOSExample/` to the path-alias consumers list under `## Imports`.

## Test plan

- `yarn check-types` runs cleanly on this branch (the only command newly documented in the `Verify TypeScript` subsection).
- `yarn prepare` was not re-run as part of this PR (no behavioral change to the build pipeline; the script is unchanged in `package.json`).
- No source code is modified; the diff is limited to `AGENTS.md`.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes