### PR TITLE
fix(FabricExample): Wrap some components with SAV to prevent hiding behind navigation bar

### DIFF
--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -8,10 +8,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
-import {
-  SafeAreaProvider,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-screens/experimental';
 
 interface ToastProps {
   index: number;
@@ -67,30 +64,6 @@ const ToastContext = createContext({
   },
 });
 
-const ToastContainer = ({
-  toasts,
-  remove,
-}: {
-  toasts: IToast[];
-  remove: (id: string) => void;
-}) => {
-  const insets = useSafeAreaInsets();
-
-  return (
-    <>
-      {toasts.map((toast, i) => (
-        <Toast
-          index={i}
-          key={toast.id}
-          style={{ bottom: insets.bottom + 5 + i * 25 }}
-          {...toast}
-          remove={remove}
-        />
-      ))}
-    </>
-  );
-};
-
 interface ToastProviderProps {
   children: React.ReactNode;
 }
@@ -108,15 +81,22 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   };
 
   return (
-    <SafeAreaProvider>
+    <SafeAreaView edges={{ bottom: true }}>
       <ToastContext.Provider value={{ push }}>
         <>
           {children}
-          {/* Render the internal container */}
-          <ToastContainer toasts={toasts} remove={remove} />
+          {toasts.map((toast, i) => (
+            <Toast
+              index={i}
+              key={toast.id}
+              style={{ marginBottom: i * 25 }}
+              {...toast}
+              remove={remove}
+            />
+          ))}
         </>
       </ToastContext.Provider>
-    </SafeAreaProvider>
+    </SafeAreaView>
   );
 };
 
@@ -127,6 +107,7 @@ const styles = StyleSheet.create({
     flex: 1,
     position: 'absolute',
     alignSelf: 'center',
+    bottom: 5,
   },
   alert: {
     alignItems: 'center',

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -6,6 +6,7 @@ import {
   Dimensions,
   View,
   ViewStyle,
+  Platform,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
 import { SafeAreaView } from 'react-native-screens/experimental';
@@ -81,7 +82,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   };
 
   return (
-    <SafeAreaView edges={{ bottom: true }}>
+    <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
       <ToastContext.Provider value={{ push }}>
         <>
           {children}

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo } from 'react';
-import { Platform, ScrollView } from 'react-native';
-import {
-  SafeAreaProvider,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { ScrollView } from 'react-native';
 import type { Scenario, ScenarioGroup } from './helpers';
 import { ScenarioButton } from './ScenarioButton';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -11,19 +7,15 @@ import {
   NavigationContainer,
   NavigationIndependentTree,
 } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-screens/experimental';
 
 function ScenarioSelect(props: {
   scenarios: Record<string, Scenario>;
   groupName: string;
 }) {
-  const insets = useSafeAreaInsets();
-
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{
-        paddingBottom: Platform.OS === 'android' ? insets.bottom : 0,
-      }}
       testID={`${props.groupName}-scenarios-scrollview`}>
       {Object.values(props.scenarios).map(
         ({ scenarioDescription }: Scenario) => {
@@ -50,40 +42,40 @@ export default function ScenarioSelectionScreen(props: {
   const Stack = useMemo(() => createNativeStackNavigator(), []);
 
   return (
-    <NavigationIndependentTree>
-      <NavigationContainer>
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen
-            key="Main"
-            name="Main"
-            options={{
-              headerShown: true,
-              headerLargeTitleEnabled: true,
-              headerTitle: props.scenarioGroup.name,
-            }}>
-            {() => (
-              <SafeAreaProvider>
+    <SafeAreaView edges={{ bottom: true }}>
+      <NavigationIndependentTree>
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen
+              key="Main"
+              name="Main"
+              options={{
+                headerShown: true,
+                headerLargeTitleEnabled: true,
+                headerTitle: props.scenarioGroup.name,
+              }}>
+              {() => (
                 <ScenarioSelect
                   scenarios={props.scenarioGroup.scenarios}
                   groupName={props.scenarioGroup.name}
                 />
-              </SafeAreaProvider>
+              )}
+            </Stack.Screen>
+            {Object.values<Scenario>(props.scenarioGroup.scenarios).map(
+              (ScenarioComponent: Scenario) => {
+                const { key } = ScenarioComponent.scenarioDescription;
+                return (
+                  <Stack.Screen
+                    key={key}
+                    name={key}
+                    component={ScenarioComponent}
+                  />
+                );
+              },
             )}
-          </Stack.Screen>
-          {Object.values<Scenario>(props.scenarioGroup.scenarios).map(
-            (ScenarioComponent: Scenario) => {
-              const { key } = ScenarioComponent.scenarioDescription;
-              return (
-                <Stack.Screen
-                  key={key}
-                  name={key}
-                  component={ScenarioComponent}
-                />
-              );
-            },
-          )}
-        </Stack.Navigator>
-      </NavigationContainer>
-    </NavigationIndependentTree>
+          </Stack.Navigator>
+        </NavigationContainer>
+      </NavigationIndependentTree>
+    </SafeAreaView>
   );
 }

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -1,5 +1,9 @@
 import React, { useMemo } from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
+import {
+  SafeAreaProvider,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import type { Scenario, ScenarioGroup } from './helpers';
 import { ScenarioButton } from './ScenarioButton';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -12,9 +16,14 @@ function ScenarioSelect(props: {
   scenarios: Record<string, Scenario>;
   groupName: string;
 }) {
+  const insets = useSafeAreaInsets();
+
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={{
+        paddingBottom: Platform.OS === 'android' ? insets.bottom : 0,
+      }}
       testID={`${props.groupName}-scenarios-scrollview`}>
       {Object.values(props.scenarios).map(
         ({ scenarioDescription }: Scenario) => {
@@ -53,10 +62,12 @@ export default function ScenarioSelectionScreen(props: {
               headerTitle: props.scenarioGroup.name,
             }}>
             {() => (
-              <ScenarioSelect
-                scenarios={props.scenarioGroup.scenarios}
-                groupName={props.scenarioGroup.name}
-              />
+              <SafeAreaProvider>
+                <ScenarioSelect
+                  scenarios={props.scenarioGroup.scenarios}
+                  groupName={props.scenarioGroup.name}
+                />
+              </SafeAreaProvider>
             )}
           </Stack.Screen>
           {Object.values<Scenario>(props.scenarioGroup.scenarios).map(

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
 import type { Scenario, ScenarioGroup } from './helpers';
 import { ScenarioButton } from './ScenarioButton';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -42,7 +42,7 @@ export default function ScenarioSelectionScreen(props: {
   const Stack = useMemo(() => createNativeStackNavigator(), []);
 
   return (
-    <SafeAreaView edges={{ bottom: true }}>
+    <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
       <NavigationIndependentTree>
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>


### PR DESCRIPTION
## Description

Important for e2e tests. Some pressabels weren't working on Android 10, because were hidden behind old-style navigation bar. Also changing the approach for Toast https://github.com/software-mansion/react-native-screens/pull/3942 , becaue after internal discussion we decided that we shouldn't rely on `react-native-safe-area-context` and use our SAV with proper edges configuration.

## Changes

- add paddingBottom to ScrollView content
- revert changes from https://github.com/software-mansion/react-native-screens/pull/3942
- wrap ToastProvider with SAV

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <img width="592" height="1228" alt="Screenshot 2026-04-28 at 10 32 21" src="https://github.com/user-attachments/assets/7bfcfceb-cb7b-4c3a-a18d-0922aa7bf7e3" /> | <img width="610" height="1224" alt="Screenshot 2026-04-28 at 10 31 47" src="https://github.com/user-attachments/assets/6873399a-a591-49c4-bf89-04cb6634d431" /> |

## Test plan

ScrollView from SFT -> Tabs

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
