### PR TITLE
fix(iOS): unregister tabs accessory observer from observed wrapper

### DIFF
--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -8,8 +8,12 @@
 
 namespace react = facebook::react;
 
+static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAccessoryNativeWrapperViewContext;
+
 @implementation RNSTabsBottomAccessoryHelper {
   RNSTabsBottomAccessoryComponentView *__weak _bottomAccessoryView;
+  UIView *__weak _observedNativeWrapperView;
+  BOOL _isObservingNativeWrapperView;
 
 #if REACT_NATIVE_VERSION_MINOR < 82
   BOOL _initialStateUpdateSent;
@@ -35,6 +39,8 @@ namespace react = facebook::react;
 
 - (void)initState
 {
+  _observedNativeWrapperView = nil;
+  _isObservingNativeWrapperView = NO;
 #if REACT_NATIVE_VERSION_MINOR < 82
   _initialStateUpdateSent = NO;
   _displayLink = nil;
@@ -110,9 +116,36 @@ namespace react = facebook::react;
 
 #pragma mark - Observing frame changes
 
+- (void)unregisterForAccessoryFrameChanges
+{
+  UIView *observedNativeWrapperView = _observedNativeWrapperView;
+  if (!_isObservingNativeWrapperView || observedNativeWrapperView == nil) {
+    _observedNativeWrapperView = nil;
+    _isObservingNativeWrapperView = NO;
+    return;
+  }
+
+  [observedNativeWrapperView removeObserver:self
+                                 forKeyPath:@"center"
+                                    context:RNSTabsBottomAccessoryNativeWrapperViewContext];
+  _observedNativeWrapperView = nil;
+  _isObservingNativeWrapperView = NO;
+}
+
 - (void)registerForAccessoryFrameChanges
 {
-  [self.nativeWrapperView addObserver:self forKeyPath:@"center" options:NSKeyValueObservingOptionInitial context:nil];
+  UIView *nativeWrapperView = self.nativeWrapperView;
+  if (_isObservingNativeWrapperView && _observedNativeWrapperView == nativeWrapperView) {
+    return;
+  }
+
+  [self unregisterForAccessoryFrameChanges];
+  [nativeWrapperView addObserver:self
+                      forKeyPath:@"center"
+                         options:NSKeyValueObservingOptionInitial
+                         context:RNSTabsBottomAccessoryNativeWrapperViewContext];
+  _observedNativeWrapperView = nativeWrapperView;
+  _isObservingNativeWrapperView = YES;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
@@ -120,7 +153,11 @@ namespace react = facebook::react;
                         change:(NSDictionary *)change
                        context:(void *)context
 {
-  [self notifyWrapperViewFrameHasChanged];
+  if (context == RNSTabsBottomAccessoryNativeWrapperViewContext) {
+    [self notifyWrapperViewFrameHasChanged];
+  } else {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+  }
 }
 
 - (UIView *)nativeWrapperView
@@ -192,9 +229,7 @@ namespace react = facebook::react;
 {
   [_bottomAccessoryView unregisterForTraitChanges:_traitChangeRegistration];
   _traitChangeRegistration = nil;
-  // Using nativeWrapperView directly here to avoid failing RCTAssert in self.nativeWrapperView.
-  // If we're called from didMoveToWindow, it's not a problem, but I'm not sure if this will always be the case.
-  [_bottomAccessoryView.superview.superview removeObserver:self forKeyPath:@"center"];
+  [self unregisterForAccessoryFrameChanges];
   _bottomAccessoryView = nil;
 #if REACT_NATIVE_VERSION_MINOR < 82
   [self invalidateDisplayLink];

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -13,7 +13,6 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 @implementation RNSTabsBottomAccessoryHelper {
   RNSTabsBottomAccessoryComponentView *__weak _bottomAccessoryView;
   UIView *__weak _observedNativeWrapperView;
-  BOOL _isObservingNativeWrapperView;
 
 #if REACT_NATIVE_VERSION_MINOR < 82
   BOOL _initialStateUpdateSent;
@@ -40,7 +39,6 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 - (void)initState
 {
   _observedNativeWrapperView = nil;
-  _isObservingNativeWrapperView = NO;
 #if REACT_NATIVE_VERSION_MINOR < 82
   _initialStateUpdateSent = NO;
   _displayLink = nil;
@@ -119,9 +117,7 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 - (void)unregisterForAccessoryFrameChanges
 {
   UIView *observedNativeWrapperView = _observedNativeWrapperView;
-  if (!_isObservingNativeWrapperView || observedNativeWrapperView == nil) {
-    _observedNativeWrapperView = nil;
-    _isObservingNativeWrapperView = NO;
+  if (observedNativeWrapperView == nil) {
     return;
   }
 
@@ -129,13 +125,12 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
                                  forKeyPath:@"center"
                                     context:RNSTabsBottomAccessoryNativeWrapperViewContext];
   _observedNativeWrapperView = nil;
-  _isObservingNativeWrapperView = NO;
 }
 
 - (void)registerForAccessoryFrameChanges
 {
   UIView *nativeWrapperView = self.nativeWrapperView;
-  if (_isObservingNativeWrapperView && _observedNativeWrapperView == nativeWrapperView) {
+  if (_observedNativeWrapperView == nativeWrapperView) {
     return;
   }
 
@@ -145,7 +140,6 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
                          options:NSKeyValueObservingOptionInitial
                          context:RNSTabsBottomAccessoryNativeWrapperViewContext];
   _observedNativeWrapperView = nativeWrapperView;
-  _isObservingNativeWrapperView = YES;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath


### PR DESCRIPTION
## Description

Fixes a possible iOS 26 bottom accessory crash during invalidation.

The helper registers KVO for `center` on `self.nativeWrapperView`, but invalidation removed the observer from `_bottomAccessoryView.superview.superview` at teardown time. UIKit can detach or swap the bottom accessory wrapper before invalidation runs, so the teardown path may attempt to remove the observer from a different wrapper view and raise an `NSRangeException` because that object was never observed.

I do not see an existing issue for this exact stack, but we observed it in production on `react-native-screens` 4.23.0, and the same registration/removal pattern is present on current `main`.

## Changes

- Stores the exact native wrapper view that was registered for KVO.
- Makes `registerForAccessoryFrameChanges` idempotent for the same wrapper and unregisters the previous wrapper if the wrapper changes.
- Removes the observer from the stored observed wrapper during invalidation instead of resolving the current superview chain again.
- Uses a dedicated KVO context and forwards unrelated observations to `super`.

## Test plan

- `yarn install --immutable`
- `yarn prepare`
- `yarn check-types`
- `xcrun clang-format -i ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm`
- `git diff --check`

Existing examples that exercise bottom accessory behavior:

- `apps/src/tests/issue-tests/Test3288.tsx`
- `apps/src/tests/single-feature-tests/tabs/bottom-accessory-layout.tsx`

I did not add a JS unit test for this because the failure is caused by UIKit/KVO object identity during native view invalidation. A meaningful automated regression test would need a native iOS XCTest harness or an iOS integration/e2e test that drives bottom accessory mount, detach, and invalidation lifecycle. This repository does not appear to have an iOS native unit-test target for library internals today.

I attempted `yarn test:unit` after initializing the `react-navigation` submodule, but the root Jest command also collects the submodule's own test suites and fails on unrelated submodule Jest setup / React version issues before exercising this native change.

## Checklist

- [ ] Included code example that can be used to test this change. Existing bottom accessory examples are listed above; no new JS example was added for this native KVO lifecycle fix.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change. N/A, no visual changes.
- [x] For API changes, updated relevant public types. N/A, no API changes.
- [x] Ensured that CI passes
