### PR TITLE
refactor(tabs): split native nav state into state and update request

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -379,6 +379,9 @@ internal class TabsContainer(
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
                 actionOrigin =
                     if (isInExternalOperationContext) {
+                        check(pendingOperation != null && pendingOperation is TabSelectOp) {
+                            "[RNScreens] Unexpected pending operation $pendingOperation while in external operation context"
+                        }
                         (pendingOperation as TabSelectOp).request.actionOrigin
                     } else {
                         TabsActionOrigin.USER

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -77,7 +77,7 @@ internal class TabsContainer(
 
     internal val selectedTab: TabsScreenFragment
         get() =
-            checkNotNull(getFragmentForScreenKey(navState.selectedKey)) { "[RNScreens] No selected tab present" }
+            checkNotNull(getFragmentForScreenKey(navState.selectedScreenKey)) { "[RNScreens] No selected tab present" }
 
     internal val invalidationFlags = TabsContainerInvalidationFlags()
 
@@ -259,14 +259,14 @@ internal class TabsContainer(
         val tabSelectOp = pendingOperation as TabSelectOp
 
         val nextSelectedMenuItemId =
-            checkNotNull(getMenuItemIdForFragment(requireFragmentForScreenKey(tabSelectOp.navState.selectedKey))) {
-                "[RNScreens] Failed to find Menu Item for screenKey: ${tabSelectOp.navState.selectedKey}"
+            checkNotNull(getMenuItemIdForFragment(requireFragmentForScreenKey(tabSelectOp.request.selectedScreenKey))) {
+                "[RNScreens] Failed to find Menu Item for screenKey: ${tabSelectOp.request.selectedScreenKey}"
             }
 
-        if (rejectOpsWithStaleNavState && isNavStateStale(tabSelectOp.navState)) {
+        if (rejectOpsWithStaleNavState && isNavStateStale(tabSelectOp.request)) {
             delegate.onNavStateUpdateRejected(
                 navState,
-                tabSelectOp.navState,
+                tabSelectOp.request,
                 TabsNavStateUpdateRejectionReason.STALE,
             )
             pendingOperation = null
@@ -281,7 +281,7 @@ internal class TabsContainer(
         } else {
             delegate.onNavStateUpdateRejected(
                 navState,
-                tabSelectOp.navState,
+                tabSelectOp.request,
                 TabsNavStateUpdateRejectionReason.REPEATED,
             )
         }
@@ -328,7 +328,7 @@ internal class TabsContainer(
         val currentSelectedFragment = selectedTab
 
         if (nextSelectedFragment === currentSelectedFragment) {
-            progressNavigationState(navState.selectedKey)
+            progressNavigationState(navState.selectedScreenKey)
             return true
         }
 
@@ -343,8 +343,8 @@ internal class TabsContainer(
         return true
     }
 
-    private fun progressNavigationState(selectedKey: String) {
-        navState = TabsNavState(selectedKey, navState.provenance + 1)
+    private fun progressNavigationState(selectedScreenKey: String) {
+        navState = TabsNavState(selectedScreenKey, navState.provenance + 1)
         if (!isInExternalOperationContext) {
             lastUINavState = navState
         }
@@ -377,7 +377,12 @@ internal class TabsContainer(
                 navState,
                 isRepeated = isRepeated,
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
-                actionOrigin = if (isInExternalOperationContext) TabsActionOrigin.PROGRAMMATIC_JS else TabsActionOrigin.USER,
+                actionOrigin =
+                    if (isInExternalOperationContext) {
+                        (pendingOperation as TabSelectOp).request.actionOrigin
+                    } else {
+                        TabsActionOrigin.USER
+                    },
             )
         }
 
@@ -413,7 +418,7 @@ internal class TabsContainer(
 
     private fun getSelectedTabsScreenFragmentId(): Int? =
         tabsModel
-            .indexOfFirst { it.requireScreenKey == navState.selectedKey }
+            .indexOfFirst { it.requireScreenKey == navState.selectedScreenKey }
             .takeIf { it != -1 }
 
     private fun getMenuItemForTabsScreen(tabsScreen: TabsScreen): MenuItem? =
@@ -544,9 +549,9 @@ internal class TabsContainer(
         fragmentManager = null
     }
 
-    private fun isNavStateStale(state: TabsNavState): Boolean {
+    private fun isNavStateStale(request: TabsNavStateUpdateRequest): Boolean {
         if (navState.isEmpty() || lastUINavState.isEmpty()) return false
-        return state.provenance < lastUINavState.provenance
+        return request.baseProvenance < lastUINavState.provenance
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerDelegate.kt
@@ -24,12 +24,12 @@ internal interface TabsContainerDelegate {
      * Called when the container rejects a navigation state update.
      *
      * @param currentNavState The currently active navigation state that was kept.
-     * @param rejectedNavState The navigation state update that was rejected.
+     * @param rejectedRequest The navigation state update request that was rejected.
      * @param reason Why the update was rejected.
      */
     fun onNavStateUpdateRejected(
         currentNavState: TabsNavState,
-        rejectedNavState: TabsNavState,
+        rejectedRequest: TabsNavStateUpdateRequest,
         reason: TabsNavStateUpdateRejectionReason,
     )
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
@@ -3,5 +3,5 @@ package com.swmansion.rnscreens.gamma.tabs.container
 internal sealed class TabsContainerOp
 
 internal data class TabSelectOp(
-    val navState: TabsNavState,
+    val request: TabsNavStateUpdateRequest,
 ) : TabsContainerOp()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavState.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavState.kt
@@ -6,13 +6,13 @@ import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionR
 /**
  * Describes navigation state of a tabs container.
  *
- * @property selectedKey Screen key of the currently selected tab.
+ * @property selectedScreenKey Screen key of the currently selected tab.
  * @property provenance Monotonically increasing number describing the history (generation) of the state.
  *   State with provenance `N + 1` is derived from state with provenance `N`.
  *   This allows detecting stale updates.
  */
 data class TabsNavState(
-    val selectedKey: String,
+    val selectedScreenKey: String,
     val provenance: Int,
 ) {
     internal fun isEmpty(): Boolean = this === EMPTY
@@ -23,6 +23,23 @@ data class TabsNavState(
         val EMPTY = TabsNavState("", Int.MIN_VALUE)
     }
 }
+
+/**
+ * A request to change navigation state.
+ *
+ * Carries the target [selectedScreenKey], the [baseProvenance] of the state the request was derived from,
+ * and the [actionOrigin] (actor) that initiated it. Mirrors the public `TabsHostNavStateRequest` TS type
+ * plus an [actionOrigin] carried internally.
+ *
+ * @property selectedScreenKey Screen key of the requested tab.
+ * @property baseProvenance Provenance of the state this request was derived from. Used for staleness detection.
+ * @property actionOrigin Origin (actor) that initiated this request.
+ */
+data class TabsNavStateUpdateRequest(
+    val selectedScreenKey: String,
+    val baseProvenance: Int,
+    val actionOrigin: TabsActionOrigin,
+)
 
 /**
  * Reason why a navigation state update was rejected by the container.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -18,6 +18,7 @@ import com.swmansion.rnscreens.gamma.tabs.container.TabsContainer
 import com.swmansion.rnscreens.gamma.tabs.container.TabsContainerDelegate
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreen
 import com.swmansion.rnscreens.utils.RNSLog
 import kotlin.properties.Delegates
@@ -30,7 +31,7 @@ class TabsHost(
     TabsContainerDelegate,
     UIManagerListener {
     private val renderedScreens: ArrayList<TabsScreen> = arrayListOf()
-    private var jsNavStateRequest: TabsNavState = TabsNavState.EMPTY
+    private var jsNavStateRequest: TabsNavStateUpdateRequest? = null
 
     private val container: TabsContainer =
         TabsContainer(reactContext, this).apply {
@@ -110,9 +111,9 @@ class TabsHost(
         container.removeAllTabsScreens()
     }
 
-    internal fun updateJSNavStateRequest(navStateRequest: TabsNavState) {
+    internal fun updateJSNavStateRequest(navStateRequest: TabsNavStateUpdateRequest) {
         jsNavStateRequest = navStateRequest
-        container.setContainerOperation(TabSelectOp(jsNavStateRequest.copy()))
+        container.setContainerOperation(TabSelectOp(navStateRequest.copy()))
     }
 
     private val layoutCallback =
@@ -163,7 +164,7 @@ class TabsHost(
         actionOrigin: TabsActionOrigin,
     ) {
         eventEmitter.emitOnTabSelectedEvent(
-            navState.selectedKey,
+            navState.selectedScreenKey,
             navState.provenance,
             isRepeated,
             hasTriggeredSpecialEffect,
@@ -173,12 +174,12 @@ class TabsHost(
 
     override fun onNavStateUpdateRejected(
         currentNavState: TabsNavState,
-        rejectedNavState: TabsNavState,
+        rejectedRequest: TabsNavStateUpdateRequest,
         reason: TabsNavStateUpdateRejectionReason,
     ) {
         eventEmitter.emitOnTabSelectionRejectedEvent(
             currentNavState,
-            rejectedNavState,
+            rejectedRequest,
             reason,
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
@@ -5,6 +5,7 @@ import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
 import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
@@ -42,7 +43,7 @@ internal class TabsHostEventEmitter(
      */
     fun emitOnTabSelectionRejectedEvent(
         currentNavState: TabsNavState,
-        rejectedNavState: TabsNavState,
+        rejectedRequest: TabsNavStateUpdateRequest,
         rejectionReason: TabsNavStateUpdateRejectionReason,
     ) {
         reactEventDispatcher.dispatchEvent(
@@ -50,7 +51,7 @@ internal class TabsHostEventEmitter(
                 surfaceId,
                 viewTag,
                 currentNavState,
-                rejectedNavState,
+                rejectedRequest,
                 rejectionReason,
             ),
         )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
@@ -11,7 +11,8 @@ import com.facebook.react.viewmanagers.RNSTabsHostAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSTabsHostAndroidManagerInterface
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
@@ -79,7 +80,13 @@ class TabsHostViewManager :
         val navStateRequestMap = requireNotNull(value) { "[RNScreens] navStateRequest must not be nullish" }
         val selectedScreenKey = requireNotNull(navStateRequestMap.getString("selectedScreenKey"))
         val baseProvenance = requireNotNull(navStateRequestMap.getInt("baseProvenance"))
-        view.updateJSNavStateRequest(TabsNavState(selectedScreenKey, baseProvenance))
+        view.updateJSNavStateRequest(
+            TabsNavStateUpdateRequest(
+                selectedScreenKey = selectedScreenKey,
+                baseProvenance = baseProvenance,
+                actionOrigin = TabsActionOrigin.PROGRAMMATIC_JS,
+            ),
+        )
     }
 
     override fun setRejectStaleNavStateUpdates(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
@@ -27,7 +27,7 @@ class TabsHostTabSelectionPreventedEvent(
 
     override fun getEventData(): WritableMap? =
         Arguments.createMap().apply {
-            putString(EK_SELECTED_KEY, currentNavState.selectedKey)
+            putString(EK_SELECTED_KEY, currentNavState.selectedScreenKey)
             putInt(EK_PROVENANCE, currentNavState.provenance)
             putString(EK_PREVENTED_KEY, preventedScreenKey)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
@@ -6,19 +6,20 @@ import com.facebook.react.uimanager.events.Event
 import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
 
 /**
  * React Native event dispatched to JS when a tab selection request is rejected by the container.
  *
- * Carries the currently active navigation state ([currentNavState]), the rejected update
- * ([rejectedNavState]), and the [rejectionReason]. This event is never coalesced — every
+ * Carries the currently active navigation state ([currentNavState]), the rejected request
+ * ([rejectedRequest]), and the [rejectionReason]. This event is never coalesced — every
  * rejection is delivered individually so the JS side has a complete picture of state transitions.
  */
 class TabsHostTabSelectionRejectedEvent(
     surfaceId: Int,
     viewId: Int,
     val currentNavState: TabsNavState,
-    val rejectedNavState: TabsNavState,
+    val rejectedRequest: TabsNavStateUpdateRequest,
     val rejectionReason: TabsNavStateUpdateRejectionReason,
 ) : Event<TabsHostTabSelectionRejectedEvent>(surfaceId, viewId),
     NamingAwareEventType {
@@ -31,10 +32,10 @@ class TabsHostTabSelectionRejectedEvent(
 
     override fun getEventData(): WritableMap? =
         Arguments.createMap().apply {
-            putString(EK_SELECTED_KEY, currentNavState.selectedKey)
+            putString(EK_SELECTED_KEY, currentNavState.selectedScreenKey)
             putInt(EK_PROVENANCE, currentNavState.provenance)
-            putString(EK_REJECTED_KEY, rejectedNavState.selectedKey)
-            putInt(EK_REJECTED_PROVENANCE, rejectedNavState.provenance)
+            putString(EK_REJECTED_KEY, rejectedRequest.selectedScreenKey)
+            putInt(EK_REJECTED_PROVENANCE, rejectedRequest.baseProvenance)
             putString(EK_REJECTION_REASON, rejectionReason.toString())
         }
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -282,10 +282,11 @@ RNS_IGNORE_SUPER_CALL_END
         // in the image attribute not being updated. We manually set frame to the size of an image
         // in order to trigger proper reload that'd update the image attribute.
         RCTImageSource *imageSource = [RNSScreenStackHeaderConfig imageSourceFromImageView:imageView];
-        [imageView reactSetFrame:CGRectMake(imageView.frame.origin.x,
-                                            imageView.frame.origin.y,
-                                            imageSource.size.width,
-                                            imageSource.size.height)];
+        [imageView reactSetFrame:CGRectMake(
+                                     imageView.frame.origin.x,
+                                     imageView.frame.origin.y,
+                                     imageSource.size.width,
+                                     imageSource.size.height)];
       }
 
       UIImage *image = imageView.image;
@@ -847,12 +848,13 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
-  RCTAssert(childComponentView.superview == nil,
-            @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
-            self,
-            childComponentView,
-            @(index),
-            @([childComponentView.superview tag]));
+  RCTAssert(
+      childComponentView.superview == nil,
+      @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
+      self,
+      childComponentView,
+      @(index),
+      @([childComponentView.superview tag]));
 
   //  [_reactSubviews insertObject:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
   [self insertReactSubview:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
@@ -1129,21 +1131,23 @@ Class<RCTComponentViewProtocol> RNSScreenStackHeaderConfigCls(void)
 
 @implementation RCTConvert (RNSScreenStackHeader)
 
-RCT_ENUM_CONVERTER(UISemanticContentAttribute,
-                   (@{
-                     @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
-                     @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
-                   }),
-                   UISemanticContentAttributeUnspecified,
-                   integerValue)
+RCT_ENUM_CONVERTER(
+    UISemanticContentAttribute,
+    (@{
+      @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
+      @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
+    }),
+    UISemanticContentAttributeUnspecified,
+    integerValue)
 
-RCT_ENUM_CONVERTER(UINavigationItemBackButtonDisplayMode,
-                   (@{
-                     @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
-                     @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
-                     @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
-                   }),
-                   UINavigationItemBackButtonDisplayModeDefault,
-                   integerValue)
+RCT_ENUM_CONVERTER(
+    UINavigationItemBackButtonDisplayMode,
+    (@{
+      @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
+      @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
+      @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
+    }),
+    UINavigationItemBackButtonDisplayModeDefault,
+    integerValue)
 
 @end

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
              withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
 
 - (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    rejectedStateUpdateTo:(nonnull RNSTabsNavigationState *)rejectedNavState
+    rejectedStateUpdateTo:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
              currentState:(nonnull RNSTabsNavigationState *)currentNavState
                withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
 
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  * however.
  *
  * Updates made by this controller are synchronized by `RNSReactTransactionObserving` protocol,
- * i.e. if you made changes through one of signals method, unless you flush them immediately (not needed atm), they will
+ * i.e. if you made changes through one of signals method, unless you flush them immediately, they will
  * be executed only after react finishes the transaction (from within transaction execution block).
  */
 @interface RNSTabBarController : UITabBarController <
@@ -219,7 +219,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If you want to execute multiple updates in sequence you must flush the container after each one separately.
  */
-- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationState *)navState;
+- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate;
 
 /**
  * Tell the controller that react provided tabs have changed (count / instances) & the child view controllers need to be

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -21,9 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
              withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
 
 - (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    rejectedStateUpdateTo:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
-             currentState:(nonnull RNSTabsNavigationState *)currentNavState
-               withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
+     rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState
+              withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
 
 - (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
     preventedSelectionOf:(nonnull NSString *)screenKey

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -463,7 +463,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 {
   UIViewController *_Nonnull currSelectedViewController = self.selectedViewController;
 
-  NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.screenKey;
+  NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.selectedScreenKey;
   UIViewController *nextSelectedViewController = [self findChildViewControllerForKey:nextSelectedViewControllerKey];
 
   RCTAssert(

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -479,7 +479,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   if (self.rejectStaleNavigationStateUpdates && [self isNavigationStateUpdateStale:_pendingStateUpdate]) {
     [self.tabsHostComponentView tabBarController:self
-                           rejectedStateUpdateTo:_pendingStateUpdate
+                             rejectedStateUpdate:_pendingStateUpdate
                                     currentState:_navigationState
                                       withReason:RNSTabsNavigationStateRejectionReasonStale];
     return;
@@ -489,7 +489,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     // Nothing to do, we don't allow for programmatic repeat selection, unless
     // we're during first render.
     [self.tabsHostComponentView tabBarController:self
-                           rejectedStateUpdateTo:_pendingStateUpdate
+                             rejectedStateUpdate:_pendingStateUpdate
                                     currentState:_navigationState
                                       withReason:RNSTabsNavigationStateRejectionReasonRepeated];
     return;

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -73,7 +73,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   /// This property is nullable until first container update. Later it MUST NOT be nil.
   RNSTabsNavigationState *_Nullable _lastUINavigationState;
 
-  RNSTabsNavigationState *_Nullable _pendingOperation;
+  RNSTabsNavigationStateUpdateRequest *_Nullable _pendingStateUpdate;
 
   /// When YES, the controller is inside an explicit selection-changing code path (container update,
   /// delegate handling). Setter overrides skip reconciliation while this flag is set.
@@ -91,7 +91,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     _tabBarAppearanceCoordinator = [RNSTabBarAppearanceCoordinator new];
     _tabsHostComponentView = nil;
     _navigationState = nil;
-    _pendingOperation = nil;
+    _pendingStateUpdate = nil;
     _shouldProgressStateOnMoreNavigationControllerPush = NO;
 
     // Delegate field retains weakly, no risk of cycle.
@@ -146,9 +146,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 #pragma mark - Signals
 
-- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationState *)navState
+- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate
 {
-  _pendingOperation = navState;
+  _pendingStateUpdate = stateUpdate;
 }
 
 - (void)childViewControllersHaveChangedTo:(NSArray<RNSTabsScreenViewController *> *)reactChildControllers
@@ -438,32 +438,32 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 - (void)updateSelectedViewControllerIfNeeded
 {
-  if (_pendingOperation != nil) {
+  if (_pendingStateUpdate != nil) {
     [self updateSelectedViewController];
   }
 }
 
 - (void)updateSelectedViewController
 {
-  if (_pendingOperation == nil || self.viewControllers.count == 0) {
+  if (_pendingStateUpdate == nil || self.viewControllers.count == 0) {
     return;
   }
 
   RNSLog(@"TabBarCtrl updateSelectedViewController");
   [self updateSelectedViewControllerInner];
-  _pendingOperation = nil;
+  _pendingStateUpdate = nil;
 }
 
 /**
  * NEVER call this method directly. Call the proper function `updateSelectedViewController`
  *
- * The logic is extracted to an inner method to correctly manage _pendingOperation cleanup.
+ * The logic is extracted to an inner method to correctly manage `_pendingStateUpdate` cleanup.
  */
 - (void)updateSelectedViewControllerInner
 {
   UIViewController *_Nonnull currSelectedViewController = self.selectedViewController;
 
-  NSString *_Nonnull nextSelectedViewControllerKey = _pendingOperation.selectedScreenKey;
+  NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.screenKey;
   UIViewController *nextSelectedViewController = [self findChildViewControllerForKey:nextSelectedViewControllerKey];
 
   RCTAssert(
@@ -477,9 +477,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
       RNSTabsScreenViewController.class,
       nextSelectedViewController.class);
 
-  if (self.rejectStaleNavigationStateUpdates && [self isNavigationStateUpdateStale:_pendingOperation]) {
+  if (self.rejectStaleNavigationStateUpdates && [self isNavigationStateUpdateStale:_pendingStateUpdate]) {
     [self.tabsHostComponentView tabBarController:self
-                           rejectedStateUpdateTo:_pendingOperation
+                           rejectedStateUpdateTo:_pendingStateUpdate
                                     currentState:_navigationState
                                       withReason:RNSTabsNavigationStateRejectionReasonStale];
     return;
@@ -489,7 +489,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     // Nothing to do, we don't allow for programmatic repeat selection, unless
     // we're during first render.
     [self.tabsHostComponentView tabBarController:self
-                           rejectedStateUpdateTo:_pendingOperation
+                           rejectedStateUpdateTo:_pendingStateUpdate
                                     currentState:_navigationState
                                       withReason:RNSTabsNavigationStateRejectionReasonRepeated];
     return;
@@ -516,7 +516,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
         [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
                                                            isRepeated:NO
                                             hasTriggeredSpecialEffect:NO
-                                                         actionOrigin:RNSTabsActionOriginProgrammaticJs];
+                                                         actionOrigin:_pendingStateUpdate.actionOrigin];
     [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:context];
   }
 }
@@ -676,9 +676,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 /**
  * This function assumes that the source of the state is NOT user. In current model, user update is never stale.
  */
-- (BOOL)isNavigationStateUpdateStale:(nullable RNSTabsNavigationState *)newState
+- (BOOL)isNavigationStateUpdateStale:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate
 {
-  if (newState == nil) {
+  if (stateUpdate == nil) {
     return YES;
   }
 
@@ -686,7 +686,7 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     return NO;
   }
 
-  return newState.provenance < _lastUINavigationState.provenance;
+  return stateUpdate.baseProvenance < _lastUINavigationState.provenance;
 }
 
 #pragma mark-- More Navigation Controller

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -48,9 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSTabsHostComponentView ()
 
 /**
- * Last navigation state requested by JS. Will be nonnull after first prop update.
+ * Last navigation state update requested by JS. Will be nonnull after first prop update.
  */
-@property (nonatomic, strong, readonly, nullable) RNSTabsNavigationState *navStateRequest;
+@property (nonatomic, strong, readonly, nullable) RNSTabsNavigationStateUpdateRequest *navStateRequest;
 
 @property (nonatomic, readonly) BOOL rejectStaleNavStateUpdates;
 

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -273,10 +273,10 @@ namespace react = facebook::react;
     NSString *selectedScreenKey = RCTNSStringFromStringNilIfEmpty(newComponentProps.navStateRequest.selectedScreenKey);
     RCTAssert(selectedScreenKey != nil, @"[RNScreens] selectedScreenKey MUST NOT be nil");
     RCTAssert(newComponentProps.navStateRequest.baseProvenance >= 0, @"[RNScreens] baseProvenance MUST BE >= 0");
-    _navStateRequest =
-        [RNSTabsNavigationStateUpdateRequest requestWithScreenKey:selectedScreenKey
-                                                   baseProvenance:newComponentProps.navStateRequest.baseProvenance
-                                                     actionOrigin:RNSTabsActionOriginProgrammaticJs];
+    _navStateRequest = [RNSTabsNavigationStateUpdateRequest
+        requestWithSelectedScreenKey:selectedScreenKey
+                      baseProvenance:newComponentProps.navStateRequest.baseProvenance
+                        actionOrigin:RNSTabsActionOriginProgrammaticJs];
     [_controller setPendingNavigationStateUpdate:[_navStateRequest cloneRequest]];
   }
 
@@ -619,7 +619,8 @@ RNS_IGNORE_SUPER_CALL_END
                withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
 {
   RCTAssert(currentNavState.selectedScreenKey != nil, @"[RNScreens] Current state screenKey MUST NOT be nil");
-  RCTAssert(rejectedRequest.screenKey != nil, @"[RNScreens] Rejected request screenKey MUST NOT be nil");
+  RCTAssert(
+      rejectedRequest.selectedScreenKey != nil, @"[RNScreens] Rejected request selectedScreenKey MUST NOT be nil");
 
   [self.reactEventEmitter emitOnTabSelectionRejected:{.currentNavState = currentNavState,
                                                       .rejectedRequest = rejectedRequest,

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -53,7 +53,7 @@ namespace react = facebook::react;
   BOOL _hasModifiedBottomAccessoryInCurrentTransation;
   BOOL _needsTabBarAppearanceUpdate;
 
-  RNSTabsNavigationState *_Nullable _navStateRequest;
+  RNSTabsNavigationStateUpdateRequest *_Nullable _navStateRequest;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -614,9 +614,9 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 - (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    rejectedStateUpdateTo:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
-             currentState:(nonnull RNSTabsNavigationState *)currentNavState
-               withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
+     rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState
+              withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
 {
   RCTAssert(currentNavState.selectedScreenKey != nil, @"[RNScreens] Current state screenKey MUST NOT be nil");
   RCTAssert(

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -274,9 +274,10 @@ namespace react = facebook::react;
     RCTAssert(selectedScreenKey != nil, @"[RNScreens] selectedScreenKey MUST NOT be nil");
     RCTAssert(newComponentProps.navStateRequest.baseProvenance >= 0, @"[RNScreens] baseProvenance MUST BE >= 0");
     _navStateRequest =
-        [RNSTabsNavigationState stateWithSelectedScreenKey:selectedScreenKey
-                                                provenance:newComponentProps.navStateRequest.baseProvenance];
-    [_controller setPendingNavigationStateUpdate:[_navStateRequest cloneState]];
+        [RNSTabsNavigationStateUpdateRequest requestWithScreenKey:selectedScreenKey
+                                                   baseProvenance:newComponentProps.navStateRequest.baseProvenance
+                                                     actionOrigin:RNSTabsActionOriginProgrammaticJs];
+    [_controller setPendingNavigationStateUpdate:[_navStateRequest cloneRequest]];
   }
 
   if (newComponentProps.rejectStaleNavStateUpdates != oldComponentProps.rejectStaleNavStateUpdates) {
@@ -613,15 +614,15 @@ RNS_IGNORE_SUPER_CALL_END
 }
 
 - (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    rejectedStateUpdateTo:(nonnull RNSTabsNavigationState *)rejectedNavState
+    rejectedStateUpdateTo:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
              currentState:(nonnull RNSTabsNavigationState *)currentNavState
                withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
 {
   RCTAssert(currentNavState.selectedScreenKey != nil, @"[RNScreens] Current state screenKey MUST NOT be nil");
-  RCTAssert(rejectedNavState.selectedScreenKey != nil, @"[RNScreens] Rejected state screenKey MUST NOT be nil");
+  RCTAssert(rejectedRequest.screenKey != nil, @"[RNScreens] Rejected request screenKey MUST NOT be nil");
 
   [self.reactEventEmitter emitOnTabSelectionRejected:{.currentNavState = currentNavState,
-                                                      .rejectedNavState = rejectedNavState,
+                                                      .rejectedRequest = rejectedRequest,
                                                       .rejectionReason = reasonCode}];
 }
 

--- a/ios/tabs/host/RNSTabsHostEventEmitter.h
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.h
@@ -34,8 +34,8 @@ typedef struct {
 typedef struct {
   /** The currently active navigation state that was kept. */
   RNSTabsNavigationState *_Nonnull currentNavState;
-  /** The navigation state update that was rejected. */
-  RNSTabsNavigationState *_Nonnull rejectedNavState;
+  /** The navigation state update request that was rejected. */
+  RNSTabsNavigationStateUpdateRequest *_Nonnull rejectedRequest;
   /** Reason the update was rejected. */
   RNSTabsNavigationStateRejectionReason rejectionReason;
 } OnTabSelectionRejectedPayload;

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -61,8 +61,8 @@ namespace react = facebook::react;
     _reactEventEmitter->onTabSelectionRejected(
         {.selectedScreenKey = RCTStringFromNSString(payload.currentNavState.selectedScreenKey),
          .provenance = payload.currentNavState.provenance,
-         .rejectedScreenKey = RCTStringFromNSString(payload.rejectedNavState.selectedScreenKey),
-         .rejectedProvenance = payload.rejectedNavState.provenance,
+         .rejectedScreenKey = RCTStringFromNSString(payload.rejectedRequest.screenKey),
+         .rejectedProvenance = payload.rejectedRequest.baseProvenance,
          .rejectionReason = convertedReason});
     return YES;
   } else {

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -61,7 +61,7 @@ namespace react = facebook::react;
     _reactEventEmitter->onTabSelectionRejected(
         {.selectedScreenKey = RCTStringFromNSString(payload.currentNavState.selectedScreenKey),
          .provenance = payload.currentNavState.provenance,
-         .rejectedScreenKey = RCTStringFromNSString(payload.rejectedRequest.screenKey),
+         .rejectedScreenKey = RCTStringFromNSString(payload.rejectedRequest.selectedScreenKey),
          .rejectedProvenance = payload.rejectedRequest.baseProvenance,
          .rejectionReason = convertedReason});
     return YES;

--- a/ios/tabs/host/RNSTabsNavigationState.h
+++ b/ios/tabs/host/RNSTabsNavigationState.h
@@ -5,30 +5,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Describes navigation state of a tabs container.
- *
- * It holds information about key of a selected screen AND state provenance.
- * The provenance describes *a history of the state*. Conceptually, the state with provenance `N + 1`
- * MUST BE derived from state with provenance `N`.
- */
-@interface RNSTabsNavigationState : NSObject
-
-/** Screen key of the currently selected tab. */
-@property (nonatomic, strong, readonly, nonnull) NSString *selectedScreenKey;
-
-/** Monotonically increasing number describing the generation of this state instance.
- *  Used for stale update detection: state A is stale iff A.provenance <= B.provenance. */
-@property (nonatomic, readonly) int provenance;
-
-- (instancetype)initWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey provenance:(int)provenance;
-
-- (instancetype)cloneState;
-
-+ (instancetype)stateWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey provenance:(int)provenance;
-
-@end
-
-/**
  * Origin (actor) that requested a tab transition. Mirrors the public `actionOrigin` event field.
  *
  * - [User] direct native UI interaction (tab bar tap, drag-and-drop).
@@ -42,6 +18,63 @@ typedef NS_ENUM(NSInteger, RNSTabsActionOrigin) {
   RNSTabsActionOriginProgrammaticJs,
   RNSTabsActionOriginImplicit,
 };
+
+/** Reason why a navigation state update was rejected by the container. */
+typedef NS_ENUM(NSInteger, RNSTabsNavigationStateRejectionReason) {
+  /** The update's provenance is based on a stale state. */
+  RNSTabsNavigationStateRejectionReasonStale = 0,
+  /** The requested tab is already selected. */
+  RNSTabsNavigationStateRejectionReasonRepeated,
+};
+
+/**
+ * Describes navigation state of a tabs container.
+ *
+ * It holds information about key of a selected screen AND state provenance.
+ * The provenance describes *a history of the state*. Conceptually, the state with provenance `N + 1`
+ * MUST BE derived from state with provenance `N`.
+ */
+@interface RNSTabsNavigationState : NSObject
+
+/** Screen key of the currently selected tab. */
+@property (nonatomic, strong, readonly, nonnull) NSString *selectedScreenKey;
+
+/** Monotonically increasing number describing the generation of this state instance.
+ *  Used for stale update detection. */
+@property (nonatomic, readonly) int provenance;
+
+- (instancetype)initWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey provenance:(int)provenance;
+
+- (instancetype)cloneState;
+
++ (instancetype)stateWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey provenance:(int)provenance;
+
+@end
+
+/**
+ * A request to change navigation state.
+ *
+ * Carries the target `screenKey`, the `baseProvenance` of the state the request was derived from,
+ * and the `actionOrigin` (actor) that initiated it. Mirrors the public
+ * `TabsHostNavStateRequest` TS type plus an `actionOrigin` carried internally.
+ */
+@interface RNSTabsNavigationStateUpdateRequest : NSObject
+
+@property (nonatomic, strong, readonly, nonnull) NSString *screenKey;
+@property (nonatomic, readonly) int baseProvenance;
+@property (nonatomic, readonly) RNSTabsActionOrigin actionOrigin;
+
+- (instancetype)initWithScreenKey:(nonnull NSString *)screenKey
+                   baseProvenance:(int)baseProvenance
+                     actionOrigin:(RNSTabsActionOrigin)actionOrigin;
+
+- (instancetype)cloneRequest;
+
++ (instancetype)requestWithScreenKey:(nonnull NSString *)screenKey
+                      baseProvenance:(int)baseProvenance
+                        actionOrigin:(RNSTabsActionOrigin)actionOrigin;
+
+@end
 
 /** Bundles a navigation state change together with metadata about the selection context. */
 @interface RNSTabsNavigationStateUpdateContext : NSObject
@@ -61,13 +94,5 @@ typedef NS_ENUM(NSInteger, RNSTabsActionOrigin) {
                     actionOrigin:(RNSTabsActionOrigin)actionOrigin;
 
 @end
-
-/** Reason why a navigation state update was rejected by the container. */
-typedef NS_ENUM(NSInteger, RNSTabsNavigationStateRejectionReason) {
-  /** The update's provenance is based on a stale state. */
-  RNSTabsNavigationStateRejectionReasonStale = 0,
-  /** The requested tab is already selected. */
-  RNSTabsNavigationStateRejectionReasonRepeated,
-};
 
 NS_ASSUME_NONNULL_END

--- a/ios/tabs/host/RNSTabsNavigationState.h
+++ b/ios/tabs/host/RNSTabsNavigationState.h
@@ -54,25 +54,25 @@ typedef NS_ENUM(NSInteger, RNSTabsNavigationStateRejectionReason) {
 /**
  * A request to change navigation state.
  *
- * Carries the target `screenKey`, the `baseProvenance` of the state the request was derived from,
+ * Carries the target `selectedScreenKey`, the `baseProvenance` of the state the request was derived from,
  * and the `actionOrigin` (actor) that initiated it. Mirrors the public
  * `TabsHostNavStateRequest` TS type plus an `actionOrigin` carried internally.
  */
 @interface RNSTabsNavigationStateUpdateRequest : NSObject
 
-@property (nonatomic, strong, readonly, nonnull) NSString *screenKey;
+@property (nonatomic, strong, readonly, nonnull) NSString *selectedScreenKey;
 @property (nonatomic, readonly) int baseProvenance;
 @property (nonatomic, readonly) RNSTabsActionOrigin actionOrigin;
 
-- (instancetype)initWithScreenKey:(nonnull NSString *)screenKey
-                   baseProvenance:(int)baseProvenance
-                     actionOrigin:(RNSTabsActionOrigin)actionOrigin;
+- (instancetype)initWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey
+                           baseProvenance:(int)baseProvenance
+                             actionOrigin:(RNSTabsActionOrigin)actionOrigin;
 
 - (instancetype)cloneRequest;
 
-+ (instancetype)requestWithScreenKey:(nonnull NSString *)screenKey
-                      baseProvenance:(int)baseProvenance
-                        actionOrigin:(RNSTabsActionOrigin)actionOrigin;
++ (instancetype)requestWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey
+                              baseProvenance:(int)baseProvenance
+                                actionOrigin:(RNSTabsActionOrigin)actionOrigin;
 
 @end
 

--- a/ios/tabs/host/RNSTabsNavigationState.mm
+++ b/ios/tabs/host/RNSTabsNavigationState.mm
@@ -26,6 +26,38 @@
 
 @end
 
+@implementation RNSTabsNavigationStateUpdateRequest
+
+- (instancetype)initWithScreenKey:(nonnull NSString *)screenKey
+                   baseProvenance:(int)baseProvenance
+                     actionOrigin:(RNSTabsActionOrigin)actionOrigin
+{
+  if (self = [super init]) {
+    _screenKey = screenKey;
+    _baseProvenance = baseProvenance;
+    _actionOrigin = actionOrigin;
+  }
+  return self;
+}
+
+- (instancetype)cloneRequest
+{
+  return [[RNSTabsNavigationStateUpdateRequest alloc] initWithScreenKey:[NSString stringWithString:self.screenKey]
+                                                         baseProvenance:self.baseProvenance
+                                                           actionOrigin:self.actionOrigin];
+}
+
++ (instancetype)requestWithScreenKey:(nonnull NSString *)screenKey
+                      baseProvenance:(int)baseProvenance
+                        actionOrigin:(RNSTabsActionOrigin)actionOrigin
+{
+  return [[RNSTabsNavigationStateUpdateRequest alloc] initWithScreenKey:screenKey
+                                                         baseProvenance:baseProvenance
+                                                           actionOrigin:actionOrigin];
+}
+
+@end
+
 @implementation RNSTabsNavigationStateUpdateContext
 
 - (instancetype)initWithNavState:(nonnull RNSTabsNavigationState *)navState

--- a/ios/tabs/host/RNSTabsNavigationState.mm
+++ b/ios/tabs/host/RNSTabsNavigationState.mm
@@ -28,12 +28,12 @@
 
 @implementation RNSTabsNavigationStateUpdateRequest
 
-- (instancetype)initWithScreenKey:(nonnull NSString *)screenKey
-                   baseProvenance:(int)baseProvenance
-                     actionOrigin:(RNSTabsActionOrigin)actionOrigin
+- (instancetype)initWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey
+                           baseProvenance:(int)baseProvenance
+                             actionOrigin:(RNSTabsActionOrigin)actionOrigin
 {
   if (self = [super init]) {
-    _screenKey = screenKey;
+    _selectedScreenKey = selectedScreenKey;
     _baseProvenance = baseProvenance;
     _actionOrigin = actionOrigin;
   }
@@ -42,18 +42,19 @@
 
 - (instancetype)cloneRequest
 {
-  return [[RNSTabsNavigationStateUpdateRequest alloc] initWithScreenKey:[NSString stringWithString:self.screenKey]
-                                                         baseProvenance:self.baseProvenance
-                                                           actionOrigin:self.actionOrigin];
+  return [[RNSTabsNavigationStateUpdateRequest alloc]
+      initWithSelectedScreenKey:[NSString stringWithString:self.selectedScreenKey]
+                 baseProvenance:self.baseProvenance
+                   actionOrigin:self.actionOrigin];
 }
 
-+ (instancetype)requestWithScreenKey:(nonnull NSString *)screenKey
-                      baseProvenance:(int)baseProvenance
-                        actionOrigin:(RNSTabsActionOrigin)actionOrigin
++ (instancetype)requestWithSelectedScreenKey:(nonnull NSString *)selectedScreenKey
+                              baseProvenance:(int)baseProvenance
+                                actionOrigin:(RNSTabsActionOrigin)actionOrigin
 {
-  return [[RNSTabsNavigationStateUpdateRequest alloc] initWithScreenKey:screenKey
-                                                         baseProvenance:baseProvenance
-                                                           actionOrigin:actionOrigin];
+  return [[RNSTabsNavigationStateUpdateRequest alloc] initWithSelectedScreenKey:selectedScreenKey
+                                                                 baseProvenance:baseProvenance
+                                                                   actionOrigin:actionOrigin];
 }
 
 @end


### PR DESCRIPTION
## Description

> [!NOTE]
> This PR stacks on top of #3949 — please review/land that one first. The base branch here is `@kkafar/rename-is-native-action`, not `main`.

The native tabs JS-driven nav state update path was using a single type — `RNSTabsNavigationState` on iOS and `TabsNavState` on Android — to represent two distinct concepts:

1. **Authoritative state** held by the native container: `(selectedScreenKey, provenance)`.
2. **A JS request to change that state** delivered via the `navStateRequest` prop: `(selectedScreenKey, baseProvenance)`.

This conflation was tolerable while we only had one origin (`ProgrammaticJs` / `PROGRAMMATIC_JS`), but with the new public `actionOrigin` enum and the need to support more origins in the future (notably native-programmatic), the request needs to carry its own origin alongside its base provenance. The state type is the wrong place for that field — it describes a result, not a request.

This PR introduces a sibling `…UpdateRequest` type on both platforms and threads it through the JS-driven update path. The architectural consequence is that the native container becomes **origin-agnostic** on its success path: instead of hardcoding `actionOrigin = ProgrammaticJs` when the update succeeds, it forwards whatever the incoming request carried. The view manager / component view (which knows the origin is `ProgrammaticJs` for prop-driven updates) is now the place that decides.

The runtime value of `actionOrigin` on the public event is unchanged today — JS-driven updates still surface `'programmatic-js'`. This is purely an internal architectural shift.

## Changes

### iOS

- New `RNSTabsNavigationStateUpdateRequest` type in `RNSTabsNavigationState.h/.mm` with `selectedScreenKey`, `baseProvenance`, `actionOrigin`. Mirrors `RNSTabsNavigationState`'s utility surface (designated init, `cloneRequest`, static factory).
- `RNSTabsHostComponentView`:
  - `navStateRequest` property retyped to `RNSTabsNavigationStateUpdateRequest *`.
  - `updateProps:oldProps:` constructs the request directly from C++ props with `actionOrigin = RNSTabsActionOriginProgrammaticJs` and forwards a `cloneRequest` to the controller.
  - The `rejectedStateUpdateTo:` delegate impl reads `request.selectedScreenKey` / `request.baseProvenance` for the rejection event payload.
- `RNSTabBarController`:
  - `setPendingNavigationStateUpdate:` retyped to take the request.
  - Ivar renamed `_pendingOperation` → `_pendingStateUpdate` and retyped.
  - Success-path `RNSTabsNavigationStateUpdateContext` now uses `_pendingStateUpdate.actionOrigin` instead of hardcoded `ProgrammaticJs`.
  - `isNavigationStateUpdateStale:` retyped; reads `.baseProvenance`.
  - Delegate `rejectedStateUpdateTo:` parameter retyped to the request.
- `OnTabSelectionRejectedPayload.rejectedNavState` (in `RNSTabsHostEventEmitter.h`) renamed/retyped to `rejectedRequest: RNSTabsNavigationStateUpdateRequest *`. The JSI emit reads `selectedScreenKey` / `baseProvenance` from the request.

### Android

- New `TabsNavStateUpdateRequest` data class in `TabsNavState.kt` with `selectedScreenKey`, `baseProvenance`, `actionOrigin`.
- `TabsHostViewManager.setNavStateRequest` constructs the request with `actionOrigin = TabsActionOrigin.PROGRAMMATIC_JS` baked in (instead of just a `TabsNavState`).
- `TabsHost.jsNavStateRequest` retyped to `TabsNavStateUpdateRequest?`. `updateJSNavStateRequest` retyped.
- `TabSelectOp` retyped to wrap a `TabsNavStateUpdateRequest` (field `navState` → `request`).
- `TabsContainer`:
  - `onMenuItemSelected` no longer hardcodes `PROGRAMMATIC_JS` in the external-context branch — it reads `(pendingOperation as TabSelectOp).request.actionOrigin`. The `isInExternalOperationContext` flag stays (it still suppresses the prevent-native-selection check and the `lastUINavState` capture).
  - `isNavStateStale` retyped; reads `request.baseProvenance`.
  - All `performOperation` reads updated to `tabSelectOp.request.…`.
- `TabsContainerDelegate.onNavStateUpdateRejected` parameter `rejectedNavState: TabsNavState` retyped to `rejectedRequest: TabsNavStateUpdateRequest`. `TabsHostEventEmitter` and `TabsHostTabSelectionRejectedEvent` follow.
- Bundles a `TabsNavState.selectedKey` → `selectedScreenKey` rename for cross-platform consistency with the JS contract and the new request type. JS-facing `WritableMap` keys (`selectedScreenKey`, `rejectedScreenKey`) were already named correctly — only the Kotlin-internal field name moves.

No JS, codegen-spec, or conversion-helper changes — public contract untouched.

## Test plan

No new automated tests; this is an internal architectural refactor with no behavioral change on the user/JS-driven paths. Manual verification via `FabricExample`:

### iOS
- Tab bar tap → `actionOrigin === 'user'` (unchanged path).
- JS-driven `navStateRequest` update → `actionOrigin === 'programmatic-js'` (now sourced from the request, not hardcoded in the controller).
- iPad horizontal size-class transition forcing UIKit reshuffle → `actionOrigin === 'implicit'` (unchanged path).
- Stale JS update (`rejectStaleNavStateUpdates: true`, mid-flight tap) → `onTabSelectionRejected` fires with `rejectedScreenKey` and `rejectedProvenance` matching the request's `selectedScreenKey` and `baseProvenance`.

### Android
- Tab bar tap → `actionOrigin === 'user'` (unchanged path).
- JS-driven `navStateRequest` update → `actionOrigin === 'programmatic-js'` (now sourced from the request, not hardcoded in the container).
- Stale JS update (`rejectStaleNavStateUpdates: true`, mid-flight tap) → `onTabSelectionRejected` fires with `rejectedScreenKey` and `rejectedProvenance` matching the request's `selectedScreenKey` and `baseProvenance`.

Reproduction lives in the `FabricExample` Tabs test screens; log `e.nativeEvent.actionOrigin` from `onTabSelected` and `e.nativeEvent.rejectedScreenKey` / `rejectedProvenance` from `onTabSelectionRejected`.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes