### PR TITLE
chore(example): use prebuilt React Native for iOS on CI in FabricExample

### DIFF
--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -11,10 +11,8 @@ require_relative '../../scripts/ios/rns_set_swift_compilation_flags'
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# Using prebuilt React Native iOS binaries for faster builds
-# disable if you need to dive in and tweak into React Native native code
-ENV['RCT_USE_PREBUILT_RNCORE'] = '1'
-ENV['RCT_USE_RN_DEP'] = '1'
+# Use prebuilt binaries in CI, source in local development
+ENV['RCT_USE_PREBUILT_RNCORE'] = ENV['RCT_USE_RN_DEP'] = ENV['CI'] ? '1' : '0'
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -11,8 +11,10 @@ require_relative '../../scripts/ios/rns_set_swift_compilation_flags'
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# Disable precompiled binaries for RN core
-ENV['RCT_USE_PREBUILT_RNCORE'] = '0'
+# Using prebuilt React Native iOS binaries for faster builds
+# disable if you need to dive in and tweak into React Native native code
+ENV['RCT_USE_PREBUILT_RNCORE'] = '1'
+ENV['RCT_USE_RN_DEP'] = '1'
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -12,7 +12,9 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 # Use prebuilt binaries in CI, source in local development
-ENV['RCT_USE_PREBUILT_RNCORE'] = ENV['RCT_USE_RN_DEP'] = ENV['CI'] ? '1' : '0'
+ci_enabled = %w[1 true].include?(ENV['CI'].to_s.downcase)
+ENV['RCT_USE_PREBUILT_RNCORE'] ||= ci_enabled ? '1' : '0'
+ENV['RCT_USE_RN_DEP'] ||= ci_enabled ? '1' : '0'
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil


### PR DESCRIPTION
## Description

Speed up the build process from ~6min to ~3min (macos-xlarge-latest)

I briefly checked debugging and it seems that debug symbols aren't available in XCode - meaning that for some more advanced debugging sessions we'd have to locally rollback to building from source.

If this change proves to be counterproductive we can revert it later. It will significantly speed up the builds on CI, in local development it can be easily switched off

same in react-native-reanimated: https://github.com/software-mansion/react-native-reanimated/pull/8983

## Changes

- Enabled uising prebuilt react-native via env variables in Podfile

## Test plan

build FabricExample and try to debug something

<img width="1275" height="868" alt="Zrzut ekranu 2026-04-29 o 18 08 32" src="https://github.com/user-attachments/assets/c5f9ce89-7888-4936-a04e-90e8dd2e98db" />

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
