### PR TITLE
fix(web, SafeAreaView): replace default export with named export

### DIFF
--- a/src/components/safe-area/SafeAreaView.web.tsx
+++ b/src/components/safe-area/SafeAreaView.web.tsx
@@ -2,4 +2,4 @@ import { View } from 'react-native';
 
 const SafeAreaView = View;
 
-export default SafeAreaView;
+export { SafeAreaView };


### PR DESCRIPTION
## Description

`safe-area/index.ts` re-exports `SafeAreaView` as a named export:

```ts
export { SafeAreaView } from './SafeAreaView';
```

For web builds, webpack resolves `'./SafeAreaView'` to `'./SafeAreaView.web.tsx'`, which only had a default export:

```ts
const SafeAreaView = View;
export default SafeAreaView;
```

This causes a `ModuleDependencyWarning` at build time:

```
export 'SafeAreaView' (imported as 'SafeAreaView') was not found in './safe-area/SafeAreaView' (possible exports: default)
```

This also affects `ScreenStackItem.tsx`, which does:

```ts
import { SafeAreaView } from './safe-area/SafeAreaView';
```

For web builds this resolves to the `.web` variant, again hitting the same missing named export.

## Fix

Replace the default export with a named export in `SafeAreaView.web.tsx` to match the native variant (`SafeAreaView.tsx`), which only has a named export, and the package's public surface (`safe-area/index.ts`), which only re-exports as named.

## Test plan

- [x] Verified the warning no longer appears in a web/Storybook webpack build after this change

## Related

Found while upgrading \`react-native-screens\` to \`4.25.0-beta.1\` in [Expensify/App#89199](https://github.com/Expensify/App/pull/89199).