### PR TITLE
feat(Split): add RTL support

### DIFF
--- a/apps/src/tests/single-feature-tests/split/index.ts
+++ b/apps/src/tests/single-feature-tests/split/index.ts
@@ -1,8 +1,13 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestTopColumnForCollapsing from './test-top-column-for-collapsing';
 import TestCommandShowColumn from './test-command-show-column';
+import TestDirection from './test-direction';
 
-const scenarios = { TestTopColumnForCollapsing, TestCommandShowColumn };
+const scenarios = {
+  TestTopColumnForCollapsing,
+  TestCommandShowColumn,
+  TestDirection,
+};
 
 const SplitScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {
   name: 'Split',

--- a/apps/src/tests/single-feature-tests/split/index.ts
+++ b/apps/src/tests/single-feature-tests/split/index.ts
@@ -1,7 +1,7 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestTopColumnForCollapsing from './test-top-column-for-collapsing';
 import TestCommandShowColumn from './test-command-show-column';
-import TestDirection from './test-direction';
+import TestDirection from './test-split-direction';
 
 const scenarios = {
   TestTopColumnForCollapsing,

--- a/apps/src/tests/single-feature-tests/split/test-direction.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-direction.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Split } from 'react-native-screens/experimental';
+import { StyleSheet, Text, View, Button } from 'react-native';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Prop: layoutDirection',
+  key: 'test-split-layout-direction',
+  details: `
+    Test the direction prop in Split component.
+  `,
+  platforms: ['ios'],
+};
+
+type LayoutDirection = 'ltr' | 'rtl' | 'inherit';
+
+export function App() {
+  const [direction, setDirection] = useState<LayoutDirection>('inherit');
+
+  return (
+    <Split.Host direction={direction}>
+      <Split.Column>
+        <ColumnContent
+          columnTitle="Primary column"
+          currentDirection={direction}
+          onChangeDirection={setDirection}
+        />
+      </Split.Column>
+      <Split.Column>
+        <ColumnContent columnTitle="Supplementary column" />
+      </Split.Column>
+      <Split.Column>
+        <ColumnContent columnTitle="Secondary column" />
+      </Split.Column>
+    </Split.Host>
+  );
+}
+
+export function ColumnContent(props: {
+  columnTitle: string;
+  currentDirection?: LayoutDirection;
+  onChangeDirection?: (dir: LayoutDirection) => void;
+}) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.columnTitle}>{props.columnTitle}</Text>
+
+      {props.onChangeDirection && (
+        <View style={styles.controlPanel}>
+          <Text style={styles.statusText}>
+            Current direction:{' '}
+            <Text style={styles.bold}>{props.currentDirection}</Text>
+          </Text>
+
+          <View style={styles.buttonRow}>
+            <Button
+              title="LTR"
+              onPress={() => props.onChangeDirection?.('ltr')}
+            />
+            <Button
+              title="RTL"
+              onPress={() => props.onChangeDirection?.('rtl')}
+            />
+            <Button
+              title="INHERIT"
+              onPress={() => props.onChangeDirection?.('inherit')}
+            />
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  columnTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  controlPanel: {
+    marginTop: 20,
+    alignItems: 'center',
+  },
+  statusText: {
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  bold: {
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 10,
+    justifyContent: 'center',
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/split/test-split-direction.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-direction.tsx
@@ -5,8 +5,8 @@ import { Split, SplitHostDirection } from 'react-native-screens/experimental';
 import { StyleSheet, Text, View, Button } from 'react-native';
 
 const scenarioDescription: ScenarioDescription = {
-  name: 'Prop: layoutDirection',
-  key: 'test-split-layout-direction',
+  name: 'Prop: direction',
+  key: 'test-split-direction',
   details: `
     Test the direction prop in Split component.
   `,

--- a/apps/src/tests/single-feature-tests/split/test-split-direction.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-direction.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
-import { Split } from 'react-native-screens/experimental';
+import { Split, SplitHostDirection } from 'react-native-screens/experimental';
 import { StyleSheet, Text, View, Button } from 'react-native';
 
 const scenarioDescription: ScenarioDescription = {
@@ -13,10 +13,8 @@ const scenarioDescription: ScenarioDescription = {
   platforms: ['ios'],
 };
 
-type LayoutDirection = 'ltr' | 'rtl' | 'inherit';
-
 export function App() {
-  const [direction, setDirection] = useState<LayoutDirection>('inherit');
+  const [direction, setDirection] = useState<SplitHostDirection>('inherit');
 
   return (
     <Split.Host direction={direction}>
@@ -28,9 +26,6 @@ export function App() {
         />
       </Split.Column>
       <Split.Column>
-        <ColumnContent columnTitle="Supplementary column" />
-      </Split.Column>
-      <Split.Column>
         <ColumnContent columnTitle="Secondary column" />
       </Split.Column>
     </Split.Host>
@@ -39,8 +34,8 @@ export function App() {
 
 export function ColumnContent(props: {
   columnTitle: string;
-  currentDirection?: LayoutDirection;
-  onChangeDirection?: (dir: LayoutDirection) => void;
+  currentDirection?: SplitHostDirection;
+  onChangeDirection?: (dir: SplitHostDirection) => void;
 }) {
   return (
     <View style={styles.container}>

--- a/ios/conversion/RNSConversions-SplitView.mm
+++ b/ios/conversion/RNSConversions-SplitView.mm
@@ -115,6 +115,23 @@ std::string UISplitViewControllerDisplayModeToString(UISplitViewControllerDispla
   }
 }
 
+UITraitEnvironmentLayoutDirection UITraitEnvironmentLayoutDirectionFromSplitHostCppEquivalent(
+    react::RNSSplitHostLayoutDirection layoutDirection)
+{
+  using enum facebook::react::RNSSplitHostLayoutDirection;
+  switch (layoutDirection) {
+    case Inherit:
+      return UITraitEnvironmentLayoutDirectionUnspecified;
+    case Ltr:
+      return UITraitEnvironmentLayoutDirectionLeftToRight;
+    case Rtl:
+      return UITraitEnvironmentLayoutDirectionRightToLeft;
+    default:
+      RCTLogError(@"[RNScreens] unsupported layout direction");
+      return UITraitEnvironmentLayoutDirectionUnspecified;
+  }
+}
+
 RNSOrientation RNSOrientationFromRNSSplitHostOrientation(react::RNSSplitHostOrientation orientation)
 {
   using enum facebook::react::RNSSplitHostOrientation;

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -134,6 +134,9 @@ std::optional<UISplitViewControllerColumn> SplitViewTopColumnForCollapsingFromHo
 
 RNSOrientation RNSOrientationFromRNSSplitHostOrientation(react::RNSSplitHostOrientation orientation);
 
+UITraitEnvironmentLayoutDirection UITraitEnvironmentLayoutDirectionFromSplitHostCppEquivalent(
+    react::RNSSplitHostLayoutDirection layoutDirection);
+
 #pragma mark SplitScreen props
 
 RNSSplitScreenColumnType RNSSplitScreenColumnTypeFromScreenProp(react::RNSSplitScreenColumnType columnType);

--- a/ios/gamma/split/RNSSplitAppearanceApplicator.swift
+++ b/ios/gamma/split/RNSSplitAppearanceApplicator.swift
@@ -48,6 +48,10 @@ class RNSSplitAppearanceApplicator {
     appearanceCoordinator.updateIfNeeded(.orientationUpdate) { [] in
       RNSScreenWindowTraits.enforceDesiredDeviceOrientation()
     }
+    
+    appearanceCoordinator.updateIfNeeded(.layoutDirectionUpdateBelowIOS17) {
+      updateLayoutDirectionBelowIOS17(splitHost, splitHostController)
+    }
   }
 
   ///
@@ -189,6 +193,20 @@ class RNSSplitAppearanceApplicator {
     assert(
       minWidth <= maxWidth,
       "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
+    )
+  }
+  
+  public func updateLayoutDirectionBelowIOS17(
+    _ splitHost: RNSSplitHostComponentView,
+    _ splitHostController: RNSSplitHostController,
+  ) {
+    assert(
+      splitHostController.parent != nil,
+      "[RNScreens] Expected non-null parent view controller for layout direction update."
+    )
+    splitHostController.parent?.setOverrideTraitCollection(
+      UITraitCollection(layoutDirection: splitHost.layoutDirection),
+      forChild: splitHostController
     )
   }
 }

--- a/ios/gamma/split/RNSSplitAppearanceApplicator.swift
+++ b/ios/gamma/split/RNSSplitAppearanceApplicator.swift
@@ -48,7 +48,7 @@ class RNSSplitAppearanceApplicator {
     appearanceCoordinator.updateIfNeeded(.orientationUpdate) { [] in
       RNSScreenWindowTraits.enforceDesiredDeviceOrientation()
     }
-    
+
     appearanceCoordinator.updateIfNeeded(.layoutDirectionUpdateBelowIOS17) {
       updateLayoutDirectionBelowIOS17(splitHost, splitHostController)
     }
@@ -195,7 +195,7 @@ class RNSSplitAppearanceApplicator {
       "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
     )
   }
-  
+
   public func updateLayoutDirectionBelowIOS17(
     _ splitHost: RNSSplitHostComponentView,
     _ splitHostController: RNSSplitHostController,

--- a/ios/gamma/split/RNSSplitAppearanceApplicator.swift
+++ b/ios/gamma/split/RNSSplitAppearanceApplicator.swift
@@ -49,6 +49,12 @@ class RNSSplitAppearanceApplicator {
       RNSScreenWindowTraits.enforceDesiredDeviceOrientation()
     }
 
+    appearanceCoordinator.updateIfNeeded(.layoutDirectionUpdateAboveIOS17) {
+      if #available(iOS 17.0, *) {
+        splitHostController.traitOverrides.layoutDirection = splitHost.layoutDirection
+      }
+    }
+
     appearanceCoordinator.updateIfNeeded(.layoutDirectionUpdateBelowIOS17) {
       updateLayoutDirectionBelowIOS17(splitHost, splitHostController)
     }

--- a/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift
+++ b/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift
@@ -8,4 +8,5 @@ struct RNSSplitAppearanceUpdateFlags: OptionSet {
   static let secondaryScreenNavBarUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 1)
   static let displayModeUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 2)
   static let orientationUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 3)
+  static let layoutDirectionUpdateBelowIOS17 = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 4)
 }

--- a/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift
+++ b/ios/gamma/split/RNSSplitAppearanceUpdateFlags.swift
@@ -8,5 +8,6 @@ struct RNSSplitAppearanceUpdateFlags: OptionSet {
   static let secondaryScreenNavBarUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 1)
   static let displayModeUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 2)
   static let orientationUpdate = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 3)
-  static let layoutDirectionUpdateBelowIOS17 = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 4)
+  static let layoutDirectionUpdateAboveIOS17 = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 4)
+  static let layoutDirectionUpdateBelowIOS17 = RNSSplitAppearanceUpdateFlags(rawValue: 1 << 5)
 }

--- a/ios/gamma/split/RNSSplitHostComponentView.h
+++ b/ios/gamma/split/RNSSplitHostComponentView.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 
 @property (nonatomic, readonly) RNSOrientation orientation;
+@property (nonatomic, readonly) UITraitEnvironmentLayoutDirection layoutDirection;
 
 @end
 

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -30,6 +30,7 @@ static const CGFloat epsilon = 1e-6;
   bool _needsSplitSecondaryScreenNavBarUpdate;
   bool _needsSplitDisplayModeUpdate;
   bool _needsSplitOrientationUpdate;
+  bool _needsSplitLayoutDirectionUpdate;
   // We need this information to warn users about dynamic changes to behavior being currently unsupported.
   bool _isShowSecondaryToggleButtonSet;
 }
@@ -53,6 +54,7 @@ static const CGFloat epsilon = 1e-6;
   _needsSplitSecondaryScreenNavBarUpdate = false;
   _needsSplitDisplayModeUpdate = false;
   _needsSplitOrientationUpdate = false;
+  _needsSplitLayoutDirectionUpdate = false;
   _reactSubviews = [NSMutableArray new];
 }
 
@@ -92,6 +94,7 @@ static const CGFloat epsilon = 1e-6;
   _topColumnForCollapsingColumn = UISplitViewControllerColumnPrimary;
 
   _orientation = RNSOrientationInherit;
+  _layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified;
 
   _isShowSecondaryToggleButtonSet = false;
 }
@@ -330,6 +333,12 @@ RNS_IGNORE_SUPER_CALL_END
     _orientation = rnscreens::conversion::RNSOrientationFromRNSSplitHostOrientation(newComponentProps.orientation);
   }
 
+  if (oldComponentProps.layoutDirection != newComponentProps.layoutDirection) {
+    _needsSplitLayoutDirectionUpdate = true;
+    _layoutDirection = rnscreens::conversion::UITraitEnvironmentLayoutDirectionFromSplitHostCppEquivalent(
+        newComponentProps.layoutDirection);
+  }
+
   // This flag is set to true when showsSecondaryOnlyButton prop is assigned for the first time.
   // This allows us to identify any subsequent changes to this prop,
   // enabling us to warn users that dynamic changes are not supported.
@@ -364,6 +373,16 @@ RNS_IGNORE_SUPER_CALL_END
   if (_needsSplitOrientationUpdate && _controller != nil) {
     _needsSplitOrientationUpdate = false;
     [_controller setNeedsOrientationUpdate];
+  }
+
+  if (_needsSplitLayoutDirectionUpdate && _controller != nil) {
+    _needsSplitLayoutDirectionUpdate = false;
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+    if (@available(iOS 17.0, *)) {
+      _controller.traitOverrides.layoutDirection = _layoutDirection;
+    } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+      [_controller setNeedsLayoutDirectionUpdateBelowIOS17];
   }
 }
 

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -377,12 +377,7 @@ RNS_IGNORE_SUPER_CALL_END
 
   if (_needsSplitLayoutDirectionUpdate && _controller != nil) {
     _needsSplitLayoutDirectionUpdate = false;
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
-    if (@available(iOS 17.0, *)) {
-      _controller.traitOverrides.layoutDirection = _layoutDirection;
-    } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
-      [_controller setNeedsLayoutDirectionUpdateBelowIOS17];
+    [_controller setNeedsLayoutDirectionUpdate];
   }
 }
 

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -11,6 +11,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   RNSOrientationProvidingSwift
 {
   private var needsChildViewControllersUpdate = false
+  private var isLayoutDirectionUpdatePending = false
 
   private var splitAppearanceCoordinator: RNSSplitAppearanceCoordinator
   private var splitAppearanceApplicator: RNSSplitAppearanceApplicator
@@ -93,6 +94,15 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   public func setNeedsOrientationUpdate() {
     splitAppearanceCoordinator.needs(.orientationUpdate)
   }
+  
+  @objc
+  public func setNeedsLayoutDirectionUpdateBelowIOS17() {
+    if self.parent != nil {
+      splitAppearanceCoordinator.needs(.layoutDirectionUpdateBelowIOS17)
+    } else {
+      isLayoutDirectionUpdatePending = true
+    }
+  }
 
   // MARK: Updating
 
@@ -140,7 +150,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
 
     needsChildViewControllersUpdate = false
   }
-
+  
   func updateSplitAppearanceIfNeeded() {
     splitAppearanceApplicator.updateAppearanceIfNeeded(
       self.splitHostComponentView, self, self.splitAppearanceCoordinator)
@@ -551,5 +561,15 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
       return splitHostComponentView.topColumnForCollapsingColumn
     }
     return proposedTopColumn
+  }
+  
+  public override func didMove(toParent parent: UIViewController?) {
+    super.didMove(toParent: parent)
+
+    if parent != nil && isLayoutDirectionUpdatePending {
+      isLayoutDirectionUpdatePending = false
+      splitAppearanceApplicator.updateLayoutDirectionBelowIOS17(
+        self.splitHostComponentView, self)
+    }
   }
 }

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -94,7 +94,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   public func setNeedsOrientationUpdate() {
     splitAppearanceCoordinator.needs(.orientationUpdate)
   }
-  
+
   @objc
   public func setNeedsLayoutDirectionUpdateBelowIOS17() {
     if self.parent != nil {
@@ -150,7 +150,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
 
     needsChildViewControllersUpdate = false
   }
-  
+
   func updateSplitAppearanceIfNeeded() {
     splitAppearanceApplicator.updateAppearanceIfNeeded(
       self.splitHostComponentView, self, self.splitAppearanceCoordinator)
@@ -562,7 +562,7 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
     }
     return proposedTopColumn
   }
-  
+
   public override func didMove(toParent parent: UIViewController?) {
     super.didMove(toParent: parent)
 

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -62,11 +62,11 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   required init?(coder aDecoder: NSCoder) {
     return nil
   }
-  
+
   // MARK: UIKit callbacks
   public override func didMove(toParent parent: UIViewController?) {
     super.didMove(toParent: parent)
-    
+
     if parent != nil && isLayoutDirectionUpdatePending {
       isLayoutDirectionUpdatePending = false
       splitAppearanceApplicator.updateLayoutDirectionBelowIOS17(
@@ -107,11 +107,15 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   }
 
   @objc
-  public func setNeedsLayoutDirectionUpdateBelowIOS17() {
-    if self.parent != nil {
-      splitAppearanceCoordinator.needs(.layoutDirectionUpdateBelowIOS17)
+  public func setNeedsLayoutDirectionUpdate() {
+    if #available(iOS 17.0, *) {
+      splitAppearanceCoordinator.needs(.layoutDirectionUpdateAboveIOS17)
     } else {
-      isLayoutDirectionUpdatePending = true
+      if self.parent != nil {
+        splitAppearanceCoordinator.needs(.layoutDirectionUpdateBelowIOS17)
+      } else {
+        isLayoutDirectionUpdatePending = true
+      }
     }
   }
 

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -62,6 +62,17 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   required init?(coder aDecoder: NSCoder) {
     return nil
   }
+  
+  // MARK: UIKit callbacks
+  public override func didMove(toParent parent: UIViewController?) {
+    super.didMove(toParent: parent)
+    
+    if parent != nil && isLayoutDirectionUpdatePending {
+      isLayoutDirectionUpdatePending = false
+      splitAppearanceApplicator.updateLayoutDirectionBelowIOS17(
+        self.splitHostComponentView, self)
+    }
+  }
 
   // MARK: Signals
 
@@ -561,15 +572,5 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
       return splitHostComponentView.topColumnForCollapsingColumn
     }
     return proposedTopColumn
-  }
-
-  public override func didMove(toParent parent: UIViewController?) {
-    super.didMove(toParent: parent)
-
-    if parent != nil && isLayoutDirectionUpdatePending {
-      isLayoutDirectionUpdatePending = false
-      splitAppearanceApplicator.updateLayoutDirectionBelowIOS17(
-        self.splitHostComponentView, self)
-    }
   }
 }

--- a/src/components/gamma/split/SplitHost.tsx
+++ b/src/components/gamma/split/SplitHost.tsx
@@ -43,7 +43,7 @@ const isValidDisplayModeForSplitBehavior = (
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
 function SplitHost({ ref, ...props }: SplitHostProps) {
-  const { preferredDisplayMode, preferredSplitBehavior } = props;
+  const { direction, preferredDisplayMode, preferredSplitBehavior } = props;
   const nativeRef = React.useRef<NativeRef>(null);
 
   React.useImperativeHandle(
@@ -101,6 +101,7 @@ function SplitHost({ ref, ...props }: SplitHostProps) {
       // This enables us to fully recreate the Split when necessary, ensuring the correct column configuration is always applied.
       key={`columns-${columns.length}-inspectors-${inspectors.length}`}
       {...props}
+      layoutDirection={direction}
       style={styles.container}>
       {props.children}
     </SplitHostNativeComponent>

--- a/src/components/gamma/split/SplitHost.tsx
+++ b/src/components/gamma/split/SplitHost.tsx
@@ -43,7 +43,8 @@ const isValidDisplayModeForSplitBehavior = (
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
 function SplitHost({ ref, ...props }: SplitHostProps) {
-  const { direction, preferredDisplayMode, preferredSplitBehavior } = props;
+  const { direction, ...filteredProps } = props;
+  const { preferredDisplayMode, preferredSplitBehavior } = filteredProps;
   const nativeRef = React.useRef<NativeRef>(null);
 
   React.useImperativeHandle(
@@ -100,7 +101,7 @@ function SplitHost({ ref, ...props }: SplitHostProps) {
       // By using a specific key in this form, we can detect changes in the number of React children.
       // This enables us to fully recreate the Split when necessary, ensuring the correct column configuration is always applied.
       key={`columns-${columns.length}-inspectors-${inspectors.length}`}
-      {...props}
+      {...filteredProps}
       layoutDirection={direction}
       style={styles.container}>
       {props.children}

--- a/src/components/gamma/split/SplitHost.types.ts
+++ b/src/components/gamma/split/SplitHost.types.ts
@@ -1,5 +1,5 @@
 import type { NativeSyntheticEvent, ViewProps } from 'react-native';
-import type { InterfaceOrientation } from '../../shared/types';
+import type { Direction, InterfaceOrientation } from '../../shared/types';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;
@@ -25,6 +25,8 @@ export type SplitDisplayMode =
   | 'twoBesideSecondary'
   | 'twoOverSecondary'
   | 'twoDisplaceSecondary';
+
+export type SplitHostDirection = Direction | 'inherit';
 
 export type SplitHostOrientation = InterfaceOrientation | 'inherit';
 
@@ -116,6 +118,27 @@ export interface SplitHostProps extends ViewProps {
   children?: React.ReactNode;
   ref?: React.Ref<SplitHostCommands>;
 
+  /**
+   * @summary Specifies the layout direction of the native container, its views and child containers.
+   *
+   * The following values are currently supported:
+   *
+   * - `inherit` - uses parent's layout direction,
+   * - `ltr` - forces left-to-right layout direction,
+   * - `rtl` - forces right-to-left layout direction.
+   *
+   * On iOS, this property sets `layoutDirection` trait override for the
+   * native split view controller. Property is propagated via the native trait
+   * system. The value will fallback to direction of the **native** app
+   * (`userInterfaceLayoutDirection`), potentially ignoring `react-native`'s
+   * override (e.g. when `forceRTL` is used). To mitigate this, you can pass
+   * `ltr`/`rtl` to this property depending on the value of `I18nManager.isRTL`.
+   *
+   * @default inherit
+   *
+   * @platform ios
+   */
+  direction?: SplitHostDirection;
   /**
    * @summary An object describing bounds for column widths.
    *

--- a/src/components/gamma/split/index.ts
+++ b/src/components/gamma/split/index.ts
@@ -8,6 +8,7 @@ export type {
   SplitPrimaryEdge,
   SplitPrimaryBackgroundStyle,
   SplitDisplayMode,
+  SplitHostDirection,
   SplitHostOrientation,
   SplitColumnMetrics,
   SplitNavigableColumn,

--- a/src/fabric/gamma/split/SplitHostNativeComponent.ts
+++ b/src/fabric/gamma/split/SplitHostNativeComponent.ts
@@ -43,6 +43,8 @@ type SplitViewOrientation =
 
 type SplitViewPrimaryBackgroundStyle = 'default' | 'none' | 'sidebar';
 
+type LayoutDirection = 'inherit' | 'ltr' | 'rtl';
+
 type SplitViewTopColumnForCollapsing =
   | 'default'
   | 'primary'
@@ -68,6 +70,7 @@ interface ColumnMetrics {
 interface NativeProps extends ViewProps {
   // Appearance
 
+  layoutDirection?: CT.WithDefault<LayoutDirection, 'inherit'>;
   preferredDisplayMode?: CT.WithDefault<SplitViewDisplayMode, 'automatic'>;
   preferredSplitBehavior?: CT.WithDefault<SplitViewSplitBehavior, 'automatic'>;
   primaryEdge?: CT.WithDefault<SplitViewPrimaryEdge, 'leading'>;


### PR DESCRIPTION
## Description

This PR introduces `RTL` support to `SplitHost`.

The approach differs on iOS versions prior to iOS 17 and newer ones.

On < iOS 17 versions, we use `setOverrideTraitCollection(_: forChild:)` on the parent view controller to propagate the layout direction, accordingly to https://github.com/software-mansion/react-native-screens-labs/blob/main-issue-tracker/rfcs/0996-rtl-and-dark-mode.md

There is a specific edge case on those iOS versions: if the layout direction is changed while a column is currently open/visible, the UI becomes inconsistent. The sidebar remains on its original side, while the display mode button moves to the new side. The layout only synchronizes correctly after the column is closed and reopened. I checked this issue and it's a native bug: https://github.com/software-mansion/react-native-screens-labs/issues/1237

On ≥ iOS 17 versions, we use `traitOverrides` API on the view controller.

Closes https://github.com/issues/assigned?issue=software-mansion%7Creact-native-screens-labs%7C1027

Currently blocked by https://github.com/software-mansion/react-native-screens-labs/issues/1429 - it needs to be fixed in order to make a stable test.

## Changes

- add `direction` prop to `SplitHost`
- handle `layoutDirection` on iOS side
- add `test-split-direction.tsx`

## After - visual documentation

|  < iOS 17 |  ≥ iOS 17  |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/a60ff404-3f6f-44f0-bdf1-58c31191afd2"></video> | <video src="https://github.com/user-attachments/assets/12dbf516-d2f8-46a1-8f6a-0836b91078e1"></video> |

`inherit` option also works properly for locations with `RTL` direction as a default:

https://github.com/user-attachments/assets/720ed82d-045a-4e60-bbf7-e48accf8d117


## Test plan

Run `test-split-direction`.



## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
