### PR TITLE
chore(examples): Apply RNRepo to FabricExample

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -46,4 +46,4 @@ jobs:
         run: yarn
       - name: Build app
         working-directory: ${{ env.WORKING_DIRECTORY }}/android
-        run: ./gradlew assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a
+        run: ./gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a

--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 // Use RNRepo in CI builds
-if (System.getenv("CI") == "true") {
+if (["1", "true"].contains(System.getenv("CI"))) {
   apply plugin: "org.rnrepo.tools.prebuilds-plugin"
 }
 

--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -2,6 +2,11 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+// Use RNRepo in CI builds
+if (System.getenv("CI") == "true") {
+  apply plugin: "org.rnrepo.tools.prebuilds-plugin"
+}
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -2,9 +2,19 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
-// Use RNRepo in CI builds
-if (["1", "true"].contains(System.getenv("CI"))) {
-  apply plugin: "org.rnrepo.tools.prebuilds-plugin"
+def isCIEnabled() {
+    return ["1", "true"].contains(System.getenv("CI")?.toLowerCase())
+}
+
+// System.setProperty("DISABLE_RNREPO", "1") // Uncomment to disable RNRepo even in CI
+def isRNRepoEnabled() {
+    return System.getenv("DISABLE_RNREPO") == null
+}
+
+// Use RNRepo in CI builds. 
+// Set DISABLE_RNREPO to any value to disable RNRepo.
+if (isCIEnabled() && isRNRepoEnabled()) {
+    apply plugin: "org.rnrepo.tools.prebuilds-plugin"
 }
 
 /**

--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -15,6 +15,14 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        // RNRepo plugin in CI builds (plugin applied in app/build.gradle)
+        def rnrepoDir = new File(
+            providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
+            }.standardOutput.asText.get().trim()
+        ).getParentFile().absolutePath
+        classpath fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
     }
 }
 

--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -1,15 +1,3 @@
-// RNRepo plugin classpath for CI builds (plugin applied in app/build.gradle).
-// To disable RNRepo support, set DISABLE_RNREPO environment variable to ANY value.
-def rnrepoClasspath() {
-    def rnrepoDir = new File(
-        providers.exec {
-            workingDir(rootDir)
-            commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
-        }.standardOutput.asText.get().trim()
-    ).getParentFile().absolutePath
-    return fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
-}
-
 buildscript {
     ext {
         buildToolsVersion = "36.0.0"
@@ -22,6 +10,17 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+    }
+    // RNRepo plugin classpath for CI builds (plugin applied in app/build.gradle).
+    // To disable RNRepo support, set DISABLE_RNREPO environment variable to ANY value.
+    def rnrepoClasspath = {
+        def rnrepoDir = new File(
+            providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
+            }.standardOutput.asText.get().trim()
+        ).getParentFile().absolutePath
+        return fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
     }
     dependencies {
         classpath("com.android.tools.build:gradle")

--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -1,3 +1,15 @@
+// RNRepo plugin classpath for CI builds (plugin applied in app/build.gradle).
+// To disable RNRepo support, set DISABLE_RNREPO environment variable to ANY value.
+def rnrepoClasspath() {
+    def rnrepoDir = new File(
+        providers.exec {
+            workingDir(rootDir)
+            commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
+        }.standardOutput.asText.get().trim()
+    ).getParentFile().absolutePath
+    return fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
+}
+
 buildscript {
     ext {
         buildToolsVersion = "36.0.0"
@@ -15,14 +27,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        // RNRepo plugin in CI builds (plugin applied in app/build.gradle)
-        def rnrepoDir = new File(
-            providers.exec {
-                workingDir(rootDir)
-                commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
-            }.standardOutput.asText.get().trim()
-        ).getParentFile().absolutePath
-        classpath fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
+        classpath rnrepoClasspath()
     }
 }
 

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -5,6 +5,15 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
+# Use RNRepo in CI builds
+if ENV['CI'] == 'true'
+  require Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+      "@rnrepo/build-tools/cocoapods-plugin/lib/plugin.rb",
+      {paths: [process.argv[1]]},
+    )', __dir__]).strip
+end
+
 require_relative '../../scripts/ios/rns_update_info_plist'
 require_relative '../../scripts/ios/rns_set_swift_compilation_flags'
 
@@ -30,6 +39,9 @@ target 'FabricExample' do
   )
 
   post_install do |installer|
+    if ENV['CI'] == 'true'
+      rnrepo_post_install(installer)
+    end
     react_native_post_install(
       installer,
       config[:reactNativePath],

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -6,7 +6,7 @@ require Pod::Executable.execute_command('node', ['-p',
   )', __dir__]).strip
 
 # Use RNRepo in CI builds
-if ENV['CI'] == 'true'
+if %w[1 true].include?(ENV['CI'].to_s.downcase)
   require Pod::Executable.execute_command('node', ['-p',
     'require.resolve(
       "@rnrepo/build-tools/cocoapods-plugin/lib/plugin.rb",
@@ -39,7 +39,7 @@ target 'FabricExample' do
   )
 
   post_install do |installer|
-    if ENV['CI'] == 'true'
+    if %w[1 true].include?(ENV['CI'].to_s.downcase)
       rnrepo_post_install(installer)
     end
     react_native_post_install(

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -5,8 +5,17 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
-# Use RNRepo in CI builds
-if %w[1 true].include?(ENV['CI'].to_s.downcase)
+def is_ci_enabled?
+  %w[1 true].include?(ENV['CI'].to_s.downcase)
+end
+
+# ENV['DISABLE_RNREPO'] = "1" # Uncomment to disable RNRepo even in CI
+def is_rnrepo_enabled?
+  ENV['DISABLE_RNREPO'].nil?
+end
+
+# Use RNRepo in CI builds. Set DISABLE_RNREPO to any value to disable RNRepo.
+if is_ci_enabled? && is_rnrepo_enabled?
   require Pod::Executable.execute_command('node', ['-p',
     'require.resolve(
       "@rnrepo/build-tools/cocoapods-plugin/lib/plugin.rb",
@@ -39,7 +48,7 @@ target 'FabricExample' do
   )
 
   post_install do |installer|
-    if %w[1 true].include?(ENV['CI'].to_s.downcase)
+    if is_ci_enabled? && is_rnrepo_enabled?
       rnrepo_post_install(installer)
     end
     react_native_post_install(

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -48,6 +48,7 @@
     "@react-native/jest-preset": "0.85.0",
     "@react-native/metro-config": "0.85.0",
     "@react-native/typescript-config": "0.85.0",
+    "@rnrepo/build-tools": "~0.1.3-beta.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.0",
     "@types/react-test-renderer": "^19.1.0",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -3101,6 +3101,13 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@rnrepo/build-tools@npm:~0.1.3-beta.0":
+  version: 0.1.3-beta.0
+  resolution: "@rnrepo/build-tools@npm:0.1.3-beta.0"
+  checksum: 10c0/83d2c2b05d87ab038d139c56b2e8ea1df071c41a51094a6464d9c7bc5794f25eb289b8b9298418e829d9ebfe723a77d5556fb1eaf69d87b25dda1f7d19d2d5fb
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -3515,6 +3522,7 @@ __metadata:
     "@react-navigation/native-stack": "link:../react-navigation/packages/native-stack/"
     "@react-navigation/routers": "link:../react-navigation/packages/routers/"
     "@react-navigation/stack": "link:../react-navigation/packages/stack/"
+    "@rnrepo/build-tools": "npm:~0.1.3-beta.0"
     "@types/jest": "npm:^29.5.13"
     "@types/react": "npm:^19.2.0"
     "@types/react-test-renderer": "npm:^19.1.0"


### PR DESCRIPTION
## Description

Adds RNRepo build-tools integration to `FabricExample` so that CI builds can consume pre-built native dependencies instead of compiling them from scratch, speeding up CI.

The integration is guarded by `CI=true` / `ENV['CI']` environment variables, so local development is unaffected.

## Changes

- `FabricExample/android/build.gradle` — resolves `@rnrepo/build-tools` via Node and adds its Gradle plugin JAR to the buildscript classpath.
- `FabricExample/android/app/build.gradle` — applies `org.rnrepo.tools.prebuilds-plugin` when running in CI.
- `FabricExample/ios/Podfile` — requires the RNRepo CocoaPods plugin and calls `rnrepo_post_install` in the `post_install` hook, both gated on `ENV['CI']`.
- `FabricExample/package.json` — adds `@rnrepo/build-tools ~0.1.3-beta.0` as a dev dependency.

## Performance

CI build time comparison (rnrepo vs baseline):

| Platform | Category | rnrepo | basic | Faster |
| --- | --- | --- | --- | --- |
| Android | Without runner cache | 6:53 avg | 8:35 avg | **19.8%** |
| Android | With runner cache | 3:17 avg | 5:29 avg | **40.1%** |
| iOS | Without runner cache | 6:22 | 6:16 | -1.6% |
| iOS | With runner cache | 6:28 avg | 6:18 avg | -2.6% |
| iOS | With runner cache and prebuilt rncore | 3:31 avg | 4:01 avg | **12.4%** |

Android sees the biggest wins (~20% standard, ~40% with cache). iOS gains are visible when `rncore` is prebuilt (~12%) (tracked in #3955).

## Test plan

- Verified that a local build (without `CI=true`) still works without any RNRepo-related side effects.
- CI run with `CI=true` should pick up pre-built artifacts via the RNRepo plugin on both Android and iOS.
