### PR TITLE
feat(tabs): cohesive cross-platform native API + observer registry

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -95,7 +95,7 @@ class TabsContainer internal constructor(
         checkNotNull(pendingStateUpdateRequest) { "[RNScreens] Attempt to require nullish pendingStateUpdateRequest" }
 
     /**
-     * Denotes whether container is currently performing update triggered by the `pendingOperation`.
+     * Denotes whether container is currently performing update triggered by the `pendingStateUpdateRequest`.
      */
     private var isInExternalOperationContext: Boolean = false
 
@@ -248,7 +248,7 @@ class TabsContainer internal constructor(
 
     /**
      * Idempotent teardown. Releases observer references and clears any pending operation.
-     * Called by the host on view recycle. Note: named `tearDown` (not `invalidate`) to avoid
+     * Called by the host on view lifecycle end. Note: named `tearDown` (not `invalidate`) to avoid
      * shadowing [android.view.View.invalidate].
      */
     internal fun tearDown() {
@@ -539,9 +539,7 @@ class TabsContainer internal constructor(
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
                 actionOrigin =
                     if (isInExternalOperationContext) {
-                        checkNotNull(pendingStateUpdateRequest) {
-                            "[RNScreens] Unexpected pending operation $pendingStateUpdateRequest while in external operation context"
-                        }.actionOrigin
+                        requirePendingStateUpdateRequest().actionOrigin
                     } else {
                         TabsActionOrigin.USER
                     },

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -89,9 +89,9 @@ class TabsContainer internal constructor(
 
     internal val invalidationFlags = TabsContainerInvalidationFlags()
 
-    private var pendingOperation: TabsContainerOp? = null
-    internal val hasPendingOperation
-        get() = pendingOperation != null
+    private var pendingStateUpdateRequest: TabsNavigationStateUpdateRequest? = null
+    private val requirePendingStateUpdateRequest: TabsNavigationStateUpdateRequest
+        get() = checkNotNull(pendingStateUpdateRequest) { "[RNScreens] Attempt to require nullish pendingStateUpdateRequest" }
 
     /**
      * Denotes whether container is currently performing update triggered by the `pendingOperation`.
@@ -174,9 +174,14 @@ class TabsContainer internal constructor(
      * Queue a navigation state update. Apply via [flushPendingUpdates] or rely on the
      * host's next render cycle to apply automatically.
      */
-    fun setPendingNavigationStateUpdate(request: TabsNavigationStateUpdateRequest) {
-        pendingOperation = TabSelectOp(request)
-        invalidationFlags.isSelectedTabInvalidated = true
+    fun submitSelectionOfTabsScreenWithKey(screenKey: String) {
+        setPendingNavigationStateUpdate(
+            TabsNavigationStateUpdateRequest(
+                screenKey,
+                navigationState.provenance,
+                TabsActionOrigin.PROGRAMMATIC_NATIVE,
+            ),
+        )
     }
 
     /**
@@ -196,6 +201,15 @@ class TabsContainer internal constructor(
     // endregion
 
     // region Host-internal API
+
+    /**
+     * Queue a navigation state update. Apply via [flushPendingUpdates] or rely on the
+     * host's next render cycle to apply automatically.
+     */
+    internal fun setPendingNavigationStateUpdate(request: TabsNavigationStateUpdateRequest?) {
+        pendingStateUpdateRequest = request
+        invalidationFlags.isSelectedTabInvalidated = request != null
+    }
 
     internal fun addTabsScreenAt(
         index: Int,
@@ -238,8 +252,7 @@ class TabsContainer internal constructor(
      */
     internal fun tearDown() {
         observerRegistry.clear()
-        pendingOperation = null
-        invalidationFlags.isSelectedTabInvalidated = false
+        setPendingNavigationStateUpdate(null)
     }
 
     // endregion
@@ -397,27 +410,25 @@ class TabsContainer internal constructor(
     }
 
     private fun performOperation() {
-        if (pendingOperation == null) {
+        if (pendingStateUpdateRequest == null) {
             RNSLog.w(TAG, "TabsContainer::performOperation called w/o pending operation; skipping update")
             return
         }
 
-        check(hasPendingOperation) { "[RNScreens] Attempt to update container with empty state and no pending update" }
-        check(pendingOperation is TabSelectOp)
-        val tabSelectOp = pendingOperation as TabSelectOp
+        val stateUpdateRequest = requirePendingStateUpdateRequest
 
         val nextSelectedMenuItemId =
-            checkNotNull(getMenuItemIdForFragment(requireFragmentForScreenKey(tabSelectOp.request.selectedScreenKey))) {
-                "[RNScreens] Failed to find Menu Item for screenKey: ${tabSelectOp.request.selectedScreenKey}"
+            checkNotNull(getMenuItemIdForFragment(requireFragmentForScreenKey(stateUpdateRequest.selectedScreenKey))) {
+                "[RNScreens] Failed to find Menu Item for screenKey: ${stateUpdateRequest.selectedScreenKey}"
             }
 
-        if (rejectStaleNavigationStateUpdates && isNavigationStateStale(tabSelectOp.request)) {
+        if (rejectStaleNavigationStateUpdates && isNavigationStateStale(stateUpdateRequest)) {
             observerRegistry.emitOnNavigationStateUpdateRejected(
                 navState,
-                tabSelectOp.request,
+                stateUpdateRequest,
                 TabsNavigationStateRejectionReason.STALE,
             )
-            pendingOperation = null
+            pendingStateUpdateRequest = null
             return
         }
 
@@ -429,12 +440,12 @@ class TabsContainer internal constructor(
         } else {
             observerRegistry.emitOnNavigationStateUpdateRejected(
                 navState,
-                tabSelectOp.request,
+                stateUpdateRequest,
                 TabsNavigationStateRejectionReason.REPEATED,
             )
         }
 
-        pendingOperation = null
+        pendingStateUpdateRequest = null
     }
 
     private fun updateNavigationMenuStructure() {
@@ -464,7 +475,7 @@ class TabsContainer internal constructor(
 
     private fun updateSelectedFragment(nextSelectedFragment: TabsScreenFragment): Boolean {
         if (navState.isEmpty()) {
-            check(isInExternalOperationContext && hasPendingOperation)
+            check(isInExternalOperationContext && pendingStateUpdateRequest != null)
             navState = TabsNavigationState(nextSelectedFragment.requireScreenKey, 0)
             requireFragmentManager
                 .createTransactionWithReordering()
@@ -527,10 +538,9 @@ class TabsContainer internal constructor(
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
                 actionOrigin =
                     if (isInExternalOperationContext) {
-                        check(pendingOperation != null && pendingOperation is TabSelectOp) {
-                            "[RNScreens] Unexpected pending operation $pendingOperation while in external operation context"
-                        }
-                        (pendingOperation as TabSelectOp).request.actionOrigin
+                        checkNotNull(pendingStateUpdateRequest) {
+                            "[RNScreens] Unexpected pending operation $pendingStateUpdateRequest while in external operation context"
+                        }.actionOrigin
                     } else {
                         TabsActionOrigin.USER
                     },

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -36,10 +36,17 @@ import com.swmansion.rnscreens.safearea.SafeAreaView
 import com.swmansion.rnscreens.utils.RNSLog
 import kotlin.properties.Delegates
 
+/**
+ * View that hosts the bottom navigation bar and the currently selected tab's content.
+ *
+ * Public API surface (the only contract third-party native consumers should rely on) is
+ * grouped under the `Public API` region below. Members in `Host-internal API` and other
+ * regions are implementation detail — the host (`TabsHost`) is the only intended caller
+ * and these can change without notice.
+ */
 @SuppressLint("ViewConstructor") // Created only by us. Should never be restored.
 class TabsContainer internal constructor(
     private val context: Context,
-    private val delegate: TabsContainerDelegate,
 ) : FrameLayout(context),
     ColorSchemeProviding,
     TabsScreenDelegate,
@@ -70,10 +77,11 @@ class TabsContainer internal constructor(
         }
     }
 
-    private var navState: TabsNavState = TabsNavState.EMPTY
-    private var lastUINavState: TabsNavState = TabsNavState.EMPTY
+    private var navState: TabsNavigationState = TabsNavigationState.EMPTY
+    private var lastUINavState: TabsNavigationState = TabsNavigationState.EMPTY
     private val tabsModel: MutableList<TabsScreenFragment> = arrayListOf()
-    internal var rejectOpsWithStaleNavState: Boolean = false
+
+    internal var rejectStaleNavigationStateUpdates: Boolean = false
 
     internal val selectedTab: TabsScreenFragment
         get() =
@@ -113,6 +121,8 @@ class TabsContainer internal constructor(
     private val specialEffectsHandler = SpecialEffectsHandler()
     private val colorSchemeCoordinator = ColorSchemeCoordinator()
 
+    private val observerRegistry = TabsNavigationStateObserverRegistry()
+
     internal var colorScheme: ColorScheme by colorSchemeCoordinator::colorScheme
     internal var tabBarRespectsIMEInsets: Boolean = false
 
@@ -138,9 +148,8 @@ class TabsContainer internal constructor(
             updateInterfaceInsets()
             invalidationFlags.isNavigationMenuAppearanceInvalidated = true
             post {
-                performContainerUpdateIfNeeded()
+                flushPendingUpdates()
             }
-//            updateNavigationMenuIfNeeded(oldValue, newValue)
         }
     }
 
@@ -152,12 +161,97 @@ class TabsContainer internal constructor(
         invalidationFlags.invalidateAll()
     }
 
+    // region Public API (third-party stable)
+
+    /**
+     * Current navigation state of the container.
+     * Returns [TabsNavigationState.EMPTY] before the first tab is selected.
+     */
+    val navigationState: TabsNavigationState
+        get() = navState
+
+    /**
+     * Queue a navigation state update. Apply via [flushPendingUpdates] or rely on the
+     * host's next render cycle to apply automatically.
+     */
+    fun setPendingNavigationStateUpdate(request: TabsNavigationStateUpdateRequest) {
+        pendingOperation = TabSelectOp(request)
+        invalidationFlags.isSelectedTabInvalidated = true
+    }
+
+    /**
+     * Apply any pending invalidations and state updates in a single coordinated pass.
+     * No-op when nothing is dirty or the view is detached.
+     */
+    fun flushPendingUpdates() {
+        if (invalidationFlags.any() && isAttachedToWindow) {
+            performContainerUpdate()
+        }
+    }
+
+    fun addNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.add(observer)
+
+    fun removeNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.remove(observer)
+
+    // endregion
+
+    // region Host-internal API
+
+    internal fun addTabsScreenAt(
+        index: Int,
+        tabsScreen: TabsScreen,
+    ) {
+        tabsModel.add(index, TabsScreenFragment(tabsScreen))
+        invalidationFlags.invalidateAll()
+    }
+
+    internal fun removeTabsScreenAt(index: Int): TabsScreen? =
+        tabsModel.removeAt(index).tabsScreen.also {
+            invalidationFlags.invalidateAll()
+        }
+
+    internal fun removeTabsScreen(tabsScreen: TabsScreen): Boolean =
+        tabsModel.removeIf { it.tabsScreen === tabsScreen }.also { isRemoved ->
+            if (isRemoved) invalidationFlags.invalidateAll()
+        }
+
+    internal fun removeAllTabsScreens() {
+        tabsModel.clear()
+        invalidationFlags.invalidateAll()
+    }
+
+    internal fun setupFragmentManager() {
+        fragmentManager =
+            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
+                "[RNScreens] Nullish fragment manager - can't run container operations"
+            }
+    }
+
+    internal fun teardownFragmentManager() {
+        fragmentManager = null
+    }
+
+    /**
+     * Idempotent teardown. Releases observer references and clears any pending operation.
+     * Called by the host on view recycle. Note: named `tearDown` (not `invalidate`) to avoid
+     * shadowing [android.view.View.invalidate].
+     */
+    internal fun tearDown() {
+        observerRegistry.clear()
+        pendingOperation = null
+        invalidationFlags.isSelectedTabInvalidated = false
+    }
+
+    // endregion
+
+    // region View lifecycle / insets / appearance
+
     override fun onAttachedToWindow() {
         RNSLog.d(TAG, "TabsContainer [$id] attached to window")
 
         super.onAttachedToWindow()
         setupFragmentManager()
-        performContainerUpdateIfNeeded()
+        flushPendingUpdates()
 
         colorSchemeCoordinator.setup(this) { uiNightMode ->
             applyDayNightUiMode(uiNightMode)
@@ -196,39 +290,93 @@ class TabsContainer internal constructor(
         return insets
     }
 
-    fun setPendingNavigationStateUpdate(request: TabsNavStateUpdateRequest) {
-        pendingOperation = TabSelectOp(request)
-        invalidationFlags.isSelectedTabInvalidated = true
-    }
-
-    internal fun addTabsScreenAt(
-        index: Int,
-        tabsScreen: TabsScreen,
+    override fun onLayoutChange(
+        view: View?,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        oldLeft: Int,
+        oldTop: Int,
+        oldRight: Int,
+        oldBottom: Int,
     ) {
-        tabsModel.add(index, TabsScreenFragment(tabsScreen))
-        invalidationFlags.invalidateAll()
-    }
-
-    internal fun removeTabsScreenAt(index: Int): TabsScreen? =
-        tabsModel.removeAt(index).tabsScreen.also {
-            invalidationFlags.invalidateAll()
+        require(view is BottomNavigationView) {
+            "[RNScreens] TabsContainer's onLayoutChange expects BottomNavigationView, received $view instead"
         }
 
-    internal fun removeTabsScreen(tabsScreen: TabsScreen): Boolean =
-        tabsModel.removeIf { it.tabsScreen === tabsScreen }.also { isRemoved ->
-            if (isRemoved) invalidationFlags.invalidateAll()
-        }
+        val oldHeight = oldBottom - oldTop
+        val newHeight = bottom - top
 
-    internal fun removeAllTabsScreens() {
-        tabsModel.clear()
-        invalidationFlags.invalidateAll()
-    }
-
-    fun performContainerUpdateIfNeeded() {
-        if (invalidationFlags.any() && isAttachedToWindow) {
-            performContainerUpdate()
+        if (newHeight != oldHeight) {
+            updateInterfaceInsets(newHeight)
         }
     }
+
+    override fun setOnInterfaceInsetsChangeListener(listener: SafeAreaView) {
+        if (interfaceInsetsChangeListener == null) {
+            bottomNavigationView.addOnLayoutChangeListener(this)
+        }
+        interfaceInsetsChangeListener = listener
+    }
+
+    override fun removeOnInterfaceInsetsChangeListener(listener: SafeAreaView) {
+        if (interfaceInsetsChangeListener == listener) {
+            interfaceInsetsChangeListener = null
+            bottomNavigationView.removeOnLayoutChangeListener(this)
+        }
+    }
+
+    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
+
+    override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
+
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+
+    // endregion
+
+    // region TabsScreenDelegate impl
+
+    override fun onAppearanceChanged(tabsScreen: TabsScreen) {
+        if (selectedTab.tabsScreen === tabsScreen) {
+            invalidationFlags.isNavigationMenuAppearanceInvalidated = true
+            post {
+                this.flushPendingUpdates()
+            }
+        }
+    }
+
+    override fun onMenuItemAttributesChange(tabsScreen: TabsScreen) {
+        getMenuItemForTabsScreen(tabsScreen)?.let { menuItem ->
+            val appearance = selectedTab.tabsScreen.appearance
+            appearanceCoordinator.updateMenuItemAppearance(
+                themedContext,
+                menuItem,
+                tabsScreen,
+                appearance,
+            )
+            a11yCoordinator.setA11yPropertiesToTabItem(menuItem, tabsScreen)
+        }
+    }
+
+    override fun getFragmentForTabsScreen(tabsScreen: TabsScreen): TabsScreenFragment? =
+        tabsModel.find {
+            it.tabsScreen ===
+                tabsScreen
+        }
+
+    override fun onFragmentConfigurationChange(
+        tabsScreen: TabsScreen,
+        config: Configuration,
+    ) {
+        this.onConfigurationChanged(config)
+    }
+
+    // endregion
+
+    // region Private helpers
 
     private fun performContainerUpdate() {
         if (invalidationFlags.isNavigationMenuStructureInvalidated) {
@@ -263,11 +411,11 @@ class TabsContainer internal constructor(
                 "[RNScreens] Failed to find Menu Item for screenKey: ${tabSelectOp.request.selectedScreenKey}"
             }
 
-        if (rejectOpsWithStaleNavState && isNavStateStale(tabSelectOp.request)) {
-            delegate.onNavStateUpdateRejected(
+        if (rejectStaleNavigationStateUpdates && isNavigationStateStale(tabSelectOp.request)) {
+            observerRegistry.emitOnNavigationStateUpdateRejected(
                 navState,
                 tabSelectOp.request,
-                TabsNavStateUpdateRejectionReason.STALE,
+                TabsNavigationStateRejectionReason.STALE,
             )
             pendingOperation = null
             return
@@ -279,10 +427,10 @@ class TabsContainer internal constructor(
             bottomNavigationView.selectedItemId = nextSelectedMenuItemId
             isInExternalOperationContext = false
         } else {
-            delegate.onNavStateUpdateRejected(
+            observerRegistry.emitOnNavigationStateUpdateRejected(
                 navState,
                 tabSelectOp.request,
-                TabsNavStateUpdateRejectionReason.REPEATED,
+                TabsNavigationStateRejectionReason.REPEATED,
             )
         }
 
@@ -317,7 +465,7 @@ class TabsContainer internal constructor(
     private fun updateSelectedFragment(nextSelectedFragment: TabsScreenFragment): Boolean {
         if (navState.isEmpty()) {
             check(isInExternalOperationContext && hasPendingOperation)
-            navState = TabsNavState(nextSelectedFragment.requireScreenKey, 0)
+            navState = TabsNavigationState(nextSelectedFragment.requireScreenKey, 0)
             requireFragmentManager
                 .createTransactionWithReordering()
                 .add(contentView.id, nextSelectedFragment)
@@ -344,7 +492,7 @@ class TabsContainer internal constructor(
     }
 
     private fun progressNavigationState(selectedScreenKey: String) {
-        navState = TabsNavState(selectedScreenKey, navState.provenance + 1)
+        navState = TabsNavigationState(selectedScreenKey, navState.provenance + 1)
         if (!isInExternalOperationContext) {
             lastUINavState = navState
         }
@@ -363,7 +511,7 @@ class TabsContainer internal constructor(
 
         // If this is user action we test whether it should be prevented before we progress the state.
         if (!isRepeated && !isInExternalOperationContext && nextSelectedFragment.isPreventNativeSelectionEnabled) {
-            delegate.onNavStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
+            observerRegistry.emitOnNavigationStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
             return false
         }
 
@@ -373,7 +521,7 @@ class TabsContainer internal constructor(
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
 
         if (stateChanged) {
-            delegate.onNavStateUpdate(
+            observerRegistry.emitOnNavigationStateUpdate(
                 navState,
                 isRepeated = isRepeated,
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
@@ -432,90 +580,12 @@ class TabsContainer internal constructor(
                 bottomNavigationView.menu.findItem(menuItemIdForFragmentAtIndex(index))
             }
 
-    override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
-
-    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
-
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
-
-    override fun onAppearanceChanged(tabsScreen: TabsScreen) {
-        if (selectedTab.tabsScreen === tabsScreen) {
-            invalidationFlags.isNavigationMenuAppearanceInvalidated = true
-            post {
-                this.performContainerUpdateIfNeeded()
-            }
-        }
-    }
-
-    override fun onMenuItemAttributesChange(tabsScreen: TabsScreen) {
-        getMenuItemForTabsScreen(tabsScreen)?.let { menuItem ->
-            val appearance = selectedTab.tabsScreen.appearance
-            appearanceCoordinator.updateMenuItemAppearance(
-                themedContext,
-                menuItem,
-                tabsScreen,
-                appearance,
-            )
-            a11yCoordinator.setA11yPropertiesToTabItem(menuItem, tabsScreen)
-        }
-    }
-
-    override fun getFragmentForTabsScreen(tabsScreen: TabsScreen): TabsScreenFragment? =
-        tabsModel.find {
-            it.tabsScreen ===
-                tabsScreen
-        }
-
     private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? = tabsModel.find { it.requireScreenKey == screenKey }
 
     private fun requireFragmentForScreenKey(screenKey: String): TabsScreenFragment =
         checkNotNull(getFragmentForScreenKey(screenKey)) {
             "[RNScreens] Requested fragment for key: $screenKey does not exist"
         }
-
-    override fun onFragmentConfigurationChange(
-        tabsScreen: TabsScreen,
-        config: Configuration,
-    ) {
-        this.onConfigurationChanged(config)
-    }
-
-    override fun onLayoutChange(
-        view: View?,
-        left: Int,
-        top: Int,
-        right: Int,
-        bottom: Int,
-        oldLeft: Int,
-        oldTop: Int,
-        oldRight: Int,
-        oldBottom: Int,
-    ) {
-        require(view is BottomNavigationView) {
-            "[RNScreens] TabsContainer's onLayoutChange expects BottomNavigationView, received $view instead"
-        }
-
-        val oldHeight = oldBottom - oldTop
-        val newHeight = bottom - top
-
-        if (newHeight != oldHeight) {
-            updateInterfaceInsets(newHeight)
-        }
-    }
-
-    override fun setOnInterfaceInsetsChangeListener(listener: SafeAreaView) {
-        if (interfaceInsetsChangeListener == null) {
-            bottomNavigationView.addOnLayoutChangeListener(this)
-        }
-        interfaceInsetsChangeListener = listener
-    }
-
-    override fun removeOnInterfaceInsetsChangeListener(listener: SafeAreaView) {
-        if (interfaceInsetsChangeListener == listener) {
-            interfaceInsetsChangeListener = null
-            bottomNavigationView.removeOnLayoutChangeListener(this)
-        }
-    }
 
     private fun updateInterfaceInsets(newHeight: Int? = null) {
         val height = if (tabBarHidden) 0 else (newHeight ?: bottomNavigationView.height)
@@ -524,8 +594,6 @@ class TabsContainer internal constructor(
             this.onInterfaceInsetsChange(EdgeInsets(0.0f, 0.0f, 0.0f, height.toFloat()))
         }
     }
-
-    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
 
     private fun getInsetsForBottomNavigationView(insets: WindowInsets): WindowInsets? {
         if (tabBarRespectsIMEInsets) {
@@ -541,21 +609,12 @@ class TabsContainer internal constructor(
             .toWindowInsets()
     }
 
-    internal fun setupFragmentManager() {
-        fragmentManager =
-            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
-                "[RNScreens] Nullish fragment manager - can't run container operations"
-            }
-    }
-
-    internal fun teardownFragmentManager() {
-        fragmentManager = null
-    }
-
-    private fun isNavStateStale(request: TabsNavStateUpdateRequest): Boolean {
+    private fun isNavigationStateStale(request: TabsNavigationStateUpdateRequest): Boolean {
         if (navState.isEmpty() || lastUINavState.isEmpty()) return false
         return request.baseProvenance < lastUINavState.provenance
     }
+
+    // endregion
 
     companion object {
         const val TAG = "TabsContainer"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -90,8 +90,9 @@ class TabsContainer internal constructor(
     internal val invalidationFlags = TabsContainerInvalidationFlags()
 
     private var pendingStateUpdateRequest: TabsNavigationStateUpdateRequest? = null
-    private val requirePendingStateUpdateRequest: TabsNavigationStateUpdateRequest
-        get() = checkNotNull(pendingStateUpdateRequest) { "[RNScreens] Attempt to require nullish pendingStateUpdateRequest" }
+
+    private fun requirePendingStateUpdateRequest(): TabsNavigationStateUpdateRequest =
+        checkNotNull(pendingStateUpdateRequest) { "[RNScreens] Attempt to require nullish pendingStateUpdateRequest" }
 
     /**
      * Denotes whether container is currently performing update triggered by the `pendingOperation`.
@@ -415,7 +416,7 @@ class TabsContainer internal constructor(
             return
         }
 
-        val stateUpdateRequest = requirePendingStateUpdateRequest
+        val stateUpdateRequest = requirePendingStateUpdateRequest()
 
         val nextSelectedMenuItemId =
             checkNotNull(getMenuItemIdForFragment(requireFragmentForScreenKey(stateUpdateRequest.selectedScreenKey))) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
@@ -1,7 +1,0 @@
-package com.swmansion.rnscreens.gamma.tabs.container
-
-internal sealed class TabsContainerOp
-
-internal data class TabSelectOp(
-    val request: TabsNavigationStateUpdateRequest,
-) : TabsContainerOp()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainerOps.kt
@@ -3,5 +3,5 @@ package com.swmansion.rnscreens.gamma.tabs.container
 internal sealed class TabsContainerOp
 
 internal data class TabSelectOp(
-    val request: TabsNavStateUpdateRequest,
+    val request: TabsNavigationStateUpdateRequest,
 ) : TabsContainerOp()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationState.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationState.kt
@@ -1,7 +1,7 @@
 package com.swmansion.rnscreens.gamma.tabs.container
 
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason.REPEATED
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason.STALE
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason.REPEATED
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason.STALE
 
 /**
  * Describes navigation state of a tabs container.
@@ -11,7 +11,7 @@ import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionR
  *   State with provenance `N + 1` is derived from state with provenance `N`.
  *   This allows detecting stale updates.
  */
-data class TabsNavState(
+data class TabsNavigationState(
     val selectedScreenKey: String,
     val provenance: Int,
 ) {
@@ -20,7 +20,7 @@ data class TabsNavState(
     internal fun isNotEmpty(): Boolean = !this.isEmpty()
 
     companion object {
-        val EMPTY = TabsNavState("", Int.MIN_VALUE)
+        val EMPTY = TabsNavigationState("", Int.MIN_VALUE)
     }
 }
 
@@ -35,7 +35,7 @@ data class TabsNavState(
  * @property baseProvenance Provenance of the state this request was derived from. Used for staleness detection.
  * @property actionOrigin Origin (actor) that initiated this request.
  */
-data class TabsNavStateUpdateRequest(
+data class TabsNavigationStateUpdateRequest(
     val selectedScreenKey: String,
     val baseProvenance: Int,
     val actionOrigin: TabsActionOrigin,
@@ -47,7 +47,7 @@ data class TabsNavStateUpdateRequest(
  * - [STALE] — the update's provenance indicates that it is based on a stale state.
  * - [REPEATED] — the requested tab is already selected.
  */
-enum class TabsNavStateUpdateRejectionReason {
+enum class TabsNavigationStateRejectionReason {
     STALE,
     REPEATED,
     ;

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserver.kt
@@ -1,10 +1,15 @@
 package com.swmansion.rnscreens.gamma.tabs.container
 
 /**
- * Callback interface for observing navigation state changes and rejections
- * in [TabsContainer]. Implemented by [com.swmansion.rnscreens.gamma.tabs.host.TabsHost] to relay events to JS.
+ * Observer of navigation state changes on a [TabsContainer].
+ *
+ * Multiple observers may register against a single container via
+ * [TabsContainer.addNavigationStateObserver] / [TabsContainer.removeNavigationStateObserver].
+ * The host (`TabsHost` on Android) registers itself as an observer to relay events to JS;
+ * downstream native libraries integrating directly against [TabsContainer] may register
+ * additional observers.
  */
-internal interface TabsContainerDelegate {
+interface TabsNavigationStateObserver {
     /**
      * Called when the container accepts a navigation state change.
      *
@@ -13,8 +18,8 @@ internal interface TabsContainerDelegate {
      * @param hasTriggeredSpecialEffect Whether a special effect (e.g. scroll-to-top) was triggered.
      * @param actionOrigin Origin (actor) that requested this transition.
      */
-    fun onNavStateUpdate(
-        navState: TabsNavState,
+    fun onNavigationStateUpdate(
+        navState: TabsNavigationState,
         isRepeated: Boolean,
         hasTriggeredSpecialEffect: Boolean,
         actionOrigin: TabsActionOrigin,
@@ -27,10 +32,10 @@ internal interface TabsContainerDelegate {
      * @param rejectedRequest The navigation state update request that was rejected.
      * @param reason Why the update was rejected.
      */
-    fun onNavStateUpdateRejected(
-        currentNavState: TabsNavState,
-        rejectedRequest: TabsNavStateUpdateRequest,
-        reason: TabsNavStateUpdateRejectionReason,
+    fun onNavigationStateUpdateRejected(
+        currentNavState: TabsNavigationState,
+        rejectedRequest: TabsNavigationStateUpdateRequest,
+        reason: TabsNavigationStateRejectionReason,
     )
 
     /**
@@ -41,8 +46,8 @@ internal interface TabsContainerDelegate {
      * @param currentNavState The currently active navigation state that was kept.
      * @param preventedScreenKey The screen key of the tab whose selection was prevented.
      */
-    fun onNavStateUpdatePrevented(
-        currentNavState: TabsNavState,
+    fun onNavigationStateUpdatePrevented(
+        currentNavState: TabsNavigationState,
         preventedScreenKey: String,
     )
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt
@@ -56,12 +56,7 @@ internal class TabsNavigationStateObserverRegistry {
         hasTriggeredSpecialEffect: Boolean,
         actionOrigin: TabsActionOrigin,
     ) {
-        check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
-        isEmitting = true
-        observers.forEach {
-            it.onNavigationStateUpdate(navState, isRepeated, hasTriggeredSpecialEffect, actionOrigin)
-        }
-        isEmitting = false
+        emitSignal { observer -> observer.onNavigationStateUpdate(navState, isRepeated, hasTriggeredSpecialEffect, actionOrigin) }
     }
 
     fun emitOnNavigationStateUpdateRejected(
@@ -69,23 +64,25 @@ internal class TabsNavigationStateObserverRegistry {
         rejectedRequest: TabsNavigationStateUpdateRequest,
         reason: TabsNavigationStateRejectionReason,
     ) {
-        check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
-        isEmitting = true
-        observers.forEach {
-            it.onNavigationStateUpdateRejected(currentNavState, rejectedRequest, reason)
-        }
-        isEmitting = false
+        emitSignal { observer -> observer.onNavigationStateUpdateRejected(currentNavState, rejectedRequest, reason) }
     }
 
     fun emitOnNavigationStateUpdatePrevented(
         currentNavState: TabsNavigationState,
         preventedScreenKey: String,
     ) {
+        emitSignal { observer -> observer.onNavigationStateUpdatePrevented(currentNavState, preventedScreenKey) }
+    }
+
+    private fun emitSignal(emitBlock: (TabsNavigationStateObserver) -> Unit) {
         check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
         isEmitting = true
-        observers.forEach {
-            it.onNavigationStateUpdatePrevented(currentNavState, preventedScreenKey)
+        try {
+            observers.forEach {
+                emitBlock(it)
+            }
+        } finally {
+            isEmitting = false
         }
-        isEmitting = false
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsNavigationStateObserverRegistry.kt
@@ -1,0 +1,91 @@
+package com.swmansion.rnscreens.gamma.tabs.container
+
+/**
+ * Holds the set of [TabsNavigationStateObserver]s registered against a [TabsContainer]
+ * and fans out container events to all of them.
+ *
+ * Observers are held with strong references; callers must explicitly call
+ * [TabsContainer.removeNavigationStateObserver] before observer dealloc, or rely on the
+ * host invoking [TabsContainer.tearDown] (which calls [clear]) on container teardown.
+ *
+ * # Reentrance
+ *
+ * Recursive emission is forbidden. While an `emit*` call is in flight:
+ * - additional `emit*` calls fail-fast with [IllegalStateException] (recursion is a
+ *   programmer error — it would deliver out-of-order events to later observers),
+ * - [add] / [remove] are rejected gracefully and return `false`.
+ *
+ * The registry is single-threaded — use it from a single thread (typically the UI
+ * thread on Android). It does not synchronize.
+ */
+internal class TabsNavigationStateObserverRegistry {
+    private val observers: MutableList<TabsNavigationStateObserver> = mutableListOf()
+    private var isEmitting: Boolean = false
+
+    /**
+     * Register an observer. Returns `false` if the observer is already registered or
+     * if called during an in-flight `emit*` (modifications during emission are rejected).
+     */
+    fun add(observer: TabsNavigationStateObserver): Boolean {
+        if (isEmitting) return false
+        if (observers.contains(observer)) return false
+        observers.add(observer)
+        return true
+    }
+
+    /**
+     * Unregister an observer. Returns `false` if the observer was not registered or
+     * if called during an in-flight `emit*` (modifications during emission are rejected).
+     */
+    fun remove(observer: TabsNavigationStateObserver): Boolean {
+        if (isEmitting) return false
+        return observers.remove(observer)
+    }
+
+    /**
+     * Drop all registered observers. Must not be called during an in-flight `emit*`.
+     */
+    fun clear() {
+        check(!isEmitting) { "[RNScreens] TabsNavigationStateObserverRegistry.clear during emission" }
+        observers.clear()
+    }
+
+    fun emitOnNavigationStateUpdate(
+        navState: TabsNavigationState,
+        isRepeated: Boolean,
+        hasTriggeredSpecialEffect: Boolean,
+        actionOrigin: TabsActionOrigin,
+    ) {
+        check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
+        isEmitting = true
+        observers.forEach {
+            it.onNavigationStateUpdate(navState, isRepeated, hasTriggeredSpecialEffect, actionOrigin)
+        }
+        isEmitting = false
+    }
+
+    fun emitOnNavigationStateUpdateRejected(
+        currentNavState: TabsNavigationState,
+        rejectedRequest: TabsNavigationStateUpdateRequest,
+        reason: TabsNavigationStateRejectionReason,
+    ) {
+        check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
+        isEmitting = true
+        observers.forEach {
+            it.onNavigationStateUpdateRejected(currentNavState, rejectedRequest, reason)
+        }
+        isEmitting = false
+    }
+
+    fun emitOnNavigationStateUpdatePrevented(
+        currentNavState: TabsNavigationState,
+        preventedScreenKey: String,
+    ) {
+        check(!isEmitting) { "[RNScreens] Recursive emission on TabsNavigationStateObserverRegistry" }
+        isEmitting = true
+        observers.forEach {
+            it.onNavigationStateUpdatePrevented(currentNavState, preventedScreenKey)
+        }
+        isEmitting = false
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -14,8 +14,8 @@ import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.helpers.getFabricUIManagerNotNull
 import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
 import com.swmansion.rnscreens.gamma.tabs.container.TabsContainer
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateObserver
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateObserver
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason
 import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreen

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -14,10 +14,10 @@ import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.helpers.getFabricUIManagerNotNull
 import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
 import com.swmansion.rnscreens.gamma.tabs.container.TabsContainer
-import com.swmansion.rnscreens.gamma.tabs.container.TabsContainerDelegate
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateObserver
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreen
 import com.swmansion.rnscreens.utils.RNSLog
 import kotlin.properties.Delegates
@@ -27,13 +27,13 @@ import kotlin.properties.Delegates
 class TabsHost(
     val reactContext: ThemedReactContext,
 ) : FrameLayout(reactContext),
-    TabsContainerDelegate,
+    TabsNavigationStateObserver,
     UIManagerListener {
     private val renderedScreens: ArrayList<TabsScreen> = arrayListOf()
-    private var jsNavStateRequest: TabsNavStateUpdateRequest? = null
+    private var jsNavStateRequest: TabsNavigationStateUpdateRequest? = null
 
     private val container: TabsContainer =
-        TabsContainer(reactContext, this).apply {
+        TabsContainer(reactContext).apply {
             layoutParams =
                 LayoutParams(
                     LayoutParams.MATCH_PARENT,
@@ -41,7 +41,7 @@ class TabsHost(
                 )
         }
 
-    internal var rejectStaleNavStateUpdates: Boolean by container::rejectOpsWithStaleNavState
+    internal var rejectStaleNavigationStateUpdates: Boolean by container::rejectStaleNavigationStateUpdates
 
     internal lateinit var eventEmitter: TabsHostEventEmitter
 
@@ -60,6 +60,9 @@ class TabsHost(
 
     init {
         addView(container)
+        check(container.addNavigationStateObserver(this)) {
+            "[RNScreens] Failed to register TabsHost as navigation state observer"
+        }
         UIManagerHelper
             .getFabricUIManagerNotNull(reactContext)
             .addUIManagerEventListener(this)
@@ -110,7 +113,7 @@ class TabsHost(
         container.removeAllTabsScreens()
     }
 
-    internal fun updateJSNavStateRequest(navStateRequest: TabsNavStateUpdateRequest) {
+    internal fun updateJSNavigationStateUpdateRequest(navStateRequest: TabsNavigationStateUpdateRequest) {
         jsNavStateRequest = navStateRequest
         container.setPendingNavigationStateUpdate(navStateRequest.copy())
     }
@@ -156,8 +159,8 @@ class TabsHost(
         eventEmitter = TabsHostEventEmitter(reactContext, id)
     }
 
-    override fun onNavStateUpdate(
-        navState: TabsNavState,
+    override fun onNavigationStateUpdate(
+        navState: TabsNavigationState,
         isRepeated: Boolean,
         hasTriggeredSpecialEffect: Boolean,
         actionOrigin: TabsActionOrigin,
@@ -171,10 +174,10 @@ class TabsHost(
         )
     }
 
-    override fun onNavStateUpdateRejected(
-        currentNavState: TabsNavState,
-        rejectedRequest: TabsNavStateUpdateRequest,
-        reason: TabsNavStateUpdateRejectionReason,
+    override fun onNavigationStateUpdateRejected(
+        currentNavState: TabsNavigationState,
+        rejectedRequest: TabsNavigationStateUpdateRequest,
+        reason: TabsNavigationStateRejectionReason,
     ) {
         eventEmitter.emitOnTabSelectionRejectedEvent(
             currentNavState,
@@ -183,15 +186,27 @@ class TabsHost(
         )
     }
 
-    override fun onNavStateUpdatePrevented(
-        currentNavState: TabsNavState,
+    override fun onNavigationStateUpdatePrevented(
+        currentNavState: TabsNavigationState,
         preventedScreenKey: String,
     ) {
         eventEmitter.emitOnTabSelectionPreventedEvent(currentNavState, preventedScreenKey)
     }
 
     override fun didMountItems(uiManager: UIManager) {
-        container.performContainerUpdateIfNeeded()
+        container.flushPendingUpdates()
+    }
+
+    /**
+     * Called by [TabsHostViewManager.onDropViewInstance] when this view is recycled.
+     * Idempotent: safe to call multiple times.
+     */
+    internal fun tearDown() {
+        container.removeNavigationStateObserver(this)
+        container.tearDown()
+        UIManagerHelper
+            .getFabricUIManagerNotNull(reactContext)
+            .removeUIManagerEventListener(this)
     }
 
     override fun willDispatchViewUpdates(uiManager: UIManager) = Unit

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostEventEmitter.kt
@@ -3,9 +3,9 @@ package com.swmansion.rnscreens.gamma.tabs.host
 import com.facebook.react.bridge.ReactContext
 import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
 import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
@@ -42,9 +42,9 @@ internal class TabsHostEventEmitter(
      * Carries both the active state and the rejected update so that JS can reconcile.
      */
     fun emitOnTabSelectionRejectedEvent(
-        currentNavState: TabsNavState,
-        rejectedRequest: TabsNavStateUpdateRequest,
-        rejectionReason: TabsNavStateUpdateRejectionReason,
+        currentNavState: TabsNavigationState,
+        rejectedRequest: TabsNavigationStateUpdateRequest,
+        rejectionReason: TabsNavigationStateRejectionReason,
     ) {
         reactEventDispatcher.dispatchEvent(
             TabsHostTabSelectionRejectedEvent(
@@ -62,7 +62,7 @@ internal class TabsHostEventEmitter(
      * because the target screen has `preventNativeSelection` enabled.
      */
     fun emitOnTabSelectionPreventedEvent(
-        currentNavState: TabsNavState,
+        currentNavState: TabsNavigationState,
         preventedScreenKey: String,
     ) {
         reactEventDispatcher.dispatchEvent(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHostViewManager.kt
@@ -12,7 +12,7 @@ import com.facebook.react.viewmanagers.RNSTabsHostAndroidManagerInterface
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
 import com.swmansion.rnscreens.gamma.tabs.container.TabsActionOrigin
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateUpdateRequest
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionPreventedEvent
 import com.swmansion.rnscreens.gamma.tabs.host.event.TabsHostTabSelectionRejectedEvent
@@ -73,6 +73,11 @@ class TabsHostViewManager :
         view.onViewManagerAddEventEmitters()
     }
 
+    override fun onDropViewInstance(view: TabsHost) {
+        view.tearDown()
+        super.onDropViewInstance(view)
+    }
+
     override fun setNavStateRequest(
         view: TabsHost,
         value: ReadableMap?,
@@ -80,8 +85,8 @@ class TabsHostViewManager :
         val navStateRequestMap = requireNotNull(value) { "[RNScreens] navStateRequest must not be nullish" }
         val selectedScreenKey = requireNotNull(navStateRequestMap.getString("selectedScreenKey"))
         val baseProvenance = requireNotNull(navStateRequestMap.getInt("baseProvenance"))
-        view.updateJSNavStateRequest(
-            TabsNavStateUpdateRequest(
+        view.updateJSNavigationStateUpdateRequest(
+            TabsNavigationStateUpdateRequest(
                 selectedScreenKey = selectedScreenKey,
                 baseProvenance = baseProvenance,
                 actionOrigin = TabsActionOrigin.PROGRAMMATIC_JS,
@@ -93,7 +98,7 @@ class TabsHostViewManager :
         view: TabsHost,
         value: Boolean,
     ) {
-        view.rejectStaleNavStateUpdates = value
+        view.rejectStaleNavigationStateUpdates = value
     }
 
     override fun setTabBarHidden(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionPreventedEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationState
 
 /**
  * React Native event dispatched to JS when a tab selection is prevented because the target
@@ -15,7 +15,7 @@ import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
 class TabsHostTabSelectionPreventedEvent(
     surfaceId: Int,
     viewId: Int,
-    val currentNavState: TabsNavState,
+    val currentNavState: TabsNavigationState,
     val preventedScreenKey: String,
 ) : Event<TabsHostTabSelectionPreventedEvent>(surfaceId, viewId),
     NamingAwareEventType {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
@@ -4,9 +4,9 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavState
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRejectionReason
-import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationState
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateRejectionReason
+import com.swmansion.rnscreens.gamma.tabs.container.TabsNavigationStateUpdateRequest
 
 /**
  * React Native event dispatched to JS when a tab selection request is rejected by the container.
@@ -18,9 +18,9 @@ import com.swmansion.rnscreens.gamma.tabs.container.TabsNavStateUpdateRequest
 class TabsHostTabSelectionRejectedEvent(
     surfaceId: Int,
     viewId: Int,
-    val currentNavState: TabsNavState,
-    val rejectedRequest: TabsNavStateUpdateRequest,
-    val rejectionReason: TabsNavStateUpdateRejectionReason,
+    val currentNavState: TabsNavigationState,
+    val rejectedRequest: TabsNavigationStateUpdateRequest,
+    val rejectionReason: TabsNavigationStateRejectionReason,
 ) : Event<TabsHostTabSelectionRejectedEvent>(surfaceId, viewId),
     NamingAwareEventType {
     override fun getEventName() = EVENT_NAME

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -14,26 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class RNSTabsHostComponentView;
 @class RNSTabBarController;
 
-@protocol RNSTabBarControllerDelegate <NSObject>
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-        didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
-             withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-     rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
-            currentState:(nonnull RNSTabsNavigationState *)currentNavState
-              withReason:(RNSTabsNavigationStateRejectionReason)reasonCode;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    preventedSelectionOf:(nonnull NSString *)screenKey
-            currentState:(nonnull RNSTabsNavigationState *)currentNavState;
-
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState;
-
-@end
-
 @protocol RNSReactTransactionObserving
 
 - (void)reactMountingTransactionWillMount;
@@ -43,13 +23,31 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * This controller is responsible for tab management & all other responsibilities coming from the fact of inheritance
- * from `UITabBarController`. It is limited only to the child view controllers of type `RNSTabsScreenViewController`,
- * however.
+ * UITabBarController subclass that backs `<TabsHost>` on iOS.
+ *
+ * This controller is responsible for tab management & all other responsibilities coming from the
+ * fact of inheritance from `UITabBarController`. It is limited only to the child view controllers
+ * of type `RNSTabsScreenViewController`, however.
  *
  * Updates made by this controller are synchronized by `RNSReactTransactionObserving` protocol,
- * i.e. if you made changes through one of signals method, unless you flush them immediately, they will
- * be executed only after react finishes the transaction (from within transaction execution block).
+ * i.e. if you made changes through one of signals method, unless you flush them immediately, they
+ * will be executed only after react finishes the transaction (from within transaction execution
+ * block).
+ *
+ * # Public API
+ *
+ * Methods and properties under `#pragma mark - Public API` below are the only contract
+ * third-party native consumers should rely on:
+ *   - read the current navigation state via `navigationState`,
+ *   - request a tab change via `setPendingNavigationStateUpdate:`,
+ *   - apply pending updates via `flushPendingUpdates`,
+ *   - observe results via `addNavigationStateObserver:` / `removeNavigationStateObserver:`
+ *     (see `RNSTabsNavigationStateObserver` in `RNSTabsNavigationState.h`).
+ *
+ * # Internal API
+ *
+ * Members under `#pragma mark - Internal API` are host-only (`RNSTabsHostComponentView`)
+ * implementation detail and may change without notice. Do not call from third-party code.
  */
 @interface RNSTabBarController : UITabBarController <RNSReactTransactionObserving
 #if !TARGET_OS_TV
@@ -57,6 +55,55 @@ NS_ASSUME_NONNULL_BEGIN
                                                      RNSOrientationProviding
 #endif // !TARGET_OS_TV
                                                      >
+
+#pragma mark - Public API
+
+/**
+ * Represents current navigation state.
+ *
+ * After each model update, the container (controller) updates the navigation state. The
+ * `provenance` part is incremented monotonically with each state update.
+ *
+ * The controller manages this state. It MUST NOT be overwritten by any external actor.
+ */
+@property (nonatomic, readonly, strong, nullable) RNSTabsNavigationState *navigationState;
+
+/**
+ * Request navigation state update from the controller to the given one.
+ *
+ * Pass nil to clear any queued update.
+ *
+ * The update is applied on the next `RNSReactTransactionObserving` callback, or call
+ * `flushPendingUpdates` to apply it immediately. If you want to execute multiple updates in
+ * sequence you must flush the container after each one separately.
+ */
+- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate;
+
+/**
+ * Apply any pending invalidations and state updates in a single coordinated pass.
+ * No-op when nothing is dirty.
+ */
+- (void)flushPendingUpdates;
+
+/**
+ * Register an observer for navigation state events on this container.
+ * Observers are held strongly; call `removeNavigationStateObserver:` before observer
+ * dealloc, or rely on the host calling `tearDown` on container teardown.
+ *
+ * Returns NO if the observer is already registered or if called from within an
+ * observer callback (modifications during emission are rejected).
+ */
+- (BOOL)addNavigationStateObserver:(id<RNSTabsNavigationStateObserver>)observer;
+
+/**
+ * Unregister a previously registered observer.
+ *
+ * Returns NO if the observer was not registered or if called from within an
+ * observer callback (modifications during emission are rejected).
+ */
+- (BOOL)removeNavigationStateObserver:(id<RNSTabsNavigationStateObserver>)observer;
+
+#pragma mark - Internal API (host-only; subject to change without notice)
 
 - (instancetype)initWithTabsHostComponentView:(nullable RNSTabsHostComponentView *)tabsHostComponentView;
 
@@ -69,52 +116,60 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) RNSTabsHostComponentView *tabsHostComponentView;
 
 /**
- * Tab bar appearance coordinator. If you need to update tab bar appearance avoid using this one directly. Send the
- * controller a signal, invalidate the tab bar appearance & either wait for the update flush or flush it manually.
+ * Tab bar appearance coordinator. If you need to update tab bar appearance avoid using this one
+ * directly. Send the controller a signal, invalidate the tab bar appearance & either wait for the
+ * update flush or flush it manually.
  */
 @property (nonatomic, readonly, strong, nonnull) RNSTabBarAppearanceCoordinator *tabBarAppearanceCoordinator;
 
 /**
- * Represents current navigation state.
+ * If true, the controller will reject any navigation state updates if the provenance of the
+ * update is stale.
  *
- * After each model update, the container (controller) updates the navigation state. The `provenance` part is
- * incremented monotonically with each state update.
- *
- * The controller manages this state. It MUST NOT be overwritten by any external actor.
- */
-@property (nonatomic, readonly, strong, nullable) RNSTabsNavigationState *navigationState;
-
-/**
- *
- * If true, the controller will reject any navigation state updates
- * if the provenance of the update is stale.
- *
- * A navigation state update is considered stale if its provenance is older
- * than the provenance of the currently active navigation state.
+ * A navigation state update is considered stale if its provenance is older than the provenance
+ * of the currently active navigation state.
  *
  * This can happen, e.g. when an update from JS is dispatched, but before it reaches the native
- * side, another update happens on UI thread, e.g. user selects another tab. For such
- * situations, where to-be-applied navigation state update had been dispatched w/o
- * full context of actual navigation state you can toggle this prop.
+ * side, another update happens on UI thread, e.g. user selects another tab. For such situations,
+ * where to-be-applied navigation state update had been dispatched w/o full context of actual
+ * navigation state you can toggle this prop.
  *
- * If an update is rejected due to being stale, the controller will notify its delegate.
+ * If an update is rejected due to being stale, the controller will notify its observers.
  */
 @property (nonatomic, readwrite) BOOL rejectStaleNavigationStateUpdates;
 
 /**
+ * Tell the controller that react provided tabs have changed (count / instances) & the child
+ * view controllers need to be updated.
+ *
+ * This also automatically raises `needsUpdateOfChildViewControllers` flag, no need to call it
+ * manually.
+ */
+- (void)childViewControllersHaveChangedTo:(nonnull NSArray<RNSTabsScreenViewController *> *)childViewControllers;
+
+/**
+ * Idempotent teardown. Releases observer references and any retained host references.
+ * Called by the host on view recycle.
+ */
+- (void)tearDown;
+
+#pragma mark Individual flush methods (internal)
+
+/**
  * Update tab controller state with previously provided children.
  *
- * This method does nothing if the children have not been changed / update has not been requested before.
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * This method does nothing if the children have not been changed / update has not been requested
+ * before. The requested update is performed immediately. If you do not need this, consider just
+ * raising an appropriate invalidation signal & let the controller decide when to flush the
+ * updates.
  */
 - (void)updateChildViewControllersIfNeeded;
 
 /**
  * Force update of the tab controller state with previously provided children.
  *
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * The requested update is performed immediately. If you do not need this, consider just raising
+ * an appropriate invalidation signal & let the controller decide when to flush the updates.
  */
 - (void)updateReactChildrenControllers;
 
@@ -122,8 +177,9 @@ NS_ASSUME_NONNULL_BEGIN
  * If any state update operation is pending - perform it.
  *
  * This method does nothing if the update has not been previously requested.
- * If needed, the requested update is performed immediately. If you do not need this, consider just raising an
- * appropriate invalidation signal & let the controller decide when to flush the updates.
+ * If needed, the requested update is performed immediately. If you do not need this, consider
+ * just raising an appropriate invalidation signal & let the controller decide when to flush the
+ * updates.
  */
 - (void)updateSelectedViewControllerIfNeeded;
 
@@ -132,8 +188,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * To request update use `setPendingNavigationStateUpdate`.
  *
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * The requested update is performed immediately. If you do not need this, consider just raising
+ * an appropriate invalidation signal & let the controller decide when to flush the updates.
  */
 - (void)updateSelectedViewController;
 
@@ -141,16 +197,17 @@ NS_ASSUME_NONNULL_BEGIN
  * Updates the tab bar appearance basing on configuration sources (host view, tab screens).
  *
  * This method does nothing if the update has not been previously requested.
- * If needed, the requested update is performed immediately. If you do not need this, consider just raising an
- * appropriate invalidation signal & let the controller decide when to flush the updates.
+ * If needed, the requested update is performed immediately. If you do not need this, consider
+ * just raising an appropriate invalidation signal & let the controller decide when to flush the
+ * updates.
  */
 - (void)updateTabBarAppearanceIfNeeded;
 
 /**
  * Updates the tab bar appearance basing on configuration sources (host view, tab screens).
  *
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * The requested update is performed immediately. If you do not need this, consider just raising
+ * an appropriate invalidation signal & let the controller decide when to flush the updates.
  */
 - (void)updateTabBarAppearance;
 
@@ -158,16 +215,17 @@ NS_ASSUME_NONNULL_BEGIN
  * Updates the interface orientation based on selected tab screen and its children.
  *
  * This method does nothing if the update has not been previously requested.
- * If needed, the requested update is performed immediately. If you do not need this, consider just raising an
- * appropriate invalidation signal & let the controller decide when to flush the updates.
+ * If needed, the requested update is performed immediately. If you do not need this, consider
+ * just raising an appropriate invalidation signal & let the controller decide when to flush the
+ * updates.
  */
 - (void)updateOrientationIfNeeded;
 
 /**
  * Updates the interface orientation based on selected tab screen and its children.
  *
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * The requested update is performed immediately. If you do not need this, consider just raising
+ * an appropriate invalidation signal & let the controller decide when to flush the updates.
  */
 - (void)updateOrientation;
 
@@ -175,8 +233,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Updates the layout direction based on property on host view.
  *
  * This method does nothing if the update has not been previously requested.
- * If needed, the requested update is performed immediately. If you do not need this, consider just raising an
- * appropriate invalidation signal & let the controller decide when to flush the updates.
+ * If needed, the requested update is performed immediately. If you do not need this, consider
+ * just raising an appropriate invalidation signal & let the controller decide when to flush the
+ * updates.
  *
  * This method is necessary only on iOS versions prior to 17.
  * On iOS 17+, use `traitOverrides.layoutDirection` on the controller directly.
@@ -186,8 +245,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Updates the layout direction based on property on host view.
  *
- * The requested update is performed immediately. If you do not need this, consider just raising an appropriate
- * invalidation signal & let the controller decide when to flush the updates.
+ * The requested update is performed immediately. If you do not need this, consider just raising
+ * an appropriate invalidation signal & let the controller decide when to flush the updates.
  *
  * This method is necessary only on iOS versions prior to 17.
  * On iOS 17+, use `traitOverrides.layoutDirection` on the controller directly.
@@ -195,53 +254,33 @@ NS_ASSUME_NONNULL_BEGIN
  * This method can only be called when `parentViewController` is not nil.
  */
 - (void)updateLayoutDirectionBelowIOS17;
-@end
 
-#pragma mark - Signals
-
-/**
- * This extension defines various invalidation signals that you can send to the controller, to notify it that it needs
- * to take some action.
- */
-@interface RNSTabBarController ()
+#pragma mark Individual invalidation flags (internal)
 
 /**
- * Tell the controller that react provided tabs have changed (count / instances) & the child view controllers need to be
- * updated.
+ * Tell the controller that react provided tabs have changed (count / instances) & the child
+ * view controllers need to be updated.
  *
- * This also automatically raises `needsReactChildrenUpdate` flag, no need to call it manually.
- */
-- (void)childViewControllersHaveChangedTo:(nonnull NSArray<RNSTabsScreenViewController *> *)childViewControllers;
-
-/**
- * Request navigation state update from the controller to the given one.
- *
- * If you want to execute multiple updates in sequence you must flush the container after each one separately.
- */
-- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate;
-
-/**
- * Tell the controller that react provided tabs have changed (count / instances) & the child view controllers need to be
- * updated.
- *
- * Do not raise this signal only when you want to modify selected view controller. Use `setPendingNavigationStateUpdate`
- * instead.
+ * Do not raise this signal only when you want to modify selected view controller. Use
+ * `setPendingNavigationStateUpdate` instead.
  */
 @property (nonatomic, readwrite) bool needsUpdateOfChildViewControllers;
 
 /**
- * Tell the controller that some configuration regarding the tab bar apperance has changed & the appearance requires
- * update.
+ * Tell the controller that some configuration regarding the tab bar apperance has changed & the
+ * appearance requires update.
  */
 @property (nonatomic, readwrite) bool needsUpdateOfTabBarAppearance;
 
 /**
- * Tell the controller that some configuration regarding interface orientation has changed & it requires update.
+ * Tell the controller that some configuration regarding interface orientation has changed & it
+ * requires update.
  */
 @property (nonatomic, readwrite) bool needsOrientationUpdate;
 
 /**
- * Tell the controller that some configuration regarding layout direction has changed & it requires update.
+ * Tell the controller that some configuration regarding layout direction has changed & it
+ * requires update.
  *
  * This flag is necessary only on iOS versions prior to 17.
  * On iOS 17+, use `traitOverrides.layoutDirection` on the controller directly.

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -164,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Idempotent teardown. Releases observer references and any retained host references.
- * Called by the host on view recycle.
+ * Called by the host on view lifecycle end.
  */
 - (void)tearDown;
 

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -39,7 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Methods and properties under `#pragma mark - Public API` below are the only contract
  * third-party native consumers should rely on:
  *   - read the current navigation state via `navigationState`,
- *   - request a tab change via `setPendingNavigationStateUpdate:`,
+ *   - request a tab change via `submitSelectionOfTabsScreenWithKey:` (transition is recorded with
+ *     `RNSTabsActionOriginProgrammaticNative`),
  *   - apply pending updates via `flushPendingUpdates`,
  *   - observe results via `addNavigationStateObserver:` / `removeNavigationStateObserver:`
  *     (see `RNSTabsNavigationStateObserver` in `RNSTabsNavigationState.h`).
@@ -69,15 +70,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong, nullable) RNSTabsNavigationState *navigationState;
 
 /**
- * Request navigation state update from the controller to the given one.
- *
- * Pass nil to clear any queued update.
+ * Request a tab change. The transition is recorded with `RNSTabsActionOriginProgrammaticNative`,
+ * and is built against the current `navigationState.provenance` so it is never treated as stale.
  *
  * The update is applied on the next `RNSReactTransactionObserving` callback, or call
  * `flushPendingUpdates` to apply it immediately. If you want to execute multiple updates in
  * sequence you must flush the container after each one separately.
  */
-- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate;
+- (void)submitSelectionOfTabsScreenWithKey:(nonnull NSString *)screenKey;
 
 /**
  * Apply any pending invalidations and state updates in a single coordinated pass.
@@ -146,6 +146,21 @@ NS_ASSUME_NONNULL_BEGIN
  * manually.
  */
 - (void)childViewControllersHaveChangedTo:(nonnull NSArray<RNSTabsScreenViewController *> *)childViewControllers;
+
+/**
+ * Request navigation state update from the controller to the given one.
+ *
+ * Pass nil to clear any queued update.
+ *
+ * The update is applied on the next `RNSReactTransactionObserving` callback, or call
+ * `flushPendingUpdates` to apply it immediately. If you want to execute multiple updates in
+ * sequence you must flush the container after each one separately.
+ *
+ * Host-only: third-party native consumers should use `submitSelectionOfTabsScreenWithKey:` instead, which
+ * forces `RNSTabsActionOriginProgrammaticNative`. This method allows the host to dispatch any
+ * origin (e.g. `RNSTabsActionOriginProgrammaticJs` for JS-driven `navStateRequest` updates).
+ */
+- (void)setPendingNavigationStateUpdate:(nullable RNSTabsNavigationStateUpdateRequest *)stateUpdate;
 
 /**
  * Idempotent teardown. Releases observer references and any retained host references.

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -3,6 +3,7 @@
 #import <React/RCTLog.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <limits>
 #import "NSString+RNSUtility.h"
 #import "RNSLog.h"
 #import "RNSScreenWindowTraits.h"
@@ -113,7 +114,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
 - (void)submitSelectionOfTabsScreenWithKey:(nonnull NSString *)screenKey
 {
-  int baseProvenance = _navigationState != nil ? _navigationState.provenance : 0;
+  RCTAssert(screenKey != nil, @"[RNScreens] Requested screenKey MUST NOT be nil");
+  int baseProvenance = _navigationState != nil ? _navigationState.provenance : std::numeric_limits<int>::min();
   RNSTabsNavigationStateUpdateRequest *request =
       [RNSTabsNavigationStateUpdateRequest requestWithSelectedScreenKey:screenKey
                                                          baseProvenance:baseProvenance

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -111,6 +111,16 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
 #pragma mark - Public API
 
+- (void)submitSelectionOfTabsScreenWithKey:(nonnull NSString *)screenKey
+{
+  int baseProvenance = _navigationState != nil ? _navigationState.provenance : 0;
+  RNSTabsNavigationStateUpdateRequest *request =
+      [RNSTabsNavigationStateUpdateRequest requestWithSelectedScreenKey:screenKey
+                                                         baseProvenance:baseProvenance
+                                                           actionOrigin:RNSTabsActionOriginProgrammaticNative];
+  [self setPendingNavigationStateUpdate:request];
+}
+
 - (void)flushPendingUpdates
 {
   [self performContainerUpdate];

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -7,6 +7,7 @@
 #import "RNSLog.h"
 #import "RNSScreenWindowTraits.h"
 #import "RNSTabsHostComponentView.h"
+#import "RNSTabsNavigationStateObserverRegistry.h"
 
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
@@ -80,6 +81,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
   /// delegate handling). Setter overrides skip reconciliation while this flag is set.
   BOOL _isHandlingExplicitSelectionUpdate;
 
+  RNSTabsNavigationStateObserverRegistry *_observerRegistry;
+
 #if !RCT_NEW_ARCH_ENABLED
   BOOL _isControllerFlushBlockScheduled;
 #endif // !RCT_NEW_ARCH_ENABLED
@@ -94,6 +97,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
     _navigationState = nil;
     _pendingStateUpdate = nil;
     _shouldProgressStateOnMoreNavigationControllerPush = NO;
+    _observerRegistry = [RNSTabsNavigationStateObserverRegistry new];
 
     // Delegate field retains weakly, no risk of cycle.
     self.delegate = self;
@@ -103,6 +107,30 @@ static void rns_pushViewController(__unsafe_unretained id self,
 #endif // !RCT_NEW_ARCH_ENABLED
   }
   return self;
+}
+
+#pragma mark - Public API
+
+- (void)flushPendingUpdates
+{
+  [self performContainerUpdate];
+}
+
+- (BOOL)addNavigationStateObserver:(id<RNSTabsNavigationStateObserver>)observer
+{
+  return [_observerRegistry addObserver:observer];
+}
+
+- (BOOL)removeNavigationStateObserver:(id<RNSTabsNavigationStateObserver>)observer
+{
+  return [_observerRegistry removeObserver:observer];
+}
+
+- (void)tearDown
+{
+  [_observerRegistry clear];
+  _pendingStateUpdate = nil;
+  _tabsHostComponentView = nil;
 }
 
 - (instancetype)initWithTabsHostComponentView:(nullable RNSTabsHostComponentView *)tabsHostComponentView
@@ -277,7 +305,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
                                                          isRepeated:YES
                                           hasTriggeredSpecialEffect:repeatedSelectionHandledBySpecialEffect
                                                        actionOrigin:RNSTabsActionOriginUser];
-  [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
+  [_observerRegistry emitDidUpdateStateTo:_navigationState withContext:updateContext sender:self];
 }
 
 - (void)userDidSelectViewController:(nonnull UIViewController *)viewController
@@ -292,20 +320,20 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
     // We don't want to progress state in case a user selected the more navigation controller.
     // Instead, we emit a dedicated event so JS knows the More tab was tapped.
-    [self.tabsHostComponentView tabBarController:self didSelectMoreTabWithCurrentState:_navigationState];
+    [_observerRegistry emitDidSelectMoreTabWithCurrentState:_navigationState sender:self];
   } else {
     [self updateNavigationStateOnModelUpdate];
     auto *updateContext = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
                                                                              isRepeated:NO
                                                               hasTriggeredSpecialEffect:NO
                                                                            actionOrigin:RNSTabsActionOriginUser];
-    [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:updateContext];
+    [_observerRegistry emitDidUpdateStateTo:_navigationState withContext:updateContext sender:self];
   }
 }
 
 - (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
 {
-  [self.tabsHostComponentView tabBarController:self preventedSelectionOf:screenKey currentState:_navigationState];
+  [_observerRegistry emitPreventedSelectionOf:screenKey currentState:_navigationState sender:self];
 }
 
 - (BOOL)shouldPreventNativeTabSelection:(nonnull UIViewController *)nextViewController
@@ -473,20 +501,20 @@ static void rns_pushViewController(__unsafe_unretained id self,
             nextSelectedViewController.class);
 
   if (self.rejectStaleNavigationStateUpdates && [self isNavigationStateUpdateStale:_pendingStateUpdate]) {
-    [self.tabsHostComponentView tabBarController:self
-                             rejectedStateUpdate:_pendingStateUpdate
-                                    currentState:_navigationState
-                                      withReason:RNSTabsNavigationStateRejectionReasonStale];
+    [_observerRegistry emitRejectedStateUpdate:_pendingStateUpdate
+                                  currentState:_navigationState
+                                    withReason:RNSTabsNavigationStateRejectionReasonStale
+                                        sender:self];
     return;
   }
 
   if (currSelectedViewController == nextSelectedViewController && _navigationState != nil) {
     // Nothing to do, we don't allow for programmatic repeat selection, unless
     // we're during first render.
-    [self.tabsHostComponentView tabBarController:self
-                             rejectedStateUpdate:_pendingStateUpdate
-                                    currentState:_navigationState
-                                      withReason:RNSTabsNavigationStateRejectionReasonRepeated];
+    [_observerRegistry emitRejectedStateUpdate:_pendingStateUpdate
+                                  currentState:_navigationState
+                                    withReason:RNSTabsNavigationStateRejectionReasonRepeated
+                                        sender:self];
     return;
   }
 
@@ -512,7 +540,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
                                                            isRepeated:NO
                                             hasTriggeredSpecialEffect:NO
                                                          actionOrigin:_pendingStateUpdate.actionOrigin];
-    [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:context];
+    [_observerRegistry emitDidUpdateStateTo:_navigationState withContext:context sender:self];
   }
 }
 
@@ -660,7 +688,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
                                                                      isRepeated:NO
                                                       hasTriggeredSpecialEffect:NO
                                                                    actionOrigin:RNSTabsActionOriginImplicit];
-  [self.tabsHostComponentView tabBarController:self didUpdateStateTo:_navigationState withContext:context];
+  [_observerRegistry emitDidUpdateStateTo:_navigationState withContext:context sender:self];
 }
 
 /**

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -26,8 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
  * 2. provider of React state & props for the tab bar controller
  * 3. two way communication channel with React (commands & events)
  */
-@interface RNSTabsHostComponentView : RNSReactBaseView <RNSScreenContainerDelegate,
-                                                        RNSTabBarControllerDelegate
+@interface RNSTabsHostComponentView : RNSReactBaseView <
+                                          RNSScreenContainerDelegate,
+                                          RNSTabsNavigationStateObserver
 #if !RCT_NEW_ARCH_ENABLED
                                                         ,
                                                         RCTInvalidating

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -26,9 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
  * 2. provider of React state & props for the tab bar controller
  * 3. two way communication channel with React (commands & events)
  */
-@interface RNSTabsHostComponentView : RNSReactBaseView <
-                                          RNSScreenContainerDelegate,
-                                          RNSTabsNavigationStateObserver
+@interface RNSTabsHostComponentView : RNSReactBaseView <RNSScreenContainerDelegate,
+                                                        RNSTabsNavigationStateObserver
 #if !RCT_NEW_ARCH_ENABLED
                                                         ,
                                                         RCTInvalidating

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -85,6 +85,9 @@ namespace react = facebook::react;
   [self resetProps];
 
   _controller = [[RNSTabBarController alloc] initWithTabsHostComponentView:self];
+  RCTAssert(
+      [_controller addNavigationStateObserver:self],
+      @"[RNScreens] Failed to register RNSTabsHostComponentView as navigation state observer");
 
   _reactSubviews = [NSMutableArray new];
   _reactEventEmitter = [RNSTabsHostEventEmitter new];
@@ -119,6 +122,7 @@ namespace react = facebook::react;
   dispatch_async(dispatch_get_main_queue(), ^{
     auto strongSelf = weakSelf;
     if (strongSelf) {
+      [strongSelf->_controller tearDown];
       strongSelf->_controller = nil;
     }
   });
@@ -598,11 +602,11 @@ RNS_IGNORE_SUPER_CALL_END
   return _imageLoader;
 }
 
-#pragma mark - RNSTabBarControllerDelegate
+#pragma mark - RNSTabsNavigationStateObserver
 
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-        didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
-             withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+     didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
+          withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context
 {
   RCTAssert(navState.selectedScreenKey != nil, @"[RNScreens] screenKey MUST NOT be nil");
 
@@ -613,10 +617,10 @@ RNS_IGNORE_SUPER_CALL_END
                                              .actionOrigin = context.actionOrigin}];
 }
 
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-     rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
-            currentState:(nonnull RNSTabsNavigationState *)currentNavState
-              withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+    rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+           currentState:(nonnull RNSTabsNavigationState *)currentNavState
+             withReason:(RNSTabsNavigationStateRejectionReason)reason
 {
   RCTAssert(currentNavState.selectedScreenKey != nil, @"[RNScreens] Current state screenKey MUST NOT be nil");
   RCTAssert(rejectedRequest.selectedScreenKey != nil,
@@ -624,30 +628,32 @@ RNS_IGNORE_SUPER_CALL_END
 
   [self.reactEventEmitter emitOnTabSelectionRejected:{.currentNavState = currentNavState,
                                                       .rejectedRequest = rejectedRequest,
-                                                      .rejectionReason = reasonCode}];
+                                                      .rejectionReason = reason}];
 }
 
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
-    preventedSelectionOf:(nonnull NSString *)screenKey
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+    preventedSelectionOf:(nonnull NSString *)preventedScreenKey
             currentState:(nonnull RNSTabsNavigationState *)currentNavState
 {
-  RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
-  RCTAssert(screenKey != nil, @"[RNScreens] Expected NON NIL screenKey");
-  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
-            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(tabsContainer != nil, @"[RNScreens] Expected NON NIL tabsContainer");
+  RCTAssert(preventedScreenKey != nil, @"[RNScreens] Expected NON NIL preventedScreenKey");
+  RCTAssert(
+      currentNavState != nil && currentNavState.selectedScreenKey != nil,
+      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnTabSelectionPrevented:{
                                                           .currentNavState = currentNavState,
-                                                          .preventedScreenKey = screenKey,
+                                                          .preventedScreenKey = preventedScreenKey,
   }];
 }
 
-- (void)tabBarController:(nonnull RNSTabBarController *)tabBarController
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
     didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
 {
-  RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
-  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
-            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(tabsContainer != nil, @"[RNScreens] Expected NON NIL tabsContainer");
+  RCTAssert(
+      currentNavState != nil && currentNavState.selectedScreenKey != nil,
+      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnMoreTabSelected:{
                                                     .currentNavState = currentNavState,

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -85,9 +85,8 @@ namespace react = facebook::react;
   [self resetProps];
 
   _controller = [[RNSTabBarController alloc] initWithTabsHostComponentView:self];
-  RCTAssert(
-      [_controller addNavigationStateObserver:self],
-      @"[RNScreens] Failed to register RNSTabsHostComponentView as navigation state observer");
+  RCTAssert([_controller addNavigationStateObserver:self],
+            @"[RNScreens] Failed to register RNSTabsHostComponentView as navigation state observer");
 
   _reactSubviews = [NSMutableArray new];
   _reactEventEmitter = [RNSTabsHostEventEmitter new];
@@ -637,9 +636,8 @@ RNS_IGNORE_SUPER_CALL_END
 {
   RCTAssert(tabsContainer != nil, @"[RNScreens] Expected NON NIL tabsContainer");
   RCTAssert(preventedScreenKey != nil, @"[RNScreens] Expected NON NIL preventedScreenKey");
-  RCTAssert(
-      currentNavState != nil && currentNavState.selectedScreenKey != nil,
-      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
+            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnTabSelectionPrevented:{
                                                           .currentNavState = currentNavState,
@@ -651,9 +649,8 @@ RNS_IGNORE_SUPER_CALL_END
     didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
 {
   RCTAssert(tabsContainer != nil, @"[RNScreens] Expected NON NIL tabsContainer");
-  RCTAssert(
-      currentNavState != nil && currentNavState.selectedScreenKey != nil,
-      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
+            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnMoreTabSelected:{
                                                     .currentNavState = currentNavState,

--- a/ios/tabs/host/RNSTabsNavigationState.h
+++ b/ios/tabs/host/RNSTabsNavigationState.h
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RNSTabBarController;
+
 /**
  * Origin (actor) that requested a tab transition. Mirrors the public `actionOrigin` event field.
  */
@@ -122,6 +124,60 @@ typedef NS_ENUM(NSInteger, RNSTabsNavigationStateRejectionReason) {
                       isRepeated:(BOOL)isRepeated
        hasTriggeredSpecialEffect:(BOOL)hasTriggeredSpecialEffect
                     actionOrigin:(RNSTabsActionOrigin)actionOrigin;
+
+@end
+
+/**
+ * Observer of navigation state changes on a tabs container (`RNSTabBarController`).
+ *
+ * Multiple observers may register against a single container via
+ * `RNSTabBarController addNavigationStateObserver:` / `removeNavigationStateObserver:`.
+ * The host (`RNSTabsHostComponentView`) registers itself as an observer to relay events
+ * to JS; downstream native libraries integrating directly against `RNSTabBarController`
+ * may register additional observers.
+ *
+ * Observers are held with strong references; callers must explicitly call
+ * `removeNavigationStateObserver:` before observer dealloc, or rely on the host
+ * invoking `tearDown` (which clears the registry) on container teardown.
+ */
+@protocol RNSTabsNavigationStateObserver <NSObject>
+
+@required
+
+/**
+ * Called when the container accepts a navigation state change.
+ */
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+     didUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
+          withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context;
+
+/**
+ * Called when the container rejects a navigation state update.
+ */
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+    rejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+           currentState:(nonnull RNSTabsNavigationState *)currentNavState
+             withReason:(RNSTabsNavigationStateRejectionReason)reason;
+
+/**
+ * Called when a native user action (tap) attempts to select a tab that has
+ * `preventNativeSelection` enabled. The navigation state remains unchanged.
+ */
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+    preventedSelectionOf:(nonnull NSString *)preventedScreenKey
+            currentState:(nonnull RNSTabsNavigationState *)currentNavState;
+
+@optional
+
+/**
+ * iOS-only. Called when the user taps the More tab on iPhone or in iPad split view
+ * configurations where UIKit groups overflow tabs into a More navigation controller.
+ *
+ * This event is informational; the navigation state is not advanced as part of this callback.
+ * Android does not emit an analogue.
+ */
+- (void)tabsContainer:(nonnull RNSTabBarController *)tabsContainer
+    didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState;
 
 @end
 

--- a/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h
+++ b/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h
@@ -19,21 +19,27 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSTabsNavigationStateObserverRegistry : NSObject
 
 /**
- * Register an observer. Returns NO if the observer is already registered or if called
+ * Register an observer.
+ *
+ * @returns NO if the observer is already registered or if called
  * during an in-flight `emit*` (modifications during emission are rejected).
  */
 - (BOOL)addObserver:(id<RNSTabsNavigationStateObserver>)observer;
 
 /**
- * Unregister an observer. Returns NO if the observer was not registered or if called
+ * Unregister an observer.
+ *
+ * @returns NO if the observer was not registered or if called
  * during an in-flight `emit*` (modifications during emission are rejected).
  */
 - (BOOL)removeObserver:(id<RNSTabsNavigationStateObserver>)observer;
 
 /**
- * Drop all registered observers. Must not be called during an in-flight `emit*`.
+ * Drop all registered observers.
+ *
+ * @returns NO if called during in-flight `emit*` (modifications during emission are rejected).
  */
-- (void)clear;
+- (BOOL)clear;
 
 - (void)emitDidUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
                  withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context

--- a/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h
+++ b/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import "RNSTabsNavigationState.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Holds the set of `RNSTabsNavigationStateObserver`s registered against an
+ * `RNSTabBarController` and fans out container events to all of them.
+ *
+ * Observers are held with strong references; callers must explicitly call
+ * `removeObserver:` before observer dealloc, or rely on the host invoking
+ * `clear` (via `RNSTabBarController.tearDown`) on container teardown.
+ *
+ * `emit*` methods invoke each observer in registration order. The `@optional`
+ * More-tab callback is dispatched only to observers that respond to the selector.
+ */
+@interface RNSTabsNavigationStateObserverRegistry : NSObject
+
+/**
+ * Register an observer. Returns NO if the observer is already registered or if called
+ * during an in-flight `emit*` (modifications during emission are rejected).
+ */
+- (BOOL)addObserver:(id<RNSTabsNavigationStateObserver>)observer;
+
+/**
+ * Unregister an observer. Returns NO if the observer was not registered or if called
+ * during an in-flight `emit*` (modifications during emission are rejected).
+ */
+- (BOOL)removeObserver:(id<RNSTabsNavigationStateObserver>)observer;
+
+/**
+ * Drop all registered observers. Must not be called during an in-flight `emit*`.
+ */
+- (void)clear;
+
+- (void)emitDidUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
+                 withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context
+                      sender:(nonnull RNSTabBarController *)sender;
+
+- (void)emitRejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+                   currentState:(nonnull RNSTabsNavigationState *)currentNavState
+                     withReason:(RNSTabsNavigationStateRejectionReason)reason
+                         sender:(nonnull RNSTabBarController *)sender;
+
+- (void)emitPreventedSelectionOf:(nonnull NSString *)preventedScreenKey
+                    currentState:(nonnull RNSTabsNavigationState *)currentNavState
+                          sender:(nonnull RNSTabBarController *)sender;
+
+- (void)emitDidSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
+                                      sender:(nonnull RNSTabBarController *)sender;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm
+++ b/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm
@@ -20,10 +20,7 @@
 
 - (BOOL)addObserver:(id<RNSTabsNavigationStateObserver>)observer
 {
-  if (_isEmitting) {
-    return NO;
-  }
-  if ([_observers containsObject:observer]) {
+  if (_isEmitting || [_observers containsObject:observer]) {
     return NO;
   }
   [_observers addObject:observer];
@@ -32,32 +29,29 @@
 
 - (BOOL)removeObserver:(id<RNSTabsNavigationStateObserver>)observer
 {
-  if (_isEmitting) {
-    return NO;
-  }
-  if (![_observers containsObject:observer]) {
+  if (_isEmitting || ![_observers containsObject:observer]) {
     return NO;
   }
   [_observers removeObject:observer];
   return YES;
 }
 
-- (void)clear
+- (BOOL)clear
 {
-  RCTAssert(!_isEmitting, @"[RNScreens] RNSTabsNavigationStateObserverRegistry clear during emission");
+  if (_isEmitting) {
+    return NO;
+  }
   [_observers removeAllObjects];
+  return YES;
 }
 
 - (void)emitDidUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
                  withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context
                       sender:(nonnull RNSTabBarController *)sender
 {
-  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
-  _isEmitting = YES;
-  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+  [self emitSignal:^(id<RNSTabsNavigationStateObserver> observer) {
     [observer tabsContainer:sender didUpdateStateTo:navState withContext:context];
-  }
-  _isEmitting = NO;
+  }];
 }
 
 - (void)emitRejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
@@ -65,38 +59,46 @@
                      withReason:(RNSTabsNavigationStateRejectionReason)reason
                          sender:(nonnull RNSTabBarController *)sender
 {
-  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
-  _isEmitting = YES;
-  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+  [self emitSignal:^(id<RNSTabsNavigationStateObserver> observer) {
     [observer tabsContainer:sender rejectedStateUpdate:rejectedRequest currentState:currentNavState withReason:reason];
-  }
-  _isEmitting = NO;
+  }];
 }
 
 - (void)emitPreventedSelectionOf:(nonnull NSString *)preventedScreenKey
                     currentState:(nonnull RNSTabsNavigationState *)currentNavState
                           sender:(nonnull RNSTabBarController *)sender
 {
-  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
-  _isEmitting = YES;
-  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+  [self emitSignal:^(id<RNSTabsNavigationStateObserver> observer) {
     [observer tabsContainer:sender preventedSelectionOf:preventedScreenKey currentState:currentNavState];
-  }
-  _isEmitting = NO;
+  }];
 }
 
 - (void)emitDidSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
                                       sender:(nonnull RNSTabBarController *)sender
 {
-  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
-  _isEmitting = YES;
-  SEL sel = @selector(tabsContainer:didSelectMoreTabWithCurrentState:);
-  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
-    if ([observer respondsToSelector:sel]) {
+  SEL observerSelector = @selector(tabsContainer:didSelectMoreTabWithCurrentState:);
+  [self emitSignal:^(id<RNSTabsNavigationStateObserver> observer) {
+    if ([observer respondsToSelector:observerSelector]) {
       [observer tabsContainer:sender didSelectMoreTabWithCurrentState:currentNavState];
     }
+  }];
+}
+
+- (void)emitSignal:(void (^)(id<RNSTabsNavigationStateObserver> observer))emitBlock
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
+
+  // In release best we can do here is let it emit the event. Alternatives are to crash or not emit (certain wrong
+  // state).
+
+  _isEmitting = YES;
+  @try {
+    for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+      emitBlock(observer);
+    }
+  } @finally {
+    _isEmitting = NO;
   }
-  _isEmitting = NO;
 }
 
 @end

--- a/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm
+++ b/ios/tabs/host/RNSTabsNavigationStateObserverRegistry.mm
@@ -1,0 +1,102 @@
+#import "RNSTabsNavigationStateObserverRegistry.h"
+
+#import <React/RCTAssert.h>
+
+#import "RNSTabBarController.h"
+
+@implementation RNSTabsNavigationStateObserverRegistry {
+  NSMutableArray<id<RNSTabsNavigationStateObserver>> *_observers;
+  BOOL _isEmitting;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _observers = [NSMutableArray new];
+    _isEmitting = NO;
+  }
+  return self;
+}
+
+- (BOOL)addObserver:(id<RNSTabsNavigationStateObserver>)observer
+{
+  if (_isEmitting) {
+    return NO;
+  }
+  if ([_observers containsObject:observer]) {
+    return NO;
+  }
+  [_observers addObject:observer];
+  return YES;
+}
+
+- (BOOL)removeObserver:(id<RNSTabsNavigationStateObserver>)observer
+{
+  if (_isEmitting) {
+    return NO;
+  }
+  if (![_observers containsObject:observer]) {
+    return NO;
+  }
+  [_observers removeObject:observer];
+  return YES;
+}
+
+- (void)clear
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] RNSTabsNavigationStateObserverRegistry clear during emission");
+  [_observers removeAllObjects];
+}
+
+- (void)emitDidUpdateStateTo:(nonnull RNSTabsNavigationState *)navState
+                 withContext:(nonnull RNSTabsNavigationStateUpdateContext *)context
+                      sender:(nonnull RNSTabBarController *)sender
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
+  _isEmitting = YES;
+  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+    [observer tabsContainer:sender didUpdateStateTo:navState withContext:context];
+  }
+  _isEmitting = NO;
+}
+
+- (void)emitRejectedStateUpdate:(nonnull RNSTabsNavigationStateUpdateRequest *)rejectedRequest
+                   currentState:(nonnull RNSTabsNavigationState *)currentNavState
+                     withReason:(RNSTabsNavigationStateRejectionReason)reason
+                         sender:(nonnull RNSTabBarController *)sender
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
+  _isEmitting = YES;
+  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+    [observer tabsContainer:sender rejectedStateUpdate:rejectedRequest currentState:currentNavState withReason:reason];
+  }
+  _isEmitting = NO;
+}
+
+- (void)emitPreventedSelectionOf:(nonnull NSString *)preventedScreenKey
+                    currentState:(nonnull RNSTabsNavigationState *)currentNavState
+                          sender:(nonnull RNSTabBarController *)sender
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
+  _isEmitting = YES;
+  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+    [observer tabsContainer:sender preventedSelectionOf:preventedScreenKey currentState:currentNavState];
+  }
+  _isEmitting = NO;
+}
+
+- (void)emitDidSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
+                                      sender:(nonnull RNSTabBarController *)sender
+{
+  RCTAssert(!_isEmitting, @"[RNScreens] Recursive emission on RNSTabsNavigationStateObserverRegistry");
+  _isEmitting = YES;
+  SEL sel = @selector(tabsContainer:didSelectMoreTabWithCurrentState:);
+  for (id<RNSTabsNavigationStateObserver> observer in _observers) {
+    if ([observer respondsToSelector:sel]) {
+      [observer tabsContainer:sender didSelectMoreTabWithCurrentState:currentNavState];
+    }
+  }
+  _isEmitting = NO;
+}
+
+@end

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -243,8 +243,8 @@ export interface TabsHostPropsBase {
    * @platform android, ios
    */
   onTabSelected?:
-  | ((event: NativeSyntheticEvent<TabSelectedEvent>) => void)
-  | undefined;
+    | ((event: NativeSyntheticEvent<TabSelectedEvent>) => void)
+    | undefined;
 
   /**
    * @summary
@@ -253,8 +253,8 @@ export interface TabsHostPropsBase {
    * @see {@link TabSelectionRejectedEvent}
    */
   onTabSelectionRejected?:
-  | ((event: NativeSyntheticEvent<TabSelectionRejectedEvent>) => void)
-  | undefined;
+    | ((event: NativeSyntheticEvent<TabSelectionRejectedEvent>) => void)
+    | undefined;
 
   /**
    * @summary
@@ -264,8 +264,8 @@ export interface TabsHostPropsBase {
    * @see {@link TabSelectionPreventedEvent}
    */
   onTabSelectionPrevented?:
-  | ((event: NativeSyntheticEvent<TabSelectionPreventedEvent>) => void)
-  | undefined;
+    | ((event: NativeSyntheticEvent<TabSelectionPreventedEvent>) => void)
+    | undefined;
 }
 
 export interface TabsHostProps extends TabsHostPropsBase {


### PR DESCRIPTION
## Description

Stacked on #3951.

Defines a small, cohesive cross-platform public contract on `TabsContainer` (Android) and `RNSTabBarController` (iOS) so downstream native libraries can integrate against the tabs container with a stable surface. Today's API grew organically: the two platforms diverged, the single-delegate model can't fan out to multiple observers, and many host-only methods are visible to third-party consumers (especially on iOS where the public `.h` exposes ~12 individual `update*` flush methods plus `setNeeds*` invalidation properties).

The downstream contract is now exactly four things: read the current navigation state, submit a tab-selection request, flush pending updates, and observe results — and the observer side supports multiple registrations rather than a single delegate. The submission entry point is deliberately narrow: third-party callers cannot specify the action origin or base provenance — both are filled in by the container — so they can only ever produce `programmatic-native`-origin transitions.

This is a design / refactor PR, not a feature add. No new public-API distribution mechanism (no umbrella headers, module maps, or framework targets) per design constraint — public/internal split is enforced by Kotlin visibility on Android and `#pragma mark` sections on iOS.

## Changes

### Public API (cross-platform, identical shape)

| Capability | Android `TabsContainer` | iOS `RNSTabBarController` |
|---|---|---|
| Read current state | `val navigationState: TabsNavigationState` | `@property (readonly, nullable) RNSTabsNavigationState *navigationState;` |
| Submit tab selection | `fun submitSelectionOfTabsScreenWithKey(screenKey: String)` | `- (void)submitSelectionOfTabsScreenWithKey:(NSString *)screenKey` |
| Flush updates | `fun flushPendingUpdates()` | `- (void)flushPendingUpdates;` |
| Add observer | `fun addNavigationStateObserver(observer): Boolean` | `- (BOOL)addNavigationStateObserver:` |
| Remove observer | `fun removeNavigationStateObserver(observer): Boolean` | `- (BOOL)removeNavigationStateObserver:` |

`submitSelectionOfTabsScreenWithKey` builds a `TabsNavigationStateUpdateRequest` internally with `actionOrigin = PROGRAMMATIC_NATIVE` and the current `navigationState.provenance` (or the `EMPTY` sentinel if no state is established yet) — neither can be fabricated by the caller. The verb `submit` (not `select`) signals queued semantics: the caller still needs `flushPendingUpdates` (or the next React mounting transaction) for the change to take effect.

The fully-flexible `setPendingNavigationStateUpdate(request)` form stays accessible to the host (Kotlin `internal` / iOS Internal API section) because the host needs to dispatch JS-driven requests with `PROGRAMMATIC_JS` origin.

### Observer registry replaces single delegate

- New `TabsNavigationStateObserverRegistry` (Android) / `RNSTabsNavigationStateObserverRegistry` (iOS). Multi-observer fan-out; observers held with strong references.
- The host (`TabsHost` / `RNSTabsHostComponentView`) registers itself as one of many possible observers; downstream native consumers can register additional ones.
- Reentrant emission is forbidden: `emit*` asserts no emission is in flight (recursion would deliver out-of-order events to later observers); `add` / `remove` return `Boolean` / `BOOL` and reject during in-flight emission.

### Cross-platform name parity

Android renames:
- `TabsNavState` → `TabsNavigationState`
- `TabsNavStateUpdateRequest` → `TabsNavigationStateUpdateRequest`
- `TabsNavStateUpdateRejectionReason` → `TabsNavigationStateRejectionReason`
- `TabsContainerDelegate` → `TabsNavigationStateObserver` (now public)
- `performContainerUpdateIfNeeded` → `flushPendingUpdates`
- `rejectOpsWithStaleNavState` → `rejectStaleNavigationStateUpdates`
- Callbacks `onNavStateUpdate*` → `onNavigationStateUpdate*`
- `TabsContainerOp` / `TabSelectOp` sealed-class wrappers removed; the container now stores `TabsNavigationStateUpdateRequest?` directly (matches iOS structure).

iOS renames:
- `RNSTabBarControllerDelegate` → `RNSTabsNavigationStateObserver` (lives in `RNSTabsNavigationState.h` next to its value objects)
- Selectors `tabBarController:` → `tabsContainer:` (sender argument name unified across platforms)
- The iOS-only More-tab callback stays as `@optional` on the same protocol — no separate iOS-only protocol introduced.

### Public/internal boundary

- **Android**: Kotlin `internal` / `public` modifiers, with `// region Public API` / `// region Host-internal API` / `// region Private helpers` markers in `TabsContainer.kt` for IDE folding.
- **iOS**: `#pragma mark - Public API` and `#pragma mark - Internal API (host-only; subject to change without notice)` sections in `RNSTabBarController.h`. Class-level doc explicitly marks the boundary. The ~12 individual `update*IfNeeded` / `setNeeds*` methods, `childViewControllersHaveChangedTo:`, `tabBarAppearanceCoordinator`, `rejectStaleNavigationStateUpdates`, and the host-only `setPendingNavigationStateUpdate:` all live under the Internal API section.

### Misc

- Android `TabsContainer` constructor drops its `delegate` parameter — host registers as observer after construction.
- New internal `tearDown()` method on both platforms — clears the observer registry, releases retained host references, drops pending operation. Called from `TabsHostViewManager.onDropViewInstance` (Android) and `RNSTabsHostComponentView.invalidateImpl` (iOS). Named `tearDown` (not `invalidate`) because `Android.View.invalidate()` already exists and would shadow.
- iOS `submitSelectionOfTabsScreenWithKey:` falls back to `INT_MIN` when `_navigationState` is nil — matches Android's `TabsNavigationState.EMPTY` sentinel (`Int.MIN_VALUE`). Both `isNavigationStateUpdateStale` checks already guard on nil/empty states; the parity is for semantic alignment.
- Doc comments preserved on iOS `RNSTabBarController.h` for all originally-documented members (the structural rewrite kept content, just regrouped under the pragma marks).

### Out of scope (stays as-is)

- JS / TS / codegen — public TS types (`TabSelectedEvent`, codegen specs) unchanged.
- C++ layer — unchanged.
- Stack-related code (different gamma namespace).
- TS-side `apps/src/shared/gamma/containers/tabs/...TabsNavState` type alias — example-app-only, separate from the renamed Kotlin/Obj-C types.

## Test plan

- [x] `yarn check-types` clean.
- [x] Android Kotlin compile: `./gradlew :react-native-screens:compileDebugKotlin` clean.
- [x] Grep audit (zero hits expected, all confirmed): `TabsContainerDelegate`, `TabsNavState`, `TabsNavStateUpdateRequest`, `TabsNavStateUpdateRejectionReason`, `RNSTabBarControllerDelegate`, `performContainerUpdateIfNeeded`, `rejectOpsWithStaleNavState`, `tabBarController:self`, `TabsContainerOp`, `TabSelectOp`.
- [ ] iOS Xcode build via `bundle exec pod install && yarn ios` from `FabricExample/` — pending local Mac toolchain run (Pods not installed in CI sandbox).
- [ ] Manual smoke test on Android (`FabricExample`):
  - Tap-driven tab switches
  - JS-driven `navStateRequest` updates
  - Repeated tap → scroll-to-top / pop-to-root special effects
  - `preventNativeSelection` flow
  - `submitSelectionOfTabsScreenWithKey` from a debug-only native call site → confirm `actionOrigin` reaches JS as `programmatic-native`
- [ ] Manual smoke test on iOS (iPhone + iPad):
  - Same flows as Android
  - iPad More-tab path (verify `@optional` More-tab callback still reaches host)
- [ ] Multi-observer sanity: temporary debug patch registering a second `TabsNavigationStateObserver` (or `RNSTabsNavigationStateObserver`) and confirming fan-out fires for all callbacks.
- [ ] `tearDown` lifecycle: confirm registry is cleared on `onDropViewInstance` (Android) / `invalidateImpl` (iOS) and that subsequent emits are no-ops.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes