### PR TITLE
fix(android): prevent double status bar offset in legacy non edge-to-edge mode (in 4.25.0-beta.1)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -7,6 +7,7 @@ import android.view.Choreographer
 import android.view.WindowInsets
 import android.view.WindowManager
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.ThemedReactContext
@@ -125,7 +126,20 @@ open class CustomToolbar(
         val topInset = getDecorViewTopInset(decorView)
 
         if (topInset > 0) {
-            applyExactPadding(paddingLeft, topInset, paddingRight, paddingBottom)
+            // In legacy (non edge-to-edge) mode, the system already positions the toolbar
+            // below the status bar, so applying paddingTop would cause double offset.
+            // We detect this by comparing toolbar's position on screen with the status bar inset:
+            // in edge-to-edge the toolbar starts at y=0, in legacy it starts at y=statusBarInset.
+            val insetsCompat = ViewCompat.getRootWindowInsets(decorView)
+            val statusBarInset = insetsCompat?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+            val locationOnScreen = IntArray(2)
+            getLocationOnScreen(locationOnScreen)
+            val toolbarTopOnScreen = locationOnScreen[1]
+            val isEdgeToEdge = toolbarTopOnScreen < statusBarInset
+
+            if (isEdgeToEdge) {
+                applyExactPadding(paddingLeft, topInset, paddingRight, paddingBottom)
+            }
         }
     }
 


### PR DESCRIPTION
## Description

While investigating an unexpected bottom padding issue when using `headerShown=true` 
with `edgeToEdgeEnabled=false`, I found that it had already been fixed in the 
`4.25.0-beta.1` release (the `correctedHeight`/`correctedOffsetY` logic was removed 
from `Screen.onLayout`). 

After upgrading to the beta to confirm the fix, I encountered a new issue: the toolbar 
height was being inflated by the status bar height when running in legacy non 
edge-to-edge mode (`edgeToEdgeEnabled=false`), causing the header to render visually 
larger than expected when `headerShown=true`.

The root cause was in `applyDecorViewTopInsetIfNeeded` inside `CustomToolbar`. In 
legacy mode, `onApplyWindowInsets` is never triggered by the system, so this fallback 
runs on `onAttachedToWindow`. It was applying `topInset` as `paddingTop` to the toolbar 
unconditionally, even though in legacy mode the system already positions the toolbar 
below the status bar, making that padding redundant and causing double offset.

## Changes

Modified `applyDecorViewTopInsetIfNeeded` in `CustomToolbar.kt` to detect whether 
the app is running in edge-to-edge mode before applying `paddingTop` to the toolbar.

The detection compares the toolbar's Y position on screen with the status bar inset:
- In edge-to-edge mode, the toolbar starts at `y=0` → `toolbarTopOnScreen < statusBarInset` → padding is applied ✅
- In legacy mode, the toolbar starts at `y=statusBarInset` → condition is false → padding is skipped ✅

## Before & after - visual documentation:

| Before | After |
| --- | --- |
| Toolbar height inflated by status bar size (~99px), header visually larger than expected | Header renders with correct height |
* For a better view, see the images attached
<img width="1080" height="2400" alt="before change" src="https://github.com/user-attachments/assets/e57c8a54-7715-4a2e-8aa6-2ea7cc5ee5c8" />
<img width="1080" height="2400" alt="after change" src="https://github.com/user-attachments/assets/d3721a2b-cef2-4126-9b50-f410af655578" />


## Test plan:

Reproduced and fixed with:
- `react-native: 0.84.1`
- `react-native-screens: 4.25.0-beta.1`
- `@react-navigation/native-stack: ^7.12.0`
- Device: ZTE Axon 30 A2022L (MyOS 11, Android 11)

Steps to reproduce:
1. Set `edgeToEdgeEnabled=false` in `gradle.properties`
2. Upgrade to `react-native-screens: 4.25.0-beta.1`
3. Create a native stack navigator with `headerShown=true`
4. Observe the toolbar height is inflated by the status bar height

Tested scenarios after fix:
- `edgeToEdgeEnabled=false` + NavBar buttons + `headerShown=true/false` ✅
- `edgeToEdgeEnabled=false` + Gesture navigation + `headerShown=true/false` ✅
- `edgeToEdgeEnabled=true` + NavBar buttons + `headerShown=true/false` ✅
- `edgeToEdgeEnabled=true` + Gesture navigation + `headerShown=true/false` ✅

Here is my repository with the app in which i tested the change:
https://github.com/gusgushz/rn_screens_test

---
*This fix was authored by @gusgushz with assistance from [Claude](https://claude.ai) 
(Anthropic) for root cause analysis and debugging.*

## Related

- Reproduces with `react-native: 0.85.2`, `react-native-screens: 4.25.0-beta.1`
- `@react-navigation/native-stack: ^7.14.12`

And finally im still learning, so i did´t make more tests on different devices (with newer versions of Android or different screen sizes) but i hope this helps. 
Greetings to all the mantainers and contributors