### PR TITLE
chore: Bump clang-format to 22

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -48,12 +48,10 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
       RNSScreenStackHeaderConfigState const &previousState,
       folly::dynamic data)
       : frameSize{
-          static_cast<Float>(data["frameWidth"].getDouble()),
-          static_cast<Float>(data["frameHeight"].getDouble())
-        },
+            static_cast<Float>(data["frameWidth"].getDouble()),
+            static_cast<Float>(data["frameHeight"].getDouble())},
         paddingStart{static_cast<Float>(data["paddingStart"].getDouble())},
-        paddingEnd{static_cast<Float>(data["paddingEnd"].getDouble())}
-        {}
+        paddingEnd{static_cast<Float>(data["paddingEnd"].getDouble())} {}
 #endif
 
 #ifdef ANDROID

--- a/ios/RNSEnums.h
+++ b/ios/RNSEnums.h
@@ -108,16 +108,16 @@ typedef NS_ENUM(NSInteger, RNSBlurEffectStyle) {
   RNSBlurEffectStyleSystemMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterial,
   RNSBlurEffectStyleSystemThickMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterial,
   RNSBlurEffectStyleSystemChromeMaterial API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemChromeMaterial,
-  RNSBlurEffectStyleSystemUltraThinMaterialLight API_UNAVAILABLE(watchos, tvos) =
-      UIBlurEffectStyleSystemUltraThinMaterialLight,
+  RNSBlurEffectStyleSystemUltraThinMaterialLight API_UNAVAILABLE(watchos,
+                                                                 tvos) = UIBlurEffectStyleSystemUltraThinMaterialLight,
   RNSBlurEffectStyleSystemThinMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialLight,
   RNSBlurEffectStyleSystemMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialLight,
   RNSBlurEffectStyleSystemThickMaterialLight API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialLight,
-  RNSBlurEffectStyleSystemChromeMaterialLight API_UNAVAILABLE(watchos, tvos) =
-      UIBlurEffectStyleSystemChromeMaterialLight,
+  RNSBlurEffectStyleSystemChromeMaterialLight API_UNAVAILABLE(watchos,
+                                                              tvos) = UIBlurEffectStyleSystemChromeMaterialLight,
 
-  RNSBlurEffectStyleSystemUltraThinMaterialDark API_UNAVAILABLE(watchos, tvos) =
-      UIBlurEffectStyleSystemUltraThinMaterialDark,
+  RNSBlurEffectStyleSystemUltraThinMaterialDark API_UNAVAILABLE(watchos,
+                                                                tvos) = UIBlurEffectStyleSystemUltraThinMaterialDark,
   RNSBlurEffectStyleSystemThinMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThinMaterialDark,
   RNSBlurEffectStyleSystemMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemMaterialDark,
   RNSBlurEffectStyleSystemThickMaterialDark API_UNAVAILABLE(watchos, tvos) = UIBlurEffectStyleSystemThickMaterialDark,

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -38,13 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSScreenView;
 
-@interface RNSScreen : UIViewController <
-                           RNSViewControllerDelegate
+@interface RNSScreen : UIViewController <RNSViewControllerDelegate
 #if !TARGET_OS_TV
-                           ,
-                           RNSOrientationProviding
+                                         ,
+                                         RNSOrientationProviding
 #endif // !TARGET_OS_TV
-                           >
+                                         >
 - (instancetype)initWithView:(UIView *)view;
 - (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
 - (BOOL)hasNestedStack;
@@ -60,11 +59,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSScreenStackHeaderConfig;
 
-@interface RNSScreenView : RNSReactBaseView <
-                               RNSScreenContentWrapperDelegate,
-                               RNSScrollViewBehaviorOverriding,
-                               RNSSafeAreaProviding,
-                               RNSScrollEdgeEffectProviding>
+@interface RNSScreenView : RNSReactBaseView <RNSScreenContentWrapperDelegate,
+                                             RNSScrollViewBehaviorOverriding,
+                                             RNSSafeAreaProviding,
+                                             RNSScrollEdgeEffectProviding>
 
 /**
  * This is value of the prop as passed by the user. To get effective value see derived property

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -43,14 +43,13 @@ struct ContentWrapperBox {
   float contentHeightErrata{0.f};
 };
 
-@interface RNSScreenView () <
-    UIAdaptivePresentationControllerDelegate,
-    UIGestureRecognizerDelegate,
+@interface RNSScreenView () <UIAdaptivePresentationControllerDelegate,
+                             UIGestureRecognizerDelegate,
 #if !TARGET_OS_TV
-    UISheetPresentationControllerDelegate,
+                             UISheetPresentationControllerDelegate,
 #endif
-    RCTRNSScreenViewProtocol,
-    CAAnimationDelegate>
+                             RCTRNSScreenViewProtocol,
+                             CAAnimationDelegate>
 @end
 
 @implementation RNSScreenView {
@@ -564,9 +563,8 @@ RNS_IGNORE_SUPER_CALL_END
   if (_eventEmitter != nullptr) {
     int index = static_cast<int>(newDetentIndex);
     std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onSheetDetentChanged(
-            react::RNSScreenEventEmitter::OnSheetDetentChanged{
-                .index = index, .isStable = static_cast<bool>(isStable)});
+        ->onSheetDetentChanged(react::RNSScreenEventEmitter::OnSheetDetentChanged{
+            .index = index, .isStable = static_cast<bool>(isStable)});
   }
 }
 
@@ -637,9 +635,8 @@ RNS_IGNORE_SUPER_CALL_END
 {
   if (_eventEmitter != nullptr) {
     std::dynamic_pointer_cast<const react::RNSScreenEventEmitter>(_eventEmitter)
-        ->onTransitionProgress(
-            react::RNSScreenEventEmitter::OnTransitionProgress{
-                .progress = progress, .closing = closing ? 1 : 0, .goingForward = goingForward ? 1 : 0});
+        ->onTransitionProgress(react::RNSScreenEventEmitter::OnTransitionProgress{
+            .progress = progress, .closing = closing ? 1 : 0, .goingForward = goingForward ? 1 : 0});
   }
   RNSScreenViewEvent *event = [[RNSScreenViewEvent alloc] initWithEventName:@"onTransitionProgress"
                                                                    reactTag:[NSNumber numberWithInteger:self.tag]
@@ -2097,88 +2094,81 @@ RCT_EXPORT_MODULE()
 
 @implementation RCTConvert (RNSScreen)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenStackPresentation,
-    (@{
-      @"push" : @(RNSScreenStackPresentationPush),
-      @"modal" : @(RNSScreenStackPresentationModal),
-      @"fullScreenModal" : @(RNSScreenStackPresentationFullScreenModal),
-      @"formSheet" : @(RNSScreenStackPresentationFormSheet),
-      @"pageSheet" : @(RNSScreenStackPresentationPageSheet),
-      @"containedModal" : @(RNSScreenStackPresentationContainedModal),
-      @"transparentModal" : @(RNSScreenStackPresentationTransparentModal),
-      @"containedTransparentModal" : @(RNSScreenStackPresentationContainedTransparentModal)
-    }),
-    RNSScreenStackPresentationPush,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenStackPresentation,
+                   (@{
+                     @"push" : @(RNSScreenStackPresentationPush),
+                     @"modal" : @(RNSScreenStackPresentationModal),
+                     @"fullScreenModal" : @(RNSScreenStackPresentationFullScreenModal),
+                     @"formSheet" : @(RNSScreenStackPresentationFormSheet),
+                     @"pageSheet" : @(RNSScreenStackPresentationPageSheet),
+                     @"containedModal" : @(RNSScreenStackPresentationContainedModal),
+                     @"transparentModal" : @(RNSScreenStackPresentationTransparentModal),
+                     @"containedTransparentModal" : @(RNSScreenStackPresentationContainedTransparentModal)
+                   }),
+                   RNSScreenStackPresentationPush,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenStackAnimation,
-    (@{
-      @"default" : @(RNSScreenStackAnimationDefault),
-      @"none" : @(RNSScreenStackAnimationNone),
-      @"fade" : @(RNSScreenStackAnimationFade),
-      @"fade_from_bottom" : @(RNSScreenStackAnimationFadeFromBottom),
-      @"flip" : @(RNSScreenStackAnimationFlip),
-      @"simple_push" : @(RNSScreenStackAnimationSimplePush),
-      @"slide_from_bottom" : @(RNSScreenStackAnimationSlideFromBottom),
-      @"slide_from_right" : @(RNSScreenStackAnimationDefault),
-      @"slide_from_left" : @(RNSScreenStackAnimationSlideFromLeft),
-      @"ios_from_right" : @(RNSScreenStackAnimationDefault),
-      @"ios_from_left" : @(RNSScreenStackAnimationSlideFromLeft),
-    }),
-    RNSScreenStackAnimationDefault,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenStackAnimation,
+                   (@{
+                     @"default" : @(RNSScreenStackAnimationDefault),
+                     @"none" : @(RNSScreenStackAnimationNone),
+                     @"fade" : @(RNSScreenStackAnimationFade),
+                     @"fade_from_bottom" : @(RNSScreenStackAnimationFadeFromBottom),
+                     @"flip" : @(RNSScreenStackAnimationFlip),
+                     @"simple_push" : @(RNSScreenStackAnimationSimplePush),
+                     @"slide_from_bottom" : @(RNSScreenStackAnimationSlideFromBottom),
+                     @"slide_from_right" : @(RNSScreenStackAnimationDefault),
+                     @"slide_from_left" : @(RNSScreenStackAnimationSlideFromLeft),
+                     @"ios_from_right" : @(RNSScreenStackAnimationDefault),
+                     @"ios_from_left" : @(RNSScreenStackAnimationSlideFromLeft),
+                   }),
+                   RNSScreenStackAnimationDefault,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenReplaceAnimation,
-    (@{
-      @"push" : @(RNSScreenReplaceAnimationPush),
-      @"pop" : @(RNSScreenReplaceAnimationPop),
-    }),
-    RNSScreenReplaceAnimationPop,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenReplaceAnimation,
+                   (@{
+                     @"push" : @(RNSScreenReplaceAnimationPush),
+                     @"pop" : @(RNSScreenReplaceAnimationPop),
+                   }),
+                   RNSScreenReplaceAnimationPop,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenSwipeDirection,
-    (@{
-      @"vertical" : @(RNSScreenSwipeDirectionVertical),
-      @"horizontal" : @(RNSScreenSwipeDirectionHorizontal),
-    }),
-    RNSScreenSwipeDirectionHorizontal,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenSwipeDirection,
+                   (@{
+                     @"vertical" : @(RNSScreenSwipeDirectionVertical),
+                     @"horizontal" : @(RNSScreenSwipeDirectionHorizontal),
+                   }),
+                   RNSScreenSwipeDirectionHorizontal,
+                   integerValue)
 
 #if !TARGET_OS_TV
-RCT_ENUM_CONVERTER(
-    UIStatusBarAnimation,
-    (@{
-      @"none" : @(UIStatusBarAnimationNone),
-      @"fade" : @(UIStatusBarAnimationFade),
-      @"slide" : @(UIStatusBarAnimationSlide)
-    }),
-    UIStatusBarAnimationNone,
-    integerValue)
+RCT_ENUM_CONVERTER(UIStatusBarAnimation,
+                   (@{
+                     @"none" : @(UIStatusBarAnimationNone),
+                     @"fade" : @(UIStatusBarAnimationFade),
+                     @"slide" : @(UIStatusBarAnimationSlide)
+                   }),
+                   UIStatusBarAnimationNone,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSStatusBarStyle,
-    (@{
-      @"auto" : @(RNSStatusBarStyleAuto),
-      @"inverted" : @(RNSStatusBarStyleInverted),
-      @"light" : @(RNSStatusBarStyleLight),
-      @"dark" : @(RNSStatusBarStyleDark),
-    }),
-    RNSStatusBarStyleAuto,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSStatusBarStyle,
+                   (@{
+                     @"auto" : @(RNSStatusBarStyleAuto),
+                     @"inverted" : @(RNSStatusBarStyleInverted),
+                     @"light" : @(RNSStatusBarStyleLight),
+                     @"dark" : @(RNSStatusBarStyleDark),
+                   }),
+                   RNSStatusBarStyleAuto,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenDetentType,
-    (@{
-      @"large" : @(RNSScreenDetentTypeLarge),
-      @"medium" : @(RNSScreenDetentTypeMedium),
-      @"all" : @(RNSScreenDetentTypeAll),
-    }),
-    RNSScreenDetentTypeAll,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenDetentType,
+                   (@{
+                     @"large" : @(RNSScreenDetentTypeLarge),
+                     @"medium" : @(RNSScreenDetentTypeMedium),
+                     @"all" : @(RNSScreenDetentTypeAll),
+                   }),
+                   RNSScreenDetentTypeAll,
+                   integerValue)
 
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json
 {

--- a/ios/RNSScreenContainer.mm
+++ b/ios/RNSScreenContainer.mm
@@ -261,13 +261,12 @@ RNS_IGNORE_SUPER_CALL_END
 
   RNSScreenView *screenView = (RNSScreenView *)childComponentView;
 
-  RCTAssert(
-      childComponentView.reactSuperview == nil,
-      @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
-      self,
-      childComponentView,
-      @(index),
-      @([childComponentView.superview tag]));
+  RCTAssert(childComponentView.reactSuperview == nil,
+            @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
+            self,
+            childComponentView,
+            @(index),
+            @([childComponentView.superview tag]));
 
   [_reactSubviews insertObject:screenView atIndex:index];
   screenView.reactSuperview = self;
@@ -279,12 +278,11 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  RCTAssert(
-      childComponentView.reactSuperview == self,
-      @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
-      self,
-      childComponentView,
-      @(index));
+  RCTAssert(childComponentView.reactSuperview == self,
+            @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
+            self,
+            childComponentView,
+            @(index));
   RCTAssert(
       (_reactSubviews.count > index) && [_reactSubviews objectAtIndex:index] == childComponentView,
       @"Attempt to unmount a view which has a different index. (parent: %@, child: %@, index: %@, actual index: %@, tag at index: %@)",

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -10,14 +10,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNSNavigationController : UINavigationController <
-                                         RNSViewControllerDelegate,
-                                         RNSTabsSpecialEffectsSupporting
+@interface RNSNavigationController : UINavigationController <RNSViewControllerDelegate,
+                                                             RNSTabsSpecialEffectsSupporting
 #if !TARGET_OS_TV
-                                         ,
-                                         RNSOrientationProviding
+                                                             ,
+                                                             RNSOrientationProviding
 #endif // !TARGET_OS_TV
-                                         >
+                                                             >
 
 @end
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -27,13 +27,12 @@
 
 namespace react = facebook::react;
 
-@interface RNSScreenStackView () <
-    UINavigationControllerDelegate,
-    UIAdaptivePresentationControllerDelegate,
-    UIGestureRecognizerDelegate,
-    UIViewControllerTransitioningDelegate,
-    RNSViewInteractionAware,
-    RCTMountingTransactionObserving>
+@interface RNSScreenStackView () <UINavigationControllerDelegate,
+                                  UIAdaptivePresentationControllerDelegate,
+                                  UIGestureRecognizerDelegate,
+                                  UIViewControllerTransitioningDelegate,
+                                  RNSViewInteractionAware,
+                                  RCTMountingTransactionObserving>
 
 @property (nonatomic) NSMutableArray<UIViewController *> *presentedModals;
 @property (nonatomic) BOOL updatingModals;
@@ -1058,8 +1057,8 @@ RNS_IGNORE_SUPER_CALL_END
   float bottom = [gestureResponseDistanceValues[@"bottom"] floatValue];
 
   // we check if any of the constraints are violated and return NO if so
-  return !(
-      (start != -1 && x < start) || (end != -1 && x > end) || (top != -1 && y < top) || (bottom != -1 && y > bottom));
+  return !((start != -1 && x < start) || (end != -1 && x > end) || (top != -1 && y < top) ||
+           (bottom != -1 && y > bottom));
 }
 
 // By default, the header buttons that are not inside the native hit area
@@ -1334,13 +1333,12 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
-  RCTAssert(
-      childComponentView.reactSuperview == nil,
-      @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
-      self,
-      childComponentView,
-      @(index),
-      @([childComponentView.superview tag]));
+  RCTAssert(childComponentView.reactSuperview == nil,
+            @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
+            self,
+            childComponentView,
+            @(index),
+            @([childComponentView.superview tag]));
 
   [_reactSubviews insertObject:(RNSScreenView *)childComponentView atIndex:index];
   ((RNSScreenView *)childComponentView).reactSuperview = self;
@@ -1363,12 +1361,11 @@ RNS_IGNORE_SUPER_CALL_END
   RNSScreenView *screenChildComponent = (RNSScreenView *)childComponentView;
   [screenChildComponent.controller setViewToSnapshot];
 
-  RCTAssert(
-      screenChildComponent.reactSuperview == self,
-      @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
-      self,
-      screenChildComponent,
-      @(index));
+  RCTAssert(screenChildComponent.reactSuperview == self,
+            @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
+            self,
+            screenChildComponent,
+            @(index));
   RCTAssert(
       (_reactSubviews.count > index) && [_reactSubviews objectAtIndex:index] == childComponentView,
       @"Attempt to unmount a view which has a different index. (parent: %@, child: %@, index: %@, actual index: %@, tag at index: %@)",

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -282,11 +282,10 @@ RNS_IGNORE_SUPER_CALL_END
         // in the image attribute not being updated. We manually set frame to the size of an image
         // in order to trigger proper reload that'd update the image attribute.
         RCTImageSource *imageSource = [RNSScreenStackHeaderConfig imageSourceFromImageView:imageView];
-        [imageView reactSetFrame:CGRectMake(
-                                     imageView.frame.origin.x,
-                                     imageView.frame.origin.y,
-                                     imageSource.size.width,
-                                     imageSource.size.height)];
+        [imageView reactSetFrame:CGRectMake(imageView.frame.origin.x,
+                                            imageView.frame.origin.y,
+                                            imageSource.size.width,
+                                            imageSource.size.height)];
       }
 
       UIImage *image = imageView.image;
@@ -848,13 +847,12 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
-  RCTAssert(
-      childComponentView.superview == nil,
-      @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
-      self,
-      childComponentView,
-      @(index),
-      @([childComponentView.superview tag]));
+  RCTAssert(childComponentView.superview == nil,
+            @"Attempt to mount already mounted component view. (parent: %@, child: %@, index: %@, existing parent: %@)",
+            self,
+            childComponentView,
+            @(index),
+            @([childComponentView.superview tag]));
 
   //  [_reactSubviews insertObject:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
   [self insertReactSubview:(RNSScreenStackHeaderSubview *)childComponentView atIndex:index];
@@ -1131,23 +1129,21 @@ Class<RCTComponentViewProtocol> RNSScreenStackHeaderConfigCls(void)
 
 @implementation RCTConvert (RNSScreenStackHeader)
 
-RCT_ENUM_CONVERTER(
-    UISemanticContentAttribute,
-    (@{
-      @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
-      @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
-    }),
-    UISemanticContentAttributeUnspecified,
-    integerValue)
+RCT_ENUM_CONVERTER(UISemanticContentAttribute,
+                   (@{
+                     @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
+                     @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
+                   }),
+                   UISemanticContentAttributeUnspecified,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    UINavigationItemBackButtonDisplayMode,
-    (@{
-      @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
-      @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
-      @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
-    }),
-    UINavigationItemBackButtonDisplayModeDefault,
-    integerValue)
+RCT_ENUM_CONVERTER(UINavigationItemBackButtonDisplayMode,
+                   (@{
+                     @"default" : @(UINavigationItemBackButtonDisplayModeDefault),
+                     @"generic" : @(UINavigationItemBackButtonDisplayModeGeneric),
+                     @"minimal" : @(UINavigationItemBackButtonDisplayModeMinimal),
+                   }),
+                   UINavigationItemBackButtonDisplayModeDefault,
+                   integerValue)
 
 @end

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -209,9 +209,8 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (UIBarButtonItem *)getUIBarButtonItem
 {
-  RCTAssert(
-      _type == RNSScreenStackHeaderSubviewTypeLeft || _type == RNSScreenStackHeaderSubviewTypeRight,
-      @"[RNScreens] Unexpected subview type.");
+  RCTAssert(_type == RNSScreenStackHeaderSubviewTypeLeft || _type == RNSScreenStackHeaderSubviewTypeRight,
+            @"[RNScreens] Unexpected subview type.");
 
   if (_barButtonItem == nil) {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
@@ -317,17 +316,16 @@ Class<RCTComponentViewProtocol> RNSScreenStackHeaderSubviewCls(void)
 
 @implementation RCTConvert (RNSScreenStackHeaderSubview)
 
-RCT_ENUM_CONVERTER(
-    RNSScreenStackHeaderSubviewType,
-    (@{
-      @"back" : @(RNSScreenStackHeaderSubviewTypeBackButton),
-      @"left" : @(RNSScreenStackHeaderSubviewTypeLeft),
-      @"right" : @(RNSScreenStackHeaderSubviewTypeRight),
-      @"title" : @(RNSScreenStackHeaderSubviewTypeTitle),
-      @"center" : @(RNSScreenStackHeaderSubviewTypeCenter),
-      @"searchBar" : @(RNSScreenStackHeaderSubviewTypeSearchBar),
-    }),
-    RNSScreenStackHeaderSubviewTypeTitle,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType,
+                   (@{
+                     @"back" : @(RNSScreenStackHeaderSubviewTypeBackButton),
+                     @"left" : @(RNSScreenStackHeaderSubviewTypeLeft),
+                     @"right" : @(RNSScreenStackHeaderSubviewTypeRight),
+                     @"title" : @(RNSScreenStackHeaderSubviewTypeTitle),
+                     @"center" : @(RNSScreenStackHeaderSubviewTypeCenter),
+                     @"searchBar" : @(RNSScreenStackHeaderSubviewTypeSearchBar),
+                   }),
+                   RNSScreenStackHeaderSubviewTypeTitle,
+                   integerValue)
 
 @end

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -578,17 +578,16 @@ RCT_EXPORT_METHOD(cancelSearch : (NSNumber *_Nonnull)reactTag)
 
 @implementation RCTConvert (RNSScreen)
 
-RCT_ENUM_CONVERTER(
-    RNSSearchBarPlacement,
-    (@{
-      @"automatic" : @(RNSSearchBarPlacementAutomatic),
-      @"inline" : @(RNSSearchBarPlacementInline),
-      @"stacked" : @(RNSSearchBarPlacementStacked),
-      @"integrated" : @(RNSSearchBarPlacementIntegrated),
-      @"integratedButton" : @(RNSSearchBarPlacementIntegratedButton),
-      @"integratedCentered" : @(RNSSearchBarPlacementIntegratedCentered),
-    }),
-    RNSSearchBarPlacementAutomatic,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSSearchBarPlacement,
+                   (@{
+                     @"automatic" : @(RNSSearchBarPlacementAutomatic),
+                     @"inline" : @(RNSSearchBarPlacementInline),
+                     @"stacked" : @(RNSSearchBarPlacementStacked),
+                     @"integrated" : @(RNSSearchBarPlacementIntegrated),
+                     @"integratedButton" : @(RNSSearchBarPlacementIntegratedButton),
+                     @"integratedCentered" : @(RNSSearchBarPlacementIntegratedCentered),
+                   }),
+                   RNSSearchBarPlacementAutomatic,
+                   integerValue)
 
 @end

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -265,9 +265,8 @@ RNSTabsIconType RNSTabsIconTypeFromIcon(react::RNSTabsScreenIOSIconType iconType
   }
 }
 
-RCTImageSource *RCTImageSourceFromImageSourceAndIconType(
-    const facebook::react::ImageSource *imageSource,
-    RNSTabsIconType iconType)
+RCTImageSource *RCTImageSourceFromImageSourceAndIconType(const facebook::react::ImageSource *imageSource,
+                                                         RNSTabsIconType iconType)
 {
   RCTImageSource *iconImageSource;
 
@@ -360,8 +359,8 @@ RNSTabsScreenSystemItem RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(
 
 UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem)
 {
-  RCTAssert(
-      systemItem != RNSTabsScreenSystemItemNone, @"Attempt to convert tabs systemItem none to UITabBarSystemItem");
+  RCTAssert(systemItem != RNSTabsScreenSystemItemNone,
+            @"Attempt to convert tabs systemItem none to UITabBarSystemItem");
   switch (systemItem) {
     case RNSTabsScreenSystemItemBookmarks:
       return UITabBarSystemItemBookmarks;

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -95,9 +95,8 @@ NSString *_Nullable RNSTabsBottomAccessoryOnEnvironmentChangePayloadFromUITabAcc
 UIUserInterfaceStyle UIUserInterfaceStyleFromTabsScreenCppEquivalent(
     react::RNSTabsScreenIOSUserInterfaceStyle userInterfaceStyle);
 
-RCTImageSource *RCTImageSourceFromImageSourceAndIconType(
-    const facebook::react::ImageSource *imageSource,
-    RNSTabsIconType iconType);
+RCTImageSource *RCTImageSourceFromImageSourceAndIconType(const facebook::react::ImageSource *imageSource,
+                                                         RNSTabsIconType iconType);
 
 RNSOrientation RNSOrientationFromRNSTabsScreenOrientation(react::RNSTabsScreenIOSOrientation orientation);
 

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
@@ -61,10 +61,9 @@ namespace react = facebook::react;
 - (nullable UIScrollView *)findScrollView
 {
   // It allows 0 for cases where the child is unmounted
-  RCTAssert(
-      self.subviews.count <= 1,
-      @"[RNScreens] ScrollViewMarker expects at most a single child. Subviews: %@",
-      self.subviews);
+  RCTAssert(self.subviews.count <= 1,
+            @"[RNScreens] ScrollViewMarker expects at most a single child. Subviews: %@",
+            self.subviews);
 
   UIScrollView *_Nullable foundScrollView = [self resolveScrollViewFromChildView:self.subviews.firstObject];
 
@@ -218,10 +217,9 @@ namespace react = facebook::react;
   }
 
   // It allows 0 for cases where the child is unmounted
-  RCTAssert(
-      self.subviews.count <= 1,
-      @"[RNScreens] ScrollViewMarker expects at most a single child. Subviews: %@",
-      self.subviews);
+  RCTAssert(self.subviews.count <= 1,
+            @"[RNScreens] ScrollViewMarker expects at most a single child. Subviews: %@",
+            self.subviews);
 
   [super finalizeUpdates:updateMask];
 }

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -147,10 +147,9 @@ static const CGFloat epsilon = 1e-6;
 RNS_IGNORE_SUPER_CALL_BEGIN
 - (nonnull NSMutableArray<RNSSplitScreenComponentView *> *)reactSubviews
 {
-  RCTAssert(
-      _reactSubviews != nil,
-      @"[RNScreens] Attempt to work with non-initialized list of RNSSplitScreenComponentView subviews. (for: %@)",
-      self);
+  RCTAssert(_reactSubviews != nil,
+            @"[RNScreens] Attempt to work with non-initialized list of RNSSplitScreenComponentView subviews. (for: %@)",
+            self);
   return _reactSubviews;
 }
 RNS_IGNORE_SUPER_CALL_END
@@ -165,11 +164,10 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  RCTAssert(
-      [childComponentView isKindOfClass:RNSSplitScreenComponentView.class],
-      @"[RNScreens] Attempt to mount child of unsupported type: %@, expected %@",
-      childComponentView.class,
-      RNSSplitScreenComponentView.class);
+  RCTAssert([childComponentView isKindOfClass:RNSSplitScreenComponentView.class],
+            @"[RNScreens] Attempt to mount child of unsupported type: %@, expected %@",
+            childComponentView.class,
+            RNSSplitScreenComponentView.class);
 
   auto *childScreen = static_cast<RNSSplitScreenComponentView *>(childComponentView);
   childScreen.splitHost = self;
@@ -179,11 +177,10 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  RCTAssert(
-      [childComponentView isKindOfClass:RNSSplitScreenComponentView.class],
-      @"[RNScreens] Attempt to unmount child of unsupported type: %@, expected %@",
-      childComponentView.class,
-      RNSSplitScreenComponentView.class);
+  RCTAssert([childComponentView isKindOfClass:RNSSplitScreenComponentView.class],
+            @"[RNScreens] Attempt to unmount child of unsupported type: %@, expected %@",
+            childComponentView.class,
+            RNSSplitScreenComponentView.class);
 
   auto *childScreen = static_cast<RNSSplitScreenComponentView *>(childComponentView);
   childScreen.splitHost = nil;

--- a/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
+++ b/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
@@ -45,12 +45,11 @@ namespace react = facebook::react;
 
   if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
     auto newState = react::RNSSplitScreenState{RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin)};
-    _state->updateState(
-        std::move(newState)
+    _state->updateState(std::move(newState)
     // TODO: @t0maboro - remove this compilation check once TVOSExample is upgraded to RN 82+
 #if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                            ,
+                        facebook::react::EventQueue::UpdateMode::unstable_Immediate
 #endif
     );
 

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -71,11 +71,10 @@ namespace react = facebook::react;
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  RCTAssert(
-      [childComponentView isKindOfClass:RNSStackScreenComponentView.class],
-      @"[RNScreens] Attempt to mount child of unsupported type: %@, expected %@",
-      childComponentView.class,
-      RNSStackScreenComponentView.class);
+  RCTAssert([childComponentView isKindOfClass:RNSStackScreenComponentView.class],
+            @"[RNScreens] Attempt to mount child of unsupported type: %@, expected %@",
+            childComponentView.class,
+            RNSStackScreenComponentView.class);
 
   auto *childScreen = static_cast<RNSStackScreenComponentView *>(childComponentView);
   childScreen.stackHost = self;
@@ -85,11 +84,10 @@ namespace react = facebook::react;
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  RCTAssert(
-      [childComponentView isKindOfClass:RNSStackScreenComponentView.class],
-      @"[RNScreens] Attempt to unmount child of unsupported type: %@, expected %@",
-      childComponentView.class,
-      RNSStackScreenComponentView.class);
+  RCTAssert([childComponentView isKindOfClass:RNSStackScreenComponentView.class],
+            @"[RNScreens] Attempt to unmount child of unsupported type: %@, expected %@",
+            childComponentView.class,
+            RNSStackScreenComponentView.class);
 
   auto *childScreen = static_cast<RNSStackScreenComponentView *>(childComponentView);
   [_renderedScreens removeObject:childScreen];
@@ -103,8 +101,8 @@ namespace react = facebook::react;
     // This shouldn't happen in typical scenarios but it can happen with fast-refresh.
     [_stackOperationCoordinator addPopOperation:stackScreen];
   } else {
-    RNSLog(
-        @"[RNScreens] ignoring pop operation of %@, already not attached or natively dismissed", stackScreen.screenKey);
+    RNSLog(@"[RNScreens] ignoring pop operation of %@, already not attached or natively dismissed",
+           stackScreen.screenKey);
   }
 }
 

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -105,11 +105,10 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
   }
 
   auto newData = facebook::react::RNSSafeAreaViewState{RCTEdgeInsetsFromUIEdgeInsets(_currentSafeAreaInsets)};
-  _state->updateState(
-      std::move(newData)
+  _state->updateState(std::move(newData)
 #if REACT_NATIVE_VERSION_MINOR >= 82
-          ,
-      facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                          ,
+                      facebook::react::EventQueue::UpdateMode::unstable_Immediate
 #endif // REACT_NATIVE_VERSION_MINOR >= 82
   );
 }

--- a/ios/tabs/RCTConvert+RNSTabs.mm
+++ b/ios/tabs/RCTConvert+RNSTabs.mm
@@ -9,73 +9,68 @@
 }
 
 #if !RCT_NEW_ARCH_ENABLED
-RCT_ENUM_CONVERTER(
-    RNSTabsIconType,
-    (@{
-      @"image" : @(RNSTabsIconTypeImage),
-      @"template" : @(RNSTabsIconTypeTemplate),
-      @"sfSymbol" : @(RNSTabsIconTypeSfSymbol),
-      @"xcasset" : @(RNSTabsIconTypeXcasset),
-    }),
-    RNSTabsIconTypeSfSymbol,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSTabsIconType,
+                   (@{
+                     @"image" : @(RNSTabsIconTypeImage),
+                     @"template" : @(RNSTabsIconTypeTemplate),
+                     @"sfSymbol" : @(RNSTabsIconTypeSfSymbol),
+                     @"xcasset" : @(RNSTabsIconTypeXcasset),
+                   }),
+                   RNSTabsIconTypeSfSymbol,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSTabBarMinimizeBehavior,
-    (@{
-      @"automatic" : @(RNSTabBarMinimizeBehaviorAutomatic),
-      @"never" : @(RNSTabBarMinimizeBehaviorNever),
-      @"onScrollDown" : @(RNSTabBarMinimizeBehaviorOnScrollDown),
-      @"onScrollUp" : @(RNSTabBarMinimizeBehaviorOnScrollUp),
-    }),
-    RNSTabBarMinimizeBehaviorAutomatic,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSTabBarMinimizeBehavior,
+                   (@{
+                     @"automatic" : @(RNSTabBarMinimizeBehaviorAutomatic),
+                     @"never" : @(RNSTabBarMinimizeBehaviorNever),
+                     @"onScrollDown" : @(RNSTabBarMinimizeBehaviorOnScrollDown),
+                     @"onScrollUp" : @(RNSTabBarMinimizeBehaviorOnScrollUp),
+                   }),
+                   RNSTabBarMinimizeBehaviorAutomatic,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSTabBarControllerMode,
-    (@{
-      @"automatic" : @(RNSTabBarControllerModeAutomatic),
-      @"tabBar" : @(RNSTabBarControllerModeTabBar),
-      @"tabSidebar" : @(RNSTabBarControllerModeTabSidebar),
-    }),
-    RNSTabBarControllerModeAutomatic,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSTabBarControllerMode,
+                   (@{
+                     @"automatic" : @(RNSTabBarControllerModeAutomatic),
+                     @"tabBar" : @(RNSTabBarControllerModeTabBar),
+                     @"tabSidebar" : @(RNSTabBarControllerModeTabSidebar),
+                   }),
+                   RNSTabBarControllerModeAutomatic,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSOrientation,
-    (@{
-      @"inherit" : @(RNSOrientationInherit),
-      @"all" : @(RNSOrientationAll),
-      @"allButUpsideDown" : @(RNSOrientationAllButUpsideDown),
-      @"portrait" : @(RNSOrientationPortrait),
-      @"portraitUp" : @(RNSOrientationPortraitUp),
-      @"portraitDown" : @(RNSOrientationPortraitDown),
-      @"landscape" : @(RNSOrientationLandscape),
-      @"landscapeLeft" : @(RNSOrientationLandscapeLeft),
-      @"landscapeRight" : @(RNSOrientationLandscapeRight),
-    }),
-    RNSOrientationInherit,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSOrientation,
+                   (@{
+                     @"inherit" : @(RNSOrientationInherit),
+                     @"all" : @(RNSOrientationAll),
+                     @"allButUpsideDown" : @(RNSOrientationAllButUpsideDown),
+                     @"portrait" : @(RNSOrientationPortrait),
+                     @"portraitUp" : @(RNSOrientationPortraitUp),
+                     @"portraitDown" : @(RNSOrientationPortraitDown),
+                     @"landscape" : @(RNSOrientationLandscape),
+                     @"landscapeLeft" : @(RNSOrientationLandscapeLeft),
+                     @"landscapeRight" : @(RNSOrientationLandscapeRight),
+                   }),
+                   RNSOrientationInherit,
+                   integerValue)
 
-RCT_ENUM_CONVERTER(
-    RNSTabsScreenSystemItem,
-    (@{
-      @"none" : @(RNSTabsScreenSystemItemNone),
-      @"bookmarks" : @(RNSTabsScreenSystemItemBookmarks),
-      @"contacts" : @(RNSTabsScreenSystemItemContacts),
-      @"downloads" : @(RNSTabsScreenSystemItemDownloads),
-      @"favorites" : @(RNSTabsScreenSystemItemFavorites),
-      @"featured" : @(RNSTabsScreenSystemItemFeatured),
-      @"history" : @(RNSTabsScreenSystemItemHistory),
-      @"more" : @(RNSTabsScreenSystemItemMore),
-      @"mostRecent" : @(RNSTabsScreenSystemItemMostRecent),
-      @"mostViewed" : @(RNSTabsScreenSystemItemMostViewed),
-      @"recents" : @(RNSTabsScreenSystemItemRecents),
-      @"search" : @(RNSTabsScreenSystemItemSearch),
-      @"topRated" : @(RNSTabsScreenSystemItemTopRated),
-    }),
-    RNSTabsScreenSystemItemNone,
-    integerValue)
+RCT_ENUM_CONVERTER(RNSTabsScreenSystemItem,
+                   (@{
+                     @"none" : @(RNSTabsScreenSystemItemNone),
+                     @"bookmarks" : @(RNSTabsScreenSystemItemBookmarks),
+                     @"contacts" : @(RNSTabsScreenSystemItemContacts),
+                     @"downloads" : @(RNSTabsScreenSystemItemDownloads),
+                     @"favorites" : @(RNSTabsScreenSystemItemFavorites),
+                     @"featured" : @(RNSTabsScreenSystemItemFeatured),
+                     @"history" : @(RNSTabsScreenSystemItemHistory),
+                     @"more" : @(RNSTabsScreenSystemItemMore),
+                     @"mostRecent" : @(RNSTabsScreenSystemItemMostRecent),
+                     @"mostViewed" : @(RNSTabsScreenSystemItemMostViewed),
+                     @"recents" : @(RNSTabsScreenSystemItemRecents),
+                     @"search" : @(RNSTabsScreenSystemItemSearch),
+                     @"topRated" : @(RNSTabsScreenSystemItemTopRated),
+                   }),
+                   RNSTabsScreenSystemItemNone,
+                   integerValue)
 
 #endif // !RCT_NEW_ARCH_ENABLED
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -156,9 +156,8 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 
 - (UIView *)nativeWrapperView
 {
-  RCTAssert(
-      _bottomAccessoryView.superview.superview != nil,
-      @"[RNScreens] RNSTabsBottomAccessoryComponentView must be the set as bottom accessory.");
+  RCTAssert(_bottomAccessoryView.superview.superview != nil,
+            @"[RNScreens] RNSTabsBottomAccessoryComponentView must be the set as bottom accessory.");
   return _bottomAccessoryView.superview.superview;
 }
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm
@@ -36,11 +36,10 @@
     if (_bottomAccessoryView.state != nullptr) {
       auto newState =
           react::RNSTabsBottomAccessoryState{RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin)};
-      _bottomAccessoryView.state->updateState(
-          std::move(newState)
+      _bottomAccessoryView.state->updateState(std::move(newState)
 #if REACT_NATIVE_VERSION_MINOR >= 82
-              ,
-          facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                                                  ,
+                                              facebook::react::EventQueue::UpdateMode::unstable_Immediate
 #endif // REACT_NATIVE_VERSION_MINOR >= 82
       );
       _previousFrame = frame;

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -51,13 +51,12 @@ NS_ASSUME_NONNULL_BEGIN
  * i.e. if you made changes through one of signals method, unless you flush them immediately, they will
  * be executed only after react finishes the transaction (from within transaction execution block).
  */
-@interface RNSTabBarController : UITabBarController <
-                                     RNSReactTransactionObserving
+@interface RNSTabBarController : UITabBarController <RNSReactTransactionObserving
 #if !TARGET_OS_TV
-                                     ,
-                                     RNSOrientationProviding
+                                                     ,
+                                                     RNSOrientationProviding
 #endif // !TARGET_OS_TV
-                                     >
+                                                     >
 
 - (instancetype)initWithTabsHostComponentView:(nullable RNSTabsHostComponentView *)tabsHostComponentView;
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -34,16 +34,17 @@
  * (reached via UIKit's `tabBarController` property on the parent chain)
  * to check whether the push should be prevented (e.g. due to `preventNativeSelection`).
  */
-static void
-rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *viewController, BOOL animated)
+static void rns_pushViewController(__unsafe_unretained id self,
+                                   SEL _cmd,
+                                   UIViewController *viewController,
+                                   BOOL animated)
 {
   UITabBarController *rawTabBarController = static_cast<UIViewController *>(self).tabBarController;
 
-  RCTAssert(
-      [rawTabBarController isKindOfClass:RNSTabBarController.class],
-      @"[RNScreens] Expected tabBarController to be of class %@, got: %@",
-      RNSTabBarController.class,
-      rawTabBarController.class);
+  RCTAssert([rawTabBarController isKindOfClass:RNSTabBarController.class],
+            @"[RNScreens] Expected tabBarController to be of class %@, got: %@",
+            RNSTabBarController.class,
+            rawTabBarController.class);
   RNSTabBarController *tabBarController = static_cast<RNSTabBarController *>(rawTabBarController);
 
   if ([tabBarController moreNavigationController:self shouldPushViewController:viewController]) {
@@ -232,9 +233,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
   UIViewController *currSelectedViewController = self.selectedViewController;
 
-  RCTAssert(
-      ![NSString rnscreens_isBlankOrNull:screenKey],
-      @"[RNScreens] The screenKey MUST NOT be null if the view controller is not null");
+  RCTAssert(![NSString rnscreens_isBlankOrNull:screenKey],
+            @"[RNScreens] The screenKey MUST NOT be null if the view controller is not null");
 
   [self progressNavigationState:screenKey withOrigin:RNSTabsActionOriginProgrammaticJs];
 
@@ -259,8 +259,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 
 - (void)userDidRepeatViewControllerSelection:(nonnull UIViewController *)viewController
 {
-  RCTAssert(
-      self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
+  RCTAssert(self.selectedViewController == viewController,
+            @"[RNScreens] Expected UIKit to update selectedViewController");
 
   if ([self isSelectedViewControllerTheMoreNavigationController]) {
     // We don't want to run neither state update nor side effects.
@@ -283,8 +283,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
 - (void)userDidSelectViewController:(nonnull UIViewController *)viewController
 {
   // At this moment the `UITabBarController` model is already updated.
-  RCTAssert(
-      self.selectedViewController == viewController, @"[RNScreens] Expected UIKit to update selectedViewController");
+  RCTAssert(self.selectedViewController == viewController,
+            @"[RNScreens] Expected UIKit to update selectedViewController");
 
   if ([self isSelectedViewControllerTheMoreNavigationController]) {
     [self disableNavigationBarInMoreNavigationController];
@@ -330,11 +330,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(tabBarController == self, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   // Can be UINavigationController in case of MoreNavigationController
-  RCTAssert(
-      [viewController isKindOfClass:RNSTabsScreenViewController.class] ||
-          [viewController isKindOfClass:UINavigationController.class],
-      @"[RNScreens] Unexpected type of controller: %@",
-      viewController.class);
+  RCTAssert([viewController isKindOfClass:RNSTabsScreenViewController.class] ||
+                [viewController isKindOfClass:UINavigationController.class],
+            @"[RNScreens] Unexpected type of controller: %@",
+            viewController.class);
 
   // TODO: handle enforcing orientation with natively-driven tabs
 
@@ -383,11 +382,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   RCTAssert(self == tabBarController, @"[RNScreens] Unexpected type of controller: %@", tabBarController.class);
 
   // Can be UINavigationController in case of MoreNavigationController
-  RCTAssert(
-      [viewController isKindOfClass:RNSTabsScreenViewController.class] ||
-          [viewController isKindOfClass:UINavigationController.class],
-      @"[RNScreens] Unexpected type of controller: %@",
-      viewController.class);
+  RCTAssert([viewController isKindOfClass:RNSTabsScreenViewController.class] ||
+                [viewController isKindOfClass:UINavigationController.class],
+            @"[RNScreens] Unexpected type of controller: %@",
+            viewController.class);
 
   [self userDidSelectViewController:viewController];
   _isHandlingExplicitSelectionUpdate = NO;
@@ -400,10 +398,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
                     animated:(BOOL)animated
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
-  RCTAssert(
-      self.moreNavigationController == navigationController,
-      @"[RNScreens] Unexpected view controller called delegate method: %@",
-      navigationController);
+  RCTAssert(self.moreNavigationController == navigationController,
+            @"[RNScreens] Unexpected view controller called delegate method: %@",
+            navigationController);
 
   // The root view controller is of different type.
   if ([viewController isKindOfClass:RNSTabsScreenViewController.class] &&
@@ -466,16 +463,14 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.selectedScreenKey;
   UIViewController *nextSelectedViewController = [self findChildViewControllerForKey:nextSelectedViewControllerKey];
 
-  RCTAssert(
-      nextSelectedViewController != nil,
-      @"[RNScreens] Failed to determine next selected view controller for key: %@",
-      nextSelectedViewControllerKey);
+  RCTAssert(nextSelectedViewController != nil,
+            @"[RNScreens] Failed to determine next selected view controller for key: %@",
+            nextSelectedViewControllerKey);
 
-  RCTAssert(
-      [nextSelectedViewController isKindOfClass:RNSTabsScreenViewController.class],
-      @"[RNScreens] nextSelectedViewController MUST be %@, got: %@",
-      RNSTabsScreenViewController.class,
-      nextSelectedViewController.class);
+  RCTAssert([nextSelectedViewController isKindOfClass:RNSTabsScreenViewController.class],
+            @"[RNScreens] nextSelectedViewController MUST be %@, got: %@",
+            RNSTabsScreenViewController.class,
+            nextSelectedViewController.class);
 
   if (self.rejectStaleNavigationStateUpdates && [self isNavigationStateUpdateStale:_pendingStateUpdate]) {
     [self.tabsHostComponentView tabBarController:self
@@ -561,10 +556,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     return nil;
   }
   for (UIViewController *viewController in self.viewControllers) {
-    RCTAssert(
-        [viewController isKindOfClass:RNSTabsScreenViewController.class],
-        @"[RNScreens] Unexpected type of controller: %@",
-        viewController.class);
+    RCTAssert([viewController isKindOfClass:RNSTabsScreenViewController.class],
+              @"[RNScreens] Unexpected type of controller: %@",
+              viewController.class);
     auto *screenViewController = static_cast<RNSTabsScreenViewController *>(viewController);
     if ([screenViewController.getScreenKeyOrNull isEqualToString:screenKey]) {
       return screenViewController;
@@ -596,20 +590,18 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
  */
 - (RNSTabsScreenViewController *)selectedScreenViewController
 {
-  RCTAssert(
-      [self.selectedViewController isKindOfClass:RNSTabsScreenViewController.class],
-      @"[RNScreens] Unexpected type of selectedViewController: %@",
-      self.selectedViewController.class);
+  RCTAssert([self.selectedViewController isKindOfClass:RNSTabsScreenViewController.class],
+            @"[RNScreens] Unexpected type of selectedViewController: %@",
+            self.selectedViewController.class);
   return static_cast<RNSTabsScreenViewController *>(self.selectedViewController);
 }
 
 - (nonnull NSString *)screenKeyForViewController:(nonnull UIViewController *)viewController
 {
-  RCTAssert(
-      [viewController isKindOfClass:RNSTabsScreenViewController.class],
-      @"[RNScreens] Expected selected view controller to be of class %@, got: %@",
-      RNSTabsScreenViewController.class,
-      viewController.class);
+  RCTAssert([viewController isKindOfClass:RNSTabsScreenViewController.class],
+            @"[RNScreens] Expected selected view controller to be of class %@, got: %@",
+            RNSTabsScreenViewController.class,
+            viewController.class);
 
   auto *screenKey = static_cast<RNSTabsScreenViewController *>(viewController).getScreenKeyOrNull;
   RCTAssert(screenKey != nil, @"[RNScreens] screenKey MUST NOT be nil");
@@ -648,10 +640,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   }
 
   if (![self.selectedViewController isKindOfClass:RNSTabsScreenViewController.class]) {
-    RCTAssert(
-        NO,
-        @"[RNScreens] Unexpected controller type during state reconciliation: %@",
-        self.selectedViewController.class);
+    RCTAssert(NO,
+              @"[RNScreens] Unexpected controller type during state reconciliation: %@",
+              self.selectedViewController.class);
     return;
   }
 
@@ -660,10 +651,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     return;
   }
 
-  RNSLog(
-      @"TabBarCtrl reconcileNavigationStateWithUIKitState: %@ -> %@",
-      _navigationState.selectedScreenKey,
-      selectedScreenKey);
+  RNSLog(@"TabBarCtrl reconcileNavigationStateWithUIKitState: %@ -> %@",
+         _navigationState.selectedScreenKey,
+         selectedScreenKey);
   [self progressNavigationState:selectedScreenKey withOrigin:RNSTabsActionOriginImplicit];
 
   auto *context = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
@@ -752,10 +742,9 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     // We quietly assume here, that the root view controller is the `UIMoreListViewController`.
     if (shouldRespectSelectionPrevention) {
       UIViewController *topViewController = self.moreNavigationController.topViewController;
-      RCTAssert(
-          [topViewController isKindOfClass:RNSTabsScreenViewController.class],
-          @"[RNScreens] Unexpected type of view controller on moreNavigationControllerStack: %@",
-          topViewController.class);
+      RCTAssert([topViewController isKindOfClass:RNSTabsScreenViewController.class],
+                @"[RNScreens] Unexpected type of view controller on moreNavigationControllerStack: %@",
+                topViewController.class);
       RNSTabsScreenViewController *screenController = static_cast<RNSTabsScreenViewController *>(topViewController);
       if (screenController.isPreventNativeSelectionEnabled) {
         return [self popToRootMoreNavigationController:self.moreNavigationController animated:shouldAnimate];
@@ -783,9 +772,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   }
 
   auto *poppedViewControllers = [moreNavigationController popToRootViewControllerAnimated:animated];
-  RCTAssert(
-      poppedViewControllers != nil && poppedViewControllers.count == 1,
-      @"[RNScreens] Expected exactly one view controller to be popped");
+  RCTAssert(poppedViewControllers != nil && poppedViewControllers.count == 1,
+            @"[RNScreens] Expected exactly one view controller to be popped");
   return [poppedViewControllers firstObject];
 }
 
@@ -840,11 +828,10 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
     RCTAssert(dynamicSubclass != nil, @"[RNScreens] Failed to allocate dynamic subclass of %s", currentClassName);
 
     Method pushMethod = class_getInstanceMethod(currentClass, @selector(pushViewController:animated:));
-    class_addMethod(
-        dynamicSubclass,
-        @selector(pushViewController:animated:),
-        (IMP)rns_pushViewController,
-        method_getTypeEncoding(pushMethod));
+    class_addMethod(dynamicSubclass,
+                    @selector(pushViewController:animated:),
+                    (IMP)rns_pushViewController,
+                    method_getTypeEncoding(pushMethod));
 
     objc_registerClassPair(dynamicSubclass);
   }
@@ -980,9 +967,8 @@ rns_pushViewController(__unsafe_unretained id self, SEL _cmd, UIViewController *
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
 
-  RCTAssert(
-      self.parentViewController != nil,
-      @"[RNScreens] Expected non-null parent view controller for layout direction update.");
+  RCTAssert(self.parentViewController != nil,
+            @"[RNScreens] Expected non-null parent view controller for layout direction update.");
   [self.parentViewController
       setOverrideTraitCollection:[UITraitCollection
                                      traitCollectionWithLayoutDirection:self.tabsHostComponentView.layoutDirection]

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -26,14 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
  * 2. provider of React state & props for the tab bar controller
  * 3. two way communication channel with React (commands & events)
  */
-@interface RNSTabsHostComponentView : RNSReactBaseView <
-                                          RNSScreenContainerDelegate,
-                                          RNSTabBarControllerDelegate
+@interface RNSTabsHostComponentView : RNSReactBaseView <RNSScreenContainerDelegate,
+                                                        RNSTabBarControllerDelegate
 #if !RCT_NEW_ARCH_ENABLED
-                                          ,
-                                          RCTInvalidating
+                                                        ,
+                                                        RCTInvalidating
 #endif
-                                          >
+                                                        >
 
 #if !RCT_NEW_ARCH_ENABLED
 - (instancetype)initWithFrame:(CGRect)frame reactImageLoader:(RCTImageLoader *)imageLoader;

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -619,8 +619,8 @@ RNS_IGNORE_SUPER_CALL_END
               withReason:(RNSTabsNavigationStateRejectionReason)reasonCode
 {
   RCTAssert(currentNavState.selectedScreenKey != nil, @"[RNScreens] Current state screenKey MUST NOT be nil");
-  RCTAssert(
-      rejectedRequest.selectedScreenKey != nil, @"[RNScreens] Rejected request selectedScreenKey MUST NOT be nil");
+  RCTAssert(rejectedRequest.selectedScreenKey != nil,
+            @"[RNScreens] Rejected request selectedScreenKey MUST NOT be nil");
 
   [self.reactEventEmitter emitOnTabSelectionRejected:{.currentNavState = currentNavState,
                                                       .rejectedRequest = rejectedRequest,
@@ -633,9 +633,8 @@ RNS_IGNORE_SUPER_CALL_END
 {
   RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
   RCTAssert(screenKey != nil, @"[RNScreens] Expected NON NIL screenKey");
-  RCTAssert(
-      currentNavState != nil && currentNavState.selectedScreenKey != nil,
-      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
+            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnTabSelectionPrevented:{
                                                           .currentNavState = currentNavState,
@@ -647,9 +646,8 @@ RNS_IGNORE_SUPER_CALL_END
     didSelectMoreTabWithCurrentState:(nonnull RNSTabsNavigationState *)currentNavState
 {
   RCTAssert(tabBarController != nil, @"[RNScreens] Expected NON NIL tabBarController");
-  RCTAssert(
-      currentNavState != nil && currentNavState.selectedScreenKey != nil,
-      @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
+  RCTAssert(currentNavState != nil && currentNavState.selectedScreenKey != nil,
+            @"[RNScreens] Expected NON NIL nav state & selectedScreenKey");
 
   [self.reactEventEmitter emitOnMoreTabSelected:{
                                                     .currentNavState = currentNavState,

--- a/ios/tabs/host/RNSTabsHostComponentViewManager.mm
+++ b/ios/tabs/host/RNSTabsHostComponentViewManager.mm
@@ -27,10 +27,9 @@ RCT_EXPORT_VIEW_PROPERTY(tabBarHidden, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(nativeContainerBackgroundColor, UIColor);
 // This remapping allows us to store UITabBarMinimizeBehavior in the component while accepting a custom enum as input
 // from JS.
-RCT_REMAP_VIEW_PROPERTY(
-    tabBarMinimizeBehavior,
-    tabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior,
-    RNSTabBarMinimizeBehavior);
+RCT_REMAP_VIEW_PROPERTY(tabBarMinimizeBehavior,
+                        tabBarMinimizeBehaviorFromRNSTabBarMinimizeBehavior,
+                        RNSTabBarMinimizeBehavior);
 // This remapping allows us to store UITabBarControllerMode in the component while accepting a custom enum as input
 // from JS.
 RCT_REMAP_VIEW_PROPERTY(tabBarControllerMode, tabBarControllerModeFromRNSTabBarControllerMode, RNSTabBarControllerMode);

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -20,13 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Component view with react managed lifecycle. This view serves as root view in hierarchy
  * of a particular tab.
  */
-@interface RNSTabsScreenComponentView : RNSReactBaseView <
-                                            RNSSafeAreaProviding
+@interface RNSTabsScreenComponentView : RNSReactBaseView <RNSSafeAreaProviding
 #if !RCT_NEW_ARCH_ENABLED
-                                            ,
-                                            RCTInvalidating
+                                                          ,
+                                                          RCTInvalidating
 #endif
-                                            >
+                                                          >
 
 /**
  * View controller responsible for managing tab represented by this component view.

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -59,10 +59,9 @@
   }
 
   // Can be UINavigationController in case of MoreNavigationController
-  RCTAssert(
-      [parent isKindOfClass:RNSTabBarController.class] || [parent isKindOfClass:UINavigationController.class],
-      @"[RNScreens] TabScreenViewController added to parent of unexpected type: %@",
-      parent.class);
+  RCTAssert([parent isKindOfClass:RNSTabBarController.class] || [parent isKindOfClass:UINavigationController.class],
+            @"[RNScreens] TabScreenViewController added to parent of unexpected type: %@",
+            parent.class);
 
   if ([parent isKindOfClass:UINavigationController.class]) {
     // Hide the navigation bar for the more controller
@@ -71,8 +70,8 @@
 
   RNSTabBarController *tabBarCtrl = [self findTabBarController];
 
-  RCTAssert(
-      tabBarCtrl != nil, @"[RNScreens] nullish tabBarCtrl after TabScreenViewController has been added to parent");
+  RCTAssert(tabBarCtrl != nil,
+            @"[RNScreens] nullish tabBarCtrl after TabScreenViewController has been added to parent");
 
   [tabBarCtrl setNeedsUpdateOfTabBarAppearance:true];
   [tabBarCtrl updateTabBarAppearanceIfNeeded];


### PR DESCRIPTION
## Description

We should internally align with the latest `clang-format` version, because pre-commit might try to include changes we don't want in our PRs

## Test plan

- bump clang-format to 22 locally and run `yarn-format`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
