### PR TITLE
fix(ios): realign large title with custom left item on iOS 26

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -285,9 +285,9 @@ RNS_IGNORE_SUPER_CALL_END
       CGFloat trailing = m.trailing;
       // Float slack only (not a screen layout constant like "16pt").
       static const CGFloat kRNSDirectionalMarginAsymmetrySlack = 0.75;
-      BOOL repairedAsymmetricMargins =
+      BOOL shouldRepairAsymmetricMargins =
           (leading + kRNSDirectionalMarginAsymmetrySlack < trailing && trailing > 1.0);
-      if (repairedAsymmetricMargins) {
+      if (shouldRepairAsymmetricMargins) {
         // Preserve trailing; only align collapsed leading to the bar's own trailing inset.
         bar.directionalLayoutMargins = NSDirectionalEdgeInsetsMake(m.top, trailing, m.bottom, m.trailing);
         layoutNavigationChrome();

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -262,27 +262,37 @@ RNS_IGNORE_SUPER_CALL_END
 {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   if (@available(iOS 26.0, *)) {
-    if (config.largeTitle && config.hasSubviewLeft) {
-      // iOS 26: after drawer-driven navigation, large title can lay out with collapsed
-      // leading inset while custom left items use the standard 16pt inset. Sync nav bar
-      // directional margins and force a second layout pass on the next runloop tick.
-      dispatch_async(dispatch_get_main_queue(), ^{
-        NSDirectionalEdgeInsets m = navctr.navigationBar.directionalLayoutMargins;
-        navctr.navigationBar.directionalLayoutMargins =
-            NSDirectionalEdgeInsetsMake(m.top, 16.0, m.bottom, 16.0);
-        [navctr.view setNeedsLayout];
-        [navctr.navigationBar setNeedsLayout];
-        [navctr.view layoutIfNeeded];
-        [navctr.navigationBar layoutIfNeeded];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [navctr.view setNeedsLayout];
-          [navctr.navigationBar setNeedsLayout];
-          [navctr.view layoutIfNeeded];
-          [navctr.navigationBar layoutIfNeeded];
-        });
-      });
+    if (config == nil || !config.largeTitle) {
+      return;
     }
+
+    // iOS 26: after drawer-driven navigation, large-title headers can end up with asymmetric
+    // directional margins (collapsed leading vs normal trailing). We avoid hardcoded constants
+    // and preserve trailing: when asymmetry is detected, only leading is aligned to trailing.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      UINavigationBar *bar = navctr.navigationBar;
+      void (^layoutNavigationChrome)(void) = ^{
+        [navctr.view setNeedsLayout];
+        [bar setNeedsLayout];
+        [navctr.view layoutIfNeeded];
+        [bar layoutIfNeeded];
+      };
+
+      layoutNavigationChrome();
+
+      NSDirectionalEdgeInsets m = bar.directionalLayoutMargins;
+      CGFloat leading = m.leading;
+      CGFloat trailing = m.trailing;
+      // Float slack only (not a screen layout constant like "16pt").
+      static const CGFloat kRNSDirectionalMarginAsymmetrySlack = 0.75;
+      BOOL repairedAsymmetricMargins =
+          (leading + kRNSDirectionalMarginAsymmetrySlack < trailing && trailing > 1.0);
+      if (repairedAsymmetricMargins) {
+        // Preserve trailing; only align collapsed leading to the bar's own trailing inset.
+        bar.directionalLayoutMargins = NSDirectionalEdgeInsetsMake(m.top, trailing, m.bottom, m.trailing);
+        layoutNavigationChrome();
+      }
+    });
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 }
@@ -691,18 +701,22 @@ RNS_IGNORE_SUPER_CALL_END
           [self setAnimatedConfig:vc withConfig:config];
         }
         completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          RNSScreenStackHeaderConfig *relayoutConfig = config;
           if ([context isCancelled]) {
             UIViewController *fromVC = [context viewControllerForKey:UITransitionContextFromViewControllerKey];
-            RNSScreenStackHeaderConfig *config = nil;
+            RNSScreenStackHeaderConfig *fromHeaderConfig = nil;
             for (UIView *subview in fromVC.view.reactSubviews) {
               if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
-                config = (RNSScreenStackHeaderConfig *)subview;
+                fromHeaderConfig = (RNSScreenStackHeaderConfig *)subview;
                 break;
               }
             }
-            [self setAnimatedConfig:fromVC withConfig:config];
+            [self setAnimatedConfig:fromVC withConfig:fromHeaderConfig];
+            // Do not fall back to `config` (destination); applying the workaround with the wrong
+            // screen's header options was flagged in PR review for cancelled transitions.
+            relayoutConfig = fromHeaderConfig;
           }
-          [self scheduleDeferredNavigationBarRelayoutIfNeeded:navctr withConfig:config];
+          [self scheduleDeferredNavigationBarRelayoutIfNeeded:navctr withConfig:relayoutConfig];
         }];
   } else {
     [self setAnimatedConfig:vc withConfig:config];

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -257,6 +257,36 @@ RNS_IGNORE_SUPER_CALL_END
   // font customized on the navigation item level, so nothing to do here
 }
 
++ (void)scheduleDeferredNavigationBarRelayoutIfNeeded:(UINavigationController *)navctr
+                                            withConfig:(RNSScreenStackHeaderConfig *)config
+{
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    if (config.largeTitle && config.hasSubviewLeft) {
+      // iOS 26: after drawer-driven navigation, large title can lay out with collapsed
+      // leading inset while custom left items use the standard 16pt inset. Sync nav bar
+      // directional margins and force a second layout pass on the next runloop tick.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        NSDirectionalEdgeInsets m = navctr.navigationBar.directionalLayoutMargins;
+        navctr.navigationBar.directionalLayoutMargins =
+            NSDirectionalEdgeInsetsMake(m.top, 16.0, m.bottom, 16.0);
+        [navctr.view setNeedsLayout];
+        [navctr.navigationBar setNeedsLayout];
+        [navctr.view layoutIfNeeded];
+        [navctr.navigationBar layoutIfNeeded];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [navctr.view setNeedsLayout];
+          [navctr.navigationBar setNeedsLayout];
+          [navctr.view layoutIfNeeded];
+          [navctr.navigationBar layoutIfNeeded];
+        });
+      });
+    }
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+}
+
 + (void)setTitleAttibutes:(NSDictionary *)attrs forButton:(UIBarButtonItem *)button
 {
   [button setTitleTextAttributes:attrs forState:UIControlStateNormal];
@@ -672,9 +702,11 @@ RNS_IGNORE_SUPER_CALL_END
             }
             [self setAnimatedConfig:fromVC withConfig:config];
           }
+          [self scheduleDeferredNavigationBarRelayoutIfNeeded:navctr withConfig:config];
         }];
   } else {
     [self setAnimatedConfig:vc withConfig:config];
+    [self scheduleDeferredNavigationBarRelayoutIfNeeded:navctr withConfig:config];
   }
 }
 


### PR DESCRIPTION
**Summary**
Fixes iOS 26 large-title misalignment after drawer-driven navigation by repairing asymmetric navigation bar directional margins during deferred relayout.
The fix now applies to **iOS 26 + headerLargeTitle: true** (with or without custom `headerLeft`), since the same collapsed-leading state can occur in both cases.

**Linked Issue**
Closes #3602

**Reproduction**
Using a drawer navigator:

1. Open drawer
2. Navigate to a screen with:

- `headerLargeTitle: true`
- with or without custom `headerLeft`

3. On iOS 26.x, large title can appear misaligned due to asymmetric nav bar margins after transition
This does not reproduce on iOS 18 in the same setup.

**Root Cause**
On iOS 26, after drawer-driven navigation, `UINavigationBar` can temporarily end up with asymmetric directional margins (collapsed `leading` vs normal `trailing`) during large-title layout. This causes visible title alignment drift.

**Fix**
In `RNSScreenStackHeaderConfig.mm`:

- Updated `scheduleDeferredNavigationBarRelayoutIfNeeded:withConfig`:
- Scoped to `iOS 26 + config.largeTitle` (intentionally not restricted to `hasSubviewLeft`)
- Detects asymmetry dynamically and adjusts **only leading** while preserving trailing
- Simplified deferred relayout flow:
    - single deferred dispatch
    - second layout pass only when repair is applied
- Fixed cancelled-transition handling:
    - computes effective config for completion path
    - uses `fromHeaderConfig` on cancel
    - avoids config shadowing issues

**Why This Scope**
Although initially observed with custom `headerLeft`, the same iOS 26 asymmetry occurs on large-title screens without custom left items. Restricting to `hasSubviewLeft` regresses that case.

**Test Plan**

- Reproduced via drawer → large-title screen
- Verified on iOS 26.1 simulator:
   - `headerLargeTitle: true` + custom `headerLeft`
   - `headerLargeTitle: true` without custom `headerLeft`
- Compared against iOS 18.3 baseline
- Repeated navigation to verify consistency across first and subsequent opens

**Notes**
- Native-only change in header layout handling
- No JS API surface changes