### PR TITLE
chore: fix opt-out comment of RNRepo

### DIFF
--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -6,8 +6,8 @@ def isCIEnabled() {
     return ["1", "true"].contains(System.getenv("CI")?.toLowerCase())
 }
 
-// System.setProperty("DISABLE_RNREPO", "1") // Uncomment to disable RNRepo even in CI
 def isRNRepoEnabled() {
+    // return false // Uncomment to disable RNRepo even in CI
     return System.getenv("DISABLE_RNREPO") == null
 }
 


### PR DESCRIPTION
## Description

Mistakenly setProperty was added, whch is no longer supported as opt-out flag, so RNRepo can be disabled via uncommenting the `return false` in CI
