### PR TITLE
chore: add title check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,24 @@
+name: PR Title Check
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+      - main-labs
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title does not follow Conventional Commits format."
+            echo "Expected: <type>(<scope>): <description>"
+            echo "Types: feat, fix, chore, docs, refactor, test, style, perf, ci, build, revert"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi
+          echo "PR title is valid: $PR_TITLE"


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that validates PR titles against the [Conventional Commits](https://www.conventionalcommits.org/) specification.

## Changes

- Added .github/workflows/pr-title-check.yml — triggers on PR open/edit/sync/reopen against main and main-labs; fails if the title does not match <type>(<scope>)?!?: <description>
- Accepted types: feat, fix, chore, docs, refactor, test, style, perf, ci, build, revert

## Test

- failed: https://github.com/software-mansion/react-native-screens/actions/runs/25426136451
- then pass: https://github.com/software-mansion/react-native-screens/actions/runs/25426194870