### PR TITLE
chore(example): use prebuilt ReactNativeDependencies by default

### DIFF
--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -29,7 +29,8 @@ require_relative '../../scripts/ios/rns_set_swift_compilation_flags'
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# ReactNativeDependencies always uses prebuilts; Core uses prebuilts only in CI
+# ReactNativeDependencies: prebuilts by default (override via env flag)
+# Core: CI uses prebuilts, local uses source (override via env flag)
 ci_enabled = %w[1 true].include?(ENV['CI'].to_s.downcase)
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= ci_enabled ? '1' : '0'
 ENV['RCT_USE_RN_DEP'] ||= '1'

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -29,10 +29,10 @@ require_relative '../../scripts/ios/rns_set_swift_compilation_flags'
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# Use prebuilt binaries in CI, source in local development
+# ReactNativeDependencies always uses prebuilts; Core uses prebuilts only in CI
 ci_enabled = %w[1 true].include?(ENV['CI'].to_s.downcase)
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= ci_enabled ? '1' : '0'
-ENV['RCT_USE_RN_DEP'] ||= ci_enabled ? '1' : '0'
+ENV['RCT_USE_RN_DEP'] ||= '1'
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil


### PR DESCRIPTION
## Description

always use prebuilt ReactNativeDependencies, build Core from source locally
