### PR TITLE
iOS: scope singleSelection to leaf header menus

### DIFF
--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -4,7 +4,8 @@
 #import "RNSDefines.h"
 #import "RNSImageLoadingHelper.h"
 
-static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
+static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config, BOOL hasSubmenus);
+static BOOL RNSMenuHasSubmenus(NSArray *items);
 
 @implementation RNSBarButtonItem {
   NSString *_buttonId;
@@ -167,6 +168,7 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
 {
   NSArray *items = dict[@"items"];
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray new];
+  BOOL hasSubmenus = RNSMenuHasSubmenus(items);
   if (items.count > 0) {
     for (NSDictionary *item in items) {
       NSString *menuId = item[@"menuId"];
@@ -191,7 +193,7 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
   return [UIMenu menuWithTitle:dict[@"title"]
                          image:image
                     identifier:nil
-                       options:RNSMakeUIMenuOptionsFromConfig(dict)
+                       options:RNSMakeUIMenuOptionsFromConfig(dict, hasSubmenus)
                       children:elements];
 }
 
@@ -364,7 +366,7 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
 
 @end
 
-UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config)
+UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config, BOOL hasSubmenus)
 {
   UIMenuOptions options = 0;
   NSNumber *singleSelection = config[@"singleSelection"];
@@ -372,7 +374,7 @@ UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config)
   NSNumber *displayInline = config[@"displayInline"];
   NSNumber *destructive = config[@"destructive"];
 
-  if (singleSelection != nil && [singleSelection boolValue]) {
+  if (!hasSubmenus && singleSelection != nil && [singleSelection boolValue]) {
     options |= UIMenuOptionsSingleSelection;
   }
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
@@ -389,4 +391,14 @@ UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config)
     options |= UIMenuOptionsDestructive;
   }
   return options;
+}
+
+BOOL RNSMenuHasSubmenus(NSArray *items)
+{
+  for (NSDictionary *item in items) {
+    if (item[@"menuId"] == nil) {
+      return YES;
+    }
+  }
+  return NO;
 }


### PR DESCRIPTION
## Summary
- Fixes header menu behavior on iOS where selecting an item in one submenu clears the checkmark in a sibling submenu.
- Root cause: `UIMenuOptionsSingleSelection` was applied to menus that contain submenus, causing UIKit to treat sibling submenu actions as a shared selection group.
- This change scopes `singleSelection` to leaf menus only (menus without submenu children).

Fixes #3973.

## Repro
Using `unstable_headerRightItems`, create a header menu with:
- an inline parent submenu
- two sibling submenus (for example `Sort` and `Group`)
- each submenu contains action items with `state: 'on' | 'off'`
Observed before:
- selecting in submenu A removes checkmark in submenu B (and vice versa)
Expected / after:
- each submenu maintains its own selected checkmark independently

## Test plan
- Run app on iOS and open the header menu (`...`)
- Open submenu A (e.g. `Sort`) and select an option
- Open submenu B (e.g. `Group`) and select an option
- Verify both submenus keep their own checkmark state
- Swap submenu order in config and verify behavior remains correct

## Environment
- iOS: 26.3
- Device: iPhone 17 Pro
