### PR TITLE
chore: Enable gamma for TVOS builds on CI

### DIFF
--- a/.github/workflows/tv-os-build-test.yml
+++ b/.github/workflows/tv-os-build-test.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     env:
       WORKING_DIRECTORY: TVOSExample
-      RNS_GAMMA_ENABLED: 0
+      RNS_GAMMA_ENABLED: 1
     concurrency:
       group: ios-tv-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Description

It would be helpful to check whether new components are compiling properly on TVOS during the development phase, because tbh I don't test TVOS locally after every change I made:

Ex:
- https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/formsheet?language=objc - supported on TVOS
- https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller?language=objc - unsupported on TVOS

<img width="2137" height="399" alt="Screenshot 2026-05-06 at 13 38 48" src="https://github.com/user-attachments/assets/1606d0c8-732e-4c65-8444-6e06b0a59ffe" />
