### PR TITLE
refactor(tabs): rename rejectedProvenance to rejectedBaseProvenance

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/event/TabsHostTabSelectionRejectedEvent.kt
@@ -35,7 +35,7 @@ class TabsHostTabSelectionRejectedEvent(
             putString(EK_SELECTED_KEY, currentNavState.selectedScreenKey)
             putInt(EK_PROVENANCE, currentNavState.provenance)
             putString(EK_REJECTED_KEY, rejectedRequest.selectedScreenKey)
-            putInt(EK_REJECTED_PROVENANCE, rejectedRequest.baseProvenance)
+            putInt(EK_REJECTED_BASE_PROVENANCE, rejectedRequest.baseProvenance)
             putString(EK_REJECTION_REASON, rejectionReason.toString())
         }
 
@@ -46,7 +46,7 @@ class TabsHostTabSelectionRejectedEvent(
         private const val EK_SELECTED_KEY = "selectedScreenKey"
         private const val EK_PROVENANCE = "provenance"
         private const val EK_REJECTED_KEY = "rejectedScreenKey"
-        private const val EK_REJECTED_PROVENANCE = "rejectedProvenance"
+        private const val EK_REJECTED_BASE_PROVENANCE = "rejectedBaseProvenance"
         private const val EK_REJECTION_REASON = "rejectionReason"
 
         override fun getEventName() = EVENT_NAME

--- a/ios/tabs/host/RNSTabsHostEventEmitter.mm
+++ b/ios/tabs/host/RNSTabsHostEventEmitter.mm
@@ -62,7 +62,7 @@ namespace react = facebook::react;
         {.selectedScreenKey = RCTStringFromNSString(payload.currentNavState.selectedScreenKey),
          .provenance = payload.currentNavState.provenance,
          .rejectedScreenKey = RCTStringFromNSString(payload.rejectedRequest.selectedScreenKey),
-         .rejectedProvenance = payload.rejectedRequest.baseProvenance,
+         .rejectedBaseProvenance = payload.rejectedRequest.baseProvenance,
          .rejectionReason = convertedReason});
     return YES;
   } else {

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -103,8 +103,8 @@ export type TabSelectionRejectedEvent = {
   provenance: number;
   /** Screen key of the tab whose selection was rejected. */
   rejectedScreenKey: string;
-  /** Provenance of the rejected navigation state update. */
-  rejectedProvenance: number;
+  /** Base provenance of the rejected navigation state update. */
+  rejectedBaseProvenance: number;
   /** Reason the selection was rejected. */
   rejectionReason: TabSelectionRejectionReason;
 };

--- a/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostAndroidNativeComponent.ts
@@ -22,7 +22,7 @@ type TabSelectionRejectedEvent = Readonly<{
   selectedScreenKey: string;
   provenance: CT.Int32;
   rejectedScreenKey: string;
-  rejectedProvenance: CT.Int32;
+  rejectedBaseProvenance: CT.Int32;
   rejectionReason: 'stale' | 'repeated';
 }>;
 

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -22,7 +22,7 @@ type TabSelectionRejectedEvent = Readonly<{
   selectedScreenKey: string;
   provenance: CT.Int32;
   rejectedScreenKey: string;
-  rejectedProvenance: CT.Int32;
+  rejectedBaseProvenance: CT.Int32;
   rejectionReason: 'stale' | 'repeated';
 }>;
 


### PR DESCRIPTION
## Description

Renames `TabSelectionRejectedEvent#rejectedProvenance` to `rejectedBaseProvenance`
across every surface that touches it.

The `onTabSelectionRejected` event payload exposes the value of
`rejectedRequest.baseProvenance` from the request model introduced in RFC-1028,
but the field was named `rejectedProvenance` — inconsistent with the request
model, where `NavigationStateRequest` carries an explicit `baseProvenance`.
This rename realigns the public event payload with the request model so
JS consumers can correlate the rejected base provenance against the request
they sent.

Pure rename; no behavior change, no value-source change.

Closes software-mansion/react-native-screens-labs#1233.

## Changes

- Renamed field on the public TS type `TabSelectionRejectedEvent` (and updated its JSDoc) in `src/components/tabs/host/TabsHost.types.ts`.
- Renamed field in both codegen specs: `src/fabric/tabs/TabsHostIOSNativeComponent.ts` and `src/fabric/tabs/TabsHostAndroidNativeComponent.ts`.
- Renamed Kotlin event-key constant (`EK_REJECTED_PROVENANCE` → `EK_REJECTED_BASE_PROVENANCE`) and its string value (`"rejectedProvenance"` → `"rejectedBaseProvenance"`) in `TabsHostTabSelectionRejectedEvent.kt`.
- Renamed the codegen-struct designated-init field (`.rejectedProvenance` → `.rejectedBaseProvenance`) in `ios/tabs/host/RNSTabsHostEventEmitter.mm`.

## Test plan

Existing test scenario: `apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection.tsx`. It only `JSON.stringify`s `event.nativeEvent`, so no JS-side change was needed — the rename flows through automatically.

Repro steps:

1. Run FabricExample (`yarn ios` / `yarn android`).
2. Open the `test-tabs-stale-update-rejection` scenario.
3. Trigger a stale update (the scenario provides a control to do so).
4. Confirm the toast / console payload now contains `rejectedBaseProvenance` and not `rejectedProvenance`.

Verification performed locally:

- `grep -rn "rejectedProvenance\|REJECTED_PROVENANCE"` (excluding `node_modules`, `lib/`, submodules) → zero hits.
- `yarn check-types` → exit 0.
- Native builds (Pods regen / Gradle) deferred to CI.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes