### PR TITLE
feat(iOS, FormSheet v5): Add prefersGrabberVisible prop

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -1,9 +1,11 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestFormSheetBase from './test-form-sheet-base-ios';
+import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 
 const scenarios = {
   TestFormSheetBase,
+  TestFormSheetGrabberVisible,
   TestFormSheetPreferredCornerRadius,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/index.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Switch, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Grabber visibility',
+  key: 'test-form-sheet-grabber-visible-ios',
+  details:
+    'Allows to test the `prefersGrabberVisible` prop of the FormSheet component.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [prefersGrabberVisible, setPrefersGrabberVisible] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet Grabber Test</Text>
+      <View style={styles.row}>
+        <Text style={styles.label}>prefersGrabberVisible</Text>
+        <Switch
+          value={prefersGrabberVisible}
+          onValueChange={setPrefersGrabberVisible}
+        />
+      </View>
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        detents={[0.6, 1.0]}
+        prefersGrabberVisible={prefersGrabberVisible}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>FormSheet content</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>prefersGrabberVisible</Text>
+            <Switch
+              value={prefersGrabberVisible}
+              onValueChange={setPrefersGrabberVisible}
+            />
+          </View>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+    gap: 12,
+  },
+  label: {
+    fontSize: 16,
+    color: Colors.text,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario.md
@@ -1,0 +1,75 @@
+# Test Scenario: Sheet Grabber Visibility
+
+## Details
+
+**Description:** Verify that the `prefersGrabberVisible` prop of the `FormSheet` component correctly controls the visibility of the grabber indicator at the top of the sheet. This test covers toggling the prop both before the sheet is presented (from the underlying screen) and while the sheet is already presented (from inside the sheet).
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Grabber visibility** screen.
+
+- [ ] Expected: Content with the "prefersGrabberVisible" toggle (switched off by default) and the "Open FormSheet" button is shown.
+
+---
+
+### Initial state - grabber hidden
+
+2. Without flipping the toggle, tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). No grabber indicator is shown at the top of the sheet.
+
+3. Dismiss the FormSheet by swiping it down.
+
+- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+
+---
+
+### Toggling visibility from outside the FormSheet
+
+4. Flip the "prefersGrabberVisible" toggle on the main screen to **on**.
+
+5. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). A grabber indicator is visible at the top of the sheet.
+
+6. Dismiss the FormSheet by swiping it down.
+
+7. Flip the "prefersGrabberVisible" toggle on the main screen back to **off**.
+
+8. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens with no grabber indicator visible at the top of the sheet.
+
+9. Dismiss the FormSheet by swiping it down.
+
+---
+
+### Toggling visibility from inside the FormSheet
+
+10. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens with no grabber indicator visible at the top of the sheet. The "prefersGrabberVisible" toggle inside the sheet is switched off and reflects the same state as the toggle on the main screen.
+
+11. Flip the "prefersGrabberVisible" toggle inside the FormSheet to **on**.
+
+- [ ] Expected: The grabber indicator appears at the top of the sheet without dismissing or re-presenting the sheet.
+
+12. Flip the "prefersGrabberVisible" toggle inside the FormSheet back to **off**.
+
+- [ ] Expected: The grabber indicator disappears from the top of the sheet without dismissing or re-presenting the sheet.
+
+13. Tap the "Dismiss from JS" button.
+
+- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "prefersGrabberVisible" toggle on the main screen reflects the last value set inside the sheet (off).

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -26,6 +26,7 @@ namespace react = facebook::react;
 
   // Props
   BOOL _isOpen;
+  BOOL _prefersGrabberVisible;
   std::vector<double> _detents;
   CGFloat _preferredCornerRadius;
 
@@ -60,8 +61,9 @@ namespace react = facebook::react;
   _props = defaultProps;
 
   _isOpen = NO;
-  _detents = {};
+  _prefersGrabberVisible = NO;
   _preferredCornerRadius = -1.0;
+  _detents = {};
 }
 
 - (void)setupController
@@ -189,6 +191,11 @@ namespace react = facebook::react;
     _needsSheetConfigurationUpdate = YES;
   }
 
+  if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
+    _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
+    _needsSheetConfigurationUpdate = YES;
+  }
+
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
     _needsSheetConfigurationUpdate = YES;
@@ -256,8 +263,10 @@ namespace react = facebook::react;
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
 
+  // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
   [sheet animateChanges:^{
     sheet.detents = nativeDetents;
+    sheet.prefersGrabberVisible = _prefersGrabberVisible;
     sheet.preferredCornerRadius =
         _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
   }];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -26,8 +26,8 @@ namespace react = facebook::react;
 
   // Props
   BOOL _isOpen;
-  BOOL _prefersGrabberVisible;
   std::vector<double> _detents;
+  BOOL _prefersGrabberVisible;
   CGFloat _preferredCornerRadius;
 
   // Invalidation flags
@@ -61,9 +61,9 @@ namespace react = facebook::react;
   _props = defaultProps;
 
   _isOpen = NO;
+  _detents = {};
   _prefersGrabberVisible = NO;
   _preferredCornerRadius = -1.0;
-  _detents = {};
 }
 
 - (void)setupController

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -26,10 +26,11 @@ export interface FormSheetProps {
   detents?: number[] | undefined;
 
   /**
-   * @summary Determines whether the sheet displays a grabber at the top.
+   * @summary Determines whether the sheet requests a grabber at the top.
    *
-   * When `true`, a small grabber indicator is shown at the top of the sheet,
-   * hinting that the sheet can be resized.
+   * When `true`, the sheet requests that a small grabber indicator be shown
+   * at the top to hint that the sheet can be resized. The system may still
+   * hide the grabber in some presentation contexts.
    *
    * @default false
    * @platform ios

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -26,6 +26,17 @@ export interface FormSheetProps {
   detents?: number[] | undefined;
 
   /**
+   * @summary Determines whether the sheet displays a grabber at the top.
+   *
+   * When `true`, a small grabber indicator is shown at the top of the sheet,
+   * hinting that the sheet can be resized.
+   *
+   * @default false
+   * @platform ios
+   */
+  prefersGrabberVisible?: boolean | undefined;
+
+  /**
    * @summary The corner radius that the sheet will attempt to present with.
    *
    * If set to `systemDefault` or a negative number, it defaults to the system's

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -9,6 +9,7 @@ type GenericEmptyEvent = Readonly<{}>;
 interface NativeProps extends ViewProps {
   isOpen?: CT.WithDefault<boolean, false>;
   detents?: CT.Double[] | undefined;
+  prefersGrabberVisible?: CT.WithDefault<boolean, false>;
   preferredCornerRadius?: CT.WithDefault<CT.Float, -1.0>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
 }


### PR DESCRIPTION
## Description

Adding `prefersGrabberVisible`, which controls whether the grabber indicator is displayed at the top of the sheet. I deliberately left `prefers` prefix, because the grabber doesn't need to be always visible when the prop is set to `true`. According to the documentation:
```
The system automatically hides the grabber at appropriate times, like when the sheet is full screen in a compact-height size class or when another sheet presents on top of it.
```

Native equivalent: https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/prefersgrabbervisible

> [!NOTE]  
> I'm planning to adapt `RNSSplitAppearanceCoordinator` apporach here, but this can be done in a separate PR and shouldn't block adding props to the component.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1259

## Changes

- updated public types
- updated codegen spec
- binded react prop with the native setter

## Visual documentation

https://github.com/user-attachments/assets/17a829ed-7af3-4533-a362-eca826a87876

## Test plan

Added a dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
