### PR TITLE
feat(iOS, FormSheet v5): Add preferredCornerRadius prop

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -1,8 +1,10 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestFormSheetBase from './test-form-sheet-base-ios';
+import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 
 const scenarios = {
   TestFormSheetBase,
+  TestFormSheetPreferredCornerRadius,
 };
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { FormSheet } from 'react-native-screens/experimental';
+import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
@@ -13,9 +13,13 @@ const scenarioDescription: ScenarioDescription = {
   platforms: ['ios'],
 };
 
+type FormSheetCornerRadiusProp = NonNullable<
+  FormSheetProps['preferredCornerRadius']
+>;
+
 export function App() {
   const [isOpen, setIsOpen] = useState(false);
-  const [radius, setRadius] = useState<number>(-1.0);
+  const [radius, setRadius] = useState<FormSheetCornerRadiusProp>('systemDefault');
 
   return (
     <View style={styles.container}>
@@ -37,7 +41,7 @@ export function App() {
           <Text style={styles.sheetTitle}>Current Radius: {radius}</Text>
           <View style={styles.spacing} />
           <View style={styles.buttonGroup}>
-            <Button title="Default (-1.0)" onPress={() => setRadius(-1.0)} />
+            <Button title="System default" onPress={() => setRadius('systemDefault')} />
             <Button title="Sharp (0)" onPress={() => setRadius(0)} />
             <Button title="Small (10)" onPress={() => setRadius(10)} />
             <Button title="Large (50)" onPress={() => setRadius(50)} />

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Sheet preferred corner radius',
+  key: 'test-form-sheet-preferred-corner-radius-ios',
+  details:
+    'Allows to test the preferredCornerRadius property of the FormSheet component.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [radius, setRadius] = useState<number>(-1.0);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Corner Radius Test</Text>
+      <Text style={{ marginBottom: 12, color: Colors.text }}>
+        Current Radius: {radius}
+      </Text>
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        preferredCornerRadius={radius}
+        detents={[0.6, 1.0]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>Current Radius: {radius}</Text>
+          <View style={styles.spacing} />
+          <View style={styles.buttonGroup}>
+            <Button title="Default (-1.0)" onPress={() => setRadius(-1.0)} />
+            <Button title="Sharp (0)" onPress={() => setRadius(0)} />
+            <Button title="Small (10)" onPress={() => setRadius(10)} />
+            <Button title="Large (50)" onPress={() => setRadius(50)} />
+          </View>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  buttonGroup: {
+    gap: 12,
+    alignItems: 'center',
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -17,8 +17,8 @@ Other: Planned, but will be implemented separately.
 
 ## Note
 
-- On iPhone 18, the corner radius primarily affects the **top** corners of the bottom sheet.
-- On iPhone 26, the corner radius primarily affects **all** corners of the bottom sheet.
+- On iOS 18, the corner radius primarily affects the **top** corners of the bottom sheet.
+- On iOS 26, the corner radius primarily affects **all** corners of the bottom sheet.
 - On iPad, because the FormSheet is presented as a floating panel, the corner radius will affect **all four** corners.
 
 ## Steps - iPhone

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -27,7 +27,7 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" and current radius text (-1) is shown.
+- [ ] Expected: Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 
 ---
 
@@ -67,7 +67,7 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" and current radius text (-1) is shown.
+- [ ] Expected: Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -1,0 +1,101 @@
+# Test Scenario: Sheet corner radius
+
+## Details
+
+**Description:** Verify the `preferredCornerRadius` property of the `FormSheet` component. This test ensures that negative values successfully map to the system's automatic dimension, specific positive values correctly alter the corner rounding, and the sheet dynamically updates its radius when the prop changes while presented.
+
+**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone and iPad
+- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
+
+## Note
+
+- On iPhone, the corner radius primarily affects the **top** corners of the bottom sheet.
+- On iPad, because the FormSheet is presented as a floating panel, the corner radius will affect **all four** corners.
+
+## Steps - iPhone
+
+### Baseline
+
+1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
+
+- [ ] Expected: Content with the button "Open FormSheet" and current radius text (-1) is shown.
+
+---
+
+### Initialization & Default Value Verification
+
+2. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens. The top corners of the sheet display the standard, system-default rounded appearance.
+
+---
+
+### Dynamic Updates Validation
+
+3. Tap the "Sharp (0)" button.
+
+- [ ] Expected: The top corners of the sheet update dynamically, becoming sharp.
+
+4. Tap the "Small (10)" button.
+
+- [ ] Expected: The top corners update to a slightly rounded curve.
+
+5. Tap the "Large (50)" button.
+
+- [ ] Expected: The top corners of the sheet update dynamically, displaying deeply rounded curve.
+
+---
+
+### Dismissal Verification
+
+6. Tap the "Dismiss from JS" button (or swipe down completely).
+
+- [ ] Expected: The FormSheet dismisses smoothly. Pressables on the main screen remain active.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
+
+- [ ] Expected: Content with the button "Open FormSheet" and current radius text (-1) is shown.
+
+---
+
+### Initialization & Default Value Verification
+
+2. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens as a centered floating panel. All four corners of the panel display the standard, system-default rounded appearance.
+
+---
+
+### Dynamic Updates Validation
+
+3. Tap the "Sharp (0)" button.
+
+- [ ] Expected: All four corners of the sheet update dynamically, becoming sharp.
+
+4. Tap the "Small (10)" button.
+
+- [ ] Expected: All four corners update to a slightly rounded curve.
+
+5. Tap the "Large (50)" button.
+
+- [ ] Expected: All four corners of the sheet update dynamically, displaying deeply rounded curve.
+
+---
+
+### Dismissal Verification
+
+6. Tap the "Dismiss from JS" button (or swipe down completely).
+
+- [ ] Expected: The FormSheet dismisses smoothly. Pressables on the main screen remain active.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -17,7 +17,8 @@ Other: Planned, but will be implemented separately.
 
 ## Note
 
-- On iPhone, the corner radius primarily affects the **top** corners of the bottom sheet.
+- On iPhone 18, the corner radius primarily affects the **top** corners of the bottom sheet.
+- On iPhone 26, the corner radius primarily affects **all** corners of the bottom sheet.
 - On iPad, because the FormSheet is presented as a floating panel, the corner radius will affect **all four** corners.
 
 ## Steps - iPhone

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -34,7 +34,7 @@ Other: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens. The top corners of the sheet display the standard, system-default rounded appearance.
+- [ ] Expected: The FormSheet opens. The top corners (iOS 18) or all corners (iOS 26) of the sheet display the standard, system-default rounded appearance.
 
 ---
 
@@ -42,15 +42,15 @@ Other: Planned, but will be implemented separately.
 
 3. Tap the "Sharp (0)" button.
 
-- [ ] Expected: The top corners of the sheet update dynamically, becoming sharp.
+- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, becoming sharp.
 
 4. Tap the "Small (10)" button.
 
-- [ ] Expected: The top corners update to a slightly rounded curve.
+- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) update to a slightly rounded curve.
 
 5. Tap the "Large (50)" button.
 
-- [ ] Expected: The top corners of the sheet update dynamically, displaying deeply rounded curve.
+- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, displaying deeply rounded curve.
 
 ---
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -27,6 +27,7 @@ namespace react = facebook::react;
   // Props
   BOOL _isOpen;
   std::vector<double> _detents;
+  CGFloat _preferredCornerRadius;
 
   // Invalidation flags
   BOOL _needsSheetPresentationUpdate;
@@ -60,6 +61,7 @@ namespace react = facebook::react;
 
   _isOpen = NO;
   _detents = {};
+  _preferredCornerRadius = -1.0;
 }
 
 - (void)setupController
@@ -187,6 +189,11 @@ namespace react = facebook::react;
     _needsSheetConfigurationUpdate = YES;
   }
 
+  if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
+    _preferredCornerRadius = newComponentProps.preferredCornerRadius;
+    _needsSheetConfigurationUpdate = YES;
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -251,6 +258,8 @@ namespace react = facebook::react;
 
   [sheet animateChanges:^{
     sheet.detents = nativeDetents;
+    sheet.preferredCornerRadius =
+        _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
   }];
 #endif // !TARGET_OS_TV
 }

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -4,7 +4,19 @@ import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-s
 import type { FormSheetProps } from './FormSheet.types';
 
 export function FormSheet(props: FormSheetProps) {
-  return <FormSheetHostNativeComponent style={styles.host} {...props} />;
+  const { preferredCornerRadius, ...rest } = props;
+
+  // TODO: @t0maboro - move to SheetUtils after merging PR with largestUndimmedDetentIndex
+  const nativeCornerRadius =
+    preferredCornerRadius === 'systemDefault' ? -1.0 : preferredCornerRadius;
+
+  return (
+    <FormSheetHostNativeComponent
+      style={styles.host}
+      preferredCornerRadius={nativeCornerRadius}
+      {...rest}
+    />
+  );
 }
 
 const styles = StyleSheet.create({

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -3,12 +3,24 @@ import { StyleSheet } from 'react-native';
 import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent';
 import type { FormSheetProps } from './FormSheet.types';
 
+// TODO: @t0maboro - move to SheetUtils after merging PR with largestUndimmedDetentIndex
+export function resolveNativeCornerRadius(
+  radius?: number | 'systemDefault',
+): number | undefined {
+  if (radius === 'systemDefault') {
+    return -1.0;
+  }
+  if (typeof radius === 'number' && radius < 0) {
+    return -1.0;
+  }
+
+  return radius;
+}
+
 export function FormSheet(props: FormSheetProps) {
   const { preferredCornerRadius, ...rest } = props;
 
-  // TODO: @t0maboro - move to SheetUtils after merging PR with largestUndimmedDetentIndex
-  const nativeCornerRadius =
-    preferredCornerRadius === 'systemDefault' ? -1.0 : preferredCornerRadius;
+  const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
 
   return (
     <FormSheetHostNativeComponent

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -28,7 +28,7 @@ export interface FormSheetProps {
   /**
    * @summary The corner radius that the sheet will attempt to present with.
    *
-   * If set to `systemDefault`, it defaults to the system's
+   * If set to `systemDefault` or a negative number, it defaults to the system's
    * automatic dimension (`UISheetPresentationControllerAutomaticDimension`).
    *
    * @default systemDefault

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -25,6 +25,17 @@ export interface FormSheetProps {
    */
   detents?: number[] | undefined;
 
+  /**
+   * @summary The corner radius that the sheet will attempt to present with.
+   *
+   * If set to a negative value (e.g., `-1.0`), it defaults to the system's
+   * automatic dimension (`UISheetPresentationControllerAutomaticDimension`).
+   *
+   * @default -1.0
+   * @platform ios
+   */
+  preferredCornerRadius?: number | undefined;
+
   // Events
   /**
    * @summary Called when the sheet is dismissed natively.

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -28,13 +28,13 @@ export interface FormSheetProps {
   /**
    * @summary The corner radius that the sheet will attempt to present with.
    *
-   * If set to a negative value (e.g., `-1.0`), it defaults to the system's
+   * If set to `'systemDefault'`, it defaults to the system's
    * automatic dimension (`UISheetPresentationControllerAutomaticDimension`).
    *
-   * @default -1.0
+   * @default 'systemDefault'
    * @platform ios
    */
-  preferredCornerRadius?: number | undefined;
+  preferredCornerRadius?: number | 'systemDefault' | undefined;
 
   // Events
   /**

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -28,10 +28,10 @@ export interface FormSheetProps {
   /**
    * @summary The corner radius that the sheet will attempt to present with.
    *
-   * If set to `'systemDefault'`, it defaults to the system's
+   * If set to `systemDefault`, it defaults to the system's
    * automatic dimension (`UISheetPresentationControllerAutomaticDimension`).
    *
-   * @default 'systemDefault'
+   * @default systemDefault
    * @platform ios
    */
   preferredCornerRadius?: number | 'systemDefault' | undefined;

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -9,6 +9,7 @@ type GenericEmptyEvent = Readonly<{}>;
 interface NativeProps extends ViewProps {
   isOpen?: CT.WithDefault<boolean, false>;
   detents?: CT.Double[] | undefined;
+  preferredCornerRadius?: CT.WithDefault<CT.Float, -1.0>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
 }
 


### PR DESCRIPTION
## Description

Adding `preferredCornerRadius `, instructing the sheet about the expected radius for:
- top corners on iOS 18
- all corners on iOS 26 & iPadOS

Native equivalent: https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/preferredcornerradius-3mb5

> [!NOTE]  
> I'm planning to adapt `RNSSplitAppearanceCoordinator` apporach here, but this can be done in a separate PR and shouldn't block adding props to the component.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1260

## Changes

- updated public types
- updated codegen spec
- binded react prop with the native setter

## Visual documentation

iPhone

https://github.com/user-attachments/assets/4c0fa419-e264-4d3e-9a2f-59922853f623

iPad

https://github.com/user-attachments/assets/126cbf3a-5966-4247-b38c-e463cce0d2c8

## Test plan

Added dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
