### PR TITLE
fix(ios): block interactive pop when touch starts inside open swipeable

### DIFF
--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -18,6 +18,7 @@
 #import "RNSScreenStackHeaderConfig.h"
 #import "RNSScreenWindowTraits.h"
 #import "RNSScrollViewFinder.h"
+#import "RNSSwipeableRegistry.h"
 #import "RNSTabsScreenViewController.h"
 #import "UIScrollView+RNScreens.h"
 #import "UIView+RNSUtility.h"
@@ -781,6 +782,11 @@ RNS_IGNORE_SUPER_CALL_END
   [[self rnscreens_findTouchHandlerInAncestorChain] rnscreens_cancelTouches];
 }
 
+- (BOOL)shouldBlockPopGestureForOpenSwipeableAtPoint:(CGPoint)point
+{
+  return [RNSSwipeableRegistry hasOpenSwipeableContainingPoint:point];
+}
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
   if (_disableSwipeBack) {
@@ -841,14 +847,25 @@ RNS_IGNORE_SUPER_CALL_END
     }
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
     if (@available(iOS 26, *)) {
-      if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer &&
-          ![self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
-        return NO;
+      if (gestureRecognizer == _controller.interactiveContentPopGestureRecognizer) {
+        if (![self isInGestureResponseDistance:gestureRecognizer topScreen:topScreen]) {
+          return NO;
+        }
+
+        CGPoint point = [gestureRecognizer locationInView:_controller.view];
+        if ([self shouldBlockPopGestureForOpenSwipeableAtPoint:point]) {
+          return NO;
+        }
       }
     }
 #endif // check for iOS >= 26
 
     // _UIParallaxTransitionPanGestureRecognizer (other...)
+    CGPoint point = [gestureRecognizer locationInView:_controller.view];
+    if ([self shouldBlockPopGestureForOpenSwipeableAtPoint:point]) {
+      return NO;
+    }
+
     [self cancelTouchesInParent];
     return YES;
   }

--- a/ios/RNSSwipeableRegistry.h
+++ b/ios/RNSSwipeableRegistry.h
@@ -1,0 +1,9 @@
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface RNSSwipeableRegistry : NSObject <RCTBridgeModule>
+
++ (BOOL)hasOpenSwipeableContainingPoint:(CGPoint)point;
+
+@end

--- a/ios/RNSSwipeableRegistry.mm
+++ b/ios/RNSSwipeableRegistry.mm
@@ -1,0 +1,28 @@
+#import "RNSSwipeableRegistry.h"
+
+@implementation RNSSwipeableRegistry
+
+static CGRect sOpenSwipeableFrame = CGRectNull;
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(setOpenSwipeableFrame : (double)x y : (double)y width : (double)width height : (double)height)
+{
+  sOpenSwipeableFrame = CGRectMake(x, y, width, height);
+}
+
+RCT_EXPORT_METHOD(clearOpenSwipeable)
+{
+  sOpenSwipeableFrame = CGRectNull;
+}
+
++ (BOOL)hasOpenSwipeableContainingPoint:(CGPoint)point
+{
+  if (CGRectIsNull(sOpenSwipeableFrame) || CGRectIsEmpty(sOpenSwipeableFrame)) {
+    return NO;
+  }
+
+  return CGRectContainsPoint(sOpenSwipeableFrame, point);
+}
+
+@end


### PR DESCRIPTION
Summary
This PR introduces native-side gesture arbitration in react-native-screens to prevent iOS interactive pop from stealing a horizontal gesture that should be handled by an already-open swipeable row.

On native-stack with full-screen back gesture enabled, a rightward swipe intended to close an open swipeable can be interpreted as back navigation.
This change adds a touch-point guard in RNSScreenStack so interactive pop is not started when the initial touch is within the active open-swipeable area.

Changes
Added a native registry module:
ios/RNSSwipeableRegistry.h
ios/RNSSwipeableRegistry.mm
Updated ios/RNSScreenStack.mm:
import RNSSwipeableRegistry
add helper shouldBlockPopGestureForOpenSwipeableAtPoint:
in gestureRecognizerShouldBegin, check touch location for:
interactiveContentPopGestureRecognizer path (iOS 26+)
_UIParallaxTransitionPanGestureRecognizer path
return NO when touch starts inside open swipeable region
Why this belongs in react-native-screens
The conflict happens in native gesture recognizer arbitration (UIGestureRecognizerDelegate), which is controlled by native-stack/screens.
JS touch handlers cannot reliably resolve this race.

Compatibility
No behavior change when no open swipeable is registered.
Existing gesture flow remains unchanged outside the guarded region.
Companion work
This PR is intended as part 1 of a cross-repo fix.
A companion RNGH change is needed to publish/clear swipeable frame lifecycle data to RNSSwipeableRegistry.

Related issue: [software-mansion/react-native-gesture-handler#4104](https://github.com/software-mansion/react-native-gesture-handler/issues/4104)

Test Plan

 Repro app with @react-navigation/native-stack and full-screen back gesture enabled.
 Open a swipeable row (right actions visible).
 Start right-swipe inside row area → row closes, screen does not pop.
 Start right-swipe outside row area → interactive pop works.
 With no row open, standard back gesture behavior remains unchanged.