### PR TITLE
fix(android): apply form sheet background to sheet surface

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens
 
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
+import android.graphics.Color
 import android.graphics.Paint
 import android.os.Build
 import android.os.Parcelable
@@ -94,6 +95,7 @@ class Screen(
     var sheetElevation: Float = 24F
     var sheetShouldOverflowTopInset = false
     var sheetDefaultResizeAnimationEnabled = true
+    var sheetBackgroundColor: Int? = null
 
     /**
      * On Fabric, the view layout is completed before window insets are applied.
@@ -585,20 +587,30 @@ class Screen(
     }
 
     internal fun onSheetCornerRadiusChange() {
-        if (stackPresentation !== StackPresentation.FORM_SHEET || background == null) {
+        if (stackPresentation !== StackPresentation.FORM_SHEET) {
             return
         }
-        (background as? MaterialShapeDrawable?)?.let {
-            val resolvedCornerRadius = max(PixelUtil.toDIPFromPixel(sheetCornerRadius), 0f)
-            it.shapeAppearanceModel =
-                ShapeAppearanceModel
-                    .Builder()
-                    .apply {
-                        setTopLeftCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
-                        setTopRightCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
-                    }.build()
-        }
+
+        val shapeDrawable = resolveSheetShapeDrawable() ?: return
+        val resolvedCornerRadius = max(PixelUtil.toDIPFromPixel(sheetCornerRadius), 0f)
+        shapeDrawable.shapeAppearanceModel =
+            ShapeAppearanceModel
+                .Builder()
+                .apply {
+                    setTopLeftCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
+                    setTopRightCorner(CornerFamily.ROUNDED, resolvedCornerRadius)
+                }.build()
     }
+
+    internal fun applySheetBackgroundColor() {
+        if (stackPresentation !== StackPresentation.FORM_SHEET) {
+            return
+        }
+
+        resolveSheetShapeDrawable()?.setTint(sheetBackgroundColor ?: Color.TRANSPARENT)
+    }
+
+    private fun resolveSheetShapeDrawable(): MaterialShapeDrawable? = background as? MaterialShapeDrawable
 
     enum class StackPresentation {
         PUSH,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -424,7 +424,7 @@ class ScreenStackFragment :
                     setTopRightCorner(CornerFamily.ROUNDED, cornerSize)
                 }.build()
         val shape = MaterialShapeDrawable(shapeAppearanceModel)
-        val backgroundColor = resolveBackgroundColor(screen)
+        val backgroundColor = screen.sheetBackgroundColor ?: resolveBackgroundColor(screen)
         shape.setTint(backgroundColor ?: Color.TRANSPARENT)
         screen.background = shape
     }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -95,6 +95,20 @@ open class ScreenViewManager :
         view.onFinalizePropsUpdate()
     }
 
+    override fun setBackgroundColor(
+        view: Screen,
+        backgroundColor: Int,
+    ) {
+        view.sheetBackgroundColor = backgroundColor
+
+        if (view.stackPresentation === Screen.StackPresentation.FORM_SHEET) {
+            view.applySheetBackgroundColor()
+            return
+        }
+
+        super.setBackgroundColor(view, backgroundColor)
+    }
+
     fun setActivityState(
         view: Screen,
         activityState: Int,

--- a/apps/src/tests/issue-tests/TestFormSheetBackground.tsx
+++ b/apps/src/tests/issue-tests/TestFormSheetBackground.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  type NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+
+type StackParamList = {
+  Home: undefined;
+  FormSheet: undefined;
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+function HomeScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Home'>) {
+  return (
+    <View style={styles.home}>
+      <Text style={styles.title}>Form sheet background</Text>
+      <Button
+        title="Open form sheet"
+        onPress={() => navigation.navigate('FormSheet')}
+      />
+    </View>
+  );
+}
+
+function FormSheetScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'FormSheet'>) {
+  return (
+    <View style={styles.sheetContent}>
+      <Text style={styles.title}>
+        The rounded sheet surface should be yellow.
+      </Text>
+      <Text>
+        No red should be visible inside the sheet bounds, including behind the
+        rounded top corners.
+      </Text>
+      <Button title="Dismiss" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          contentStyle: styles.screenBackground,
+        }}>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen
+          name="FormSheet"
+          component={FormSheetScreen}
+          options={{
+            presentation: 'formSheet',
+            sheetAllowedDetents: [0.45, 0.8],
+            sheetCornerRadius: 32,
+            contentStyle: styles.sheetBackground,
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screenBackground: {
+    backgroundColor: 'crimson',
+  },
+  home: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  sheetBackground: {
+    backgroundColor: 'lemonchiffon',
+  },
+  sheetContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 24,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -183,6 +183,7 @@ export { default as Test3606 } from './Test3606';
 export { default as Test3611 } from './Test3611';
 export { default as Test3617 } from './Test3617';
 export { default as Test3636 } from './Test3636';
+export { default as TestFormSheetBackground } from './TestFormSheetBackground';
 export { default as Test3760 } from './Test3760';
 export { default as Test3770 } from './Test3770';
 export { default as Test3793 } from './Test3793';

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -108,13 +108,13 @@ function ScreenStackItem(
     stackPresentationWithDefault,
   );
 
-  // For iOS, we need to extract background color and apply it to Screen
-  // due to the safe area inset at the bottom of ScreenContentWrapper
+  // FormSheet backgrounds need to live on the outer Screen instead of the
+  // inner content wrapper so the native sheet surface can render correctly.
   let internalScreenStyle;
 
   if (
     stackPresentationWithDefault === 'formSheet' &&
-    Platform.OS === 'ios' &&
+    (Platform.OS === 'ios' || Platform.OS === 'android') &&
     contentStyle
   ) {
     const { screenStyles, contentWrapperStyles } =


### PR DESCRIPTION
## Description

Android `formSheet` screens currently extract `contentStyle.backgroundColor` only on iOS. On Android, this leaves the native Material sheet surface tinted from the inner content wrapper fallback path, which can show the wrong color around the rounded sheet surface.

This PR applies the same form sheet background split on Android and stores that color on the native `Screen`, so the `MaterialShapeDrawable` sheet surface is tinted directly.

## Changes

- Extract `contentStyle.backgroundColor` from Android `formSheet` screens in `ScreenStackItem`, matching the iOS path.
- Store Android form sheet background color on `Screen` and apply it to the native sheet `MaterialShapeDrawable`.
- Use the stored sheet background color when the form sheet shape is first attached.
- Added `TestFormSheetBackground` as a visual issue-test screen.

## Before & after - visual documentation

Screenshots pending. This PR is intentionally opened as a draft so the before/after screenshots can be added before review.

| Before | After |
| --- | --- |
| TODO: add before screenshot | TODO: add after screenshot |

## Test plan

Added visual test file: `apps/src/tests/issue-tests/TestFormSheetBackground.tsx`.

Steps to reproduce:

1. Open the issue test `TestFormSheetBackground` in the example app.
2. Tap `Open form sheet`.
3. The screen background is `crimson`; the form sheet `contentStyle.backgroundColor` is `lemonchiffon`.
4. Verify that the rounded native sheet surface is `lemonchiffon` and no `crimson` background is visible inside the sheet bounds, including behind the rounded top corners.

Minimal reproduction:

```tsx
import React from 'react';
import { Button, StyleSheet, Text, View } from 'react-native';
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';

const Stack = createNativeStackNavigator();

function HomeScreen({ navigation }) {
  return (
    <View style={styles.home}>
      <Text style={styles.title}>Form sheet background</Text>
      <Button title="Open form sheet" onPress={() => navigation.navigate('FormSheet')} />
    </View>
  );
}

function FormSheetScreen() {
  return (
    <View style={styles.sheetContent}>
      <Text style={styles.title}>The rounded sheet surface should be yellow.</Text>
      <Text>No red should be visible inside the sheet bounds.</Text>
    </View>
  );
}

export default function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator screenOptions={{ contentStyle: styles.screenBackground }}>
        <Stack.Screen name="Home" component={HomeScreen} />
        <Stack.Screen
          name="FormSheet"
          component={FormSheetScreen}
          options={{
            presentation: 'formSheet',
            sheetAllowedDetents: [0.45, 0.8],
            sheetCornerRadius: 32,
            contentStyle: styles.sheetBackground,
          }}
        />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

const styles = StyleSheet.create({
  screenBackground: { backgroundColor: 'crimson' },
  sheetBackground: { backgroundColor: 'lemonchiffon' },
  home: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
  title: { fontSize: 20, fontWeight: '700' },
  sheetContent: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16, padding: 24 },
});
```

Commands run:

- `yarn check-types`
- `yarn lint-android`
- `git diff --check`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./FabricExample/android/gradlew -p FabricExample/android :react-native-screens:compileDebugKotlin`

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
