### PR TITLE
fix(Examples): Wrap only selection screen with SAV instead of all examples

### DIFF
--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -14,25 +14,27 @@ function ScenarioSelect(props: {
   groupName: string;
 }) {
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="automatic"
-      testID={`${props.groupName}-scenarios-scrollview`}>
-      {Object.values(props.scenarios).map(
-        ({ scenarioDescription }: Scenario) => {
-          const { name, key, details, platforms } = scenarioDescription;
-          return (
-            <ScenarioButton
-              title={name}
-              details={details}
-              route={key}
-              key={key}
-              platformsHint={platforms}
-              testID={key}
-            />
-          );
-        },
-      )}
-    </ScrollView>
+    <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        testID={`${props.groupName}-scenarios-scrollview`}>
+        {Object.values(props.scenarios).map(
+          ({ scenarioDescription }: Scenario) => {
+            const { name, key, details, platforms } = scenarioDescription;
+            return (
+              <ScenarioButton
+                title={name}
+                details={details}
+                route={key}
+                key={key}
+                platformsHint={platforms}
+                testID={key}
+              />
+            );
+          },
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
@@ -42,40 +44,38 @@ export default function ScenarioSelectionScreen(props: {
   const Stack = useMemo(() => createNativeStackNavigator(), []);
 
   return (
-    <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
-      <NavigationIndependentTree>
-        <NavigationContainer>
-          <Stack.Navigator screenOptions={{ headerShown: false }}>
-            <Stack.Screen
-              key="Main"
-              name="Main"
-              options={{
-                headerShown: true,
-                headerLargeTitleEnabled: true,
-                headerTitle: props.scenarioGroup.name,
-              }}>
-              {() => (
-                <ScenarioSelect
-                  scenarios={props.scenarioGroup.scenarios}
-                  groupName={props.scenarioGroup.name}
-                />
-              )}
-            </Stack.Screen>
-            {Object.values<Scenario>(props.scenarioGroup.scenarios).map(
-              (ScenarioComponent: Scenario) => {
-                const { key } = ScenarioComponent.scenarioDescription;
-                return (
-                  <Stack.Screen
-                    key={key}
-                    name={key}
-                    component={ScenarioComponent}
-                  />
-                );
-              },
+    <NavigationIndependentTree>
+      <NavigationContainer>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen
+            key="Main"
+            name="Main"
+            options={{
+              headerShown: true,
+              headerLargeTitleEnabled: true,
+              headerTitle: props.scenarioGroup.name,
+            }}>
+            {() => (
+              <ScenarioSelect
+                scenarios={props.scenarioGroup.scenarios}
+                groupName={props.scenarioGroup.name}
+              />
             )}
-          </Stack.Navigator>
-        </NavigationContainer>
-      </NavigationIndependentTree>
-    </SafeAreaView>
+          </Stack.Screen>
+          {Object.values<Scenario>(props.scenarioGroup.scenarios).map(
+            (ScenarioComponent: Scenario) => {
+              const { key } = ScenarioComponent.scenarioDescription;
+              return (
+                <Stack.Screen
+                  key={key}
+                  name={key}
+                  component={ScenarioComponent}
+                />
+              );
+            },
+          )}
+        </Stack.Navigator>
+      </NavigationContainer>
+    </NavigationIndependentTree>
   );
 }


### PR DESCRIPTION
## Description

Fixing the regression introduced by: https://github.com/software-mansion/react-native-screens/commit/8c4273acb00d204c0fc8543f09d92aadb285b88d#diff-899d6fdebc7c2ac1de9524d319dc0c6b37a19c9f8351b393ac75bfd9bb55daeb - we shouldn't wrap the whole navigator in SAV and determine whether SAV should be added on a per-screen basis.

*Note: this may have an impact on some TCs - if SAV is needed, it should be added at the top-level of the proper example.*

## Changes

- Move SAV from Navigator level to `ScenarioSelect` level.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
