### PR TITLE
feat(iOS, FormSheet v5): Add largestUndimmedDetentIndex support

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -1,11 +1,13 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestFormSheetBase from './test-form-sheet-base-ios';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
+import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 
 const scenarios = {
   TestFormSheetBase,
   TestFormSheetGrabberVisible,
+  TestFormSheetLargestUndimmedDetentIndex,
   TestFormSheetPreferredCornerRadius,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -7,7 +7,7 @@ import { Colors } from '@apps/shared/styling';
 
 const scenarioDescription: ScenarioDescription = {
   name: 'Sheet largest undimmed detent index',
-  key: 'test-form-largest-undimmed-detent-index-ios',
+  key: 'test-form-sheet-largest-undimmed-detent-index-ios',
   details:
     'Allows to test largestUndimmedDetentIndex prop of FormSheet component.',
   platforms: ['ios'],

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { FormSheet } from 'react-native-screens/experimental';
+import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
@@ -13,7 +13,9 @@ const scenarioDescription: ScenarioDescription = {
   platforms: ['ios'],
 };
 
-type LargestUndimmedDetentIndexProp = number | 'none' | 'last';
+type LargestUndimmedDetentIndexProp = NonNullable<
+  FormSheetProps['largestUndimmedDetentIndex']
+>;
 
 export function App() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Sheet largest undimmed detent index',
+  key: 'test-form-largest-undimmed-detent-index-ios',
+  details:
+    'Allows to test largestUndimmedDetentIndex prop of FormSheet component.',
+  platforms: ['ios'],
+};
+
+type largestUndimmedDetentIndexProp = number | 'none' | 'last';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [undimmedIndex, setUndimmedIndex] = useState<largestUndimmedDetentIndexProp>('none');
+  const [bgCounter, setBgCounter] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.topSection}>
+        <Text style={styles.title}>Main Screen</Text>
+        <Text style={styles.counterText}>Background clicks: {bgCounter}</Text>
+        <Button
+          title="Increment Background Counter"
+          color={Colors.primary}
+          onPress={() => setBgCounter(c => c + 1)}
+        />
+      </View>
+
+      <View style={styles.centerSection}>
+        <Button
+          title="Open FormSheet"
+          color={Colors.primary}
+          onPress={() => setIsOpen(true)}
+        />
+      </View>
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        largestUndimmedDetentIndex={undimmedIndex}
+        detents={[0.3, 0.6, 0.8]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>
+            Undimmed Index: {String(undimmedIndex)}
+          </Text>
+          <View style={styles.spacing} />
+          <View style={styles.buttonGroup}>
+            <Button
+              title="Set 'none'"
+              onPress={() => setUndimmedIndex('none')}
+            />
+            <Button
+              title="Set 0 (0.3 height)"
+              onPress={() => setUndimmedIndex(0)}
+            />
+            <Button
+              title="Set 1 (0.6 height)"
+              onPress={() => setUndimmedIndex(1)}
+            />
+            <Button
+              title="Set 'last'"
+              onPress={() => setUndimmedIndex('last')}
+            />
+          </View>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.offBackground,
+  },
+  topSection: {
+    paddingTop: 80,
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  centerSection: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  counterText: {
+    marginBottom: 12,
+    color: Colors.text,
+    fontSize: 16,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  buttonGroup: {
+    gap: 12,
+    alignItems: 'center',
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -13,11 +13,11 @@ const scenarioDescription: ScenarioDescription = {
   platforms: ['ios'],
 };
 
-type largestUndimmedDetentIndexProp = number | 'none' | 'last';
+type LargestUndimmedDetentIndexProp = number | 'none' | 'last';
 
 export function App() {
   const [isOpen, setIsOpen] = useState(false);
-  const [undimmedIndex, setUndimmedIndex] = useState<largestUndimmedDetentIndexProp>('none');
+  const [undimmedIndex, setUndimmedIndex] = useState<LargestUndimmedDetentIndexProp>('none');
   const [bgCounter, setBgCounter] = useState(0);
 
   return (

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -51,7 +51,7 @@ Other: Planned, but will be implemented separately.
 
 6. Inside the sheet, tap the "Set 'last'" button.
 
-- [ ] Expected: The background is undimmed immediately, despite the sheet being at the 0.6 detent.
+- [ ] Expected: The background is undimmed for lower detents (0.3 and 0.6).
 - [ ] Expected: Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
 - [ ] Expected: Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -1,0 +1,72 @@
+# Test Scenario: Sheet largest undimmed detent index
+
+## Details
+
+**Description:** Verify the `largestUndimmedDetentIndex` property of the `FormSheet` component. This test ensures that the background dimming view is correctly applied or removed based on the current detent index, and that the underlying screen is interactive, when the sheet is undimmed. 
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator (iPhone).
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Sheet largest undimmed detent index** screen.
+2. Tap the "Increment Background Counter" button at the top of the screen a few times.
+
+- [ ] Expected: The counter increases successfully.
+
+---
+
+### Initialization & Default 'none' Behavior
+
+3. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the first detent (0.3). The background behind the sheet immediately becomes dimmed. 
+- [ ] Expected: Tapping the "Increment Background Counter" button does **not** work (the tap is intercepted by the dimming view and it dismisses the sheet).
+
+---
+
+### Dynamic Updates: Index 0 Validation
+
+4. Inside the sheet, tap the "Set 0 (0.3 height)" button.
+
+- [ ] Expected: The background is undimmed immediately.
+- [ ] Expected: Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.3.
+
+5. Grab the top of the sheet and drag it up to the middle detent (0.6).
+
+- [ ] Expected: As the sheet transitions to index 1 (0.6), the background is dimmed again. The background counter button is no longer pressable.
+
+---
+
+### Dynamic Updates: 'last' Validation
+
+6. Inside the sheet, tap the "Set 'last'" button.
+
+- [ ] Expected: The background is undimmed immediately, despite the sheet being at the 0.6 detent.
+- [ ] Expected: Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
+- [ ] Expected: Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
+
+---
+
+### Fallback to 'none'
+
+7. Inside the sheet, tap the "Set 'none'" button.
+
+- [ ] Expected: The background dims immediately. Interaction with the background counter is blocked.
+
+---
+
+### Dismissal Verification
+
+8. Tap the "Dismiss from JS" button (or swipe down completely).
+
+- [ ] Expected: The FormSheet dismisses smoothly. The background counter button becomes pressable again.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -15,8 +15,8 @@
 namespace react = facebook::react;
 
 // Predefined values for `largestUndimmedDetentIndex`.
-static NSInteger const kRNSSheetAlwaysDimmed = -1;
-static NSInteger const kRNSSheetNeverDimmed = -2;
+static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
+static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end
@@ -69,7 +69,7 @@ static NSInteger const kRNSSheetNeverDimmed = -2;
   _detents = {};
   _prefersGrabberVisible = NO;
   _preferredCornerRadius = -1.0;
-  _largestUndimmedDetentIndex = kRNSSheetAlwaysDimmed;
+  _largestUndimmedDetentIndex = kRNSFormSheetAlwaysDimmed;
 }
 
 - (void)setupController
@@ -273,7 +273,7 @@ static NSInteger const kRNSSheetNeverDimmed = -2;
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
-  UISheetPresentationControllerDetentIdentifier ludIdentifier =
+  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
       [self largestUndimmedDetentIdentifierForDetents:nativeDetents];
 
   // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
@@ -282,7 +282,7 @@ static NSInteger const kRNSSheetNeverDimmed = -2;
     sheet.prefersGrabberVisible = _prefersGrabberVisible;
     sheet.preferredCornerRadius =
         _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
-    sheet.largestUndimmedDetentIdentifier = ludIdentifier;
+    sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
   }];
 #endif // !TARGET_OS_TV
 }
@@ -352,12 +352,12 @@ static NSInteger const kRNSSheetNeverDimmed = -2;
 - (UISheetPresentationControllerDetentIdentifier)largestUndimmedDetentIdentifierForDetents:
     (NSArray<UISheetPresentationControllerDetent *> *)detents
 {
-  if (_largestUndimmedDetentIndex == kRNSSheetAlwaysDimmed) {
+  if (_largestUndimmedDetentIndex == kRNSFormSheetAlwaysDimmed) {
     return nil;
   }
 
-  NSInteger ludIndex =
-      _largestUndimmedDetentIndex == kRNSSheetNeverDimmed ? (NSInteger)detents.count - 1 : _largestUndimmedDetentIndex;
+  NSInteger ludIndex = _largestUndimmedDetentIndex == kRNSFormSheetNeverDimmed ? (NSInteger)detents.count - 1
+                                                                               : _largestUndimmedDetentIndex;
 
   if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
     RCTLogError(
@@ -370,18 +370,19 @@ static NSInteger const kRNSSheetNeverDimmed = -2;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
   if (@available(iOS 16.0, *)) {
     return detents[(NSUInteger)ludIndex].identifier;
-  }
+  } else
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-
-  // iOS 15 Fallback - mirroring buildSheetDetents
-  if (_detents.size() == 0) {
-    return UISheetPresentationControllerDetentIdentifierLarge;
-  } else if (_detents.size() == 1) {
-    return _detents[0] < 1.0 ? UISheetPresentationControllerDetentIdentifierMedium
-                             : UISheetPresentationControllerDetentIdentifierLarge;
-  } else {
-    return ludIndex == 0 ? UISheetPresentationControllerDetentIdentifierMedium
-                         : UISheetPresentationControllerDetentIdentifierLarge;
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetents
+    if (_detents.size() == 0) {
+      return UISheetPresentationControllerDetentIdentifierLarge;
+    } else if (_detents.size() == 1) {
+      return _detents[0] < 1.0 ? UISheetPresentationControllerDetentIdentifierMedium
+                               : UISheetPresentationControllerDetentIdentifierLarge;
+    } else {
+      return ludIndex == 0 ? UISheetPresentationControllerDetentIdentifierMedium
+                           : UISheetPresentationControllerDetentIdentifierLarge;
+    }
   }
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -374,15 +374,13 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
   {
     // iOS 15 Fallback - mirroring buildSheetDetents
-    if (_detents.size() == 0) {
-      return UISheetPresentationControllerDetentIdentifierLarge;
-    } else if (_detents.size() == 1) {
-      return _detents[0] < 1.0 ? UISheetPresentationControllerDetentIdentifierMedium
-                               : UISheetPresentationControllerDetentIdentifierLarge;
-    } else {
-      return ludIndex == 0 ? UISheetPresentationControllerDetentIdentifierMedium
-                           : UISheetPresentationControllerDetentIdentifierLarge;
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)ludIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
     }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
   }
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -14,6 +14,10 @@
 
 namespace react = facebook::react;
 
+// Predefined values for `largestUndimmedDetentIndex`.
+static NSInteger const kRNSSheetAlwaysDimmed = -1;
+static NSInteger const kRNSSheetNeverDimmed = -2;
+
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end
 
@@ -29,6 +33,7 @@ namespace react = facebook::react;
   std::vector<double> _detents;
   BOOL _prefersGrabberVisible;
   CGFloat _preferredCornerRadius;
+  NSInteger _largestUndimmedDetentIndex;
 
   // Invalidation flags
   BOOL _needsSheetPresentationUpdate;
@@ -64,6 +69,7 @@ namespace react = facebook::react;
   _detents = {};
   _prefersGrabberVisible = NO;
   _preferredCornerRadius = -1.0;
+  _largestUndimmedDetentIndex = kRNSSheetAlwaysDimmed;
 }
 
 - (void)setupController
@@ -201,6 +207,11 @@ namespace react = facebook::react;
     _needsSheetConfigurationUpdate = YES;
   }
 
+  if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
+    _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
+    _needsSheetConfigurationUpdate = YES;
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -262,6 +273,8 @@ namespace react = facebook::react;
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
+  UISheetPresentationControllerDetentIdentifier ludIdentifier =
+      [self largestUndimmedDetentIdentifierForDetents:nativeDetents];
 
   // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
   [sheet animateChanges:^{
@@ -269,6 +282,7 @@ namespace react = facebook::react;
     sheet.prefersGrabberVisible = _prefersGrabberVisible;
     sheet.preferredCornerRadius =
         _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
+    sheet.largestUndimmedDetentIdentifier = ludIdentifier;
   }];
 #endif // !TARGET_OS_TV
 }
@@ -334,6 +348,43 @@ namespace react = facebook::react;
 
   return nativeDetents;
 }
+
+- (UISheetPresentationControllerDetentIdentifier)largestUndimmedDetentIdentifierForDetents:
+    (NSArray<UISheetPresentationControllerDetent *> *)detents
+{
+  if (_largestUndimmedDetentIndex == kRNSSheetAlwaysDimmed) {
+    return nil;
+  }
+
+  NSInteger ludIndex =
+      _largestUndimmedDetentIndex == kRNSSheetNeverDimmed ? (NSInteger)detents.count - 1 : _largestUndimmedDetentIndex;
+
+  if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
+    RCTLogError(
+        @"[RNScreens] largestUndimmedDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to the default behavior (always dimmed).",
+        (long)_largestUndimmedDetentIndex,
+        (unsigned long)detents.count);
+    return nil;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)ludIndex].identifier;
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+
+  // iOS 15 Fallback - mirroring buildSheetDetents
+  if (_detents.size() == 0) {
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  } else if (_detents.size() == 1) {
+    return _detents[0] < 1.0 ? UISheetPresentationControllerDetentIdentifierMedium
+                             : UISheetPresentationControllerDetentIdentifierLarge;
+  } else {
+    return ludIndex == 0 ? UISheetPresentationControllerDetentIdentifierMedium
+                         : UISheetPresentationControllerDetentIdentifierLarge;
+  }
+}
+
 #endif // !TARGET_OS_TV
 
 - (BOOL)areDetentsValid

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -19,19 +19,17 @@ export function resolveNativeCornerRadius(
 }
 
 export function FormSheet(props: FormSheetProps) {
-  const {  detents, largestUndimmedDetentIndex ,preferredCornerRadius, ...rest } = props;
+  const { largestUndimmedDetentIndex, preferredCornerRadius, ...rest } = props;
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
 
   const resolvedUndimmedIndex = resolveLargestUndimmedDetentIndex(
     largestUndimmedDetentIndex,
-    detents?.length,
   );
 
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
-      detents={detents}
       largestUndimmedDetentIndex={resolvedUndimmedIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent';
 import type { FormSheetProps } from './FormSheet.types';
+import { resolveLargestUndimmedDetentIndex } from './FormSheetUtils';
 
 // TODO: @t0maboro - move to SheetUtils after merging PR with largestUndimmedDetentIndex
 export function resolveNativeCornerRadius(
@@ -18,13 +19,20 @@ export function resolveNativeCornerRadius(
 }
 
 export function FormSheet(props: FormSheetProps) {
-  const { preferredCornerRadius, ...rest } = props;
+  const {  detents, largestUndimmedDetentIndex ,preferredCornerRadius, ...rest } = props;
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
+
+  const resolvedUndimmedIndex = resolveLargestUndimmedDetentIndex(
+    largestUndimmedDetentIndex,
+    detents?.length,
+  );
 
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
+      detents={detents}
+      largestUndimmedDetentIndex={resolvedUndimmedIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}
     />

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -19,7 +19,12 @@ export function resolveNativeCornerRadius(
 }
 
 export function FormSheet(props: FormSheetProps) {
-  const { detents, largestUndimmedDetentIndex, preferredCornerRadius, ...rest } = props;
+  const {
+    detents,
+    largestUndimmedDetentIndex,
+    preferredCornerRadius,
+    ...rest
+  } = props;
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -2,21 +2,10 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent';
 import type { FormSheetProps } from './FormSheet.types';
-import { resolveLargestUndimmedDetentIndex } from './FormSheetUtils';
-
-// TODO: @t0maboro - move to SheetUtils after merging PR with largestUndimmedDetentIndex
-export function resolveNativeCornerRadius(
-  radius?: number | 'systemDefault',
-): number | undefined {
-  if (radius === 'systemDefault') {
-    return -1.0;
-  }
-  if (typeof radius === 'number' && radius < 0) {
-    return -1.0;
-  }
-
-  return radius;
-}
+import {
+  resolveLargestUndimmedDetentIndex,
+  resolveNativeCornerRadius,
+} from './FormSheetUtils';
 
 export function FormSheet(props: FormSheetProps) {
   const {

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -19,17 +19,19 @@ export function resolveNativeCornerRadius(
 }
 
 export function FormSheet(props: FormSheetProps) {
-  const { largestUndimmedDetentIndex, preferredCornerRadius, ...rest } = props;
+  const { detents, largestUndimmedDetentIndex, preferredCornerRadius, ...rest } = props;
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
 
   const resolvedUndimmedIndex = resolveLargestUndimmedDetentIndex(
     largestUndimmedDetentIndex,
+    detents?.length ?? 0,
   );
 
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
+      detents={detents}
       largestUndimmedDetentIndex={resolvedUndimmedIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -48,6 +48,21 @@ export interface FormSheetProps {
    */
   preferredCornerRadius?: number | 'systemDefault' | undefined;
 
+  /**
+   * @summary The largest sheet detent for which a view underneath won't be dimmed.
+   *
+   * This prop can be set to a number, which indicates the index of the detent in the
+   * `detents` array for which there won't be a dimming view beneath the sheet.
+   *
+   * Additionally, there are the following options available:
+   * * `none` - there will be a dimming view for all detent levels.
+   * * `last` - there won't be a dimming view for any detent level.
+   *
+   * @default 'none'
+   * @platform ios
+   */
+  largestUndimmedDetentIndex?: number | 'none' | 'last' | undefined;
+
   // Events
   /**
    * @summary Called when the sheet is dismissed natively.

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -28,7 +28,16 @@ export function resolveLargestUndimmedDetentIndex(
     if (!Number.isInteger(largestUndimmedDetent)) {
       if (__DEV__) {
         console.error(
-          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected an integer. Falling back to the default behavior (always dimmed).`,
+          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected a non-negative integer. Falling back to the default behavior (always dimmed).`,
+        );
+      }
+      return FORM_SHEET_ALWAYS_DIMMED;
+    }
+
+    if (largestUndimmedDetent < 0) {
+      if (__DEV__) {
+        console.error(
+          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected a non-negative integer. Falling back to the default behavior (always dimmed).`,
         );
       }
       return FORM_SHEET_ALWAYS_DIMMED;

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -10,8 +10,8 @@ const FORM_SHEET_NEVER_DIMMED = -2;
  * @param largestUndimmedDetent The prop value passed from the FormSheet.
  * @param detentsCount Length of the `detents` array as seen from JS.
  * @returns A value to pass to the native component:
- * - `-1` (always dimmed),
- * - `-2` (never dimmed),
+ * - `-1` (`FORM_SHEET_ALWAYS_DIMMED`),
+ * - `-2` (`FORM_SHEET_NEVER_DIMMED`),
  * - a non-negative index.
  */
 export function resolveLargestUndimmedDetentIndex(

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -4,6 +4,19 @@ import type { FormSheetProps } from './FormSheet.types';
 const FORM_SHEET_ALWAYS_DIMMED = -1;
 const FORM_SHEET_NEVER_DIMMED = -2;
 
+export function resolveNativeCornerRadius(
+  radius?: number | 'systemDefault',
+): number | undefined {
+  if (radius === 'systemDefault') {
+    return -1.0;
+  }
+  if (typeof radius === 'number' && radius < 0) {
+    return -1.0;
+  }
+
+  return radius;
+}
+
 /**
  * Resolves the JS `largestUndimmedDetentIndex` prop to a native numeric value.
  *

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -1,0 +1,60 @@
+import type { FormSheetProps } from './FormSheet.types';
+
+// Keep these predefined values in sync with native equivalents.
+const SHEET_ALWAYS_DIMMED = -1;
+const SHEET_NEVER_DIMMED = -2;
+
+/**
+ * Resolves the JS `largestUndimmedDetentIndex` prop to a value the native side
+ * can interpret directly.
+ *
+ * Empty/missing `detents` array maps to a single default detent on iOS, thus effectiveDetentsCount
+ * will be always positive value. `'last'` is forwarded to native as a predefined value, because
+ * the native side knows how many detents were accepted.
+ *
+ * @param largestUndimmedDetent The prop value passed from the FormSheet..
+ * @param detentsCount Length of the `detents` array as seen from JS.
+ * @returns A value to pass to the native component:
+ * `-1` (always dimmed),
+ * `-2` (never dimmed),
+ * - a non-negative index.
+ */
+export function resolveLargestUndimmedDetentIndex(
+  largestUndimmedDetent: FormSheetProps['largestUndimmedDetentIndex'],
+  detentsCount: number = 0,
+): number {
+  if (largestUndimmedDetent === 'none' || largestUndimmedDetent === undefined) {
+    return SHEET_ALWAYS_DIMMED;
+  }
+
+  if (largestUndimmedDetent === 'last') {
+    return SHEET_NEVER_DIMMED;
+  }
+
+  if (typeof largestUndimmedDetent === 'number') {
+    // An empty/missing `detents` array maps to a single large detent on the
+    // native side, so the effective count is always positive.
+    const effectiveDetentsCount = Math.max(detentsCount, 1);
+
+    if (
+      largestUndimmedDetent < 0 ||
+      largestUndimmedDetent >= effectiveDetentsCount
+    ) {
+      if (__DEV__) {
+        console.error(
+          `[RNScreens] 'largestUndimmedDetentIndex' (${largestUndimmedDetent}) is out of bounds. The sheet has ${effectiveDetentsCount} detent(s). Falling back to the default behavior (always dimmed).`,
+        );
+      }
+      return SHEET_ALWAYS_DIMMED;
+    }
+
+    return largestUndimmedDetent;
+  }
+
+  if (__DEV__) {
+    console.error(
+      "[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex'. Expected a number, 'none', or 'last'. Falling back to the default behavior (always dimmed).",
+    );
+  }
+  return SHEET_ALWAYS_DIMMED;
+}

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -30,22 +30,18 @@ export function resolveLargestUndimmedDetentIndex(
     const lastDetentIndex = Math.max(detentsCount - 1, 0);
 
     if (!isIndexInClosedRange(largestUndimmedDetent, 0, lastDetentIndex)) {
-      if (__DEV__) {
-        console.error(
-          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to the default behavior (always dimmed).`,
-        );
-      }
+      console.error(
+        `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to the default behavior (always dimmed).`,
+      );
       return FORM_SHEET_ALWAYS_DIMMED;
     }
 
     return largestUndimmedDetent;
   }
 
-  if (__DEV__) {
-    console.error(
-      "[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex'. Expected a number, 'none', or 'last'. Falling back to the default behavior (always dimmed).",
-    );
-  }
+  console.error(
+    "[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex'. Expected a number, 'none', or 'last'. Falling back to the default behavior (always dimmed).",
+  );
   return FORM_SHEET_ALWAYS_DIMMED;
 }
 

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -1,8 +1,8 @@
 import type { FormSheetProps } from './FormSheet.types';
 
 // Keep these predefined values in sync with native equivalents.
-const SHEET_ALWAYS_DIMMED = -1;
-const SHEET_NEVER_DIMMED = -2;
+const FORM_SHEET_ALWAYS_DIMMED = -1;
+const FORM_SHEET_NEVER_DIMMED = -2;
 
 /**
  * Resolves the JS `largestUndimmedDetentIndex` prop to a value the native side
@@ -24,11 +24,11 @@ export function resolveLargestUndimmedDetentIndex(
   detentsCount: number = 0,
 ): number {
   if (largestUndimmedDetent === 'none' || largestUndimmedDetent === undefined) {
-    return SHEET_ALWAYS_DIMMED;
+    return FORM_SHEET_ALWAYS_DIMMED;
   }
 
   if (largestUndimmedDetent === 'last') {
-    return SHEET_NEVER_DIMMED;
+    return FORM_SHEET_NEVER_DIMMED;
   }
 
   if (typeof largestUndimmedDetent === 'number') {
@@ -45,7 +45,7 @@ export function resolveLargestUndimmedDetentIndex(
           `[RNScreens] 'largestUndimmedDetentIndex' (${largestUndimmedDetent}) is out of bounds. The sheet has ${effectiveDetentsCount} detent(s). Falling back to the default behavior (always dimmed).`,
         );
       }
-      return SHEET_ALWAYS_DIMMED;
+      return FORM_SHEET_ALWAYS_DIMMED;
     }
 
     return largestUndimmedDetent;
@@ -56,5 +56,5 @@ export function resolveLargestUndimmedDetentIndex(
       "[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex'. Expected a number, 'none', or 'last'. Falling back to the default behavior (always dimmed).",
     );
   }
-  return SHEET_ALWAYS_DIMMED;
+  return FORM_SHEET_ALWAYS_DIMMED;
 }

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -5,15 +5,9 @@ const FORM_SHEET_ALWAYS_DIMMED = -1;
 const FORM_SHEET_NEVER_DIMMED = -2;
 
 /**
- * Resolves the JS `largestUndimmedDetentIndex` prop to a value the native side
- * can interpret directly.
+ * Resolves the JS `largestUndimmedDetentIndex` prop to a native numeric value.
  *
- * Empty/missing `detents` array maps to a single default detent on iOS, thus effectiveDetentsCount
- * will be always positive value. `'last'` is forwarded to native as a predefined value, because
- * the native side knows how many detents were accepted.
- *
- * @param largestUndimmedDetent The prop value passed from the FormSheet..
- * @param detentsCount Length of the `detents` array as seen from JS.
+ * @param largestUndimmedDetent The prop value passed from the FormSheet.
  * @returns A value to pass to the native component:
  * `-1` (always dimmed),
  * `-2` (never dimmed),
@@ -21,7 +15,6 @@ const FORM_SHEET_NEVER_DIMMED = -2;
  */
 export function resolveLargestUndimmedDetentIndex(
   largestUndimmedDetent: FormSheetProps['largestUndimmedDetentIndex'],
-  detentsCount: number = 0,
 ): number {
   if (largestUndimmedDetent === 'none' || largestUndimmedDetent === undefined) {
     return FORM_SHEET_ALWAYS_DIMMED;
@@ -32,22 +25,6 @@ export function resolveLargestUndimmedDetentIndex(
   }
 
   if (typeof largestUndimmedDetent === 'number') {
-    // An empty/missing `detents` array maps to a single large detent on the
-    // native side, so the effective count is always positive.
-    const effectiveDetentsCount = Math.max(detentsCount, 1);
-
-    if (
-      largestUndimmedDetent < 0 ||
-      largestUndimmedDetent >= effectiveDetentsCount
-    ) {
-      if (__DEV__) {
-        console.error(
-          `[RNScreens] 'largestUndimmedDetentIndex' (${largestUndimmedDetent}) is out of bounds. The sheet has ${effectiveDetentsCount} detent(s). Falling back to the default behavior (always dimmed).`,
-        );
-      }
-      return FORM_SHEET_ALWAYS_DIMMED;
-    }
-
     return largestUndimmedDetent;
   }
 

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -25,6 +25,15 @@ export function resolveLargestUndimmedDetentIndex(
   }
 
   if (typeof largestUndimmedDetent === 'number') {
+    if (!Number.isInteger(largestUndimmedDetent)) {
+      if (__DEV__) {
+        console.error(
+          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected an integer. Falling back to the default behavior (always dimmed).`,
+        );
+      }
+      return FORM_SHEET_ALWAYS_DIMMED;
+    }
+
     return largestUndimmedDetent;
   }
 

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -8,13 +8,15 @@ const FORM_SHEET_NEVER_DIMMED = -2;
  * Resolves the JS `largestUndimmedDetentIndex` prop to a native numeric value.
  *
  * @param largestUndimmedDetent The prop value passed from the FormSheet.
+ * @param detentsCount Length of the `detents` array as seen from JS.
  * @returns A value to pass to the native component:
- * `-1` (always dimmed),
- * `-2` (never dimmed),
+ * - `-1` (always dimmed),
+ * - `-2` (never dimmed),
  * - a non-negative index.
  */
 export function resolveLargestUndimmedDetentIndex(
   largestUndimmedDetent: FormSheetProps['largestUndimmedDetentIndex'],
+  detentsCount: number = 0,
 ): number {
   if (largestUndimmedDetent === 'none' || largestUndimmedDetent === undefined) {
     return FORM_SHEET_ALWAYS_DIMMED;
@@ -25,19 +27,12 @@ export function resolveLargestUndimmedDetentIndex(
   }
 
   if (typeof largestUndimmedDetent === 'number') {
-    if (!Number.isInteger(largestUndimmedDetent)) {
-      if (__DEV__) {
-        console.error(
-          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected a non-negative integer. Falling back to the default behavior (always dimmed).`,
-        );
-      }
-      return FORM_SHEET_ALWAYS_DIMMED;
-    }
+    const lastDetentIndex = Math.max(detentsCount - 1, 0);
 
-    if (largestUndimmedDetent < 0) {
+    if (!isIndexInClosedRange(largestUndimmedDetent, 0, lastDetentIndex)) {
       if (__DEV__) {
         console.error(
-          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected a non-negative integer. Falling back to the default behavior (always dimmed).`,
+          `[RNScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetent}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to the default behavior (always dimmed).`,
         );
       }
       return FORM_SHEET_ALWAYS_DIMMED;
@@ -52,4 +47,12 @@ export function resolveLargestUndimmedDetentIndex(
     );
   }
   return FORM_SHEET_ALWAYS_DIMMED;
+}
+
+function isIndexInClosedRange(
+  value: number,
+  lowerBound: number,
+  upperBound: number,
+): boolean {
+  return Number.isInteger(value) && value >= lowerBound && value <= upperBound;
 }

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -11,6 +11,7 @@ interface NativeProps extends ViewProps {
   detents?: CT.Double[] | undefined;
   prefersGrabberVisible?: CT.WithDefault<boolean, false>;
   preferredCornerRadius?: CT.WithDefault<CT.Float, -1.0>;
+  largestUndimmedDetentIndex?: CT.WithDefault<CT.Int32, -1>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
 }
 


### PR DESCRIPTION
## Description

Adds `largestUndimmedDetentIndex` prop to the `FormSheet` component. It controls the largest detent, at which the dimming view below the sheet is not rendered. From JS, we're accepting following values for the parity with v4 implementation:
- 'none': the background is always dimmed.
- 'last': the background is never dimmed at any detent.
- number: specific index from detents array.

Resolution model:

| JS prop | Associated value | Native behavior |
|---|---|---|
| 'none' / undefined | -1 | largestUndimmedDetentIdentifier = nil |
| 'last' | -2 | resolves to the last index from the native detents array |
| explicit numeric index | >= 0 | directly maps into detents index |

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1262

## Changes

- JS spec, bindings & helper method in SheetUtils, to validate, return feedback to the user, or pass the expected value to the native
- native `largestUndimmedDetentIdentifierForDetents` for transforming the index passed from JS to proper native detent identifier
- SFT for testing

## Visual documentation

| iOS 15 | iOS 18 | iOS 26 |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/6919a1ff-8358-4461-a89c-3d041372ed3a" /> | <video src="https://github.com/user-attachments/assets/b44f228d-3747-4f5f-93d0-72a31d134e4f" /> | <video src="https://github.com/user-attachments/assets/633356da-8b93-4f4b-a586-31c21da24e87" /> |

## Test plan

Added dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
