### PR TITLE
fix(iOS, Tabs): fix moreNavigationController navigation bar visible on nav

### DIFF
--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -15,6 +15,11 @@
 // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
 static constexpr NSUInteger kMinCountOfVCsForMoreVCPresence = 6;
 
+/// Index of the first view controller hosted by the More navigation controller.
+/// When More is present, UIKit shows the first 4 view controllers in the tab bar
+/// and moves the rest (index >= 4) into the More list.
+static constexpr NSUInteger kFirstIndexInMoreNavigationController = 4;
+
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
@@ -197,7 +202,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   }
 
   if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass &&
-      [self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
+      [self isViewControllerHostedByMoreNavigationController:self.selectedViewController]) {
     [self disableNavigationBarInMoreNavigationController];
   }
 }
@@ -565,8 +570,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   BOOL hasStateProgressed = [self updateSelectedViewControllerTo:nextSelectedViewController
                                                          withKey:nextSelectedViewControllerKey];
 
-  if (hasStateProgressed &&
-      [self isViewControllerPresentedFromTheMoreNavigationController:nextSelectedViewController]) {
+  if (hasStateProgressed && [self isViewControllerHostedByMoreNavigationController:nextSelectedViewController]) {
     [self disableNavigationBarInMoreNavigationController];
   }
 
@@ -720,7 +724,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
          selectedScreenKey);
   [self progressNavigationState:selectedScreenKey withOrigin:RNSTabsActionOriginImplicit];
 
-  if ([self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
+  if ([self isViewControllerHostedByMoreNavigationController:self.selectedViewController]) {
     [self disableNavigationBarInMoreNavigationController];
   }
 
@@ -753,6 +757,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
+  // The count is documented. Size class check is empirical, to tigthen the condition and have less
+  // false positives. If we ever find it not correct, we can safely remove it.
   return self.viewControllers.count >= kMinCountOfVCsForMoreVCPresence &&
       self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
 #else
@@ -760,12 +766,19 @@ static void rns_pushViewController(__unsafe_unretained id self,
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
 }
 
-- (BOOL)isViewControllerPresentedFromTheMoreNavigationController:(nonnull UIViewController *)viewController
+- (BOOL)isViewControllerHostedByMoreNavigationController:(nonnull UIViewController *)viewController
 {
-  // -2, because: we need 6 controllers, but when more tab is present, the fifth one is put inside it
-  return [self canHaveMoreNavigationController] && [self isMoreNavigationControllerPresentInTabBar] &&
-      ![self.tabBar.items containsObject:viewController.tabBarItem] &&
-      [self.viewControllers indexOfObject:viewController] >= (kMinCountOfVCsForMoreVCPresence - 2);
+  if (![self canHaveMoreNavigationController] || ![self isMoreNavigationControllerPresentInTabBar]) {
+    return NO;
+  }
+
+  NSUInteger index = [self.viewControllers indexOfObject:viewController];
+  if (index == NSNotFound) {
+    return NO;
+  }
+
+  return ![self.tabBar.items containsObject:viewController.tabBarItem] &&
+      index >= kFirstIndexInMoreNavigationController;
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -192,6 +192,10 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
   [super traitCollectionDidChange:previousTraitCollection];
 
+  if (previousTraitCollection == nil || self.selectedViewController == nil) {
+    return;
+  }
+
   if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass &&
       [self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
     [self disableNavigationBarInMoreNavigationController];

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -13,7 +13,7 @@
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
 // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-static constexpr int kMinCountOfVCsForMoreVCPresence = 6;
+static constexpr NSUInteger kMinCountOfVCsForMoreVCPresence = 6;
 
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -762,9 +762,10 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
 - (BOOL)isViewControllerPresentedFromTheMoreNavigationController:(nonnull UIViewController *)viewController
 {
+  // -2, because: we need 6 controllers, but when more tab is present, the fifth one is put inside it
   return [self canHaveMoreNavigationController] && [self isMoreNavigationControllerPresentInTabBar] &&
       ![self.tabBar.items containsObject:viewController.tabBarItem] &&
-      [self.viewControllers indexOfObject:viewController] > (kMinCountOfVCsForMoreVCPresence - 1);
+      [self.viewControllers indexOfObject:viewController] >= (kMinCountOfVCsForMoreVCPresence - 2);
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -15,11 +15,6 @@
 // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
 static constexpr NSUInteger kMinCountOfVCsForMoreVCPresence = 6;
 
-/// Index of the first view controller hosted by the More navigation controller.
-/// When More is present, UIKit shows the first 4 view controllers in the tab bar
-/// and moves the rest (index >= 4) into the More list.
-static constexpr NSUInteger kFirstIndexInMoreNavigationController = 4;
-
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
@@ -772,13 +767,14 @@ static void rns_pushViewController(__unsafe_unretained id self,
     return NO;
   }
 
-  NSUInteger index = [self.viewControllers indexOfObject:viewController];
-  if (index == NSNotFound) {
+  // Guard: VC must be one we manage (excludes arbitrary external VCs).
+  if ([self.viewControllers indexOfObject:viewController] == NSNotFound) {
     return NO;
   }
 
-  return ![self.tabBar.items containsObject:viewController.tabBarItem] &&
-      index >= kFirstIndexInMoreNavigationController;
+  // Ground truth: if our VC's tabBarItem is NOT in the visible tab bar, it is hosted by the
+  // More navigation controller. Correct even when users reorder tabs via the More list's Edit UI.
+  return ![self.tabBar.items containsObject:viewController.tabBarItem];
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -192,10 +192,9 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
   [super traitCollectionDidChange:previousTraitCollection];
 
-  if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass) {
-    if ([self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
-      [self disableNavigationBarInMoreNavigationController];
-    }
+  if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass &&
+      [self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
   }
 }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -757,7 +757,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-  // The count is documented. Size class check is empirical, to tigthen the condition and have less
+  // The count is documented. Size class check is empirical, to tighten the condition and have less
   // false positives. If we ever find it not correct, we can safely remove it.
   return self.viewControllers.count >= kMinCountOfVCsForMoreVCPresence &&
       self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -13,7 +13,7 @@
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
 // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-static constexpr int kMinCountOfVCsForMoreVCPresence = 5;
+static constexpr int kMinCountOfVCsForMoreVCPresence = 6;
 
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
@@ -753,7 +753,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-  return self.viewControllers.count > kMinCountOfVCsForMoreVCPresence &&
+  return self.viewControllers.count >= kMinCountOfVCsForMoreVCPresence &&
       self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
 #else
   return NO;
@@ -764,8 +764,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
   return [self canHaveMoreNavigationController] && [self isMoreNavigationControllerPresentInTabBar] &&
       ![self.tabBar.items containsObject:viewController.tabBarItem] &&
-      [self.viewControllers indexOfObject:viewController] >
-      (kMinCountOfVCsForMoreVCPresence - 1); // -1 because one item is replaced by the more nav. ctrl item.
+      [self.viewControllers indexOfObject:viewController] > (kMinCountOfVCsForMoreVCPresence - 1);
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -12,6 +12,9 @@
 
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
+// https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
+static constexpr int kMinCountOfVCsForMoreVCPresence = 5;
+
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
@@ -182,6 +185,17 @@ static void rns_pushViewController(__unsafe_unretained id self,
   [super setSelectedViewController:selectedViewController];
   if (!_isHandlingExplicitSelectionUpdate) {
     [self reconcileNavigationStateWithUIKitState];
+  }
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass) {
+    if ([self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
+      [self disableNavigationBarInMoreNavigationController];
+    }
   }
 }
 
@@ -498,6 +512,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
  */
 - (void)updateSelectedViewControllerInner
 {
+  RCTAssert(_pendingStateUpdate != nil, @"[RNScreens] Pending update MUST NOT be nil");
+
   UIViewController *_Nonnull currSelectedViewController = self.selectedViewController;
 
   NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.selectedScreenKey;
@@ -545,6 +561,11 @@ static void rns_pushViewController(__unsafe_unretained id self,
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
   BOOL hasStateProgressed = [self updateSelectedViewControllerTo:nextSelectedViewController
                                                          withKey:nextSelectedViewControllerKey];
+
+  if (hasStateProgressed &&
+      [self isViewControllerPresentedFromTheMoreNavigationController:nextSelectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
+  }
 
   if (hasStateProgressed) {
     RNSTabsNavigationStateUpdateContext *context =
@@ -696,6 +717,10 @@ static void rns_pushViewController(__unsafe_unretained id self,
          selectedScreenKey);
   [self progressNavigationState:selectedScreenKey withOrigin:RNSTabsActionOriginImplicit];
 
+  if ([self isViewControllerPresentedFromTheMoreNavigationController:self.selectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
+  }
+
   auto *context = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
                                                                      isRepeated:NO
                                                       hasTriggeredSpecialEffect:NO
@@ -725,10 +750,19 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-  return self.viewControllers.count > 5;
+  return self.viewControllers.count > kMinCountOfVCsForMoreVCPresence &&
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
 #else
   return NO;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+- (BOOL)isViewControllerPresentedFromTheMoreNavigationController:(nonnull UIViewController *)viewController
+{
+  return [self canHaveMoreNavigationController] && [self isMoreNavigationControllerPresentInTabBar] &&
+      ![self.tabBar.items containsObject:viewController.tabBarItem] &&
+      [self.viewControllers indexOfObject:viewController] >
+      (kMinCountOfVCsForMoreVCPresence - 1); // -1 because one item is replaced by the more nav. ctrl item.
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController


### PR DESCRIPTION
## Description

Fixes an issue on iOS Tabs where the `moreNavigationController`'s navigation bar would be briefly visible and then animated away after the user navigated for the first time to a screen hosted inside the *more navigation controller*.

Also patches a closely related issue (not covered by the linked issue) where the navigation bar would briefly appear and animate away during transitions to/from the more navigation controller triggered by a horizontal size class change.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1101

## Changes

- `RNSTabBarController.mm`:
  - In `updateSelectedViewControllerInner`, preemptively hide the navigation bar when the `nextSelectedViewController` is hosted inside the *more navigation controller*.
  - Tightened `canHaveMoreNavigationController` to also require `horizontalSizeClass == UIUserInterfaceSizeClassCompact`, so the check correctly reflects when the more nav. controller is actually present.
  - Added `isViewControllerPresentedFromTheMoreNavigationController:` helper that combines the above with the tab bar items check and the index check (accounting for the slot replaced by the more nav. controller).
  - Overrode `traitCollectionDidChange:` to handle size-class transitions (call `super` first, then query `self.selectedViewController` so UIKit has updated its model). Used the deprecated API instead of `registerForTraitCollectionChange:withAction:` because the latter is iOS 17+ and we still support iOS 15.
  - Added an `RCTAssert` that `_pendingStateUpdate` must not be nil in `updateSelectedViewControllerInner`.
  - Extracted magic number `5` into `kMinCountOfVCsForMoreVCPresence` constant with a link to the Apple docs.

## Visual documentation

| before | after |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/dd1c4484-1b52-4ee1-a90a-5601de6260b0" alt="before" /> | <video src="https://github.com/user-attachments/assets/c5592a28-08dc-4bfe-9e84-410dc413d31b" alt="after" /> |

## Test plan

Manual repro on iOS (iPhone, compact horizontal size class):

1. Run `FabricExample` on iOS.
2. Open the Tabs example with more than 5 tab screens so the *More* tab appears.
3. Tap *More*, then select a screen hosted inside the more navigation controller.
4. Before the fix: the navigation bar of the more navigation controller is visible for a moment, then animates away.
5. After the fix: navigation bar is hidden preemptively, no flicker.

Additional case (size-class transitions):

1. Same setup as above on a device/simulator that supports size-class changes (e.g. iPad split view, or device rotation where applicable).
2. Trigger a horizontal size-class change while a more-nav-hosted screen is selected.
3. Before the fix: nav bar flashes and animates away.
4. After the fix: nav bar stays hidden across the transition.

## Checklist

- [ ] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes