### PR TITLE
fix(iOS, Tabs): correctly pass action origin to progressNavigationState

### DIFF
--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -266,6 +266,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
  */
 - (BOOL)updateSelectedViewControllerTo:(nullable UIViewController *)nextSelectedViewController
                                withKey:(nullable NSString *)screenKey
+                          actionOrigin:(RNSTabsActionOrigin)actionOrigin
 {
   if (nextSelectedViewController == nil) {
     return NO;
@@ -276,7 +277,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   RCTAssert(![NSString rnscreens_isBlankOrNull:screenKey],
             @"[RNScreens] The screenKey MUST NOT be null if the view controller is not null");
 
-  [self progressNavigationState:screenKey withOrigin:RNSTabsActionOriginProgrammaticJs];
+  [self progressNavigationState:screenKey withOrigin:actionOrigin];
 
   if (currSelectedViewController == nextSelectedViewController) {
     return YES;
@@ -544,7 +545,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
   BOOL hasStateProgressed = [self updateSelectedViewControllerTo:nextSelectedViewController
-                                                         withKey:nextSelectedViewControllerKey];
+                                                         withKey:nextSelectedViewControllerKey
+                                                    actionOrigin:_pendingStateUpdate.actionOrigin];
 
   if (hasStateProgressed) {
     RNSTabsNavigationStateUpdateContext *context =


### PR DESCRIPTION
## Description

`-[RNSTabBarController updateSelectedViewControllerTo:withKey:]` was hardcoding the action origin passed to `progressNavigationState:` as `RNSTabsActionOriginProgrammaticJs`, even when the actual origin was `RNSTabsActionOriginProgrammaticNative`. This caused the navigation state progression to report an incorrect origin for native-driven tab changes.

## Changes

- Added `actionOrigin:` parameter to `-[RNSTabBarController updateSelectedViewControllerTo:withKey:]` and forwarded it to `progressNavigationState:withOrigin:`.
- Updated the sole call site to pass `_pendingStateUpdate.actionOrigin` instead of relying on the hardcoded value.

## Test plan

Reproduction:
1. Trigger a tab change from the native side (path that resolves to `RNSTabsActionOriginProgrammaticNative`).
2. Observe the origin reported by `progressNavigationState`.

Before the fix the origin is reported as `ProgrammaticJs`; after the fix it matches the actual origin from `_pendingStateUpdate.actionOrigin`.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes