### PR TITLE
feat(iOS, FormSheet v5): Add support for initialDetentIndex

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -1,12 +1,14 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestFormSheetBase from './test-form-sheet-base-ios';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
+import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index-ios';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 
 const scenarios = {
   TestFormSheetBase,
   TestFormSheetGrabberVisible,
+  TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,
   TestFormSheetPreferredCornerRadius,
 };

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Sheet initial detent index',
+  key: 'test-form-initial-detent-index-ios',
+  details: 'Allows to test initialDetentIndex prop of FormSheet component.',
+  platforms: ['ios'],
+};
+
+type InitialDetentProp = number | 'last';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialIndex, setInitialIndex] = useState<InitialDetentProp>(0);
+  const [dummyState, setDummyState] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.topSection}>
+        <Text style={styles.title}>Main Screen</Text>
+        <Text style={styles.counterText}>
+          Selected Initial Detent: {String(initialIndex)}
+        </Text>
+
+        <View style={styles.buttonGroup}>
+          <Button
+            title="Set Initial to 0 (0.3)"
+            onPress={() => setInitialIndex(0)}
+          />
+          <Button
+            title="Set Initial to 1 (0.6)"
+            onPress={() => setInitialIndex(1)}
+          />
+          <Button
+            title="Set Initial to 'last' (1.0)"
+            onPress={() => setInitialIndex('last')}
+          />
+        </View>
+
+        <View style={styles.spacing} />
+        <Button
+          title="Open FormSheet"
+          color={Colors.primary}
+          onPress={() => setIsOpen(true)}
+        />
+      </View>
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        initialDetentIndex={initialIndex}
+        detents={[0.3, 0.6, 1.0]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>
+            Opened at Initial Index: {String(initialIndex)}
+          </Text>
+
+          <View style={styles.spacing} />
+
+          <Button
+            title={`Force Re-render (${dummyState})`}
+            onPress={() => setDummyState(s => s + 1)}
+          />
+
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.offBackground,
+  },
+  topSection: {
+    paddingTop: 80,
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  counterText: {
+    marginBottom: 12,
+    color: Colors.text,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  buttonGroup: {
+    gap: 12,
+    alignItems: 'center',
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
@@ -7,7 +7,7 @@ import { Colors } from '@apps/shared/styling';
 
 const scenarioDescription: ScenarioDescription = {
   name: 'Sheet initial detent index',
-  key: 'test-form-initial-detent-index-ios',
+  key: 'test-form-sheet-initial-detent-index-ios',
   details: 'Allows to test initialDetentIndex prop of FormSheet component.',
   platforms: ['ios'],
 };

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { FormSheet } from 'react-native-screens/experimental';
+import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
@@ -12,7 +12,7 @@ const scenarioDescription: ScenarioDescription = {
   platforms: ['ios'],
 };
 
-type InitialDetentProp = number | 'last';
+type InitialDetentProp = FormSheetProps['initialDetentIndex'];
 
 export function App() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario.md
@@ -1,0 +1,57 @@
+# Test Scenario: Sheet initial detent index
+
+## Details
+
+**Description:** Verify the `initialDetentIndex` property of the `FormSheet` component. This test ensures that the FormSheet correctly respects the initial index when mounting and does not forcibly snap back to the initial index if the component re-renders while already presented.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator (iPhone).
+
+## Steps
+
+### Baseline & Default (Index 0)
+
+1. Launch the app and navigate to the **Sheet initial detent index** screen.
+2. Ensure "Selected Initial Detent: 0" is displayed.
+3. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens and snaps immediately to the lowest detent (0.3 detent).
+
+### Re-render Validation
+
+4. While the sheet is open at the 0.3 detent, drag it up to the middle detent (0.6).
+5. Tap the "Force Re-render" button inside the sheet.
+
+- [ ] Expected: The button's counter updates (confirming a React render cycle occurred).
+- [ ] Expected: The sheet remains at the 0.6 detent.
+
+6. Dismiss the sheet by swiping down or tapping "Dismiss from JS".
+
+---
+
+### Middle Detent (Index 1)
+
+7. On the main screen, tap "Set Initial to 1 (0.6)".
+8. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens directly at the middle detent (0.6 detent).
+
+9. Dismiss the sheet.
+
+---
+
+### 'last' Detent (Index N-1)
+
+10. On the main screen, tap "Set Initial to 'last' (1.0)".
+11. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens and snaps directly to the maximum height (1.0 detent).
+
+12. Dismiss the sheet.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -198,7 +198,8 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
       _needsSheetConfigurationUpdate = YES;
-      // Forcefully reset the sheet initialDetentIndex when reopening.
+      // Reset the initial-detent applied flag when reopening so the
+      // configured initialDetentIndex can be applied again.
       _initialDetentApplied = NO;
     }
   }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -14,10 +14,11 @@
 
 namespace react = facebook::react;
 
+// Predefined values for `initialDetentIndex`.
+static NSInteger const kRNSFormSheetLastDetent = -1;
 // Predefined values for `largestUndimmedDetentIndex`.
 static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
 static NSInteger const kRNSFormSheetNeverDimmed = -2;
-static NSInteger const kRNSFormSheetLastDetent = -3;
 
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -17,6 +17,7 @@ namespace react = facebook::react;
 // Predefined values for `largestUndimmedDetentIndex`.
 static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
 static NSInteger const kRNSFormSheetNeverDimmed = -2;
+static NSInteger const kRNSFormSheetLastDetent = -3;
 
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end
@@ -34,6 +35,10 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
   BOOL _prefersGrabberVisible;
   CGFloat _preferredCornerRadius;
   NSInteger _largestUndimmedDetentIndex;
+  NSInteger _initialDetentIndex;
+
+  // State
+  BOOL _initialDetentApplied;
 
   // Invalidation flags
   BOOL _needsSheetPresentationUpdate;
@@ -56,6 +61,8 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
 
+  _initialDetentApplied = NO;
+
   _needsSheetPresentationUpdate = NO;
   _needsSheetConfigurationUpdate = NO;
 }
@@ -70,6 +77,7 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
   _prefersGrabberVisible = NO;
   _preferredCornerRadius = -1.0;
   _largestUndimmedDetentIndex = kRNSFormSheetAlwaysDimmed;
+  _initialDetentIndex = 0;
 }
 
 - (void)setupController
@@ -185,10 +193,12 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
     _needsSheetPresentationUpdate = YES;
 
-    // ALWAYS refresh the sheet configuration when reopening,
-    // because UIKit destroys the presentationController after the modal is dismissed.
     if (_isOpen) {
+      // ALWAYS refresh the sheet configuration when reopening,
+      // because UIKit destroys the presentationController after the modal is dismissed.
       _needsSheetConfigurationUpdate = YES;
+      // Forcefully reset the sheet initialDetentIndex when reopening.
+      _initialDetentApplied = NO;
     }
   }
 
@@ -210,6 +220,10 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
     _needsSheetConfigurationUpdate = YES;
+  }
+
+  if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
+    _initialDetentIndex = newComponentProps.initialDetentIndex;
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -273,6 +287,9 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
+  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier =
+      [self consumeInitialDetentIdentifierForDetents:nativeDetents];
+
   UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
       [self largestUndimmedDetentIdentifierForDetents:nativeDetents];
 
@@ -283,6 +300,10 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
     sheet.preferredCornerRadius =
         _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
     sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
+
+    if (initialDetentIdentifier != nil) {
+      sheet.selectedDetentIdentifier = initialDetentIdentifier;
+    }
   }];
 #endif // !TARGET_OS_TV
 }
@@ -347,6 +368,42 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
   }
 
   return nativeDetents;
+}
+
+- (UISheetPresentationControllerDetentIdentifier)consumeInitialDetentIdentifierForDetents:
+    (NSArray<UISheetPresentationControllerDetent *> *)detents
+{
+  if (_initialDetentApplied) {
+    return nil;
+  }
+
+  _initialDetentApplied = YES;
+
+  NSInteger initialIndex =
+      _initialDetentIndex == kRNSFormSheetLastDetent ? (NSInteger)detents.count - 1 : _initialDetentIndex;
+
+  if (initialIndex < 0 || initialIndex >= (NSInteger)detents.count) {
+    RCTLogError(@"[RNScreens] initialDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to 0.",
+                (long)_initialDetentIndex,
+                (unsigned long)detents.count);
+    initialIndex = 0;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)initialIndex].identifier;
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetents
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)initialIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
+    }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  }
 }
 
 - (UISheetPresentationControllerDetentIdentifier)largestUndimmedDetentIdentifierForDetents:

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent';
 import type { FormSheetProps } from './FormSheet.types';
 import {
+  resolveInitialDetentIndex,
   resolveLargestUndimmedDetentIndex,
   resolveNativeCornerRadius,
 } from './FormSheetUtils';
@@ -10,6 +11,7 @@ import {
 export function FormSheet(props: FormSheetProps) {
   const {
     detents,
+    initialDetentIndex,
     largestUndimmedDetentIndex,
     preferredCornerRadius,
     ...rest
@@ -17,16 +19,24 @@ export function FormSheet(props: FormSheetProps) {
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
 
-  const resolvedUndimmedIndex = resolveLargestUndimmedDetentIndex(
+  const detentsCount = detents?.length ?? 0;
+
+  const resolvedInitialDetentIndex = resolveInitialDetentIndex(
+    initialDetentIndex,
+    detentsCount,
+  );
+
+  const resolvedUndimmedDetentIndex = resolveLargestUndimmedDetentIndex(
     largestUndimmedDetentIndex,
-    detents?.length ?? 0,
+    detentsCount,
   );
 
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
       detents={detents}
-      largestUndimmedDetentIndex={resolvedUndimmedIndex}
+      initialDetentIndex={resolvedInitialDetentIndex}
+      largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}
     />

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -63,6 +63,18 @@ export interface FormSheetProps {
    */
   largestUndimmedDetentIndex?: number | 'none' | 'last' | undefined;
 
+  /**
+   * @summary The index of the detent the sheet should snap to when first opened.
+   *
+   * This prop can be set to a number, indicating the zero-based index of the detent in the
+   * `detents` array. If set to `'last'`, it will snap to the largest defined detent.
+   * This prop only applies when the sheet transitions from closed to open.
+   *
+   * @default 0
+   * @platform ios
+   */
+  initialDetentIndex?: number | 'last' | undefined;
+
   // Events
   /**
    * @summary Called when the sheet is dismissed natively.

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -67,7 +67,7 @@ export interface FormSheetProps {
    * @summary The index of the detent the sheet should snap to when first opened.
    *
    * This prop can be set to a number, indicating the zero-based index of the detent in the
-   * `detents` array. If set to `'last'`, it will snap to the largest defined detent.
+   * `detents` array. If set to `last`, it will snap to the largest defined detent.
    * This prop only applies when the sheet transitions from closed to open.
    *
    * @default 0

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -1,9 +1,10 @@
 import type { FormSheetProps } from './FormSheet.types';
 
-// Keep these predefined values in sync with native equivalents.
+// Predefined values for `initialDetentIndex`. Keep in sync with native counterpart.
+const FORM_SHEET_LAST_DETENT = -1;
+// Predefined values for `largestUndimmedDetentIndex`. Keep in sync with native counterpart.
 const FORM_SHEET_ALWAYS_DIMMED = -1;
 const FORM_SHEET_NEVER_DIMMED = -2;
-const FORM_SHEET_LAST_DETENT = -3;
 
 export function resolveInitialDetentIndex(
   initialDetentIndex: FormSheetProps['initialDetentIndex'],

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -3,6 +3,42 @@ import type { FormSheetProps } from './FormSheet.types';
 // Keep these predefined values in sync with native equivalents.
 const FORM_SHEET_ALWAYS_DIMMED = -1;
 const FORM_SHEET_NEVER_DIMMED = -2;
+const FORM_SHEET_LAST_DETENT = -3;
+
+export function resolveInitialDetentIndex(
+  initialDetentIndex: FormSheetProps['initialDetentIndex'],
+  detentsCount: number = 0,
+): number {
+  if (initialDetentIndex === undefined) {
+    return 0;
+  }
+
+  if (initialDetentIndex === 'last') {
+    return FORM_SHEET_LAST_DETENT;
+  }
+
+  if (typeof initialDetentIndex === 'number') {
+    const lastDetentIndex = Math.max(detentsCount - 1, 0);
+
+    if (!isIndexInClosedRange(initialDetentIndex, 0, lastDetentIndex)) {
+      if (__DEV__) {
+        console.error(
+          `[RNScreens] Invalid value provided for 'initialDetentIndex' (${initialDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to 0.`,
+        );
+      }
+      return 0;
+    }
+
+    return initialDetentIndex;
+  }
+
+  if (__DEV__) {
+    console.error(
+      "[RNScreens] Invalid value provided for 'initialDetentIndex'. Expected a number or 'last'. Falling back to 0.",
+    );
+  }
+  return 0;
+}
 
 export function resolveNativeCornerRadius(
   radius?: number | 'systemDefault',

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -22,22 +22,18 @@ export function resolveInitialDetentIndex(
     const lastDetentIndex = Math.max(detentsCount - 1, 0);
 
     if (!isIndexInClosedRange(initialDetentIndex, 0, lastDetentIndex)) {
-      if (__DEV__) {
-        console.error(
-          `[RNScreens] Invalid value provided for 'initialDetentIndex' (${initialDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to 0.`,
-        );
-      }
+      console.error(
+        `[RNScreens] Invalid value provided for 'initialDetentIndex' (${initialDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to 0.`,
+      );
       return 0;
     }
 
     return initialDetentIndex;
   }
 
-  if (__DEV__) {
-    console.error(
-      "[RNScreens] Invalid value provided for 'initialDetentIndex'. Expected a number or 'last'. Falling back to 0.",
-    );
-  }
+  console.error(
+    "[RNScreens] Invalid value provided for 'initialDetentIndex'. Expected a number or 'last'. Falling back to 0.",
+  );
   return 0;
 }
 

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -12,6 +12,7 @@ interface NativeProps extends ViewProps {
   prefersGrabberVisible?: CT.WithDefault<boolean, false>;
   preferredCornerRadius?: CT.WithDefault<CT.Float, -1.0>;
   largestUndimmedDetentIndex?: CT.WithDefault<CT.Int32, -1>;
+  initialDetentIndex?: CT.WithDefault<CT.Int32, 0>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
 }
 


### PR DESCRIPTION
## Description

Adds `initialDetentIndex` prop to the `FormSheet` component. It controls the index of the detent the sheet should snap to when opened. From JS, we're accepting the following values for parity with the v4 implementation:

- 'last': snapping to the largest defined detent
- number: snapping to the specific index from detents array.

| JS prop | Associated value | Native behavior |
|---|---|---|
| 'last' | -1 | resolves to the last index from the native detents array |
| explicit numeric index | >= 0 | directly maps into detents index |

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1263

## Changes

- JS spec, bindings & helper method in `SheetUtils`, to validate, return feedback to the user, or pass the expected value to the native
- native method for transforming the index passed from JS to proper native detent identifier
- SFT for testing

## Before & after - visual documentation

| iOS 15 | iOS 18 | iOS 26 |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/0097777d-827d-4a2e-a65e-bb7f742fa79e" /> | <video src="https://github.com/user-attachments/assets/e356fd63-c17e-4f7c-a2de-4702f66c7052" /> | <video src="https://github.com/user-attachments/assets/e60f8d57-4202-46d7-a3fe-1229c0704de1" /> |

## Test plan

Added dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
