### PR TITLE
fix(Android, Tabs): propagate actionOrigin into navigation state progression

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -527,18 +527,18 @@ class TabsContainer internal constructor(
 
         val isRepeated = nextSelectedFragment === currSelectedFragment
 
-        // If this is user action we test whether it should be prevented before we progress the state.
-        if (!isRepeated && !isInExternalOperationContext && nextSelectedFragment.isPreventNativeSelectionEnabled) {
-            observerRegistry.emitOnNavigationStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
-            return false
-        }
-
         val actionOrigin =
             if (isInExternalOperationContext) {
                 requirePendingStateUpdateRequest().actionOrigin
             } else {
                 TabsActionOrigin.USER
             }
+
+        // If this is user action we test whether it should be prevented before we progress the state.
+        if (!isRepeated && actionOrigin == TabsActionOrigin.USER && nextSelectedFragment.isPreventNativeSelectionEnabled) {
+            observerRegistry.emitOnNavigationStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
+            return false
+        }
 
         val stateChanged = updateSelectedFragment(nextSelectedFragment, actionOrigin)
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -474,7 +474,10 @@ class TabsContainer internal constructor(
         }
     }
 
-    private fun updateSelectedFragment(nextSelectedFragment: TabsScreenFragment): Boolean {
+    private fun updateSelectedFragment(
+        nextSelectedFragment: TabsScreenFragment,
+        actionOrigin: TabsActionOrigin,
+    ): Boolean {
         if (navState.isEmpty()) {
             check(isInExternalOperationContext && pendingStateUpdateRequest != null)
             navState = TabsNavigationState(nextSelectedFragment.requireScreenKey, 0)
@@ -488,11 +491,11 @@ class TabsContainer internal constructor(
         val currentSelectedFragment = selectedTab
 
         if (nextSelectedFragment === currentSelectedFragment) {
-            progressNavigationState(navState.selectedScreenKey)
+            progressNavigationState(navState.selectedScreenKey, actionOrigin)
             return true
         }
 
-        progressNavigationState(nextSelectedFragment.requireScreenKey)
+        progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
         requireFragmentManager
             .createTransactionWithReordering()
             .let {
@@ -503,7 +506,10 @@ class TabsContainer internal constructor(
         return true
     }
 
-    private fun progressNavigationState(selectedScreenKey: String) {
+    private fun progressNavigationState(
+        selectedScreenKey: String,
+        actionOrigin: TabsActionOrigin,
+    ) {
         navState = TabsNavigationState(selectedScreenKey, navState.provenance + 1)
         if (!isInExternalOperationContext) {
             lastUINavState = navState
@@ -527,7 +533,14 @@ class TabsContainer internal constructor(
             return false
         }
 
-        val stateChanged = updateSelectedFragment(nextSelectedFragment)
+        val actionOrigin =
+            if (isInExternalOperationContext) {
+                requirePendingStateUpdateRequest().actionOrigin
+            } else {
+                TabsActionOrigin.USER
+            }
+
+        val stateChanged = updateSelectedFragment(nextSelectedFragment, actionOrigin)
 
         val hasTriggeredSpecialEffect =
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
@@ -537,12 +550,7 @@ class TabsContainer internal constructor(
                 navState,
                 isRepeated = isRepeated,
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
-                actionOrigin =
-                    if (isInExternalOperationContext) {
-                        requirePendingStateUpdateRequest().actionOrigin
-                    } else {
-                        TabsActionOrigin.USER
-                    },
+                actionOrigin = actionOrigin,
             )
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -511,7 +511,7 @@ class TabsContainer internal constructor(
         actionOrigin: TabsActionOrigin,
     ) {
         navState = TabsNavigationState(selectedScreenKey, navState.provenance + 1)
-        if (!isInExternalOperationContext) {
+        if (actionOrigin != TabsActionOrigin.PROGRAMMATIC_JS) {
             lastUINavState = navState
         }
     }


### PR DESCRIPTION
## Description

`TabsContainer` (Android, gamma) was deciding several things off `isInExternalOperationContext` even though the real intent was to gate on the action's `actionOrigin`. The two were aligned only by accident — `isInExternalOperationContext == true` ⇔ `actionOrigin ∈ { PROGRAMMATIC_JS, PROGRAMMATIC_NATIVE }` — which made `PROGRAMMATIC_NATIVE` updates behave incorrectly on Android compared to iOS:

1. `progressNavigationState` did not have `actionOrigin` available, so consumers observing the progression could not distinguish user-driven from external/programmatic transitions.
2. `lastUINavState` was not updated for `PROGRAMMATIC_NATIVE`, even though that origin represents a native-authoritative state change (downstream library calling `submitSelectionOfTabsScreenWithKey`). This caused subsequent JS requests with stale `baseProvenance` to slip through `isNavigationStateStale` checks instead of being rejected.
3. The "prevent native selection" gate fired on `!isInExternalOperationContext`, which incidentally also rejected `PROGRAMMATIC_NATIVE` updates. Per intent (and matching iOS), this gate should reject only `USER` actions.

This PR threads the resolved `actionOrigin` through the relevant code paths and switches each gate to test the origin directly. iOS and Android now agree on semantics.

Side note: `isPreventNativeSelectionEnabled` is misnamed — it really means "prevent user selection". Renaming it deferred until a future major release.

## Changes

- Compute `actionOrigin` once in `onMenuItemSelected`, before any gate that depends on it.
- Thread `actionOrigin` through `updateSelectedFragment` and `progressNavigationState`.
- `lastUINavState` now updates whenever `actionOrigin != PROGRAMMATIC_JS` (was: whenever `!isInExternalOperationContext`).
- Prevent-native-selection gate now checks `actionOrigin == USER` (was: `!isInExternalOperationContext`).

## Test plan

Manual reproduction on Android via `FabricExample`:

1. **`PROGRAMMATIC_NATIVE` no longer rejected by prevent-selection.** From a downstream-library code path (or a temporary call site) invoke `tabsContainer.submitSelectionOfTabsScreenWithKey(key)` on a `TabsScreen` whose `isPreventNativeSelectionEnabled = true`. Before: selection blocked, `onNavigationStateUpdatePrevented` emitted. After: selection applied, no prevention emitted.
2. **`lastUINavState` advances for `PROGRAMMATIC_NATIVE`.** After the above selection, dispatch a JS `navStateRequest` with the pre-native-update `baseProvenance`. Before: request applied (stale not detected). After: request rejected as stale via `isNavigationStateStale`.
3. **`actionOrigin` reaches observers during progression.** Register a `TabsNavigationStateObserver` and verify `actionOrigin` on `dispatchOnNativeStateChange` for each of: native tab tap (`USER`), `navStateRequest` from JS (`PROGRAMMATIC_JS`), `submitSelectionOfTabsScreenWithKey` (`PROGRAMMATIC_NATIVE`).
4. **Regression check.** Standard tab tap on a tab with `isPreventNativeSelectionEnabled = true` is still prevented and emits `onNavigationStateUpdatePrevented`.

No automated tests exist for this path yet; recommend adding one matrix test in a follow-up.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes