### PR TITLE
fix(iOS, Tabs): register navigation state observer outside RCTAssert

### DIFF
--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -85,7 +85,8 @@ namespace react = facebook::react;
   [self resetProps];
 
   _controller = [[RNSTabBarController alloc] initWithTabsHostComponentView:self];
-  RCTAssert([_controller addNavigationStateObserver:self],
+  [[maybe_unused]] BOOL didRegisterObserver = [_controller addNavigationStateObserver:self];
+  RCTAssert(didRegisterObserver,
             @"[RNScreens] Failed to register RNSTabsHostComponentView as navigation state observer");
 
   _reactSubviews = [NSMutableArray new];


### PR DESCRIPTION
## Description

In release builds, `RCTAssert` expands to `do {} while (false)` and does **not** evaluate its argument. In `RNSTabsHostComponentView.mm` the call

```objc
RCTAssert([_controller addNavigationStateObserver:self], @"...");
```

placed the side-effecting registration *inside* the macro, so in archive/release builds the observer was never registered. `_observerRegistry._observers` stayed empty, `emitDidUpdateStateTo:` iterated zero observers, and `tabsContainer:didUpdateStateTo:withContext:` was never invoked — `onTabSelected` events never reached JS and tab switching silently no-op'd. Debug builds were unaffected because there `RCTAssert` evaluates its condition.

Closes #3998.

## Changes

- Moved `[_controller addNavigationStateObserver:self]` out of the `RCTAssert` macro into a `[[maybe_unused]] BOOL didRegisterObserver` local. The assertion now reads the captured value, so the registration call always executes regardless of build configuration.

## Test plan

Reproduction (from the issue):

1. Build the FabricExample app (or any app using the new Tabs API — `Tabs.Host` / `Tabs.Screen`) in **Release** configuration on iOS.
2. Tap a different tab in the bottom tab bar.
3. **Before this fix:** nothing happens — `onTabSelected` is never dispatched.
4. **After this fix:** tab switches as expected and JS receives the event.

Debug builds continue to behave as before (the `RCTAssert` still fires on registration failure).

Touched file:

- `ios/tabs/host/RNSTabsHostComponentView.mm`

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes