### PR TITLE
chore: cherry-pick changes to 4.25.0 stable

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -474,7 +474,10 @@ class TabsContainer internal constructor(
         }
     }
 
-    private fun updateSelectedFragment(nextSelectedFragment: TabsScreenFragment): Boolean {
+    private fun updateSelectedFragment(
+        nextSelectedFragment: TabsScreenFragment,
+        actionOrigin: TabsActionOrigin,
+    ): Boolean {
         if (navState.isEmpty()) {
             check(isInExternalOperationContext && pendingStateUpdateRequest != null)
             navState = TabsNavigationState(nextSelectedFragment.requireScreenKey, 0)
@@ -488,11 +491,11 @@ class TabsContainer internal constructor(
         val currentSelectedFragment = selectedTab
 
         if (nextSelectedFragment === currentSelectedFragment) {
-            progressNavigationState(navState.selectedScreenKey)
+            progressNavigationState(navState.selectedScreenKey, actionOrigin)
             return true
         }
 
-        progressNavigationState(nextSelectedFragment.requireScreenKey)
+        progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
         requireFragmentManager
             .createTransactionWithReordering()
             .let {
@@ -503,9 +506,12 @@ class TabsContainer internal constructor(
         return true
     }
 
-    private fun progressNavigationState(selectedScreenKey: String) {
+    private fun progressNavigationState(
+        selectedScreenKey: String,
+        actionOrigin: TabsActionOrigin,
+    ) {
         navState = TabsNavigationState(selectedScreenKey, navState.provenance + 1)
-        if (!isInExternalOperationContext) {
+        if (actionOrigin != TabsActionOrigin.PROGRAMMATIC_JS) {
             lastUINavState = navState
         }
     }
@@ -521,13 +527,20 @@ class TabsContainer internal constructor(
 
         val isRepeated = nextSelectedFragment === currSelectedFragment
 
+        val actionOrigin =
+            if (isInExternalOperationContext) {
+                requirePendingStateUpdateRequest().actionOrigin
+            } else {
+                TabsActionOrigin.USER
+            }
+
         // If this is user action we test whether it should be prevented before we progress the state.
-        if (!isRepeated && !isInExternalOperationContext && nextSelectedFragment.isPreventNativeSelectionEnabled) {
+        if (!isRepeated && actionOrigin == TabsActionOrigin.USER && nextSelectedFragment.isPreventNativeSelectionEnabled) {
             observerRegistry.emitOnNavigationStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
             return false
         }
 
-        val stateChanged = updateSelectedFragment(nextSelectedFragment)
+        val stateChanged = updateSelectedFragment(nextSelectedFragment, actionOrigin)
 
         val hasTriggeredSpecialEffect =
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
@@ -537,12 +550,7 @@ class TabsContainer internal constructor(
                 navState,
                 isRepeated = isRepeated,
                 hasTriggeredSpecialEffect = hasTriggeredSpecialEffect,
-                actionOrigin =
-                    if (isInExternalOperationContext) {
-                        requirePendingStateUpdateRequest().actionOrigin
-                    } else {
-                        TabsActionOrigin.USER
-                    },
+                actionOrigin = actionOrigin,
             )
         }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -283,6 +283,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
  */
 - (BOOL)updateSelectedViewControllerTo:(nullable UIViewController *)nextSelectedViewController
                                withKey:(nullable NSString *)screenKey
+                          actionOrigin:(RNSTabsActionOrigin)actionOrigin
 {
   if (nextSelectedViewController == nil) {
     return NO;
@@ -293,7 +294,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   RCTAssert(![NSString rnscreens_isBlankOrNull:screenKey],
             @"[RNScreens] The screenKey MUST NOT be null if the view controller is not null");
 
-  [self progressNavigationState:screenKey withOrigin:RNSTabsActionOriginProgrammaticJs];
+  [self progressNavigationState:screenKey withOrigin:actionOrigin];
 
   if (currSelectedViewController == nextSelectedViewController) {
     return YES;
@@ -563,7 +564,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
   BOOL hasStateProgressed = [self updateSelectedViewControllerTo:nextSelectedViewController
-                                                         withKey:nextSelectedViewControllerKey];
+                                                         withKey:nextSelectedViewControllerKey
+                                                    actionOrigin:_pendingStateUpdate.actionOrigin];
 
   if (hasStateProgressed && [self isViewControllerHostedByMoreNavigationController:nextSelectedViewController]) {
     [self disableNavigationBarInMoreNavigationController];

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -12,6 +12,9 @@
 
 #define RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE !TARGET_OS_TV && !TARGET_OS_VISION
 
+// https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
+static constexpr NSUInteger kMinCountOfVCsForMoreVCPresence = 6;
+
 // We need UINavigationControllerDelegate to handle navigation within `moreNavigationController`
 @interface RNSTabBarController () <UITabBarControllerDelegate, UINavigationControllerDelegate>
 @end
@@ -182,6 +185,20 @@ static void rns_pushViewController(__unsafe_unretained id self,
   [super setSelectedViewController:selectedViewController];
   if (!_isHandlingExplicitSelectionUpdate) {
     [self reconcileNavigationStateWithUIKitState];
+  }
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (previousTraitCollection == nil || self.selectedViewController == nil) {
+    return;
+  }
+
+  if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass &&
+      [self isViewControllerHostedByMoreNavigationController:self.selectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
   }
 }
 
@@ -498,6 +515,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
  */
 - (void)updateSelectedViewControllerInner
 {
+  RCTAssert(_pendingStateUpdate != nil, @"[RNScreens] Pending update MUST NOT be nil");
+
   UIViewController *_Nonnull currSelectedViewController = self.selectedViewController;
 
   NSString *_Nonnull nextSelectedViewControllerKey = _pendingStateUpdate.selectedScreenKey;
@@ -545,6 +564,10 @@ static void rns_pushViewController(__unsafe_unretained id self,
   RNSLog(@"Change selected view controller to: %@", nextSelectedViewControllerKey);
   BOOL hasStateProgressed = [self updateSelectedViewControllerTo:nextSelectedViewController
                                                          withKey:nextSelectedViewControllerKey];
+
+  if (hasStateProgressed && [self isViewControllerHostedByMoreNavigationController:nextSelectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
+  }
 
   if (hasStateProgressed) {
     RNSTabsNavigationStateUpdateContext *context =
@@ -696,6 +719,10 @@ static void rns_pushViewController(__unsafe_unretained id self,
          selectedScreenKey);
   [self progressNavigationState:selectedScreenKey withOrigin:RNSTabsActionOriginImplicit];
 
+  if ([self isViewControllerHostedByMoreNavigationController:self.selectedViewController]) {
+    [self disableNavigationBarInMoreNavigationController];
+  }
+
   auto *context = [[RNSTabsNavigationStateUpdateContext alloc] initWithNavState:_navigationState
                                                                      isRepeated:NO
                                                       hasTriggeredSpecialEffect:NO
@@ -725,10 +752,29 @@ static void rns_pushViewController(__unsafe_unretained id self,
 {
 #if RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
   // https://developer.apple.com/documentation/uikit/uitabbarcontroller?language=objc#The-More-navigation-controller
-  return self.viewControllers.count > 5;
+  // The count is documented. Size class check is empirical, to tighten the condition and have less
+  // false positives. If we ever find it not correct, we can safely remove it.
+  return self.viewControllers.count >= kMinCountOfVCsForMoreVCPresence &&
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
 #else
   return NO;
 #endif // RNS_MORE_NAVIGATION_CONTROLLER_AVAILABLE
+}
+
+- (BOOL)isViewControllerHostedByMoreNavigationController:(nonnull UIViewController *)viewController
+{
+  if (![self canHaveMoreNavigationController] || ![self isMoreNavigationControllerPresentInTabBar]) {
+    return NO;
+  }
+
+  // Guard: VC must be one we manage (excludes arbitrary external VCs).
+  if ([self.viewControllers indexOfObject:viewController] == NSNotFound) {
+    return NO;
+  }
+
+  // Ground truth: if our VC's tabBarItem is NOT in the visible tab bar, it is hosted by the
+  // More navigation controller. Correct even when users reorder tabs via the More list's Edit UI.
+  return ![self.tabBar.items containsObject:viewController.tabBarItem];
 }
 
 - (BOOL)isViewControllerTheMoreNavigationController:(nonnull UIViewController *)viewController

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -85,7 +85,8 @@ namespace react = facebook::react;
   [self resetProps];
 
   _controller = [[RNSTabBarController alloc] initWithTabsHostComponentView:self];
-  RCTAssert([_controller addNavigationStateObserver:self],
+  [[maybe_unused]] BOOL didRegisterObserver = [_controller addNavigationStateObserver:self];
+  RCTAssert(didRegisterObserver,
             @"[RNScreens] Failed to register RNSTabsHostComponentView as navigation state observer");
 
   _reactSubviews = [NSMutableArray new];

--- a/ios/utils/UIView+RNSUtility.h
+++ b/ios/utils/UIView+RNSUtility.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#import <Foundation/Foundation.h>
-#import <React/RCTSurfaceTouchHandler.h>
+#import <UIKit/UIKit.h>
+
+@class RCTSurfaceTouchHandler;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/utils/UIView+RNSUtility.mm
+++ b/ios/utils/UIView+RNSUtility.mm
@@ -1,5 +1,6 @@
 #import "UIView+RNSUtility.h"
 
+#import <React/RCTSurfaceTouchHandler.h>
 #import <React/RCTSurfaceView.h>
 #import "RNSModalScreen.h"
 

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.web.tsx
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.web.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View } from 'react-native';
+import { ScrollViewMarkerProps } from './ScrollViewMarker.types';
+
+export function ScrollViewMarker({
+  scrollEdgeEffects: _,
+  ...rest
+}: ScrollViewMarkerProps) {
+  return <View {...rest} />;
+}


### PR DESCRIPTION

- **fix(iOS, Tabs): fix moreNavigationController navigation bar visible on nav (#3993)**
- **fix(iOS, Tabs): correctly pass action origin to progressNavigationState (#3994)**
- **fix(Android, Tabs): propagate actionOrigin into navigation state progression (#3996)**
- **fix(iOS): forward-declare RCTSurfaceTouchHandler in UIView+RNSUtility.h (#3986)**
- **fix(iOS, Tabs): register navigation state observer outside RCTAssert (#4004)**
- **fix: add web fallback for ScrollViewMarker (#4008)**