### PR TITLE
fix: add web fallback for ScrollViewMarker

### DIFF
--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.web.tsx
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.web.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View } from 'react-native';
+import { ScrollViewMarkerProps } from './ScrollViewMarker.types';
+
+export function ScrollViewMarker({
+  scrollEdgeEffects: _,
+  ...rest
+}: ScrollViewMarkerProps) {
+  return <View {...rest} />;
+}


### PR DESCRIPTION
## Description

Currently, the web build fails on Vite because of `codegenNativeComponent` import.

## Changes

This adds a fallback for `ScrollViewMarker` on web to avoid build issues.

## Before & after - visual documentation

### Before

<img width="1448" height="1454" alt="CleanShot 2026-05-11 at 11 37 39@2x" src="https://github.com/user-attachments/assets/0f92f712-7f1f-4141-91e4-bd2d5d7423e9" />

### After

<img width="1422" height="1184" alt="CleanShot 2026-05-11 at 11 38 25@2x" src="https://github.com/user-attachments/assets/a96cb35e-60bc-44a4-8c56-12988f935ac1" />

## Test plan

Tested in React Navigation repo which has a Vite build setup.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
