### PR TITLE
fix(Android, FormSheet): start postponed transition immediately when screen has valid dimensions after pre-layout

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -263,6 +263,11 @@ class ScreenStackFragment :
             )
             coordinatorLayout.layout(0, 0, container.width, container.height)
 
+            if (screen.width > 0 && screen.height > 0) {
+                screen.requestTriggeringPostponedEnterTransition()
+                screen.triggerPostponedEnterTransitionIfNeeded()
+            }
+
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
                 val bottomSheetWindowInsetListenerChain = requireBottomSheetWindowInsetsListenerChain()
                 bottomSheetWindowInsetListenerChain.addListener { _, windowInsets ->


### PR DESCRIPTION
## Description

  Fixes #4010 — formSheet modals are invisible on presentation in brownfield Android apps on Fabric.

  In brownfield apps, the host activity's window insets are dispatched before the formSheet's `ViewCompat.setOnApplyWindowInsetsListener` is attached. `BottomSheetTransitionCoordinator.areInsetsApplied` therefore never becomes `true` and the postponed enter transition is permanently stuck — the sheet is sized correctly but never becomes visible until something
  forces a re-layout (lock/unlock, rotate, keyboard).

  ## Changes

  After the pre-layout pass in `ScreenStackFragment.onCreateView()`, if the screen already has valid dimensions, start the postponed enter transition immediately instead of waiting for the insets callback that will never fire.

  In greenfield apps the existing insets-driven trigger still fires; the postpone mechanism is idempotent so there is no double-trigger.

  ## Test plan

  A minimal brownfield Android reproduction (RN 0.83.2, Fabric, react-native-screens 4.24.0) is at https://github.com/lhanindeed/react-native-screens-brownfield-bug-repro — the `main` branch demonstrates the invisible-modal behavior and the `proposed-fix` branch applies this change via `patch-package` to confirm the modal appears immediately on presentation.

  - Before: formSheet modal is invisible until lock/unlock or rotation forces a re-layout.
  - After: formSheet modal appears immediately on presentation.
  - Greenfield (default RN template): no behavior change.
  - Keyboard interaction: existing insets listener still handles re-layout when keyboard appears/disappears.

  ## Checklist

  - [x] Included code example that can be used to test this change.
  - [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
  - [ ] For API changes, updated relevant public types.
  - [ ] Ensured that CI passes