### PR TITLE
fix(FabricExample, FormSheet v5): Fix stacking FormSheets

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -12,6 +12,7 @@ import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-io
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state-ios';
 import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss-ios';
+import TestFormSheetStacking from './test-form-sheet-stacking-ios';
 
 const scenarios = {
   TestFormSheetBase,
@@ -27,6 +28,7 @@ const scenarios = {
   TestFormSheetPreferredCornerRadius,
   TestFormSheetPresentationState,
   TestFormSheetPreventNativeDismiss,
+  TestFormSheetStacking,
 };
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'Stacking FormSheets',
+  key: 'test-form-sheet-stacking-ios',
+  details:
+    'Allows testing of stacking multiple FormSheet components with different detents.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  const [isFirstOpen, setIsFirstOpen] = useState(false);
+  const [isSecondOpen, setIsSecondOpen] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Stacking FormSheets Test</Text>
+      <Button
+        title="Open First FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsFirstOpen(true)}
+      />
+
+      <FormSheet
+        isOpen={isFirstOpen}
+        onNativeDismiss={() => setIsFirstOpen(false)}
+        detents={[0.4, 1.0]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>First FormSheet</Text>
+          <Text style={styles.description}>Detents: [0.4, 1.0]</Text>
+          <View style={styles.spacing} />
+
+          <Button
+            title="Open Second FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsSecondOpen(true)}
+          />
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss First FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsFirstOpen(false)}
+          />
+
+          <FormSheet
+            isOpen={isSecondOpen}
+            onNativeDismiss={() => setIsSecondOpen(false)}
+            detents={[0.6, 0.9]}>
+            <View
+              style={[
+                styles.sheetContent,
+                { backgroundColor: Colors.offBackground },
+              ]}>
+              <Text style={styles.sheetTitle}>Second FormSheet</Text>
+              <Text style={styles.description}>Detents: [0.6, 0.9]</Text>
+              <View style={styles.spacing} />
+              <Button
+                title="Dismiss Second FormSheet"
+                color={Colors.primary}
+                onPress={() => setIsSecondOpen(false)}
+              />
+            </View>
+          </FormSheet>
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  description: {
+    fontSize: 16,
+    color: Colors.text,
+    marginBottom: 12,
+  },
+  spacing: {
+    height: 24,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/index.tsx
@@ -1,21 +1,14 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens/experimental';
-import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
+import { scenarioDescription } from './scenario-description';
 import { Colors } from '@apps/shared/styling';
-
-const scenarioDescription: ScenarioDescription = {
-  name: 'Stacking FormSheets',
-  key: 'test-form-sheet-stacking-ios',
-  details:
-    'Allows testing of stacking multiple FormSheet components with different detents.',
-  platforms: ['ios'],
-};
 
 export function App() {
   const [isFirstOpen, setIsFirstOpen] = useState(false);
   const [isSecondOpen, setIsSecondOpen] = useState(false);
+  const [isThirdOpen, setIsThirdOpen] = useState(false);
 
   return (
     <View style={styles.container}>
@@ -25,14 +18,13 @@ export function App() {
         color={Colors.primary}
         onPress={() => setIsFirstOpen(true)}
       />
-
       <FormSheet
         isOpen={isFirstOpen}
         onNativeDismiss={() => setIsFirstOpen(false)}
         detents={[0.4, 1.0]}>
-        <View style={styles.sheetContent}>
+        <View
+          style={[styles.sheetContent, { backgroundColor: Colors.BlueDark40 }]}>
           <Text style={styles.sheetTitle}>First FormSheet</Text>
-          <Text style={styles.description}>Detents: [0.4, 1.0]</Text>
           <View style={styles.spacing} />
 
           <Button
@@ -46,26 +38,65 @@ export function App() {
             color={Colors.primary}
             onPress={() => setIsFirstOpen(false)}
           />
-
-          <FormSheet
-            isOpen={isSecondOpen}
-            onNativeDismiss={() => setIsSecondOpen(false)}
-            detents={[0.6, 0.9]}>
-            <View
-              style={[
-                styles.sheetContent,
-                { backgroundColor: Colors.offBackground },
-              ]}>
-              <Text style={styles.sheetTitle}>Second FormSheet</Text>
-              <Text style={styles.description}>Detents: [0.6, 0.9]</Text>
-              <View style={styles.spacing} />
-              <Button
-                title="Dismiss Second FormSheet"
-                color={Colors.primary}
-                onPress={() => setIsSecondOpen(false)}
-              />
-            </View>
-          </FormSheet>
+        </View>
+      </FormSheet>
+      <FormSheet
+        isOpen={isSecondOpen}
+        onNativeDismiss={() => setIsSecondOpen(false)}
+        detents={[0.4, 1.0]}>
+        <View
+          style={[
+            styles.sheetContent,
+            { backgroundColor: Colors.GreenDark40 },
+          ]}>
+          <Text style={styles.sheetTitle}>Second FormSheet</Text>
+          <Button
+            title="Open Third FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsThirdOpen(true)}
+          />
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss First FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsFirstOpen(false)}
+          />
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss Second FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsSecondOpen(false)}
+          />
+        </View>
+      </FormSheet>
+      <FormSheet
+        isOpen={isThirdOpen}
+        onNativeDismiss={() => setIsThirdOpen(false)}
+        detents={[0.4, 1.0]}>
+        <View
+          style={[
+            styles.sheetContent,
+            { backgroundColor: Colors.YellowDark40 },
+          ]}>
+          <Text style={styles.sheetTitle}>Third FormSheet</Text>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss First FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsFirstOpen(false)}
+          />
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss Second FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsSecondOpen(false)}
+          />
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss Third FormSheet"
+            color={Colors.primary}
+            onPress={() => setIsThirdOpen(false)}
+          />
         </View>
       </FormSheet>
     </View>
@@ -97,11 +128,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginBottom: 8,
     color: Colors.text,
-  },
-  description: {
-    fontSize: 16,
-    color: Colors.text,
-    marginBottom: 12,
   },
   spacing: {
     height: 24,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stacking FormSheets',
+  key: 'test-form-sheet-stacking-ios',
+  details:
+    'Allows testing of stacking multiple FormSheet components with different detents.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario.md
@@ -1,0 +1,67 @@
+# Test Scenario: Stacking FormSheets
+
+## Details
+
+**Description:** Verify stacking over a `FormSheet` another `FormSheet` instance. This test ensures that the underlying `FormSheet` correctly handles touches, that the new `FormSheet` presents with theirs independent configurations, and that both sheets maintain stability during dismissal and manual detent adjustments.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone
+
+## Steps - iPhone
+
+### Baseline
+
+1. Launch the app and navigate to the **Stacking FormSheets** screen.
+
+- [ ] Expected: Content with the button "Open First FormSheet" is shown.
+
+---
+
+### First FormSheet Initialization
+
+2. Tap the "Open First FormSheet" button.
+
+- [ ] Expected: The first FormSheet opens at the initial lower detent (0.4). The "First FormSheet" text, along with the "Open Second FormSheet" and "Dismiss First FormSheet" buttons, are visible. 
+
+---
+
+### First FormSheet Detent Adaptation
+
+3. Grab the top edge of the First FormSheet and swipe up to expand it to its maximum detent (1.0).
+
+- [ ] Expected: The first FormSheet expands smoothly to take up the maximum available height.
+
+---
+
+### Stacking the Second FormSheet
+
+4. Tap the "Open Second FormSheet" button from within the first sheet.
+
+- [ ] Expected: A second FormSheet opens over the top of the first one, presenting at its own initial detent (0.6). The first FormSheet remains visible in the background, maintaining its expanded 1.0 detent state. The "Second FormSheet" text and "Dismiss Second FormSheet" button are centered and visible.
+
+---
+
+### Independent Detent Adaptation
+
+5. Grab the top edge of the Second FormSheet and swipe up to expand it to its maximum detent (0.9).
+
+- [ ] Expected: The second FormSheet expands smoothly to ~90% of the screen height without affecting the expanded state of the first FormSheet beneath it.
+
+---
+
+### Sequential Dismissal Verification
+
+6. Tap the "Dismiss Second FormSheet" button (or swipe down completely on the top sheet).
+
+- [ ] Expected: The second FormSheet dismisses smoothly. The first FormSheet comes back into full focus and remains at its expanded 1.0 detent state from Step 3. Its internal buttons ("Open Second FormSheet", "Dismiss First FormSheet") are pressable.
+
+7. Tap the "Dismiss First FormSheet" button (or swipe down completely).
+
+- [ ] Expected: The first FormSheet dismisses smoothly, returning the user to the underlying main screen. Pressables on the main screen are working normally.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking-ios/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify stacking over a `FormSheet` another `FormSheet` instance. This test ensures that the underlying `FormSheet` correctly handles touches, that the new `FormSheet` presents with theirs independent configurations, and that both sheets maintain stability during dismissal and manual detent adjustments.
+**Description:** Verify the present/dismiss flow for stacked `FormSheet` components. The screen presents up to three sheets stacked on top of each other. Every sheet exposes buttons that dismiss any sheet in the stack.
 
 **OS test creation version:** iOS: 18.6 and 26.4
 
@@ -20,48 +20,87 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Stacking FormSheets** screen.
 
-- [ ] Expected: Content with the button "Open First FormSheet" is shown.
+- [ ] Content with the button "Open First FormSheet" is shown.
 
 ---
 
-### First FormSheet Initialization
+### Build the full stack
 
-2. Tap the "Open First FormSheet" button.
+2. Tap "Open First FormSheet".
 
-- [ ] Expected: The first FormSheet opens at the initial lower detent (0.4). The "First FormSheet" text, along with the "Open Second FormSheet" and "Dismiss First FormSheet" buttons, are visible. 
+- [ ] The First (blue) FormSheet opens at the initial lower detent (0.4). The "Open Second FormSheet" and "Dismiss First FormSheet" buttons are visible.
 
----
+3. Grab the top edge of the First FormSheet and swipe up to its maximum detent (1.0).
 
-### First FormSheet Detent Adaptation
+- [ ] The First FormSheet expands smoothly to the maximum available height.
 
-3. Grab the top edge of the First FormSheet and swipe up to expand it to its maximum detent (1.0).
+4. Tap "Open Second FormSheet".
 
-- [ ] Expected: The first FormSheet expands smoothly to take up the maximum available height.
+- [ ] The Second (green) FormSheet opens over the first at its initial detent (0.4). The First FormSheet remains visible in the background, keeping its expanded 1.0 detent.
 
----
+5. Grab the top edge of the Second FormSheet and swipe up to its maximum detent (1.0).
 
-### Stacking the Second FormSheet
+- [ ] The Second FormSheet expands smoothly.
 
-4. Tap the "Open Second FormSheet" button from within the first sheet.
+6. Tap "Open Third FormSheet".
 
-- [ ] Expected: A second FormSheet opens over the top of the first one, presenting at its own initial detent (0.6). The first FormSheet remains visible in the background, maintaining its expanded 1.0 detent state. The "Second FormSheet" text and "Dismiss Second FormSheet" button are centered and visible.
-
----
-
-### Independent Detent Adaptation
-
-5. Grab the top edge of the Second FormSheet and swipe up to expand it to its maximum detent (0.9).
-
-- [ ] Expected: The second FormSheet expands smoothly to ~90% of the screen height without affecting the expanded state of the first FormSheet beneath it.
+- [ ] The Third (yellow) FormSheet opens over the second at its initial detent (0.4). The Second and First FormSheets remain in the background at their previous detents.
 
 ---
 
-### Sequential Dismissal Verification
+### Top dismissal
 
-6. Tap the "Dismiss Second FormSheet" button (or swipe down completely on the top sheet).
+7. Tap "Dismiss Third FormSheet" inside the Third sheet.
 
-- [ ] Expected: The second FormSheet dismisses smoothly. The first FormSheet comes back into full focus and remains at its expanded 1.0 detent state from Step 3. Its internal buttons ("Open Second FormSheet", "Dismiss First FormSheet") are pressable.
+- [ ] Only the Third FormSheet dismisses. The Second FormSheet returns and its expanded 1.0 detent. Its buttons are pressable.
+- [ ] The First FormSheet is still present behind the Second.
 
-7. Tap the "Dismiss First FormSheet" button (or swipe down completely).
+8. Swipe the Second FormSheet (now the top sheet) down to fully dismiss it via native gesture.
 
-- [ ] Expected: The first FormSheet dismisses smoothly, returning the user to the underlying main screen. Pressables on the main screen are working normally.
+- [ ] The Second FormSheet dismisses. The First FormSheet returns and its expanded 1.0 detent. Its buttons are pressable.
+
+9. Tap "Dismiss First FormSheet" inside the First sheet.
+
+- [ ] The First FormSheet dismisses, returning to the underlying main screen. Main-screen pressables work normally.
+
+---
+
+### Middle dismissal
+
+10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
+
+- [ ] All three sheets are stacked, Third on top.
+
+11. Tap "Dismiss Second FormSheet" inside the Third sheet. This dismisses the middle sheet while the Third sheet is still on top of it.
+
+- [ ] The Second **and** Third FormSheets both dismiss. The user is returned to the First FormSheet.
+- [ ] The First FormSheet remains present and interactive.
+
+12. Tap "Open Second FormSheet" inside the First sheet, then "Open Third FormSheet" inside the Second sheet.
+
+- [ ] Both sheets re-present correctly.
+
+---
+
+### Bottom dismissal
+
+13. With all three sheets stacked, tap "Dismiss First FormSheet" inside the Third sheet. This dismisses the bottom-most sheet while the entire stack is open.
+
+- [ ] All three FormSheets dismiss together, returning directly to the underlying main screen.
+- [ ] Main-screen pressables work normally.
+
+14. Tap "Open First FormSheet" again.
+
+- [ ] The First FormSheet opens.
+
+---
+
+### Mid-stack dismissal from a two-sheet stack
+
+15. With the First FormSheet open, tap "Open Second FormSheet".
+
+- [ ] First and Second are stacked, Second on top.
+
+16. Tap "Dismiss First FormSheet" inside the Second sheet.
+
+- [ ] Both the First and Second FormSheets dismiss, returning to the underlying main screen.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -92,7 +92,12 @@
 
   // This covers the case when a sheet deeper in the stack is dismissed, UIKit tears down
   // every sheet above it without calling `presentationControllerDidDismiss:` on them.
-  if ([_presentationManager handleNativeDismiss]) {
+  // Additionally, `viewDidDisappear:` can be triggered when this controller is temporarily
+  // covered by another full-screen modal presented from it, not only when it is dismissed.
+  // We need to gate this path to only run for actual dismissals when the controller no
+  // longer has a presentingViewController.
+  BOOL isStillInPresentationHierarchy = self.presentingViewController != nil;
+  if (!isStillInPresentationHierarchy && [_presentationManager handleNativeDismiss]) {
     [self.delegate sheetControllerDidNativeDismiss:self];
   }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -90,6 +90,12 @@
   [super viewDidDisappear:animated];
   [self detachBackdropTapGestureRecognizer];
 
+  // This covers the case when a sheet deeper in the stack is dismissed, UIKit tears down
+  // every sheet above it without calling `presentationControllerDidDismiss:` on them.
+  if ([_presentationManager handleNativeDismiss]) {
+    [self.delegate sheetControllerDidNativeDismiss:self];
+  }
+
   [self.delegate sheetControllerDidDisappear:self];
 }
 
@@ -207,9 +213,9 @@
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
-  [_presentationManager handleNativeDismiss];
-
-  [self.delegate sheetControllerDidNativeDismiss:self];
+  if ([_presentationManager handleNativeDismiss]) {
+    [self.delegate sheetControllerDidNativeDismiss:self];
+  }
 }
 
 #if !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
@@ -12,7 +12,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updatePresentationIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
                                     controller:(RNSFormSheetContentController *)controller;
 
-- (void)handleNativeDismiss;
+///
+/// Transitions the manager into the dismissed state in response to a dismissal that this manager
+/// did not itself initiate (an interactive swipe, or a dismissal cascaded down from a lower sheet).
+///
+/// @return NO if the manager was already dismissed or is mid programmatic dismissal.
+///         YES otherwise.
+///
+///
+- (BOOL)handleNativeDismiss;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
@@ -12,14 +12,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updatePresentationIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
                                     controller:(RNSFormSheetContentController *)controller;
 
-///
-/// Transitions the manager into the dismissed state in response to a dismissal that this manager
-/// did not itself initiate (an interactive swipe, or a dismissal cascaded down from a lower sheet).
-///
-/// @return NO if the manager was already dismissed or is mid programmatic dismissal.
-///         YES otherwise.
-///
-///
+/**
+ * Transitions the manager into the dismissed state in response to a dismissal that this manager
+ * did not itself initiate (an interactive swipe, or a dismissal cascaded down from a lower sheet).
+ *
+ * @return NO if the manager was already dismissed or is mid programmatic dismissal.
+ *         YES otherwise.
+ */
 - (BOOL)handleNativeDismiss;
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
@@ -74,7 +74,8 @@
     return;
   }
 
-  if (controller.presentingViewController == nil) {
+  UIViewController *presentingViewController = controller.presentingViewController;
+  if (presentingViewController == nil) {
     _state = RNSFormSheetPresentationStateDismissed;
     return;
   }
@@ -82,23 +83,29 @@
   _state = RNSFormSheetPresentationStateDismissing;
 
   __weak auto weakSelf = self;
-  [controller dismissViewControllerAnimated:YES
-                                 completion:^{
-                                   auto strongSelf = weakSelf;
-                                   if (!strongSelf) {
-                                     return;
-                                   }
+  [presentingViewController dismissViewControllerAnimated:YES
+                                               completion:^{
+                                                 auto strongSelf = weakSelf;
+                                                 if (!strongSelf) {
+                                                   return;
+                                                 }
 
-                                   strongSelf->_state = RNSFormSheetPresentationStateDismissed;
-                                   [strongSelf updatePresentationIfNeededWithProvider:provider controller:controller];
+                                                 strongSelf->_state = RNSFormSheetPresentationStateDismissed;
+                                                 [strongSelf updatePresentationIfNeededWithProvider:provider
+                                                                                         controller:controller];
 
-                                   [controller.delegate sheetControllerDidDismiss:controller];
-                                 }];
+                                                 [controller.delegate sheetControllerDidDismiss:controller];
+                                               }];
 }
 
-- (void)handleNativeDismiss
+- (BOOL)handleNativeDismiss
 {
+  if (_state == RNSFormSheetPresentationStateDismissing || _state == RNSFormSheetPresentationStateDismissed) {
+    return NO;
+  }
+
   _state = RNSFormSheetPresentationStateDismissed;
+  return YES;
 }
 
 @end


### PR DESCRIPTION
## Description

Dismissing a sheet from the middle/bottom of a stack only dismissed the top sheet. This is because `dismissViewControllerAnimated:` dismisses the receiver's presented view controller, not the receiver itself - so it tore down whatever was on top instead of the targeted sheet.

- `RNSFormSheetPresentationManager` now calls `dismissViewControllerAnimated:` on `presentingViewController`, so dismissing a sheet cascades to every sheet stacked above it.
- Sheets torn down by a lower sheet's dismissal don't receive `presentationControllerDidDismiss:`. We now detect this in `viewDidDisappear:` and route it through the native-dismiss path so each higher sheet emits `onNativeDismiss` to JS, allowing syncing the state. `viewDidDisappear:` is used because it only fires on a committed dismissal.
- `handleNativeDismiss` now returns whether it actually performed the transition and is a no-op when already dismissed or mid programmatic dismissal. This prevents the duplicate `onNativeDismiss` event emission.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1280 

## Changes

- Added SFT for stacking FormSheets

## Before & after - visual documentation

https://github.com/user-attachments/assets/a305a7b5-54df-4264-80ed-7bb80d488ebf

## Test plan

Added a dedicated SFT for testing sheets stacking

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
