### PR TITLE
refactor(test): fix scroll-to-top e2e test on Android

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -7,7 +7,7 @@ export const describeIfiOS =
 export const describeIfAndroid =
   device.getPlatform() === 'android' ? describe : describe.skip;
 
-async function scrollUntilVisible(id: string, scrollViewId: string) {
+export async function scrollUntilVisible(id: string, scrollViewId: string) {
   await waitFor(element(by.id(id)))
     .toBeVisible()
     .whileElement(by.id(scrollViewId))
@@ -72,18 +72,18 @@ export async function getElementAttributes(
   testLabel: string,
 ): Promise<ElementAttributes> {
   const attrs = await element(by.label(testLabel)).getAttributes();
-  
+
   if ('elements' in attrs) {
     throw new Error(
-      `Multiple elements (${attrs.elements.length}) found for label: "${testLabel}". `
+      `Multiple elements (${attrs.elements.length}) found for label: "${testLabel}". `,
     );
   }
-  
+
   return attrs as ElementAttributes;
 }
 
 /**
- * Performs a coordinate-based tap on iOS to interact with an element that may be 
+ * Performs a coordinate-based tap on iOS to interact with an element that may be
  * obstructed by other UI layers, bypassing Detox's default visibility checks.
  */
 export async function forceTapByLabeliOS(testLabel: string) {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
@@ -5,7 +5,7 @@ import {
 } from '../../e2e-utils';
 
 /**
- * Selects a tab bar item. On iOS, this uses a forced coordinate tap to 
+ * Selects a tab bar item. On iOS, this uses a forced coordinate tap to
  * ensure the tab is selected even if it is obstructed by the iOS 26 Liquid Glass lens.
  */
 async function forceSelectTabByLabel(label: string) {
@@ -16,6 +16,12 @@ async function forceSelectTabByLabel(label: string) {
   }
 }
 
+async function scrollDown(targetId: string, scrollViewId: string) {
+  await waitFor(element(by.id(targetId)))
+    .toBeVisible()
+    .whileElement(by.id(scrollViewId))
+    .scroll(500, 'down', NaN, 0.85);
+}
 describe('Tabs specialEffects — scrollToTop', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -38,7 +44,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
   });
 
   it('Tab1 (scrollToTop: true) — re-tapping active tab scrolls list back to top', async () => {
-    await element(by.id('tab1-scrollview')).scroll(300, 'down', NaN, 0.85);
+    await scrollDown('tab1-item-22', 'tab1-scrollview');
     await expect(element(by.id('tab1-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab1-tab-item-label');
@@ -52,7 +58,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await element(by.id('tab2-tab-item')).tap();
     await expect(element(by.id('tab2-item-1'))).toBeVisible();
 
-    await element(by.id('tab2-scrollview')).scroll(300, 'down', NaN, 0.85);
+    await scrollDown('tab2-item-22', 'tab2-scrollview');
     await expect(element(by.id('tab2-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab2-tab-item-label');
@@ -64,7 +70,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await element(by.id('tab3-tab-item')).tap();
     await expect(element(by.id('tab3-item-1'))).toBeVisible();
 
-    await element(by.id('tab3-scrollview')).scroll(300, 'down', NaN, 0.85);
+    await scrollDown('tab3-item-22', 'tab3-scrollview');
     await expect(element(by.id('tab3-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab3-tab-item-label');
@@ -78,7 +84,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await forceSelectTabByLabel('tab1-tab-item-label');
     await expect(element(by.id('tab1-item-1'))).toBeVisible();
 
-    await element(by.id('tab1-scrollview')).scroll(300, 'down', NaN, 0.85);
+    await scrollDown('tab1-item-22', 'tab1-scrollview');
     await expect(element(by.id('tab1-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab3-tab-item-label');

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
@@ -1,9 +1,9 @@
 import { device, expect, element, by } from 'detox';
 import {
+  scrollUntilVisible,
   selectSingleFeatureTestsScreen,
   forceTapByLabeliOS,
 } from '../../e2e-utils';
-
 /**
  * Selects a tab bar item. On iOS, this uses a forced coordinate tap to
  * ensure the tab is selected even if it is obstructed by the iOS 26 Liquid Glass lens.
@@ -16,12 +16,6 @@ async function forceSelectTabByLabel(label: string) {
   }
 }
 
-async function scrollDown(targetId: string, scrollViewId: string) {
-  await waitFor(element(by.id(targetId)))
-    .toBeVisible()
-    .whileElement(by.id(scrollViewId))
-    .scroll(500, 'down', NaN, 0.85);
-}
 describe('Tabs specialEffects — scrollToTop', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -44,7 +38,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
   });
 
   it('Tab1 (scrollToTop: true) — re-tapping active tab scrolls list back to top', async () => {
-    await scrollDown('tab1-item-22', 'tab1-scrollview');
+    await scrollUntilVisible('tab1-item-22', 'tab1-scrollview');
     await expect(element(by.id('tab1-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab1-tab-item-label');
@@ -58,7 +52,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await element(by.id('tab2-tab-item')).tap();
     await expect(element(by.id('tab2-item-1'))).toBeVisible();
 
-    await scrollDown('tab2-item-22', 'tab2-scrollview');
+    await scrollUntilVisible('tab2-item-22', 'tab2-scrollview');
     await expect(element(by.id('tab2-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab2-tab-item-label');
@@ -70,7 +64,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await element(by.id('tab3-tab-item')).tap();
     await expect(element(by.id('tab3-item-1'))).toBeVisible();
 
-    await scrollDown('tab3-item-22', 'tab3-scrollview');
+    await scrollUntilVisible('tab3-item-22', 'tab3-scrollview');
     await expect(element(by.id('tab3-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab3-tab-item-label');
@@ -84,7 +78,7 @@ describe('Tabs specialEffects — scrollToTop', () => {
     await forceSelectTabByLabel('tab1-tab-item-label');
     await expect(element(by.id('tab1-item-1'))).toBeVisible();
 
-    await scrollDown('tab1-item-22', 'tab1-scrollview');
+    await scrollUntilVisible('tab1-item-22', 'tab1-scrollview');
     await expect(element(by.id('tab1-item-1'))).not.toBeVisible();
 
     await forceSelectTabByLabel('tab3-tab-item-label');

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
@@ -23,7 +23,7 @@ interface ScrollScreenProps {
 
 export function ScrollScreen({ tabName }: ScrollScreenProps) {
   return (
-    <SafeAreaView>
+    <SafeAreaView edges={{ bottom: Platform.OS === 'android', top:Platform.OS === 'android' }}>
       <ScrollView testID={`${tabName}-scrollview`}>
         <Text style={styles.hint}>Scroll Screen — scroll down or re-tap the tab.</Text>
         {Array.from({ length: 50 }, (_, i) => (

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
@@ -7,6 +7,7 @@ import {
   type TabRouteConfig,
   DEFAULT_TAB_ROUTE_OPTIONS,
 } from '@apps/shared/gamma/containers/tabs';
+import { SafeAreaView } from 'react-native-screens/experimental';
 
 const scenarioDescription: ScenarioDescription = {
   name: 'Tabs special effect scroll to top',
@@ -22,14 +23,16 @@ interface ScrollScreenProps {
 
 export function ScrollScreen({ tabName }: ScrollScreenProps) {
   return (
-    <ScrollView testID={`${tabName}-scrollview`}>
-      <Text style={styles.hint}>Scroll Screen — scroll down or re-tap the tab.</Text>
-      {Array.from({ length: 50 }, (_, i) => (
-        <Text key={i} testID={`${tabName}-item-${i + 1}`} style={styles.item}>
-          Item {i + 1}
-        </Text>
-      ))}
-    </ScrollView>
+    <SafeAreaView>
+      <ScrollView testID={`${tabName}-scrollview`}>
+        <Text style={styles.hint}>Scroll Screen — scroll down or re-tap the tab.</Text>
+        {Array.from({ length: 50 }, (_, i) => (
+          <Text key={i} testID={`${tabName}-item-${i + 1}`} style={styles.item}>
+            Item {i + 1}
+          </Text>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
@@ -23,7 +23,12 @@ interface ScrollScreenProps {
 
 export function ScrollScreen({ tabName }: ScrollScreenProps) {
   return (
-    <SafeAreaView edges={{ bottom: Platform.OS === 'android', top:Platform.OS === 'android' }}>
+    <SafeAreaView
+      edges={{
+        bottom: Platform.OS === 'android',
+        top: Platform.OS === 'android',
+      }}
+    >
       <ScrollView testID={`${tabName}-scrollview`}>
         <Text style={styles.hint}>Scroll Screen — scroll down or re-tap the tab.</Text>
         {Array.from({ length: 50 }, (_, i) => (


### PR DESCRIPTION
## Description

The `test-tabs-special-effects-scroll-to-top` e2e test was failing on Android because the previous approach used a fixed-distance scroll on the ScrollView element directly, which is unreliable — Android does not guarantee the same scroll offset per unit distance as iOS, so the list might not scroll far enough to push `item-1` off screen. This PR switches the scroll calls to use a `waitFor(...).whileElement(...).scroll(...)` pattern that scrolls until a specific far-off item (`item-22`) becomes visible, making the scroll deterministic on both platforms.

Additionally, `SafeAreaView` from `react-native-screens/experimental` is wrapped around the `ScrollView` in the test screen component. This ensures the content is properly inset on Android (where system bars can otherwise occlude list items) and prevents the first item from being partially hidden behind navigation bars, which was causing false-positive visibility assertions.

Affected platform: Android (test reliability fix; iOS behavior unchanged).

## Changes

- **E2E / Tabs scroll-to-top test**: Replaced `element.scroll(300, 'down')` calls with a `scrollDown(targetId, scrollViewId)` helper that uses `waitFor().whileElement().scroll(500, 'down')` to scroll until `item-22` is visible — guarantees sufficient scroll depth on Android
- **Test screen component**: Wrapped `ScrollView` with `SafeAreaView` (from `react-native-screens/experimental`) and imported `Platform` to ensure content is correctly inset on Android, preventing system bars from occluding list items during the test