### PR TITLE
chore(Example): add SVM to SFT scenario groups

### DIFF
--- a/apps/src/tests/single-feature-tests/index.tsx
+++ b/apps/src/tests/single-feature-tests/index.tsx
@@ -10,6 +10,7 @@ import TabsScenarioGroup from './tabs';
 import SplitScenarioGroup from './split';
 import StackV5ScenarioGroup from './stack-v5';
 import StackV4ScenarioGroup from './stack-v4';
+import ScrollViewMarkerScenarioGroup from './scroll-view-marker';
 import { ScenarioButton } from '@apps/tests/shared/ScenarioButton';
 import ScenarioSelectionScreen from '@apps/tests/shared/ScenarioScreen';
 
@@ -18,6 +19,7 @@ export const COMPONENT_SCENARIOS = {
   Split: SplitScenarioGroup,
   StackV5: StackV5ScenarioGroup,
   StackV4: StackV4ScenarioGroup,
+  ScrollViewMarker: ScrollViewMarkerScenarioGroup,
 } as const;
 
 type ParamsList = { [k: keyof typeof COMPONENT_SCENARIOS]: undefined } & {
@@ -26,8 +28,9 @@ type ParamsList = { [k: keyof typeof COMPONENT_SCENARIOS]: undefined } & {
 
 function HomeScreen() {
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic"
-      testID="single-feature-tests-scrollview"> 
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      testID="single-feature-tests-scrollview">
       {Object.entries(COMPONENT_SCENARIOS).map(([key, scenarioGroup]) => (
         <ScenarioButton
           key={key}


### PR DESCRIPTION
## Description

Adds ScrollViewMarker's scenario group to SFT scenarios. It seems like we forgot to add it earlier.

## Changes

- add `ScrollViewMarkerScenarioGroup` to `COMPONENT_SCENARIOS`

## Before & after - visual documentation

N/A

## Test plan

Run example app, enter SVM scenario groups.

## Checklist

- [x] Ensured that CI passes
