### PR TITLE
feat(iOS, FormSheet v5): Add support for preventNativeDismiss & onNativeDismissPrevented

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -7,6 +7,7 @@ import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-u
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state-ios';
+import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss-ios';
 
 const scenarios = {
   TestFormSheetBase,
@@ -17,6 +18,7 @@ const scenarios = {
   TestFormSheetOnDetentChanged,
   TestFormSheetPreferredCornerRadius,
   TestFormSheetPresentationState,
+  TestFormSheetPreventNativeDismiss,
 };
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/index.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { Alert, Button, StyleSheet, Switch, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'PreventNativeDismiss',
+  key: 'test-form-sheet-prevent-native-dismiss-ios',
+  details:
+    'Allows testing the preventNativeDismiss property and firing the onNativeDismissPrevented event.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [preventDismiss, setPreventDismiss] = useState(true);
+
+  const handleDismissPrevented = () => {
+    Alert.alert(
+      'Dismissal Prevented',
+      'Native dismissal is currently disabled. Please use the button to close the sheet.',
+      [{ text: 'OK', style: 'cancel' }],
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>PreventNativeDismiss Test</Text>
+
+      <View style={styles.controls}>
+        <Text style={styles.statusText}>
+          Prevent Native Dismiss: {preventDismiss ? 'ON' : 'OFF'}
+        </Text>
+        <Switch
+          value={preventDismiss}
+          onValueChange={setPreventDismiss}
+          trackColor={{ true: Colors.GreenLight100, false: Colors.RedLight100 }}
+        />
+      </View>
+
+      <View style={styles.spacing} />
+
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        onNativeDismissPrevented={handleDismissPrevented}
+        detents={[0.5, 1.0]}
+        preventNativeDismiss={preventDismiss}>
+        <View style={styles.sheetContainer}>
+          <Text style={styles.sheetTitle}>FormSheet Content</Text>
+          <Text style={styles.instruction}>
+            {preventDismiss
+              ? 'Try swiping down or tapping the backdrop to dismiss. It should show an Alert.'
+              : 'Swipe down or tap the backdrop to dismiss. It should close without showing an Alert.'}
+          </Text>
+
+          <View style={styles.spacing} />
+
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.cardBackground,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.cardBorder,
+  },
+  statusText: {
+    fontSize: 16,
+    marginRight: 12,
+    color: Colors.text,
+  },
+  sheetContainer: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 16,
+    color: Colors.text,
+  },
+  instruction: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: Colors.NavyLight60,
+    paddingHorizontal: 20,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: preventNativeDismiss
+# Test Scenario: PreventNativeDismiss
 
 ## Details
 
@@ -13,10 +13,6 @@ Other: Planned, but will be implemented separately.
 ## Prerequisites
 
 - iOS device or simulator (iPhone)
-
-## Note
-
-- The default value of `preventNativeDismiss` is `false`.
 
 ## Steps
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
@@ -1,0 +1,81 @@
+# Test Scenario: preventNativeDismiss
+
+## Details
+
+**Description:** Verify the `preventNativeDismiss` property and the `onNativeDismissPrevented` event of the `FormSheet` component. This test ensures that when the property is set to `true`, the user cannot dismiss the sheet natively by swiping it down or tapping the backdrop behind the sheet. Instead, the sheet fires an event that displays an Alert. However, the user can still swipe between detents, and programmatic dismissals triggered by React state changes will still work. When set to `false`, the sheet can be dismissed natively without triggering the prevented event.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator (iPhone)
+
+## Note
+
+- The default value of `preventNativeDismiss` is `false`.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **PreventNativeDismiss** screen.
+
+- [ ] Expected: A status text indicating the current prop value (e.g., "Prevent Native Dismiss: ON"), a switch component, and an "Open FormSheet" button are shown.
+
+### Native Dismissal Prevented & Event Fired
+
+2. Ensure the switch is set to ON. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+
+3. Swipe up to expand the sheet to the maximum detent (1.0).
+
+- [ ] Expected: The sheet expands successfully. 
+
+4. Swipe down on the sheet to collapse it back to the lower detent (0.5).
+
+- [ ] Expected: The sheet collapses successfully.
+
+5. Swipe down on the sheet to attempt to dismiss it completely.
+
+- [ ] Expected: The FormSheet **does not** dismiss. It resists the gesture and bounces back to the 0.5 detent. An alert with the title "Dismissal Prevented" appears.
+
+6. Tap "OK" on the alert.
+
+- [ ] Expected: The alert closes and the FormSheet remains open.
+
+7. Tap the backdrop (the dimmed area behind/above the sheet).
+
+- [ ] Expected: The FormSheet **does not** dismiss. An alert with the title "Dismissal Prevented" appears again.
+
+8. Tap "OK" on the alert.
+
+- [ ] Expected: The alert closes and the FormSheet remains open.
+
+9. Tap the "Dismiss from JS" button.
+
+- [ ] Expected: The FormSheet dismisses successfully.
+
+### Native Dismissal Allowed
+
+10. Tap the switch component so the status reads "Prevent Native Dismiss: OFF".
+
+11. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+
+12. Swipe down on the sheet to attempt to dismiss it completely.
+
+- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
+
+13. Tap the "Open FormSheet" button again.
+
+- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+
+14. Tap the backdrop.
+
+- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
@@ -89,8 +89,6 @@
         preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : preferredCornerRadius;
     sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
   }];
-
-  controller.preventNativeDismiss = behaviorProvider.preventNativeDismiss;
 #endif // !TARGET_OS_TV
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
@@ -89,6 +89,8 @@
         preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : preferredCornerRadius;
     sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
   }];
+
+  controller.preventNativeDismiss = behaviorProvider.preventNativeDismiss;
 #endif // !TARGET_OS_TV
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sheetController:(RNSFormSheetContentController *)controller
     didChangeDetentIdentifier:(nullable NSString *)identifier;
 #endif // !TARGET_OS_TV
+- (void)sheetControllerDidPreventNativeDismiss:(RNSFormSheetContentController *)controller;
 @end
 
 @interface RNSFormSheetContentController : UIViewController
@@ -26,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<RNSFormSheetBehaviorProvider> behaviorProvider;
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
+
+@property (nonatomic, assign) BOOL preventNativeDismiss;
 
 #pragma mark - Presentation
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
-@property (nonatomic, assign) BOOL preventNativeDismiss;
-
 #pragma mark - Presentation
 
 - (void)prepareForPresentation;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -9,7 +9,7 @@
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 
-@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate
+@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate, UIGestureRecognizerDelegate
 #if !TARGET_OS_TV
                                              ,
                                              UISheetPresentationControllerDelegate
@@ -21,6 +21,8 @@
   RNSFormSheetUpdateCoordinator *_Nonnull _updateCoordinator;
   RNSFormSheetConfigurationApplicator *_Nonnull _configurationApplicator;
   RNSFormSheetPresentationManager *_Nonnull _presentationManager;
+
+  UITapGestureRecognizer *_Nullable _backdropTapGestureRecognizer;
 
   BOOL _needsInitialDetentReset;
 }
@@ -60,7 +62,13 @@
   [self.delegate sheetControllerViewDidLayoutSubviews:self];
 }
 
-#pragma mark - Presentation
+- (void)viewWillAppear:(BOOL)animated
+{
+  [super viewWillAppear:animated];
+  [self attachBackdropTapGestureRecognizer];
+}
+
+#pragma mark - Presentation Setup
 
 - (void)updatePresentationIfNeeded
 {
@@ -188,5 +196,66 @@
   [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
 }
 #endif // !TARGET_OS_TV
+
+#pragma mark - Backdrop tap handling
+
+- (void)attachBackdropTapGestureRecognizer
+{
+  UIPresentationController *presentationController = self.presentationController;
+  if (presentationController && presentationController.containerView && !_backdropTapGestureRecognizer) {
+    _backdropTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                            action:@selector(handleBackdropTap:)];
+    _backdropTapGestureRecognizer.delegate = self;
+    _backdropTapGestureRecognizer.cancelsTouchesInView = NO;
+    [presentationController.containerView addGestureRecognizer:_backdropTapGestureRecognizer];
+  }
+}
+
+- (void)detachBackdropTapGestureRecognizer
+{
+  [_backdropTapGestureRecognizer.view removeGestureRecognizer:_backdropTapGestureRecognizer];
+  _backdropTapGestureRecognizer = nil;
+}
+
+- (void)handleBackdropTap:(UITapGestureRecognizer *)gesture
+{
+  if (gesture.state == UIGestureRecognizerStateRecognized) {
+    if (_preventNativeDismiss) {
+      [self.delegate sheetControllerDidPreventNativeDismiss:self];
+    }
+  }
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+  if (gestureRecognizer == _backdropTapGestureRecognizer) {
+    // When native dismissal is not being prevented, this recognizer should not
+    // participate in handling touches to avoid interfering with UIKit.
+    if (!_preventNativeDismiss) {
+      return NO;
+    }
+
+    UIPresentationController *presentationController = self.presentationController;
+
+    // Ignore any touches that land inside the actual sheet content.
+    if (presentationController && presentationController.presentedView &&
+        [touch.view isDescendantOfView:presentationController.presentedView]) {
+      return NO;
+    }
+    return YES;
+  }
+  return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  if (gestureRecognizer == _backdropTapGestureRecognizer) {
+    return YES;
+  }
+  return NO;
+}
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -176,7 +176,7 @@
 
 - (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController
 {
-  if (self.preventNativeDismiss) {
+  if (_behaviorProvider.preventNativeDismiss) {
     return NO;
   }
   return YES;
@@ -227,7 +227,7 @@
 - (void)handleBackdropTap:(UITapGestureRecognizer *)gesture
 {
   if (gesture.state == UIGestureRecognizerStateRecognized) {
-    if (_preventNativeDismiss) {
+    if (_behaviorProvider.preventNativeDismiss) {
       [self.delegate sheetControllerDidPreventNativeDismiss:self];
     }
   }
@@ -240,7 +240,7 @@
   if (gestureRecognizer == _backdropTapGestureRecognizer) {
     // When native dismissal is not being prevented, this recognizer should not
     // participate in handling touches to avoid interfering with UIKit.
-    if (!_preventNativeDismiss) {
+    if (!_behaviorProvider.preventNativeDismiss) {
       return NO;
     }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -9,7 +9,8 @@
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 
-@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate, UIGestureRecognizerDelegate
+@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate,
+                                             UIGestureRecognizerDelegate
 #if !TARGET_OS_TV
                                              ,
                                              UISheetPresentationControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -159,6 +159,19 @@
 
 #pragma mark - UIAdaptivePresentationControllerDelegate
 
+- (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController
+{
+  if (self.preventNativeDismiss) {
+    return NO;
+  }
+  return YES;
+}
+
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)presentationController
+{
+  [self.delegate sheetControllerDidPreventNativeDismiss:self];
+}
+
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
   [_presentationManager handleNativeDismiss];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -69,6 +69,12 @@
   [self attachBackdropTapGestureRecognizer];
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+  [super viewDidDisappear:animated];
+  [self detachBackdropTapGestureRecognizer];
+}
+
 #pragma mark - Presentation Setup
 
 - (void)updatePresentationIfNeeded

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
 @property (nonatomic, readonly) NSInteger initialDetentIndex;
 @property (nonatomic, readonly) BOOL prefersScrollingExpandsWhenScrolledToEdge;
+@property (nonatomic, readonly) BOOL preventNativeDismiss;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -203,6 +203,11 @@ namespace react = facebook::react;
     [_controller setNeedsBehaviorUpdate];
   }
 
+  if (oldComponentProps.preventNativeDismiss != newComponentProps.preventNativeDismiss) {
+    _preventNativeDismiss = static_cast<BOOL>(newComponentProps.preventNativeDismiss);
+    [_controller setNeedsBehaviorUpdate];
+  }
+
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
     [_controller setNeedsAppearanceUpdate];
@@ -220,11 +225,6 @@ namespace react = facebook::react;
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
     _initialDetentIndex = newComponentProps.initialDetentIndex;
-  }
-
-  if (oldComponentProps.preventNativeDismiss != newComponentProps.preventNativeDismiss) {
-    _preventNativeDismiss = static_cast<BOOL>(newComponentProps.preventNativeDismiss);
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -36,6 +36,7 @@ namespace react = facebook::react;
   NSInteger _largestUndimmedDetentIndex;
   NSInteger _initialDetentIndex;
   BOOL _prefersScrollingExpandsWhenScrolledToEdge;
+  BOOL _preventNativeDismiss;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -67,6 +68,7 @@ namespace react = facebook::react;
   _largestUndimmedDetentIndex = kRNSFormSheetAlwaysDimmed;
   _initialDetentIndex = 0;
   _prefersScrollingExpandsWhenScrolledToEdge = YES;
+  _preventNativeDismiss = NO;
 }
 
 - (void)setupController
@@ -109,6 +111,11 @@ namespace react = facebook::react;
 {
   _isOpen = NO;
   [_reactEventEmitter emitOnNativeDismiss];
+}
+
+- (void)sheetControllerDidPreventNativeDismiss:(RNSFormSheetContentController *)controller
+{
+  [_reactEventEmitter emitOnNativeDismissPrevented];
 }
 
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller
@@ -213,6 +220,11 @@ namespace react = facebook::react;
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
     _initialDetentIndex = newComponentProps.initialDetentIndex;
+  }
+
+  if (oldComponentProps.preventNativeDismiss != newComponentProps.preventNativeDismiss) {
+    _preventNativeDismiss = static_cast<BOOL>(newComponentProps.preventNativeDismiss);
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSFormSheetHostEventEmitter : NSObject
 
 - (BOOL)emitOnNativeDismiss;
+- (BOOL)emitOnNativeDismissPrevented;
 #if !TARGET_OS_TV
 - (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index;
 #endif // !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
@@ -16,6 +16,17 @@
   }
 }
 
+- (BOOL)emitOnNativeDismissPrevented
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onNativeDismissPrevented({});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnNativeDismissPrevented event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 #if !TARGET_OS_TV
 - (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index
 {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 - (NSInteger)initialDetentIndex;
 - (BOOL)prefersScrollingExpandsWhenScrolledToEdge;
+- (BOOL)preventNativeDismiss;
 
 @end
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -100,7 +100,7 @@ export interface FormSheetProps {
    * @summary Prevents the user from dismissing the sheet natively by swiping down or tapping the backdrop.
    *
    * When set to `true`, the sheet will resist the swipe-down gesture and backdrop tap,
-   * remaining on the resting detent. Dismissal programmatically via `isOpen={false}` will still work.
+   * remaining on the resting detent. Programmatically dismissing the sheet via `isOpen={false}` will still work.
    *
    * @default false
    * @platform ios

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -99,7 +99,7 @@ export interface FormSheetProps {
   /**
    * @summary Prevents the user from dismissing the sheet natively by swiping down or tapping the backdrop.
    *
-   * When set to `true`, the sheet will resist the swipe-down gesture and backdrop tap
+   * When set to `true`, the sheet will resist the swipe-down gesture and backdrop tap,
    * remaining on the resting detent. Dismissal programmatically via `isOpen={false}` will still work.
    * The default value is `false`.
    *

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -96,6 +96,17 @@ export interface FormSheetProps {
    */
   prefersScrollingExpandsWhenScrolledToEdge?: boolean | undefined;
 
+  /**
+   * @summary Prevents the user from dismissing the sheet natively by swiping down or tapping the backdrop.
+   *
+   * When set to `true`, the sheet will resist the swipe-down gesture and backdrop tap
+   * remaining on the resting detent. Dismissal programmatically via `isOpen={false}` will still work.
+   * The default value is `false`.
+   *
+   * @platform ios
+   */
+  preventNativeDismiss?: boolean | undefined;
+
   // Events
   /**
    * @summary Called when the sheet is dismissed natively.
@@ -117,4 +128,15 @@ export interface FormSheetProps {
   onDetentChanged?:
     | ((e: NativeSyntheticEvent<FormSheetDetentChangedEvent>) => void)
     | undefined;
+
+  /**
+   * @summary Called when the user attempts to dismiss the sheet by swiping down or tapping the backdrop, but the dismissal is prevented.
+   *
+   * This event is only fired if `preventNativeDismiss` is set to `true`.
+   * It is useful for triggering custom feedback, such as an alert
+   * to inform the user why the sheet cannot be closed.
+   *
+   * @platform ios
+   */
+  onNativeDismissPrevented?: (() => void) | undefined;
 }

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -101,8 +101,8 @@ export interface FormSheetProps {
    *
    * When set to `true`, the sheet will resist the swipe-down gesture and backdrop tap,
    * remaining on the resting detent. Dismissal programmatically via `isOpen={false}` will still work.
-   * The default value is `false`.
    *
+   * @default false
    * @platform ios
    */
   preventNativeDismiss?: boolean | undefined;

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -21,8 +21,8 @@ interface NativeProps extends ViewProps {
   preventNativeDismiss?: CT.WithDefault<boolean, false>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onNativeDismissPrevented?:
-  | CT.DirectEventHandler<GenericEmptyEvent>
-  | undefined;
+    | CT.DirectEventHandler<GenericEmptyEvent>
+    | undefined;
   onDetentChanged?: CT.DirectEventHandler<DetentChangedEvent> | undefined;
 }
 

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -18,7 +18,11 @@ interface NativeProps extends ViewProps {
   largestUndimmedDetentIndex?: CT.WithDefault<CT.Int32, -1>;
   initialDetentIndex?: CT.WithDefault<CT.Int32, 0>;
   prefersScrollingExpandsWhenScrolledToEdge?: CT.WithDefault<boolean, true>;
+  preventNativeDismiss?: CT.WithDefault<boolean, false>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onNativeDismissPrevented?:
+  | CT.DirectEventHandler<GenericEmptyEvent>
+  | undefined;
   onDetentChanged?: CT.DirectEventHandler<DetentChangedEvent> | undefined;
 }
 


### PR DESCRIPTION
## Description

Adds `preventNativeDismiss` support. When `preventNativeDismiss` is `true`, the user cannot dismiss the sheet natively via swipe-down or by tapping the backdrop. Programmatic dismissal from JS still works.
When dismissal is prevented, the sheet emits a new `onNativeDismissPrevented` event so JS can react.

> [!NOTE]
> Backdrop taps need extra handling because UIKit doesn't fire delegate callbacks for this path. I follow the same approach as in https://github.com/software-mansion/react-native-screens/pull/3771 with attaching a `UITapGestureRecognizer` to the presentation controller's `containerView` and filter touches, so only taps outside `presentedView` are recognized. The recognizer is attached/detached in `viewWillAppear`/`viewDidDisappear`, because UIKit recreates the container view on every present cycle.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1272

## Changes

- `preventNativeDismiss` prop
- `onNativeDismissPrevented` event
- attached a `UITapGestureRecognizer` for backdrop taps.
- overriden delegate methods: `presentationControllerShouldDismiss` , `presentationControllerDidAttemptToDismiss`

## Visual documentation

<video src="https://github.com/user-attachments/assets/77132bc7-a9eb-4a2f-a8aa-ba626b5e7c05" />

## Test plan

Added a dedicated SFT in this PR

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
