### PR TITLE
chore(test): e2e tests for stale update rejection

### DIFF
--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
@@ -1,0 +1,152 @@
+import { device, expect, element, by } from 'detox';
+import { selectSingleFeatureTestsScreen } from '../../e2e-utils';
+
+async function dismissToast(message: string) {
+  await waitFor(element(by.label(message)))
+    .toBeVisible()
+    .withTimeout(3000);
+  await element(by.label(message)).tap();
+}
+
+// These scenarios are split into two separate suites using `device.reloadReactNative()`.
+// Running these scenarios sequentially within a single app lifecycle caused deterministic
+// failures in Detox that do not occur during manual testing.
+//
+// Incorrect behavior in Detox manifests as follows:
+// 1. If starting with `true` (Toast appears), switching to `false` fails to
+//    auto-select the Third tab after the heavy render; Second remains selected.
+// 2. If starting with `false` (Third is selected), switching to `true` fails
+//    to trigger the rejection Toast.
+//
+// To ensure both logic paths are verified correctly, the tests are divided into
+// separate runs with a full JS reload in between. No further effort was made
+// to fix these runtime state transitions in Detox.
+
+describe('Stale update rejection - rejectStaleNavStateUpdates:true', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Tabs',
+      'test-tabs-stale-update-rejection',
+    );
+  });
+
+  it('should display First tab with correct initial state', async () => {
+    await expect(element(by.id('First-route-key-label'))).toBeVisible();
+    await expect(element(by.id('First-heavy-render-label'))).toHaveText(
+      'heavyRender: false',
+    );
+    await expect(element(by.id('First-reject-stale-label'))).toHaveText(
+      'rejectStaleNavStateUpdates: true',
+    );
+  });
+
+  it('should navigate to Third tab and enable heavyRender', async () => {
+    await element(by.label('stale-rejection-tab-third-label')).tap();
+
+    await waitFor(element(by.id('Third-route-key-label')))
+      .toHaveLabel('Third')
+      .withTimeout(3000);
+
+    await expect(element(by.id('Third-heavy-render-label'))).toHaveText(
+      'heavyRender: false',
+    );
+
+    await element(by.id('Third-toggle-heavy-render')).tap();
+
+    await waitFor(element(by.id('Third-heavy-render-label')))
+      .toHaveText('heavyRender: true')
+      .withTimeout(6000);
+  });
+
+  it('should fire onTabSelectionRejected toast', async () => {
+    await waitFor(element(by.id('Third-reject-stale-label')))
+      .toHaveText('rejectStaleNavStateUpdates: true')
+      .withTimeout(3000);
+
+    await element(by.label('stale-rejection-tab-first-label')).tap();
+    await waitFor(element(by.id('First-route-key-label')))
+      .toHaveLabel('First')
+      .withTimeout(6000);
+
+    await device.disableSynchronization();
+
+    await element(by.id('First-select-third')).tap();
+
+    await element(by.label('stale-rejection-tab-second-label')).tap();
+
+    await device.enableSynchronization();
+
+    await waitFor(element(by.label('1. onTabSelectionRejected')))
+      .toBeVisible()
+      .withTimeout(20000);
+
+    await dismissToast('1. onTabSelectionRejected');
+
+    await expect(element(by.id('Second-route-key-label'))).toBeVisible();
+  });
+});
+
+describe('Stale update rejection - rejectStaleNavStateUpdates:false', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Tabs',
+      'test-tabs-stale-update-rejection',
+    );
+  });
+
+  it('should navigate to Third tab, enable heavyRender and disable rejectStaleNavStateUpdates', async () => {
+    await element(by.label('stale-rejection-tab-third-label')).tap();
+
+    await waitFor(element(by.id('Third-route-key-label')))
+      .toHaveLabel('Third')
+      .withTimeout(3000);
+
+    await expect(element(by.id('Third-heavy-render-label'))).toHaveText(
+      'heavyRender: false',
+    );
+
+    await element(by.id('Third-toggle-heavy-render')).tap();
+
+    await waitFor(element(by.id('Third-heavy-render-label')))
+      .toHaveText('heavyRender: true')
+      .withTimeout(6000);
+
+    await expect(element(by.id('Third-reject-stale-label'))).toHaveText(
+      'rejectStaleNavStateUpdates: true',
+    );
+    await element(by.id('Third-toggle-reject-stale')).tap();
+
+    await waitFor(element(by.id('Third-reject-stale-label')))
+      .toHaveText('rejectStaleNavStateUpdates: false')
+      .withTimeout(6000);
+  });
+
+  it('should NOT fire onTabSelectionRejected', async () => {
+    await waitFor(element(by.id('Third-reject-stale-label')))
+      .toHaveText('rejectStaleNavStateUpdates: false')
+      .withTimeout(3000);
+
+    await element(by.label('stale-rejection-tab-first-label')).tap();
+    await waitFor(element(by.id('First-route-key-label')))
+      .toHaveLabel('First')
+      .withTimeout(3000);
+
+    await device.disableSynchronization();
+
+    await element(by.id('First-select-third')).tap();
+
+    await element(by.label('stale-rejection-tab-second-label')).tap();
+
+    await device.enableSynchronization();
+
+    await waitFor(element(by.label('1. onTabSelectionRejected')))
+      .not.toBeVisible()
+      .withTimeout(8000);
+
+    await waitFor(element(by.id('Third-route-key-label')))
+      .toHaveLabel('Third')
+      .withTimeout(8000);
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
@@ -70,13 +70,13 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:true', () => {
       .withTimeout(6000);
 
     await device.disableSynchronization();
+    try {
+      await element(by.id('First-select-third')).tap();
 
-    await element(by.id('First-select-third')).tap();
-
-    await element(by.label('stale-rejection-tab-second-label')).tap();
-
-    await device.enableSynchronization();
-
+      await element(by.label('stale-rejection-tab-second-label')).tap();
+    } finally {
+      await device.enableSynchronization();
+    }
     await waitFor(element(by.label('1. onTabSelectionRejected: Third')))
       .toBeVisible()
       .withTimeout(20000);
@@ -134,13 +134,13 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:false', () => {
       .withTimeout(3000);
 
     await device.disableSynchronization();
+    try {
+      await element(by.id('First-select-third')).tap();
 
-    await element(by.id('First-select-third')).tap();
-
-    await element(by.label('stale-rejection-tab-second-label')).tap();
-
-    await device.enableSynchronization();
-
+      await element(by.label('stale-rejection-tab-second-label')).tap();
+    } finally {
+      await device.enableSynchronization();
+    }
     await waitFor(element(by.label('1. onTabSelectionRejected: Third')))
       .not.toBeVisible()
       .withTimeout(8000);

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
@@ -77,11 +77,11 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:true', () => {
 
     await device.enableSynchronization();
 
-    await waitFor(element(by.label('1. onTabSelectionRejected')))
+    await waitFor(element(by.label('1. onTabSelectionRejected: Third')))
       .toBeVisible()
       .withTimeout(20000);
 
-    await dismissToast('1. onTabSelectionRejected');
+    await dismissToast('1. onTabSelectionRejected: Third');
 
     await expect(element(by.id('Second-route-key-label'))).toBeVisible();
   });
@@ -141,7 +141,7 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:false', () => {
 
     await device.enableSynchronization();
 
-    await waitFor(element(by.label('1. onTabSelectionRejected')))
+    await waitFor(element(by.label('1. onTabSelectionRejected: Third')))
       .not.toBeVisible()
       .withTimeout(8000);
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
@@ -30,23 +30,31 @@ function ContentView() {
 
   return (
     <CenteredLayoutView>
-      <Text style={{ fontWeight: 'bold', textAlign: 'center' }}>
+      <Text
+        testID={`${routeKey}-route-key-label`}
+        style={{ fontWeight: 'bold', textAlign: 'center' }}>
         {routeKey}
       </Text>
-      <Text style={{ textAlign: 'center' }}>
+      <Text
+        testID={`${routeKey}-heavy-render-label`}
+        style={{ textAlign: 'center' }}>
         heavyRender: {JSON.stringify(heavyRenderEnabled)}
       </Text>
-      <Text style={{ textAlign: 'center' }}>
+      <Text
+        testID={`${routeKey}-reject-stale-label`}
+        style={{ textAlign: 'center' }}>
         rejectStaleNavStateUpdates:{' '}
         {JSON.stringify(hostConfig.rejectStaleNavStateUpdates)}
       </Text>
       <HeavyRenderHierarchy enabled={heavyRenderEnabled} timeMs={3000} />
       <TabsNavigationButtons />
       <Button
+        testID={`${routeKey}-toggle-heavy-render`}
         title="Toggle heavyRender"
         onPress={() => setHeavyRenderEnabled(prev => !prev)}
       />
       <Button
+        testID={`${routeKey}-toggle-reject-stale`}
         title="Toggle rejectStaleNavStateUpdates"
         onPress={() =>
           updateHostConfig({
@@ -60,13 +68,30 @@ function ContentView() {
 
 function TabsNavigationButtons() {
   const nav = useTabsNavigationContext();
+  const { routeKey } = useTabsNavigationContext();
 
   return (
     <View>
-      <Button title="Select First" onPress={() => nav.selectTab('First')} />
-      <Button title="Select Second" onPress={() => nav.selectTab('Second')} />
-      <Button title="Select Third" onPress={() => nav.selectTab('Third')} />
-      <Button title="Select Fourth" onPress={() => nav.selectTab('Fourth')} />
+      <Button
+        testID={`${routeKey}-select-first`}
+        title="Select First"
+        onPress={() => nav.selectTab('First')}
+      />
+      <Button
+        testID={`${routeKey}-select-second`}
+        title="Select Second"
+        onPress={() => nav.selectTab('Second')}
+      />
+      <Button
+        testID={`${routeKey}-select-third`}
+        title="Select Third"
+        onPress={() => nav.selectTab('Third')}
+      />
+      <Button
+        testID={`${routeKey}-select-fourth`}
+        title="Select Fourth"
+        onPress={() => nav.selectTab('Fourth')}
+      />
     </View>
   );
 }
@@ -75,22 +100,42 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
     Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'First',
+      tabBarItemTestID: 'stale-rejection-tab-first',
+      tabBarItemAccessibilityLabel: 'stale-rejection-tab-first-label',
+    },
   },
   {
     name: 'Second',
     Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Second',
+      tabBarItemTestID: 'stale-rejection-tab-second',
+      tabBarItemAccessibilityLabel: 'stale-rejection-tab-second-label',
+    },
   },
   {
     name: 'Third',
     Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Third',
+      tabBarItemTestID: 'stale-rejection-tab-third',
+      tabBarItemAccessibilityLabel: 'stale-rejection-tab-third-label',
+    },
   },
   {
     name: 'Fourth',
     Component: ContentView,
-    options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Fourth',
+      tabBarItemTestID: 'stale-rejection-tab-fourth',
+      tabBarItemAccessibilityLabel: 'stale-rejection-tab-fourth-label',
+    },
   },
 ];
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
@@ -67,30 +67,29 @@ function ContentView() {
 }
 
 function TabsNavigationButtons() {
-  const nav = useTabsNavigationContext();
-  const { routeKey } = useTabsNavigationContext();
+  const { routeKey, selectTab } = useTabsNavigationContext();
 
   return (
     <View>
       <Button
         testID={`${routeKey}-select-first`}
         title="Select First"
-        onPress={() => nav.selectTab('First')}
+        onPress={() => selectTab('First')}
       />
       <Button
         testID={`${routeKey}-select-second`}
         title="Select Second"
-        onPress={() => nav.selectTab('Second')}
+        onPress={() => selectTab('Second')}
       />
       <Button
         testID={`${routeKey}-select-third`}
         title="Select Third"
-        onPress={() => nav.selectTab('Third')}
+        onPress={() => selectTab('Third')}
       />
       <Button
         testID={`${routeKey}-select-fourth`}
         title="Select Fourth"
-        onPress={() => nav.selectTab('Fourth')}
+        onPress={() => selectTab('Fourth')}
       />
     </View>
   );

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
@@ -68,7 +68,7 @@ Ensure the app's behavior strictly matches the expected results at each transiti
 
 - [ ] Expected: The tab bar changes to **Second** immediately. After
   the heavy render on Third finishes, a toast labeled
-  `onTabSelectionRejected` appears. The final active tab is
+  `onTabSelectionRejected: Third` appears. The final active tab is
   **Second**, not Third.
 
 ---
@@ -96,5 +96,5 @@ Ensure the app's behavior strictly matches the expected results at each transiti
 
 - [ ] Expected: The tab bar changes to **Second** immediately. After
   the heavy render on Third finishes, a toast labeled
-  `onTabSelectionRejected` appears. The final active tab is
+  `onTabSelectionRejected: Third` appears. The final active tab is
   **Second**, not Third.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
@@ -14,7 +14,14 @@ was committed before the JS update reached the UI thread. Each rejection fires
 
 ## E2E test
 
-Other: Planned, but will be implemented separately after research.
+Yes, partially. Steps 1–3 (rejectStaleNavStateUpdates:true) and steps 4–5
+(rejectStaleNavStateUpdates:false) are covered as separate test suites,
+each preceded by a reloadReactNative to guarantee a clean baseline.
+Not covered:
+Testing changes to rejectStaleNavStateUpdates within the same session - including
+switching from false back to true - is not automated. Due to inconsistent behavior
+in Detox when toggling this setting at runtime, the only reliable way to verify
+the logic for both states is to restart the app between tests.
 
 ## Prerequisites
 
@@ -28,6 +35,12 @@ Other: Planned, but will be implemented separately after research.
 - `heavyRender` is per-tab state. Toggling it on a given tab blocks the
   JS thread for 3 000 ms on every render of that tab, simulating a slow
   update that can arrive after the user has already acted.
+- Runtime State Changes (Steps 5–7): Automated coverage is limited to fresh app
+launches. Testing the transition from true to false and back to true mid-session
+(starting at Step 5) must be done manually.
+Attention: Because of the 3000ms "heavy render" window, these steps are highly
+sensitive to timing. If the interaction is too slow, you will get a false pass.
+Ensure the app's behavior strictly matches the expected results at each transition.
 
 ## Steps
 


### PR DESCRIPTION
## Description

This PR adds automated Detox e2e tests for the `rejectStaleNavStateUpdates` prop on `TabsHost` and the `onTabSelectionRejected` callback, covering the race condition scenario where a slow JS render races against a user tap. Two describe suites are included: one verifying that `onTabSelectionRejected` fires when rejection is enabled, and one confirming no rejection fires (and the slower update wins) when the prop is disabled at runtime. The scenario screen (`test-tabs-stale-update-rejection`) is instrumented with `testID`, `accessibilityLabel`, `tabBarItemTestID`, and `tabBarItemAccessibilityLabel` props throughout so that Detox selectors are stable and unambiguous. `scenario.md` is updated to reflect that E2E coverage now exists (previously marked as planned). This PR depends on #4019, which restructured the scenario screen into a directory module - it should be merged after that PR lands.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1458

## Changes

- **FabricExample/e2e**: Added `test-tabs-stale-update-rejection.e2e.ts` with two Detox describe suites covering `rejectStaleNavStateUpdates: true` (rejection fires) and `rejectStaleNavStateUpdates: false` (rejection suppressed, stale update wins)
- **Tests/Tabs**: Instrumented `ContentView` text labels and buttons with `testID` props (e.g. `${routeKey}-route-key-label`, `${routeKey}-toggle-heavy-render`) for reliable Detox queries
- **Tests/Tabs**: Added `tabBarItemTestID` and `tabBarItemAccessibilityLabel` to all four `ROUTE_CONFIGS` entries to enable tab bar tap targeting in tests
- **Tests/Tabs**: Updated `scenario.md` E2E section from "Planned" to reflect actual coverage, noting step 7 and the final-tab assertion with rejection disabled remain manual-only