### PR TITLE
refactor(test): emulator set to pixel 8 

### DIFF
--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_9
+          profile: pixel_8
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false
@@ -110,7 +110,7 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_9
+          profile: pixel_8
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false


### PR DESCRIPTION
## Description

Pixel 8 is latest supported emulator/device for api level 34. As we are currently no update api level to 36 due to problem with test on stack v4 after changing OnBackPressedDispatcher settings https://github.com/software-mansion/react-native-screens-labs/issues/1459 we need to use emulator for api level 34. 

It will be updated to pixel9 (or newer) when we will change API level for tests.

## Changes

Emulator in workflow updated to Pixel 8.