### PR TITLE
feat(iOS, FormSheet v5): Add onDetentChanged event

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -4,6 +4,7 @@ import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index-ios';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
+import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 
 const scenarios = {
@@ -12,6 +13,7 @@ const scenarios = {
   TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,
+  TestFormSheetOnDetentChanged,
   TestFormSheetPreferredCornerRadius,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/index.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const scenarioDescription: ScenarioDescription = {
+  name: 'OnDetentChanged',
+  key: 'test-form-sheet-on-detent-changed-ios',
+  details:
+    'Allows testing the onDetentChanged event, verifying that the correct detent index is reported when swiping.',
+  platforms: ['ios'],
+};
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [detentIndex, setDetentIndex] = useState<number>(0);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+    setDetentIndex(0);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>onDetentChanged Test</Text>
+
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={handleOpen}
+      />
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={handleClose}
+        detents={[0.4, 0.7, 1.0]}
+        onDetentChanged={e => setDetentIndex(e.nativeEvent.index)}>
+        <View style={styles.sheetContainer}>
+          <Text style={styles.sheetTitle}>FormSheet Content</Text>
+
+          <View style={styles.stateCard}>
+            <Text style={styles.instruction}>Active Index</Text>
+            <Text style={styles.hugeText}>{detentIndex}</Text>
+          </View>
+
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={handleClose}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  sheetContainer: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 24,
+    color: Colors.text,
+  },
+  stateCard: {
+    backgroundColor: Colors.NavyLight10,
+    padding: 24,
+    borderRadius: 16,
+    alignItems: 'center',
+    marginBottom: 24,
+    width: '80%',
+  },
+  hugeText: {
+    fontSize: 40,
+    fontWeight: 'bold',
+    color: Colors.NavyDark140,
+  },
+  instruction: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: Colors.NavyLight60,
+    paddingHorizontal: 20,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/scenario.md
@@ -1,0 +1,45 @@
+# Test Scenario: onDetentChanged
+
+## Details
+
+**Description:** Verify the `onDetentChanged` event of the `FormSheet` component. This test ensures that when the user manually drags the sheet between multiple configured detents, the event is fired and accurately reports the array index of the newly settled detent.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator (iPhone)
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **OnDetentChanged** screen.
+
+- [ ] Expected: A status text "Current Detent Index: 0" and an "Open FormSheet" button are shown.
+
+### Track Detent Changes
+
+2. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens at the smallest initial detent (0.4). The textbox inside the sheet displays `0`.
+
+3. Grab the drag indicator and swipe up until the sheet snaps to the middle detent (0.7).
+
+- [ ] Expected: The sheet settles in the middle of the screen. The textbox inside the sheet updates to `1`.
+
+4. Swipe up again to expand the sheet to the maximum detent (1.0).
+
+- [ ] Expected: The sheet expands to fill the available screen height. The textbox inside the sheet updates to `2`.
+
+5. Swipe down to collapse the sheet back to the smallest detent (0.4).
+
+- [ ] Expected: The sheet shrinks back to the smallest size. The textbox inside the sheet updates back to `0`.
+
+6. Tap the "Dismiss from JS" button or swipe the sheet all the way down to dismiss it.
+
+- [ ] Expected: The FormSheet dismisses successfully.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol RNSFormSheetContentControllerDelegate <NSObject>
 - (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller;
+- (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier;
 @end
 
 @interface RNSFormSheetContentController : UIViewController

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -11,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller;
 #if !TARGET_OS_TV
-- (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier;
+- (void)sheetController:(RNSFormSheetContentController *)controller
+    didChangeDetentIdentifier:(nullable NSString *)identifier;
 #endif // !TARGET_OS_TV
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -10,7 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol RNSFormSheetContentControllerDelegate <NSObject>
 - (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller;
+#if !TARGET_OS_TV
 - (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier;
+#endif // !TARGET_OS_TV
 @end
 
 @interface RNSFormSheetContentController : UIViewController

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -3,8 +3,12 @@
 
 #import <React/RCTAssert.h>
 
-@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate,
-                                             UISheetPresentationControllerDelegate>
+@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate
+#if !TARGET_OS_TV
+                                             ,
+                                             UISheetPresentationControllerDelegate
+#endif // !TARGET_OS_TV
+                                             >
 @end
 
 @implementation RNSFormSheetContentController
@@ -38,7 +42,9 @@
   // The presentation controller is recreated by UIKit on every present/dismiss cycle.
   // We must assign this delegate before actual presentation
   self.presentationController.delegate = self;
+#if !TARGET_OS_TV
   self.sheetPresentationController.delegate = self;
+#endif // !TARGET_OS_TV
 }
 
 - (void)viewDidLayoutSubviews
@@ -55,6 +61,7 @@
   [self.delegate sheetControllerDidNativeDismiss:self];
 }
 
+#if !TARGET_OS_TV
 #pragma mark - UISheetPresentationControllerDelegate
 
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
@@ -62,5 +69,6 @@
 {
   [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
 }
+#endif // !TARGET_OS_TV
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -60,9 +60,7 @@
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
     (UISheetPresentationController *)sheetPresentationController
 {
-  if ([self.delegate respondsToSelector:@selector(sheetController:didChangeDetentIdentifier:)]) {
-    [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
-  }
+  [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
 }
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -3,7 +3,8 @@
 
 #import <React/RCTAssert.h>
 
-@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate>
+@interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate,
+                                             UISheetPresentationControllerDelegate>
 @end
 
 @implementation RNSFormSheetContentController
@@ -37,6 +38,7 @@
   // The presentation controller is recreated by UIKit on every present/dismiss cycle.
   // We must assign this delegate before actual presentation
   self.presentationController.delegate = self;
+  self.sheetPresentationController.delegate = self;
 }
 
 - (void)viewDidLayoutSubviews
@@ -51,6 +53,16 @@
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
   [self.delegate sheetControllerDidNativeDismiss:self];
+}
+
+#pragma mark - UISheetPresentationControllerDelegate
+
+- (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
+    (UISheetPresentationController *)sheetPresentationController
+{
+  if ([self.delegate respondsToSelector:@selector(sheetController:didChangeDetentIdentifier:)]) {
+    [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
+  }
 }
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
@@ -34,6 +34,13 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 #endif // !TARGET_OS_TV
 
+#if !TARGET_OS_TV && defined(__cplusplus)
+
++ (NSInteger)detentIndexFromDetentIdentifier:(nullable UISheetPresentationControllerDetentIdentifier)identifier
+                               forRawDetents:(const std::vector<double> &)detents;
+
+#endif // !TARGET_OS_TV && __cplusplus
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -158,7 +158,7 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
                                forRawDetents:(const std::vector<double> &)detents
 {
   if (identifier == nil) {
-    return 0;
+    return -1;
   }
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -154,6 +154,32 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
   }
 }
 
++ (NSInteger)detentIndexFromDetentIdentifier:(nullable UISheetPresentationControllerDetentIdentifier)identifier
+                               forRawDetents:(const std::vector<double> &)detents
+{
+  if (identifier == nil) {
+    return 0;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    if (!detents.empty()) {
+      return [identifier integerValue];
+    }
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+
+  // Legacy Fallback for iOS 15 or when no custom detents are provided -
+  // mirroring buildSheetDetentsForFractions:
+  if ([identifier isEqualToString:UISheetPresentationControllerDetentIdentifierMedium]) {
+    return 0;
+  } else if ([identifier isEqualToString:UISheetPresentationControllerDetentIdentifierLarge]) {
+    return detents.size() > 1 ? 1 : 0;
+  }
+
+  return 0;
+}
+
 @end
 
 #endif // !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -140,6 +140,14 @@ namespace react = facebook::react;
   [self syncShadowNodeState];
 }
 
+- (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier
+{
+#if !TARGET_OS_TV
+  NSInteger index = [self detentIndexFromDetentIdentifier:identifier];
+  [_reactEventEmitter emitOnDetentChangedWithIndex:index];
+#endif
+}
+
 #pragma mark - RCTComponentViewProtocol
 
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -145,7 +145,9 @@ namespace react = facebook::react;
     didChangeDetentIdentifier:(nullable NSString *)identifier
 {
   NSInteger index = [RNSFormSheetDetentResolver detentIndexFromDetentIdentifier:identifier forRawDetents:_detents];
-  [_reactEventEmitter emitOnDetentChangedWithIndex:index];
+  if (index >= 0) {
+    [_reactEventEmitter emitOnDetentChangedWithIndex:index];
+  }
 }
 #endif // !TARGET_OS_TV
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -140,13 +140,13 @@ namespace react = facebook::react;
   [self syncShadowNodeState];
 }
 
+#if !TARGET_OS_TV
 - (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier
 {
-#if !TARGET_OS_TV
   NSInteger index = [self detentIndexFromDetentIdentifier:identifier];
   [_reactEventEmitter emitOnDetentChangedWithIndex:index];
-#endif
 }
+#endif // !TARGET_OS_TV
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -141,7 +141,8 @@ namespace react = facebook::react;
 }
 
 #if !TARGET_OS_TV
-- (void)sheetController:(RNSFormSheetContentController *)controller didChangeDetentIdentifier:(NSString *)identifier
+- (void)sheetController:(RNSFormSheetContentController *)controller
+    didChangeDetentIdentifier:(nullable NSString *)identifier
 {
   NSInteger index = [self detentIndexFromDetentIdentifier:identifier];
   [_reactEventEmitter emitOnDetentChangedWithIndex:index];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -144,7 +144,7 @@ namespace react = facebook::react;
 - (void)sheetController:(RNSFormSheetContentController *)controller
     didChangeDetentIdentifier:(nullable NSString *)identifier
 {
-  NSInteger index = [self detentIndexFromDetentIdentifier:identifier];
+  NSInteger index = [RNSFormSheetDetentResolver detentIndexFromDetentIdentifier:identifier forRawDetents:_detents];
   [_reactEventEmitter emitOnDetentChangedWithIndex:index];
 }
 #endif // !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
@@ -14,7 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSFormSheetHostEventEmitter : NSObject
 
 - (BOOL)emitOnNativeDismiss;
+#if !TARGET_OS_TV
 - (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index;
+#endif // !TARGET_OS_TV
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSFormSheetHostEventEmitter : NSObject
 
 - (BOOL)emitOnNativeDismiss;
+- (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
@@ -16,6 +16,17 @@
   }
 }
 
+- (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onDetentChanged({.index = static_cast<int>(index)});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnDetentChanged event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 - (void)updateEventEmitter:(const std::shared_ptr<const react::RNSFormSheetHostEventEmitter> &)emitter
 {
   _reactEventEmitter = emitter;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
@@ -16,6 +16,7 @@
   }
 }
 
+#if !TARGET_OS_TV
 - (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index
 {
   if (_reactEventEmitter != nullptr) {
@@ -26,6 +27,7 @@
     return NO;
   }
 }
+#endif // !TARGET_OS_TV
 
 - (void)updateEventEmitter:(const std::shared_ptr<const react::RNSFormSheetHostEventEmitter> &)emitter
 {

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -1,5 +1,9 @@
 import { ViewProps } from 'react-native';
 
+export interface FormSheetDetentChangedEvent {
+  index: number;
+}
+
 export interface FormSheetProps {
   children?: ViewProps['children'] | undefined;
 
@@ -95,4 +99,15 @@ export interface FormSheetProps {
    * @platform ios
    */
   onNativeDismiss?: (() => void) | undefined;
+
+  /**
+   * @summary Called when the sheet settles at a new detent.
+   *
+   * Provides the `index` of the newly selected detent from the `detents` array.
+   *
+   * @platform ios
+   */
+  onDetentChanged?:
+    | ((event: { nativeEvent: FormSheetDetentChangedEvent }) => void)
+    | undefined;
 }

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -1,4 +1,4 @@
-import { ViewProps } from 'react-native';
+import { NativeSyntheticEvent, ViewProps } from 'react-native';
 
 export interface FormSheetDetentChangedEvent {
   index: number;
@@ -108,6 +108,6 @@ export interface FormSheetProps {
    * @platform ios
    */
   onDetentChanged?:
-    | ((event: { nativeEvent: FormSheetDetentChangedEvent }) => void)
+    | ((e: NativeSyntheticEvent<FormSheetDetentChangedEvent>) => void)
     | undefined;
 }

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -1,4 +1,4 @@
-import { NativeSyntheticEvent, ViewProps } from 'react-native';
+import type { NativeSyntheticEvent, ViewProps } from 'react-native';
 
 export interface FormSheetDetentChangedEvent {
   index: number;

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -6,6 +6,10 @@ import { codegenNativeComponent } from 'react-native';
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;
 
+type DetentChangedEvent = Readonly<{
+  index: CT.Int32;
+}>;
+
 interface NativeProps extends ViewProps {
   isOpen?: CT.WithDefault<boolean, false>;
   detents?: CT.Double[] | undefined;
@@ -15,6 +19,7 @@ interface NativeProps extends ViewProps {
   initialDetentIndex?: CT.WithDefault<CT.Int32, 0>;
   prefersScrollingExpandsWhenScrolledToEdge?: CT.WithDefault<boolean, true>;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onDetentChanged?: CT.DirectEventHandler<DetentChangedEvent> | undefined;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSFormSheetHost', {


### PR DESCRIPTION
## Description

Adding a callback that gets invoked when the FormSheet's detent has changed.

> [!NOTE]  
> As for now, I'm making it functional, to have a base for testing, before making the planned refactor for moving out some logic from the Host.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1270

## Changes

- Updated codegen spec
- Updated JS types
- Overridden `sheetPresentationControllerDidChangeSelectedDetentIdentifier:sheetPresentationController` callback from `UISheetPresentationControllerDelegate`

## Before & after - visual documentation

| iOS 15 | iOS 18 | iOS 26 |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/4fecda4f-a21c-4016-8f07-60c4580068fe" /> | <video src="https://github.com/user-attachments/assets/05c5976d-2a67-4ac4-aff2-49871f6da9ad" /> | <video src="https://github.com/user-attachments/assets/e046ea34-c581-4862-9b10-609268e52004" /> |

## Test plan

Added a dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
