### PR TITLE
refactor(test): update afterAll for e2e test-tabs-tab-bar-layout-direction

### DIFF
--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -155,11 +155,16 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
           .toHaveLabel('forceRTL: true')
           .withTimeout(3000);
       } finally {
-        const label = await element(
+        const attrs = await element(
           by.id('react-force-rtl-picker'),
         ).getAttributes();
-        if ((label as any).label === 'forceRTL: true') {
+        const currentLabel =
+          'elements' in attrs ? attrs.elements[0]?.label : attrs.label;
+        if (currentLabel === 'forceRTL: true') {
           await element(by.id('react-force-rtl-picker')).tap();
+          await waitFor(element(by.id('react-force-rtl-picker')))
+            .toHaveLabel('forceRTL: false')
+            .withTimeout(3000);
         }
         await device.reloadReactNative();
       }

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -45,6 +45,13 @@ async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
   }
 }
 
+async function launchAppWithAttributes(launchArgs?: Record<string, any>) {
+  await device.launchApp({
+    newInstance: true,
+    ...(launchArgs && { launchArgs }),
+  });
+}
+
 describe('Tab Bar Layout Direction - system settings: LTR', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -137,10 +144,15 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
   });
 
   afterAll(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
-    await device.reloadReactNative();
+    if (device.getPlatform() === 'ios') {
+      await launchAppWithAttributes({
+        AppleTextDirection: 'NO',
+        NSForceRightToLeftWritingDirection: 'NO',
+        I18NIsRTL: 'NO',
+      });
+    } else {
+      await launchAppWithAttributes();
+    }
   });
 
   it('displays default options and renders Tab2 at the visually leftmost position (RTL)', async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -137,41 +137,10 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
   });
 
   afterAll(async () => {
-    if (device.getPlatform() === 'ios') {
-      await device.launchApp({
-        newInstance: true,
-        launchArgs: {
-          AppleTextDirection: 'NO',
-          NSForceRightToLeftWritingDirection: 'NO',
-          I18NIsRTL: 'NO',
-        },
-      });
-    } else {
-      await device.launchApp({ newInstance: true });
-      await selectSingleFeatureTestsScreen(
-        'Tabs',
-        'test-tabs-tab-bar-layout-direction',
-      );
-      try {
-        await element(by.id('react-force-rtl-picker')).tap();
-        await waitFor(element(by.id('react-force-rtl-picker')))
-          .toHaveLabel('forceRTL: true')
-          .withTimeout(3000);
-      } finally {
-        const attrs = await element(
-          by.id('react-force-rtl-picker'),
-        ).getAttributes();
-        const currentLabel =
-          'elements' in attrs ? attrs.elements[0]?.label : attrs.label;
-        if (currentLabel === 'forceRTL: true') {
-          await element(by.id('react-force-rtl-picker')).tap();
-          await waitFor(element(by.id('react-force-rtl-picker')))
-            .toHaveLabel('forceRTL: false')
-            .withTimeout(3000);
-        }
-        await device.reloadReactNative();
-      }
-    }
+    await device.launchApp({
+      newInstance: true,
+    });
+    await device.reloadReactNative();
   });
 
   it('displays default options and renders Tab2 at the visually leftmost position (RTL)', async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -45,13 +45,6 @@ async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
   }
 }
 
-async function launchAppWithAttributes(launchArgs?: Record<string, any>) {
-  await device.launchApp({
-    newInstance: true,
-    ...(launchArgs && { launchArgs }),
-  });
-}
-
 describe('Tab Bar Layout Direction - system settings: LTR', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -132,6 +125,9 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
         'test-tabs-tab-bar-layout-direction',
       );
       await element(by.id('react-force-rtl-picker')).tap();
+      await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
+        'forceRTL: true',
+      );
       await device.reloadReactNative();
     }
     await selectSingleFeatureTestsScreen(
@@ -141,16 +137,10 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
   });
 
   afterAll(async () => {
-    if (device.getPlatform() === 'ios') {
-      await launchAppWithAttributes({
-        AppleTextDirection: 'NO',
-        NSForceRightToLeftWritingDirection: 'NO',
-        I18NIsRTL: 'NO',
-      });
-    } else {
-      await launchAppWithAttributes();
-      await device.reloadReactNative();
-    }
+    await device.launchApp({
+      newInstance: true,
+    });
+    await device.reloadReactNative();
   });
 
   it('displays default options and renders Tab2 at the visually leftmost position (RTL)', async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -137,9 +137,6 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
   });
 
   afterAll(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
     await device.reloadReactNative();
   });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -45,67 +45,67 @@ async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
   }
 }
 
-describe('Tab Bar Layout Direction - system settings: LTR', () => {
-  beforeEach(async () => {
-    await device.reloadReactNative();
-    await selectSingleFeatureTestsScreen(
-      'Tabs',
-      'test-tabs-tab-bar-layout-direction',
-    );
-  });
+// describe('Tab Bar Layout Direction - system settings: LTR', () => {
+//   beforeEach(async () => {
+//     await device.reloadReactNative();
+//     await selectSingleFeatureTestsScreen(
+//       'Tabs',
+//       'test-tabs-tab-bar-layout-direction',
+//     );
+//   });
 
-  it('displays default options and renders Tab1 at the visually leftmost position (LTR)', async () => {
-    await expect(
-      element(by.id('tab-bar-layout-direction-scrollview')),
-    ).toBeVisible();
-    await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
-      'forceRTL: false',
-    );
-    await expect(element(by.id('react-allow-rtl-picker'))).toHaveLabel(
-      'allowRTL: true',
-    );
-    await scrollTo({ id: 'tab-bar-layout-direction-picker' });
-    await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
-      'direction: inherit',
-    );
-    await expect(element(by.id('is-rtl-information'))).toHaveText(
-      'I18nManager.isRTL == false',
-    );
-    await expectTab1ToBeLeftOfTab2(true);
-  });
+//   it('displays default options and renders Tab1 at the visually leftmost position (LTR)', async () => {
+//     await expect(
+//       element(by.id('tab-bar-layout-direction-scrollview')),
+//     ).toBeVisible();
+//     await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
+//       'forceRTL: false',
+//     );
+//     await expect(element(by.id('react-allow-rtl-picker'))).toHaveLabel(
+//       'allowRTL: true',
+//     );
+//     await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+//     await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
+//       'direction: inherit',
+//     );
+//     await expect(element(by.id('is-rtl-information'))).toHaveText(
+//       'I18nManager.isRTL == false',
+//     );
+//     await expectTab1ToBeLeftOfTab2(true);
+//   });
 
-  it('follows system LTR settings when direction is set to inherit', async () => {
-    await selectDirection('inherit');
-    await expectTab1ToBeLeftOfTab2(true);
-  });
+//   it('follows system LTR settings when direction is set to inherit', async () => {
+//     await selectDirection('inherit');
+//     await expectTab1ToBeLeftOfTab2(true);
+//   });
 
-  it('overrides system LTR settings and renders the tab bar in RTL order', async () => {
-    await selectDirection('rtl');
-    await expectTab1ToBeLeftOfTab2(false);
-  });
+//   it('overrides system LTR settings and renders the tab bar in RTL order', async () => {
+//     await selectDirection('rtl');
+//     await expectTab1ToBeLeftOfTab2(false);
+//   });
 
-  it('remains in LTR order when direction is explicitly set to ltr', async () => {
-    await selectDirection('ltr');
-    await expectTab1ToBeLeftOfTab2(true);
-  });
+//   it('remains in LTR order when direction is explicitly set to ltr', async () => {
+//     await selectDirection('ltr');
+//     await expectTab1ToBeLeftOfTab2(true);
+//   });
 
-  it('cycle through inherit → rtl → ltr → rtl → inherit renders the tab bar in correct order', async () => {
-    await selectDirection('inherit');
-    await expectTab1ToBeLeftOfTab2(true);
+//   it('cycle through inherit → rtl → ltr → rtl → inherit renders the tab bar in correct order', async () => {
+//     await selectDirection('inherit');
+//     await expectTab1ToBeLeftOfTab2(true);
 
-    await selectDirection('rtl');
-    await expectTab1ToBeLeftOfTab2(false);
+//     await selectDirection('rtl');
+//     await expectTab1ToBeLeftOfTab2(false);
 
-    await selectDirection('ltr');
-    await expectTab1ToBeLeftOfTab2(true);
+//     await selectDirection('ltr');
+//     await expectTab1ToBeLeftOfTab2(true);
 
-    await selectDirection('rtl');
-    await expectTab1ToBeLeftOfTab2(false);
+//     await selectDirection('rtl');
+//     await expectTab1ToBeLeftOfTab2(false);
 
-    await selectDirection('inherit');
-    await expectTab1ToBeLeftOfTab2(true);
-  });
-});
+//     await selectDirection('inherit');
+//     await expectTab1ToBeLeftOfTab2(true);
+//   });
+// });
 
 describe('Tab Bar Layout Direction - system settings: RTL', () => {
   beforeAll(async () => {
@@ -149,11 +149,20 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
         'Tabs',
         'test-tabs-tab-bar-layout-direction',
       );
-      await element(by.id('react-force-rtl-picker')).multiTap(2);
-      await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
-        'forceRTL: false',
-      );
-      await device.reloadReactNative();
+      try {
+        await element(by.id('react-force-rtl-picker')).tap();
+        await waitFor(element(by.id('react-force-rtl-picker')))
+          .toHaveLabel('forceRTL: true')
+          .withTimeout(3000);
+      } finally {
+        const label = await element(
+          by.id('react-force-rtl-picker'),
+        ).getAttributes();
+        if ((label as any).label === 'forceRTL: true') {
+          await element(by.id('react-force-rtl-picker')).tap();
+        }
+        await device.reloadReactNative();
+      }
     }
   });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -45,6 +45,13 @@ async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
   }
 }
 
+async function launchAppWithAttributes(launchArgs?: Record<string, any>) {
+  await device.launchApp({
+    newInstance: true,
+    ...(launchArgs && { launchArgs }),
+  });
+}
+
 describe('Tab Bar Layout Direction - system settings: LTR', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
@@ -135,39 +142,14 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
 
   afterAll(async () => {
     if (device.getPlatform() === 'ios') {
-      await device.launchApp({
-        newInstance: true,
-        launchArgs: {
-          AppleTextDirection: 'NO',
-          NSForceRightToLeftWritingDirection: 'NO',
-          I18NIsRTL: 'NO',
-        },
+      await launchAppWithAttributes({
+        AppleTextDirection: 'NO',
+        NSForceRightToLeftWritingDirection: 'NO',
+        I18NIsRTL: 'NO',
       });
     } else {
-      await device.launchApp({ newInstance: true });
-      await selectSingleFeatureTestsScreen(
-        'Tabs',
-        'test-tabs-tab-bar-layout-direction',
-      );
-      try {
-        await element(by.id('react-force-rtl-picker')).tap();
-        await waitFor(element(by.id('react-force-rtl-picker')))
-          .toHaveLabel('forceRTL: true')
-          .withTimeout(3000);
-      } finally {
-        const attrs = await element(
-          by.id('react-force-rtl-picker'),
-        ).getAttributes();
-        const currentLabel =
-          'elements' in attrs ? attrs.elements[0]?.label : attrs.label;
-        if (currentLabel === 'forceRTL: true') {
-          await element(by.id('react-force-rtl-picker')).tap();
-          await waitFor(element(by.id('react-force-rtl-picker')))
-            .toHaveLabel('forceRTL: false')
-            .withTimeout(3000);
-        }
-        await device.reloadReactNative();
-      }
+      await launchAppWithAttributes();
+      await device.reloadReactNative();
     }
   });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -45,67 +45,67 @@ async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
   }
 }
 
-// describe('Tab Bar Layout Direction - system settings: LTR', () => {
-//   beforeEach(async () => {
-//     await device.reloadReactNative();
-//     await selectSingleFeatureTestsScreen(
-//       'Tabs',
-//       'test-tabs-tab-bar-layout-direction',
-//     );
-//   });
+describe('Tab Bar Layout Direction - system settings: LTR', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Tabs',
+      'test-tabs-tab-bar-layout-direction',
+    );
+  });
 
-//   it('displays default options and renders Tab1 at the visually leftmost position (LTR)', async () => {
-//     await expect(
-//       element(by.id('tab-bar-layout-direction-scrollview')),
-//     ).toBeVisible();
-//     await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
-//       'forceRTL: false',
-//     );
-//     await expect(element(by.id('react-allow-rtl-picker'))).toHaveLabel(
-//       'allowRTL: true',
-//     );
-//     await scrollTo({ id: 'tab-bar-layout-direction-picker' });
-//     await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
-//       'direction: inherit',
-//     );
-//     await expect(element(by.id('is-rtl-information'))).toHaveText(
-//       'I18nManager.isRTL == false',
-//     );
-//     await expectTab1ToBeLeftOfTab2(true);
-//   });
+  it('displays default options and renders Tab1 at the visually leftmost position (LTR)', async () => {
+    await expect(
+      element(by.id('tab-bar-layout-direction-scrollview')),
+    ).toBeVisible();
+    await expect(element(by.id('react-force-rtl-picker'))).toHaveLabel(
+      'forceRTL: false',
+    );
+    await expect(element(by.id('react-allow-rtl-picker'))).toHaveLabel(
+      'allowRTL: true',
+    );
+    await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+    await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
+      'direction: inherit',
+    );
+    await expect(element(by.id('is-rtl-information'))).toHaveText(
+      'I18nManager.isRTL == false',
+    );
+    await expectTab1ToBeLeftOfTab2(true);
+  });
 
-//   it('follows system LTR settings when direction is set to inherit', async () => {
-//     await selectDirection('inherit');
-//     await expectTab1ToBeLeftOfTab2(true);
-//   });
+  it('follows system LTR settings when direction is set to inherit', async () => {
+    await selectDirection('inherit');
+    await expectTab1ToBeLeftOfTab2(true);
+  });
 
-//   it('overrides system LTR settings and renders the tab bar in RTL order', async () => {
-//     await selectDirection('rtl');
-//     await expectTab1ToBeLeftOfTab2(false);
-//   });
+  it('overrides system LTR settings and renders the tab bar in RTL order', async () => {
+    await selectDirection('rtl');
+    await expectTab1ToBeLeftOfTab2(false);
+  });
 
-//   it('remains in LTR order when direction is explicitly set to ltr', async () => {
-//     await selectDirection('ltr');
-//     await expectTab1ToBeLeftOfTab2(true);
-//   });
+  it('remains in LTR order when direction is explicitly set to ltr', async () => {
+    await selectDirection('ltr');
+    await expectTab1ToBeLeftOfTab2(true);
+  });
 
-//   it('cycle through inherit → rtl → ltr → rtl → inherit renders the tab bar in correct order', async () => {
-//     await selectDirection('inherit');
-//     await expectTab1ToBeLeftOfTab2(true);
+  it('cycle through inherit → rtl → ltr → rtl → inherit renders the tab bar in correct order', async () => {
+    await selectDirection('inherit');
+    await expectTab1ToBeLeftOfTab2(true);
 
-//     await selectDirection('rtl');
-//     await expectTab1ToBeLeftOfTab2(false);
+    await selectDirection('rtl');
+    await expectTab1ToBeLeftOfTab2(false);
 
-//     await selectDirection('ltr');
-//     await expectTab1ToBeLeftOfTab2(true);
+    await selectDirection('ltr');
+    await expectTab1ToBeLeftOfTab2(true);
 
-//     await selectDirection('rtl');
-//     await expectTab1ToBeLeftOfTab2(false);
+    await selectDirection('rtl');
+    await expectTab1ToBeLeftOfTab2(false);
 
-//     await selectDirection('inherit');
-//     await expectTab1ToBeLeftOfTab2(true);
-//   });
-// });
+    await selectDirection('inherit');
+    await expectTab1ToBeLeftOfTab2(true);
+  });
+});
 
 describe('Tab Bar Layout Direction - system settings: RTL', () => {
   beforeAll(async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -137,7 +137,41 @@ describe('Tab Bar Layout Direction - system settings: RTL', () => {
   });
 
   afterAll(async () => {
-    await device.reloadReactNative();
+    if (device.getPlatform() === 'ios') {
+      await device.launchApp({
+        newInstance: true,
+        launchArgs: {
+          AppleTextDirection: 'NO',
+          NSForceRightToLeftWritingDirection: 'NO',
+          I18NIsRTL: 'NO',
+        },
+      });
+    } else {
+      await device.launchApp({ newInstance: true });
+      await selectSingleFeatureTestsScreen(
+        'Tabs',
+        'test-tabs-tab-bar-layout-direction',
+      );
+      try {
+        await element(by.id('react-force-rtl-picker')).tap();
+        await waitFor(element(by.id('react-force-rtl-picker')))
+          .toHaveLabel('forceRTL: true')
+          .withTimeout(3000);
+      } finally {
+        const attrs = await element(
+          by.id('react-force-rtl-picker'),
+        ).getAttributes();
+        const currentLabel =
+          'elements' in attrs ? attrs.elements[0]?.label : attrs.label;
+        if (currentLabel === 'forceRTL: true') {
+          await element(by.id('react-force-rtl-picker')).tap();
+          await waitFor(element(by.id('react-force-rtl-picker')))
+            .toHaveLabel('forceRTL: false')
+            .withTimeout(3000);
+        }
+        await device.reloadReactNative();
+      }
+    }
   });
 
   it('displays default options and renders Tab2 at the visually leftmost position (RTL)', async () => {


### PR DESCRIPTION
### Description
Simplify RTL cleanup in tab bar layout direction tests

Extracted a `launchAppWithAttributes` helper and removed redundant `react-force-rtl-picker` interactions from the `afterAll` teardown.

Relaunching the app via `device.launchApp({ newInstance: true })` already resets RTL settings to their defaults (LTR), so manually tapping `react-force-rtl-picker` to toggle `forceRTL` back to `false` after each test suite was unnecessary. The extra `multiTap(2)` and `reloadReactNative()` calls were dead weight that added flakiness and test runtime with no actual cleanup benefit.

### Changes

- Added `launchAppWithAttributes` helper
- Removed `selectSingleFeatureTestsScreen`, picker tap, and `reloadReactNative` from the Android `afterAll` section - a plain `launchAppWithAttributes()` is sufficient to restore defaults
- Simplified the iOS `afterAll` branch similarly, replacing the inline `device.launchApp` object with the new helper
