### PR TITLE
fix(Android, FormSheet): dismiss form sheet only on ACTION_UP to prevent double-back

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingView.kt
@@ -54,7 +54,7 @@ internal class DimmingView(
     // We do not want to have any action defined here. We just want listeners notified that the click happened.
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent?): Boolean {
-        if (blockGestures) {
+        if (blockGestures && event?.actionMasked == MotionEvent.ACTION_UP) {
             callOnClick()
         }
         return blockGestures


### PR DESCRIPTION
## Description

`DimmingView.onTouchEvent` currently calls `callOnClick` for every `MotionEvent` it receives, especially `ACTION_DOWN`. With Android gesture navigation enabled, an edge-swipe back triggers the dismissal the instant the finger lands on the DimmingView, and then the system's back action dismisses the screen again - producing the double-dismiss like the one in the linked recording.

The fix narrows the click to `actionMasked == ACTION_UP`, so the dismiss only fires on a **completed** tap.

> [!NOTE]  
> This aligns the flow with the iOS, on which the dismiss is performed on finger lift.

https://github.com/user-attachments/assets/23f5c1eb-16f8-42fd-937e-5dd3d0f63eeb

## Changes

- narrow dismissing FormSheet only for completing the tap on the DimmingView

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/43ef6ed7-ebdb-49f0-994a-fde241800bda" /> | <video src="https://github.com/user-attachments/assets/779d30a9-1bff-4dcd-9b63-5c633f3b22a5" /> |

## Test plan

You can test that on any FormSheet with `rnsGammaEnabled=false` - to ensure that native back press is working properly in v4 scope

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
