### PR TITLE
fix(Android, Tabs): handle Tabs reattachment to window

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -265,6 +265,11 @@ class TabsContainer internal constructor(
 
         super.onAttachedToWindow()
         setupFragmentManager()
+
+        if (navState.isNotEmpty()) {
+            restoreNavigationStateIfNeeded()
+        }
+
         flushPendingUpdates()
 
         colorSchemeCoordinator.setup(this) { uiNightMode ->
@@ -557,6 +562,26 @@ class TabsContainer internal constructor(
 
         // Block other callbacks
         return true
+    }
+
+    private fun restoreNavigationStateIfNeeded() {
+        check(navState.isNotEmpty()) {
+            "[RNScreens] Attempted to restore empty navigation state."
+        }
+
+        val currentFragments =
+            requireFragmentManager.fragments.filterIsInstance<TabsScreenFragment>().toList()
+
+        if (currentFragments.size == 1 && currentFragments[0] === selectedTab) {
+            return
+        } else if (currentFragments.isEmpty()) {
+            requireFragmentManager
+                .createTransactionWithReordering()
+                .add(contentView.id, selectedTab)
+                .commitAllowingStateLoss()
+        } else {
+            error("[RNScreens] Unexpected fragment manager state.")
+        }
     }
 
     private fun applyDayNightUiMode(uiMode: Int) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -577,7 +577,10 @@ class TabsContainer internal constructor(
         }
 
         val currentFragments =
-            requireFragmentManager.fragments.filterIsInstance<TabsScreenFragment>().toList()
+            requireFragmentManager.fragments
+                .filterIsInstance<TabsScreenFragment>()
+                .filter { it in tabsModel }
+                .toList()
 
         if (currentFragments.size == 1 && currentFragments[0] === selectedTab) {
             return

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -266,7 +266,14 @@ class TabsContainer internal constructor(
         super.onAttachedToWindow()
         setupFragmentManager()
 
-        // Handle reattachment
+        // When TabsContainer is reattached to window, it might find new fragment manager (other
+        // than previous instance, e.g. in Stack v4 when screen is pushed & popped over screen with
+        // Tabs). In such case, we need to re-add currently selected tab screen fragment. As there
+        // might be another operation pending, we need to make sure that the state is restored
+        // before flushPendingUpdates is called. That's why inside restoreNavigationStateIfNeeded
+        // we're commiting the transaction synchronously. This might lead to a crash if another
+        // transaction is currently being commited. If this happens to be problematic, we might need
+        // to reevaluate our approach. See #4035.
         if (navState.isNotEmpty()) {
             restoreNavigationStateIfNeeded()
         }
@@ -566,8 +573,9 @@ class TabsContainer internal constructor(
     }
 
     /**
-     * When Tabs are reattached to window, they might find new fragment manager. In this case
-     * we need to restore navigation state.
+     * When Tabs are reattached to window, they might find new fragment manager. In this case we
+     * need to restore navigation state. We're commiting the transaction synchronously so that any
+     * following operations have valid restored state before their execution.
      *
      * This function is a no-op if navigation state is empty.
      */
@@ -588,7 +596,7 @@ class TabsContainer internal constructor(
             requireFragmentManager
                 .createTransactionWithReordering()
                 .add(contentView.id, selectedTab)
-                .commitAllowingStateLoss()
+                .commitNowAllowingStateLoss()
         } else {
             error("[RNScreens] Unexpected fragment manager state.")
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -275,6 +275,7 @@ class TabsContainer internal constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         teardownFragmentManager()
+        colorSchemeCoordinator.teardown()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration?) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -271,8 +271,8 @@ class TabsContainer internal constructor(
         // Tabs). In such case, we need to re-add currently selected tab screen fragment. As there
         // might be another operation pending, we need to make sure that the state is restored
         // before flushPendingUpdates is called. That's why inside restoreNavigationStateIfNeeded
-        // we're commiting the transaction synchronously. This might lead to a crash if another
-        // transaction is currently being commited. If this happens to be problematic, we might need
+        // we're committing the transaction synchronously. This might lead to a crash if another
+        // transaction is currently being committed. If this happens to be problematic, we might need
         // to reevaluate our approach. See #4035.
         if (navState.isNotEmpty()) {
             restoreNavigationStateIfNeeded()
@@ -574,7 +574,7 @@ class TabsContainer internal constructor(
 
     /**
      * When Tabs are reattached to window, they might find new fragment manager. In this case we
-     * need to restore navigation state. We're commiting the transaction synchronously so that any
+     * need to restore navigation state. We're committing the transaction synchronously so that any
      * following operations have valid restored state before their execution.
      *
      * This function is a no-op if navigation state is empty.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -266,6 +266,7 @@ class TabsContainer internal constructor(
         super.onAttachedToWindow()
         setupFragmentManager()
 
+        // Handle reattachment
         if (navState.isNotEmpty()) {
             restoreNavigationStateIfNeeded()
         }
@@ -564,9 +565,15 @@ class TabsContainer internal constructor(
         return true
     }
 
+    /**
+     * When Tabs are reattached to window, they might find new fragment manager. In this case
+     * we need to restore navigation state.
+     *
+     * This function is a no-op if navigation state is empty.
+     */
     private fun restoreNavigationStateIfNeeded() {
-        check(navState.isNotEmpty()) {
-            "[RNScreens] Attempted to restore empty navigation state."
+        if (navState.isEmpty()) {
+            return
         }
 
         val currentFragments =

--- a/apps/src/tests/issue-tests/Test4027.tsx
+++ b/apps/src/tests/issue-tests/Test4027.tsx
@@ -5,7 +5,10 @@ import {
   createNativeStackNavigator,
 } from '@react-navigation/native-stack';
 import { Button } from 'react-native';
-import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
+import {
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  TabsContainer,
+} from '@apps/shared/gamma/containers/tabs';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 
 type RouteParamList = {
@@ -36,14 +39,26 @@ function Screen1({ navigation }: StackNavigationProp) {
         {
           name: 'Tab1',
           Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab1',
+          },
         },
         {
           name: 'Tab2',
           Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab2',
+          },
         },
         {
           name: 'Tab3',
           Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab3',
+          },
         },
       ]}
     />

--- a/apps/src/tests/issue-tests/Test4027.tsx
+++ b/apps/src/tests/issue-tests/Test4027.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button } from 'react-native';
+import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
+import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
+
+type RouteParamList = {
+  Screen1: undefined;
+  Screen2: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function TabsScreen({ navigation }: StackNavigationProp) {
+  return (
+    <CenteredLayoutView>
+      <Button title="Push" onPress={() => navigation.push('Screen2')} />
+    </CenteredLayoutView>
+  );
+}
+
+function Screen1({ navigation }: StackNavigationProp) {
+  return (
+    <TabsContainer
+      routeConfigs={[
+        {
+          name: 'Tab1',
+          Component: () => TabsScreen({ navigation }),
+        },
+        {
+          name: 'Tab2',
+          Component: () => TabsScreen({ navigation }),
+        },
+        {
+          name: 'Tab3',
+          Component: () => TabsScreen({ navigation }),
+        },
+      ]}
+    />
+  );
+}
+
+function Screen2({ navigation }: StackNavigationProp) {
+  return (
+    <CenteredLayoutView>
+      <Button title="Pop" onPress={() => navigation.pop()} />
+    </CenteredLayoutView>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Screen1" component={Screen1} />
+        <Stack.Screen name="Screen2" component={Screen2} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -192,6 +192,7 @@ export { default as Test3835 } from './Test3835';
 export { default as Test3867 } from './Test3867';
 export { default as Test3885 } from './Test3885';
 export { default as Test3910 } from './Test3910';
+export { default as Test4027 } from './Test4027';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
## Description

Fixes 2 bugs related to `TabsContainer` reattachment on Android.

1. During recent refactors, `colorSchemeCoordinator.teardown()` call was removed by mistake which resulted in an error when `setup` was called for the second time.
2. Prior to this PR, when `TabsContainer` was reattached to window, it did not handle correctly a situation where fragment manager has changed (which happens e.g. when you nest Tabs in Stack v4). In this PR, we're ensuring that the navigation state is restored.

Closes https://github.com/software-mansion/react-native-screens/issues/4027.

## Changes

- add `colorSchemeCoordinator.teardown()` in `onDetachedFromWindow`
- add `restoreNavigationStateIfNeeded` method that adds currently selected fragment to fragment manager if it's not already there
- call `restoreNavigationStateIfNeeded` function that runs when non-empty navigation state is present on attachment to window
- add `Test4027.tsx`

## Before & after - visual documentation

| Before | After handling `colorSchemeCoordinator` teardown | After |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/bac10814-48a7-45a3-92a4-b7bf41770b28" /> | <video src="https://github.com/user-attachments/assets/f6d3fab2-397e-4bae-a832-6033a72aa800" /> | <video src="https://github.com/user-attachments/assets/615f2ed1-b195-4ff7-9b8f-e2078d6b37cc" /> |

## Test plan

Run `Test4027.tsx`. Push screen and pop. The app shouldn't crash and tab screen's content should be visible.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] Ensured that CI passes
