### PR TITLE
feat: enable gamma project by default

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -2,7 +2,8 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-gamma_project_enabled = ENV['RNS_GAMMA_ENABLED'] == '1'
+# Gamma is opt-out: enabled unless RNS_GAMMA_ENABLED is explicitly '0'.
+gamma_project_enabled = !(ENV['RNS_GAMMA_ENABLED'] == '0')
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 debug_logging_enabled = ENV['RNS_DEBUG_LOGGING'] == '1'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,9 @@ def areDebugLogsEnabled() {
     return project.hasProperty("rnsDebugLogsEnabled") && project.rnsDebugLogsEnabled == "true"
 }
 
+// Gamma is opt-out: enabled unless rnsGammaEnabled is explicitly "false".
 def isGammaEnabled() {
-    return project.hasProperty("rnsGammaEnabled") && project.rnsGammaEnabled == "true"
+    return !(project.hasProperty("rnsGammaEnabled") && project.rnsGammaEnabled == "false")
 }
 
 def resolveReactNativeDirectory() {


### PR DESCRIPTION
## Description

Flip the gamma-project gate from opt-in to opt-out on both platforms.
Previously gamma sources were included only when the env var / Gradle
property was explicitly set to a truthy value; now they are included
by default and excluded only when the value is explicitly set to the
disable sentinel.

This makes gamma the default for downstream consumers and CI, while
still giving users a clean escape hatch if they need the pre-gamma
build.

The main motivation behind the change is to allow downstream solutions
exposing our experimental APIs w/o additional setup steps for the 
end users.

I want to also note, that this should be safe to do, because the 
synchronous event APIs are available since 0.82, which is the currently
oldest supported RN version.

> [!important]
> If any reviewer is aware of any React Native API we use in gamma code, 
> that is not available in 0.82, please point it out. 

## Changes

- iOS (`RNScreens.podspec`): `RNS_GAMMA_ENABLED` switched from
  `== '1'` opt-in to `!= '0'` opt-out. Set `RNS_GAMMA_ENABLED=0` to
  disable.
- Android (`android/build.gradle`): `rnsGammaEnabled` switched from
  `== "true"` opt-in to `!= "false"` opt-out. Set
  `rnsGammaEnabled=false` (e.g. in `gradle.properties` or
  `-PrnsGammaEnabled=false`) to disable.
- Added one-line comments on both sides documenting the opt-out
  semantics.

## Test plan

No new tests — this is a build-config default change. Manual verification:

- iOS, default (no env set): `pod install` in `FabricExample/ios`
  should log `[RNScreens] Gamma project enabled. Including source files.`
  and include `ios/gamma/**` sources.
- iOS, explicit disable: `RNS_GAMMA_ENABLED=0 pod install` should
  exclude `ios/gamma/**` and instead pull in `ios/stubs/**`.
- Android, default (no property): `BuildConfig.RNS_GAMMA_ENABLED`
  resolves to `true`.
- Android, explicit disable: `./gradlew ... -PrnsGammaEnabled=false`
  resolves `BuildConfig.RNS_GAMMA_ENABLED` to `false`.

Follow-ups (not in this PR):

- `FabricExample/android/app/build.gradle:91` still uses the old
  opt-in check and will need a matching flip if the example app
  should track the library default.
- CI workflows still pass `RNS_GAMMA_ENABLED: 1` (now redundant); no
  job currently exercises the disabled path.
- `guides/CONTRIBUTING.md:128` documents the old opt-in flow and
  needs updating.
- Stale podspec comment about `DEFINES_MODULE` / `React-RCTImage`
  will be removed in a separate PR.

> [!important]
> Before merging I need to verify build on 0.82
> We need to also establish whether we'll want to use any APIs above 0.82 in near future. > If so, we can not turn this flag on. 

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes