### PR TITLE
chore(iOS): drop stale React-RCTImage DEFINES_MODULE comment

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -34,12 +34,6 @@ rnscreens_config  =  {
 }
 
 if gamma_project_enabled
-  # This setting is required to make Swift code build. However we have 
-  # dependency on `React-RCTImage` pod, which does not set `DEFINES_MODULE` 
-  # and therefore it fails to build. Currently we do patch react-native source
-  # code to make it work & the fix is already merged, however it'll be most likely released 
-  # with 0.81. We can not expect users to patch the react-native sources, thus 
-  # we can not have Swift code in stable package. 
   rnscreens_config['DEFINES_MODULE'] = 'YES'
 end
 


### PR DESCRIPTION
> Stacked on top of #4036. Merge that one first.

## Description

Removes the long comment above `rnscreens_config['DEFINES_MODULE'] = 'YES'`
in `RNScreens.podspec`. The comment warned that this setting required
patching `React-RCTImage` to set `DEFINES_MODULE`, and concluded
"we can not have Swift code in stable package."

That justification no longer applies: the upstream `React-RCTImage`
`DEFINES_MODULE` fix shipped in React Native 0.81, and this library's
minimum supported RN version is now >= 0.81. Users no longer need
to patch their `react-native` sources, so the comment is misleading.

This is split out from #4036 (which flips the gamma default to
opt-out) on purpose: that PR is a behavior change, this one is a
pure comment removal with its own justification.

## Changes

- Drop the 6-line comment block in `RNScreens.podspec` above the
  `DEFINES_MODULE` assignment.

## Test plan

No code change — only a comment removed. Verified locally that
`pod install` in `FabricExample/ios` still succeeds with the
default (gamma-enabled) configuration.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes