### PR TITLE
refactor(iOS, FormSheet v5): Move detents resolving to dedicated class

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+#if defined(__cplusplus)
+#import <vector>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Predefined values for `initialDetentIndex`.
+static NSInteger const kRNSFormSheetLastDetent = -1;
+// Predefined values for `largestUndimmedDetentIndex`.
+static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
+static NSInteger const kRNSFormSheetNeverDimmed = -2;
+
+@interface RNSFormSheetDetentResolver : NSObject
+
+#if !TARGET_OS_TV && defined(__cplusplus)
+
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents;
+
+#endif // !TARGET_OS_TV && __cplusplus
+
+#if !TARGET_OS_TV
+
++ (nullable UISheetPresentationControllerDetentIdentifier)initialDetentIdentifierForDetents:
+                                                              (NSArray<UISheetPresentationControllerDetent *> *)detents
+                                                                           atRequestedIndex:(NSInteger)requestedIndex;
+
++ (nullable UISheetPresentationControllerDetentIdentifier)
+    largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
+                                      atIndex:(NSInteger)requestedIndex;
+
+#endif // !TARGET_OS_TV
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
@@ -30,7 +30,7 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 + (nullable UISheetPresentationControllerDetentIdentifier)
     largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
-                                      atIndex:(NSInteger)requestedIndex;
+                             atRequestedIndex:(NSInteger)requestedIndex;
 
 #endif // !TARGET_OS_TV
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -1,0 +1,159 @@
+#import "RNSFormSheetDetentResolver.h"
+#import "RNSDefines.h"
+
+#import <React/RCTLog.h>
+
+#if !TARGET_OS_TV
+
+static BOOL RNSAreDetentsValid(const std::vector<double> &detents)
+{
+  for (double currentDetent : detents) {
+    if (isnan(currentDetent)) {
+      return NO;
+    }
+    if (currentDetent < 0.0 || currentDetent > 1.0) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
+{
+  for (size_t i = 1; i < detents.size(); i++) {
+    if (detents[i - 1] >= detents[i]) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+@implementation RNSFormSheetDetentResolver
+
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents
+{
+  size_t detentsCount = detents.size();
+
+  // Defaults to large detent across all iOS versions
+  if (detentsCount == 0) {
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  if (!RNSAreDetentsValid(detents)) {
+    RCTLogError(
+        @"[RNScreens] The values in the detents array must fall within the 0.0 to 1.0 range. Falling back to large detent.");
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  if (!RNSAreDetentsStrictlyAscending(detents)) {
+    RCTLogError(
+        @"[RNScreens] The values in the detents array must be in strictly ascending order. Falling back to large detent.");
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  NSMutableArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [[NSMutableArray alloc] initWithCapacity:detentsCount];
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    for (size_t i = 0; i < detentsCount; i++) {
+      double fraction = detents[i];
+      NSString *ident = [NSString stringWithFormat:@"%zu", i];
+
+      [nativeDetents
+          addObject:[UISheetPresentationControllerDetent
+                        customDetentWithIdentifier:ident
+                                          resolver:^CGFloat(
+                                              id<UISheetPresentationControllerDetentResolutionContext> context) {
+                                            return context.maximumDetentValue * fraction;
+                                          }]];
+    }
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Legacy Fallback
+    if (detentsCount == 1) {
+      double firstDetentFraction = detents[0];
+      if (firstDetentFraction < 1.0) {
+        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+      } else {
+        [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
+      }
+    } else {
+      // Handles detentsCount > 1
+      [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+      [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
+    }
+  }
+
+  return nativeDetents;
+}
+
++ (nullable UISheetPresentationControllerDetentIdentifier)initialDetentIdentifierForDetents:
+                                                              (NSArray<UISheetPresentationControllerDetent *> *)detents
+                                                                           atRequestedIndex:(NSInteger)requestedIndex
+{
+  NSInteger initialIndex = requestedIndex == kRNSFormSheetLastDetent ? (NSInteger)detents.count - 1 : requestedIndex;
+
+  if (initialIndex < 0 || initialIndex >= (NSInteger)detents.count) {
+    RCTLogError(@"[RNScreens] initialDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to 0.",
+                (long)requestedIndex,
+                (unsigned long)detents.count);
+    initialIndex = 0;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)initialIndex].identifier;
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetentsForFractions:
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)initialIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
+    }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  }
+}
+
++ (nullable UISheetPresentationControllerDetentIdentifier)
+    largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
+                                      atIndex:(NSInteger)requestedIndex
+{
+  if (requestedIndex == kRNSFormSheetAlwaysDimmed) {
+    return nil;
+  }
+
+  NSInteger ludIndex = requestedIndex == kRNSFormSheetNeverDimmed ? (NSInteger)detents.count - 1 : requestedIndex;
+
+  if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
+    RCTLogError(
+        @"[RNScreens] largestUndimmedDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to the default behavior (always dimmed).",
+        (long)requestedIndex,
+        (unsigned long)detents.count);
+    return nil;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)ludIndex].identifier;
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetentsForFractions:
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)ludIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
+    }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  }
+}
+
+@end
+
+#endif // !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -121,7 +121,7 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
 
 + (nullable UISheetPresentationControllerDetentIdentifier)
     largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
-                                      atIndex:(NSInteger)requestedIndex
+                             atRequestedIndex:(NSInteger)requestedIndex
 {
   if (requestedIndex == kRNSFormSheetAlwaysDimmed) {
     return nil;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -2,6 +2,7 @@
 #import "RNSDefines.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 #import "RNSPresentationSourceProvider.h"
@@ -13,12 +14,6 @@
 #import <rnscreens/RNSFormSheetHostComponentDescriptor.h>
 
 namespace react = facebook::react;
-
-// Predefined values for `initialDetentIndex`.
-static NSInteger const kRNSFormSheetLastDetent = -1;
-// Predefined values for `largestUndimmedDetentIndex`.
-static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
-static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end
@@ -288,12 +283,19 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
       sheet != nil,
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
-  NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
-  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier =
-      [self consumeInitialDetentIdentifierForDetents:nativeDetents];
+  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:_detents];
+
+  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
+  if (!_initialDetentApplied) {
+    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
+                                                                           atRequestedIndex:_initialDetentIndex];
+    _initialDetentApplied = YES;
+  }
 
   UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
-      [self largestUndimmedDetentIdentifierForDetents:nativeDetents];
+      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
+                                                                    atIndex:_largestUndimmedDetentIndex];
 
   // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
   [sheet animateChanges:^{
@@ -308,165 +310,6 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
     }
   }];
 #endif // !TARGET_OS_TV
-}
-
-#if !TARGET_OS_TV
-- (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetents
-{
-  size_t detentsCount = _detents.size();
-
-  // Defaults to large detent across all iOS versions
-  if (detentsCount == 0) {
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  if (![self areDetentsValid]) {
-    RCTLogError(
-        @"[RNScreens] The values in the detents array must fall within the 0.0 to 1.0 range. Falling back to large detent.");
-
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  if (![self areDetentsStrictlyAscending]) {
-    RCTLogError(
-        @"[RNScreens] The values in the detents array must be in strictly ascending order. Falling back to large detent.");
-
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  NSMutableArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [[NSMutableArray alloc] initWithCapacity:detentsCount];
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    for (size_t i = 0; i < detentsCount; i++) {
-      double fraction = _detents[i];
-      NSString *ident = [NSString stringWithFormat:@"%zu", i];
-
-      [nativeDetents
-          addObject:[UISheetPresentationControllerDetent
-                        customDetentWithIdentifier:ident
-                                          resolver:^CGFloat(
-                                              id<UISheetPresentationControllerDetentResolutionContext> context) {
-                                            return context.maximumDetentValue * fraction;
-                                          }]];
-    }
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Legacy Fallback
-    if (detentsCount == 1) {
-      double firstDetentFraction = _detents[0];
-      if (firstDetentFraction < 1.0) {
-        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
-      } else {
-        [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
-      }
-    } else {
-      // Handles detentsCount > 1
-      [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
-      [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
-    }
-  }
-
-  return nativeDetents;
-}
-
-- (UISheetPresentationControllerDetentIdentifier)consumeInitialDetentIdentifierForDetents:
-    (NSArray<UISheetPresentationControllerDetent *> *)detents
-{
-  if (_initialDetentApplied) {
-    return nil;
-  }
-
-  _initialDetentApplied = YES;
-
-  NSInteger initialIndex =
-      _initialDetentIndex == kRNSFormSheetLastDetent ? (NSInteger)detents.count - 1 : _initialDetentIndex;
-
-  if (initialIndex < 0 || initialIndex >= (NSInteger)detents.count) {
-    RCTLogError(@"[RNScreens] initialDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to 0.",
-                (long)_initialDetentIndex,
-                (unsigned long)detents.count);
-    initialIndex = 0;
-  }
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    return detents[(NSUInteger)initialIndex].identifier;
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Fallback - mirroring buildSheetDetents
-    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)initialIndex];
-
-    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
-      return UISheetPresentationControllerDetentIdentifierMedium;
-    }
-
-    return UISheetPresentationControllerDetentIdentifierLarge;
-  }
-}
-
-- (UISheetPresentationControllerDetentIdentifier)largestUndimmedDetentIdentifierForDetents:
-    (NSArray<UISheetPresentationControllerDetent *> *)detents
-{
-  if (_largestUndimmedDetentIndex == kRNSFormSheetAlwaysDimmed) {
-    return nil;
-  }
-
-  NSInteger ludIndex = _largestUndimmedDetentIndex == kRNSFormSheetNeverDimmed ? (NSInteger)detents.count - 1
-                                                                               : _largestUndimmedDetentIndex;
-
-  if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
-    RCTLogError(
-        @"[RNScreens] largestUndimmedDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to the default behavior (always dimmed).",
-        (long)_largestUndimmedDetentIndex,
-        (unsigned long)detents.count);
-    return nil;
-  }
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    return detents[(NSUInteger)ludIndex].identifier;
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Fallback - mirroring buildSheetDetents
-    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)ludIndex];
-
-    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
-      return UISheetPresentationControllerDetentIdentifierMedium;
-    }
-
-    return UISheetPresentationControllerDetentIdentifierLarge;
-  }
-}
-
-#endif // !TARGET_OS_TV
-
-- (BOOL)areDetentsValid
-{
-  for (double currentDetent : _detents) {
-    if (isnan(currentDetent)) {
-      return NO;
-    }
-
-    if (currentDetent < 0.0 || currentDetent > 1.0) {
-      return NO;
-    }
-  }
-  return YES;
-}
-
-- (BOOL)areDetentsStrictlyAscending
-{
-  for (size_t i = 1; i < _detents.size(); i++) {
-    if (_detents[i - 1] >= _detents[i]) {
-      return NO;
-    }
-  }
-  return YES;
 }
 
 #pragma mark - Touch Handling overrides

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -295,7 +295,7 @@ namespace react = facebook::react;
 
   UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
       [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
-                                                                    atIndex:_largestUndimmedDetentIndex];
+                                                           atRequestedIndex:_largestUndimmedDetentIndex];
 
   // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
   [sheet animateChanges:^{


### PR DESCRIPTION
## Description

Move `buildSheetDetents`, `consumeInitialDetentIdentifierForDetents`, `largestUndimmedDetentIdentifierForDetents`, `areDetentsValid`, `areDetentsStrictlyAscending` to a dedicated file. All logic related to transforming JS payload to native detents should now go through this file.

## Changes

- moved methods responsible for building detents and resolving identifiers based on JS payload was moved to a dedicated class

## Before & after - visual documentation

N/A

## Test plan

I went through all SFTs for FormSheet, especially related to `largestUndimmedDetentIndex` & `initialDetentIndex`.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
