### PR TITLE
refactor(iOS, FormSheet v5): Prepare AppearanceCoordinator logic

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block;
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetAppearanceCoordinator : NSObject
 
-- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flag;
+- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flags;
 
-- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
+- (BOOL)needsAll:(RNSFormSheetAppearanceUpdateFlags)flags;
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block;
+- (void)updateIfNeeds:(RNSFormSheetAppearanceUpdateFlags)flags performOperations:(dispatch_block_t)block;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block;
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetAppearanceCoordinator : NSObject
 
-- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag;
+- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flag;
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import "RNSFormSheetAppearanceUpdateFlags.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetAppearanceCoordinator : NSObject
+
+- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag;
+
+- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
+
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -19,6 +19,10 @@
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag
 {
+  if (flag == RNSFormSheetAppearanceUpdateFlagsNone) {
+    return NO;
+  }
+
   return (_updateFlags & flag) == flag;
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -12,7 +12,7 @@
   return self;
 }
 
-- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag
+- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flag
 {
   _updateFlags |= flag;
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -26,7 +26,7 @@
   return (_updateFlags & flag) == flag;
 }
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block
 {
   if ([self isNeeded:flag]) {
     _updateFlags &= ~flag;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -22,7 +22,7 @@
   return (_updateFlags & flag) == flag;
 }
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block
 {
   if ([self isNeeded:flag]) {
     _updateFlags &= ~flag;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -1,0 +1,33 @@
+#import "RNSFormSheetAppearanceCoordinator.h"
+
+@implementation RNSFormSheetAppearanceCoordinator {
+  RNSFormSheetAppearanceUpdateFlags _updateFlags;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _updateFlags = RNSFormSheetAppearanceUpdateFlagsNone;
+  }
+  return self;
+}
+
+- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag
+{
+  _updateFlags |= flag;
+}
+
+- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag
+{
+  return (_updateFlags & flag) == flag;
+}
+
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block
+{
+  if ([self isNeeded:flag]) {
+    _updateFlags &= ~flag;
+    block();
+  }
+}
+
+@end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -29,8 +29,8 @@
 - (void)updateIfNeeds:(RNSFormSheetAppearanceUpdateFlags)flags performOperations:(dispatch_block_t)block
 {
   if ([self needsAll:flags]) {
-    _updateFlags &= ~flags;
     block();
+    _updateFlags &= ~flags;
   }
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -12,24 +12,24 @@
   return self;
 }
 
-- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flag
+- (void)setNeeds:(RNSFormSheetAppearanceUpdateFlags)flags
 {
-  _updateFlags |= flag;
+  _updateFlags |= flags;
 }
 
-- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag
+- (BOOL)needsAll:(RNSFormSheetAppearanceUpdateFlags)flags
 {
-  if (flag == RNSFormSheetAppearanceUpdateFlagsNone) {
+  if (flags == RNSFormSheetAppearanceUpdateFlagsNone) {
     return NO;
   }
 
-  return (_updateFlags & flag) == flag;
+  return (_updateFlags & flags) == flags;
 }
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block
+- (void)updateIfNeeds:(RNSFormSheetAppearanceUpdateFlags)flags performOperations:(dispatch_block_t)block
 {
-  if ([self isNeeded:flag]) {
-    _updateFlags &= ~flag;
+  if ([self needsAll:flags]) {
+    _updateFlags &= ~flags;
     block();
   }
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceUpdateFlags.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceUpdateFlags.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+typedef NS_OPTIONS(NSUInteger, RNSFormSheetAppearanceUpdateFlags) {
+  RNSFormSheetAppearanceUpdateFlagsNone = 0,
+  // The sheet needs to be presented or dismissed to match the requested open state.
+  RNSFormSheetAppearanceUpdateFlagsPresentation = 1 << 0,
+  // The sheet's visual appearance configuration (detents, grabber, dimming view) needs to be re-applied.
+  RNSFormSheetAppearanceUpdateFlagsConfiguration = 1 << 1,
+};

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -183,12 +183,12 @@ namespace react = facebook::react;
 
   if (oldComponentProps.isOpen != newComponentProps.isOpen) {
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
-    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsPresentation];
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation];
 
     if (_isOpen) {
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
-      [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+      [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
       _initialDetentApplied = NO;
@@ -197,22 +197,22 @@ namespace react = facebook::react;
 
   if (oldComponentProps.detents != newComponentProps.detents) {
     _detents = newComponentProps.detents;
-    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
-    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
-    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
-    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,5 +1,6 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSDefines.h"
+#import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
 #import "RNSFormSheetDetentResolver.h"
@@ -21,6 +22,7 @@ namespace react = facebook::react;
 @implementation RNSFormSheetHostComponentView {
   RNSFormSheetHostEventEmitter *_Nonnull _reactEventEmitter;
   RNSFormSheetHostShadowStateProxy *_Nonnull _shadowStateProxy;
+  RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
 
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
@@ -35,10 +37,6 @@ namespace react = facebook::react;
 
   // State
   BOOL _initialDetentApplied;
-
-  // Invalidation flags
-  BOOL _needsSheetPresentationUpdate;
-  BOOL _needsSheetConfigurationUpdate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -56,11 +54,9 @@ namespace react = facebook::react;
 
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
+  _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
 
   _initialDetentApplied = NO;
-
-  _needsSheetPresentationUpdate = NO;
-  _needsSheetConfigurationUpdate = NO;
 }
 
 - (void)resetProps
@@ -187,12 +183,12 @@ namespace react = facebook::react;
 
   if (oldComponentProps.isOpen != newComponentProps.isOpen) {
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
-    _needsSheetPresentationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsPresentation];
 
     if (_isOpen) {
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
-      _needsSheetConfigurationUpdate = YES;
+      [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
       _initialDetentApplied = NO;
@@ -201,22 +197,22 @@ namespace react = facebook::react;
 
   if (oldComponentProps.detents != newComponentProps.detents) {
     _detents = newComponentProps.detents;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
@@ -230,15 +226,15 @@ namespace react = facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  if (_needsSheetConfigurationUpdate) {
-    _needsSheetConfigurationUpdate = NO;
-    [self updateConfiguration];
-  }
+  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
+                            performBlock:^{
+                              [self updateConfiguration];
+                            }];
 
-  if (_needsSheetPresentationUpdate) {
-    _needsSheetPresentationUpdate = NO;
-    [self updatePresentationState];
-  }
+  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
+                            performBlock:^{
+                              [self updatePresentationState];
+                            }];
 }
 
 - (void)invalidate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -226,15 +226,15 @@ namespace react = facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
-                       performOperations:^{
-                         [self updateConfiguration];
-                       }];
+  [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration
+                      performOperations:^{
+                        [self updateConfiguration];
+                      }];
 
-  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
-                       performOperations:^{
-                         [self updatePresentationState];
-                       }];
+  [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
+                      performOperations:^{
+                        [self updatePresentationState];
+                      }];
 }
 
 - (void)invalidate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -227,14 +227,14 @@ namespace react = facebook::react;
   [super finalizeUpdates:updateMask];
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
-                            performBlock:^{
-                              [self updateConfiguration];
-                            }];
+                       performOperations:^{
+                         [self updateConfiguration];
+                       }];
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
-                            performBlock:^{
-                              [self updatePresentationState];
-                            }];
+                       performOperations:^{
+                         [self updatePresentationState];
+                       }];
 }
 
 - (void)invalidate


### PR DESCRIPTION
## Description

The plan is to mirror the SplitView's flow by using a single class to update the sheets config and introducing the AppearanceCoordinator & invalidation flags. 
As for now, I'm replacing the current logic from the `main` branch, but in the follow-up PRs, I'm aiming to move that from the HostView level to the Controller.

## Changes

- AppearanceCoordinator pattern was created for FormSheet.
- Invalidation flags were defined.

## Before & after - visual documentation

N/A - no visual changes

## Test plan

I went through examples from FormSheet SFTs

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
