### PR TITLE
refactor(iOS, FormSheet v5): Introduce AppearanceApplicator

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class RNSFormSheetAppearanceCoordinator;
+@class RNSFormSheetContentController;
+@class RNSFormSheetHostComponentView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetAppearanceApplicator : NSObject
+
+- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
+
+- (void)resetInitialDetent;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
@@ -1,0 +1,80 @@
+#import "RNSFormSheetAppearanceApplicator.h"
+
+#import <React/RCTAssert.h>
+
+#import "RNSFormSheetAppearanceCoordinator.h"
+#import "RNSFormSheetAppearanceUpdateFlags.h"
+#import "RNSFormSheetContentController.h"
+#import "RNSFormSheetDetentResolver.h"
+#import "RNSFormSheetHostComponentView.h"
+
+@implementation RNSFormSheetAppearanceApplicator {
+  BOOL _initialDetentApplied;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _initialDetentApplied = NO;
+  }
+  return self;
+}
+
+- (void)resetInitialDetent
+{
+  _initialDetentApplied = NO;
+}
+
+- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
+{
+  [coordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
+            performOperations:^{
+              [self updateSheetConfigurationForHost:host controller:controller];
+            }];
+}
+
+#pragma mark - Updaters
+
+- (void)updateSheetConfigurationForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+{
+#if !TARGET_OS_TV
+  UISheetPresentationController *sheet = controller.sheetPresentationController;
+  RCTAssert(
+      sheet != nil,
+      @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
+
+  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:host.detents];
+
+  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
+  if (!_initialDetentApplied) {
+    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
+                                                                           atRequestedIndex:host.initialDetentIndex];
+    _initialDetentApplied = YES;
+  }
+
+  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
+      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
+                                                                    atIndex:host.largestUndimmedDetentIndex];
+
+  BOOL prefersGrabberVisible = host.prefersGrabberVisible;
+  CGFloat preferredCornerRadius = host.preferredCornerRadius;
+
+  [sheet animateChanges:^{
+    sheet.detents = nativeDetents;
+    sheet.prefersGrabberVisible = prefersGrabberVisible;
+    sheet.preferredCornerRadius =
+        preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : preferredCornerRadius;
+    sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
+
+    if (initialDetentIdentifier != nil) {
+      sheet.selectedDetentIdentifier = initialDetentIdentifier;
+    }
+  }];
+#endif // !TARGET_OS_TV
+}
+
+@end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
@@ -29,10 +29,10 @@
                              controller:(RNSFormSheetContentController *)controller
                             coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
 {
-  [coordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
-            performOperations:^{
-              [self updateSheetConfigurationForHost:host controller:controller];
-            }];
+  [coordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration
+           performOperations:^{
+             [self updateSheetConfigurationForHost:host controller:controller];
+           }];
 }
 
 #pragma mark - Updaters
@@ -58,7 +58,7 @@
 
   UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
       [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
-                                                                    atIndex:host.largestUndimmedDetentIndex];
+                                                           atRequestedIndex:host.largestUndimmedDetentIndex];
 
   BOOL prefersGrabberVisible = host.prefersGrabberVisible;
   CGFloat preferredCornerRadius = host.preferredCornerRadius;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -2,9 +2,28 @@
 
 #import "RNSReactBaseView.h"
 
+#if defined(__cplusplus)
+#import <vector>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetHostComponentView : RNSReactBaseView
+
+@end
+
+#pragma mark - Props
+
+@interface RNSFormSheetHostComponentView ()
+
+#if defined(__cplusplus)
+- (const std::vector<double> &)detents;
+#endif
+
+@property (nonatomic, readonly) BOOL prefersGrabberVisible;
+@property (nonatomic, readonly) CGFloat preferredCornerRadius;
+@property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
+@property (nonatomic, readonly) NSInteger initialDetentIndex;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,5 +1,6 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSDefines.h"
+#import "RNSFormSheetAppearanceApplicator.h"
 #import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
@@ -23,6 +24,7 @@ namespace react = facebook::react;
   RNSFormSheetHostEventEmitter *_Nonnull _reactEventEmitter;
   RNSFormSheetHostShadowStateProxy *_Nonnull _shadowStateProxy;
   RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
+  RNSFormSheetAppearanceApplicator *_Nonnull _appearanceApplicator;
 
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
@@ -30,13 +32,6 @@ namespace react = facebook::react;
   // Props
   BOOL _isOpen;
   std::vector<double> _detents;
-  BOOL _prefersGrabberVisible;
-  CGFloat _preferredCornerRadius;
-  NSInteger _largestUndimmedDetentIndex;
-  NSInteger _initialDetentIndex;
-
-  // State
-  BOOL _initialDetentApplied;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -55,8 +50,7 @@ namespace react = facebook::react;
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
   _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
-
-  _initialDetentApplied = NO;
+  _appearanceApplicator = [RNSFormSheetAppearanceApplicator new];
 }
 
 - (void)resetProps
@@ -70,6 +64,11 @@ namespace react = facebook::react;
   _preferredCornerRadius = -1.0;
   _largestUndimmedDetentIndex = kRNSFormSheetAlwaysDimmed;
   _initialDetentIndex = 0;
+}
+
+- (const std::vector<double> &)detents
+{
+  return _detents;
 }
 
 - (void)setupController
@@ -191,7 +190,7 @@ namespace react = facebook::react;
       [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
-      _initialDetentApplied = NO;
+      [_appearanceApplicator resetInitialDetent];
     }
   }
 
@@ -226,10 +225,9 @@ namespace react = facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration
-                      performOperations:^{
-                        [self updateConfiguration];
-                      }];
+  [_appearanceApplicator updateAppearanceIfNeededForHost:self
+                                              controller:_controller
+                                             coordinator:_appearanceCoordinator];
 
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
                       performOperations:^{
@@ -269,43 +267,6 @@ namespace react = facebook::react;
                                             contentViewOriginInWindow.y - hostOriginInWindow.y);
 
   [_shadowStateProxy updateShadowStateWithBounds:_controller.contentView.bounds origin:contentOriginOffset];
-}
-
-- (void)updateConfiguration
-{
-#if !TARGET_OS_TV
-  UISheetPresentationController *sheet = _controller.sheetPresentationController;
-  RCTAssert(
-      sheet != nil,
-      @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
-
-  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:_detents];
-
-  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
-  if (!_initialDetentApplied) {
-    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
-                                                                           atRequestedIndex:_initialDetentIndex];
-    _initialDetentApplied = YES;
-  }
-
-  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
-      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
-                                                           atRequestedIndex:_largestUndimmedDetentIndex];
-
-  // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
-  [sheet animateChanges:^{
-    sheet.detents = nativeDetents;
-    sheet.prefersGrabberVisible = _prefersGrabberVisible;
-    sheet.preferredCornerRadius =
-        _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
-    sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
-
-    if (initialDetentIdentifier != nil) {
-      sheet.selectedDetentIdentifier = initialDetentIdentifier;
-    }
-  }];
-#endif // !TARGET_OS_TV
 }
 
 #pragma mark - Touch Handling overrides


### PR DESCRIPTION
## Description

Introducing the `AppearanceApplicator` class, which is responsible for the configuration of `UISheetPresentationController`. Moving already implemented configuration from the HostView's scope.
Note: This might not be the final shape, because the Host should only receive props and notify the controller, but it seems to be independent of introducing the AppearanceApplicator concept, and it can be implemented in the stacked PR.

> [!NOTE]  
> I know that AppearanceApplicator should be stateless, but in this PR, I just want to introduce the concept and move the implementation to a dedicated class, preserving all functionalities. I want to move both AppearanceApplicator & AppearanceCoordinator to the Controller level in a follow-up PR.

## Changes

- Introduced `AppearanceApplicator` following the SplitView's implementation.
- Moved the logic related to sheet configuration from Host to AppearanceApplicator

## Before & after - visual documentation

N/A - refactor

## Test plan

Go through available SFTs for sheets.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
