### PR TITLE
refactor(iOS, FormSheet v5): Move presentation logic from HostView to ContentController

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
-- (void)prepareForPresentation;
+- (void)presentFromWindow:(nullable UIWindow *)window;
+- (void)dismiss;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
-- (void)presentFromWindow:(nullable UIWindow *)window;
-- (void)dismiss;
+- (void)presentFromWindowIfNeeded:(nonnull UIWindow *)window;
+- (void)dismissIfNeeded;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -1,7 +1,9 @@
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSPresentationSourceProvider.h"
 
 #import <React/RCTAssert.h>
+#import <React/RCTLog.h>
 
 @interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate>
 @end
@@ -30,7 +32,14 @@
   self.view = [RNSFormSheetContentView new];
 }
 
-#pragma mark - Presentation Setup
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+
+  [self.delegate sheetControllerViewDidLayoutSubviews:self];
+}
+
+#pragma mark - Presentation
 
 - (void)prepareForPresentation
 {
@@ -39,11 +48,39 @@
   self.presentationController.delegate = self;
 }
 
-- (void)viewDidLayoutSubviews
+// TODO: @t0maboro - This presentation logic is currently quite primitive.
+// We are not entirely safe from rapid conflicting updates, and there are edge cases
+// where the presentation state might become desynchronized. Addressing this robustly
+// might require an approach similar to the tabs implementation using state provenance,
+// which will be handled separately.
+// Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
+- (void)presentFromWindow:(nullable UIWindow *)window
 {
-  [super viewDidLayoutSubviews];
+  if (window == nil) {
+    return;
+  }
+  if (self.presentingViewController != nil) {
+    return;
+  }
 
-  [self.delegate sheetControllerViewDidLayoutSubviews:self];
+  UIViewController *presentationSourceViewController =
+      [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
+  if (presentationSourceViewController == nil) {
+    RCTLogError(
+        @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
+    return;
+  }
+
+  [self prepareForPresentation];
+  [presentationSourceViewController presentViewController:self animated:YES completion:nil];
+}
+
+- (void)dismiss
+{
+  if (self.presentingViewController == nil) {
+    return;
+  }
+  [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - UIAdaptivePresentationControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -54,11 +54,8 @@
 // might require an approach similar to the tabs implementation using state provenance,
 // which will be handled separately.
 // Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
-- (void)presentFromWindow:(nullable UIWindow *)window
+- (void)presentFromWindowIfNeeded:(nonnull UIWindow *)window
 {
-  if (window == nil) {
-    return;
-  }
   if (self.presentingViewController != nil) {
     return;
   }
@@ -75,7 +72,7 @@
   [presentationSourceViewController presentViewController:self animated:YES completion:nil];
 }
 
-- (void)dismiss
+- (void)dismissIfNeeded
 {
   if (self.presentingViewController == nil) {
     return;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -7,9 +7,7 @@
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
-#import "RNSPresentationSourceProvider.h"
 
-#import <React/RCTLog.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -81,48 +79,10 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  if (self.window != nil) {
-    [self updatePresentationState];
-  }
-}
-
-#pragma mark - Presentation Logic
-
-- (void)updatePresentationState
-{
-  if (self.window == nil) {
-    return;
-  }
-
-  BOOL isPresented = _controller.presentingViewController != nil;
-
-  // TODO: @t0maboro - This presentation logic is currently quite primitive.
-  // We are not entirely safe from rapid conflicting updates, and there are edge cases
-  // where the presentation state might become desynchronized. Addressing this robustly
-  // might require an approach similar to the tabs implementation using state provenance,
-  // which will be handled separately.
-  // Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
-  if (_isOpen && !isPresented) {
-    UIViewController *presentationSourceViewController =
-        [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:self.window];
-    if (presentationSourceViewController == nil) {
-      RCTLogError(
-          @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
-      return;
-    }
-
-    // TODO: @t0maboro - this log definitely requires refactor now and it should be removed outside Host in a followup
-    // PR
-    [_controller prepareForPresentation];
-    [presentationSourceViewController presentViewController:_controller animated:YES completion:nil];
-  } else if (!_isOpen && isPresented) {
-    [_controller dismissViewControllerAnimated:YES completion:nil];
+  if (_isOpen) {
+    [_controller presentFromWindow:self.window];
   } else {
-    // The remaining two combinations are valid and require no action:
-    // 1. _isOpen == NO and isPresented == NO: This occurs on the initial mount before the sheet is opened,
-    //    or when the sheet has already been successfully dismissed.
-    // 2. _isOpen == YES and isPresented == YES: This occurs when the sheet is already visible
-    //    and we are just updating other configuration props (e.g., detents) via updateProps.
+    [_controller dismiss];
   }
 }
 
@@ -239,7 +199,11 @@ namespace react = facebook::react;
 
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
                       performOperations:^{
-                        [self updatePresentationState];
+                        if (_isOpen) {
+                           [_controller presentFromWindow:self.window];
+                         } else {
+                           [_controller dismiss];
+                         }
                       }];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -76,14 +76,19 @@ namespace react = facebook::react;
   _controller.delegate = self;
 }
 
-- (void)didMoveToWindow
+- (void)updatePresentationState
 {
-  [super didMoveToWindow];
   if (_isOpen) {
     [_controller presentFromWindow:self.window];
   } else {
     [_controller dismiss];
   }
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  [self updatePresentationState];
 }
 
 #pragma mark - RNSFormSheetContentControllerDelegate
@@ -199,11 +204,7 @@ namespace react = facebook::react;
 
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
                       performOperations:^{
-                        if (_isOpen) {
-                           [_controller presentFromWindow:self.window];
-                         } else {
-                           [_controller dismiss];
-                         }
+                        [self updatePresentationState];
                       }];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -80,10 +80,10 @@ namespace react = facebook::react;
 {
   if (_isOpen) {
     if (self.window != nil) {
-      [_controller presentFromWindow:self.window];
+      [_controller presentFromWindowIfNeeded:self.window];
     }
   } else {
-    [_controller dismiss];
+    [_controller dismissIfNeeded];
   }
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -79,7 +79,9 @@ namespace react = facebook::react;
 - (void)updatePresentationState
 {
   if (_isOpen) {
-    [_controller presentFromWindow:self.window];
+    if (self.window != nil) {
+      [_controller presentFromWindow:self.window];
+    }
   } else {
     [_controller dismiss];
   }


### PR DESCRIPTION
## Description

This PR moves the present/dismiss lifecycle out of `RNSFormSheetHostComponentView` and into `RNSFormSheetContentController`, which should be a manager for the native presentation.
The `updatePresentationState` helper is replaced by two explicit single-responsibility methods on the controller - `presentFromWindow:` and `dismiss`. The Host just decides which one to call based on `_isOpen`.
Note: resolving the issue reported in https://github.com/software-mansion/react-native-screens-labs/issues/1420 will be a subject of a separate PR.

## Changes

- RNSFormSheetContentController now has `presentFromWindow:` and `dismiss` methods to manage the native sheet's presentation state
- `prepareForPresentation` was moved to the ContentController
- `RNSPresentationSourceProvider` now operates from the controller level

## Before & after - visual documentation

N/A - refactor

## Test plan

Go through the FormSheet SFTs.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
