### PR TITLE
chore(iOS, Tabs): make properties readonly in Tabs on iOS side

### DIFF
--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
 
-@property (nonatomic) RNSTabsBottomAccessoryEnvironment environment;
+@property (nonatomic, readonly) RNSTabsBottomAccessoryEnvironment environment;
 
 #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
 @end

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -37,14 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface RNSTabsScreenComponentView () <RNSScrollViewBehaviorOverriding>
 
-// TODO: All of these properties should be `readonly`. Do this when support for legacy
-// architecture is dropped.
+@property (nonatomic, readonly, nullable) NSString *screenKey;
+@property (nonatomic, readonly, nullable) NSString *badgeValue;
 
-@property (nonatomic, nullable) NSString *screenKey;
-@property (nonatomic, nullable) NSString *badgeValue;
-
-@property (nonatomic, nullable) NSString *tabBarItemTestID;
-@property (nonatomic, nullable) NSString *tabBarItemAccessibilityLabel;
+@property (nonatomic, readonly, nullable) NSString *tabBarItemTestID;
+@property (nonatomic, readonly, nullable) NSString *tabBarItemAccessibilityLabel;
 
 @property (nonatomic, readonly) RNSTabsIconType iconType;
 
@@ -57,22 +54,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) UITabBarAppearance *standardAppearance;
 @property (nonatomic, strong, readonly, nullable) UITabBarAppearance *scrollEdgeAppearance;
 
-@property (nonatomic, nullable) NSString *title;
+@property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly) BOOL isTitleUndefined;
 @property (nonatomic, readonly) RNSOrientation orientation;
 
-@property (nonatomic) BOOL shouldUseRepeatedTabSelectionPopToRootSpecialEffect;
-@property (nonatomic) BOOL shouldUseRepeatedTabSelectionScrollToTopSpecialEffect;
+@property (nonatomic, readonly) BOOL shouldUseRepeatedTabSelectionPopToRootSpecialEffect;
+@property (nonatomic, readonly) BOOL shouldUseRepeatedTabSelectionScrollToTopSpecialEffect;
 
-@property (nonatomic) BOOL preventNativeSelection;
+@property (nonatomic, readonly) BOOL preventNativeSelection;
 
 @property (nonatomic, readonly) BOOL overrideScrollViewContentInsetAdjustmentBehavior;
 
-@property (nonatomic, nullable) NSString *tabItemTestID;
-@property (nonatomic, nullable) NSString *tabItemAccessibilityLabel;
+@property (nonatomic, readonly, nullable) NSString *tabItemTestID;
+@property (nonatomic, readonly, nullable) NSString *tabItemAccessibilityLabel;
 @property (nonatomic) BOOL tabBarItemNeedsA11yUpdate;
 
-@property (nonatomic) RNSTabsScreenSystemItem systemItem;
+@property (nonatomic, readonly) RNSTabsScreenSystemItem systemItem;
 
 @end
 
@@ -80,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSTabsScreenComponentView ()
 
-@property (nonatomic) UIUserInterfaceStyle userInterfaceStyle;
+@property (nonatomic, readonly) UIUserInterfaceStyle userInterfaceStyle;
 
 @end
 


### PR DESCRIPTION
## Description

This PR makes properties regarding `Tabs` on iOS side `readonly` if they are not updated externally. This change is related to legacy architecture removal - on Paper props are applied via setters, outside the class, while on Fabric they are applied internally via `updateProps`. 

## Changes

- make properties in `RNSTabsScreenComponentView.h` and `RNSTabsBottomAccessoryContentComponentView.h` `readonly` if possible

## Before & after - visual documentation

N/A

## Test plan

Make sure that updated properties still work properly.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
