### PR TITLE
chore(Example): Turn `apps/` into a separate module

### DIFF
--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native-stack": "link:../react-navigation/packages/native-stack/",
     "@react-navigation/routers": "link:../react-navigation/packages/routers/",
     "@react-navigation/stack": "link:../react-navigation/packages/stack/",
+    "@rnscreens/apps": "link:../apps",
     "nanoid": "^4.0.2",
     "react": "19.2.3",
     "react-native": "0.85.0",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -3131,6 +3131,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rnscreens/apps@link:../apps::locator=FabricExample%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@rnscreens/apps@link:../apps::locator=FabricExample%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -3546,6 +3552,7 @@ __metadata:
     "@react-navigation/routers": "link:../react-navigation/packages/routers/"
     "@react-navigation/stack": "link:../react-navigation/packages/stack/"
     "@rnrepo/build-tools": "npm:~0.1.3-beta.0"
+    "@rnscreens/apps": "link:../apps"
     "@types/jest": "npm:^29.5.13"
     "@types/react": "npm:^19.2.0"
     "@types/react-test-renderer": "npm:^19.1.0"

--- a/TVOSExample/package.json
+++ b/TVOSExample/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native-stack": "link:../react-navigation/packages/native-stack/",
     "@react-navigation/routers": "link:../react-navigation/packages/routers/",
     "@react-navigation/stack": "link:../react-navigation/packages/stack/",
+    "@rnscreens/apps": "link:../apps",
     "jotai": "^2.9.0",
     "react": "19.2.3",
     "react-native": "npm:react-native-tvos@0.85.0-0",

--- a/TVOSExample/yarn.lock
+++ b/TVOSExample/yarn.lock
@@ -3002,6 +3002,12 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@rnscreens/apps@link:../apps::locator=TVOSExample%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@rnscreens/apps@link:../apps::locator=TVOSExample%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -3388,6 +3394,7 @@ __metadata:
     "@react-navigation/native-stack": "link:../react-navigation/packages/native-stack/"
     "@react-navigation/routers": "link:../react-navigation/packages/routers/"
     "@react-navigation/stack": "link:../react-navigation/packages/stack/"
+    "@rnscreens/apps": "link:../apps"
     "@types/jest": "npm:^29.5.13"
     "@types/react": "npm:^19.2.0"
     "@types/react-test-renderer": "npm:^19.1.0"

--- a/apps/package.json
+++ b/apps/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rnscreens/apps",
+  "version": "0.0.0",
+  "private": true,
+  "peerDependencies": {
+    "@react-navigation/bottom-tabs": "*",
+    "@react-navigation/core": "*",
+    "@react-navigation/drawer": "*",
+    "@react-navigation/elements": "*",
+    "@react-navigation/native": "*",
+    "@react-navigation/native-stack": "*",
+    "@react-navigation/routers": "*",
+    "@react-navigation/stack": "*",
+    "nanoid": "*",
+    "jotai": "*",
+    "react": "*",
+    "react-native": "*",
+    "react-native-gesture-handler": "*",
+    "react-native-reanimated": "*",
+    "react-native-restart": "*",
+    "react-native-safe-area-context": "*",
+    "react-native-screens": "*",
+    "react-native-worklets": "*"
+  }
+}


### PR DESCRIPTION
## Description

This PR turns `apps/` into a separate module according to https://github.com/software-mansion/react-native-screens/pull/3959#discussion_r3240866416

Such approach will allow us to make clean changes in https://github.com/software-mansion/react-native-screens/pull/3959

## Changes

- add `package.json` to `apps/` making it a private module
- list union of `FabricExample` and `TVOSExample` runtime dependencies as peer dependencies
- add `@rnscreens/apps` as a `link:` dependency in both example apps

## Before & after - visual documentation

N/A

## Test plan

Make sure that both example apps build.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
