### PR TITLE
fix(Android, FormSheet): Add fallbacks for unblocking sheet transition

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -85,6 +85,8 @@ class ScreenStackFragment :
 
     private var lastInsetsCompat: WindowInsetsCompat? = null
 
+    private var sheetContainerLayoutListener: View.OnLayoutChangeListener? = null
+
     @SuppressLint("ValidFragment")
     constructor(screenView: Screen) : super(screenView)
 
@@ -324,9 +326,15 @@ class ScreenStackFragment :
     }
 
     override fun onDestroyView() {
+        sheetContainerLayoutListener?.let { listener ->
+            screen.container?.removeOnLayoutChangeListener(listener)
+        }
+        sheetContainerLayoutListener = null
+
         if (::sheetTransitionCoordinator.isInitialized) {
             sheetTransitionCoordinator.cancel()
         }
+
         // ScreenStackHeaderConfig.onUpdate() calls activity.setSupportActionBar(toolbar) each time
         // the top screen updates. AppCompatDelegateImpl stores the resulting ToolbarActionBar in
         // its mActionBar field for the lifetime of the activity. When a screen is popped and the new
@@ -548,9 +556,12 @@ class ScreenStackFragment :
         }
 
         screen.container?.apply {
-            addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
-            }
+            val listener =
+                View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                    sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+                }
+            sheetContainerLayoutListener = listener
+            addOnLayoutChangeListener(listener)
 
             // The layout listener only catches future passes, so this prevents the
             // transition coordinator from hanging indefinitely in cases where the layout has

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -324,6 +324,9 @@ class ScreenStackFragment :
     }
 
     override fun onDestroyView() {
+        if (::sheetTransitionCoordinator.isInitialized) {
+            sheetTransitionCoordinator.cancel()
+        }
         // ScreenStackHeaderConfig.onUpdate() calls activity.setSupportActionBar(toolbar) each time
         // the top screen updates. AppCompatDelegateImpl stores the resulting ToolbarActionBar in
         // its mActionBar field for the lifetime of the activity. When a screen is popped and the new
@@ -544,8 +547,17 @@ class ScreenStackFragment :
             }
         }
 
-        screen.container?.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+        screen.container?.apply {
+            addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+            }
+
+            // The layout listener only catches future passes, so this prevents the
+            // transition coordinator from hanging indefinitely in cases where the layout has
+            // finished before we attached the listener.
+            if (isLaidOut && width > 0 && height > 0) {
+                sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+            }
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -85,7 +85,7 @@ class ScreenStackFragment :
 
     private var lastInsetsCompat: WindowInsetsCompat? = null
 
-    private var sheetContainerLayoutListener: View.OnLayoutChangeListener? = null
+    private var removeLayoutListenerAction: (() -> Unit)? = null
 
     @SuppressLint("ValidFragment")
     constructor(screenView: Screen) : super(screenView)
@@ -326,10 +326,8 @@ class ScreenStackFragment :
     }
 
     override fun onDestroyView() {
-        sheetContainerLayoutListener?.let { listener ->
-            screen.container?.removeOnLayoutChangeListener(listener)
-        }
-        sheetContainerLayoutListener = null
+        removeLayoutListenerAction?.invoke()
+        removeLayoutListenerAction = null
 
         if (::sheetTransitionCoordinator.isInitialized) {
             sheetTransitionCoordinator.cancel()
@@ -560,8 +558,10 @@ class ScreenStackFragment :
                 View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                     sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
                 }
-            sheetContainerLayoutListener = listener
             addOnLayoutChangeListener(listener)
+            removeLayoutListenerAction = {
+                removeOnLayoutChangeListener(listener)
+            }
 
             // The layout listener only catches future passes, so this prevents the
             // transition coordinator from hanging indefinitely in cases where the layout has

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
@@ -51,11 +51,12 @@ class BottomSheetTransitionCoordinator {
         if (areInsetsApplied || insetsFallbackRunnable != null) {
             return
         }
-        val runnable = Runnable {
-            insetsFallbackRunnable = null
-            areInsetsApplied = true
-            triggerSheetEnterTransitionIfReady(screen)
-        }
+        val runnable =
+            Runnable {
+                insetsFallbackRunnable = null
+                areInsetsApplied = true
+                triggerSheetEnterTransitionIfReady(screen)
+            }
 
         insetsFallbackRunnable = runnable
         handler.postDelayed(runnable, INSETS_FALLBACK_MS)

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
@@ -40,7 +40,7 @@ class BottomSheetTransitionCoordinator {
     // - a WindowInsets dispatch reaching the listener attached in
     // ScreenStackFragment#attachInsetsAndLayoutListenersToBottomSheet.
     //
-    // In some setups, e.g. in brownfield these signals are unreliable, because
+    // In some setups, e.g. in brownfield setups these signals are unreliable because
     // the host Activity has already dispatched its insets and these might not be
     // reached e.g. when some View higher in the hierarchy decided to consume them.
     //

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
@@ -40,7 +40,7 @@ class BottomSheetTransitionCoordinator {
     // - a WindowInsets dispatch reaching the listener attached in
     // ScreenStackFragment#attachInsetsAndLayoutListenersToBottomSheet.
     //
-    // In some setups, e.g. brownfield these signals are unreliable, because
+    // In some setups, e.g. in brownfield these signals are unreliable, because
     // the host Activity has already dispatched its insets and these might not be
     // reached e.g. when some View higher in the hierarchy decided to consume them.
     //

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/BottomSheetTransitionCoordinator.kt
@@ -1,19 +1,30 @@
 package com.swmansion.rnscreens.bottomsheet
 
+import android.os.Handler
+import android.os.Looper
 import com.swmansion.rnscreens.Screen
 
 class BottomSheetTransitionCoordinator {
     private var isLayoutComplete = false
     private var areInsetsApplied = false
 
+    private val handler = Handler(Looper.getMainLooper())
+    private var insetsFallbackRunnable: Runnable? = null
+
     internal fun onScreenContainerLayoutChanged(screen: Screen) {
         isLayoutComplete = true
         triggerSheetEnterTransitionIfReady(screen)
+        scheduleInsetsFallbackIfNeeded(screen)
     }
 
     internal fun onScreenContainerInsetsApplied(screen: Screen) {
+        cancelInsetsFallback()
         areInsetsApplied = true
         triggerSheetEnterTransitionIfReady(screen)
+    }
+
+    internal fun cancel() {
+        cancelInsetsFallback()
     }
 
     private fun triggerSheetEnterTransitionIfReady(screen: Screen) {
@@ -21,5 +32,41 @@ class BottomSheetTransitionCoordinator {
 
         screen.requestTriggeringPostponedEnterTransition()
         screen.triggerPostponedEnterTransitionIfNeeded()
+    }
+
+    //
+    // The FormSheet's transition is gated on two signals:
+    // - the screen container being laid out
+    // - a WindowInsets dispatch reaching the listener attached in
+    // ScreenStackFragment#attachInsetsAndLayoutListenersToBottomSheet.
+    //
+    // In some setups, e.g. brownfield these signals are unreliable, because
+    // the host Activity has already dispatched its insets and these might not be
+    // reached e.g. when some View higher in the hierarchy decided to consume them.
+    //
+    // As a workaround, we need to accept that the listener may never
+    // fire and unblock the transition after some arbitrary time (INSETS_FALLBACK_MS).
+    //
+    private fun scheduleInsetsFallbackIfNeeded(screen: Screen) {
+        if (areInsetsApplied || insetsFallbackRunnable != null) {
+            return
+        }
+        val runnable = Runnable {
+            insetsFallbackRunnable = null
+            areInsetsApplied = true
+            triggerSheetEnterTransitionIfReady(screen)
+        }
+
+        insetsFallbackRunnable = runnable
+        handler.postDelayed(runnable, INSETS_FALLBACK_MS)
+    }
+
+    private fun cancelInsetsFallback() {
+        insetsFallbackRunnable?.let { handler.removeCallbacks(it) }
+        insetsFallbackRunnable = null
+    }
+
+    companion object {
+        private const val INSETS_FALLBACK_MS = 250L
     }
 }


### PR DESCRIPTION
## Description

Currently, the FormSheet enter transition relies on two signals to start:
- The screen container being laid out
- `WindowInsets` being dispatched to the listener attached in ScreenStackFragment.

On devices running API 34 and below in brownfield setups, the bottom sheet transition may hang indefinitely. This happens because the `WindowInsets` are consumed higher up in the view hierarchy and never reach our listener.

---

The difference in behavior comes down to how system window insets are handled by the `PhoneWindow` and `ViewRootImpl` before and after edge-to-edge enforcement.

---
On API 34 and below:

During `Activity.onCreate` the `PhoneWindow.generateLayout` is called for the native hierarchy setup, the default behavior is to fit the content to system windows (`mDecorFitsSystemWindows = true`).

When `DecorView` is attached to the window, `applyDecorFitsSystemWindows` attaches a default insets listener (`sDefaultContentInsetsApplier`) to `ViewRootImpl`.

When `ViewRootImpl` dispatches insets via `computeSystemWindowInsets`, the `sDefaultContentInsetsApplier` calculates the required paddings and consumes the insets. As a result, the LinearLayout below the DecorView doesn't propagate insets down to our `ScreenContainer`.

---
On API 36:

With enforced edge-to-edge, `PhoneWindow.generateLayout` explicitly sets `mDecorFitsSystemWindows = false` under the hood.

Because of this, `applyDecorFitsSystemWindows` passes `null` to `ViewRootImpl` instead of the default applier.

In `computeSystemWindowInsets`, since the listener is `null`, the insets are not consumed and are simply passed down the view hierarchy, successfully reaching our `ScreenContainer` and unblocking the transition.

---
Proposed Solution:
- Since we cannot guarantee that `WindowInsets` will ever reach our view, I'm introducing a fallback mechanism. If the insets are not received within an arbitrary time, I assume they were consumed upstream, and I should trigger the transition. If insets arrive, the fallback is cancelled.
- `OnLayoutChangeListener` only catches future layout passes. We now check if (isLaidOut && width > 0 && height > 0) immediately after attaching the listener. If the view is already laid out, we manually trigger the onScreenContainerLayoutChanged callback to prevent the coordinator from hanging from this path.

Closes: https://github.com/software-mansion/react-native-screens/issues/4010

## Changes

- timeout fallback in BottomSheetTransitionCoordinator regarding insets
- synchronous path for triggering layout callback for BottomSheetTransitionCoordinator rather than relying on the listener

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/290e3864-8ae2-476e-9d07-757e2474e7d0" /> | <video src="https://github.com/user-attachments/assets/d423cf7e-4428-4779-9d70-671714a60bd0" /> |

## Test plan

- Brownfield setup with patch: https://github.com/t0maboro/RNS4010
- Test3336 - ensuring that the top inset is respected relatively to the `sheetShouldOverflowTopInset` prop value

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
