### PR TITLE
chore: cherry-pick changes to 4.25.1 stable - attempt 2

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -26,9 +26,11 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.swmansion.rnscreens.bottomsheet.SheetAnimationCoordinator
 import com.swmansion.rnscreens.bottomsheet.SheetDetents
 import com.swmansion.rnscreens.bottomsheet.fitToContentsSheetHeight
 import com.swmansion.rnscreens.bottomsheet.isSheetFitToContents
+import com.swmansion.rnscreens.bottomsheet.resolveClampedHeight
 import com.swmansion.rnscreens.bottomsheet.updateMetrics
 import com.swmansion.rnscreens.bottomsheet.useSingleDetent
 import com.swmansion.rnscreens.bottomsheet.usesFormSheetPresentation
@@ -49,6 +51,8 @@ class Screen(
 
     val sheetBehavior: BottomSheetBehavior<Screen>?
         get() = (layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<Screen>
+
+    internal val sheetAnimationCoordinator: SheetAnimationCoordinator by lazy { SheetAnimationCoordinator(this) }
 
     val reactEventDispatcher: EventDispatcher?
         get() = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
@@ -155,7 +159,7 @@ class Screen(
                 if (isInitial) {
                     setupInitialSheetContentHeight(sheetBehavior, height)
                 } else if (sheetDefaultResizeAnimationEnabled) {
-                    updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
+                    sheetAnimationCoordinator.updateSheetContentHeightWithAnimation(sheetBehavior, oldHeight, height)
                 } else {
                     updateSheetContentHeightWithoutAnimation(sheetBehavior, height)
                 }
@@ -169,104 +173,6 @@ class Screen(
         headerHeight: Int,
     ) {
         updateState(width, height, headerHeight)
-    }
-
-    /**
-     * This should be used only with sheet in `fitToContents` mode.
-     */
-    private fun updateSheetContentHeightWithAnimation(
-        behavior: BottomSheetBehavior<Screen>,
-        oldHeight: Int,
-        newHeight: Int,
-    ) {
-        val currentTranslationY = this.translationY
-
-        /*
-         * WHY OVERFLOW MATTERS:
-         * BottomSheetBehavior has a physical limit (maxHeight) defined by the parent container.
-         * If the new content height exceeds this limit (by its size or keyboard offset), simply
-         * animating translationY back to 'currentTranslationY' would attempt to render the sheet
-         * larger than the screen.
-         *
-         * We need to have constraint height inside the container's bounds.
-         * By including this overflow to our animation, we ensure the sheet stops
-         * expanding exactly at the maxHeight, preventing from being pushed
-         * off-screen or causing layout synchronization issues with the CoordinatorLayout.
-         */
-        val clampedOldHeight = resolveClampedHeight(oldHeight, currentTranslationY)
-        val clampedNewHeight = resolveClampedHeight(newHeight, currentTranslationY)
-        val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
-
-        if (visibleDelta == 0f) return
-
-        val isContentExpanding = visibleDelta > 0
-
-        if (isContentExpanding) {
-            /*
-             * Expanding content animation:
-             *
-             * Before animation, we're updating the SheetBehavior - the maximum height is the new
-             * content height, then we're forcing a layout pass. This ensures the view calculates
-             * with its new bounds when the animation starts.
-             *
-             * In the animation, we're translating the Screen back to it's (newly calculated) origin
-             * position, providing an impression that FormSheet expands. It already has the final size,
-             * but some content is not yet visible on the screen.
-             *
-             * After animation, we just need to send a notification that ShadowTree state should be updated,
-             * as the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            this.translationY += visibleDelta
-            this
-                .animate()
-                .translationY(currentTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                    layout(this.left, this.bottom - clampedNewHeight, this.right, this.bottom)
-                }.withEndAction {
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    parent.requestLayout()
-                    onSheetYTranslationChanged()
-                }.start()
-        } else {
-            /*
-             * Shrinking content animation:
-             *
-             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
-             *
-             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
-             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
-             * of shrink & expand animation is detected.
-             *
-             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
-             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
-             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
-             *
-             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
-             * another layout pass. Additionally, since the actual layout and the target position are equal,
-             * we can reset translationY to 0.
-             *
-             * After animation, we need to send a notification that ShadowTree state should be updated,
-             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            val targetTranslationY = currentTranslationY - visibleDelta
-            this
-                .animate()
-                .translationY(targetTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                }.withEndAction {
-                    layout(this.left, this.bottom - clampedNewHeight, this.right, this.bottom)
-                    this.translationY = currentTranslationY
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    parent.requestLayout()
-                    onSheetYTranslationChanged()
-                }.start()
-        }
     }
 
     private fun updateSheetContentHeightWithoutAnimation(
@@ -297,22 +203,6 @@ class Screen(
         // During the initial call in `onCreateView`, insets are not yet available,
         // so we need to request an additional layout pass later to account for them.
         requestLayout()
-    }
-
-    private fun resolveClampedHeight(
-        targetHeight: Int,
-        currentTranslationY: Float,
-    ): Int {
-        val maxAvailableVerticalSpace =
-            this.fragment
-                ?.asScreenStackFragment()
-                ?.sheetDelegate
-                ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
-
-        // Please note that currentTranslationY is rather < 0 here.
-        // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
-        // avoid the keyboard.
-        return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
     }
 
     fun registerLayoutCallbackForWrapper(wrapper: ScreenContentWrapper) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
@@ -270,6 +270,14 @@ class ScreenStackFragment :
                 object : WindowInsetsAnimationCompat.Callback(
                     WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP,
                 ) {
+                    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                        super.onPrepare(animation)
+
+                        if ((animation.typeMask and WindowInsetsCompat.Type.ime()) != 0) {
+                            sheetDelegate.notifyKeyboardAnimationStart()
+                        }
+                    }
+
                     // Replace InsetsAnimationCallback created by BottomSheetBehavior
                     // to avoid interfering with custom animations.
                     // See: https://github.com/software-mansion/react-native-screens/pull/2909
@@ -287,6 +295,10 @@ class ScreenStackFragment :
 
                     override fun onEnd(animation: WindowInsetsAnimationCompat) {
                         super.onEnd(animation)
+
+                        if ((animation.typeMask and WindowInsetsCompat.Type.ime()) != 0) {
+                            sheetDelegate.notifyKeyboardAnimationEnd()
+                        }
 
                         screen.onSheetYTranslationChanged()
                     }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -1,0 +1,302 @@
+package com.swmansion.rnscreens.bottomsheet
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ValueAnimator
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.swmansion.rnscreens.Screen
+import com.swmansion.rnscreens.ScreenStackFragment
+import com.swmansion.rnscreens.events.ScreenAnimationDelegate
+import com.swmansion.rnscreens.events.ScreenEventEmitter
+import com.swmansion.rnscreens.ext.asScreenStackFragment
+import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
+import java.lang.ref.WeakReference
+
+internal class SheetAnimationCoordinator(
+    screen: Screen,
+) {
+    private val screenRef = WeakReference(screen)
+    private val screen: Screen get() =
+        checkNotNull(screenRef.get()) {
+            "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
+        }
+    private var isSheetAnimationInProgress: Boolean = false
+
+    private var lastKeyboardBottomOffset: Int = 0
+
+    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetDelegate.SheetAnimationContext): Animator {
+        val animatorSet = AnimatorSet()
+
+        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
+        val screenStackFragment = sheetAnimationContext.fragment
+
+        val alphaAnimator = createDimmingViewAlphaAnimator(0f, dimmingDelegate.maxAlpha, dimmingDelegate)
+        val slideAnimator = createSheetSlideInAnimator()
+
+        animatorSet
+            .play(slideAnimator)
+            .takeIf {
+                dimmingDelegate.willDimForDetentIndex(screen, screen.sheetInitialDetentIndex)
+            }?.with(alphaAnimator)
+
+        attachCommonListeners(animatorSet, isEnter = true, screenStackFragment)
+
+        return animatorSet
+    }
+
+    internal fun createSheetExitAnimator(sheetAnimationContext: SheetDelegate.SheetAnimationContext): Animator {
+        val animatorSet = AnimatorSet()
+
+        val coordinatorLayout = sheetAnimationContext.coordinatorLayout
+        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
+        val screenStackFragment = sheetAnimationContext.fragment
+
+        val alphaAnimator =
+            createDimmingViewAlphaAnimator(dimmingDelegate.dimmingView.alpha, 0f, dimmingDelegate)
+        val slideAnimator = createSheetSlideOutAnimator(coordinatorLayout)
+
+        animatorSet.play(alphaAnimator).with(slideAnimator)
+
+        attachCommonListeners(animatorSet, isEnter = false, screenStackFragment)
+
+        return animatorSet
+    }
+
+    /**
+     * This should be used only with sheet in `fitToContents` mode.
+     *
+     * If an entry/exit animation is already in progress, we silently update the
+     * behavior metrics and view layout without starting a competing translationY
+     * animation - this is the fix for the race condition between the slide-in
+     * ValueAnimator and externally triggered layout pass (e.g. applying padding from SAV insets).
+     */
+    internal fun updateSheetContentHeightWithAnimation(
+        behavior: BottomSheetBehavior<Screen>,
+        oldHeight: Int,
+        newHeight: Int,
+    ) {
+        val currentTranslationY = screen.translationY
+
+        /*
+         * WHY OVERFLOW MATTERS:
+         * BottomSheetBehavior has a physical limit (maxHeight) defined by the parent container.
+         * If the new content height exceeds this limit (by its size or keyboard offset), simply
+         * animating translationY back to 'currentTranslationY' would attempt to render the sheet
+         * larger than the screen.
+         *
+         * We need to constrain the height within the container's bounds.
+         * By including this overflow to our animation, we ensure the sheet stops
+         * expanding exactly at the maxHeight, preventing from being pushed
+         * off-screen or causing layout synchronization issues with the CoordinatorLayout.
+         */
+        val clampedOldHeight = screen.resolveClampedHeight(oldHeight, currentTranslationY)
+        val clampedNewHeight = screen.resolveClampedHeight(newHeight, currentTranslationY)
+
+        // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
+        // Silently update behavior metrics and re-layout so the ongoing slide animation
+        // lands at the correct final geometry, without firing a competing animation.
+        if (isSheetAnimationInProgress) {
+            behavior.updateMetrics(clampedNewHeight)
+            screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+            // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+            // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+            // to its old position when the user starts a gesture.
+            screen.parent.requestLayout()
+            return
+        }
+
+        val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
+        if (visibleDelta == 0f) return
+
+        val isContentExpanding = visibleDelta > 0
+
+        if (isContentExpanding) {
+            /*
+             * Expanding content animation:
+             *
+             * Before animation, we're updating the SheetBehavior - the maximum height is the new
+             * content height, then we're forcing a layout pass. This ensures the view calculates
+             * with its new bounds when the animation starts.
+             *
+             * In the animation, we're translating the Screen back to it's (newly calculated) origin
+             * position, providing an impression that FormSheet expands. It already has the final size,
+             * but some content is not yet visible on the screen.
+             *
+             * After animation, we just need to send a notification that ShadowTree state should be updated,
+             * as the positioning of pressables has changed due to the Y translation manipulation.
+             */
+            screen.translationY += visibleDelta
+            screen
+                .animate()
+                .translationY(currentTranslationY)
+                .withStartAction {
+                    behavior.updateMetrics(clampedNewHeight)
+                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                }.withEndAction {
+                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                    // to its old position when the user starts a gesture.
+                    screen.parent.requestLayout()
+                    screen.onSheetYTranslationChanged()
+                }.start()
+        } else {
+            /*
+             * Shrinking content animation:
+             *
+             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
+             *
+             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
+             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
+             * of shrink & expand animation is detected.
+             *
+             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
+             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
+             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
+             *
+             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
+             * another layout pass. Additionally, since the actual layout and the target position are equal,
+             * we can reset translationY to 0.
+             *
+             * After animation, we need to send a notification that ShadowTree state should be updated,
+             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
+             */
+            val targetTranslationY = currentTranslationY - visibleDelta
+            screen
+                .animate()
+                .translationY(targetTranslationY)
+                .withStartAction {
+                    behavior.updateMetrics(clampedNewHeight)
+                }.withEndAction {
+                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
+                    screen.translationY = currentTranslationY
+                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+                    // to its old position when the user starts a gesture.
+                    screen.parent.requestLayout()
+                    screen.onSheetYTranslationChanged()
+                }.start()
+        }
+    }
+
+    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
+        lastKeyboardBottomOffset = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+        // Prioritize enter/exit animations over direct keyboard inset reactions.
+        // We store the latest keyboard offset in `lastKeyboardBottomOffset`
+        // so that it can always be respected when applying translations in `updateSheetTranslationY`.
+        //
+        // This approach allows screen translation to be triggered from two sources, but without messing them together:
+        // - During enter/exit animations, while accounting for the keyboard height.
+        // - While interacting with a TextInput inside the bottom sheet, to handle keyboard show/hide events.
+        if (!isSheetAnimationInProgress) {
+            updateSheetTranslationY(0f)
+        }
+    }
+
+    // This function calculates the Y offset to which the FormSheet should animate
+    // when appearing (entering) or disappearing (exiting) with the on-screen keyboard (IME) present.
+    // Its purpose is to ensure the FormSheet does not exceed the top edge of the screen.
+    // It tries to display the FormSheet fully above the keyboard when there's enough space.
+    // Otherwise, it shifts the sheet as high as possible, even if it means part of its content
+    // will remain hidden behind the keyboard.
+    private fun computeSheetOffsetYWithIMEPresent(keyboardHeight: Int): Int {
+        val containerHeight =
+            screen.fragment
+                ?.asScreenStackFragment()
+                ?.sheetDelegate
+                ?.tryResolveMaxFormSheetHeight()
+        check(containerHeight != null) {
+            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
+        }
+
+        if (screen.isSheetFitToContents()) {
+            val contentHeight = screen.contentWrapper?.height ?: 0
+            val offsetFromTop = maxOf(containerHeight - contentHeight, 0)
+            // If the content is higher than the Screen, offsetFromTop becomes negative.
+            // In such cases, we return 0 because a negative translation would shift the Screen
+            // to the bottom, which is not intended.
+            return minOf(offsetFromTop, keyboardHeight)
+        }
+
+        val detents = screen.sheetDetents
+
+        val detentValue = detents.highest().coerceIn(0.0, 1.0)
+        val sheetHeight = (detentValue * containerHeight).toInt()
+        val offsetFromTop = containerHeight - sheetHeight
+
+        return minOf(offsetFromTop, keyboardHeight)
+    }
+
+    private fun updateSheetTranslationY(baseTranslationY: Float) {
+        val keyboardCorrection = lastKeyboardBottomOffset
+        val bottomOffset = computeSheetOffsetYWithIMEPresent(keyboardCorrection).toFloat()
+
+        screen.translationY = baseTranslationY - bottomOffset
+    }
+
+    private fun createSheetSlideInAnimator(): ValueAnimator {
+        val startValueCallback = { _: Number? -> screen.height.toFloat() }
+        val evaluator = ExternalBoundaryValuesEvaluator(startValueCallback, { 0f })
+
+        return ValueAnimator.ofObject(evaluator, screen.height.toFloat(), 0f).apply {
+            addUpdateListener { updateSheetTranslationY(it.animatedValue as Float) }
+        }
+    }
+
+    private fun createSheetSlideOutAnimator(coordinatorLayout: CoordinatorLayout): ValueAnimator {
+        val endValue = (coordinatorLayout.bottom - screen.top - screen.translationY)
+
+        return ValueAnimator.ofFloat(0f, endValue).apply {
+            addUpdateListener {
+                updateSheetTranslationY(it.animatedValue as Float)
+            }
+        }
+    }
+
+    private fun createDimmingViewAlphaAnimator(
+        from: Float,
+        to: Float,
+        dimmingDelegate: DimmingViewManager,
+    ): ValueAnimator =
+        ValueAnimator.ofFloat(from, to).apply {
+            addUpdateListener { animator ->
+                (animator.animatedValue as? Float)?.let {
+                    dimmingDelegate.dimmingView.alpha = it
+                }
+            }
+        }
+
+    private fun attachCommonListeners(
+        animatorSet: AnimatorSet,
+        isEnter: Boolean,
+        screenStackFragment: ScreenStackFragment,
+    ) {
+        animatorSet.addListener(
+            ScreenAnimationDelegate(
+                screenStackFragment,
+                ScreenEventEmitter(screen),
+                if (isEnter) {
+                    ScreenAnimationDelegate.AnimationType.ENTER
+                } else {
+                    ScreenAnimationDelegate.AnimationType.EXIT
+                },
+            ),
+        )
+
+        animatorSet.addListener(
+            object : AnimatorListenerAdapter() {
+                override fun onAnimationStart(animation: Animator) {
+                    isSheetAnimationInProgress = true
+                }
+
+                override fun onAnimationEnd(animation: Animator) {
+                    isSheetAnimationInProgress = false
+
+                    screen.onSheetYTranslationChanged()
+                }
+            },
+        )
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -23,6 +23,9 @@ internal class SheetAnimationCoordinator(
         checkNotNull(screenRef.get()) {
             "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
         }
+    private var activeKeyboardAnimationsCount: Int = 0
+    private val isKeyboardAnimationInProgress: Boolean
+        get() = activeKeyboardAnimationsCount > 0
     private var isSheetAnimationInProgress: Boolean = false
     private var currentContentAnimator: ValueAnimator? = null
 
@@ -96,10 +99,11 @@ internal class SheetAnimationCoordinator(
         val clampedOldHeight = screen.resolveClampedHeight(oldHeight, currentTranslationY)
         val clampedNewHeight = screen.resolveClampedHeight(newHeight, currentTranslationY)
 
-        // If isSheetAnimationInProgress is set, the entry/exit animator already owns translationY writes.
-        // Silently update behavior metrics and re-layout so the ongoing slide animation
+        // If an entry/exit animation or a keyboard animation is in progress - it owns
+        // translationY writes. Then when the content size is changing, we silently
+        // update behavior metrics and re-layout so the ongoing slide animation
         // lands at the correct final geometry, without firing a competing animation.
-        if (isSheetAnimationInProgress) {
+        if (isSheetAnimationInProgress || isKeyboardAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
             screen.layoutBottomSheetAtHeight(clampedNewHeight)
             screen.finalizeBottomSheetLayoutUpdates()
@@ -205,6 +209,14 @@ internal class SheetAnimationCoordinator(
                 addUpdateListener { screen.translationY = it.animatedValue as Float }
                 start()
             }
+    }
+
+    internal fun notifyKeyboardAnimationStart() {
+        activeKeyboardAnimationsCount++
+    }
+
+    internal fun notifyKeyboardAnimationEnd() {
+        activeKeyboardAnimationsCount = maxOf(0, activeKeyboardAnimationsCount - 1)
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -100,85 +100,90 @@ internal class SheetAnimationCoordinator(
         // lands at the correct final geometry, without firing a competing animation.
         if (isSheetAnimationInProgress) {
             behavior.updateMetrics(clampedNewHeight)
-            screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
-            // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-            // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-            // to its old position when the user starts a gesture.
-            screen.parent.requestLayout()
+            screen.layoutBottomSheetAtHeight(clampedNewHeight)
+            screen.finalizeBottomSheetLayoutUpdates()
             return
         }
 
         val visibleDelta = (clampedNewHeight - clampedOldHeight).toFloat()
         if (visibleDelta == 0f) return
 
-        val isContentExpanding = visibleDelta > 0
-
-        if (isContentExpanding) {
-            /*
-             * Expanding content animation:
-             *
-             * Before animation, we're updating the SheetBehavior - the maximum height is the new
-             * content height, then we're forcing a layout pass. This ensures the view calculates
-             * with its new bounds when the animation starts.
-             *
-             * In the animation, we're translating the Screen back to it's (newly calculated) origin
-             * position, providing an impression that FormSheet expands. It already has the final size,
-             * but some content is not yet visible on the screen.
-             *
-             * After animation, we just need to send a notification that ShadowTree state should be updated,
-             * as the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            screen.translationY += visibleDelta
-            screen
-                .animate()
-                .translationY(currentTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
-                }.withEndAction {
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    screen.parent.requestLayout()
-                    screen.onSheetYTranslationChanged()
-                }.start()
+        if (visibleDelta > 0) {
+            animateContentExpanding(behavior, clampedNewHeight, currentTranslationY, visibleDelta)
         } else {
-            /*
-             * Shrinking content animation:
-             *
-             * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
-             *
-             * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
-             * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
-             * of shrink & expand animation is detected.
-             *
-             * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
-             * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
-             * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
-             *
-             * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
-             * another layout pass. Additionally, since the actual layout and the target position are equal,
-             * we can reset translationY to 0.
-             *
-             * After animation, we need to send a notification that ShadowTree state should be updated,
-             * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
-             */
-            val targetTranslationY = currentTranslationY - visibleDelta
-            screen
-                .animate()
-                .translationY(targetTranslationY)
-                .withStartAction {
-                    behavior.updateMetrics(clampedNewHeight)
-                }.withEndAction {
-                    screen.layout(screen.left, screen.bottom - clampedNewHeight, screen.right, screen.bottom)
-                    screen.translationY = currentTranslationY
-                    // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
-                    // internal offsets with the new maxHeight. This prevents the sheet from snapping back
-                    // to its old position when the user starts a gesture.
-                    screen.parent.requestLayout()
-                    screen.onSheetYTranslationChanged()
-                }.start()
+            animateContentShrinking(behavior, clampedNewHeight, currentTranslationY, visibleDelta)
         }
+    }
+
+    /*
+     * Expanding content animation:
+     *
+     * Before animation, we're updating the SheetBehavior - the maximum height is the new
+     * content height, then we're forcing a layout pass. This ensures the view calculates
+     * with its new bounds when the animation starts.
+     *
+     * In the animation, we're translating the Screen back to its (newly calculated) origin
+     * position, providing an impression that FormSheet expands. It already has the final size,
+     * but some content is not yet visible on the screen.
+     *
+     * After animation, we just need to send a notification that ShadowTree state should be updated,
+     * as the positioning of pressables has changed due to the Y translation manipulation.
+     */
+    private fun animateContentExpanding(
+        behavior: BottomSheetBehavior<Screen>,
+        clampedNewHeight: Int,
+        currentTranslationY: Float,
+        visibleDelta: Float,
+    ) {
+        screen.translationY += visibleDelta
+        screen
+            .animate()
+            .translationY(currentTranslationY)
+            .withStartAction {
+                behavior.updateMetrics(clampedNewHeight)
+                screen.layoutBottomSheetAtHeight(clampedNewHeight)
+            }.withEndAction {
+                screen.finalizeBottomSheetLayoutUpdates()
+            }.start()
+    }
+
+    /*
+     * Shrinking content animation:
+     *
+     * Before the animation, our Screen translationY is 0 - because its actual layout and visual position are equal.
+     *
+     * Before the animation, I'm updating sheet metrics to the target value - it won't update until the next layout pass,
+     * which is controlled by end action. This is done deliberately, to allow catching the case when quick combination
+     * of shrink & expand animation is detected.
+     *
+     * In the animation, we're translating the Screen down by the calculated height delta to the position (which will
+     * be new absolute 0 for the Screen, after ending the transition), providing an impression that FormSheet shrinks.
+     * FormSheet's size remains unchanged during the whole animation, therefore there is no view clipping.
+     *
+     * After animation, we can update the layout: the maximum FormSheet height is updated and we're forcing
+     * another layout pass. Additionally, since the actual layout and the target position are equal,
+     * we can reset translationY to 0.
+     *
+     * After animation, we need to send a notification that ShadowTree state should be updated,
+     * as the FormSheet size has changed and the positioning of pressables has changed due to the Y translation manipulation.
+     */
+    private fun animateContentShrinking(
+        behavior: BottomSheetBehavior<Screen>,
+        clampedNewHeight: Int,
+        currentTranslationY: Float,
+        visibleDelta: Float,
+    ) {
+        val targetTranslationY = currentTranslationY - visibleDelta
+        screen
+            .animate()
+            .translationY(targetTranslationY)
+            .withStartAction {
+                behavior.updateMetrics(clampedNewHeight)
+            }.withEndAction {
+                screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                screen.translationY = currentTranslationY
+                screen.finalizeBottomSheetLayoutUpdates()
+            }.start()
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
@@ -268,6 +273,19 @@ internal class SheetAnimationCoordinator(
             }
         }
 
+    private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
+
+    private fun Screen.finalizeBottomSheetLayoutUpdates() {
+        // Force a layout pass on the CoordinatorLayout to synchronize BottomSheetBehavior's
+        // internal offsets with the new maxHeight. This prevents the sheet from snapping back
+        // to its old position when the user starts a gesture.
+        parent.requestLayout()
+
+        // Notify that ShadowTree state should be updated, as the positioning of pressables
+        // has changed due to the Y translation manipulation.
+        onSheetYTranslationChanged()
+    }
+
     private fun attachCommonListeners(
         animatorSet: AnimatorSet,
         isEnter: Boolean,
@@ -289,6 +307,10 @@ internal class SheetAnimationCoordinator(
             object : AnimatorListenerAdapter() {
                 override fun onAnimationStart(animation: Animator) {
                     isSheetAnimationInProgress = true
+                }
+
+                override fun onAnimationCancel(animation: Animator) {
+                    isSheetAnimationInProgress = false
                 }
 
                 override fun onAnimationEnd(animation: Animator) {

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetAnimationCoordinator.kt
@@ -24,6 +24,7 @@ internal class SheetAnimationCoordinator(
             "[RNScreens] Screen has been destroyed and shouldn't be the subject of any animations"
         }
     private var isSheetAnimationInProgress: Boolean = false
+    private var currentContentAnimator: ValueAnimator? = null
 
     private var lastKeyboardBottomOffset: Int = 0
 
@@ -136,15 +137,25 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         screen.translationY += visibleDelta
-        screen
-            .animate()
-            .translationY(currentTranslationY)
-            .withStartAction {
-                behavior.updateMetrics(clampedNewHeight)
-                screen.layoutBottomSheetAtHeight(clampedNewHeight)
-            }.withEndAction {
-                screen.finalizeBottomSheetLayoutUpdates()
-            }.start()
+        cancelCurrentContentAnimation()
+        currentContentAnimator =
+            ValueAnimator.ofFloat(screen.translationY, currentTranslationY).apply {
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationStart(animation: Animator) {
+                            behavior.updateMetrics(clampedNewHeight)
+                            screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                        }
+
+                        override fun onAnimationEnd(animation: Animator) {
+                            currentContentAnimator = null
+                            screen.finalizeBottomSheetLayoutUpdates()
+                        }
+                    },
+                )
+                addUpdateListener { screen.translationY = it.animatedValue as Float }
+                start()
+            }
     }
 
     /*
@@ -174,16 +185,26 @@ internal class SheetAnimationCoordinator(
         visibleDelta: Float,
     ) {
         val targetTranslationY = currentTranslationY - visibleDelta
-        screen
-            .animate()
-            .translationY(targetTranslationY)
-            .withStartAction {
-                behavior.updateMetrics(clampedNewHeight)
-            }.withEndAction {
-                screen.layoutBottomSheetAtHeight(clampedNewHeight)
-                screen.translationY = currentTranslationY
-                screen.finalizeBottomSheetLayoutUpdates()
-            }.start()
+        cancelCurrentContentAnimation()
+        currentContentAnimator =
+            ValueAnimator.ofFloat(currentTranslationY, targetTranslationY).apply {
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationStart(animation: Animator) {
+                            behavior.updateMetrics(clampedNewHeight)
+                        }
+
+                        override fun onAnimationEnd(animation: Animator) {
+                            currentContentAnimator = null
+                            screen.layoutBottomSheetAtHeight(clampedNewHeight)
+                            screen.translationY = currentTranslationY
+                            screen.finalizeBottomSheetLayoutUpdates()
+                        }
+                    },
+                )
+                addUpdateListener { screen.translationY = it.animatedValue as Float }
+                start()
+            }
     }
 
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
@@ -272,6 +293,13 @@ internal class SheetAnimationCoordinator(
                 }
             }
         }
+
+    private fun cancelCurrentContentAnimation() {
+        currentContentAnimator?.removeAllListeners()
+        currentContentAnimator?.removeAllUpdateListeners()
+        currentContentAnimator?.cancel()
+        currentContentAnimator = null
+    }
 
     private fun Screen.layoutBottomSheetAtHeight(height: Int) = layout(left, bottom - height, right, bottom)
 

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -1,9 +1,6 @@
 package com.swmansion.rnscreens.bottomsheet
 
 import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
-import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Build
 import android.view.View
@@ -24,9 +21,6 @@ import com.swmansion.rnscreens.KeyboardState
 import com.swmansion.rnscreens.KeyboardVisible
 import com.swmansion.rnscreens.Screen
 import com.swmansion.rnscreens.ScreenStackFragment
-import com.swmansion.rnscreens.events.ScreenAnimationDelegate
-import com.swmansion.rnscreens.events.ScreenEventEmitter
-import com.swmansion.rnscreens.transition.ExternalBoundaryValuesEvaluator
 import com.swmansion.rnscreens.utils.isSoftKeyboardVisibleOrNull
 
 class SheetDelegate(
@@ -36,10 +30,7 @@ class SheetDelegate(
     private var isKeyboardVisible: Boolean = false
     private var keyboardState: KeyboardState = KeyboardNotVisible
 
-    private var isSheetAnimationInProgress: Boolean = false
-
     private var lastTopInset: Int = 0
-    private var lastKeyboardBottomOffset: Int = 0
 
     var lastStableDetentIndex: Int = screen.sheetInitialDetentIndex
         private set
@@ -348,36 +339,6 @@ class SheetDelegate(
         }
     }
 
-    // This function calculates the Y offset to which the FormSheet should animate
-    // when appearing (entering) or disappearing (exiting) with the on-screen keyboard (IME) present.
-    // Its purpose is to ensure the FormSheet does not exceed the top edge of the screen.
-    // It tries to display the FormSheet fully above the keyboard when there's enough space.
-    // Otherwise, it shifts the sheet as high as possible, even if it means part of its content
-    // will remain hidden behind the keyboard.
-    internal fun computeSheetOffsetYWithIMEPresent(keyboardHeight: Int): Int {
-        val containerHeight = tryResolveMaxFormSheetHeight()
-        check(containerHeight != null) {
-            "[RNScreens] Failed to find window height during bottom sheet behaviour configuration"
-        }
-
-        if (screen.isSheetFitToContents()) {
-            val contentHeight = screen.contentWrapper?.height ?: 0
-            val offsetFromTop = maxOf(containerHeight - contentHeight, 0)
-            // If the content is higher than the Screen, offsetFromTop becomes negative.
-            // In such cases, we return 0 because a negative translation would shift the Screen
-            // to the bottom, which is not intended.
-            return minOf(offsetFromTop, keyboardHeight)
-        }
-
-        val detents = screen.sheetDetents
-
-        val detentValue = detents.highest().coerceIn(0.0, 1.0)
-        val sheetHeight = (detentValue * containerHeight).toInt()
-        val offsetFromTop = containerHeight - sheetHeight
-
-        return minOf(offsetFromTop, keyboardHeight)
-    }
-
     // This is listener function, not the view's.
     override fun onApplyWindowInsets(
         v: View,
@@ -473,128 +434,14 @@ class SheetDelegate(
 
     // Sheet entering/exiting animations
 
-    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetAnimationContext): Animator {
-        val animatorSet = AnimatorSet()
+    internal fun createSheetEnterAnimator(sheetAnimationContext: SheetAnimationContext): Animator =
+        screen.sheetAnimationCoordinator.createSheetEnterAnimator(sheetAnimationContext)
 
-        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
-        val screenStackFragment = sheetAnimationContext.fragment
+    internal fun createSheetExitAnimator(sheetAnimationContext: SheetAnimationContext): Animator =
+        screen.sheetAnimationCoordinator.createSheetExitAnimator(sheetAnimationContext)
 
-        val alphaAnimator = createDimmingViewAlphaAnimator(0f, dimmingDelegate.maxAlpha, dimmingDelegate)
-        val slideAnimator = createSheetSlideInAnimator()
-
-        animatorSet
-            .play(slideAnimator)
-            .takeIf {
-                dimmingDelegate.willDimForDetentIndex(screen, screen.sheetInitialDetentIndex)
-            }?.with(alphaAnimator)
-
-        attachCommonListeners(animatorSet, isEnter = true, screenStackFragment)
-
-        return animatorSet
-    }
-
-    internal fun createSheetExitAnimator(sheetAnimationContext: SheetAnimationContext): Animator {
-        val animatorSet = AnimatorSet()
-
-        val coordinatorLayout = sheetAnimationContext.coordinatorLayout
-        val dimmingDelegate = sheetAnimationContext.dimmingDelegate
-        val screenStackFragment = sheetAnimationContext.fragment
-
-        val alphaAnimator =
-            createDimmingViewAlphaAnimator(dimmingDelegate.dimmingView.alpha, 0f, dimmingDelegate)
-        val slideAnimator = createSheetSlideOutAnimator(coordinatorLayout)
-
-        animatorSet.play(alphaAnimator).with(slideAnimator)
-
-        attachCommonListeners(animatorSet, isEnter = false, screenStackFragment)
-
-        return animatorSet
-    }
-
-    private fun createDimmingViewAlphaAnimator(
-        from: Float,
-        to: Float,
-        dimmingDelegate: DimmingViewManager,
-    ): ValueAnimator =
-        ValueAnimator.ofFloat(from, to).apply {
-            addUpdateListener { animator ->
-                (animator.animatedValue as? Float)?.let {
-                    dimmingDelegate.dimmingView.alpha = it
-                }
-            }
-        }
-
-    private fun createSheetSlideInAnimator(): ValueAnimator {
-        val startValueCallback = { _: Number? -> screen.height.toFloat() }
-        val evaluator = ExternalBoundaryValuesEvaluator(startValueCallback, { 0f })
-
-        return ValueAnimator.ofObject(evaluator, screen.height.toFloat(), 0f).apply {
-            addUpdateListener { updateSheetTranslationY(it.animatedValue as Float) }
-        }
-    }
-
-    private fun createSheetSlideOutAnimator(coordinatorLayout: CoordinatorLayout): ValueAnimator {
-        val endValue = (coordinatorLayout.bottom - screen.top - screen.translationY)
-
-        return ValueAnimator.ofFloat(0f, endValue).apply {
-            addUpdateListener {
-                updateSheetTranslationY(it.animatedValue as Float)
-            }
-        }
-    }
-
-    private fun updateSheetTranslationY(baseTranslationY: Float) {
-        val keyboardCorrection = lastKeyboardBottomOffset
-        val bottomOffset = computeSheetOffsetYWithIMEPresent(keyboardCorrection).toFloat()
-
-        screen.translationY = baseTranslationY - bottomOffset
-    }
-
-    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) {
-        lastKeyboardBottomOffset = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-        // Prioritize enter/exit animations over direct keyboard inset reactions.
-        // We store the latest keyboard offset in `lastKeyboardBottomOffset`
-        // so that it can always be respected when applying translations in `updateSheetTranslationY`.
-        //
-        // This approach allows screen translation to be triggered from two sources, but without messing them together:
-        // - During enter/exit animations, while accounting for the keyboard height.
-        // - While interacting with a TextInput inside the bottom sheet, to handle keyboard show/hide events.
-        if (!isSheetAnimationInProgress) {
-            updateSheetTranslationY(0f)
-        }
-    }
-
-    private fun attachCommonListeners(
-        animatorSet: AnimatorSet,
-        isEnter: Boolean,
-        screenStackFragment: ScreenStackFragment,
-    ) {
-        animatorSet.addListener(
-            ScreenAnimationDelegate(
-                screenStackFragment,
-                ScreenEventEmitter(screen),
-                if (isEnter) {
-                    ScreenAnimationDelegate.AnimationType.ENTER
-                } else {
-                    ScreenAnimationDelegate.AnimationType.EXIT
-                },
-            ),
-        )
-
-        animatorSet.addListener(
-            object : AnimatorListenerAdapter() {
-                override fun onAnimationStart(animation: Animator) {
-                    isSheetAnimationInProgress = true
-                }
-
-                override fun onAnimationEnd(animation: Animator) {
-                    isSheetAnimationInProgress = false
-
-                    screen.onSheetYTranslationChanged()
-                }
-            },
-        )
-    }
+    internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) =
+        screen.sheetAnimationCoordinator.handleKeyboardInsetsProgress(insets)
 
     private inner class KeyboardHandler : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetDelegate.kt
@@ -443,6 +443,10 @@ class SheetDelegate(
     internal fun handleKeyboardInsetsProgress(insets: WindowInsetsCompat) =
         screen.sheetAnimationCoordinator.handleKeyboardInsetsProgress(insets)
 
+    internal fun notifyKeyboardAnimationStart() = screen.sheetAnimationCoordinator.notifyKeyboardAnimationStart()
+
+    internal fun notifyKeyboardAnimationEnd() = screen.sheetAnimationCoordinator.notifyKeyboardAnimationEnd()
+
     private inner class KeyboardHandler : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(
             bottomSheet: View,

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/SheetUtils.kt
@@ -158,3 +158,19 @@ fun Screen.sheetShouldUseDimmingView(): Boolean {
  * is reattached to container.
  */
 fun View.isLaidOutOrHasCachedLayout() = this.isLaidOut || height > 0 || width > 0
+
+internal fun Screen.resolveClampedHeight(
+    targetHeight: Int,
+    currentTranslationY: Float,
+): Int {
+    val maxAvailableVerticalSpace =
+        fragment
+            ?.asScreenStackFragment()
+            ?.sheetDelegate
+            ?.tryResolveMaxFormSheetHeight() ?: return targetHeight
+
+    // Please note that currentTranslationY is rather < 0 here.
+    // The translation is included in constraining the available space, because the FormSheet can have some offset, e.g. to
+    // avoid the keyboard.
+    return targetHeight.coerceAtMost((maxAvailableVerticalSpace + currentTranslationY).toInt())
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -265,6 +265,19 @@ class TabsContainer internal constructor(
 
         super.onAttachedToWindow()
         setupFragmentManager()
+
+        // When TabsContainer is reattached to window, it might find new fragment manager (other
+        // than previous instance, e.g. in Stack v4 when screen is pushed & popped over screen with
+        // Tabs). In such case, we need to re-add currently selected tab screen fragment. As there
+        // might be another operation pending, we need to make sure that the state is restored
+        // before flushPendingUpdates is called. That's why inside restoreNavigationStateIfNeeded
+        // we're committing the transaction synchronously. This might lead to a crash if another
+        // transaction is currently being committed. If this happens to be problematic, we might need
+        // to reevaluate our approach. See #4035.
+        if (navState.isNotEmpty()) {
+            restoreNavigationStateIfNeeded()
+        }
+
         flushPendingUpdates()
 
         colorSchemeCoordinator.setup(this) { uiNightMode ->
@@ -275,6 +288,7 @@ class TabsContainer internal constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         teardownFragmentManager()
+        colorSchemeCoordinator.teardown()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration?) {
@@ -556,6 +570,36 @@ class TabsContainer internal constructor(
 
         // Block other callbacks
         return true
+    }
+
+    /**
+     * When Tabs are reattached to window, they might find new fragment manager. In this case we
+     * need to restore navigation state. We're committing the transaction synchronously so that any
+     * following operations have valid restored state before their execution.
+     *
+     * This function is a no-op if navigation state is empty.
+     */
+    private fun restoreNavigationStateIfNeeded() {
+        if (navState.isEmpty()) {
+            return
+        }
+
+        val currentFragments =
+            requireFragmentManager.fragments
+                .filterIsInstance<TabsScreenFragment>()
+                .filter { it in tabsModel }
+                .toList()
+
+        if (currentFragments.size == 1 && currentFragments[0] === selectedTab) {
+            return
+        } else if (currentFragments.isEmpty()) {
+            requireFragmentManager
+                .createTransactionWithReordering()
+                .add(contentView.id, selectedTab)
+                .commitNowAllowingStateLoss()
+        } else {
+            error("[RNScreens] Unexpected fragment manager state.")
+        }
     }
 
     private fun applyDayNightUiMode(uiMode: Int) {

--- a/apps/src/tests/issue-tests/Test4027.tsx
+++ b/apps/src/tests/issue-tests/Test4027.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button } from 'react-native';
+import {
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  TabsContainer,
+} from '@apps/shared/gamma/containers/tabs';
+import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
+
+type RouteParamList = {
+  Screen1: undefined;
+  Screen2: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function TabsScreen({ navigation }: StackNavigationProp) {
+  return (
+    <CenteredLayoutView>
+      <Button title="Push" onPress={() => navigation.push('Screen2')} />
+    </CenteredLayoutView>
+  );
+}
+
+function Screen1({ navigation }: StackNavigationProp) {
+  return (
+    <TabsContainer
+      routeConfigs={[
+        {
+          name: 'Tab1',
+          Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab1',
+          },
+        },
+        {
+          name: 'Tab2',
+          Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab2',
+          },
+        },
+        {
+          name: 'Tab3',
+          Component: () => TabsScreen({ navigation }),
+          options: {
+            ...DEFAULT_TAB_ROUTE_OPTIONS,
+            title: 'Tab3',
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function Screen2({ navigation }: StackNavigationProp) {
+  return (
+    <CenteredLayoutView>
+      <Button title="Pop" onPress={() => navigation.pop()} />
+    </CenteredLayoutView>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Screen1" component={Screen1} />
+        <Stack.Screen name="Screen2" component={Screen2} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -191,6 +191,8 @@ export { default as Test3833 } from './Test3833';
 export { default as Test3835 } from './Test3835';
 export { default as Test3867 } from './Test3867';
 export { default as Test3885 } from './Test3885';
+export { default as Test3910 } from './Test3910';
+export { default as Test4027 } from './Test4027';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -191,7 +191,6 @@ export { default as Test3833 } from './Test3833';
 export { default as Test3835 } from './Test3835';
 export { default as Test3867 } from './Test3867';
 export { default as Test3885 } from './Test3885';
-export { default as Test3910 } from './Test3910';
 export { default as Test4027 } from './Test4027';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated


### PR DESCRIPTION

- **fix(Android, FormSheet): Create SheetAnimationCoordinator to synchronize animations coming from different sources (#3914)**
- **refactor(Android, FormSheet): Minor cleanups in SheetAnimationCoordinator (#3921)**
- **refactor(Android, FormSheet): Align animators implementation to use ValueAnimator (#3922)**
- **fix(Android, FormSheet): Prioritize keyboard animation over content resize animation (#3924)**
- **fix(Android, Tabs): handle Tabs reattachment to window (#4035)**
- **Remove import of test 3910**
