### PR TITLE
refactor(test): updates screen and scenario for test-tabs-tab-bar-layout-direction to include specific behaviors and edge-cases

### DIFF
--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
@@ -41,8 +41,10 @@ function ConfigScreen() {
   }, [reactAllowRtl]);
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}
-      testID='tab-bar-layout-direction-scrollview'>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      testID="tab-bar-layout-direction-scrollview">
       <View style={styles.section}>
         <Text>
           There are 3 sources of layout direction: system, React Native and our
@@ -63,7 +65,7 @@ function ConfigScreen() {
 
       <View style={styles.section}>
         <Text style={styles.heading}>React Native's isRTL</Text>
-        <Text style={styles.rtlInfo} testID='is-rtl-information'>
+        <Text style={styles.rtlInfo} testID="is-rtl-information">
           {'I18nManager.isRTL == ' + (I18nManager.isRTL ? 'true' : 'false')}
         </Text>
       </View>
@@ -80,7 +82,7 @@ function ConfigScreen() {
           onValueChange={function (value: boolean): void {
             setReactForceRtl(value);
           }}
-          testID='react-force-rtl-picker'
+          testID="react-force-rtl-picker"
         />
       </View>
 
@@ -96,18 +98,29 @@ function ConfigScreen() {
           onValueChange={function (value: boolean): void {
             setReactAllowRtl(value);
           }}
-          testID='react-allow-rtl-picker'
+          testID="react-allow-rtl-picker"
         />
       </View>
 
       <View style={styles.section}>
         <Text style={styles.heading}>TabsHost layout direction</Text>
+        <Text style={styles.description}>
+          TabsContainer by default reads I18nManager.isRTL and applies direction
+          prop based on that value. You can override this by manually choosing
+          different direction below or using "inherit" which will fallback to
+          default behavior which is platform-dependent. On Android, layout
+          direction depends on view hierarchy propagation which in most cases
+          will result in using react-native's preference. On iOS, layout
+          direction depends on trait system which is not affected by
+          react-native and the effective layout direction of the tab bar will
+          depend on app/device language.
+        </Text>
         <SettingsPicker<NonNullable<TabsHostProps['direction']>>
           label={'direction'}
-          value={hostConfig.direction ?? 'inherit'}
+          value={hostConfig.direction ?? (I18nManager.isRTL ? 'rtl' : 'ltr')}
           onValueChange={value => updateHostConfig({ direction: value })}
           items={['inherit', 'ltr', 'rtl']}
-          testID='tab-bar-layout-direction-picker'
+          testID="tab-bar-layout-direction-picker"
         />
       </View>
     </ScrollView>

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
@@ -56,7 +56,7 @@ function ConfigScreen() {
         <Text style={styles.heading}>System layout direction</Text>
         <Text>
           System layout direction depends on the language of the device
-          (Android/iOS) and supportRtl in app manifest (Android) or available
+          (Android/iOS) and supportsRtl in app manifest (Android) or available
           localizations in Xcode (iOS). In Xcode remember that you must select
           the language as default or provide at least 1 localization file (e.g.
           empty ar.lproj/InfoPlist.strings).

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -9,13 +9,17 @@ rendering by testing the precedence between system-level settings, React
 Native's I18nManager, and the explicit direction prop from
 react-native-screens.
 
-On iOS, all scenarios follow a system direction × RN direction matrix,
-because `direction = inherit` falls back to the **native** app direction
-(i.e. the system setting), potentially overriding React Native's `forceRTL`.
-On Android, scenarios only set the RN direction, because `direction =
-inherit` propagates via `style.direction` through the view hierarchy and
-therefore follows the RN setting - no system-direction dimension is needed.
-Each section exercises `inherit`, `ltr`, and `rtl` prop values.
+When `direction` is set to `inherit`, the resolution is platform-dependent.
+On iOS, the layout is driven by the native trait system, which ignores
+React Native's `forceRTL` and strictly follows the device or app language.
+On Android, the direction propagates through the view hierarchy and in most cases
+aligns with React Native's own `I18nManager` setting, effectively letting RN override the system.
+
+Reflecting this divide, the iOS scenario set covers the full
+**System Direction × RN Direction** matrix to capture cases where native and JS
+contexts disagree. The Android scenarios omit those conflict cases - because RN's
+setting overrides the system, only the RN-direction dimension is varied.
+Both platforms validate `inherit`, `ltr`, and `rtl` prop values.
 
 **OS test creation version:** iOS: 18.6 and 26.5, Android: API Level 36.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -107,7 +107,7 @@ RTL language are NOT covered by E2E tests.
    `inherit` → `rtl` → `ltr` → `rtl` → `inherit` rapidly.
 
 - [ ] Expected: Tab bar direction updates immediately with each change with
-result described as expected above.
+  the result described as expected above.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -21,13 +21,15 @@ Each section exercises `inherit`, `ltr`, and `rtl` prop values.
 
 ## E2E test
 
-Yes: Covers all manual scenario steps for LTR/RTL configurations:
+Other: Covers first two manual scenarios for LTR/RTL configurations:
 
 - iOS: The system RTL direction is set by app configuration setting
   `AppleTextDirection`, `NSForceRightToLeftWritingDirection` and `I18NIsRTL`
   to `YES` during the app launch sequence.
 - Android: Via React Native - RTL direction must be triggered using the
   `forceRTL` toggle located within the Layout Direction screen.
+
+E2E tests for iOS specific scenarios have to be implemented.
 
 Scenarios where RTL is enabled at the device level by setting a system-wide
 RTL language are NOT covered by E2E tests.
@@ -97,6 +99,12 @@ RTL language are NOT covered by E2E tests.
 - [ ] Expected: Tab bar switches to RTL order. Tab2 becomes the leftmost
   item.
 
+5. Cycle `TabsHost direction` through
+   `inherit` → `rtl` → `ltr` → `rtl` → `inherit` rapidly.
+
+- [ ] Expected: Tab bar direction updates immediately with each change with
+result described as expected above.
+
 ---
 
 ### System RTL / RN RTL
@@ -104,21 +112,21 @@ RTL language are NOT covered by E2E tests.
 > Setup: System language is RTL (e.g. Arabic or Hebrew). RN: Enable
 > `forceRTL = true` and restart the app. `I18nManager.isRTL == true` and `TabsHost direction = rtl`.
 
-5. Set `TabsHost direction = inherit`.
+6. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
-6. Set `TabsHost direction = ltr`.
+7. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
   the leftmost item.
 
-7. Set `TabsHost direction = rtl`.
+8. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
   the leftmost item.
 
-8. Cycle `TabsHost direction` through
+9. Cycle `TabsHost direction` through
    `inherit` → `ltr` → `rtl` → `ltr` → `inherit` rapidly.
 
 - [ ] Expected: Tab bar direction updates immediately with each change with
@@ -131,19 +139,25 @@ result described as expected above.
 > Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
 > `allowRTL = false` and restart the app. `I18nManager.isRTL == false` and `TabsHost direction = ltr`.
 
-9. Set `TabsHost direction = inherit`.
+10. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
-10. Set `TabsHost direction = ltr`.
+11. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-11. Set `TabsHost direction = rtl`.
+12. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order. Tab2 is
   the leftmost item.
+
+13. Cycle `TabsHost direction` through
+   `inherit` → `ltr` → `rtl` → `ltr` → `inherit` rapidly.
+
+- [ ] Expected: Tab bar direction updates immediately with each change with
+result described as expected above.
 
 ---
 
@@ -152,16 +166,22 @@ result described as expected above.
 > Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
 > and restart the app. `I18nManager.isRTL == true` and `TabsHost direction = rtl`
 
-12. Set `TabsHost direction = inherit`.
+14. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
 
-13. Set `TabsHost direction = ltr`.
+15. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-14. Set `TabsHost direction = rtl`.
+16. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order. Tab2 is
   the leftmost item.
+
+17. Cycle `TabsHost direction` through
+`inherit` → `rtl` → `ltr` → `rtl` → `inherit` rapidly.
+
+- [ ] Expected: Tab bar direction updates immediately with each change with
+result described as expected above.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -40,9 +40,10 @@ RTL language are NOT covered by E2E tests.
 
 ## Prerequisites
 
-- iOS device or simulator with at least one RTL language localization
-  configured in Xcode (e.g., an empty `ar.lproj/InfoPlist.strings`) and system
-  language set to Arabic/Hebrew.
+- iOS device or simulator with system language set to Arabic/Hebrew.
+- Valid RTL configuration in Xcode application project (RTL language set as app's
+default language or RTL language added to supported languages + at least one
+localization file, e.g. an empty `ar.lproj/InfoPlist.strings`).
 - Android emulator with `supportsRtl` enabled in app manifest.
 
 ## Note

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -20,7 +20,7 @@ Each matrix section exercises `inherit`, `ltr`, and `rtl` prop values.
 
 ## E2E test
 
-Yes: Covers all manual scenario steps for LTR/RTL configured:
+Incomplet: Covers all manual scenario steps for LTR/RTL configured:
 
 - iOS: The system RTL direction is set by app configuration setting
   `AppleTextDirection`, `NSForceRightToLeftWritingDirection` and `I18NIsRTL`

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: direction
+# Test Scenario: Layout direction
 
 ## Details
 
@@ -9,12 +9,13 @@ rendering by testing the precedence between system-level settings, React
 Native's I18nManager, and the explicit direction prop from
 react-native-screens.
 
-The test is organized as a matrix of system direction × React Native (RN)
-direction, because on iOS `direction = inherit` falls back to the **native**
-app direction (i.e. the system setting), potentially ignoring React Native's
-`forceRTL` override. On Android, `direction = inherit` propagates via
-`style.direction` through the view hierarchy, so it follows the RN setting.
-Each matrix section exercises `inherit`, `ltr`, and `rtl` prop values.
+On iOS, all scenarios follow a system direction × RN direction matrix,
+because `direction = inherit` falls back to the **native** app direction
+(i.e. the system setting), potentially overriding React Native's `forceRTL`.
+On Android, scenarios only set the RN direction, because `direction =
+inherit` propagates via `style.direction` through the view hierarchy and
+therefore follows the RN setting — no system-direction dimension is needed.
+Each section exercises `inherit`, `ltr`, and `rtl` prop values.
 
 **OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
 
@@ -34,7 +35,7 @@ RTL language are NOT covered by E2E tests.
 ## Prerequisites
 
 - iOS device or simulator with at least one RTL language localization
-  configured in Xcode (e.g. empty `ar.lproj/InfoPlist.strings`) and system
+  configured in Xcode (e.g., an empty `ar.lproj/InfoPlist.strings`) and system
   language set to Arabic/Hebrew.
 - Android emulator with `supportsRtl` enabled in app manifest.
 
@@ -45,16 +46,23 @@ RTL language are NOT covered by E2E tests.
 - **Tab order reference:** Tab1 is the first-defined tab, Tab2 is the
   second. In LTR order Tab1 is the leftmost item; in RTL order Tab2 is the
   leftmost item.
-- For iOS below scenarios (except last one) should be executed twice: once for
-System direction and once for React Native settings.
-- For Android check only React Native settings as it overrides system settings.
+- For iOS, scenarios labeled e.g. `System LTR / RN LTR` require configuring
+  **both** the system direction and the RN direction to match the label
+  before running the steps.
+- For Android, only the RN direction needs to be set — the system direction
+  is ignored because RN's setting overrides it.
 - After toggling `forceRTL` or `allowRTL`, **restart the app** for the
   change to take effect (the screen shows a reminder).
 - The `I18nManager.isRTL` readout on the config screen reflects the current
   effective RN direction after restart.
-- Last scenario is edge-case scenario for iOS where after changing TabHost value
-and then setting it back to inherit, `direction = inherit` defers to the native
-app layout direction (system) rather than RN's `forceRTL`.
+- The last two iOS scenarios are a consequence of the behavior described
+  above: when `direction` is switched to `inherit` after being set to
+  another value, the tab bar follows the native (system) layout direction
+  rather than RN's `forceRTL`. The initial value of `TabsHost direction`
+  is not fixed — it reflects whatever direction is actually displayed on
+  mount, which depends on the system and RN settings. When the two
+  disagree, the displayed direction at startup is the resolved one (e.g.
+  RN RTL with LTR system can display as RTL initially).
 
 ---
 
@@ -66,17 +74,17 @@ app layout direction (system) rather than RN's `forceRTL`.
 
 - [ ] Expected: Tab1 and Tab2 are shown in LTR order. Tab1 is the leftmost
   item. Controls default to `forceRTL = false`, `allowRTL = true`, and
-  `TabsHost direction = inherit`. The `I18nManager.isRTL == false` label
+  `TabsHost direction = ltr`. The `I18nManager.isRTL == false` label
   is shown.
 
 ---
 
 ### System LTR / RN LTR
 
-> Setup: iOS system: System language is LTR (e.g. English). RN: `forceRTL = false` (default).
+> Setup: System language is LTR (e.g. English). RN: `forceRTL = false` (default).
 > `I18nManager.isRTL == false`.
 
-2. Set `TabsHost direction = inherit`.
+1. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
 
@@ -93,8 +101,8 @@ app layout direction (system) rather than RN's `forceRTL`.
 
 ### System RTL / RN RTL
 
-> Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). RN: Enable
-> `forceRTL = true` and restart the app. `I18nManager.isRTL == true`.
+> Setup: System language is RTL (e.g. Arabic or Hebrew). RN: Enable
+> `forceRTL = true` and restart the app. `I18nManager.isRTL == true` and `TabsHost direction = rtl`.
 
 5. Set `TabsHost direction = inherit`.
 
@@ -118,42 +126,42 @@ result described as expected above.
 
 ---
 
-### iOS only: System RTL and RN LTR
+### iOS only: System RTL / RN LTR
 
 > Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
-> `allowRTL = false` and restart the app. `I18nManager.isRTL == false`.
+> `allowRTL = false` and restart the app. `I18nManager.isRTL == false` and `TabsHost direction = ltr`.
 
 9. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
-  the leftmost item. Explicit `ltr` overrides RN's RTL setting.
-
-10. Set `TabsHost direction = rtl`.
-
-- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+- [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-11. Set `TabsHost direction = inherit`.
+10.   Set `TabsHost direction = rtl`.
+
+- [ ] Expected: Tab bar displays in RTL order. Tab2 is
+  the leftmost item.
+
+11.  Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
 ---
 
-### iOS only: System LTR and RN RTL
+### iOS only: System LTR / RN RTL
 
 > Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
-> and restart the app. `I18nManager.isRTL == true`.
+> and restart the app. `I18nManager.isRTL == true` and `TabsHost direction = rtl`
 
 12. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
+- [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-13. Set `TabsHost direction = rtl`.
+13.  Set `TabsHost direction = rtl`.
 
-- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+- [ ] Expected: Tab bar displays in RTL order. Tab2 is
   the leftmost item.
 
-14. Set `TabsHost direction = inherit`.
+14.  Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -9,18 +9,24 @@ rendering by testing the precedence between system-level settings, React
 Native's I18nManager, and the explicit direction prop from
 react-native-screens.
 
+The test is organized as a matrix of system direction × React Native (RN)
+direction, because on iOS `direction = inherit` falls back to the **native**
+app direction (i.e. the system setting), potentially ignoring React Native's
+`forceRTL` override. On Android, `direction = inherit` propagates via
+`style.direction` through the view hierarchy, so it follows the RN setting.
+Each matrix section exercises `inherit`, `ltr`, and `rtl` prop values.
+
 **OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
 
 ## E2E test
 
-Yes: Covers all manual scenario steps for LTR/RTL configured via React Native.
+Yes: Covers all manual scenario steps for LTR/RTL configured:
 
-Implementation Details:
-
-- iOS: The system RTL direction is set by configuring I18NIsRTL to YES
-  during the app launch sequence.
-- Android: RTL direction must be triggered using the forceRTL toggle located
-  within the Layout Direction screen.
+- iOS: The system RTL direction is set by app configuration setting
+  `AppleTextDirection`, `NSForceRightToLeftWritingDirection` and `I18NIsRTL`
+  to `YES` during the app launch sequence.
+- Android: Via React Native — RTL direction must be triggered using the
+  `forceRTL` toggle located within the Layout Direction screen.
 
 Scenarios where RTL is enabled at the device level by setting a system-wide
 RTL language are NOT covered by e2e tests.
@@ -28,78 +34,109 @@ RTL language are NOT covered by e2e tests.
 ## Prerequisites
 
 - iOS device or simulator with at least one RTL language localization
-  configured in Xcode (e.g. empty ar.lproj/InfoPlist.strings), or system
-  language set to Arabic/Hebrew,
-- Android emulator with supportRtl enabled in app manifest.
+  configured in Xcode (e.g. empty `ar.lproj/InfoPlist.strings`), or system
+  language set to Arabic/Hebrew.
+- Android emulator with `supportRtl` enabled in app manifest.
 
 ## Note
 
-- Assumption: System and RN settings are working correctly. Here only
-  react-native-screens prop is tested.
-- Each of the below steps must be executed twice: once with a system-wide RTL
-  language enabled at the device level and once with the RTL direction set
-  via React Native. The device-level test is particularly critical, as the
-  React Native configuration is already covered by E2E tests.
+- Assumption: System and RN settings are working correctly. Here only the
+  `direction` prop on `TabsHost` is tested.
+- **Tab order reference:** Tab1 is the first-defined tab, Tab2 is the
+  second. In LTR order Tab1 is the leftmost item; in RTL order Tab2 is the
+  leftmost item.
+- For iOS below scenarios (except last one) should be executed twice: once for
+System direction and once for React Native settings.
+- For Android check only React Native settings as it overrides system settings.
+- After toggling `forceRTL` or `allowRTL`, **restart the app** for the
+  change to take effect (the screen shows a reminder).
+- The `I18nManager.isRTL` readout on the config screen reflects the current
+  effective RN direction after restart.
+- Last scenario is egde case scenario for iOS where after changing TabHost value
+and then setting it back to inherit, `direction = inherit` defers to the
+**native** app layout direction (system), not to RN's `forceRTL`.
+
+---
 
 ## Steps
 
 ### Baseline
 
-1. Launch the app and navigate to the scenario.
+1. Launch the app and navigate to the **Layout Direction** scenario.
 
-- [ ] Expected: Tab1 and Tab2 are shown in LTR order. Tab1 displayed as the
-  leftmost item and Tab2 as second. All controls default to
-  forceRTL=false, allowRTL=true, TabsHost direction = inherit.
-
----
-
-### TabsHost inherit — follows RN/system
-
-2. Ensure system/RN is LTR (I18nManager.isRTL == false), set TabsHost
-   direction = inherit.
-
-- [ ] Expected: Tab bar displays in LTR order. Tab1 is displayed as the
-  leftmost item and Tab2 as second.
-
-3. Set system/RN to RTL (I18nManager.isRTL == true), keep TabsHost
-   direction = inherit.
-
-- [ ] Expected: Tab bar displays in RTL order. Tab2 displayed as the
-  leftmost item and Tab1 as second.
+- [ ] Expected: Tab1 and Tab2 are shown in LTR order. Tab1 is the leftmost
+  item. Controls default to `forceRTL = false`, `allowRTL = true`, and
+  `TabsHost direction = inherit`. The `I18nManager.isRTL == false` label
+  is shown.
 
 ---
 
-### TabsHost ltr
+### System LTR / RN LTR
 
-4. Set system/RN to RTL, set TabsHost direction = ltr.
+> Setup: iOS system: System language is LTR (e.g. English). RN: `forceRTL = false` (default).
+> `I18nManager.isRTL == false`.
 
-- [ ] Expected: Tab bar displays in LTR order — TabsHost overrides RTL from
-  RN/system. Tab1 is displayed as the leftmost item.
+2. Set `TabsHost direction = inherit`.
 
-1. Set system/RN to LTR, keep TabsHost direction = ltr.
+- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
 
-- [ ] Expected: Tab bar remains in LTR order. Tab1 is displayed as the the
-  leftmost item.
+3. Set `TabsHost direction = ltr`.
 
-6. Cycle through inherit → rtl → ltr → rtl → inherit.
+- [ ] Expected: Tab bar remains in LTR order. Tab1 is the leftmost item.
 
-- [ ] Expected: Tab bar direction updates immediately with each change; no
-  crashes or layout freezes occur.
+4. Set `TabsHost direction = rtl`.
+
+- [ ] Expected: Tab bar switches to RTL order. Tab2 becomes the leftmost
+  item.
 
 ---
 
-### TabsHost rtl
+### System RTL / RN RTL
 
-7. Set system/RN to LTR, set TabsHost direction = rtl.
+> Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). RN: Enable
+> `forceRTL = true` and restart the app. `I18nManager.isRTL == true`.
 
-- [ ] Expected: Tab bar displays in RTL order — TabsHost overrides LTR from
-  RN/system. Tab2 displayed as the leftmost item.
+5. Set `TabsHost direction = inherit`.
 
-8. Set system/RN to RTL, keep TabsHost direction = rtl.
+- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
-- [ ] Expected: Tab bar remains RTL. Tab2 displayed as the leftmost item.
+6. Set `TabsHost direction = ltr`.
 
-9. Cycle through inherit → ltr → rtl → ltr → inherit.
+- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
+  the leftmost item.
 
-- [ ] Expected: Tab bar direction updates immediately with each change, no
-  crashes or layout freezes occur.
+7. Set `TabsHost direction = rtl`.
+
+- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+  the leftmost item.
+
+8. Cycle `TabsHost direction` through
+   `inherit` → `ltr` → `rtl` → `ltr` → `inherit` rapidly.
+
+- [ ] Expected: Tab bar direction updates immediately with each change with
+result described as expected above.
+
+---
+
+### iOS only: System LTR and RN RTL
+
+> Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
+> and restart the app. `I18nManager.isRTL == true`.
+
+9. Set `TabsHost direction = inherit`.
+
+- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
+
+10.  Set `TabsHost direction = ltr`.
+
+- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
+  the leftmost item. Explicit `ltr` overrides RN's RTL setting.
+
+11. Set `TabsHost direction = rtl`.
+
+- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+  the leftmost item.
+
+12.  Set `TabsHost direction = inherit`.
+
+- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -20,7 +20,7 @@ Each matrix section exercises `inherit`, `ltr`, and `rtl` prop values.
 
 ## E2E test
 
-Incomplet: Covers all manual scenario steps for LTR/RTL configured:
+Yes: Covers all manual scenario steps for LTR/RTL configurations:
 
 - iOS: The system RTL direction is set by app configuration setting
   `AppleTextDirection`, `NSForceRightToLeftWritingDirection` and `I18NIsRTL`
@@ -29,14 +29,14 @@ Incomplet: Covers all manual scenario steps for LTR/RTL configured:
   `forceRTL` toggle located within the Layout Direction screen.
 
 Scenarios where RTL is enabled at the device level by setting a system-wide
-RTL language are NOT covered by e2e tests.
+RTL language are NOT covered by E2E tests.
 
 ## Prerequisites
 
 - iOS device or simulator with at least one RTL language localization
-  configured in Xcode (e.g. empty `ar.lproj/InfoPlist.strings`), or system
+  configured in Xcode (e.g. empty `ar.lproj/InfoPlist.strings`) and system
   language set to Arabic/Hebrew.
-- Android emulator with `supportRtl` enabled in app manifest.
+- Android emulator with `supportsRtl` enabled in app manifest.
 
 ## Note
 
@@ -52,9 +52,9 @@ System direction and once for React Native settings.
   change to take effect (the screen shows a reminder).
 - The `I18nManager.isRTL` readout on the config screen reflects the current
   effective RN direction after restart.
-- Last scenario is egde case scenario for iOS where after changing TabHost value
-and then setting it back to inherit, `direction = inherit` defers to the
-**native** app layout direction (system), not to RN's `forceRTL`.
+- Last scenario is edge-case scenario for iOS where after changing TabHost value
+and then setting it back to inherit, `direction = inherit` defers to the native
+app layout direction (system) rather than RN's `forceRTL`.
 
 ---
 
@@ -118,25 +118,42 @@ result described as expected above.
 
 ---
 
+### iOS only: System RTL and RN LTR
+
+> Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
+> `allowRTL = false` and restart the app. `I18nManager.isRTL == false`.
+
+9.   Set `TabsHost direction = ltr`.
+
+- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
+  the leftmost item. Explicit `ltr` overrides RN's RTL setting.
+
+10. Set `TabsHost direction = rtl`.
+
+- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+  the leftmost item.
+
+11.  Set `TabsHost direction = inherit`.
+
+- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
+
+---
+
 ### iOS only: System LTR and RN RTL
 
 > Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
 > and restart the app. `I18nManager.isRTL == true`.
 
-9. Set `TabsHost direction = inherit`.
-
-- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
-
-10.  Set `TabsHost direction = ltr`.
+12.   Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
-  the leftmost item. Explicit `ltr` overrides RN's RTL setting.
+  the leftmost item.
 
-11. Set `TabsHost direction = rtl`.
+1.  Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
   the leftmost item.
 
-12.  Set `TabsHost direction = inherit`.
+14.  Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -123,7 +123,7 @@ result described as expected above.
 > Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
 > `allowRTL = false` and restart the app. `I18nManager.isRTL == false`.
 
-9.   Set `TabsHost direction = ltr`.
+9. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
   the leftmost item. Explicit `ltr` overrides RN's RTL setting.
@@ -133,7 +133,7 @@ result described as expected above.
 - [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
   the leftmost item.
 
-11.  Set `TabsHost direction = inherit`.
+11. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
@@ -144,16 +144,16 @@ result described as expected above.
 > Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
 > and restart the app. `I18nManager.isRTL == true`.
 
-12.   Set `TabsHost direction = ltr`.
+12. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
   the leftmost item.
 
-1.  Set `TabsHost direction = rtl`.
+13. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
   the leftmost item.
 
-14.  Set `TabsHost direction = inherit`.
+14. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -84,7 +84,7 @@ RTL language are NOT covered by E2E tests.
 > Setup: System language is LTR (e.g. English). RN: `forceRTL = false` (default).
 > `I18nManager.isRTL == false`.
 
-1. Set `TabsHost direction = inherit`.
+2. Set `TabsHost direction = inherit`.
 
 - [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Layout direction
+# Test Scenario: Layout Direction
 
 ## Details
 
@@ -14,10 +14,10 @@ because `direction = inherit` falls back to the **native** app direction
 (i.e. the system setting), potentially overriding React Native's `forceRTL`.
 On Android, scenarios only set the RN direction, because `direction =
 inherit` propagates via `style.direction` through the view hierarchy and
-therefore follows the RN setting — no system-direction dimension is needed.
+therefore follows the RN setting - no system-direction dimension is needed.
 Each section exercises `inherit`, `ltr`, and `rtl` prop values.
 
-**OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -26,7 +26,7 @@ Yes: Covers all manual scenario steps for LTR/RTL configurations:
 - iOS: The system RTL direction is set by app configuration setting
   `AppleTextDirection`, `NSForceRightToLeftWritingDirection` and `I18NIsRTL`
   to `YES` during the app launch sequence.
-- Android: Via React Native — RTL direction must be triggered using the
+- Android: Via React Native - RTL direction must be triggered using the
   `forceRTL` toggle located within the Layout Direction screen.
 
 Scenarios where RTL is enabled at the device level by setting a system-wide
@@ -49,7 +49,7 @@ RTL language are NOT covered by E2E tests.
 - For iOS, scenarios labeled e.g. `System LTR / RN LTR` require configuring
   **both** the system direction and the RN direction to match the label
   before running the steps.
-- For Android, only the RN direction needs to be set — the system direction
+- For Android, only the RN direction needs to be set - the system direction
   is ignored because RN's setting overrides it.
 - After toggling `forceRTL` or `allowRTL`, **restart the app** for the
   change to take effect (the screen shows a reminder).
@@ -59,7 +59,7 @@ RTL language are NOT covered by E2E tests.
   above: when `direction` is switched to `inherit` after being set to
   another value, the tab bar follows the native (system) layout direction
   rather than RN's `forceRTL`. The initial value of `TabsHost direction`
-  is not fixed — it reflects whatever direction is actually displayed on
+  is not fixed - it reflects whatever direction is actually displayed on
   mount, which depends on the system and RN settings. When the two
   disagree, the displayed direction at startup is the resolved one (e.g.
   RN RTL with LTR system can display as RTL initially).
@@ -131,19 +131,19 @@ result described as expected above.
 > Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
 > `allowRTL = false` and restart the app. `I18nManager.isRTL == false` and `TabsHost direction = ltr`.
 
-9. Set `TabsHost direction = ltr`.
+9. Set `TabsHost direction = inherit`.
+
+- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
+
+10. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-10.   Set `TabsHost direction = rtl`.
+11. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order. Tab2 is
   the leftmost item.
-
-11.  Set `TabsHost direction = inherit`.
-
-- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
 
 ---
 
@@ -152,16 +152,16 @@ result described as expected above.
 > Setup: System language is LTR (e.g. English). Enable `forceRTL = true`
 > and restart the app. `I18nManager.isRTL == true` and `TabsHost direction = rtl`
 
-12. Set `TabsHost direction = ltr`.
+12. Set `TabsHost direction = inherit`.
+
+- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
+
+13. Set `TabsHost direction = ltr`.
 
 - [ ] Expected: Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
-13.  Set `TabsHost direction = rtl`.
+14. Set `TabsHost direction = rtl`.
 
 - [ ] Expected: Tab bar displays in RTL order. Tab2 is
   the leftmost item.
-
-14.  Set `TabsHost direction = inherit`.
-
-- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.


### PR DESCRIPTION
## Description

test-tabs-tab-bar-layout-direction files:

**scenario.md** has been updated to include specific behaviors and edge-cases:
- Android always override system settings with RN settings - note to execute scenario agains React Native settings were added
- iOS while picking inherit from list is setting value to system direction setting - when RN is set to LTR and system to RTL primary tab bar will be displayed in LTR but after reselect inherit value for TabHost it will be set to RTL (for RN: RTL and system:LTR start tab bar direction will be RTL and final: LTR)
- scenario were refactored to divide steps into System/RN rtl settings not TabHost 

**index.tsx** file was updated to fix the default value for the TabsHost layout direction. Now, displayed default value for TabsHost corresponds to the I18nManager.isRTL value, which is read by TabsContainer and applied to the direction prop based on that reading.
