### PR TITLE
refactor(iOS, FormSheet v5): Move RCTTouchHandler to ContentView

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class RNSFormSheetAppearanceCoordinator;
+@class RNSFormSheetContentController;
+@class RNSFormSheetHostComponentView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetAppearanceApplicator : NSObject
+
+- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
+
+- (void)resetInitialDetent;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
@@ -1,0 +1,80 @@
+#import "RNSFormSheetAppearanceApplicator.h"
+
+#import <React/RCTAssert.h>
+
+#import "RNSFormSheetAppearanceCoordinator.h"
+#import "RNSFormSheetAppearanceUpdateFlags.h"
+#import "RNSFormSheetContentController.h"
+#import "RNSFormSheetDetentResolver.h"
+#import "RNSFormSheetHostComponentView.h"
+
+@implementation RNSFormSheetAppearanceApplicator {
+  BOOL _initialDetentApplied;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _initialDetentApplied = NO;
+  }
+  return self;
+}
+
+- (void)resetInitialDetent
+{
+  _initialDetentApplied = NO;
+}
+
+- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
+{
+  [coordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
+            performOperations:^{
+              [self updateSheetConfigurationForHost:host controller:controller];
+            }];
+}
+
+#pragma mark - Updaters
+
+- (void)updateSheetConfigurationForHost:(RNSFormSheetHostComponentView *)host
+                             controller:(RNSFormSheetContentController *)controller
+{
+#if !TARGET_OS_TV
+  UISheetPresentationController *sheet = controller.sheetPresentationController;
+  RCTAssert(
+      sheet != nil,
+      @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
+
+  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:host.detents];
+
+  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
+  if (!_initialDetentApplied) {
+    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
+                                                                           atRequestedIndex:host.initialDetentIndex];
+    _initialDetentApplied = YES;
+  }
+
+  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
+      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
+                                                                    atIndex:host.largestUndimmedDetentIndex];
+
+  BOOL prefersGrabberVisible = host.prefersGrabberVisible;
+  CGFloat preferredCornerRadius = host.preferredCornerRadius;
+
+  [sheet animateChanges:^{
+    sheet.detents = nativeDetents;
+    sheet.prefersGrabberVisible = prefersGrabberVisible;
+    sheet.preferredCornerRadius =
+        preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : preferredCornerRadius;
+    sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
+
+    if (initialDetentIdentifier != nil) {
+      sheet.selectedDetentIdentifier = initialDetentIdentifier;
+    }
+  }];
+#endif // !TARGET_OS_TV
+}
+
+@end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block;
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block;
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import "RNSFormSheetAppearanceUpdateFlags.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetAppearanceCoordinator : NSObject
+
+- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag;
+
+- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag;
+
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -19,6 +19,10 @@
 
 - (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag
 {
+  if (flag == RNSFormSheetAppearanceUpdateFlagsNone) {
+    return NO;
+  }
+
   return (_updateFlags & flag) == flag;
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -26,7 +26,7 @@
   return (_updateFlags & flag) == flag;
 }
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(dispatch_block_t)block
 {
   if ([self isNeeded:flag]) {
     _updateFlags &= ~flag;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -22,7 +22,7 @@
   return (_updateFlags & flag) == flag;
 }
 
-- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performOperations:(NS_NOESCAPE dispatch_block_t)block
 {
   if ([self isNeeded:flag]) {
     _updateFlags &= ~flag;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceCoordinator.mm
@@ -1,0 +1,33 @@
+#import "RNSFormSheetAppearanceCoordinator.h"
+
+@implementation RNSFormSheetAppearanceCoordinator {
+  RNSFormSheetAppearanceUpdateFlags _updateFlags;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _updateFlags = RNSFormSheetAppearanceUpdateFlagsNone;
+  }
+  return self;
+}
+
+- (void)needs:(RNSFormSheetAppearanceUpdateFlags)flag
+{
+  _updateFlags |= flag;
+}
+
+- (BOOL)isNeeded:(RNSFormSheetAppearanceUpdateFlags)flag
+{
+  return (_updateFlags & flag) == flag;
+}
+
+- (void)updateIfNeeded:(RNSFormSheetAppearanceUpdateFlags)flag performBlock:(NS_NOESCAPE dispatch_block_t)block
+{
+  if ([self isNeeded:flag]) {
+    _updateFlags &= ~flag;
+    block();
+  }
+}
+
+@end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceUpdateFlags.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceUpdateFlags.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+typedef NS_OPTIONS(NSUInteger, RNSFormSheetAppearanceUpdateFlags) {
+  RNSFormSheetAppearanceUpdateFlagsNone = 0,
+  // The sheet needs to be presented or dismissed to match the requested open state.
+  RNSFormSheetAppearanceUpdateFlagsPresentation = 1 << 0,
+  // The sheet's visual appearance configuration (detents, grabber, dimming view) needs to be re-applied.
+  RNSFormSheetAppearanceUpdateFlagsConfiguration = 1 << 1,
+};

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
-- (void)prepareForPresentation;
+- (void)presentFromWindow:(nullable UIWindow *)window;
+- (void)dismiss;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentFromWindow:(nullable UIWindow *)window;
 - (void)dismiss;
 
+- (void)invalidate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -1,7 +1,9 @@
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSPresentationSourceProvider.h"
 
 #import <React/RCTAssert.h>
+#import <React/RCTLog.h>
 
 @interface RNSFormSheetContentController () <UIAdaptivePresentationControllerDelegate>
 @end
@@ -30,7 +32,14 @@
   self.view = [RNSFormSheetContentView new];
 }
 
-#pragma mark - Presentation Setup
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+
+  [self.delegate sheetControllerViewDidLayoutSubviews:self];
+}
+
+#pragma mark - Presentation
 
 - (void)prepareForPresentation
 {
@@ -39,11 +48,39 @@
   self.presentationController.delegate = self;
 }
 
-- (void)viewDidLayoutSubviews
+// TODO: @t0maboro - This presentation logic is currently quite primitive.
+// We are not entirely safe from rapid conflicting updates, and there are edge cases
+// where the presentation state might become desynchronized. Addressing this robustly
+// might require an approach similar to the tabs implementation using state provenance,
+// which will be handled separately.
+// Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
+- (void)presentFromWindow:(nullable UIWindow *)window
 {
-  [super viewDidLayoutSubviews];
+  if (window == nil) {
+    return;
+  }
+  if (self.presentingViewController != nil) {
+    return;
+  }
 
-  [self.delegate sheetControllerViewDidLayoutSubviews:self];
+  UIViewController *presentationSourceViewController =
+      [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
+  if (presentationSourceViewController == nil) {
+    RCTLogError(
+        @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
+    return;
+  }
+
+  [self prepareForPresentation];
+  [presentationSourceViewController presentViewController:self animated:YES completion:nil];
+}
+
+- (void)dismiss
+{
+  if (self.presentingViewController == nil) {
+    return;
+  }
+  [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - UIAdaptivePresentationControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -90,4 +90,11 @@
   [self.delegate sheetControllerDidNativeDismiss:self];
 }
 
+#pragma mark - Teardown
+
+- (void)invalidate
+{
+  [self.contentView invalidate];
+}
+
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
@@ -9,6 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)index;
 - (void)removeReactSubview:(UIView *)subview;
 
+- (void)invalidate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentView.mm
@@ -1,6 +1,9 @@
 #import "RNSFormSheetContentView.h"
+#import <React/RCTSurfaceTouchHandler.h>
 
-@implementation RNSFormSheetContentView
+@implementation RNSFormSheetContentView {
+  RCTSurfaceTouchHandler *_Nullable _touchHandler;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -11,6 +14,51 @@
     self.backgroundColor = [UIColor clearColor];
   }
   return self;
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window != nil) {
+    [self attachTouchHandler];
+  } else {
+    [self detachTouchHandler];
+  }
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+
+  if (_touchHandler != nil) {
+    // Touch handler requires absolute positioning coordinates, relatively to root (UIWindow)
+    CGPoint contentViewOriginInWindow = [self convertPoint:CGPointZero toView:nil];
+    _touchHandler.viewOriginOffset = contentViewOriginInWindow;
+  }
+}
+
+- (void)invalidate
+{
+  [self detachTouchHandler];
+}
+
+#pragma mark - Touch handling
+
+- (void)attachTouchHandler
+{
+  if (_touchHandler == nil) {
+    _touchHandler = [RCTSurfaceTouchHandler new];
+    [_touchHandler attachToView:self];
+  }
+}
+
+- (void)detachTouchHandler
+{
+  if (_touchHandler != nil) {
+    [_touchHandler detachFromView:self];
+    _touchHandler = nil;
+  }
 }
 
 #pragma mark - RN Subviews Management

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+#if defined(__cplusplus)
+#import <vector>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Predefined values for `initialDetentIndex`.
+static NSInteger const kRNSFormSheetLastDetent = -1;
+// Predefined values for `largestUndimmedDetentIndex`.
+static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
+static NSInteger const kRNSFormSheetNeverDimmed = -2;
+
+@interface RNSFormSheetDetentResolver : NSObject
+
+#if !TARGET_OS_TV && defined(__cplusplus)
+
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents;
+
+#endif // !TARGET_OS_TV && __cplusplus
+
+#if !TARGET_OS_TV
+
++ (nullable UISheetPresentationControllerDetentIdentifier)initialDetentIdentifierForDetents:
+                                                              (NSArray<UISheetPresentationControllerDetent *> *)detents
+                                                                           atRequestedIndex:(NSInteger)requestedIndex;
+
++ (nullable UISheetPresentationControllerDetentIdentifier)
+    largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
+                                      atIndex:(NSInteger)requestedIndex;
+
+#endif // !TARGET_OS_TV
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -1,0 +1,159 @@
+#import "RNSFormSheetDetentResolver.h"
+#import "RNSDefines.h"
+
+#import <React/RCTLog.h>
+
+#if !TARGET_OS_TV
+
+static BOOL RNSAreDetentsValid(const std::vector<double> &detents)
+{
+  for (double currentDetent : detents) {
+    if (isnan(currentDetent)) {
+      return NO;
+    }
+    if (currentDetent < 0.0 || currentDetent > 1.0) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
+{
+  for (size_t i = 1; i < detents.size(); i++) {
+    if (detents[i - 1] >= detents[i]) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+@implementation RNSFormSheetDetentResolver
+
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents
+{
+  size_t detentsCount = detents.size();
+
+  // Defaults to large detent across all iOS versions
+  if (detentsCount == 0) {
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  if (!RNSAreDetentsValid(detents)) {
+    RCTLogError(
+        @"[RNScreens] The values in the detents array must fall within the 0.0 to 1.0 range. Falling back to large detent.");
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  if (!RNSAreDetentsStrictlyAscending(detents)) {
+    RCTLogError(
+        @"[RNScreens] The values in the detents array must be in strictly ascending order. Falling back to large detent.");
+    return @[ [UISheetPresentationControllerDetent largeDetent] ];
+  }
+
+  NSMutableArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [[NSMutableArray alloc] initWithCapacity:detentsCount];
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    for (size_t i = 0; i < detentsCount; i++) {
+      double fraction = detents[i];
+      NSString *ident = [NSString stringWithFormat:@"%zu", i];
+
+      [nativeDetents
+          addObject:[UISheetPresentationControllerDetent
+                        customDetentWithIdentifier:ident
+                                          resolver:^CGFloat(
+                                              id<UISheetPresentationControllerDetentResolutionContext> context) {
+                                            return context.maximumDetentValue * fraction;
+                                          }]];
+    }
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Legacy Fallback
+    if (detentsCount == 1) {
+      double firstDetentFraction = detents[0];
+      if (firstDetentFraction < 1.0) {
+        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+      } else {
+        [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
+      }
+    } else {
+      // Handles detentsCount > 1
+      [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+      [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
+    }
+  }
+
+  return nativeDetents;
+}
+
++ (nullable UISheetPresentationControllerDetentIdentifier)initialDetentIdentifierForDetents:
+                                                              (NSArray<UISheetPresentationControllerDetent *> *)detents
+                                                                           atRequestedIndex:(NSInteger)requestedIndex
+{
+  NSInteger initialIndex = requestedIndex == kRNSFormSheetLastDetent ? (NSInteger)detents.count - 1 : requestedIndex;
+
+  if (initialIndex < 0 || initialIndex >= (NSInteger)detents.count) {
+    RCTLogError(@"[RNScreens] initialDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to 0.",
+                (long)requestedIndex,
+                (unsigned long)detents.count);
+    initialIndex = 0;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)initialIndex].identifier;
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetentsForFractions:
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)initialIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
+    }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  }
+}
+
++ (nullable UISheetPresentationControllerDetentIdentifier)
+    largestUndimmedDetentIdentifierForDetents:(NSArray<UISheetPresentationControllerDetent *> *)detents
+                                      atIndex:(NSInteger)requestedIndex
+{
+  if (requestedIndex == kRNSFormSheetAlwaysDimmed) {
+    return nil;
+  }
+
+  NSInteger ludIndex = requestedIndex == kRNSFormSheetNeverDimmed ? (NSInteger)detents.count - 1 : requestedIndex;
+
+  if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
+    RCTLogError(
+        @"[RNScreens] largestUndimmedDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to the default behavior (always dimmed).",
+        (long)requestedIndex,
+        (unsigned long)detents.count);
+    return nil;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  if (@available(iOS 16.0, *)) {
+    return detents[(NSUInteger)ludIndex].identifier;
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+  {
+    // iOS 15 Fallback - mirroring buildSheetDetentsForFractions:
+    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)ludIndex];
+
+    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
+      return UISheetPresentationControllerDetentIdentifierMedium;
+    }
+
+    return UISheetPresentationControllerDetentIdentifierLarge;
+  }
+}
+
+@end
+
+#endif // !TARGET_OS_TV

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -2,9 +2,28 @@
 
 #import "RNSReactBaseView.h"
 
+#if defined(__cplusplus)
+#import <vector>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetHostComponentView : RNSReactBaseView
+
+@end
+
+#pragma mark - Props
+
+@interface RNSFormSheetHostComponentView ()
+
+#if defined(__cplusplus)
+- (const std::vector<double> &)detents;
+#endif
+
+@property (nonatomic, readonly) BOOL prefersGrabberVisible;
+@property (nonatomic, readonly) CGFloat preferredCornerRadius;
+@property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
+@property (nonatomic, readonly) NSInteger initialDetentIndex;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -2,6 +2,7 @@
 #import "RNSDefines.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 #import "RNSPresentationSourceProvider.h"
@@ -13,12 +14,6 @@
 #import <rnscreens/RNSFormSheetHostComponentDescriptor.h>
 
 namespace react = facebook::react;
-
-// Predefined values for `initialDetentIndex`.
-static NSInteger const kRNSFormSheetLastDetent = -1;
-// Predefined values for `largestUndimmedDetentIndex`.
-static NSInteger const kRNSFormSheetAlwaysDimmed = -1;
-static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 @interface RNSFormSheetHostComponentView () <RNSFormSheetHostControllerDelegate>
 @end
@@ -288,12 +283,19 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
       sheet != nil,
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
-  NSArray<UISheetPresentationControllerDetent *> *nativeDetents = [self buildSheetDetents];
-  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier =
-      [self consumeInitialDetentIdentifierForDetents:nativeDetents];
+  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
+      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:_detents];
+
+  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
+  if (!_initialDetentApplied) {
+    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
+                                                                           atRequestedIndex:_initialDetentIndex];
+    _initialDetentApplied = YES;
+  }
 
   UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
-      [self largestUndimmedDetentIdentifierForDetents:nativeDetents];
+      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
+                                                                    atIndex:_largestUndimmedDetentIndex];
 
   // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
   [sheet animateChanges:^{
@@ -308,165 +310,6 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
     }
   }];
 #endif // !TARGET_OS_TV
-}
-
-#if !TARGET_OS_TV
-- (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetents
-{
-  size_t detentsCount = _detents.size();
-
-  // Defaults to large detent across all iOS versions
-  if (detentsCount == 0) {
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  if (![self areDetentsValid]) {
-    RCTLogError(
-        @"[RNScreens] The values in the detents array must fall within the 0.0 to 1.0 range. Falling back to large detent.");
-
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  if (![self areDetentsStrictlyAscending]) {
-    RCTLogError(
-        @"[RNScreens] The values in the detents array must be in strictly ascending order. Falling back to large detent.");
-
-    return @[ [UISheetPresentationControllerDetent largeDetent] ];
-  }
-
-  NSMutableArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [[NSMutableArray alloc] initWithCapacity:detentsCount];
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    for (size_t i = 0; i < detentsCount; i++) {
-      double fraction = _detents[i];
-      NSString *ident = [NSString stringWithFormat:@"%zu", i];
-
-      [nativeDetents
-          addObject:[UISheetPresentationControllerDetent
-                        customDetentWithIdentifier:ident
-                                          resolver:^CGFloat(
-                                              id<UISheetPresentationControllerDetentResolutionContext> context) {
-                                            return context.maximumDetentValue * fraction;
-                                          }]];
-    }
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Legacy Fallback
-    if (detentsCount == 1) {
-      double firstDetentFraction = _detents[0];
-      if (firstDetentFraction < 1.0) {
-        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
-      } else {
-        [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
-      }
-    } else {
-      // Handles detentsCount > 1
-      [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
-      [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
-    }
-  }
-
-  return nativeDetents;
-}
-
-- (UISheetPresentationControllerDetentIdentifier)consumeInitialDetentIdentifierForDetents:
-    (NSArray<UISheetPresentationControllerDetent *> *)detents
-{
-  if (_initialDetentApplied) {
-    return nil;
-  }
-
-  _initialDetentApplied = YES;
-
-  NSInteger initialIndex =
-      _initialDetentIndex == kRNSFormSheetLastDetent ? (NSInteger)detents.count - 1 : _initialDetentIndex;
-
-  if (initialIndex < 0 || initialIndex >= (NSInteger)detents.count) {
-    RCTLogError(@"[RNScreens] initialDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to 0.",
-                (long)_initialDetentIndex,
-                (unsigned long)detents.count);
-    initialIndex = 0;
-  }
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    return detents[(NSUInteger)initialIndex].identifier;
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Fallback - mirroring buildSheetDetents
-    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)initialIndex];
-
-    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
-      return UISheetPresentationControllerDetentIdentifierMedium;
-    }
-
-    return UISheetPresentationControllerDetentIdentifierLarge;
-  }
-}
-
-- (UISheetPresentationControllerDetentIdentifier)largestUndimmedDetentIdentifierForDetents:
-    (NSArray<UISheetPresentationControllerDetent *> *)detents
-{
-  if (_largestUndimmedDetentIndex == kRNSFormSheetAlwaysDimmed) {
-    return nil;
-  }
-
-  NSInteger ludIndex = _largestUndimmedDetentIndex == kRNSFormSheetNeverDimmed ? (NSInteger)detents.count - 1
-                                                                               : _largestUndimmedDetentIndex;
-
-  if (ludIndex < 0 || ludIndex >= (NSInteger)detents.count) {
-    RCTLogError(
-        @"[RNScreens] largestUndimmedDetentIndex (%ld) exceeds effective detents count (%lu). Falling back to the default behavior (always dimmed).",
-        (long)_largestUndimmedDetentIndex,
-        (unsigned long)detents.count);
-    return nil;
-  }
-
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  if (@available(iOS 16.0, *)) {
-    return detents[(NSUInteger)ludIndex].identifier;
-  } else
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-  {
-    // iOS 15 Fallback - mirroring buildSheetDetents
-    UISheetPresentationControllerDetent *targetDetent = detents[(NSUInteger)ludIndex];
-
-    if ([targetDetent isEqual:[UISheetPresentationControllerDetent mediumDetent]]) {
-      return UISheetPresentationControllerDetentIdentifierMedium;
-    }
-
-    return UISheetPresentationControllerDetentIdentifierLarge;
-  }
-}
-
-#endif // !TARGET_OS_TV
-
-- (BOOL)areDetentsValid
-{
-  for (double currentDetent : _detents) {
-    if (isnan(currentDetent)) {
-      return NO;
-    }
-
-    if (currentDetent < 0.0 || currentDetent > 1.0) {
-      return NO;
-    }
-  }
-  return YES;
-}
-
-- (BOOL)areDetentsStrictlyAscending
-{
-  for (size_t i = 1; i < _detents.size(); i++) {
-    if (_detents[i - 1] >= _detents[i]) {
-      return NO;
-    }
-  }
-  return YES;
 }
 
 #pragma mark - Touch Handling overrides

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,5 +1,6 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSDefines.h"
+#import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
 #import "RNSFormSheetDetentResolver.h"
@@ -21,6 +22,7 @@ namespace react = facebook::react;
 @implementation RNSFormSheetHostComponentView {
   RNSFormSheetHostEventEmitter *_Nonnull _reactEventEmitter;
   RNSFormSheetHostShadowStateProxy *_Nonnull _shadowStateProxy;
+  RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
 
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
@@ -35,10 +37,6 @@ namespace react = facebook::react;
 
   // State
   BOOL _initialDetentApplied;
-
-  // Invalidation flags
-  BOOL _needsSheetPresentationUpdate;
-  BOOL _needsSheetConfigurationUpdate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -56,11 +54,9 @@ namespace react = facebook::react;
 
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
+  _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
 
   _initialDetentApplied = NO;
-
-  _needsSheetPresentationUpdate = NO;
-  _needsSheetConfigurationUpdate = NO;
 }
 
 - (void)resetProps
@@ -187,12 +183,12 @@ namespace react = facebook::react;
 
   if (oldComponentProps.isOpen != newComponentProps.isOpen) {
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
-    _needsSheetPresentationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsPresentation];
 
     if (_isOpen) {
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
-      _needsSheetConfigurationUpdate = YES;
+      [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
       _initialDetentApplied = NO;
@@ -201,22 +197,22 @@ namespace react = facebook::react;
 
   if (oldComponentProps.detents != newComponentProps.detents) {
     _detents = newComponentProps.detents;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
-    _needsSheetConfigurationUpdate = YES;
+    [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
   }
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
@@ -230,15 +226,15 @@ namespace react = facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  if (_needsSheetConfigurationUpdate) {
-    _needsSheetConfigurationUpdate = NO;
-    [self updateConfiguration];
-  }
+  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
+                            performBlock:^{
+                              [self updateConfiguration];
+                            }];
 
-  if (_needsSheetPresentationUpdate) {
-    _needsSheetPresentationUpdate = NO;
-    [self updatePresentationState];
-  }
+  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
+                            performBlock:^{
+                              [self updatePresentationState];
+                            }];
 }
 
 - (void)invalidate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -7,9 +7,7 @@
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
-#import "RNSPresentationSourceProvider.h"
 
-#import <React/RCTLog.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -80,48 +78,10 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  if (self.window != nil) {
-    [self updatePresentationState];
-  }
-}
-
-#pragma mark - Presentation Logic
-
-- (void)updatePresentationState
-{
-  if (self.window == nil) {
-    return;
-  }
-
-  BOOL isPresented = _controller.presentingViewController != nil;
-
-  // TODO: @t0maboro - This presentation logic is currently quite primitive.
-  // We are not entirely safe from rapid conflicting updates, and there are edge cases
-  // where the presentation state might become desynchronized. Addressing this robustly
-  // might require an approach similar to the tabs implementation using state provenance,
-  // which will be handled separately.
-  // Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
-  if (_isOpen && !isPresented) {
-    UIViewController *presentationSourceViewController =
-        [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:self.window];
-    if (presentationSourceViewController == nil) {
-      RCTLogError(
-          @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
-      return;
-    }
-
-    // TODO: @t0maboro - this log definitely requires refactor now and it should be removed outside Host in a followup
-    // PR
-    [_controller prepareForPresentation];
-    [presentationSourceViewController presentViewController:_controller animated:YES completion:nil];
-  } else if (!_isOpen && isPresented) {
-    [_controller dismissViewControllerAnimated:YES completion:nil];
+  if (_isOpen) {
+    [_controller presentFromWindow:self.window];
   } else {
-    // The remaining two combinations are valid and require no action:
-    // 1. _isOpen == NO and isPresented == NO: This occurs on the initial mount before the sheet is opened,
-    //    or when the sheet has already been successfully dismissed.
-    // 2. _isOpen == YES and isPresented == YES: This occurs when the sheet is already visible
-    //    and we are just updating other configuration props (e.g., detents) via updateProps.
+    [_controller dismiss];
   }
 }
 
@@ -231,7 +191,11 @@ namespace react = facebook::react;
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
                        performOperations:^{
-                         [self updatePresentationState];
+                         if (_isOpen) {
+                           [_controller presentFromWindow:self.window];
+                         } else {
+                           [_controller dismiss];
+                         }
                        }];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,5 +1,6 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSDefines.h"
+#import "RNSFormSheetAppearanceApplicator.h"
 #import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
@@ -23,6 +24,7 @@ namespace react = facebook::react;
   RNSFormSheetHostEventEmitter *_Nonnull _reactEventEmitter;
   RNSFormSheetHostShadowStateProxy *_Nonnull _shadowStateProxy;
   RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
+  RNSFormSheetAppearanceApplicator *_Nonnull _appearanceApplicator;
 
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
@@ -30,13 +32,6 @@ namespace react = facebook::react;
   // Props
   BOOL _isOpen;
   std::vector<double> _detents;
-  BOOL _prefersGrabberVisible;
-  CGFloat _preferredCornerRadius;
-  NSInteger _largestUndimmedDetentIndex;
-  NSInteger _initialDetentIndex;
-
-  // State
-  BOOL _initialDetentApplied;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -55,8 +50,7 @@ namespace react = facebook::react;
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
   _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
-
-  _initialDetentApplied = NO;
+  _appearanceApplicator = [RNSFormSheetAppearanceApplicator new];
 }
 
 - (void)resetProps
@@ -70,6 +64,11 @@ namespace react = facebook::react;
   _preferredCornerRadius = -1.0;
   _largestUndimmedDetentIndex = kRNSFormSheetAlwaysDimmed;
   _initialDetentIndex = 0;
+}
+
+- (const std::vector<double> &)detents
+{
+  return _detents;
 }
 
 - (void)setupController
@@ -191,7 +190,7 @@ namespace react = facebook::react;
       [_appearanceCoordinator needs:RNSFormSheetAppearanceUpdateFlagsConfiguration];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
-      _initialDetentApplied = NO;
+      [_appearanceApplicator resetInitialDetent];
     }
   }
 
@@ -226,10 +225,9 @@ namespace react = facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
-                       performOperations:^{
-                         [self updateConfiguration];
-                       }];
+  [_appearanceApplicator updateAppearanceIfNeededForHost:self
+                                              controller:_controller
+                                             coordinator:_appearanceCoordinator];
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
                        performOperations:^{
@@ -269,43 +267,6 @@ namespace react = facebook::react;
                                             contentViewOriginInWindow.y - hostOriginInWindow.y);
 
   [_shadowStateProxy updateShadowStateWithBounds:_controller.contentView.bounds origin:contentOriginOffset];
-}
-
-- (void)updateConfiguration
-{
-#if !TARGET_OS_TV
-  UISheetPresentationController *sheet = _controller.sheetPresentationController;
-  RCTAssert(
-      sheet != nil,
-      @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
-
-  NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:_detents];
-
-  UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
-  if (!_initialDetentApplied) {
-    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
-                                                                           atRequestedIndex:_initialDetentIndex];
-    _initialDetentApplied = YES;
-  }
-
-  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
-      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
-                                                                    atIndex:_largestUndimmedDetentIndex];
-
-  // TODO: @t0maboro - consider refactoring to follow the RNSSplitAppearanceCoordinator convention
-  [sheet animateChanges:^{
-    sheet.detents = nativeDetents;
-    sheet.prefersGrabberVisible = _prefersGrabberVisible;
-    sheet.preferredCornerRadius =
-        _preferredCornerRadius < 0 ? UISheetPresentationControllerAutomaticDimension : _preferredCornerRadius;
-    sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
-
-    if (initialDetentIdentifier != nil) {
-      sheet.selectedDetentIdentifier = initialDetentIdentifier;
-    }
-  }];
-#endif // !TARGET_OS_TV
 }
 
 #pragma mark - Touch Handling overrides

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -8,7 +8,6 @@
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 
-#import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <rnscreens/RNSFormSheetHostComponentDescriptor.h>
@@ -25,7 +24,6 @@ namespace react = facebook::react;
   RNSFormSheetAppearanceApplicator *_Nonnull _appearanceApplicator;
 
   RNSFormSheetContentController *_Nullable _controller;
-  RCTSurfaceTouchHandler *_Nullable _touchHandler;
 
   // Props
   BOOL _isOpen;
@@ -95,7 +93,6 @@ namespace react = facebook::react;
 
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller
 {
-  [self syncTouchHandlerOrigin];
   [self syncShadowNodeState];
 }
 
@@ -201,15 +198,11 @@ namespace react = facebook::react;
 
 - (void)invalidate
 {
-  if (_touchHandler != nil) {
-    [_touchHandler detachFromView:_controller.contentView];
-    _touchHandler = nil;
-  }
-
   if (_controller != nil) {
     if (_controller.presentingViewController != nil) {
       [_controller dismissViewControllerAnimated:NO completion:nil];
     }
+    [_controller invalidate];
     _controller = nil;
   }
 }
@@ -240,30 +233,6 @@ namespace react = facebook::react;
   // The actual React children are "teleported" and mounted inside a separate view hierarchy (RNSFormSheetContentView).
   // Returning nil ensures that this host view never intercepts touch events meant for the underlying screen.
   return nil;
-}
-
-#pragma mark - Touch Handling helpers
-
-- (void)syncTouchHandlerOrigin
-{
-  if (_controller == nil || _controller.contentView == nil) {
-    return;
-  }
-
-  // Touch handler requires absolute positioning coordinates, relatively to root (UIWindow)
-  CGPoint contentViewOriginInWindow = [_controller.contentView convertPoint:CGPointZero toView:nil];
-  [self updateTouchHandlerWithOrigin:contentViewOriginInWindow];
-}
-
-- (void)updateTouchHandlerWithOrigin:(CGPoint)origin
-{
-  if (_touchHandler == nil) {
-    _touchHandler = [RCTSurfaceTouchHandler new];
-    [_touchHandler attachToView:_controller.contentView];
-  }
-
-  // Aligns touch coordinate space with window coordinate space
-  _touchHandler.viewOriginOffset = origin;
 }
 
 #pragma mark - Dynamic frameworks support

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -227,14 +227,14 @@ namespace react = facebook::react;
   [super finalizeUpdates:updateMask];
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsConfiguration
-                            performBlock:^{
-                              [self updateConfiguration];
-                            }];
+                       performOperations:^{
+                         [self updateConfiguration];
+                       }];
 
   [_appearanceCoordinator updateIfNeeded:RNSFormSheetAppearanceUpdateFlagsPresentation
-                            performBlock:^{
-                              [self updatePresentationState];
-                            }];
+                       performOperations:^{
+                         [self updatePresentationState];
+                       }];
 }
 
 - (void)invalidate


### PR DESCRIPTION
## Description

Manage RCTSurfaceTouchHandler lifecycle on ContentView attach/detach to the window. Move touch handler content origin synchronization to ContetView. Left only hitTest override on the Host level (strictly related to the Host), the rest of touch handling logic was removed.

## Changes

- RCTSurfaceTouchHandler lifecycle was moved from Host to ContentView.

## Before & after - visual documentation

N/A - refactor

## Test plan

All SFTs should work the same

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
