### PR TITLE
chore(iOS): remove guards regarding RN < 0.82 version

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -147,14 +147,10 @@ RNS_IGNORE_SUPER_CALL_END
 
     auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
 
-    _state->updateState(
-        std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        _synchronousShadowStateUpdatesEnabled ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
-                                              : facebook::react::EventQueue::UpdateMode::Asynchronous
-#endif
-    );
+    _state->updateState(std::move(newState),
+                        _synchronousShadowStateUpdatesEnabled
+                            ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                            : facebook::react::EventQueue::UpdateMode::Asynchronous);
 
     // TODO: Requesting layout on every layout is wrong. We should look for a way to get rid of this.
     UINavigationController *navctr = _controller.navigationController;

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -1353,7 +1353,7 @@ RNS_IGNORE_SUPER_CALL_END
     // Note that self.tag might be invalid in cases this stack is removed.
     // This mostlikely does not cause any problems now, but it is something
     // worth to be aware of.
-    if (MUTATION_PARENT_TAG(mutation) == self.tag &&
+    if (mutation.parentTag == self.tag &&
         (mutation.type == react::ShadowViewMutation::Type::Insert ||
          mutation.type == react::ShadowViewMutation::Type::Remove)) {
       // we need to wait until children have their layout set. At this point they don't have the layout

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -178,14 +178,10 @@ RNS_IGNORE_SUPER_CALL_END
 
   if (newState != _lastSendState) {
     _lastSendState = newState;
-    _state->updateState(
-        std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        _synchronousShadowStateUpdatesEnabled ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
-                                              : facebook::react::EventQueue::UpdateMode::Asynchronous
-#endif
-    );
+    _state->updateState(std::move(newState),
+                        _synchronousShadowStateUpdatesEnabled
+                            ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                            : facebook::react::EventQueue::UpdateMode::Asynchronous);
   }
 }
 

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -91,14 +91,10 @@ namespace react = facebook::react;
   if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
     auto newState =
         react::RNSScreenStackHeaderSubviewState(RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin));
-    _state->updateState(
-        std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        _synchronousShadowStateUpdatesEnabled ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
-                                              : facebook::react::EventQueue::UpdateMode::Asynchronous
-#endif
-    );
+    _state->updateState(std::move(newState),
+                        _synchronousShadowStateUpdatesEnabled
+                            ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
+                            : facebook::react::EventQueue::UpdateMode::Asynchronous);
 
     _lastScheduledFrame = frame;
   }

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -375,7 +375,6 @@ RNSTabsBottomAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UI
   }
 }
 
-#if REACT_NATIVE_VERSION_MINOR >= 82
 RNSTabsBottomAccessoryEnvironment RNSTabsBottomAccessoryEnvironmentFromCppEquivalent(
     react::RNSTabsBottomAccessoryContentEnvironment environment)
 {
@@ -392,7 +391,6 @@ RNSTabsBottomAccessoryEnvironment RNSTabsBottomAccessoryEnvironmentFromCppEquiva
       RCTLogError(@"[RNScreens] Unsupported TabsBottomAccessory environment");
   }
 }
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
 
 #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -68,10 +68,8 @@ API_AVAILABLE(ios(26.0))
 std::optional<react::RNSTabsBottomAccessoryEventEmitter::OnEnvironmentChangeEnvironment>
 RNSTabsBottomAccessoryOnEnvironmentChangePayloadFromUITabAccessoryEnvironment(UITabAccessoryEnvironment environment);
 
-#if REACT_NATIVE_VERSION_MINOR >= 82
 RNSTabsBottomAccessoryEnvironment RNSTabsBottomAccessoryEnvironmentFromCppEquivalent(
     react::RNSTabsBottomAccessoryContentEnvironment environment);
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
 
 #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 

--- a/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
+++ b/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
@@ -45,13 +45,7 @@ namespace react = facebook::react;
 
   if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
     auto newState = react::RNSSplitScreenState{RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin)};
-    _state->updateState(std::move(newState)
-    // TODO: @t0maboro - remove this compilation check once TVOSExample is upgraded to RN 82+
-#if REACT_NATIVE_VERSION_MINOR >= 82
-                            ,
-                        facebook::react::EventQueue::UpdateMode::unstable_Immediate
-#endif
-    );
+    _state->updateState(std::move(newState), facebook::react::EventQueue::UpdateMode::unstable_Immediate);
 
     _lastScheduledFrame = frame;
   }

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -105,12 +105,7 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
   }
 
   auto newData = facebook::react::RNSSafeAreaViewState{RCTEdgeInsetsFromUIEdgeInsets(_currentSafeAreaInsets)};
-  _state->updateState(std::move(newData)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-                          ,
-                      facebook::react::EventQueue::UpdateMode::unstable_Immediate
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
-  );
+  _state->updateState(std::move(newData), facebook::react::EventQueue::UpdateMode::unstable_Immediate);
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
@@ -14,11 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSTabsBottomAccessoryContentComponentView : RNSReactBaseView
 
-#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus)
 
 @property (nonatomic, readonly) RNSTabsBottomAccessoryEnvironment environment;
 
-#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && defined(__cplusplus)
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
@@ -12,9 +12,9 @@ namespace react = facebook::react;
 #pragma mark - View implementation
 
 @implementation RNSTabsBottomAccessoryContentComponentView {
-#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && REACT_NATIVE_VERSION_MINOR >= 82
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
   RNSTabsBottomAccessoryComponentView *__weak _Nullable _accessoryView;
-#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && REACT_NATIVE_VERSION_MINOR >= 82
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -25,7 +25,7 @@ namespace react = facebook::react;
 
 #pragma mark - UIKit callbacks
 
-#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && REACT_NATIVE_VERSION_MINOR >= 82
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 - (void)didMoveToWindow
 {
@@ -53,15 +53,13 @@ namespace react = facebook::react;
   }
 }
 
-#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE && REACT_NATIVE_VERSION_MINOR >= 82
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 #if RCT_NEW_ARCH_ENABLED
 
 #pragma mark - RCTViewComponentViewProtocol
 
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
-
-#if REACT_NATIVE_VERSION_MINOR >= 82
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props
            oldProps:(const facebook::react::Props::Shared &)oldProps
@@ -90,8 +88,6 @@ namespace react = facebook::react;
   // visibility, we call `handleContentViewVisibilityForEnvironmentIfNeeded` here.
   [_accessoryView.helper handleContentViewVisibilityForEnvironmentIfNeeded];
 }
-
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h
@@ -36,7 +36,7 @@ API_AVAILABLE(ios(26.0))
 
 #pragma mark - Content view switching workaround
 
-#if defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
+#if defined(__cplusplus)
 
 /**
  * Due to *synchronous* events not being actually *synchronous*, we are unable to handle layout modifications
@@ -63,7 +63,7 @@ API_AVAILABLE(ios(26.0))
 
 @end
 
-#endif // defined(__cplusplus) && REACT_NATIVE_VERSION_MINOR >= 82
+#endif // defined(__cplusplus)
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -14,13 +14,8 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
   RNSTabsBottomAccessoryComponentView *__weak _bottomAccessoryView;
   UIView *__weak _observedNativeWrapperView;
 
-#if REACT_NATIVE_VERSION_MINOR < 82
-  BOOL _initialStateUpdateSent;
-  CADisplayLink *_displayLink;
-#else // REACT_NATIVE_VERSION_MINOR < 82
   RNSTabsBottomAccessoryContentComponentView *__weak _regularContentView;
   RNSTabsBottomAccessoryContentComponentView *__weak _inlineContentView;
-#endif // REACT_NATIVE_VERSION_MINOR < 82
 
   id<UITraitChangeRegistration> _traitChangeRegistration;
 }
@@ -39,18 +34,11 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 - (void)initState
 {
   _observedNativeWrapperView = nil;
-#if REACT_NATIVE_VERSION_MINOR < 82
-  _initialStateUpdateSent = NO;
-  _displayLink = nil;
-#else // REACT_NATIVE_VERSION_MINOR < 82
   _regularContentView = nil;
   _inlineContentView = nil;
-#endif // REACT_NATIVE_VERSION_MINOR < 82
 }
 
 #pragma mark - Content view switching workaround
-
-#if REACT_NATIVE_VERSION_MINOR >= 82
 
 - (BOOL)isContentViewSwitchingWorkaroundActive
 {
@@ -94,8 +82,6 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
   }
 }
 
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
-
 #pragma mark - Observing environment changes
 
 - (id<UITraitChangeRegistration>)registerForAccessoryEnvironmentChanges
@@ -106,9 +92,7 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
                     UITabAccessoryEnvironment environment =
                         self->_bottomAccessoryView.traitCollection.tabAccessoryEnvironment;
                     [self->_bottomAccessoryView.reactEventEmitter emitOnEnvironmentChangeIfNeeded:environment];
-#if REACT_NATIVE_VERSION_MINOR >= 82
                     [self handleContentViewVisibilityForEnvironmentIfNeeded];
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
                   }];
 }
 
@@ -163,58 +147,10 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 
 - (void)notifyWrapperViewFrameHasChanged
 {
-#if REACT_NATIVE_VERSION_MINOR < 82
-  // Make sure that bottom accessory's size is sent to ShadowNode as soon as possible.
-  // We set origin to (0,0) because initially self.nativeWrapperView's origin is incorrect.
-  // We want the enable the display link as well so that it takes over later with correct origin.
-  if (!_initialStateUpdateSent) {
-    CGRect frame = CGRectMake(0, 0, self.nativeWrapperView.frame.size.width, self.nativeWrapperView.frame.size.height);
-    [_bottomAccessoryView.shadowStateProxy updateShadowStateWithFrame:frame];
-    _initialStateUpdateSent = YES;
-  }
-
-  if (_displayLink == nil) {
-    [self setupDisplayLink];
-  }
-#else // REACT_NATIVE_VERSION_MINOR < 82
   // We use self.nativeWrapperView because it has both the size and the origin
   // that we want to send to the ShadowNode.
   [_bottomAccessoryView.shadowStateProxy updateShadowStateWithFrame:self.nativeWrapperView.frame];
-#endif // REACT_NATIVE_VERSION_MINOR < 82
 }
-
-#if REACT_NATIVE_VERSION_MINOR < 82
-- (void)setupDisplayLink
-{
-  _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleDisplayLink:)];
-  [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-}
-
-- (void)handleDisplayLink:(CADisplayLink *)sender
-{
-  // We use self.nativeWrapperView because it has both the size and the origin
-  // that we want to send to the ShadowNode.
-  CGRect presentationFrame = self.nativeWrapperView.layer.presentationLayer.frame;
-  if (CGRectEqualToRect(presentationFrame, CGRectZero)) {
-    return;
-  }
-
-  [_bottomAccessoryView.shadowStateProxy updateShadowStateWithFrame:presentationFrame];
-
-  // self.nativeWrapperView.frame is set to final value at the beginning of the transition.
-  // When frame from presentation layer matches self.nativeWrapperView.frame, it indicates that
-  // the transition is over and we can disable the display link.
-  if (CGRectEqualToRect(presentationFrame, self.nativeWrapperView.frame)) {
-    [self invalidateDisplayLink];
-  }
-}
-
-- (void)invalidateDisplayLink
-{
-  [_displayLink invalidate];
-  _displayLink = nil;
-}
-#endif // REACT_NATIVE_VERSION_MINOR < 82
 
 #pragma mark - Invalidation
 
@@ -224,12 +160,8 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
   _traitChangeRegistration = nil;
   [self unregisterForAccessoryFrameChanges];
   _bottomAccessoryView = nil;
-#if REACT_NATIVE_VERSION_MINOR < 82
-  [self invalidateDisplayLink];
-#else // REACT_NATIVE_VERSION_MINOR < 82
   _regularContentView = nil;
   _inlineContentView = nil;
-#endif // REACT_NATIVE_VERSION_MINOR < 82
 }
 
 @end

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryShadowStateProxy.mm
@@ -31,12 +31,8 @@
     if (_bottomAccessoryView.state != nullptr) {
       auto newState =
           react::RNSTabsBottomAccessoryState{RCTSizeFromCGSize(frame.size), RCTPointFromCGPoint(frame.origin)};
-      _bottomAccessoryView.state->updateState(std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-                                                  ,
-                                              facebook::react::EventQueue::UpdateMode::unstable_Immediate
-#endif // REACT_NATIVE_VERSION_MINOR >= 82
-      );
+      _bottomAccessoryView.state->updateState(std::move(newState),
+                                              facebook::react::EventQueue::UpdateMode::unstable_Immediate);
       _previousFrame = frame;
     }
   }

--- a/ios/utils/RNSDefines.h
+++ b/ios/utils/RNSDefines.h
@@ -8,25 +8,7 @@
 
 #define RNS_IGNORE_SUPER_CALL_END _Pragma("clang diagnostic pop")
 
-#pragma mark - React Native version dependent code
-
-#if defined __has_include
-#if __has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) ||\
-    __has_include(<React_RCTAppDelegate/RCTReactNativeFactory.h>) // added in 78; underscore is used in dynamic frameworks
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 0
-#else
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 1
-#endif
-#else
-#define RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78 \
-  1 // Wild guess, close eyes and hope for the best.
-#endif
-
-#if RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78
-#define MUTATION_PARENT_TAG(mutation) mutation.parentShadowView.tag
-#else
 #define MUTATION_PARENT_TAG(mutation) mutation.parentTag
-#endif
 
 #pragma mark - React Native architecture dependent code
 

--- a/ios/utils/RNSDefines.h
+++ b/ios/utils/RNSDefines.h
@@ -8,8 +8,6 @@
 
 #define RNS_IGNORE_SUPER_CALL_END _Pragma("clang diagnostic pop")
 
-#define MUTATION_PARENT_TAG(mutation) mutation.parentTag
-
 #pragma mark - React Native architecture dependent code
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Description

According to `peerDependencies` we only support RN versions >= 0.82.0.
This PR removes guards regarding lower versions.

## Changes

- remove `REACT_NATIVE_VERSION_MINOR >= 82` guards
- remove `REACT_NATIVE_VERSION_MINOR < 82` guards and code executed on this condition
- remove `RNS_REACT_NATIVE_VERSION_MINOR_BELOW_78` flag in `RNSDefines.h`

## Before & after - visual documentation

N/A

## Test plan

Build example apps.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
