### PR TITLE
fix(Android, FormSheet): include keyboard translationY in shadow update

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -248,7 +248,7 @@ class Screen(
         }
 
         if (coordinatorLayoutDidChange) {
-            updateShadowNodeScreenSize(width, height, top)
+            updateShadowNodeScreenSize(width, height, top + translationY.toInt())
         }
 
         footer?.onParentLayout(coordinatorLayoutDidChange, left, top, right, bottom, container!!.height)

--- a/apps/src/tests/issue-tests/Test4064.tsx
+++ b/apps/src/tests/issue-tests/Test4064.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  createStaticNavigation,
+  useNavigation,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { Colors } from '@apps/shared/styling';
+
+export function SecureForm() {
+  const [secure, setSecure] = useState(true);
+  const [count, setCount] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        autoFocus
+        secureTextEntry={secure}
+        placeholder="Password"
+      />
+      <Button
+        title={secure ? 'Show Password' : 'Hide Password'}
+        onPress={() => setSecure(s => !s)}
+      />
+      <Button
+        title={`TAP ME — count: ${count}`}
+        onPress={() => setCount(c => c + 1)}
+      />
+    </View>
+  );
+}
+
+export function Home() {
+  const navigation = useNavigation<any>();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet</Text>
+      <Text style={styles.hint}>
+        1. The password field below is autofocused (keyboard open){'\n'}
+        2. Tap "Show / Hide" 2–3 times{'\n'}
+        3. Tap "TAP ME" — counter is frozen until the keyboard closes
+      </Text>
+      <Button
+        title="Open FormSheet"
+        onPress={() => navigation.navigate('Sheet')}
+      />
+    </View>
+  );
+}
+
+const RootNavigator = createNativeStackNavigator({
+  screens: {
+    Home: { screen: Home, options: { headerShown: false } },
+    Sheet: {
+      screen: SecureForm,
+      options: {
+        presentation: 'formSheet',
+        sheetAllowedDetents: [0.8],
+        headerShown: Platform.OS === 'android',
+        headerTitle: 'Auth',
+      },
+    },
+  },
+});
+
+const Navigation = createStaticNavigation(RootNavigator);
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <Navigation />
+    </SafeAreaProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    gap: 16,
+    justifyContent: 'center',
+    backgroundColor: Colors.White,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  hint: {
+    fontSize: 14,
+    color: Colors.text,
+    lineHeight: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: Colors.NavyDark100,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -193,6 +193,7 @@ export { default as Test3867 } from './Test3867';
 export { default as Test3885 } from './Test3885';
 export { default as Test3910 } from './Test3910';
 export { default as Test4027 } from './Test4027';
+export { default as Test4064 } from './Test4064';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
# fix(android/Fabric): include keyboard `translationY` in `onBottomSheetBehaviorDidLayout` shadow update

Fixes #4064

## Summary

On Android + New Architecture, a `Pressable` inside a FormSheet becomes
unresponsive while the keyboard is open. `Screen.onBottomSheetBehaviorDidLayout()`
reports the sheet content position to Fabric as `top` only, whereas
`Screen.onSheetYTranslationChanged()` reports `top + translationY`. When the
keyboard `translationY` offset is active and a layout pass goes through
`onBottomSheetBehaviorDidLayout()`, Fabric's `contentOffsetY` desyncs from the
real visual position by the keyboard height, so RN's JS touch responder no
longer matches where the view is rendered.

This aligns the two code paths.

## Change

```diff
  // android/.../com/swmansion/rnscreens/Screen.kt — onBottomSheetBehaviorDidLayout()
  if (coordinatorLayoutDidChange) {
-     updateShadowNodeScreenSize(width, height, top)
+     // Keep consistent with onSheetYTranslationChanged(): the FormSheet may be
+     // shifted by translationY to stay above the keyboard. Sending `top` alone
+     // desyncs the Fabric contentOffsetY from the native visual position.
+     updateShadowNodeScreenSize(width, height, top + translationY.toInt())
  }
```

This is exactly the value `onSheetYTranslationChanged()` already sends, so the
two reporting paths now agree. It also fixes the hard-coded
`onBottomSheetBehaviorDidLayout(true)` caller in
`ScreenStackFragment.handleInsetsUpdateAndNotifyTransition()`.

## Why this is safe

- When `translationY == 0` (no keyboard offset), `top + 0 == top` → behavior is
  **identical** to before. No change for the common case.
- The shadow update is `IS_NEW_ARCHITECTURE_ENABLED`-gated → **Paper is
  unaffected**.
- Single line; no API change; no new allocation.
- Likely tied to PR #3248 (4.19.0), which introduced the keyboard `translationY`
  mechanism without propagating the offset to this layout path (not verified
  against 4.19.0 directly; confirmed on 4.24.0 and 4.25.1). This restores
  consistency between the two paths rather than adding a workaround.

## Test plan

Verified with the standalone repro (Expo SDK 55, RN 0.83.6,
`react-native-screens@4.25.1` pinned, New Arch, Android):

- [x] FormSheet + `autoFocus` `secureTextEntry` input + `Pressable`, single
      detent `[0.8]`: **before** — `Pressable` dead after toggling
      `secureTextEntry` with keyboard open; **after** — works normally.
- [x] Same fix independently verified in a production app (both the
      `secureTextEntry` path and a nested-navigation path that exhibits the
      same desync).
- [x] No-keyboard case unaffected (manual check; `top + 0 == top`).

Not yet covered (happy to extend or get reviewer guidance):

- [ ] `sheetAllowedDetents: 'fitToContents'`
- [ ] 2- and 3-detent sheets
- [ ] Additional Android API levels
- [ ] iOS (expected: unaffected — Android-only path)
- [ ] New Architecture disabled (expected: unaffected — Fabric-gated)

## Notes

There is a related, separate observation (not addressed here): the
`view === focusedChild` guard in `ScreenContainer.removeView()` appears racy for
screens popped inside a nested/FormSheet stack (focus can be cleared by React
unmount before `removeView` runs). That only affects whether the keyboard stays
open; the desync itself — and this fix — are independent of it. Happy to file a
follow-up if useful.

---

> _Disclaimer: the root-cause investigation and this description were produced
> with the assistance of Claude (Anthropic's AI). The one-line change was
> verified on a physical Android device — bug reproduced on pristine 4.25.1,
> resolved after the fix — both in a standalone repro and in a production app,
> before opening this PR._
