### PR TITLE
fix(iOS, SplitView): Fix SplitView crash on assertion when maxWidth wasn't defined for column

### DIFF
--- a/ios/gamma/split/RNSSplitAppearanceApplicator.swift
+++ b/ios/gamma/split/RNSSplitAppearanceApplicator.swift
@@ -186,14 +186,14 @@ class RNSSplitAppearanceApplicator {
     splitHostController.preferredDisplayMode = splitHost.preferredDisplayMode
   }
 
-    func validateColumnConstraints(minWidth: CGFloat, maxWidth: CGFloat) {
-        // Compare values only if both are non-negative.
-        // The default value, which is -1, indicates that the constraint was not provided.
-        if minWidth >= 0 && maxWidth >= 0 {
-            assert(
-                minWidth <= maxWidth,
-                "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
-            )
-        }
+  func validateColumnConstraints(minWidth: CGFloat, maxWidth: CGFloat) {
+    // Compare values only if both are non-negative.
+    // The default value, which is -1, indicates that the constraint was not provided.
+    if minWidth >= 0 && maxWidth >= 0 {
+      assert(
+        minWidth <= maxWidth,
+        "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
+      )
     }
+  }
 }

--- a/ios/gamma/split/RNSSplitAppearanceApplicator.swift
+++ b/ios/gamma/split/RNSSplitAppearanceApplicator.swift
@@ -186,10 +186,14 @@ class RNSSplitAppearanceApplicator {
     splitHostController.preferredDisplayMode = splitHost.preferredDisplayMode
   }
 
-  func validateColumnConstraints(minWidth: CGFloat, maxWidth: CGFloat) {
-    assert(
-      minWidth <= maxWidth,
-      "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
-    )
-  }
+    func validateColumnConstraints(minWidth: CGFloat, maxWidth: CGFloat) {
+        // Compare values only if both are non-negative.
+        // The default value, which is -1, indicates that the constraint was not provided.
+        if minWidth >= 0 && maxWidth >= 0 {
+            assert(
+                minWidth <= maxWidth,
+                "[RNScreens] Split column constraints are invalid: minWidth \(minWidth) cannot be greater than maxWidth \(maxWidth)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Description

The default value for column width is -1, so if we define only `minWidth` the assertion will fail & result in a crash, while passing `maxWidth` is optional and it should be fine to skip it.

## Changes

- asserting that min < max only for non-negative values

## Before & after - visual documentation

### Before

crash

### After

no crash

## Test plan

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { SafeAreaProvider } from 'react-native-safe-area-context';
import { Split } from 'react-native-screens/experimental';

export default function App() {
  return (
    <SafeAreaProvider>
      <Split.Host
        preferredDisplayMode="twoBesideSecondary"
        preferredSplitBehavior="tile"
        columnMetrics={{
          minimumSupplementaryColumnWidth: 320,
        }}
      >
        <Split.Column>
          <View style={[styles.col, { backgroundColor: 'salmon' }]}>
            <Text style={styles.label}>PRIMARY</Text>
          </View>
        </Split.Column>
        <Split.Column>
          <View style={[styles.col, { backgroundColor: 'khaki' }]}>
            <Text style={styles.label}>SUPPLEMENTARY</Text>
          </View>
        </Split.Column>
        <Split.Column>
          <View style={[styles.col, { backgroundColor: 'lightblue' }]}>
            <Text style={styles.label}>SECONDARY</Text>
          </View>
        </Split.Column>
      </Split.Host>
    </SafeAreaProvider>
  );
}

const styles = StyleSheet.create({
  col: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  label: {
    fontSize: 24,
    fontWeight: '700',
  },
});
```

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
