### PR TITLE
refactor(iOS, FormSheet v5): Move AppearanceCoordinator/Applicator to ContentController

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import "RNSFormSheetProviders.h"
 
 @class RNSFormSheetAppearanceCoordinator;
 @class RNSFormSheetContentController;
@@ -10,9 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetAppearanceApplicator : NSObject
 
-- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
-                             controller:(RNSFormSheetContentController *)controller
-                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
+- (void)updateAppearanceIfNeededForAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
+                                     behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
+                                           controller:(RNSFormSheetContentController *)controller
+                                          coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
 
 - (void)resetInitialDetent;
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
@@ -10,10 +10,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetAppearanceApplicator : NSObject
 
-- (void)updateAppearanceIfNeededForAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
-                                     behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
-                                           controller:(RNSFormSheetContentController *)controller
-                                          coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
+- (void)updateAppearanceIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
+                                      behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
+                                            controller:(RNSFormSheetContentController *)controller
+                                           coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator;
 
 - (void)resetInitialDetent;
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.h
@@ -5,7 +5,6 @@
 
 @class RNSFormSheetAppearanceCoordinator;
 @class RNSFormSheetContentController;
-@class RNSFormSheetHostComponentView;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
@@ -24,10 +24,10 @@
   _initialDetentApplied = NO;
 }
 
-- (void)updateAppearanceIfNeededForAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
-                                     behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
-                                           controller:(RNSFormSheetContentController *)controller
-                                          coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
+- (void)updateAppearanceIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
+                                      behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
+                                            controller:(RNSFormSheetContentController *)controller
+                                           coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
 {
   [coordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration
            performOperations:^{

--- a/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetAppearanceApplicator.mm
@@ -6,7 +6,6 @@
 #import "RNSFormSheetAppearanceUpdateFlags.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetDetentResolver.h"
-#import "RNSFormSheetHostComponentView.h"
 
 @implementation RNSFormSheetAppearanceApplicator {
   BOOL _initialDetentApplied;
@@ -25,20 +24,24 @@
   _initialDetentApplied = NO;
 }
 
-- (void)updateAppearanceIfNeededForHost:(RNSFormSheetHostComponentView *)host
-                             controller:(RNSFormSheetContentController *)controller
-                            coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
+- (void)updateAppearanceIfNeededForAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
+                                     behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
+                                           controller:(RNSFormSheetContentController *)controller
+                                          coordinator:(RNSFormSheetAppearanceCoordinator *)coordinator
 {
   [coordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration
            performOperations:^{
-             [self updateSheetConfigurationForHost:host controller:controller];
+             [self updateSheetConfigurationForAppearanceProvider:appearanceProvider
+                                                behaviorProvider:behaviorProvider
+                                                      controller:controller];
            }];
 }
 
 #pragma mark - Updaters
 
-- (void)updateSheetConfigurationForHost:(RNSFormSheetHostComponentView *)host
-                             controller:(RNSFormSheetContentController *)controller
+- (void)updateSheetConfigurationForAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
+                                     behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
+                                           controller:(RNSFormSheetContentController *)controller
 {
 #if !TARGET_OS_TV
   UISheetPresentationController *sheet = controller.sheetPresentationController;
@@ -47,22 +50,23 @@
       @"[RNScreens] sheetPresentationController is nil. Ensure modalPresentationStyle is set to UIModalPresentationFormSheet.");
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:host.detents];
+      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:behaviorProvider.detents];
 
   UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
   if (!_initialDetentApplied) {
-    initialDetentIdentifier = [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
-                                                                           atRequestedIndex:host.initialDetentIndex];
+    initialDetentIdentifier =
+        [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
+                                                     atRequestedIndex:behaviorProvider.initialDetentIndex];
     _initialDetentApplied = YES;
   }
 
-  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier =
-      [RNSFormSheetDetentResolver largestUndimmedDetentIdentifierForDetents:nativeDetents
-                                                           atRequestedIndex:host.largestUndimmedDetentIndex];
+  UISheetPresentationControllerDetentIdentifier largestUndimmedDetentIdentifier = [RNSFormSheetDetentResolver
+      largestUndimmedDetentIdentifierForDetents:nativeDetents
+                               atRequestedIndex:appearanceProvider.largestUndimmedDetentIndex];
 
-  BOOL prefersGrabberVisible = host.prefersGrabberVisible;
-  CGFloat preferredCornerRadius = host.preferredCornerRadius;
-  BOOL prefersScrollingExpandsWhenScrolledToEdge = host.prefersScrollingExpandsWhenScrolledToEdge;
+  BOOL prefersGrabberVisible = appearanceProvider.prefersGrabberVisible;
+  CGFloat preferredCornerRadius = appearanceProvider.preferredCornerRadius;
+  BOOL prefersScrollingExpandsWhenScrolledToEdge = behaviorProvider.prefersScrollingExpandsWhenScrolledToEdge;
 
   [sheet animateChanges:^{
     sheet.detents = nativeDetents;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -7,7 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSFormSheetContentView;
 @class RNSFormSheetContentController;
-@class RNSFormSheetHostComponentView;
 
 @protocol RNSFormSheetContentControllerDelegate <NSObject>
 - (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+#import "RNSFormSheetProviders.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id<RNSFormSheetContentControllerDelegate> delegate;
 
-@property (nonatomic, weak, nullable) RNSFormSheetHostComponentView *hostComponentView;
+@property (nonatomic, weak, nullable) id<RNSFormSheetPresentationProvider> presentationProvider;
+@property (nonatomic, weak, nullable) id<RNSFormSheetAppearanceProvider> appearanceProvider;
+@property (nonatomic, weak, nullable) id<RNSFormSheetBehaviorProvider> behaviorProvider;
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RNSFormSheetContentView;
 @class RNSFormSheetContentController;
+@class RNSFormSheetHostComponentView;
 
 @protocol RNSFormSheetContentControllerDelegate <NSObject>
 - (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;
@@ -20,10 +21,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id<RNSFormSheetContentControllerDelegate> delegate;
 
+@property (nonatomic, weak, nullable) RNSFormSheetHostComponentView *hostComponentView;
+
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
-- (void)presentFromWindowIfNeeded:(nonnull UIWindow *)window;
-- (void)dismissIfNeeded;
+#pragma mark - Signals
+
+- (void)setNeedsPresentationUpdate;
+- (void)setNeedsAppearanceUpdate;
+- (void)setNeedsInitialDetentReset;
+
+#pragma mark - Mounting transaction signals
+
+- (void)reactMountingTransactionWillMount;
+- (void)reactMountingTransactionDidMount;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -34,10 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setNeedsAppearanceUpdate;
 - (void)setNeedsInitialDetentReset;
 
-#pragma mark - Mounting transaction signals
+#pragma mark - Updating
 
-- (void)reactMountingTransactionWillMount;
-- (void)reactMountingTransactionDidMount;
+- (void)flushPendingUpdates;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setNeedsAppearanceUpdate;
 - (void)setNeedsInitialDetentReset;
 
-#pragma mark - Updating
+#pragma mark - Updates
 
 - (void)flushPendingUpdates;
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -60,11 +60,12 @@
 
 #pragma mark - Presentation
 
-- (void)updatePresentationStateForHost:(nonnull RNSFormSheetHostComponentView *)host
+- (void)updatePresentationState
 {
-  if (host.isOpen) {
-    if (host.window != nil) {
-      [self presentFromWindowIfNeeded:host.window];
+  if (self.presentationProvider.isOpen) {
+    UIWindow *window = self.presentationProvider.hostWindow;
+    if (window != nil) {
+      [self presentFromWindowIfNeeded:window];
     }
   } else {
     [self dismissIfNeeded];
@@ -115,19 +116,21 @@
 
 #pragma mark - Appearance
 
-- (void)updateAppearanceIfNeededForHost:(nonnull RNSFormSheetHostComponentView *)host
+- (void)updateAppearanceIfNeeded
 {
   if (_needsInitialDetentReset) {
     _needsInitialDetentReset = NO;
     [_appearanceApplicator resetInitialDetent];
   }
 
-  [_appearanceApplicator updateAppearanceIfNeededForHost:host controller:self coordinator:_appearanceCoordinator];
+  [_appearanceApplicator updateAppearanceIfNeededForAppearanceProvider:self.appearanceProvider
+                                                      behaviorProvider:self.behaviorProvider
+                                                            controller:self
+                                                           coordinator:_appearanceCoordinator];
 
-  // TODO: @t0maboro - move presentation logic to dedicated presentationCoordinator with 4-state logic
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
                       performOperations:^{
-                        [self updatePresentationStateForHost:host];
+                        [self updatePresentationState];
                       }];
 }
 
@@ -157,9 +160,9 @@
 
 - (void)reactMountingTransactionDidMount
 {
-  RNSFormSheetHostComponentView *host = self.hostComponentView;
-  RCTAssert(host != nil, @"[RNScreens] hostComponentView must be set before mounting transactions are observed");
-  [self updateAppearanceIfNeededForHost:host];
+  RCTAssert(self.presentationProvider != nil,
+            @"[RNScreens] presentationProvider must be set before mounting transactions are observed");
+  [self updateAppearanceIfNeeded];
 }
 
 #pragma mark - UIAdaptivePresentationControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -171,7 +171,7 @@
   _needsInitialDetentReset = YES;
 }
 
-#pragma mark - Updating
+#pragma mark - Updates
 
 - (void)flushPendingUpdates
 {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -142,10 +142,10 @@
     [_appearanceApplicator resetInitialDetent];
   }
 
-  [_appearanceApplicator updateAppearanceIfNeededForAppearanceProvider:appearanceProvider
-                                                      behaviorProvider:behaviorProvider
-                                                            controller:self
-                                                           coordinator:_appearanceCoordinator];
+  [_appearanceApplicator updateAppearanceIfNeededWithAppearanceProvider:appearanceProvider
+                                                       behaviorProvider:behaviorProvider
+                                                             controller:self
+                                                            coordinator:_appearanceCoordinator];
 
   // TODO: @t0maboro - decouple presentation logic from AppearanceCoordinator
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -1,5 +1,9 @@
 #import "RNSFormSheetContentController.h"
+#import "RNSFormSheetAppearanceApplicator.h"
+#import "RNSFormSheetAppearanceCoordinator.h"
+#import "RNSFormSheetAppearanceUpdateFlags.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetHostComponentView.h"
 #import "RNSPresentationSourceProvider.h"
 
 #import <React/RCTAssert.h>
@@ -13,12 +17,22 @@
                                              >
 @end
 
-@implementation RNSFormSheetContentController
+@implementation RNSFormSheetContentController {
+  RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
+  RNSFormSheetAppearanceApplicator *_Nonnull _appearanceApplicator;
+
+  BOOL _needsInitialDetentReset;
+}
 
 - (instancetype)init
 {
   if (self = [super init]) {
     self.modalPresentationStyle = UIModalPresentationFormSheet;
+
+    _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
+    _appearanceApplicator = [RNSFormSheetAppearanceApplicator new];
+
+    _needsInitialDetentReset = NO;
   }
   return self;
 }
@@ -45,6 +59,17 @@
 }
 
 #pragma mark - Presentation
+
+- (void)updatePresentationStateForHost:(nonnull RNSFormSheetHostComponentView *)host
+{
+  if (host.isOpen) {
+    if (host.window != nil) {
+      [self presentFromWindowIfNeeded:host.window];
+    }
+  } else {
+    [self dismissIfNeeded];
+  }
+}
 
 - (void)prepareForPresentation
 {
@@ -86,6 +111,55 @@
     return;
   }
   [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Appearance
+
+- (void)updateAppearanceIfNeededForHost:(nonnull RNSFormSheetHostComponentView *)host
+{
+  if (_needsInitialDetentReset) {
+    _needsInitialDetentReset = NO;
+    [_appearanceApplicator resetInitialDetent];
+  }
+
+  [_appearanceApplicator updateAppearanceIfNeededForHost:host controller:self coordinator:_appearanceCoordinator];
+
+  // TODO: @t0maboro - move presentation logic to dedicated presentationCoordinator with 4-state logic
+  [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
+                      performOperations:^{
+                        [self updatePresentationStateForHost:host];
+                      }];
+}
+
+#pragma mark - Signals
+
+- (void)setNeedsPresentationUpdate
+{
+  [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation];
+}
+
+- (void)setNeedsAppearanceUpdate
+{
+  [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+}
+
+- (void)setNeedsInitialDetentReset
+{
+  _needsInitialDetentReset = YES;
+}
+
+#pragma mark - Mounting transaction signals
+
+- (void)reactMountingTransactionWillMount
+{
+  // noop
+}
+
+- (void)reactMountingTransactionDidMount
+{
+  RNSFormSheetHostComponentView *host = self.hostComponentView;
+  RCTAssert(host != nil, @"[RNScreens] hostComponentView must be set before mounting transactions are observed");
+  [self updateAppearanceIfNeededForHost:host];
 }
 
 #pragma mark - UIAdaptivePresentationControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -3,7 +3,6 @@
 #import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetAppearanceUpdateFlags.h"
 #import "RNSFormSheetContentView.h"
-#import "RNSFormSheetHostComponentView.h"
 #import "RNSPresentationSourceProvider.h"
 
 #import <React/RCTAssert.h>

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -151,14 +151,9 @@
   _needsInitialDetentReset = YES;
 }
 
-#pragma mark - Mounting transaction signals
+#pragma mark - Updating
 
-- (void)reactMountingTransactionWillMount
-{
-  // noop
-}
-
-- (void)reactMountingTransactionDidMount
+- (void)flushPendingUpdates
 {
   RCTAssert(self.presentationProvider != nil,
             @"[RNScreens] presentationProvider must be set before mounting transactions are observed");

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -148,6 +148,7 @@
                                                             controller:self
                                                            coordinator:_appearanceCoordinator];
 
+  // TODO: @t0maboro - decouple presentation logic from AppearanceCoordinator
   [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
                       performOperations:^{
                         [self updatePresentationState];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -62,8 +62,17 @@
 
 - (void)updatePresentationState
 {
-  if (self.presentationProvider.isOpen) {
-    UIWindow *window = self.presentationProvider.hostWindow;
+  id<RNSFormSheetPresentationProvider> presentationProvider = self.presentationProvider;
+
+  RCTAssert(presentationProvider != nil,
+            @"[RNScreens] Presentation provider must be set before updating presentation state.");
+
+  if (presentationProvider == nil) {
+    return;
+  }
+
+  if (presentationProvider.isOpen) {
+    UIWindow *window = presentationProvider.hostWindow;
     if (window != nil) {
       [self presentFromWindowIfNeeded:window];
     }
@@ -118,13 +127,24 @@
 
 - (void)updateAppearanceIfNeeded
 {
+  id<RNSFormSheetAppearanceProvider> appearanceProvider = self.appearanceProvider;
+  id<RNSFormSheetBehaviorProvider> behaviorProvider = self.behaviorProvider;
+
+  RCTAssert(appearanceProvider != nil, @"[RNScreens] Appearance provider must be set before updating appearance.");
+
+  RCTAssert(behaviorProvider != nil, @"[RNScreens] Behavior provider must be set before updating appearance.");
+
+  if (appearanceProvider == nil || behaviorProvider == nil) {
+    return;
+  }
+
   if (_needsInitialDetentReset) {
     _needsInitialDetentReset = NO;
     [_appearanceApplicator resetInitialDetent];
   }
 
-  [_appearanceApplicator updateAppearanceIfNeededForAppearanceProvider:self.appearanceProvider
-                                                      behaviorProvider:self.behaviorProvider
+  [_appearanceApplicator updateAppearanceIfNeededForAppearanceProvider:appearanceProvider
+                                                      behaviorProvider:behaviorProvider
                                                             controller:self
                                                            coordinator:_appearanceCoordinator];
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -155,8 +155,6 @@
 
 - (void)flushPendingUpdates
 {
-  RCTAssert(self.presentationProvider != nil,
-            @"[RNScreens] presentationProvider must be set before mounting transactions are observed");
   [self updateAppearanceIfNeeded];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -16,17 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetHostComponentView ()
 
-#if defined(__cplusplus)
-- (const std::vector<double> &)detents;
-#endif
-
-@property (nonatomic, readonly) BOOL isOpen;
-@property (nonatomic, readonly) BOOL prefersGrabberVisible;
-@property (nonatomic, readonly) CGFloat preferredCornerRadius;
-@property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
-@property (nonatomic, readonly) NSInteger initialDetentIndex;
-@property (nonatomic, readonly) BOOL prefersScrollingExpandsWhenScrolledToEdge;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (const std::vector<double> &)detents;
 #endif
 
+@property (nonatomic, readonly) BOOL isOpen;
 @property (nonatomic, readonly) BOOL prefersGrabberVisible;
 @property (nonatomic, readonly) CGFloat preferredCornerRadius;
 @property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -16,6 +16,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetHostComponentView ()
 
+#if defined(__cplusplus)
+- (const std::vector<double> &)detents;
+#endif
+
+@property (nonatomic, readonly) BOOL isOpen;
+@property (nonatomic, readonly) BOOL prefersGrabberVisible;
+@property (nonatomic, readonly) CGFloat preferredCornerRadius;
+@property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
+@property (nonatomic, readonly) NSInteger initialDetentIndex;
+@property (nonatomic, readonly) BOOL prefersScrollingExpandsWhenScrolledToEdge;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -97,7 +97,7 @@ namespace react = facebook::react;
   return _isOpen;
 }
 
-- (UIWindow *)hostWindow
+- (nullable UIWindow *)hostWindow;
 {
   return self.window;
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -91,31 +91,9 @@ namespace react = facebook::react;
 
 #pragma mark - RNSFormSheetPresentationProvider
 
-- (BOOL)isOpen
-{
-  return _isOpen;
-}
-
 - (nullable UIWindow *)hostWindow
 {
   return self.window;
-}
-
-#pragma mark - RNSFormSheetAppearanceProvider
-
-- (BOOL)prefersGrabberVisible
-{
-  return _prefersGrabberVisible;
-}
-
-- (CGFloat)preferredCornerRadius
-{
-  return _preferredCornerRadius;
-}
-
-- (NSInteger)largestUndimmedDetentIndex
-{
-  return _largestUndimmedDetentIndex;
 }
 
 #pragma mark - RNSFormSheetBehaviorProvider
@@ -123,16 +101,6 @@ namespace react = facebook::react;
 - (const std::vector<double> &)detents
 {
   return _detents;
-}
-
-- (NSInteger)initialDetentIndex
-{
-  return _initialDetentIndex;
-}
-
-- (BOOL)prefersScrollingExpandsWhenScrolledToEdge
-{
-  return _prefersScrollingExpandsWhenScrolledToEdge;
 }
 
 #pragma mark - RNSFormSheetContentControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -96,7 +96,7 @@ namespace react = facebook::react;
   return _isOpen;
 }
 
-- (nullable UIWindow *)hostWindow;
+- (nullable UIWindow *)hostWindow
 {
   return self.window;
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,13 +1,12 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSDefines.h"
-#import "RNSFormSheetAppearanceApplicator.h"
-#import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 
+#import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -15,20 +14,22 @@
 
 namespace react = facebook::react;
 
-@interface RNSFormSheetHostComponentView () <RNSFormSheetContentControllerDelegate>
+@interface RNSFormSheetHostComponentView () <RCTMountingTransactionObserving, RNSFormSheetContentControllerDelegate>
 @end
 
 @implementation RNSFormSheetHostComponentView {
   RNSFormSheetHostEventEmitter *_Nonnull _reactEventEmitter;
   RNSFormSheetHostShadowStateProxy *_Nonnull _shadowStateProxy;
-  RNSFormSheetAppearanceCoordinator *_Nonnull _appearanceCoordinator;
-  RNSFormSheetAppearanceApplicator *_Nonnull _appearanceApplicator;
 
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
 
+  // Invalidation flags
+  BOOL _needsPresentationUpdate;
+  BOOL _needsAppearanceUpdate;
+  BOOL _needsInitialDetentReset;
+
   // Props
-  BOOL _isOpen;
   std::vector<double> _detents;
 }
 
@@ -47,8 +48,10 @@ namespace react = facebook::react;
 
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
-  _appearanceCoordinator = [RNSFormSheetAppearanceCoordinator new];
-  _appearanceApplicator = [RNSFormSheetAppearanceApplicator new];
+
+  _needsPresentationUpdate = NO;
+  _needsAppearanceUpdate = NO;
+  _needsInitialDetentReset = NO;
 }
 
 - (void)resetProps
@@ -74,23 +77,14 @@ namespace react = facebook::react;
 {
   _controller = [RNSFormSheetContentController new];
   _controller.delegate = self;
-}
-
-- (void)updatePresentationState
-{
-  if (_isOpen) {
-    if (self.window != nil) {
-      [_controller presentFromWindowIfNeeded:self.window];
-    }
-  } else {
-    [_controller dismissIfNeeded];
-  }
+  _controller.hostComponentView = self;
 }
 
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  [self updatePresentationState];
+  _needsPresentationUpdate = YES;
+  [self requestContentControllerForUpdates];
 }
 
 #pragma mark - RNSFormSheetContentControllerDelegate
@@ -161,36 +155,36 @@ namespace react = facebook::react;
 
   if (oldComponentProps.isOpen != newComponentProps.isOpen) {
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation];
+    _needsPresentationUpdate = YES;
 
     if (_isOpen) {
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
-      [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+      _needsAppearanceUpdate = YES;
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
-      [_appearanceApplicator resetInitialDetent];
+      _needsInitialDetentReset = YES;
     }
   }
 
   if (oldComponentProps.detents != newComponentProps.detents) {
     _detents = newComponentProps.detents;
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    _needsAppearanceUpdate = YES;
   }
 
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    _needsAppearanceUpdate = YES;
   }
 
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    _needsAppearanceUpdate = YES;
   }
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    _needsAppearanceUpdate = YES;
   }
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
@@ -201,7 +195,7 @@ namespace react = facebook::react;
       newComponentProps.prefersScrollingExpandsWhenScrolledToEdge) {
     _prefersScrollingExpandsWhenScrolledToEdge =
         static_cast<BOOL>(newComponentProps.prefersScrollingExpandsWhenScrolledToEdge);
-    [_appearanceCoordinator setNeeds:RNSFormSheetAppearanceUpdateFlagsConfiguration];
+    _needsAppearanceUpdate = YES;
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -209,16 +203,30 @@ namespace react = facebook::react;
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
+  [self requestContentControllerForUpdates];
   [super finalizeUpdates:updateMask];
+}
 
-  [_appearanceApplicator updateAppearanceIfNeededForHost:self
-                                              controller:_controller
-                                             coordinator:_appearanceCoordinator];
+- (void)requestContentControllerForUpdates
+{
+  if (_controller == nil) {
+    return;
+  }
 
-  [_appearanceCoordinator updateIfNeeds:RNSFormSheetAppearanceUpdateFlagsPresentation
-                      performOperations:^{
-                        [self updatePresentationState];
-                      }];
+  if (_needsPresentationUpdate) {
+    _needsPresentationUpdate = NO;
+    [_controller setNeedsPresentationUpdate];
+  }
+
+  if (_needsAppearanceUpdate) {
+    _needsAppearanceUpdate = NO;
+    [_controller setNeedsAppearanceUpdate];
+  }
+
+  if (_needsInitialDetentReset) {
+    _needsInitialDetentReset = NO;
+    [_controller setNeedsInitialDetentReset];
+  }
 }
 
 - (void)invalidate
@@ -234,6 +242,20 @@ namespace react = facebook::react;
     }
     _controller = nil;
   }
+}
+
+#pragma mark - RCTMountingTransactionObserving
+
+- (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction
+                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
+{
+  [_controller reactMountingTransactionWillMount];
+}
+
+- (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
+               withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
+{
+  [_controller reactMountingTransactionDidMount];
 }
 
 #pragma mark - Layout helpers

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -29,11 +29,6 @@ namespace react = facebook::react;
   RNSFormSheetContentController *_Nullable _controller;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
 
-  // Invalidation flags
-  BOOL _needsPresentationUpdate;
-  BOOL _needsAppearanceUpdate;
-  BOOL _needsInitialDetentReset;
-
   // Props
   BOOL _isOpen;
   std::vector<double> _detents;
@@ -59,10 +54,6 @@ namespace react = facebook::react;
 
   _reactEventEmitter = [RNSFormSheetHostEventEmitter new];
   _shadowStateProxy = [RNSFormSheetHostShadowStateProxy new];
-
-  _needsPresentationUpdate = NO;
-  _needsAppearanceUpdate = NO;
-  _needsInitialDetentReset = NO;
 }
 
 - (void)resetProps
@@ -92,8 +83,6 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  _needsPresentationUpdate = YES;
-  [self requestContentControllerForUpdates];
 }
 
 #pragma mark - RNSFormSheetPresentationProvider
@@ -210,36 +199,36 @@ namespace react = facebook::react;
 
   if (oldComponentProps.isOpen != newComponentProps.isOpen) {
     _isOpen = static_cast<BOOL>(newComponentProps.isOpen);
-    _needsPresentationUpdate = YES;
+    [_controller setNeedsPresentationUpdate];
 
     if (_isOpen) {
       // ALWAYS refresh the sheet configuration when reopening,
       // because UIKit destroys the presentationController after the modal is dismissed.
-      _needsAppearanceUpdate = YES;
+      [_controller setNeedsAppearanceUpdate];
       // Reset the initial-detent applied flag when reopening so the
       // configured initialDetentIndex can be applied again.
-      _needsInitialDetentReset = YES;
+      [_controller setNeedsInitialDetentReset];
     }
   }
 
   if (oldComponentProps.detents != newComponentProps.detents) {
     _detents = newComponentProps.detents;
-    _needsAppearanceUpdate = YES;
+    [_controller setNeedsAppearanceUpdate];
   }
 
   if (oldComponentProps.prefersGrabberVisible != newComponentProps.prefersGrabberVisible) {
     _prefersGrabberVisible = newComponentProps.prefersGrabberVisible;
-    _needsAppearanceUpdate = YES;
+    [_controller setNeedsAppearanceUpdate];
   }
 
   if (oldComponentProps.preferredCornerRadius != newComponentProps.preferredCornerRadius) {
     _preferredCornerRadius = newComponentProps.preferredCornerRadius;
-    _needsAppearanceUpdate = YES;
+    [_controller setNeedsAppearanceUpdate];
   }
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
-    _needsAppearanceUpdate = YES;
+    [_controller setNeedsAppearanceUpdate];
   }
 
   if (oldComponentProps.initialDetentIndex != newComponentProps.initialDetentIndex) {
@@ -250,38 +239,10 @@ namespace react = facebook::react;
       newComponentProps.prefersScrollingExpandsWhenScrolledToEdge) {
     _prefersScrollingExpandsWhenScrolledToEdge =
         static_cast<BOOL>(newComponentProps.prefersScrollingExpandsWhenScrolledToEdge);
-    _needsAppearanceUpdate = YES;
-  }
-
-  [super updateProps:props oldProps:oldProps];
-}
-
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
-{
-  [self requestContentControllerForUpdates];
-  [super finalizeUpdates:updateMask];
-}
-
-- (void)requestContentControllerForUpdates
-{
-  if (_controller == nil) {
-    return;
-  }
-
-  if (_needsPresentationUpdate) {
-    _needsPresentationUpdate = NO;
-    [_controller setNeedsPresentationUpdate];
-  }
-
-  if (_needsAppearanceUpdate) {
-    _needsAppearanceUpdate = NO;
     [_controller setNeedsAppearanceUpdate];
   }
 
-  if (_needsInitialDetentReset) {
-    _needsInitialDetentReset = NO;
-    [_controller setNeedsInitialDetentReset];
-  }
+  [super updateProps:props oldProps:oldProps];
 }
 
 - (void)invalidate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,5 +1,4 @@
 #import "RNSFormSheetHostComponentView.h"
-#import "RNSDefines.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
 #import "RNSFormSheetDetentResolver.h"

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -5,6 +5,7 @@
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
+#import "RNSFormSheetProviders.h"
 
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTSurfaceTouchHandler.h>
@@ -14,7 +15,11 @@
 
 namespace react = facebook::react;
 
-@interface RNSFormSheetHostComponentView () <RCTMountingTransactionObserving, RNSFormSheetContentControllerDelegate>
+@interface RNSFormSheetHostComponentView () <RCTMountingTransactionObserving,
+                                             RNSFormSheetContentControllerDelegate,
+                                             RNSFormSheetPresentationProvider,
+                                             RNSFormSheetAppearanceProvider,
+                                             RNSFormSheetBehaviorProvider>
 @end
 
 @implementation RNSFormSheetHostComponentView {
@@ -30,7 +35,13 @@ namespace react = facebook::react;
   BOOL _needsInitialDetentReset;
 
   // Props
+  BOOL _isOpen;
   std::vector<double> _detents;
+  BOOL _prefersGrabberVisible;
+  CGFloat _preferredCornerRadius;
+  NSInteger _largestUndimmedDetentIndex;
+  NSInteger _initialDetentIndex;
+  BOOL _prefersScrollingExpandsWhenScrolledToEdge;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -68,17 +79,14 @@ namespace react = facebook::react;
   _prefersScrollingExpandsWhenScrolledToEdge = YES;
 }
 
-- (const std::vector<double> &)detents
-{
-  return _detents;
-}
-
 - (void)setupController
 {
   _controller = [RNSFormSheetContentController new];
   _controller.delegate = self;
-  // TODO: @t0maboro - migrate
-  // _controller.hostComponentView = self;
+
+  _controller.presentationProvider = self;
+  _controller.appearanceProvider = self;
+  _controller.behaviorProvider = self;
 }
 
 - (void)didMoveToWindow
@@ -86,6 +94,52 @@ namespace react = facebook::react;
   [super didMoveToWindow];
   _needsPresentationUpdate = YES;
   [self requestContentControllerForUpdates];
+}
+
+#pragma mark - RNSFormSheetPresentationProvider
+
+- (BOOL)isOpen
+{
+  return _isOpen;
+}
+
+- (UIWindow *)hostWindow
+{
+  return self.window;
+}
+
+#pragma mark - RNSFormSheetAppearanceProvider
+
+- (BOOL)prefersGrabberVisible
+{
+  return _prefersGrabberVisible;
+}
+
+- (CGFloat)preferredCornerRadius
+{
+  return _preferredCornerRadius;
+}
+
+- (NSInteger)largestUndimmedDetentIndex
+{
+  return _largestUndimmedDetentIndex;
+}
+
+#pragma mark - RNSFormSheetBehaviorProvider
+
+- (const std::vector<double> &)detents
+{
+  return _detents;
+}
+
+- (NSInteger)initialDetentIndex
+{
+  return _initialDetentIndex;
+}
+
+- (BOOL)prefersScrollingExpandsWhenScrolledToEdge
+{
+  return _prefersScrollingExpandsWhenScrolledToEdge;
 }
 
 #pragma mark - RNSFormSheetContentControllerDelegate
@@ -247,16 +301,10 @@ namespace react = facebook::react;
 
 #pragma mark - RCTMountingTransactionObserving
 
-- (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction
-                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
-{
-  [_controller reactMountingTransactionWillMount];
-}
-
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
-  [_controller reactMountingTransactionDidMount];
+  [_controller flushPendingUpdates];
 }
 
 #pragma mark - Layout helpers

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -77,7 +77,8 @@ namespace react = facebook::react;
 {
   _controller = [RNSFormSheetContentController new];
   _controller.delegate = self;
-  _controller.hostComponentView = self;
+  // TODO: @t0maboro - migrate
+  // _controller.hostComponentView = self;
 }
 
 - (void)didMoveToWindow

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -83,6 +83,11 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
+
+  if (self.window != nil) {
+    [_controller setNeedsPresentationUpdate];
+    [_controller flushPendingUpdates];
+  }
 }
 
 #pragma mark - RNSFormSheetPresentationProvider

--- a/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+#ifdef __cplusplus
+#include <vector>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSFormSheetPresentationProvider <NSObject>
+
+- (BOOL)isOpen;
+- (nullable UIWindow *)hostWindow;
+
+@end
+
+@protocol RNSFormSheetAppearanceProvider <NSObject>
+
+- (BOOL)prefersGrabberVisible;
+- (CGFloat)preferredCornerRadius;
+- (NSInteger)largestUndimmedDetentIndex;
+
+@end
+
+@protocol RNSFormSheetBehaviorProvider <NSObject>
+
+#ifdef __cplusplus
+- (const std::vector<double> &)detents;
+#endif
+- (NSInteger)initialDetentIndex;
+- (BOOL)prefersScrollingExpandsWhenScrolledToEdge;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Previously, there was a tight coupling where `RNSFormSheetContentController` and `RNSFormSheetHostComponentView` had a direct dependency. By introducing dedicated provider protocols, the UIKit is now completely agnostic of React.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1454

## Changes

- defining contracts that Host now implements to supply data.
- removed all `RNSFormSheetHostComponentView` dependencies from `RNSFormSheetContentController` and `RNSFormSheetAppearanceApplicator`
- moved invalidation flags logic from the Host to the Controller

## Before & after - visual documentation

N/A - refactor

## Test plan

No regression in existing examples

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
