### PR TITLE
fix(Android, Tabs): trigger appearance update on user tab selection

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/CustomBottomNavigationView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/CustomBottomNavigationView.kt
@@ -1,0 +1,37 @@
+package com.swmansion.rnscreens.gamma.tabs.container
+
+import android.annotation.SuppressLint
+import android.content.Context
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+@SuppressLint("ViewConstructor") // Should not be restored & should only be constructed by us.
+class CustomBottomNavigationView(
+    context: Context,
+    val container: TabsContainer,
+) : BottomNavigationView(context) {
+    private var actionOrigin: TabsActionOrigin? = null
+
+    internal fun setSelectedItemIdWithActionOrigin(
+        itemId: Int,
+        actionOrigin: TabsActionOrigin,
+    ) {
+        require(actionOrigin !== TabsActionOrigin.USER) {
+            "[RNScreens] User-triggered actions should be processed via regular setSelectedItemId callback"
+        }
+        this.actionOrigin = actionOrigin
+        selectedItemId = itemId
+        this.actionOrigin = null
+    }
+
+    override fun setSelectedItemId(itemId: Int) {
+        if (this.actionOrigin == null) {
+            this.actionOrigin = TabsActionOrigin.USER
+        }
+
+        val actionOrigin = checkNotNull(this.actionOrigin)
+        super.setSelectedItemId(itemId)
+        container.onAfterSetSelectedItemId(itemId, actionOrigin)
+
+        this.actionOrigin = null
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -256,7 +256,10 @@ class TabsContainer internal constructor(
         setPendingNavigationStateUpdate(null)
     }
 
-    internal fun onAfterSetSelectedItemId(itemId: Int, actionOrigin: TabsActionOrigin) {
+    internal fun onAfterSetSelectedItemId(
+        itemId: Int,
+        actionOrigin: TabsActionOrigin,
+    ) {
         if (actionOrigin === TabsActionOrigin.USER) {
             // For non-user actions these will be performed in [performContainerUpdate]
             performPostSelectedTabUpdateActions()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -559,6 +559,10 @@ class TabsContainer internal constructor(
         val hasTriggeredSpecialEffect =
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
 
+        if (stateChanged && !isRepeated) {
+            onAppearanceChanged(selectedTab.tabsScreen)
+        }
+
         if (stateChanged) {
             observerRegistry.emitOnNavigationStateUpdate(
                 navState,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -109,8 +109,8 @@ class TabsContainer internal constructor(
             R.style.Theme_Material3_DayNight_NoActionBar,
         )
 
-    internal val bottomNavigationView: BottomNavigationView =
-        BottomNavigationView(themedContext).apply {
+    internal val bottomNavigationView: CustomBottomNavigationView =
+        CustomBottomNavigationView(themedContext, this).apply {
             layoutParams =
                 LayoutParams(
                     LayoutParams.MATCH_PARENT,
@@ -254,6 +254,13 @@ class TabsContainer internal constructor(
     internal fun tearDown() {
         observerRegistry.clear()
         setPendingNavigationStateUpdate(null)
+    }
+
+    internal fun onAfterSetSelectedItemId(itemId: Int, actionOrigin: TabsActionOrigin) {
+        if (actionOrigin === TabsActionOrigin.USER) {
+            // For non-user actions these will be performed in [performContainerUpdate]
+            performPostSelectedTabUpdateActions()
+        }
     }
 
     // endregion
@@ -406,27 +413,62 @@ class TabsContainer internal constructor(
 
     // region Private helpers
 
+    /**
+     * This is where programmatic update flow starts.
+     * This includes any JS-triggered action (navigation state update, prop update, etc.)
+     * and native programmatic actions - tab change.
+     *
+     * This method is supposed to perform all the necessary steps, satisfying all invalidation
+     * signals in a coordinated manner.
+     *
+     * The update actions are split into three phases: pre-, selection change, and post-.
+     * Pre-selection actions are run only here, in programmatic flow. This is not a hard requirement,
+     * it is just not needed now.
+     *
+     * Post-selection actions are performed here or in parallel flow triggered on user selection.
+     *
+     * The selected tab update takes place here only for programmatic changes.
+     * User triggered changes have separate entry-point.
+     */
     private fun performContainerUpdate() {
+        performPreSelectedTabUpdateActions()
+        performSelectedTabUpdateIfNeeded()
+        performPostSelectedTabUpdateActions()
+    }
+
+    private fun performPreSelectedTabUpdateActions() {
+        updateNavigationMenuStructureIfNeeded()
+    }
+
+    private fun performPostSelectedTabUpdateActions() {
+        updateBottomNavigationViewAppearanceIfNeeded()
+    }
+
+    private fun updateNavigationMenuStructureIfNeeded() {
         if (invalidationFlags.isNavigationMenuStructureInvalidated) {
             invalidationFlags.isNavigationMenuStructureInvalidated = false
             updateNavigationMenuStructure()
         }
+    }
 
+    private fun performSelectedTabUpdateIfNeeded() {
         if (invalidationFlags.isSelectedTabInvalidated) {
             invalidationFlags.isSelectedTabInvalidated = false
-            performOperation()
+            performSelectedTabUpdate()
         }
+    }
 
+    private fun updateBottomNavigationViewAppearanceIfNeeded() {
         if (invalidationFlags.isNavigationMenuAppearanceInvalidated) {
             invalidationFlags.isNavigationMenuAppearanceInvalidated = false
-            this.updateBottomNavigationViewAppearance()
+            updateBottomNavigationViewAppearance()
             a11yCoordinator.setA11yPropertiesToAllTabItems()
         }
     }
 
-    private fun performOperation() {
+    private fun performSelectedTabUpdate() {
         if (pendingStateUpdateRequest == null) {
-            RNSLog.w(TAG, "TabsContainer::performOperation called w/o pending operation; skipping update")
+            RNSLog.w(TAG, "TabsContainer::performSelectedTabUpdate called w/o pending operation; skipping update")
             return
         }
 
@@ -450,7 +492,7 @@ class TabsContainer internal constructor(
         if (bottomNavigationView.selectedItemId != nextSelectedMenuItemId || navState.isEmpty()) {
             isInExternalOperationContext = true
             // This triggers on OnMenuItemClicked callback, where we perform actual update from
-            bottomNavigationView.selectedItemId = nextSelectedMenuItemId
+            bottomNavigationView.setSelectedItemIdWithActionOrigin(nextSelectedMenuItemId, stateUpdateRequest.actionOrigin)
             isInExternalOperationContext = false
         } else {
             observerRegistry.emitOnNavigationStateUpdateRejected(
@@ -560,7 +602,10 @@ class TabsContainer internal constructor(
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
 
         if (stateChanged && !isRepeated) {
-            onAppearanceChanged(selectedTab.tabsScreen)
+            // If we've effectively changed the tab, we need to raise appropriate flags.
+            // This line assumes that any required e.g. appearance actions will be performed
+            // synchronously later in the flow.
+            invalidationFlags.invalidateOnSelectedTabChanged()
         }
 
         if (stateChanged) {
@@ -697,5 +742,9 @@ internal class TabsContainerInvalidationFlags(
         isSelectedTabInvalidated = true
         isNavigationMenuAppearanceInvalidated = true
         isNavigationMenuStructureInvalidated = true
+    }
+
+    internal fun invalidateOnSelectedTabChanged() {
+        isNavigationMenuAppearanceInvalidated = true
     }
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
-import scenarioDescription from './scenario-description';
+import { Button, Text, View } from 'react-native';
+import { TabsContainer, useTabsNavigationContext } from '@apps/shared/gamma/containers/tabs';
 import { createScenario } from '@apps/tests/shared/helpers';
+import scenarioDescription from './scenario-description';
 import {
   TabsScreenAppearanceAndroid,
   TabsScreenAppearanceIOS,
 } from 'react-native-screens';
 import { Colors } from '@apps/shared/styling';
+import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 
 const DEFAULT_APPEARANCE_ANDROID: TabsScreenAppearanceAndroid = {
   tabBarBackgroundColor: Colors.NavyLight100,
@@ -61,9 +62,23 @@ const DEFAULT_APPEARANCE_IOS: TabsScreenAppearanceIOS = {
 };
 
 function TabScreen() {
+  const navigation = useTabsNavigationContext()
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Tab</Text>
+    <CenteredLayoutView>
+      <TabsRouteInformation />
+      <Button title='Select tab 1' onPress={() => navigation.selectTab('Tab1')} />
+      <Button title='Select tab 2' onPress={() => navigation.selectTab('Tab2')} />
+      <Button title='Select tab 3' onPress={() => navigation.selectTab('Tab3')} />
+    </CenteredLayoutView>
+  );
+}
+
+export function TabsRouteInformation() {
+  const navigation = useTabsNavigationContext()
+
+  return (
+    <View>
+      <Text>{navigation.routeKey}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Description

On Android, when the user selected a tab natively (tap on bottom navigation item) the tab bar appearance was not updated, even when the appearance is defined per-tab (`tabBarBackgroundColor`, etc. resolved from the selected tab's appearance). Programmatic / JS-driven tab changes worked, because they flow through `performContainerUpdate`, which runs the appearance update step. User-triggered selections bypassed that flow.

This PR routes user-triggered selections through the same post-selection update step, so per-tab appearance is applied consistently regardless of who initiated the change.


Closes https://github.com/software-mansion/react-native-screens/issues/4069


## Changes

Until this commit, for user-triggered tab change we've only updated the
navigation state and selected fragment. We haven't triggered any other
actions including appearance updates.

Now, I've split the "container update actions" into three categories:
pre-selection update, selection update and post-selection update.
We now trigger the "post-selection update" from callback we get from
overridden `BottomNavigationView`.

To ensure that the appearance and other appropriate flags are invalidated
on tab change, we notify the `InvalidationFlags` from the tab update code.

I didn't want to invalidate flags directly from tab update code, as the
knowledge of what to invalidate should be separated from there.

## Before & after - visual documentation

<!-- TODO: attach recording showing tab bar background color updating on native tap vs. before -->

## Test plan

- `test-tabs-appearance-defined-by-selected-tab`

Repro / verification steps:

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes