### PR TITLE
refactor(iOS, FormSheet v5): Expose reactEventEmitter from Host

### DIFF
--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -8,13 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class RNSFormSheetContentController;
 @class RNSFormSheetHostComponentView;
 
+// TODO: @t0maboro - now we should get rid of that delegate and handle ShadowStateProxy/TouchHandler origin sync from
+// controller
 @protocol RNSFormSheetContentControllerDelegate <NSObject>
-- (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller;
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller;
-#if !TARGET_OS_TV
-- (void)sheetController:(RNSFormSheetContentController *)controller
-    didChangeDetentIdentifier:(nullable NSString *)identifier;
-#endif // !TARGET_OS_TV
 @end
 
 @interface RNSFormSheetContentController : UIViewController

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -3,7 +3,9 @@
 #import "RNSFormSheetAppearanceCoordinator.h"
 #import "RNSFormSheetAppearanceUpdateFlags.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostComponentView.h"
+#import "RNSFormSheetHostEventEmitter.h"
 #import "RNSPresentationSourceProvider.h"
 
 #import <React/RCTAssert.h>
@@ -166,7 +168,10 @@
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
-  [self.delegate sheetControllerDidNativeDismiss:self];
+  RNSFormSheetHostComponentView *host = self.hostComponentView;
+  RCTAssert(host != nil, @"[RNScreens] hostComponentView must be set before delegate callbacks fire");
+  [host onNativeDismiss];
+  [[host reactEventEmitter] emitOnNativeDismiss];
 }
 
 #if !TARGET_OS_TV
@@ -175,7 +180,14 @@
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
     (UISheetPresentationController *)sheetPresentationController
 {
-  [self.delegate sheetController:self didChangeDetentIdentifier:sheetPresentationController.selectedDetentIdentifier];
+  RNSFormSheetHostComponentView *host = self.hostComponentView;
+  RCTAssert(host != nil, @"[RNScreens] hostComponentView must be set before delegate callbacks fire");
+  NSInteger index =
+      [RNSFormSheetDetentResolver detentIndexFromDetentIdentifier:sheetPresentationController.selectedDetentIdentifier
+                                                    forRawDetents:host.detents];
+  if (index >= 0) {
+    [[host reactEventEmitter] emitOnDetentChangedWithIndex:index];
+  }
 }
 #endif // !TARGET_OS_TV
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#import "RNSFormSheetHostEventEmitter.h"
 #import "RNSReactBaseView.h"
 
 #if defined(__cplusplus)
@@ -9,6 +10,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetHostComponentView : RNSReactBaseView
+
+- (void)onNativeDismiss;
 
 @end
 
@@ -26,6 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSInteger largestUndimmedDetentIndex;
 @property (nonatomic, readonly) NSInteger initialDetentIndex;
 @property (nonatomic, readonly) BOOL prefersScrollingExpandsWhenScrolledToEdge;
+
+@end
+
+#pragma mark - Events
+
+@interface RNSFormSheetHostComponentView ()
+
+- (nonnull RNSFormSheetHostEventEmitter *)reactEventEmitter;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -2,10 +2,10 @@
 #import "RNSDefines.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
-#import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 
+#import <React/RCTAssert.h>
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
@@ -87,30 +87,24 @@ namespace react = facebook::react;
   [self requestContentControllerForUpdates];
 }
 
-#pragma mark - RNSFormSheetContentControllerDelegate
-
-- (void)sheetControllerDidNativeDismiss:(RNSFormSheetContentController *)controller
+- (void)onNativeDismiss
 {
   _isOpen = NO;
-  [_reactEventEmitter emitOnNativeDismiss];
 }
+
+- (nonnull RNSFormSheetHostEventEmitter *)reactEventEmitter
+{
+  RCTAssert(_reactEventEmitter != nil, @"[RNScreens] Attempt to access uninitialized _reactEventEmitter");
+  return _reactEventEmitter;
+}
+
+#pragma mark - RNSFormSheetContentControllerDelegate
 
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller
 {
   [self syncTouchHandlerOrigin];
   [self syncShadowNodeState];
 }
-
-#if !TARGET_OS_TV
-- (void)sheetController:(RNSFormSheetContentController *)controller
-    didChangeDetentIdentifier:(nullable NSString *)identifier
-{
-  NSInteger index = [RNSFormSheetDetentResolver detentIndexFromDetentIdentifier:identifier forRawDetents:_detents];
-  if (index >= 0) {
-    [_reactEventEmitter emitOnDetentChangedWithIndex:index];
-  }
-}
-#endif // !TARGET_OS_TV
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -2,6 +2,7 @@
 #import "RNSDefines.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
 


### PR DESCRIPTION
## Description

Similarly to Split, I'm exposing reactEventEmitter from Host, moving the logic to the ContentController.

## Changes

- expose reactEventEmitter from Host
- replace delegate callbacks with dispatching event from the Controller level

## Before & after - visual documentation

N/A - refactor

## Test plan

Focused on OnDetentChanged SFT, performed regression testing, randomly selecting other examples.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
