### PR TITLE
fix(Android, Stack v5): change header subview type to render callback

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -127,7 +127,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
     }
     const dims = getSubviewDimensions(size);
     return {
-      Component: (
+      render: () => (
         <PressableWithFeedback
           hitSlop={hitSlop}
           pressRetentionOffset={pressRetentionOffset}>
@@ -142,7 +142,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
   const backgroundSubview = config.backgroundEnabled
     ? {
         collapseMode: config.backgroundCollapseMode,
-        Component: (
+        render: () => (
           <View style={styles.backgroundContainer}>
             <Image
               source={require('@assets/trees.jpg')}

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -56,22 +56,22 @@ function StackHeaderConfig(props: StackHeaderConfigProps) {
         <StackHeaderSubview
           type="background"
           collapseMode={backgroundSubview.collapseMode}>
-          {backgroundSubview.Component}
+          {backgroundSubview.render()}
         </StackHeaderSubview>
       )}
       {leadingSubview && (
         <StackHeaderSubview type="leading">
-          {leadingSubview.Component}
+          {leadingSubview.render()}
         </StackHeaderSubview>
       )}
       {centerSubview && (
         <StackHeaderSubview type="center">
-          {centerSubview.Component}
+          {centerSubview.render()}
         </StackHeaderSubview>
       )}
       {trailingSubview && (
         <StackHeaderSubview type="trailing">
-          {trailingSubview.Component}
+          {trailingSubview.render()}
         </StackHeaderSubview>
       )}
     </StackHeaderConfigAndroidNativeComponent>

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import type { ColorValue } from 'react-native';
 import type { StackHeaderSubviewCollapseModeAndroid } from './android/StackHeaderSubview.android.types';
 import type { PlatformIconAndroid } from '../../../../types';
@@ -10,13 +10,12 @@ export type StackHeaderBackgroundSubviewCollapseModeAndroid =
 
 export interface StackHeaderToolbarSubviewAndroid {
   /**
-   * @summary The React component rendered in this toolbar slot.
+   * @summary Render callback for the React element placed in this toolbar slot.
    *
    * The subview is sized by React Native's layout engine but positioned by the
    * platform native layout. Each subview is placed independently — subviews do
    * not participate in a shared flex layout and cannot influence each other's
    * sizing.
-   *
    *
    * @remarks
    * Intrinsic sizing and explicit dimensions work as expected. Avoid
@@ -26,7 +25,7 @@ export interface StackHeaderToolbarSubviewAndroid {
    *
    * @platform android
    */
-  Component: NonNullable<ReactNode>;
+  render: () => ReactElement;
 }
 
 export interface StackHeaderBackgroundSubviewAndroid {
@@ -51,14 +50,16 @@ export interface StackHeaderBackgroundSubviewAndroid {
    */
   collapseMode?: StackHeaderSubviewCollapseModeAndroid | undefined;
   /**
-   * @summary The React component rendered as the header background.
+   * @summary Render callback for the React element used as the header
+   * background.
    *
+   * @remarks
    * The subview is stretched to match the header (`AppBarLayout`) dimensions,
    * so parent-relative sizing (e.g. `flex: 1`) works correctly.
    *
    * @platform android
    */
-  Component: NonNullable<ReactNode>;
+  render: () => ReactElement;
 }
 
 export interface StackHeaderConfigPropsAndroid {


### PR DESCRIPTION
## Description

Fixes type of `Component` prop in header subviews in Stack v5 on Android.

## Changes

- change type of `StackHeaderToolbarSubviewAndroid` and `StackHeaderBackgroundSubviewAndroid` to render callback (`() => React.ReactElement`)
- adjust `test-stack-subviews-android`

## Before & after - visual documentation

N/A

## Test plan

Run `test-stack-subviews-android` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
