### PR TITLE
chore(Example): remove default exports from `scenario-description.ts` files

### DIFF
--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { StackContainer } from '@apps/shared/gamma/containers/stack';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'FormSheet with Nested Stack v5',
   key: 'test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios',
   details: 'Test nesting Stack v5 inside a FormSheet',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollView } from 'react-native';
 import { SettingsPicker } from '@apps/shared/SettingsPicker';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,

--- a/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'StackInTabs',
   details:
     'Configuration in Stack contained within TabScreen always takes precedence',
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollView } from 'react-native';
 import { SettingsPicker } from '@apps/shared/SettingsPicker';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,

--- a/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'TabsInStack',
   details:
     'Configuration in Tabs contained within StackScreen should have precedence over configuraton in Stack contained within TabScreen',
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Basic functionality',
   key: 'test-form-sheet-base-ios',
   details: 'Allows to test the basic functionality of FormSheet component.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Switch, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Grabber visibility',
   key: 'test-form-sheet-grabber-visible-ios',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Sheet initial detent index',
   key: 'test-form-sheet-initial-detent-index-ios',
   details: 'Allows to test initialDetentIndex prop of FormSheet component.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Sheet largest undimmed detent index',
   key: 'test-form-sheet-largest-undimmed-detent-index-ios',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens/experimental';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Sheet preferred corner radius',
   key: 'test-form-sheet-preferred-corner-radius-ios',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { ScrollViewMarker } from 'react-native-screens/experimental';

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Basic functionality',
   key: 'test-svm-configures-scroll-view',
   details:
@@ -12,5 +12,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/split/test-command-show-column/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-command-show-column/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Split, SplitHostCommands } from 'react-native-screens/experimental';
 import { Button, StyleSheet, Text, View } from 'react-native';

--- a/apps/src/tests/single-feature-tests/split/test-command-show-column/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/split/test-command-show-column/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Command: showColumn',
   key: 'test-command-show-column',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/index.tsx
@@ -8,7 +8,7 @@ import {
   View,
   PlatformColor,
 } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import React, { useEffect, useState } from 'react';
 import { SettingsPicker } from '@apps/shared';

--- a/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Split Color Scheme',
   key: 'test-split-color-scheme',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/split/test-top-column-for-collapsing/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-top-column-for-collapsing/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Split } from 'react-native-screens/experimental';
 import { StyleSheet, Text, View } from 'react-native';

--- a/apps/src/tests/single-feature-tests/split/test-top-column-for-collapsing/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/split/test-top-column-for-collapsing/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Prop: topColumnForCollapsing',
   key: 'test-split-top-column-for-collapsing',
   details: `
@@ -11,5 +11,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v4/stack-v4-orientation/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v4/stack-v4-orientation/index.tsx
@@ -6,7 +6,7 @@ import {
   createAutoConfiguredStack,
   findStackScreenOptions,
 } from '@apps/tests/shared/stack';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 
 type StackParamList = {

--- a/apps/src/tests/single-feature-tests/stack-v4/stack-v4-orientation/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v4/stack-v4-orientation/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Orientation',
   key: 'stack-v4-orientation',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-nested-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-nested-stack/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-nested-stack/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-nested-stack/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Prevent native dismiss - nested stack',
   key: 'prevent-native-dismiss-nested-stack',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-single-stack/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-single-stack/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/prevent-native-dismiss-single-stack/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Prevent native dismiss - single stack',
   key: 'prevent-native-dismiss-single-stack',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/test-animation-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-animation-android/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { StackContainer } from '@apps/shared/gamma/containers/stack';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';

--- a/apps/src/tests/single-feature-tests/stack-v5/test-animation-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-animation-android/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Animation Android',
   key: 'test-animation-android',
   details: 'High contrast screens to test animations on Android',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, ScrollView, StyleSheet, Text } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Back Button',
   key: 'test-stack-back-button',
   details: 'Tests back button customization: hidden, tint color, custom icon.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { StyleSheet, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Simple navigation scenario',
   key: 'test-stack-simple-nav',
   details: 'Test simple push and pop operations',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Subviews',
   key: 'test-stack-subviews-android',
   details: 'Tests header config and subview customization.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation/index.tsx
@@ -2,7 +2,7 @@ import { SettingsPicker } from '@apps/shared/SettingsPicker';
 import React from 'react';
 import { ScrollView } from 'react-native';
 import { DummyScreen } from '@apps/tests/shared/DummyScreens';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   TabsContainer,

--- a/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/tabs-screen-orientation/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tabs Screen Orientation',
   key: 'tabs-screen-orientation',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Text, View } from 'react-native';
 import { TabsContainer, useTabsNavigationContext } from '@apps/shared/gamma/containers/tabs';
 import { createScenario } from '@apps/tests/shared/helpers';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import {
   TabsScreenAppearanceAndroid,
   TabsScreenAppearanceIOS,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Appearance',
   key: 'test-tabs-appearance-defined-by-selected-tab',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
@@ -1,7 +1,7 @@
 import LongText from '@apps/shared/LongText';
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Pressable, ScrollView } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   TabsContainerWithHostConfigContext,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Bottom Accessory',
   key: 'test-tabs-bottom-accessory-layout-ios',
   details: 'Test tabs bottom accessory with various contents',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets/index.tsx
@@ -1,5 +1,5 @@
 import { Platform, StyleSheet, Text, TextInput, View } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import React, { useEffect, useState } from 'react';
 import { SettingsSwitch } from '@apps/shared';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'IME insets',
   key: 'test-tabs-ime-insets',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   TabsContainer,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario-description.ts
@@ -1,13 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tabs lifecycle events',
   key: 'test-tabs-lifecycle-events',
-  details:
-    'Verify lifecycle events (onWillAppear, etc.) fire on tab switch',
+  details: 'Verify lifecycle events (onWillAppear, etc.) fire on tab switch',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Button, Text, View, type NativeSyntheticEvent } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'More navigation controller',
   key: 'test-tabs-more-navigation-controller',
   details: 'Test navigation and interactions with "More Navigation Controller"',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/index.tsx
@@ -5,7 +5,7 @@ import {
   NavigationIndependentTree,
 } from '@react-navigation/native';
 import { TabsContainer } from '@apps/shared/gamma/containers/tabs';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 
 const ITEM_COUNT = 30;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Override ScrollView Content Inset',
   key: 'test-tabs-override-scroll-view-content-inset-ios',
   details:
@@ -10,5 +10,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '../../../shared/helpers';
 import { Button, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Prevent native selection',
   key: 'test-tabs-prevent-native-selection',
   details: 'Test preventNativeSelection prop on TabsScreen',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Button, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Test simple navigation',
   key: 'test-tabs-simple-nav',
   details: 'Test basic navigation scenarios',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   TabsContainer,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario-description.ts
@@ -1,13 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tabs special effect scroll to top',
   key: 'test-tabs-special-effects-scroll-to-top',
-  details:
-    'Test settings of specialEffect scrollToTop.',
+  details: 'Test settings of specialEffect scrollToTop.',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Button, Text, View } from 'react-native';
 import {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Stale update rejection',
   key: 'test-tabs-stale-update-rejection',
   details: 'Test stale update rejection mechanism',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
@@ -8,7 +8,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import React, { useEffect } from 'react';
 import { SettingsPicker } from '@apps/shared';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Color Scheme',
   key: 'test-tabs-tab-bar-color-scheme',
   details: 'Tests how tabs handle system, React Native and prop color scheme.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@apps/shared/gamma/containers/tabs';
 import React from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { SettingsPicker } from '@apps/shared';
 import { TabBarControllerMode } from 'react-native-screens';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Controller Mode',
   key: 'test-tabs-tab-bar-controller-mode-ios',
   details: 'Test different tab bar modes.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { StackContainer, StackRouteConfig, useStackNavigationContext } from '@apps/shared/gamma/containers/stack';
 import {  LightRootScreen, LightInterfaceStyleScreen, DarkRootScreen, DarkInterfaceStyleScreen } from './ThemeScreen';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 
 export function HomeScreen() {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Experimental UIStyle',
   key: 'test-tabs-tab-bar-experimental-user-interface-style-ios',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
@@ -1,7 +1,7 @@
 import { SettingsSwitch } from '@apps/shared/SettingsSwitch';
 import React from 'react';
 import { ScrollView, Text } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   TabsContainerWithHostConfigContext,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario-description.ts
@@ -1,11 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Hidden',
   key: 'test-tabs-tab-bar-hidden',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import React, { useEffect, useState } from 'react';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Layout Direction',
   key: 'test-tabs-tab-bar-layout-direction',
   details:
@@ -9,5 +9,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@apps/shared/gamma/containers/tabs';
 import React from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
-import scenarioDescription from './scenario-description';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { SettingsPicker } from '@apps/shared';
 import { TabBarMinimizeBehavior } from 'react-native-screens';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario-description.ts
@@ -1,6 +1,6 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
-const scenarioDescription: ScenarioDescription = {
+export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Minimize Behavior',
   key: 'test-tabs-tab-bar-minimize-behavior-ios',
   details: 'Test tab bar minimize behavior for iOS 26+.',
@@ -8,5 +8,3 @@ const scenarioDescription: ScenarioDescription = {
   e2eCoverage: 'tbd',
   smokeTest: false,
 };
-
-export default scenarioDescription;


### PR DESCRIPTION
## Description

This PR removes default exports from `scenario-description.ts` files.

We are making a script mentioned in https://github.com/software-mansion/react-native-screens-labs/issues/1475 and such approach will give us a cleaner solution when it comes to extracting object from `module`.

## Changes

- make exports named instead of default ones
- update imports properly

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
