### PR TITLE
feat(iOS, FormSheet v5): Introduce PresentationManager for FormSheet component

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -6,6 +6,7 @@ import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-in
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
+import TestFormSheetPresentationState from './test-form-sheet-presentation-state-ios';
 
 const scenarios = {
   TestFormSheetBase,
@@ -15,6 +16,7 @@ const scenarios = {
   TestFormSheetLargestUndimmedDetentIndex,
   TestFormSheetOnDetentChanged,
   TestFormSheetPreferredCornerRadius,
+  TestFormSheetPresentationState,
 };
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/index.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet Test</Text>
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => {
+          setIsOpen(false);
+        }}
+        detents={[0.6, 1.0]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>FormSheet content</Text>
+          <View style={styles.spacing} />
+          <Button
+            title="Quickly dismiss & present"
+            color={Colors.primary}
+            onPress={() => {
+              setIsOpen(false);
+              setTimeout(() => {
+                setIsOpen(true);
+              }, 32);
+            }}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario-description.ts
@@ -1,7 +1,7 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Presentation State',
+  name: 'Presentation state',
   key: 'test-form-sheet-presentation-state-ios',
   details:
     'Verifies the presentation state machine when subjected to rapid consecutive open/close state changes from JS.',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Presentation State',
+  key: 'test-form-sheet-presentation-state-ios',
+  details:
+    'Verifies the presentation state machine when subjected to rapid consecutive open/close state changes from JS.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Presentation State
+# Test Scenario: Presentation state
 
 ## Details
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
@@ -1,0 +1,47 @@
+# Test Scenario: Presentation State
+
+## Details
+
+**Description:** Verify the presentation state machine. This test ensures that when the React Native state rapidly toggles between `false` and `true` the native layer correctly queues the presentation changes and prevents state desynchronization.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+Other: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone
+
+## Steps - iPhone
+
+### Baseline
+
+1. Launch the app and navigate to the **Presentation state** screen.
+
+- [ ] Expected: Content with the button "Open FormSheet" is shown.
+
+---
+
+### Initialization
+
+2. Tap the "Open FormSheet" button.
+
+- [ ] Expected: The FormSheet opens smoothly and displays its content.
+
+---
+
+### Rapid State Toggling (Stress Test)
+
+3. Tap the "Quickly dismiss & present" button.
+
+- [ ] Expected: The FormSheet should begin the dismissal animation. As soon as the dismissal animation finishes, the FormSheet should immediately automatically re-present itself. The final state should be opened FormSheet.
+
+---
+
+### Final Dismissal Verification
+
+4. Grab the top edge of the FormSheet and swipe down completely to natively dismiss it.
+
+- [ ] Expected: The FormSheet dismisses and returns the user to the underlying main screen. The native state is synchronized, and tapping "Open FormSheet" again works correctly.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -27,6 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) RNSFormSheetContentView *contentView;
 
+#pragma mark - Presentation
+
+- (void)prepareForPresentation;
+
 #pragma mark - Signals
 
 - (void)setNeedsPresentationUpdate;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -1,6 +1,7 @@
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetConfigurationApplicator.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetPresentationManager.h"
 #import "RNSFormSheetUpdateCoordinator.h"
 #import "RNSFormSheetUpdateFlags.h"
 #import "RNSPresentationSourceProvider.h"
@@ -19,6 +20,7 @@
 @implementation RNSFormSheetContentController {
   RNSFormSheetUpdateCoordinator *_Nonnull _updateCoordinator;
   RNSFormSheetConfigurationApplicator *_Nonnull _configurationApplicator;
+  RNSFormSheetPresentationManager *_Nonnull _presentationManager;
 
   BOOL _needsInitialDetentReset;
 }
@@ -30,6 +32,7 @@
 
     _updateCoordinator = [RNSFormSheetUpdateCoordinator new];
     _configurationApplicator = [RNSFormSheetConfigurationApplicator new];
+    _presentationManager = [RNSFormSheetPresentationManager new];
 
     _needsInitialDetentReset = NO;
   }
@@ -78,14 +81,7 @@
     return;
   }
 
-  if (presentationProvider.isOpen) {
-    UIWindow *window = presentationProvider.hostWindow;
-    if (window != nil) {
-      [self presentFromWindowIfNeeded:window];
-    }
-  } else {
-    [self dismissIfNeeded];
-  }
+  [_presentationManager updatePresentationIfNeededWithProvider:presentationProvider controller:self];
 }
 
 - (void)prepareForPresentation
@@ -96,38 +92,6 @@
 #if !TARGET_OS_TV
   self.sheetPresentationController.delegate = self;
 #endif // !TARGET_OS_TV
-}
-
-// TODO: @t0maboro - This presentation logic is currently quite primitive.
-// We are not entirely safe from rapid conflicting updates, and there are edge cases
-// where the presentation state might become desynchronized. Addressing this robustly
-// might require an approach similar to the tabs implementation using state provenance,
-// which will be handled separately.
-// Followup ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1420
-- (void)presentFromWindowIfNeeded:(nonnull UIWindow *)window
-{
-  if (self.presentingViewController != nil) {
-    return;
-  }
-
-  UIViewController *presentationSourceViewController =
-      [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
-  if (presentationSourceViewController == nil) {
-    RCTLogError(
-        @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
-    return;
-  }
-
-  [self prepareForPresentation];
-  [presentationSourceViewController presentViewController:self animated:YES completion:nil];
-}
-
-- (void)dismissIfNeeded
-{
-  if (self.presentingViewController == nil) {
-    return;
-  }
-  [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Sheet Configuration
@@ -189,6 +153,8 @@
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
+  [_presentationManager handleNativeDismiss];
+
   [self.delegate sheetControllerDidNativeDismiss:self];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -92,6 +92,14 @@
 #if !TARGET_OS_TV
   self.sheetPresentationController.delegate = self;
 #endif // !TARGET_OS_TV
+
+  // Since UIKit has recreated sheetPresentationController, any configuration that could be applied
+  // during the Dismissed or Dismissing state was lost.
+  // We must force a full configuration update for this new instance.
+  [self setNeedsAppearanceUpdate];
+  [self setNeedsBehaviorUpdate];
+  [self setNeedsInitialDetentReset];
+  [self updateConfigurationIfNeeded];
 }
 
 #pragma mark - Sheet Configuration

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import "RNSFormSheetProviders.h"
+
+@class RNSFormSheetContentController;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetPresentationManager : NSObject
+
+- (void)updatePresentationIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
+                                    controller:(RNSFormSheetContentController *)controller;
+
+- (void)handleNativeDismiss;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
@@ -50,9 +50,6 @@
   }
 
   _state = RNSFormSheetPresentationStatePresenting;
-
-  // The presentation controller is recreated by UIKit on every present/dismiss cycle.
-  // We must assign this delegate before actual presentation
   [controller prepareForPresentation];
 
   __weak auto weakSelf = self;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
@@ -23,14 +23,14 @@
   BOOL shouldBeOpen = provider.isOpen;
 
   if (shouldBeOpen) {
-    [self presentIfNeededForProvider:provider controller:controller];
+    [self presentIfNeededWithProvider:provider controller:controller];
   } else {
-    [self dismissIfNeededForProvider:provider controller:controller];
+    [self dismissIfNeededWithProvider:provider controller:controller];
   }
 }
 
-- (void)presentIfNeededForProvider:(id<RNSFormSheetPresentationProvider>)provider
-                        controller:(RNSFormSheetContentController *)controller
+- (void)presentIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
+                         controller:(RNSFormSheetContentController *)controller
 {
   if (_state != RNSFormSheetPresentationStateDismissed) {
     return;
@@ -70,8 +70,8 @@
                                                }];
 }
 
-- (void)dismissIfNeededForProvider:(id<RNSFormSheetPresentationProvider>)provider
-                        controller:(RNSFormSheetContentController *)controller
+- (void)dismissIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
+                         controller:(RNSFormSheetContentController *)controller
 {
   if (_state != RNSFormSheetPresentationStatePresented) {
     return;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
@@ -41,8 +41,9 @@
     return;
   }
 
-  UIViewController *sourceVC = [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
-  if (sourceVC == nil) {
+  UIViewController *presentationSourceViewController =
+      [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
+  if (presentationSourceViewController == nil) {
     RCTLogError(
         @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
     return;
@@ -55,17 +56,18 @@
   [controller prepareForPresentation];
 
   __weak auto weakSelf = self;
-  [sourceVC presentViewController:controller
-                         animated:YES
-                       completion:^{
-                         auto strongSelf = weakSelf;
-                         if (!strongSelf) {
-                           return;
-                         }
+  [presentationSourceViewController presentViewController:controller
+                                                 animated:YES
+                                               completion:^{
+                                                 auto strongSelf = weakSelf;
+                                                 if (!strongSelf) {
+                                                   return;
+                                                 }
 
-                         strongSelf->_state = RNSFormSheetPresentationStatePresented;
-                         [strongSelf updatePresentationIfNeededWithProvider:provider controller:controller];
-                       }];
+                                                 strongSelf->_state = RNSFormSheetPresentationStatePresented;
+                                                 [strongSelf updatePresentationIfNeededWithProvider:provider
+                                                                                         controller:controller];
+                                               }];
 }
 
 - (void)dismissIfNeededForProvider:(id<RNSFormSheetPresentationProvider>)provider

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationManager.mm
@@ -1,0 +1,103 @@
+#import "RNSFormSheetPresentationManager.h"
+#import "RNSFormSheetContentController.h"
+#import "RNSFormSheetPresentationState.h"
+#import "RNSPresentationSourceProvider.h"
+
+#import <React/RCTLog.h>
+
+@implementation RNSFormSheetPresentationManager {
+  RNSFormSheetPresentationState _state;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _state = RNSFormSheetPresentationStateDismissed;
+  }
+  return self;
+}
+
+- (void)updatePresentationIfNeededWithProvider:(id<RNSFormSheetPresentationProvider>)provider
+                                    controller:(RNSFormSheetContentController *)controller
+{
+  BOOL shouldBeOpen = provider.isOpen;
+
+  if (shouldBeOpen) {
+    [self presentIfNeededForProvider:provider controller:controller];
+  } else {
+    [self dismissIfNeededForProvider:provider controller:controller];
+  }
+}
+
+- (void)presentIfNeededForProvider:(id<RNSFormSheetPresentationProvider>)provider
+                        controller:(RNSFormSheetContentController *)controller
+{
+  if (_state != RNSFormSheetPresentationStateDismissed) {
+    return;
+  }
+
+  UIWindow *window = provider.hostWindow;
+  if (window == nil) {
+    return;
+  }
+
+  UIViewController *sourceVC = [RNSPresentationSourceProvider findViewControllerForPresentationInWindow:window];
+  if (sourceVC == nil) {
+    RCTLogError(
+        @"[RNScreens] Failed to present form sheet: The source view controller cannot be found for target window.");
+    return;
+  }
+
+  _state = RNSFormSheetPresentationStatePresenting;
+
+  // The presentation controller is recreated by UIKit on every present/dismiss cycle.
+  // We must assign this delegate before actual presentation
+  [controller prepareForPresentation];
+
+  __weak auto weakSelf = self;
+  [sourceVC presentViewController:controller
+                         animated:YES
+                       completion:^{
+                         auto strongSelf = weakSelf;
+                         if (!strongSelf) {
+                           return;
+                         }
+
+                         strongSelf->_state = RNSFormSheetPresentationStatePresented;
+                         [strongSelf updatePresentationIfNeededWithProvider:provider controller:controller];
+                       }];
+}
+
+- (void)dismissIfNeededForProvider:(id<RNSFormSheetPresentationProvider>)provider
+                        controller:(RNSFormSheetContentController *)controller
+{
+  if (_state != RNSFormSheetPresentationStatePresented) {
+    return;
+  }
+
+  if (controller.presentingViewController == nil) {
+    _state = RNSFormSheetPresentationStateDismissed;
+    return;
+  }
+
+  _state = RNSFormSheetPresentationStateDismissing;
+
+  __weak auto weakSelf = self;
+  [controller dismissViewControllerAnimated:YES
+                                 completion:^{
+                                   auto strongSelf = weakSelf;
+                                   if (!strongSelf) {
+                                     return;
+                                   }
+
+                                   strongSelf->_state = RNSFormSheetPresentationStateDismissed;
+                                   [strongSelf updatePresentationIfNeededWithProvider:provider controller:controller];
+                                 }];
+}
+
+- (void)handleNativeDismiss
+{
+  _state = RNSFormSheetPresentationStateDismissed;
+}
+
+@end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationState.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationState.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#import <Foundation/Foundation.h>
+
 typedef NS_ENUM(NSInteger, RNSFormSheetPresentationState) {
   RNSFormSheetPresentationStateDismissed,
   RNSFormSheetPresentationStateDismissing,

--- a/ios/gamma/modals/form-sheet/RNSFormSheetPresentationState.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetPresentationState.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef NS_ENUM(NSInteger, RNSFormSheetPresentationState) {
+  RNSFormSheetPresentationStateDismissed,
+  RNSFormSheetPresentationStateDismissing,
+  RNSFormSheetPresentationStatePresented,
+  RNSFormSheetPresentationStatePresenting
+};


### PR DESCRIPTION
## Description

This PR addresses cases where rapid updates to the `isOpen` prop from JS may cause the native presentation state to desynchronize. Previously, the presentation logic was primitive, and triggering a present or dismiss while another UIKit animation was already in flight would cause UIKit to ignore the call, permanently breaking the component's state.

I'm solving this by introducing a dedicated PresentationManager with a state machine.

1. The PresentationManager will only fire a present if the current state is `Dismissed`, and will only fire a dismiss if the state is `Presented`.
2. If React toggles the `isOpen` prop while an animation (state `Presenting` or `Dismissing`) is actively running, the manager intentionally suppresses the call to prevent conflicts.
3. Inside the completion block of every UIKit animation, the manager updates its internal state (from `Dismissing` to `Dismissed`, from `Presenting` to `Presented`) and then immediately re-evaluates the desired React state. If React updates the value mid-animation, the manager instantly catches up and triggers the next transition.

Note:
The quick `isOpen` toggle may try to apply the configuration to an old `sheetPresentationController` that we're going to destroy in `Dismissing -> Dismissed` transition. I need to force a complete configuration refresh inside `prepareForPresentation` to guarantee the newly recreated UIKit controller always receives the latest props before it appears on screen.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1420

## Changes

- `RNSFormSheetPresentationState` was defined
- `RNSFormSheetPresentationManager` was defined to define the state machine
- Stripped the presentation logic from `RNSFormSheetContentController`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e7901080-4cbe-46f0-866f-64ba88b52d79" /> | <video src="https://github.com/user-attachments/assets/7f9f6075-2015-4b38-98fc-c9865e8b6a79" /> |

## Test plan

Added a new dedicated SFT that will toggle `isOpen` prop twice with timeout 32ms.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
