### PR TITLE
chore(tests): add checkmark script for tests

### DIFF
--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-import type { ScenarioDescription } from '../../apps/src/tests/shared/helpers.ts';
+import type { ScenarioDescription } from '../../apps/src/tests/shared/helpers';
 
 type E2eCoverage = ScenarioDescription['e2eCoverage'];
 

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -9,11 +9,9 @@ interface ScenarioFile {
   subdirectory: string;
 }
 
-interface TableColumn {
-  header: string;
-  prop: keyof ScenarioDescription | null;
-  defaultValue?: string;
-}
+type TableColumn =
+  | { header: string; prop: keyof ScenarioDescription }
+  | { header: string; prop: null; defaultValue: string };
 
 interface Entry extends ScenarioDescription {
   subdirectory: string;
@@ -105,9 +103,9 @@ function formatTable(entries: Entry[]): string {
   }
 
   const cellValue = (col: TableColumn, entry: Entry) =>
-    col.prop
+    col.prop !== null
       ? String(entry[col.prop as keyof Entry] ?? 'N/A')
-      : col.defaultValue!;
+      : col.defaultValue;
 
   const colWidths = TABLE_COLUMNS.map(col =>
     Math.max(col.header.length, ...entries.map(e => cellValue(col, e).length)),

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -90,7 +90,7 @@ function compareEntries(a: Entry, b: Entry): number {
     return coverageDiff;
   }
 
-  if (a.key !== b.subdirectory) {
+  if (a.subdirectory !== b.subdirectory) {
     return a.subdirectory.localeCompare(b.subdirectory);
   }
 

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -1,0 +1,166 @@
+const fs = require('fs');
+const path = require('path');
+import type { ScenarioDescription } from '../../apps/src/tests/shared/helpers.ts';
+
+type E2eCoverage = ScenarioDescription['e2eCoverage'];
+
+interface ScenarioFile {
+  file: string;
+  subdirectory: string;
+}
+
+interface TableColumn {
+  header: string;
+  prop: keyof ScenarioDescription | null;
+  defaultValue?: string;
+}
+
+interface Entry extends ScenarioDescription {
+  subdirectory: string;
+}
+
+const DEFAULT_TESTS_DIR = path.resolve(__dirname, '../../apps/src/tests');
+const SCENARIO_FILENAME = 'scenario-description.ts';
+const OBJECT_NAME = 'scenarioDescription';
+
+const TABLE_COLUMNS: TableColumn[] = [
+  { header: 'Mark', prop: null, defaultValue: '[ ]' },
+  { header: 'Test Name', prop: 'name' },
+  { header: 'E2E Coverage', prop: 'e2eCoverage' },
+  { header: 'Key', prop: 'key' },
+];
+
+const COVERAGE_ORDER: Record<E2eCoverage, number> = {
+  full: 0,
+  incomplete: 1,
+  tbd: 2,
+};
+
+function getCustomTestPath(): string | null {
+  const flagIndex = process.argv.indexOf('--test-path');
+  if (flagIndex !== -1 && flagIndex + 1 < process.argv.length) {
+    return process.argv[flagIndex + 1];
+  }
+  return null;
+}
+
+function findScenarioFiles(dir: string, baseDir: string = dir): ScenarioFile[] {
+  let results: ScenarioFile[] = [];
+
+  if (!fs.existsSync(dir)) {
+    return results;
+  }
+
+  const items = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const item of items) {
+    const fullPath = path.join(dir, item.name);
+
+    if (item.isDirectory()) {
+      results = results.concat(findScenarioFiles(fullPath, baseDir));
+    } else if (item.isFile() && item.name === SCENARIO_FILENAME) {
+      const relativePath = path.relative(baseDir, dir);
+
+      results.push({
+        file: fullPath,
+        subdirectory: relativePath === '' ? 'root' : relativePath,
+      });
+    }
+  }
+
+  return results;
+}
+
+async function parseScenarioFile(
+  filePath: string,
+): Promise<ScenarioDescription | null> {
+  try {
+    const module = require(filePath);
+    return module[OBJECT_NAME];
+  } catch (e) {
+    console.error(
+      `Warning: could not import ${filePath}: ${(e as Error).message}`,
+    );
+    return null;
+  }
+}
+
+function compareEntries(a: Entry, b: Entry): number {
+  const coverageDiff =
+    COVERAGE_ORDER[a.e2eCoverage] - COVERAGE_ORDER[b.e2eCoverage];
+  if (coverageDiff !== 0) {
+    return coverageDiff;
+  }
+
+  if (a.subdirectory !== b.subdirectory) {
+    return a.subdirectory.localeCompare(b.subdirectory);
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+function formatTable(entries: Entry[]): string {
+  if (entries.length === 0) {
+    return 'No tests in this category.\n';
+  }
+
+  const cellValue = (col: TableColumn, entry: Entry) =>
+    col.prop
+      ? String(entry[col.prop as keyof Entry] ?? 'N/A')
+      : col.defaultValue!;
+
+  const colWidths = TABLE_COLUMNS.map(col =>
+    Math.max(col.header.length, ...entries.map(e => cellValue(col, e).length)),
+  );
+
+  const row = (values: string[]) =>
+    '| ' + values.map((v, i) => v.padEnd(colWidths[i])).join(' | ') + ' |';
+
+  const separator = '| ' + colWidths.map(w => '-'.repeat(w)).join(' | ') + ' |';
+
+  const lines = [
+    row(TABLE_COLUMNS.map(col => col.header)),
+    separator,
+    ...entries.map(e => row(TABLE_COLUMNS.map(col => cellValue(col, e)))),
+  ];
+
+  return lines.join('\n') + '\n';
+}
+
+async function main() {
+  const allEntries: Entry[] = [];
+
+  const customTestPath = getCustomTestPath();
+  const searchDir = customTestPath
+    ? path.resolve(process.cwd(), customTestPath)
+    : path.resolve(__dirname, DEFAULT_TESTS_DIR);
+
+  const files = findScenarioFiles(searchDir);
+
+  for (const { file, subdirectory } of files) {
+    const parsed = await parseScenarioFile(file);
+    if (parsed) {
+      allEntries.push({
+        ...parsed,
+        subdirectory,
+      });
+    }
+  }
+
+  const smokeTests = allEntries.filter(e => e.smokeTest).sort(compareEntries);
+  const nonSmokeTests = allEntries
+    .filter(e => !e.smokeTest)
+    .sort(compareEntries);
+
+  const output = [
+    '## Smoke Tests\n',
+    formatTable(smokeTests),
+    '',
+    '## Non-Smoke Tests\n',
+    formatTable(nonSmokeTests),
+  ].join('\n');
+
+  process.stdout.write(output);
+}
+
+main();

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -131,7 +131,7 @@ async function main() {
   const customTestPath = getCustomTestPath();
   const searchDir = customTestPath
     ? path.resolve(process.cwd(), customTestPath)
-    : path.resolve(__dirname, DEFAULT_TESTS_DIR);
+    : DEFAULT_TESTS_DIR;
 
   const files = findScenarioFiles(searchDir);
 

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -1,3 +1,20 @@
+/**
+ * This script aggregates scenario descriptions from test directories and generates
+ * formatted Markdown tables detailing test coverage. It separates the results into
+ * "Smoke Tests" and "Non-Smoke Tests".
+ *
+ * Sorting:
+ * Entries in the output tables are sorted primarily by E2E Coverage ('full' ->
+ * 'incomplete' -> 'tbd'), secondarily by subdirectory (alphabetically), and
+ * finally by the scenario's key (alphabetically).
+ *
+ * Usage:
+ * By default, the script searches for `scenario-description.ts` files inside
+ * the `../../apps/src/tests` directory.
+ * You can override this default search path by using the `--test-path` flag:
+ * Example: `node generate-test-checklist.ts --test-path custom/path/to/tests`
+ */
+
 const fs = require('fs');
 const path = require('path');
 import type { ScenarioDescription } from '../../apps/src/tests/shared/helpers';

--- a/scripts/release/generate-test-checklist.ts
+++ b/scripts/release/generate-test-checklist.ts
@@ -90,11 +90,11 @@ function compareEntries(a: Entry, b: Entry): number {
     return coverageDiff;
   }
 
-  if (a.subdirectory !== b.subdirectory) {
+  if (a.key !== b.subdirectory) {
     return a.subdirectory.localeCompare(b.subdirectory);
   }
 
-  return a.name.localeCompare(b.name);
+  return a.key.localeCompare(b.key);
 }
 
 function formatTable(entries: Entry[]): string {


### PR DESCRIPTION
## Description

This PR adds a new utility script that automatically collects information about test scenarios and generates readable Markdown tables based on their metadata.
The script processes the collected data and outputs it into two separate sections: Smoke Tests and Non-Smoke Tests. Currently, the generated tables include the following columns: `Mark` (rendered as an empty checkbox [ ]), `Test Name`, `E2E Coverage` and `Key`. The entries in both tables are sorted first by E2E coverage priority, and then alphabetically by their file path. This ensures that tests related to the same features or areas are grouped logically together in the list.

If you want to add a new property or column to the table in the future, you simply need to add a new object to the `TABLE_COLUMNS` array inside the script.

To execute the script, simply run it using Node.js:
`node path-to/generate-test-checklist.ts`

By default, the script searches the standard test directory, but you can override this behavior by passing a custom path using the `--test-path <path>` flag.

> [!NOTE]  
> Adding `tsconfig.json` and `.eslintrc.js` files to `scripts` directory will be handled in a separate PR.


## Changes

- add `generate-test-checklist.ts` in `scripts/release` directory

## Visual documentation

That's how tables are meant to look like:

<img width="881" height="576" alt="table" src="https://github.com/user-attachments/assets/e035aa2f-8f08-4a9d-85ad-91195af8dd44" />



## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
