### PR TITLE
feat: support hintTextColor on iOS search bar

### DIFF
--- a/apps/src/tests/issue-tests/Test4089.tsx
+++ b/apps/src/tests/issue-tests/Test4089.tsx
@@ -1,0 +1,198 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useLayoutEffect, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { SearchBarPlacement, SearchBarProps } from 'react-native-screens';
+
+type StackParamList = {
+  Home: undefined;
+  SearchBar: undefined;
+};
+
+type PlaceholderMode = 'default' | 'custom' | 'empty';
+type HintColorMode = 'default' | 'red' | 'blue';
+
+type SearchBarConfig = {
+  placement: SearchBarPlacement;
+  placeholderMode: PlaceholderMode;
+  hintColorMode: HintColorMode;
+  allowToolbarIntegration: boolean;
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+const placements: SearchBarPlacement[] = [
+  'automatic',
+  'inline',
+  'stacked',
+  'integrated',
+  'integratedButton',
+  'integratedCentered',
+];
+
+const placeholderModes: PlaceholderMode[] = ['default', 'custom', 'empty'];
+const hintColorModes: HintColorMode[] = ['default', 'red', 'blue'];
+
+const defaultConfig: SearchBarConfig = {
+  placement: 'automatic',
+  placeholderMode: 'default',
+  hintColorMode: 'default',
+  allowToolbarIntegration: true,
+};
+
+function getNextValue<T>(values: readonly T[], currentValue: T): T {
+  const currentIndex = values.indexOf(currentValue);
+  return values[(currentIndex + 1) % values.length];
+}
+
+function getPlaceholder(mode: PlaceholderMode): SearchBarProps['placeholder'] {
+  switch (mode) {
+    case 'custom':
+      return 'Custom placeholder';
+    case 'empty':
+      return '';
+    default:
+      return undefined;
+  }
+}
+
+function getHintTextColor(
+  mode: HintColorMode,
+): SearchBarProps['hintTextColor'] {
+  switch (mode) {
+    case 'red':
+      return 'red';
+    case 'blue':
+      return 'blue';
+    default:
+      return undefined;
+  }
+}
+
+function Home({ navigation }: NativeStackScreenProps<StackParamList, 'Home'>) {
+  return (
+    <View style={styles.centeredContainer}>
+      <Text style={styles.title}>Test4089</Text>
+      <Button
+        title="Open search bar test"
+        onPress={() => navigation.navigate('SearchBar')}
+      />
+    </View>
+  );
+}
+
+function SearchBarScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'SearchBar'>) {
+  const [config, setConfig] = useState<SearchBarConfig>(defaultConfig);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerSearchBarOptions: {
+        placement: config.placement,
+        allowToolbarIntegration: config.allowToolbarIntegration,
+        hideWhenScrolling: false,
+        placeholder: getPlaceholder(config.placeholderMode),
+        hintTextColor: getHintTextColor(config.hintColorMode),
+      },
+    });
+  }, [config, navigation]);
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.contentContainer}>
+      <Text style={styles.title}>Search bar options</Text>
+      <Text>Placement: {config.placement}</Text>
+      <Text>Placeholder: {config.placeholderMode}</Text>
+      <Text>Hint text color: {config.hintColorMode}</Text>
+      <Text>
+        Allow toolbar integration:{' '}
+        {config.allowToolbarIntegration ? 'true' : 'false'}
+      </Text>
+
+      <Button
+        title="Cycle placement"
+        onPress={() =>
+          setConfig(currentConfig => ({
+            ...currentConfig,
+            placement: getNextValue(placements, currentConfig.placement),
+          }))
+        }
+      />
+      <Button
+        title="Cycle placeholder"
+        onPress={() =>
+          setConfig(currentConfig => ({
+            ...currentConfig,
+            placeholderMode: getNextValue(
+              placeholderModes,
+              currentConfig.placeholderMode,
+            ),
+          }))
+        }
+      />
+      <Button
+        title="Cycle hint color"
+        onPress={() =>
+          setConfig(currentConfig => ({
+            ...currentConfig,
+            hintColorMode: getNextValue(
+              hintColorModes,
+              currentConfig.hintColorMode,
+            ),
+          }))
+        }
+      />
+      <Button
+        title="Toggle toolbar integration"
+        onPress={() =>
+          setConfig(currentConfig => ({
+            ...currentConfig,
+            allowToolbarIntegration: !currentConfig.allowToolbarIntegration,
+          }))
+        }
+      />
+      <Button
+        title="Restore default values"
+        onPress={() => setConfig(defaultConfig)}
+      />
+    </ScrollView>
+  );
+}
+
+export default function App(): React.JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen
+          name="SearchBar"
+          component={SearchBarScreen}
+          options={{
+            headerLargeTitle: true,
+            title: 'Search bar',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  centeredContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  contentContainer: {
+    padding: 16,
+    gap: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -194,6 +194,7 @@ export { default as Test3885 } from './Test3885';
 export { default as Test3910 } from './Test3910';
 export { default as Test4027 } from './Test4027';
 export { default as Test4064 } from './Test4064';
+export { default as Test4089 } from './Test4089';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -533,7 +533,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `placement` - Placement of the search bar in the navigation bar. (iOS only)
 - `allowToolbarIntegration` - Indicates whether the system can place the search bar among other toolbar items on iPhone. (iOS only)
 - `textColor` - The search field text color.
-- `hintTextColor` - The search hint text color. (Android only)
+- `hintTextColor` - The search hint text color.
 - `headerIconColor` - The search and close icon color shown in the header. (Android only)
 - `shouldShowHintSearchIcon` - Show the search hint icon when search bar is focused. (Android only)
 - `ref` - A React ref to imperatively modify search bar.

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -614,6 +614,7 @@ RNS_IGNORE_SUPER_CALL_END
             }
           }
 #endif /* Check for iOS 26.0 */
+          [searchBar updatePlaceholder];
 #endif /* !TARGET_OS_TV */
         }
         break;

--- a/ios/RNSSearchBar.h
+++ b/ios/RNSSearchBar.h
@@ -26,6 +26,8 @@
 
 @property (nonatomic, retain) UISearchController *controller;
 
+- (void)updatePlaceholder;
+
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) && !TARGET_OS_TV
 - (UINavigationItemSearchBarPlacement)placementAsUINavigationItemSearchBarPlacement API_AVAILABLE(ios(16.0))
     API_UNAVAILABLE(tvos, watchos);

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -24,6 +24,8 @@ namespace react = facebook::react;
   __weak RCTBridge *_bridge;
   UISearchController *_controller;
   UIColor *_textColor;
+  UIColor *_hintTextColor;
+  NSString *_placeholder;
 
   // We use those booleans to log a warning if user attempts to restore
   // default behavior after setting explicit value for the prop.
@@ -204,7 +206,14 @@ namespace react = facebook::react;
 
 - (void)setPlaceholder:(NSString *)placeholder
 {
-  [_controller.searchBar setPlaceholder:placeholder];
+  _placeholder = placeholder;
+
+  if (_hintTextColor != nil && _placeholder != nil) {
+    _controller.searchBar.searchTextField.attributedPlaceholder =
+        [[NSAttributedString alloc] initWithString:_placeholder attributes:@{NSForegroundColorAttributeName : _hintTextColor}];
+  } else {
+    [_controller.searchBar setPlaceholder:_placeholder];
+  }
 }
 
 - (void)setBarTintColor:(UIColor *)barTintColor
@@ -224,6 +233,14 @@ namespace react = facebook::react;
 #if !TARGET_OS_TV
   _textColor = textColor;
   [_controller.searchBar.searchTextField setTextColor:_textColor];
+#endif
+}
+
+- (void)setHintTextColor:(UIColor *)hintTextColor
+{
+#if !TARGET_OS_TV
+  _hintTextColor = hintTextColor;
+  [self setPlaceholder:_placeholder];
 #endif
 }
 
@@ -429,6 +446,10 @@ namespace react = facebook::react;
     [self setTextColor:RCTUIColorFromSharedColor(newScreenProps.textColor)];
   }
 
+  if (oldScreenProps.hintTextColor != newScreenProps.hintTextColor) {
+    [self setHintTextColor:RCTUIColorFromSharedColor(newScreenProps.hintTextColor)];
+  }
+
   if (oldScreenProps.placement != newScreenProps.placement) {
     self.placement = [RNSConvert RNSScreenSearchBarPlacementFromCppEquivalent:newScreenProps.placement];
   }
@@ -512,6 +533,7 @@ RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(hintTextColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placement, RNSSearchBarPlacement)
 RCT_EXPORT_VIEW_PROPERTY(allowToolbarIntegration, BOOL)

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -235,10 +235,20 @@ namespace react = facebook::react;
 
 - (void)updatePlaceholder
 {
-  NSString *placeholder = _placeholder != nil ? _placeholder : _defaultPlaceholder;
+  NSString *placeholder = _placeholder;
 
 #if !TARGET_OS_TV
+  if (placeholder == nil) {
+    if (_didSetPlaceholder) {
+      placeholder = _defaultPlaceholder;
+    } else {
+      NSString *currentPlaceholder = _controller.searchBar.placeholder ?: _controller.searchBar.searchTextField.placeholder;
+      placeholder = currentPlaceholder ?: _defaultPlaceholder;
+    }
+  }
+
   if (_hintTextColor != nil && placeholder != nil) {
+    [_controller.searchBar setPlaceholder:placeholder];
     _controller.searchBar.searchTextField.attributedPlaceholder =
         [[NSAttributedString alloc] initWithString:placeholder attributes:@{NSForegroundColorAttributeName : _hintTextColor}];
   } else {
@@ -248,6 +258,10 @@ namespace react = facebook::react;
     }
   }
 #else
+  if (placeholder == nil) {
+    placeholder = _defaultPlaceholder;
+  }
+
   if (placeholder != nil || _didSetPlaceholder) {
     [_controller.searchBar setPlaceholder:placeholder];
   }

--- a/ios/RNSSearchBar.mm
+++ b/ios/RNSSearchBar.mm
@@ -20,12 +20,19 @@
 namespace react = facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED
 
+@interface RNSSearchBar ()
+- (void)setPlaceholder:(NSString *)placeholder;
+- (void)setHintTextColor:(UIColor *)hintTextColor;
+@end
+
 @implementation RNSSearchBar {
   __weak RCTBridge *_bridge;
   UISearchController *_controller;
   UIColor *_textColor;
   UIColor *_hintTextColor;
   NSString *_placeholder;
+  NSString *_defaultPlaceholder;
+  BOOL _didSetPlaceholder;
 
   // We use those booleans to log a warning if user attempts to restore
   // default behavior after setting explicit value for the prop.
@@ -67,6 +74,17 @@ namespace react = facebook::react;
 #endif
 
   _controller.searchBar.delegate = self;
+
+  _didSetPlaceholder = NO;
+
+#if !TARGET_OS_TV
+  _defaultPlaceholder = _controller.searchBar.placeholder;
+  if (_defaultPlaceholder == nil) {
+    _defaultPlaceholder = _controller.searchBar.searchTextField.placeholder;
+  }
+#else
+  _defaultPlaceholder = _controller.searchBar.placeholder;
+#endif
 
   _isObscureBackgroundSet = NO;
   _isHideNavigationBarSet = NO;
@@ -207,13 +225,33 @@ namespace react = facebook::react;
 - (void)setPlaceholder:(NSString *)placeholder
 {
   _placeholder = placeholder;
+  _didSetPlaceholder = YES;
+}
 
-  if (_hintTextColor != nil && _placeholder != nil) {
+- (void)setHintTextColor:(UIColor *)hintTextColor
+{
+  _hintTextColor = hintTextColor;
+}
+
+- (void)updatePlaceholder
+{
+  NSString *placeholder = _placeholder != nil ? _placeholder : _defaultPlaceholder;
+
+#if !TARGET_OS_TV
+  if (_hintTextColor != nil && placeholder != nil) {
     _controller.searchBar.searchTextField.attributedPlaceholder =
-        [[NSAttributedString alloc] initWithString:_placeholder attributes:@{NSForegroundColorAttributeName : _hintTextColor}];
+        [[NSAttributedString alloc] initWithString:placeholder attributes:@{NSForegroundColorAttributeName : _hintTextColor}];
   } else {
-    [_controller.searchBar setPlaceholder:_placeholder];
+    _controller.searchBar.searchTextField.attributedPlaceholder = nil;
+    if (placeholder != nil || _didSetPlaceholder) {
+      [_controller.searchBar setPlaceholder:placeholder];
+    }
   }
+#else
+  if (placeholder != nil || _didSetPlaceholder) {
+    [_controller.searchBar setPlaceholder:placeholder];
+  }
+#endif
 }
 
 - (void)setBarTintColor:(UIColor *)barTintColor
@@ -233,14 +271,6 @@ namespace react = facebook::react;
 #if !TARGET_OS_TV
   _textColor = textColor;
   [_controller.searchBar.searchTextField setTextColor:_textColor];
-#endif
-}
-
-- (void)setHintTextColor:(UIColor *)hintTextColor
-{
-#if !TARGET_OS_TV
-  _hintTextColor = hintTextColor;
-  [self setPlaceholder:_placeholder];
 #endif
 }
 
@@ -424,8 +454,11 @@ namespace react = facebook::react;
                                  RNSOptionalBooleanFromRNSSearchBarHideNavigationBar:newScreenProps.hideNavigationBar]];
   }
 
+  BOOL shouldUpdatePlaceholder = NO;
+
   if (oldScreenProps.placeholder != newScreenProps.placeholder) {
     [self setPlaceholder:RCTNSStringFromStringNilIfEmpty(newScreenProps.placeholder)];
+    shouldUpdatePlaceholder = YES;
   }
 
 #if !TARGET_OS_VISION
@@ -448,6 +481,11 @@ namespace react = facebook::react;
 
   if (oldScreenProps.hintTextColor != newScreenProps.hintTextColor) {
     [self setHintTextColor:RCTUIColorFromSharedColor(newScreenProps.hintTextColor)];
+    shouldUpdatePlaceholder = YES;
+  }
+
+  if (shouldUpdatePlaceholder) {
+    [self updatePlaceholder];
   }
 
   if (oldScreenProps.placement != newScreenProps.placement) {
@@ -529,11 +567,21 @@ RCT_CUSTOM_VIEW_PROPERTY(autoCapitalize, UITextAutocapitalizationType, RNSSearch
   }
 }
 
-RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
+RCT_CUSTOM_VIEW_PROPERTY(placeholder, NSString, RNSSearchBar)
+{
+  RNSSearchBar *searchBarView = static_cast<RNSSearchBar *>(view);
+  [searchBarView setPlaceholder:[RCTConvert NSString:json]];
+  [searchBarView updatePlaceholder];
+}
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
-RCT_EXPORT_VIEW_PROPERTY(hintTextColor, UIColor)
+RCT_CUSTOM_VIEW_PROPERTY(hintTextColor, UIColor, RNSSearchBar)
+{
+  RNSSearchBar *searchBarView = static_cast<RNSSearchBar *>(view);
+  [searchBarView setHintTextColor:[RCTConvert UIColor:json]];
+  [searchBarView updatePlaceholder];
+}
 RCT_EXPORT_VIEW_PROPERTY(cancelButtonText, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placement, RNSSearchBarPlacement)
 RCT_EXPORT_VIEW_PROPERTY(allowToolbarIntegration, BOOL)

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -60,6 +60,7 @@ export interface NativeProps extends ViewProps {
   barTintColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
   textColor?: ColorValue | undefined;
+  hintTextColor?: ColorValue | undefined;
 
   // Android only
   autoFocus?: CT.WithDefault<boolean, false>;
@@ -68,7 +69,6 @@ export interface NativeProps extends ViewProps {
   inputType?: string | undefined;
   onClose?: CT.DirectEventHandler<SearchBarEvent> | null | undefined;
   onOpen?: CT.DirectEventHandler<SearchBarEvent> | null | undefined;
-  hintTextColor?: ColorValue | undefined;
   headerIconColor?: ColorValue | undefined;
   shouldShowHintSearchIcon?: CT.WithDefault<boolean, true>;
 }

--- a/src/fabric/SearchBarNativeComponent.ts
+++ b/src/fabric/SearchBarNativeComponent.ts
@@ -56,11 +56,11 @@ export interface NativeProps extends ViewProps {
   obscureBackground?: CT.WithDefault<OptionalBoolean, 'undefined'>;
   hideNavigationBar?: CT.WithDefault<OptionalBoolean, 'undefined'>;
   cancelButtonText?: string | undefined;
+  hintTextColor?: ColorValue | undefined;
   // TODO: implement these on iOS
   barTintColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
   textColor?: ColorValue | undefined;
-  hintTextColor?: ColorValue | undefined;
 
   // Android only
   autoFocus?: CT.WithDefault<boolean, false>;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1064,8 +1064,6 @@ export interface SearchBarProps {
   textColor?: ColorValue | undefined;
   /**
    * The search hint text color
-   *
-   * @plaform android
    */
   hintTextColor?: ColorValue | undefined;
   /**


### PR DESCRIPTION
## Summary
- apply `hintTextColor` to the iOS search bar placeholder
- keep the placeholder string stable when the hint color changes
- update search bar types/docs so `hintTextColor` is no longer marked Android-only

## Test plan
- `git diff --check`

`clang-format` and full package checks were not run locally because this environment does not have the repo toolchain installed.