### PR TITLE
chore: add typescript configuration files to `scripts` directory

### DIFF
--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: '@react-native',
+};

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@apps/*": ["src/*"],
-      "@assets/*": ["assets/*"],
+      "@apps/*": ["../apps/src/*"],
+      "@assets/*": ["../apps/assets/*"],
       "react-native-screens": ["../src"],
       "react-native-screens/*": ["../src/*"]
     }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@apps/*": ["src/*"],
+      "@assets/*": ["assets/*"],
+      "react-native-screens": ["../src"],
+      "react-native-screens/*": ["../src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js"]
+}


### PR DESCRIPTION
## Description

Adding `tsconfig.json` and `.eslintrc.js` to `scripts` directory is necessary in order for the new script, introduced in https://github.com/software-mansion/react-native-screens/pull/4087, to work properly.

## Changes

- add `tsconfig.json` and `.eslintrc.js` to `scripts` directory

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
