### PR TITLE
feat(iOS, FormSheet v5): Add support for fitToContents

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -1,6 +1,7 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestFormSheetBase from './test-form-sheet-base-ios';
 import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
+import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents-ios';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index-ios';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
@@ -12,6 +13,7 @@ import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-
 const scenarios = {
   TestFormSheetBase,
   TestFormSheetExpandScrollView,
+  TestFormSheetFitToContents,
   TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet Test</Text>
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        detents="fitToContents">
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>FormSheet content</Text>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
@@ -7,6 +7,12 @@ import { Colors } from '@apps/shared/styling';
 
 export function App() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleDismiss = () => {
+    setIsOpen(false);
+    setTimeout(() => setIsExpanded(false), 300);
+  };
 
   return (
     <View style={styles.container}>
@@ -18,15 +24,39 @@ export function App() {
       />
       <FormSheet
         isOpen={isOpen}
-        onNativeDismiss={() => setIsOpen(false)}
+        onNativeDismiss={handleDismiss}
         detents="fitToContents">
         <View style={styles.sheetContent}>
           <Text style={styles.sheetTitle}>FormSheet content</Text>
+
+          <Text style={styles.description}>
+            This sheet dynamically wraps its content. Press the button below to
+            change the height.
+          </Text>
+
           <View style={styles.spacing} />
+
+          <Button
+            title={isExpanded ? 'Collapse Content' : 'Expand Content'}
+            color={Colors.primary}
+            onPress={() => setIsExpanded(!isExpanded)}
+          />
+
+          {isExpanded && (
+            <View style={styles.extraContentBox}>
+              <Text style={styles.extraText}>
+                Here is some extra content! The FormSheet should seamlessly
+                animate to accommodate this new height without any glitches.
+              </Text>
+            </View>
+          )}
+
+          <View style={styles.spacing} />
+
           <Button
             title="Dismiss from JS"
             color={Colors.primary}
-            onPress={() => setIsOpen(false)}
+            onPress={handleDismiss}
           />
         </View>
       </FormSheet>
@@ -48,7 +78,6 @@ const styles = StyleSheet.create({
     color: Colors.text,
   },
   sheetContent: {
-    flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
     justifyContent: 'center',
@@ -60,8 +89,26 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     color: Colors.text,
   },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: Colors.text,
+    paddingHorizontal: 16,
+  },
+  extraContentBox: {
+    marginTop: 20,
+    padding: 16,
+    backgroundColor: Colors.offBackground,
+    borderRadius: 8,
+    width: '100%',
+  },
+  extraText: {
+    fontSize: 15,
+    color: Colors.text,
+    textAlign: 'center',
+  },
   spacing: {
-    height: 32,
+    height: 24,
   },
 });
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/index.tsx
@@ -11,7 +11,6 @@ export function App() {
 
   const handleDismiss = () => {
     setIsOpen(false);
-    setTimeout(() => setIsExpanded(false), 300);
   };
 
   return (

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
@@ -3,7 +3,8 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 export const scenarioDescription: ScenarioDescription = {
   name: 'Fit to contents',
   key: 'test-form-sheet-fit-to-contents-ios',
-  details: 'Allows to test the fitToContents detent and dynamic height changes of the FormSheet component.',
+  details:
+    'Allows to test the fitToContents detent and dynamic height changes of the FormSheet component.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'FitToContents',
+  key: 'test-form-sheet-fit-to-contents-ios',
+  details: 'Allows to test fitToContents detents setup of FormSheet component.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario-description.ts
@@ -1,9 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'FitToContents',
+  name: 'Fit to contents',
   key: 'test-form-sheet-fit-to-contents-ios',
-  details: 'Allows to test fitToContents detents setup of FormSheet component.',
+  details: 'Allows to test the fitToContents detent and dynamic height changes of the FormSheet component.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
@@ -1,0 +1,45 @@
+# Test Scenario: Test case name
+
+Example: Test Scenario: colorScheme
+
+## Details
+
+**Description:** Provide a high-level overview of the feature or property being tested. Identify the specific functionality and transitions being validated, while defining the success criteria. Focus on the underlying goal, such as preventing specific UI regressions, visual glitches, or inconsistent behaviors.
+
+**OS test creation version:** Specify the OS version used during the initial implementation of the scenario and screen. This serves as a baseline where the described behavior and visual results were confirmed to work correctly.
+
+## E2E test
+
+Yes/No/Other
+
+- If **Yes:** Add a description of what is covered by automated E2E tests and what remains manual only.
+- If **No:** - If the scenario cannot be automated, include an explanation why.
+- If **Other:** Add relevant information e.g. research is required, or automation is possible and planned but not yet implemented.
+
+## Prerequisites
+
+List of devices or platforms required to run this test.
+
+Example: iOS physical device, Android emulator
+
+## Note (Optional)
+
+Include any critical information for scenario execution not covered elsewhere. Use this section to document Known Issues (KI) or specific behaviors that might appear misleading but are considered expected results. Define rules that apply to the entire scenario to avoid repetition in individual steps.
+
+## Steps
+
+Step-by-step instructions for a tester to manually verify the scenario.
+
+You can use subheadings to group steps logically (e.g., ### Baseline) or define separate step sections for different device types if their execution paths differ significantly.
+
+1. Navigate to ...
+
+- [ ] Expected:
+
+2. Tap ...
+
+- [ ] Expected:
+
+3. Verify that ...
+
+- [ ] Expected:

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
@@ -1,45 +1,60 @@
-# Test Scenario: Test case name
-
-Example: Test Scenario: colorScheme
+# Test Scenario: Fit to contents
 
 ## Details
 
-**Description:** Provide a high-level overview of the feature or property being tested. Identify the specific functionality and transitions being validated, while defining the success criteria. Focus on the underlying goal, such as preventing specific UI regressions, visual glitches, or inconsistent behaviors.
+**Description:** Verify the `fitToContents` for the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening, and dynamically animates to a new height when the internal content size changes.
 
-**OS test creation version:** Specify the OS version used during the initial implementation of the scenario and screen. This serves as a baseline where the described behavior and visual results were confirmed to work correctly.
+**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4
 
 ## E2E test
 
-Yes/No/Other
-
-- If **Yes:** Add a description of what is covered by automated E2E tests and what remains manual only.
-- If **No:** - If the scenario cannot be automated, include an explanation why.
-- If **Other:** Add relevant information e.g. research is required, or automation is possible and planned but not yet implemented.
+Other: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-List of devices or platforms required to run this test.
+- iOS device or simulator: iPhone and iPad
+- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
 
-Example: iOS physical device, Android emulator
+## Note
 
-## Note (Optional)
-
-Include any critical information for scenario execution not covered elsewhere. Use this section to document Known Issues (KI) or specific behaviors that might appear misleading but are considered expected results. Define rules that apply to the entire scenario to avoid repetition in individual steps.
+- On iPad: The FormSheet is presented as a **centered floating panel**. The `fitToContents` behavior still applies to the height of this panel seamlessly, while its width remains fixed. Therefore, explicit separate steps for iPad are omitted.
 
 ## Steps
 
-Step-by-step instructions for a tester to manually verify the scenario.
+### Baseline
 
-You can use subheadings to group steps logically (e.g., ### Baseline) or define separate step sections for different device types if their execution paths differ significantly.
+1. Launch the app and navigate to the **Fit to contents** screen.
 
-1. Navigate to ...
+- [ ] Expected: Content with the button "Open FormSheet" is shown.
 
-- [ ] Expected:
+---
 
-2. Tap ...
+### Initialization & `fitToContents` Verification
 
-- [ ] Expected:
+2. Tap the "Open FormSheet" button.
 
-3. Verify that ...
+- [ ] Expected: The FormSheet opens smoothly. Its height is matched to its internal content (it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
 
-- [ ] Expected:
+---
+
+### Dynamic Height Adaptation
+
+3. Tap the "Expand Content" button inside the FormSheet.
+
+- [ ] Expected: The extra text box appears. The native FormSheet smoothly animates and grows in height to fully accommodate the newly added content without any visual glitches.
+
+---
+
+### Dynamic Height Adaptation
+
+4. Tap the "Collapse Content" button.
+
+- [ ] Expected: The extra text box disappears. The native FormSheet smoothly animates and shrinks back to its original, smaller height.
+
+---
+
+### Dismissal Verification
+
+5. Tap the "Dismiss from JS" button (or swipe down completely).
+
+- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
@@ -8,7 +8,7 @@
 
 ## E2E test
 
-Other: Planned, but will be implemented separately.
+TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
@@ -33,7 +33,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens smoothly. Its height is matched to its internal content (it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
+- [ ] Expected: The FormSheet opens smoothly. Its height is matched to its internal content (on iPhone, it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
 
 ---
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
@@ -54,7 +54,7 @@
   // Behavior data
 
   NSArray<UISheetPresentationControllerDetent *> *nativeDetents =
-      [RNSFormSheetDetentResolver buildSheetDetentsForFractions:behaviorProvider.detents];
+      [RNSFormSheetDetentResolver buildSheetDetentsWithBehaviorProvider:behaviorProvider];
 
   UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
   if (!_initialDetentApplied) {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
@@ -1,13 +1,10 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
-#import "RNSFormSheetContentWrapperDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetContentView : UIView
-
-@property (nonatomic, weak, nullable) id<RNSFormSheetContentWrapperDelegate> contentWrapperDelegate;
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)index;
 - (void)removeReactSubview:(UIView *)subview;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentView.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+#import "RNSFormSheetContentWrapperDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetContentView : UIView
+
+@property (nonatomic, weak, nullable) id<RNSFormSheetContentWrapperDelegate> contentWrapperDelegate;
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)index;
 - (void)removeReactSubview:(UIView *)subview;

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#import "RNSFormSheetContentWrapperDelegate.h"
+#import "RNSReactBaseView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetContentWrapperComponentView : RNSReactBaseView
+
+@property (nonatomic, weak, nullable) id<RNSFormSheetContentWrapperDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
@@ -7,6 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetContentWrapperComponentView : RNSReactBaseView
 
+@property (nonatomic, weak, nullable) id<RNSFormSheetContentWrapperDelegate> delegate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.h
@@ -7,8 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetContentWrapperComponentView : RNSReactBaseView
 
-@property (nonatomic, weak, nullable) id<RNSFormSheetContentWrapperDelegate> delegate;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -1,49 +1,15 @@
 #import "RNSFormSheetContentWrapperComponentView.h"
 
-#import <React/RCTMountingTransactionObserving.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
 namespace react = facebook::react;
 
-@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol,
-                                                       RCTMountingTransactionObserving>
+@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol>
 @end
 
-@implementation RNSFormSheetContentWrapperComponentView {
-  BOOL _initialHeightReported;
-}
-
-- (instancetype)initWithFrame:(CGRect)frame
-{
-  if (self = [super initWithFrame:frame]) {
-    [self initState];
-  }
-  return self;
-}
-
-- (void)initState
-{
-  _initialHeightReported = NO;
-}
-
-#pragma mark - RCTMountingTransactionObserving
-
-- (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
-               withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
-{
-  // We only need to catch the initial mount because subsequent dynamic height changes
-  // are handled directly by `updateLayoutMetrics`.
-  if (_initialHeightReported) {
-    return;
-  }
-
-  if (_delegate && self.frame.size.height > 0) {
-    _initialHeightReported = YES;
-    [_delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];
-  }
-}
+@implementation RNSFormSheetContentWrapperComponentView
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -24,7 +24,7 @@ namespace react = facebook::react;
 
   if (newHeight != oldHeight) {
     if (_delegate) {
-      [_delegate contentWrapper:self didChangeContentHeight:newHeight];
+      [_delegate contentWrapper:self didChangeReactContentsHeight:newHeight];
     }
   }
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -5,8 +5,6 @@
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
-#import "RNSFormSheetContentView.h"
-
 namespace react = facebook::react;
 
 @interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol,
@@ -30,18 +28,6 @@ namespace react = facebook::react;
   _initialHeightReported = NO;
 }
 
-- (id<RNSFormSheetContentWrapperDelegate>)resolveFormSheetContentWrapperDelegate
-{
-  UIView *view = self.superview;
-  while (view != nil) {
-    if ([view isKindOfClass:[RNSFormSheetContentView class]]) {
-      return ((RNSFormSheetContentView *)view).contentWrapperDelegate;
-    }
-    view = view.superview;
-  }
-  return nil;
-}
-
 #pragma mark - RCTMountingTransactionObserving
 
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
@@ -53,10 +39,9 @@ namespace react = facebook::react;
     return;
   }
 
-  id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
-  if (delegate && self.frame.size.height > 0) {
+  if (_delegate && self.frame.size.height > 0) {
     _initialHeightReported = YES;
-    [delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];
+    [_delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];
   }
 }
 
@@ -76,11 +61,20 @@ namespace react = facebook::react;
   CGFloat oldHeight = oldLayoutMetrics.frame.size.height;
 
   if (newHeight != oldHeight) {
-    id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
-    if (delegate) {
-      [delegate contentWrapper:self didChangeContentHeight:newHeight];
+    if (_delegate) {
+      [_delegate contentWrapper:self didChangeContentHeight:newHeight];
     }
   }
+}
+
++ (BOOL)shouldBeRecycled
+{
+  return NO;
+}
+
+- (void)invalidate
+{
+  _delegate = nil;
 }
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -2,12 +2,8 @@
 
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
-#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
 namespace react = facebook::react;
-
-@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol>
-@end
 
 @implementation RNSFormSheetContentWrapperComponentView
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -13,7 +13,22 @@ namespace react = facebook::react;
                                                        RCTMountingTransactionObserving>
 @end
 
-@implementation RNSFormSheetContentWrapperComponentView
+@implementation RNSFormSheetContentWrapperComponentView {
+  BOOL _initialHeightReported;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    [self initState];
+  }
+  return self;
+}
+
+- (void)initState
+{
+  _initialHeightReported = NO;
+}
 
 - (id<RNSFormSheetContentWrapperDelegate>)resolveFormSheetContentWrapperDelegate
 {
@@ -32,6 +47,12 @@ namespace react = facebook::react;
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
+  // We only need to catch the initial mount because subsequent dynamic height changes
+  // are handled directly by `updateLayoutMetrics`.
+  if (_initialHeightReported) {
+    return;
+  }
+
   id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
   if (delegate && self.frame.size.height > 0) {
     [delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -1,17 +1,44 @@
 #import "RNSFormSheetContentWrapperComponentView.h"
 
+#import <React/RCTMountingTransactionObserving.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
+#import "RNSFormSheetContentView.h"
+
 namespace react = facebook::react;
 
-@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol>
+@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol,
+                                                       RCTMountingTransactionObserving>
 @end
 
-#pragma mark - RCTComponentViewProtocol
-
 @implementation RNSFormSheetContentWrapperComponentView
+
+- (id<RNSFormSheetContentWrapperDelegate>)resolveFormSheetContentWrapperDelegate
+{
+  UIView *view = self.superview;
+  while (view != nil) {
+    if ([view isKindOfClass:[RNSFormSheetContentView class]]) {
+      return ((RNSFormSheetContentView *)view).contentWrapperDelegate;
+    }
+    view = view.superview;
+  }
+  return nil;
+}
+
+#pragma mark - RCTMountingTransactionObserving
+
+- (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
+               withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
+{
+  id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
+  if (delegate && self.frame.size.height > 0) {
+    [delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];
+  }
+}
+
+#pragma mark - RCTComponentViewProtocol
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {
@@ -27,7 +54,10 @@ namespace react = facebook::react;
   CGFloat oldHeight = oldLayoutMetrics.frame.size.height;
 
   if (newHeight != oldHeight) {
-    [self.delegate contentWrapper:self didChangeContentHeight:newHeight];
+    id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
+    if (delegate) {
+      [delegate contentWrapper:self didChangeContentHeight:newHeight];
+    }
   }
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -55,6 +55,7 @@ namespace react = facebook::react;
 
   id<RNSFormSheetContentWrapperDelegate> delegate = [self resolveFormSheetContentWrapperDelegate];
   if (delegate && self.frame.size.height > 0) {
+    _initialHeightReported = YES;
     [delegate contentWrapper:self didChangeContentHeight:self.frame.size.height];
   }
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperComponentView.mm
@@ -1,0 +1,39 @@
+#import "RNSFormSheetContentWrapperComponentView.h"
+
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+
+namespace react = facebook::react;
+
+@interface RNSFormSheetContentWrapperComponentView () <RCTRNSFormSheetContentWrapperViewProtocol>
+@end
+
+#pragma mark - RCTComponentViewProtocol
+
+@implementation RNSFormSheetContentWrapperComponentView
+
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return react::concreteComponentDescriptorProvider<react::RNSFormSheetContentWrapperComponentDescriptor>();
+}
+
+- (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  CGFloat newHeight = layoutMetrics.frame.size.height;
+  CGFloat oldHeight = oldLayoutMetrics.frame.size.height;
+
+  if (newHeight != oldHeight) {
+    [self.delegate contentWrapper:self didChangeContentHeight:newHeight];
+  }
+}
+
+@end
+
+Class<RCTComponentViewProtocol> RNSFormSheetContentWrapperCls(void)
+{
+  return RNSFormSheetContentWrapperComponentView.class;
+}

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
@@ -1,0 +1,13 @@
+#pragma once
+
+@class RNSFormSheetContentWrapperComponentView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSFormSheetContentWrapperDelegate <NSObject>
+
+- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper didChangeContentHeight:(CGFloat)contentHeight;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
@@ -8,7 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSFormSheetContentWrapperDelegate <NSObject>
 
-- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper didChangeContentHeight:(CGFloat)contentHeight;
+- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper
+    didChangeReactContentsHeight:(CGFloat)reactContentsHeight;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentWrapperDelegate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#import <UIKit/UIKit.h>
+
 @class RNSFormSheetContentWrapperComponentView;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.h
@@ -6,8 +6,12 @@
 #import <vector>
 #endif
 
+@protocol RNSFormSheetBehaviorProvider;
+
 NS_ASSUME_NONNULL_BEGIN
 
+// Predefined value for `fitToContents` detent.
+static const double kRNSFormSheetFitToContents = -1.0;
 // Predefined values for `initialDetentIndex`.
 static NSInteger const kRNSFormSheetLastDetent = -1;
 // Predefined values for `largestUndimmedDetentIndex`.
@@ -18,7 +22,8 @@ static NSInteger const kRNSFormSheetNeverDimmed = -2;
 
 #if !TARGET_OS_TV && defined(__cplusplus)
 
-+ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents;
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsWithBehaviorProvider:
+    (id<RNSFormSheetBehaviorProvider>)provider;
 
 #endif // !TARGET_OS_TV && __cplusplus
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -101,8 +101,8 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
       double firstDetentFraction = detents[0];
       if (firstDetentFraction == kRNSFormSheetFitToContents) {
         RCTLogError(
-            @"[RNScreens] 'fitToContents' is unsupported on iOS versions below 16. Falling back to medium detent.");
-        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+            @"[RNScreens] 'fitToContents' is unsupported on iOS versions below 16. Falling back to large detent.");
+        [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];
       } else if (firstDetentFraction < 1.0) {
         [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
       } else {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -8,10 +8,11 @@
 
 static BOOL RNSAreDetentsValid(const std::vector<double> &detents)
 {
+  if (detents.size() == 1 && detents[0] == kRNSFormSheetFitToContents) {
+    return YES;
+  }
+
   for (double currentDetent : detents) {
-    if (currentDetent == kRNSFormSheetFitToContents) {
-      continue;
-    }
     if (isnan(currentDetent)) {
       return NO;
     }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -74,7 +74,8 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
                           customDetentWithIdentifier:ident
                                             resolver:^CGFloat(
                                                 id<UISheetPresentationControllerDetentResolutionContext> context) {
-                                              CGFloat currentHeight = weakProvider ? [weakProvider contentHeight] : 0.0;
+                                              CGFloat currentHeight =
+                                                  weakProvider ? [weakProvider reactContentsHeight] : 0.0;
 
                                               // Safe fallback for uncalculated layout or deallocated provider
                                               if (currentHeight <= 0.0) {

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -1,5 +1,6 @@
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSDefines.h"
+#import "RNSFormSheetProviders.h"
 
 #import <React/RCTLog.h>
 
@@ -8,6 +9,9 @@
 static BOOL RNSAreDetentsValid(const std::vector<double> &detents)
 {
   for (double currentDetent : detents) {
+    if (currentDetent == kRNSFormSheetFitToContents) {
+      continue;
+    }
     if (isnan(currentDetent)) {
       return NO;
     }
@@ -30,8 +34,10 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
 
 @implementation RNSFormSheetDetentResolver
 
-+ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsForFractions:(const std::vector<double> &)detents
++ (NSArray<UISheetPresentationControllerDetent *> *)buildSheetDetentsWithBehaviorProvider:
+    (id<RNSFormSheetBehaviorProvider>)provider
 {
+  const std::vector<double> &detents = provider.detents;
   size_t detentsCount = detents.size();
 
   // Defaults to large detent across all iOS versions
@@ -56,17 +62,30 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
   if (@available(iOS 16.0, *)) {
+    __weak id<RNSFormSheetBehaviorProvider> weakProvider = provider;
+
     for (size_t i = 0; i < detentsCount; i++) {
       double fraction = detents[i];
       NSString *ident = [NSString stringWithFormat:@"%zu", i];
-
-      [nativeDetents
-          addObject:[UISheetPresentationControllerDetent
-                        customDetentWithIdentifier:ident
-                                          resolver:^CGFloat(
-                                              id<UISheetPresentationControllerDetentResolutionContext> context) {
-                                            return context.maximumDetentValue * fraction;
-                                          }]];
+      if (fraction == kRNSFormSheetFitToContents) {
+        [nativeDetents
+            addObject:[UISheetPresentationControllerDetent
+                          customDetentWithIdentifier:ident
+                                            resolver:^CGFloat(
+                                                id<UISheetPresentationControllerDetentResolutionContext> context) {
+                                              CGFloat currentHeight =
+                                                  weakProvider ? [weakProvider contentHeight] : -1.0;
+                                              return currentHeight;
+                                            }]];
+      } else {
+        [nativeDetents
+            addObject:[UISheetPresentationControllerDetent
+                          customDetentWithIdentifier:ident
+                                            resolver:^CGFloat(
+                                                id<UISheetPresentationControllerDetentResolutionContext> context) {
+                                              return context.maximumDetentValue * fraction;
+                                            }]];
+      }
     }
   } else
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
@@ -74,7 +93,11 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
     // iOS 15 Legacy Fallback
     if (detentsCount == 1) {
       double firstDetentFraction = detents[0];
-      if (firstDetentFraction < 1.0) {
+      if (firstDetentFraction == kRNSFormSheetFitToContents) {
+        RCTLogError(
+            @"[RNScreens] 'fitToContents' is unsupported on iOS versions below 16. Falling back to medium detent.");
+        [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
+      } else if (firstDetentFraction < 1.0) {
         [nativeDetents addObject:UISheetPresentationControllerDetent.mediumDetent];
       } else {
         [nativeDetents addObject:UISheetPresentationControllerDetent.largeDetent];

--- a/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetDetentResolver.mm
@@ -73,9 +73,14 @@ static BOOL RNSAreDetentsStrictlyAscending(const std::vector<double> &detents)
                           customDetentWithIdentifier:ident
                                             resolver:^CGFloat(
                                                 id<UISheetPresentationControllerDetentResolutionContext> context) {
-                                              CGFloat currentHeight =
-                                                  weakProvider ? [weakProvider contentHeight] : -1.0;
-                                              return currentHeight;
+                                              CGFloat currentHeight = weakProvider ? [weakProvider contentHeight] : 0.0;
+
+                                              // Safe fallback for uncalculated layout or deallocated provider
+                                              if (currentHeight <= 0.0) {
+                                                currentHeight = context.maximumDetentValue;
+                                              }
+
+                                              return MIN(context.maximumDetentValue, currentHeight);
                                             }]];
       } else {
         [nativeDetents

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -86,8 +86,6 @@ namespace react = facebook::react;
   _controller.presentationProvider = self;
   _controller.appearanceProvider = self;
   _controller.behaviorProvider = self;
-
-  _controller.contentView.contentWrapperDelegate = self;
 }
 
 - (void)didMoveToWindow
@@ -187,10 +185,20 @@ namespace react = facebook::react;
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_controller.contentView insertReactSubview:childComponentView atIndex:index];
+
+  // Assuming that for `fitToContents` the RNSFormSheetContentWrapperComponentView will be a direct child of
+  // RNSFormSheetHostComponentView.
+  if ([childComponentView isKindOfClass:[RNSFormSheetContentWrapperComponentView class]]) {
+    ((RNSFormSheetContentWrapperComponentView *)childComponentView).delegate = self;
+  }
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
+  if ([childComponentView isKindOfClass:[RNSFormSheetContentWrapperComponentView class]]) {
+    ((RNSFormSheetContentWrapperComponentView *)childComponentView).delegate = nil;
+  }
+
   [_controller.contentView removeReactSubview:childComponentView];
 }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -1,6 +1,8 @@
 #import "RNSFormSheetHostComponentView.h"
 #import "RNSFormSheetContentController.h"
 #import "RNSFormSheetContentView.h"
+#import "RNSFormSheetContentWrapperComponentView.h"
+#import "RNSFormSheetContentWrapperDelegate.h"
 #import "RNSFormSheetDetentResolver.h"
 #import "RNSFormSheetHostEventEmitter.h"
 #import "RNSFormSheetHostShadowStateProxy.h"
@@ -16,6 +18,7 @@ namespace react = facebook::react;
 
 @interface RNSFormSheetHostComponentView () <RCTMountingTransactionObserving,
                                              RNSFormSheetContentControllerDelegate,
+                                             RNSFormSheetContentWrapperDelegate,
                                              RNSFormSheetPresentationProvider,
                                              RNSFormSheetAppearanceProvider,
                                              RNSFormSheetBehaviorProvider>
@@ -37,6 +40,8 @@ namespace react = facebook::react;
   NSInteger _initialDetentIndex;
   BOOL _prefersScrollingExpandsWhenScrolledToEdge;
   BOOL _preventNativeDismiss;
+
+  CGFloat _contentHeight;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -69,6 +74,8 @@ namespace react = facebook::react;
   _initialDetentIndex = 0;
   _prefersScrollingExpandsWhenScrolledToEdge = YES;
   _preventNativeDismiss = NO;
+
+  _contentHeight = 0.0;
 }
 
 - (void)setupController
@@ -79,6 +86,8 @@ namespace react = facebook::react;
   _controller.presentationProvider = self;
   _controller.appearanceProvider = self;
   _controller.behaviorProvider = self;
+
+  _controller.contentView.contentWrapperDelegate = self;
 }
 
 - (void)didMoveToWindow
@@ -103,6 +112,21 @@ namespace react = facebook::react;
 - (const std::vector<double> &)detents
 {
   return _detents;
+}
+
+- (CGFloat)contentHeight
+{
+  return _contentHeight;
+}
+
+#pragma mark - RNSFormSheetContentWrapperDelegate
+
+- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper didChangeContentHeight:(CGFloat)contentHeight
+{
+  if (_contentHeight != contentHeight) {
+    _contentHeight = contentHeight;
+    [_controller setNeedsBehaviorUpdate];
+  }
 }
 
 #pragma mark - RNSFormSheetContentControllerDelegate

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -41,7 +41,7 @@ namespace react = facebook::react;
   BOOL _prefersScrollingExpandsWhenScrolledToEdge;
   BOOL _preventNativeDismiss;
 
-  CGFloat _contentHeight;
+  CGFloat _reactContentsHeight;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -75,7 +75,7 @@ namespace react = facebook::react;
   _prefersScrollingExpandsWhenScrolledToEdge = YES;
   _preventNativeDismiss = NO;
 
-  _contentHeight = 0.0;
+  _reactContentsHeight = 0.0;
 }
 
 - (void)setupController
@@ -112,17 +112,18 @@ namespace react = facebook::react;
   return _detents;
 }
 
-- (CGFloat)contentHeight
+- (CGFloat)reactContentsHeight
 {
-  return _contentHeight;
+  return _reactContentsHeight;
 }
 
 #pragma mark - RNSFormSheetContentWrapperDelegate
 
-- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper didChangeContentHeight:(CGFloat)contentHeight
+- (void)contentWrapper:(RNSFormSheetContentWrapperComponentView *)wrapper
+    didChangeReactContentsHeight:(CGFloat)reactContentsHeight
 {
-  if (_contentHeight != contentHeight) {
-    _contentHeight = contentHeight;
+  if (_reactContentsHeight != reactContentsHeight) {
+    _reactContentsHeight = reactContentsHeight;
     [_controller setNeedsBehaviorUpdate];
   }
 }

--- a/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSInteger)initialDetentIndex;
 - (BOOL)prefersScrollingExpandsWhenScrolledToEdge;
 - (BOOL)preventNativeDismiss;
+- (CGFloat)contentHeight;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSInteger)initialDetentIndex;
 - (BOOL)prefersScrollingExpandsWhenScrolledToEdge;
 - (BOOL)preventNativeDismiss;
-- (CGFloat)contentHeight;
+- (CGFloat)reactContentsHeight;
 
 @end
 

--- a/ios/stubs/RNSGammaStubs.h
+++ b/ios/stubs/RNSGammaStubs.h
@@ -27,4 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSFormSheetHostComponentView : NSObject
 @end
 
+@interface RNSFormSheetContentWrapperComponentView : NSObject
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/stubs/RNSGammaStubs.mm
+++ b/ios/stubs/RNSGammaStubs.mm
@@ -17,3 +17,6 @@
 
 @implementation RNSFormSheetHostComponentView
 @end
+
+@implementation RNSFormSheetContentWrapperComponentView
+@end

--- a/package.json
+++ b/package.json
@@ -223,6 +223,9 @@
         },
         "RNSFormSheetHost": {
           "className": "RNSFormSheetHostComponentView"
+        },
+        "RNSFormSheetContentWrapper": {
+          "className": "RNSFormSheetContentWrapperComponentView"
         }
       }
     }

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -45,14 +45,14 @@ export function FormSheet(props: FormSheetProps) {
       largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}>
-      <FormSheetContentWrapperNativeComponent
-        style={
-          isFitToContents
-            ? styles.absoluteWithNoBottom
-            : StyleSheet.absoluteFill
-        }>
-        {children}
-      </FormSheetContentWrapperNativeComponent>
+      {isFitToContents ? (
+        <FormSheetContentWrapperNativeComponent
+          style={styles.absoluteWithNoBottom}>
+          {children}
+        </FormSheetContentWrapperNativeComponent>
+      ) : (
+        children
+      )}
     </FormSheetHostNativeComponent>
   );
 }

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -6,6 +6,7 @@ import {
   resolveInitialDetentIndex,
   resolveLargestUndimmedDetentIndex,
   resolveNativeCornerRadius,
+  resolveNativeDetents,
 } from './FormSheetUtils';
 
 export function FormSheet(props: FormSheetProps) {
@@ -18,8 +19,9 @@ export function FormSheet(props: FormSheetProps) {
   } = props;
 
   const nativeCornerRadius = resolveNativeCornerRadius(preferredCornerRadius);
+  const nativeDetents = resolveNativeDetents(detents);
 
-  const detentsCount = detents?.length ?? 0;
+  const detentsCount = nativeDetents?.length ?? 0;
 
   const resolvedInitialDetentIndex = resolveInitialDetentIndex(
     initialDetentIndex,
@@ -34,7 +36,7 @@ export function FormSheet(props: FormSheetProps) {
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
-      detents={detents}
+      detents={nativeDetents}
       initialDetentIndex={resolvedInitialDetentIndex}
       largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -35,6 +35,8 @@ export function FormSheet(props: FormSheetProps) {
     detentsCount,
   );
 
+  const isFitToContents = detents === 'fitToContents';
+
   return (
     <FormSheetHostNativeComponent
       style={styles.host}
@@ -43,7 +45,12 @@ export function FormSheet(props: FormSheetProps) {
       largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}
       {...rest}>
-      <FormSheetContentWrapperNativeComponent>
+      <FormSheetContentWrapperNativeComponent
+        style={
+          isFitToContents
+            ? styles.absoluteWithNoBottom
+            : StyleSheet.absoluteFill
+        }>
         {children}
       </FormSheetContentWrapperNativeComponent>
     </FormSheetHostNativeComponent>
@@ -61,5 +68,11 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
+  },
+  absoluteWithNoBottom: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
   },
 });

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import FormSheetHostNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent';
+import FormSheetContentWrapperNativeComponent from '../../../../fabric/gamma/modals/form-sheet/FormSheetContentWrapperNativeComponent';
 import type { FormSheetProps } from './FormSheet.types';
 import {
   resolveInitialDetentIndex,
@@ -11,6 +12,7 @@ import {
 
 export function FormSheet(props: FormSheetProps) {
   const {
+    children,
     detents,
     initialDetentIndex,
     largestUndimmedDetentIndex,
@@ -40,8 +42,11 @@ export function FormSheet(props: FormSheetProps) {
       initialDetentIndex={resolvedInitialDetentIndex}
       largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}
-      {...rest}
-    />
+      {...rest}>
+      <FormSheetContentWrapperNativeComponent>
+        {children}
+      </FormSheetContentWrapperNativeComponent>
+    </FormSheetHostNativeComponent>
   );
 }
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -24,13 +24,15 @@ export interface FormSheetProps {
    * This can be either an array of fractional screen heights (ranging from `0.0` to `1.0`)
    * or the `fitToContents` string literal.
    *
-   * - **Fractional heights:** The sheet will snap to these specific height proportions.
-   * - **`fitToContents`:** The sheet automatically calculates its height to wrap its content.
+   * - Fractional heights: The sheet will snap to these specific height proportions.
+   * - `fitToContents`: The sheet automatically calculates its height to wrap its content.
    *   It will dynamically animate to adapt to any internal layout changes.
-   *  *(Note: `fitToContents` is supported on iOS 16+. On iOS 15, it falls back to a medium detent).*
    *
    * On iOS, these map directly to `UISheetPresentationController` detents.
    * If an empty array is provided, it defaults to a single large detent.
+   *
+   * @remarks
+   * `fitToContents` is supported on iOS 16+. On iOS 15, it falls back to a medium detent
    *
    * @platform ios
    */

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -18,10 +18,16 @@ export interface FormSheetProps {
    */
   isOpen: boolean;
 
-  // TODO: @t0maboro - update description after implementing fitToContents
   /**
-   * @summary An array of fractional screen heights (ranging from `0.0` to `1.0`) that define
-   * the resting positions of the sheet.
+   * @summary Defines the resting positions of the sheet.
+   *
+   * This can be either an array of fractional screen heights (ranging from `0.0` to `1.0`)
+   * or the `'fitToContents'` string literal.
+   *
+   * - **Fractional heights:** The sheet will snap to these specific height proportions.
+   * - **`'fitToContents'`:** The sheet automatically calculates its height to wrap its content.
+   *   It will dynamically animate to adapt to any internal layout changes.
+   *  *(Note: `fitToContents` is supported on iOS 16+. On iOS 15, it falls back to a medium detent).*
    *
    * On iOS, these map directly to `UISheetPresentationController` detents.
    * If an empty array is provided, it defaults to a single large detent.

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -18,6 +18,7 @@ export interface FormSheetProps {
    */
   isOpen: boolean;
 
+  // TODO: @t0maboro - update description after implementing fitToContents
   /**
    * @summary An array of fractional screen heights (ranging from `0.0` to `1.0`) that define
    * the resting positions of the sheet.
@@ -27,7 +28,7 @@ export interface FormSheetProps {
    *
    * @platform ios
    */
-  detents?: number[] | undefined;
+  detents?: number[] | 'fitToContents' | undefined;
 
   /**
    * @summary Determines whether the sheet requests a grabber at the top.

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -22,10 +22,10 @@ export interface FormSheetProps {
    * @summary Defines the resting positions of the sheet.
    *
    * This can be either an array of fractional screen heights (ranging from `0.0` to `1.0`)
-   * or the `'fitToContents'` string literal.
+   * or the `fitToContents` string literal.
    *
    * - **Fractional heights:** The sheet will snap to these specific height proportions.
-   * - **`'fitToContents'`:** The sheet automatically calculates its height to wrap its content.
+   * - **`fitToContents`:** The sheet automatically calculates its height to wrap its content.
    *   It will dynamically animate to adapt to any internal layout changes.
    *  *(Note: `fitToContents` is supported on iOS 16+. On iOS 15, it falls back to a medium detent).*
    *

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -1,7 +1,7 @@
 import type { FormSheetProps } from './FormSheet.types';
 
 // Predefined value for `fitToContents`. Keep in sync with native counterpart.
-export const NATIVE_FIT_TO_CONTENTS = -1.0;
+const FORM_SHEET_NATIVE_FIT_TO_CONTENTS = -1.0;
 // Predefined values for `initialDetentIndex`. Keep in sync with native counterpart.
 const FORM_SHEET_LAST_DETENT = -1;
 // Predefined values for `largestUndimmedDetentIndex`. Keep in sync with native counterpart.
@@ -16,7 +16,7 @@ export function resolveNativeDetents(
   }
 
   if (detents === 'fitToContents') {
-    return [NATIVE_FIT_TO_CONTENTS];
+    return [FORM_SHEET_NATIVE_FIT_TO_CONTENTS];
   }
 
   return detents;

--- a/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheetUtils.ts
@@ -1,10 +1,26 @@
 import type { FormSheetProps } from './FormSheet.types';
 
+// Predefined value for `fitToContents`. Keep in sync with native counterpart.
+export const NATIVE_FIT_TO_CONTENTS = -1.0;
 // Predefined values for `initialDetentIndex`. Keep in sync with native counterpart.
 const FORM_SHEET_LAST_DETENT = -1;
 // Predefined values for `largestUndimmedDetentIndex`. Keep in sync with native counterpart.
 const FORM_SHEET_ALWAYS_DIMMED = -1;
 const FORM_SHEET_NEVER_DIMMED = -2;
+
+export function resolveNativeDetents(
+  detents?: number[] | 'fitToContents',
+): number[] | undefined {
+  if (!detents) {
+    return undefined;
+  }
+
+  if (detents === 'fitToContents') {
+    return [NATIVE_FIT_TO_CONTENTS];
+  }
+
+  return detents;
+}
 
 export function resolveInitialDetentIndex(
   initialDetentIndex: FormSheetProps['initialDetentIndex'],

--- a/src/fabric/gamma/modals/form-sheet/FormSheetContentWrapperNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetContentWrapperNativeComponent.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ViewProps } from 'react-native';
+import { codegenNativeComponent } from 'react-native';
+
+interface NativeProps extends ViewProps {}
+
+export default codegenNativeComponent<NativeProps>(
+  'RNSFormSheetContentWrapper',
+  {
+    excludedPlatforms: ['android'],
+  },
+);


### PR DESCRIPTION
## Description

This PR introduces support for the `fitToContents` detents setup in iOS FormSheet stanadlone component.

It automatically calculates its initial height based on its React children and animate whenever the size of the content changes dynamically.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1266

---
Implementation Details

1. I'm exposing in a public type 'fitToContents' literal, which under the hood is mapped to `[-1.0]` array, which is handled natively as a special case.

2. I introduced a transparent, from the end-user's perspective, native component responsible for listening to Yoga's layout calculations via `updateLayoutMetrics`.

3. ScreenContentWrapper on the JS side is rendered only for `fitToContents` mode.

4. Natively, the Host assigns `self` as a ContentWrapper's delegate.

## Before & after - visual documentation

| iOS 18 | iOS 26 | iPadOS |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/2fc5a066-2e9f-4f4a-a374-6bc184fb2eb3" /> | <video src="https://github.com/user-attachments/assets/33c76d34-6fe1-4ec6-86d7-86fbfe8d0548" /> | <video src="https://github.com/user-attachments/assets/e5492ffd-5e07-4a00-b91f-717ee48ec363" /> |

## Test plan

Added dedicated SFT, went through some random examples to ensure no regression.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
