### PR TITLE
feat(Android, Stack v5): ensure StackHeaderCoordinator teardown on Screen fragment destroyed

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -90,7 +90,7 @@ internal class StackHeaderCoordinator(
     }
 
     private fun removeHeader(coordinatorLayout: StackHeaderCoordinatorLayout) {
-        tearDownHeader(coordinatorLayout)
+        resetHeader(coordinatorLayout)
         removeContentBehavior(coordinatorLayout)
         coordinatorLayout.requestLayout()
     }
@@ -121,7 +121,7 @@ internal class StackHeaderCoordinator(
         coordinatorLayout: StackHeaderCoordinatorLayout,
         config: StackHeaderConfigProviding,
     ) {
-        tearDownHeader(coordinatorLayout)
+        resetHeader(coordinatorLayout)
 
         if (!config.hidden) {
             val appBar = StackHeaderAppBarLayout.create(wrappedContext, config.type)
@@ -151,11 +151,11 @@ internal class StackHeaderCoordinator(
     }
 
     internal fun tearDown(coordinatorLayout: StackHeaderCoordinatorLayout) {
-        tearDownHeader(coordinatorLayout)
+        removeHeader(coordinatorLayout)
         currentConfig = null
     }
 
-    private fun tearDownHeader(coordinatorLayout: StackHeaderCoordinatorLayout) {
+    private fun resetHeader(coordinatorLayout: StackHeaderCoordinatorLayout) {
         detachSubviews()
         appBarLayout?.let {
             detachAppBarListeners(it)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -90,7 +90,7 @@ internal class StackHeaderCoordinator(
     }
 
     private fun removeHeader(coordinatorLayout: StackHeaderCoordinatorLayout) {
-        teardown(coordinatorLayout)
+        tearDownHeader(coordinatorLayout)
         removeContentBehavior(coordinatorLayout)
         coordinatorLayout.requestLayout()
     }
@@ -121,7 +121,7 @@ internal class StackHeaderCoordinator(
         coordinatorLayout: StackHeaderCoordinatorLayout,
         config: StackHeaderConfigProviding,
     ) {
-        teardown(coordinatorLayout)
+        tearDownHeader(coordinatorLayout)
 
         if (!config.hidden) {
             val appBar = StackHeaderAppBarLayout.create(wrappedContext, config.type)
@@ -150,7 +150,12 @@ internal class StackHeaderCoordinator(
         cacheRebuildTriggers(config)
     }
 
-    private fun teardown(coordinatorLayout: StackHeaderCoordinatorLayout) {
+    internal fun tearDown(coordinatorLayout: StackHeaderCoordinatorLayout) {
+        tearDownHeader(coordinatorLayout)
+        currentConfig = null
+    }
+
+    private fun tearDownHeader(coordinatorLayout: StackHeaderCoordinatorLayout) {
         detachSubviews()
         appBarLayout?.let {
             detachAppBarListeners(it)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -45,6 +45,14 @@ internal class StackHeaderCoordinatorLayout(
 
     private var isHeaderUpdatePending = false
 
+    // Read currentConfig when the runnable executes, not when it's posted,
+    // to avoid applying a stale config that was swapped out in the meantime.
+    private val headerUpdateRunnable =
+        Runnable {
+            isHeaderUpdatePending = false
+            headerCoordinator.applyHeaderConfig(this, currentConfig)
+        }
+
     /**
      * This callback is used to listen for header config changes.
      * We use [isHeaderUpdatePending] to batch changes and pass them to [headerCoordinator].
@@ -53,12 +61,7 @@ internal class StackHeaderCoordinatorLayout(
         OnHeaderConfigChangeListener {
             if (!isHeaderUpdatePending) {
                 isHeaderUpdatePending = true
-                // Read currentConfig when the runnable executes, not when it's posted,
-                // to avoid applying a stale config that was swapped out in the meantime.
-                post {
-                    isHeaderUpdatePending = false
-                    headerCoordinator.applyHeaderConfig(this, currentConfig)
-                }
+                post(headerUpdateRunnable)
             }
         }
 
@@ -87,8 +90,8 @@ internal class StackHeaderCoordinatorLayout(
     }
 
     private fun handleHeaderConfigAttach(config: StackHeaderConfigProviding?) {
-        // Disconnect old config to prevent spurious updates from a detached config
-        currentConfig?.setOnConfigChangeListener(null)
+        // Disconnect old config to prevent spurious updates from a detached config.
+        currentConfig?.removeOnConfigChangeListener(onHeaderConfigChange)
         currentConfig = config
 
         config?.setOnConfigChangeListener(onHeaderConfigChange)
@@ -96,5 +99,22 @@ internal class StackHeaderCoordinatorLayout(
         // We run this even if config is null to properly remove the header if config
         // is removed in runtime.
         headerCoordinator.applyHeaderConfig(this, config)
+    }
+
+    internal fun tearDown() {
+        removeCallbacks(headerUpdateRunnable)
+        isHeaderUpdatePending = false
+
+        stackScreenWrapper.removeView(stackScreen)
+
+        currentConfig?.removeOnConfigChangeListener(onHeaderConfigChange)
+        currentConfig = null
+
+        stackScreen.onHeaderConfigAttachListener
+            ?.get()
+            ?.takeIf { it === onHeaderConfigAttach }
+            ?.let { stackScreen.onHeaderConfigAttachListener = null }
+
+        headerCoordinator.tearDown(this)
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -111,8 +111,14 @@ class StackHeaderConfig(
 
     private var onConfigChangeListener: WeakReference<OnHeaderConfigChangeListener>? = null
 
-    override fun setOnConfigChangeListener(listener: OnHeaderConfigChangeListener?) {
-        onConfigChangeListener = listener?.let { WeakReference(it) }
+    override fun setOnConfigChangeListener(listener: OnHeaderConfigChangeListener) {
+        onConfigChangeListener = WeakReference(listener)
+    }
+
+    override fun removeOnConfigChangeListener(listener: OnHeaderConfigChangeListener) {
+        if (onConfigChangeListener?.get() === listener) {
+            onConfigChangeListener = null
+        }
     }
 
     internal fun notifyConfigChanged() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
@@ -29,5 +29,7 @@ interface StackHeaderConfigProviding {
         contentOffsetY: Int,
     )
 
-    fun setOnConfigChangeListener(listener: OnHeaderConfigChangeListener?)
+    fun setOnConfigChangeListener(listener: OnHeaderConfigChangeListener)
+
+    fun removeOnConfigChangeListener(listener: OnHeaderConfigChangeListener)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreenFragment.kt
@@ -56,6 +56,11 @@ internal class StackScreenFragment(
     }
 
     override fun onDestroyView() {
+        val coordinatorLayout = view
+        check(coordinatorLayout is StackHeaderCoordinatorLayout) {
+            "[RNScreens] Unexpected fragment view type: $view"
+        }
+        coordinatorLayout.tearDown()
         super.onDestroyView()
         screenLifecycleEventEmitter = null
     }


### PR DESCRIPTION
## Description

Ensures proper teardown of `StackHeaderCoordinatorLayout` when `StackScreenFragment` is destroyed.

Prior to this PR, `StackScreen` remained a child of `StackHeaderCoordinatorLayout` through `stackScreenWrapper` which caused a crash when the screen was retained after pop and same `StackScreen` instance was used for new fragment (adding a view which already has a parent causes a crash on Android).

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1487.

## Changes

- add `StackHeaderCoordinatorLayout.tearDown()` that clears callbacks, observers, tears down header coordinator and removes `StackScreen` from `stackScreenWrapper`
- rename `StackHeaderCoordinator.teardown()` method to `StackHeaderCoordinator.resetHeader()`
- add `StackHeaderCoordinator.tearDown()` that uses `removeHeader` -> `resetHeader` and resets current config
- call `coordinatorLayout.tearDown()` in `StackScreenFragment.onDestroyView()`
- adapt `StackHeaderConfigProviding` to allow clearing explicit listener
- move header update lambda to property to allow cancelling

## Before & after - visual documentation

N/A

## Test plan

The functionality to retain screens is not implemented yet in our JS `StackContainer`. This functionality will be added in follow-up PRs. For now, check for regressions with `Stack v5` related tests.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
