### PR TITLE
feat(Android, Stack v5): expose showAsAction prop for toolbar menu items

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -16,6 +16,7 @@ import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemDefaults
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
 open class StackHeaderConfigViewManager :
@@ -210,6 +211,11 @@ open class StackHeaderConfigViewManager :
                         id = item.requireNotNullString("id"),
                         title = item.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
                         hidden = item.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+                        showAsAction =
+                            item.readShowAsActionEnum(
+                                "showAsAction",
+                                StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
+                            ),
                     )
                 }
             } ?: emptyList()
@@ -226,9 +232,19 @@ open class StackHeaderConfigViewManager :
             StackHeaderToolbarMenuItemOptions(
                 title = map.readNullableStringUpdate("title", StackHeaderToolbarMenuItemDefaults.TITLE),
                 hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+                showAsAction =
+                    map.readNullableShowAsActionEnumUpdate(
+                        "showAsAction",
+                        StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
+                    ),
             ),
         )
     }
+
+    override fun setDO_NOT_USE(
+        view: StackHeaderConfig,
+        value: ReadableMap?,
+    ) = Unit
 
     companion object {
         const val REACT_CLASS = "RNSStackHeaderConfigAndroid"
@@ -251,6 +267,14 @@ private fun ReadableMap.readBoolean(
     default: Boolean,
 ): Boolean = if (!this.hasKey(key) || this.isNull(key)) default else this.getBoolean(key)
 
+private fun ReadableMap.readShowAsActionEnum(
+    key: String,
+    default: StackHeaderToolbarMenuItemShowAsAction,
+): StackHeaderToolbarMenuItemShowAsAction {
+    val stringValue = this.getString(key) ?: return default
+    return toMenuItemShowAsActionEnum(stringValue)
+}
+
 // Helpers for view commands:
 // - not defined -> null (means "no update")
 // - null -> default (means "reset to default value")
@@ -272,4 +296,27 @@ private fun ReadableMap.readNullableBooleanUpdate(
         !this.hasKey(key) -> null
         this.isNull(key) -> default
         else -> this.getBoolean(key)
+    }
+
+private fun ReadableMap.readNullableShowAsActionEnumUpdate(
+    key: String,
+    default: StackHeaderToolbarMenuItemShowAsAction,
+): StackHeaderToolbarMenuItemShowAsAction? =
+    when {
+        !this.hasKey(key) -> null
+        this.isNull(key) -> default
+        else ->
+            this.getString(key)?.let {
+                toMenuItemShowAsActionEnum(it)
+            } ?: default
+    }
+
+private fun toMenuItemShowAsActionEnum(value: String): StackHeaderToolbarMenuItemShowAsAction =
+    when (value) {
+        "always" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS
+        "alwaysWithText" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS_WITH_TEXT
+        "ifRoom" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM
+        "ifRoomWithText" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM_WITH_TEXT
+        "never" -> StackHeaderToolbarMenuItemShowAsAction.NEVER
+        else -> throw JSApplicationIllegalArgumentException("[RNScreens] Invalid value for StackHeaderToolbarMenuItemShowAsAction: $value.")
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -40,13 +40,13 @@ internal class StackHeaderToolbarMenuCoordinator(
         lastMenuItems = items
     }
 
-    fun clear() {
+    internal fun clear() {
         forwardIdMap.clear()
         reverseIdMap.clear()
         lastMenuItems = emptyList()
     }
 
-    fun updateItem(
+    internal fun updateItem(
         menu: Menu,
         id: String,
         options: StackHeaderToolbarMenuItemOptions,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -30,9 +30,6 @@ internal class StackHeaderToolbarMenuCoordinator(
             val menuItem = toolbar.menu.add(Menu.NONE, nativeId, index, null)
 
             applyOptions(menuItem, item.toOptions())
-
-            // This property will be exposed to the user in the future.
-            menuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
         }
 
         toolbar.setOnMenuItemClickListener { menuItem ->
@@ -69,12 +66,14 @@ internal class StackHeaderToolbarMenuCoordinator(
     ) {
         options.title?.let { menuItem.title = it }
         options.hidden?.let { menuItem.isVisible = !it }
+        options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
     }
 
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =
         StackHeaderToolbarMenuItemOptions(
             title = title,
             hidden = hidden,
+            showAsAction = showAsAction,
         )
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -4,4 +4,5 @@ data class StackHeaderToolbarMenuItemConfig(
     val id: String,
     val title: String,
     val hidden: Boolean,
+    val showAsAction: StackHeaderToolbarMenuItemShowAsAction,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -10,4 +10,5 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 internal object StackHeaderToolbarMenuItemDefaults {
     const val TITLE: String = ""
     const val HIDDEN: Boolean = false
+    val SHOW_AS_ACTION: StackHeaderToolbarMenuItemShowAsAction = StackHeaderToolbarMenuItemShowAsAction.NEVER
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -9,4 +9,6 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
+    val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
+    val showAsActionWithText: Boolean? = null,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -10,5 +10,4 @@ data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
-    val showAsActionWithText: Boolean? = null,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemShowAsAction.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemShowAsAction.kt
@@ -1,0 +1,24 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+import android.view.MenuItem.SHOW_AS_ACTION_ALWAYS
+import android.view.MenuItem.SHOW_AS_ACTION_IF_ROOM
+import android.view.MenuItem.SHOW_AS_ACTION_NEVER
+import android.view.MenuItem.SHOW_AS_ACTION_WITH_TEXT
+
+enum class StackHeaderToolbarMenuItemShowAsAction {
+    ALWAYS,
+    ALWAYS_WITH_TEXT,
+    IF_ROOM,
+    IF_ROOM_WITH_TEXT,
+    NEVER,
+    ;
+
+    internal fun toNativeShowAsAction(): Int =
+        when (this) {
+            ALWAYS -> SHOW_AS_ACTION_ALWAYS
+            ALWAYS_WITH_TEXT -> SHOW_AS_ACTION_ALWAYS or SHOW_AS_ACTION_WITH_TEXT
+            IF_ROOM -> SHOW_AS_ACTION_IF_ROOM
+            IF_ROOM_WITH_TEXT -> SHOW_AS_ACTION_IF_ROOM or SHOW_AS_ACTION_WITH_TEXT
+            NEVER -> SHOW_AS_ACTION_NEVER
+        }
+}

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -6,6 +6,7 @@ import TestStackSimpleNav from './test-stack-simple-nav';
 import TestStackSubviews from './test-stack-subviews-android';
 import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
+import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
 
 const scenarios = {
   PreventNativeDismissSingleStack,
@@ -15,6 +16,7 @@ const scenarios = {
   TestStackSubviews,
   TestStackBackButton,
   TestStackToolbarMenuCommands,
+  TestStackToolbarMenuShowAsAction,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { Button, ScrollView, StyleSheet, Text } from 'react-native';
-import {
-  createScenario,
-  ScenarioDescription,
-} from '@apps/tests/shared/helpers';
+import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,
   useStackNavigationContext,
@@ -14,13 +11,7 @@ import {
   type StackHeaderConfigRef,
   type StackHeaderToolbarMenuItemOptionsAndroid,
 } from 'react-native-screens/experimental';
-
-const scenarioDescription: ScenarioDescription = {
-  name: 'Stack Toolbar Menu Commands',
-  key: 'test-stack-toolbar-menu-commands-android',
-  details: 'Tests toolbar menu items prop config and imperative commands.',
-  platforms: ['android'],
-};
+import { scenarioDescription } from './scenario-descriptions';
 
 type IdOption = 'item-1' | 'item-2' | 'item-3';
 type TitleOption =

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-descriptions.ts
@@ -1,0 +1,13 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Commands',
+  key: 'test-stack-toolbar-menu-commands-android',
+  details:
+    'Tests toolbar menu items prop config and imperative commands. ' +
+    'It focuses on the flow of updates rather than testing specific props ' +
+    'but it covers the hidden prop.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -14,7 +14,7 @@ value last seen from props), and any props update rebuilds the entire
 menu — discarding all prior command-applied state across all items, not
 just the slot whose prop changed.
 
-**OS test creation version:** API 36
+**OS test creation version:** Android: API Level 36
 
 ## E2E test
 
@@ -22,7 +22,7 @@ Other — automation is not implemented yet.
 
 ## Prerequisites
 
-- Android emulator
+- Android emulator or device
 
 ## Note (Optional)
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuItemOptionsAndroid,
+  type StackHeaderToolbarMenuItemShowAsActionAndroid,
+} from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-descriptions';
+
+type IdOption = 'item-1' | 'item-2' | 'item-3';
+type ShowAsActionOption =
+  | 'undefined'
+  | 'never'
+  | 'always'
+  | 'alwaysWithText'
+  | 'ifRoom'
+  | 'ifRoomWithText';
+type CmdShowAsActionOption = 'no change' | ShowAsActionOption;
+
+const ID_OPTIONS: IdOption[] = ['item-1', 'item-2', 'item-3'];
+const SHOW_AS_ACTION_OPTIONS: ShowAsActionOption[] = [
+  'undefined',
+  'never',
+  'always',
+  'alwaysWithText',
+  'ifRoom',
+  'ifRoomWithText',
+];
+const CMD_SHOW_AS_ACTION_OPTIONS: CmdShowAsActionOption[] = [
+  'no change',
+  ...SHOW_AS_ACTION_OPTIONS,
+];
+
+interface SlotConfig {
+  include: boolean;
+  id: IdOption;
+  showAsAction: ShowAsActionOption;
+}
+
+type Slots = [SlotConfig, SlotConfig, SlotConfig];
+
+const DEFAULT_SLOTS: Slots = [
+  { include: true, id: 'item-1', showAsAction: 'undefined' },
+  { include: true, id: 'item-2', showAsAction: 'undefined' },
+  { include: true, id: 'item-3', showAsAction: 'undefined' },
+];
+
+function resolveShowAsAction(
+  v: ShowAsActionOption,
+): StackHeaderToolbarMenuItemShowAsActionAndroid | undefined {
+  return v === 'undefined' ? undefined : v;
+}
+
+const ITEM_TITLES: Record<IdOption, string> = {
+  'item-1': 'I1',
+  'item-2': 'Item 2',
+  'item-3': 'Item Number Three',
+};
+
+function buildItems(slots: Slots) {
+  return slots
+    .filter(s => s.include)
+    .map(({ id, showAsAction }) => ({
+      id,
+      title: ITEM_TITLES[id],
+      showAsAction: resolveShowAsAction(showAsAction),
+    }));
+}
+
+function updateSlotAt(
+  slots: Slots,
+  index: number,
+  patch: Partial<SlotConfig>,
+): Slots {
+  return slots.map((s, i) => (i === index ? { ...s, ...patch } : s)) as Slots;
+}
+
+const HEADER_TITLE = 'Show As Action Test';
+
+export function App() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Main',
+          Component: MainScreen,
+          options: {
+            headerConfig: {
+              title: HEADER_TITLE,
+              android: { toolbarMenuItems: buildItems(DEFAULT_SLOTS) },
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function MainScreen() {
+  const [slots, setSlots] = useState<Slots>(DEFAULT_SLOTS);
+  const [lastClicked, setLastClicked] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<IdOption>('item-1');
+  const [cmdShowAsAction, setCmdShowAsAction] =
+    useState<CmdShowAsActionOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenuItems: buildItems(DEFAULT_SLOTS),
+          onToolbarMenuItemClicked: event =>
+            setLastClicked(event.nativeEvent.id),
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey]);
+
+  const applySlots = useCallback(
+    (next: Slots) => {
+      setSlots(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenuItems: buildItems(next),
+            onToolbarMenuItemClicked: event =>
+              setLastClicked(event.nativeEvent.id),
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdShowAsAction !== 'no change' && {
+        showAsAction: resolveShowAsAction(cmdShowAsAction),
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [cmdTargetId, cmdShowAsAction]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<IdOption>
+        label="target id"
+        value={cmdTargetId}
+        items={ID_OPTIONS}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdShowAsActionOption>
+        label="showAsAction"
+        value={cmdShowAsAction}
+        items={CMD_SHOW_AS_ACTION_OPTIONS}
+        onValueChange={setCmdShowAsAction}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Result</Text>
+      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+
+      <Text style={styles.heading}>Menu Items — Props</Text>
+      <SlotControls
+        slots={slots}
+        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+      />
+    </ScrollView>
+  );
+}
+
+interface SlotControlsProps {
+  slots: Slots;
+  updateSlot: (index: number, patch: Partial<SlotConfig>) => void;
+}
+
+function SlotControls({ slots, updateSlot }: SlotControlsProps) {
+  return (
+    <>
+      {slots.map((slot, i) => (
+        <React.Fragment key={i}>
+          <Text style={styles.slotLabel}>
+            Slot {i + 1} (item-{i + 1})
+          </Text>
+          <SettingsSwitch
+            label="include"
+            value={slot.include}
+            onValueChange={v => updateSlot(i, { include: v })}
+          />
+          <SettingsPicker<ShowAsActionOption>
+            label="showAsAction"
+            value={slot.showAsAction}
+            items={SHOW_AS_ACTION_OPTIONS}
+            onValueChange={v => updateSlot(i, { showAsAction: v })}
+          />
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  slotLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario-descriptions.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Show As Action',
+  key: 'test-stack-toolbar-menu-show-as-action-android',
+  details: 'Tests the showAsAction prop on toolbar menu items.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
@@ -1,0 +1,151 @@
+# Test Scenario: Stack Toolbar Menu Show As Action
+
+## Details
+
+**Description:** This test covers the `showAsAction` prop on Android toolbar
+menu items. It verifies that items placed in the action bar vs overflow menu
+behave correctly for all five values: `never`, `always`, `alwaysWithText`,
+`ifRoom`, `ifRoomWithText`. It also verifies that the default (omitted prop)
+is equivalent to `never`, and that runtime updates via
+`setToolbarMenuItemOptions` — including resetting to the default with
+`undefined` — take effect immediately.
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+Other — automation is not implemented yet.
+
+## Prerequisites
+
+- Android emulator or device
+
+## Note
+
+The WITH_TEXT modifier forces text labels alongside icons. Without icons (not
+yet exposed), these values are indistinguishable from `always` / `ifRoom` — the
+item still appears in the toolbar, showing its title as a text action.
+
+The number of `ifRoom` / `ifRoomWithText` items that fit in the toolbar is
+determined on first layout and is not updated on subsequent orientation changes.
+If the app starts in landscape the toolbar is wider, so more items may be
+promoted but rotating to portrait will not hide the items (the title bar may
+shrink instead); if it starts in portrait, rotating to landscape will not
+promote additional items.
+
+## Steps
+
+### Baseline — default is equivalent to `never`
+
+1. Launch the app and navigate to **Stack Toolbar Menu Show As Action**.
+
+- [ ] Expected: Header title reads "Show As Action Test". The toolbar
+      shows only the overflow (⋮) icon — no items appear as direct
+      action buttons. Open the overflow menu: three items are listed
+      ("I1", "Item 2", "Item Number Three").
+
+2. Open the overflow menu and tap "I1".
+
+- [ ] Expected: Menu closes. "Last clicked" updates to `item-1`.
+
+3. Open the overflow menu and tap "Item Number Three".
+
+- [ ] Expected: "Last clicked" updates to `item-3`.
+
+---
+
+### Props — explicit `never`
+
+4. In **Menu Items — Props**, change Slot 1 `showAsAction` from
+   `undefined` to `never`.
+
+- [ ] Expected: Item 1 remains in the overflow menu — identical to the
+      default behaviour.
+
+---
+
+### Props — `always`
+
+5. Change Slot 1 `showAsAction` to `always`.
+
+- [ ] Expected: "I1" appears directly in the toolbar as a text
+      action button. The overflow menu now contains only "Item 2" and
+      "Item Number Three".
+
+6. Tap the "I1" action button in the toolbar.
+
+- [ ] Expected: "Last clicked" updates to `item-1`.
+
+---
+
+### Props — `alwaysWithText`
+
+> TODO: The difference between `always` and `alwaysWithText` (forcing a
+> text label alongside an icon) cannot be verified until icon support is
+> added. This step only confirms the item appears in the toolbar.
+
+7. Change Slot 1 `showAsAction` to `alwaysWithText`.
+
+- [ ] Expected: "I1" still appears directly in the toolbar. Visually
+      indistinguishable from `always` without an icon.
+
+---
+
+### Props — `ifRoom`
+
+8. Change all three slots to `ifRoom` (Slot 1, Slot 2, Slot 3).
+
+- [ ] Expected: Items that fit within the available toolbar space appear
+      as action buttons; the rest fall back to the overflow menu. Exact
+      count depends on screen width.
+
+---
+
+### Props — `ifRoomWithText`
+
+> TODO: Same icon limitation as `alwaysWithText`. This step only
+> confirms `ifRoomWithText` behaves like `ifRoom` without icons.
+
+9. Change all three slots to `ifRoomWithText`.
+
+- [ ] Expected: Behaviour matches `ifRoom` — items appear in the toolbar
+      when there is room, otherwise in overflow.
+
+---
+
+### Runtime command — `never` → `always`
+
+10. Reset all slots to `showAsAction = undefined` (all items in
+    overflow). Verify the overflow menu shows "I1", "Item 2",
+    "Item Number Three" and no action buttons are visible.
+
+11. In **Send Command**, set target id = `item-1`,
+    showAsAction = `always`. Tap **Send Command**.
+
+- [ ] Expected: "I1" immediately moves from the overflow menu to the
+      toolbar as an action button without any prop change.
+
+---
+
+### Runtime command — `always` → `never`
+
+12. Set target id = `item-1`, showAsAction = `never`. Tap
+    **Send Command**.
+
+- [ ] Expected: "I1" moves back to the overflow menu.
+
+---
+
+### Runtime command — reset to default via `undefined`
+
+13. Set target id = `item-2`, showAsAction = `always`. Tap
+    **Send Command**.
+
+- [ ] Expected: "Item 2" appears as a toolbar action button.
+
+14. Set target id = `item-2`, showAsAction = `undefined`. Tap
+    **Send Command**.
+
+- [ ] Expected: "Item 2" returns to the overflow menu. The
+      `showAsAction` override is cleared and falls back to the regular
+      default (`never`).

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
@@ -14,12 +14,18 @@ function TintOverrideTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Tint Override</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{" "}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
-        This tab&apos;s `tabBarItemTitleFontColor`:{" "}
-        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>{'\n'}
+        Host `tabBarTintColor`:{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
         {'\n'}
-        When selected: title text should appear <Text style={{ color: Colors.RedLight100 }}>RED</Text>{'\n'} and icon should appear <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}
+        This tab&apos;s `tabBarItemTitleFontColor`:{' '}
+        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>
+        {'\n'}
+        {'\n'}
+        When selected: title text should appear{' '}
+        <Text style={{ color: Colors.RedLight100 }}>RED</Text>
+        {'\n'} and icon should appear{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
+        {'\n'}
         {'\n'}
         Confirms `tabBarItemTitleFontColor` overrides `tabBarTintColor` for the
         label but not the icon, which should still be tinted by the host config.
@@ -33,8 +39,9 @@ function FontTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Font and Position</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{" "}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
+        Host `tabBarTintColor`:{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
+        {'\n'}
         `tabBarItemTitleFontFamily`: &quot;Georgia&quot;{'\n'}
         `tabBarItemTitleFontSize`: &quot;12&quot;{'\n'}
         `tabBarItemTitleFontStyle`: &quot;italic&quot;{'\n'}
@@ -44,7 +51,11 @@ function FontTab() {
         {'\n'}
         {'\n'}
         When selected: title text should be visibly shifted upward relative to a
-        default-positioned label in <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title color for unselected tabs is <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
+        default-positioned label in{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
+        {'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title
+        color for unselected tabs is{' '}
+        <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
       </Text>
     </View>
   );
@@ -58,8 +69,8 @@ function LongTitleTab() {
         Tab title: &quot;A Very Long Tab Title That Should Truncate&quot;{'\n'}
         {'\n'}
         Demonstrates that `options.title` with an overly wide string is
-        truncated by the system tab bar with an ellipsis rather than wrapping
-        or overflowing.
+        truncated by the system tab bar with an ellipsis rather than wrapping or
+        overflowing.
       </Text>
     </View>
   );
@@ -110,7 +121,10 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
               tabBarItemTitleFontSize: 12,
               tabBarItemTitleFontStyle: 'italic',
               tabBarItemTitleFontWeight: '700',
-              tabBarItemTitlePositionAdjustment: { vertical: -6, horizontal: 0 },
+              tabBarItemTitlePositionAdjustment: {
+                vertical: -6,
+                horizontal: 0,
+              },
             },
             normal: {
               tabBarItemTitleFontColor: Colors.BlueDark100,
@@ -123,7 +137,12 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
 ];
 
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} ios={{ tabBarTintColor: Colors.GreenDark100 }} />;
+  return (
+    <TabsContainerWithHostConfigContext
+      routeConfigs={ROUTE_CONFIGS}
+      ios={{ tabBarTintColor: Colors.GreenDark100 }}
+    />
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
@@ -14,18 +14,12 @@ function TintOverrideTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Tint Override</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
+        Host `tabBarTintColor`:{" "}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
+        This tab&apos;s `tabBarItemTitleFontColor`:{" "}
+        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>{'\n'}
         {'\n'}
-        This tab&apos;s `tabBarItemTitleFontColor`:{' '}
-        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>
-        {'\n'}
-        {'\n'}
-        When selected: title text should appear{' '}
-        <Text style={{ color: Colors.RedLight100 }}>RED</Text>
-        {'\n'} and icon should appear{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
-        {'\n'}
+        When selected: title text should appear <Text style={{ color: Colors.RedLight100 }}>RED</Text>{'\n'} and icon should appear <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}
         {'\n'}
         Confirms `tabBarItemTitleFontColor` overrides `tabBarTintColor` for the
         label but not the icon, which should still be tinted by the host config.
@@ -39,9 +33,8 @@ function FontTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Font and Position</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
-        {'\n'}
+        Host `tabBarTintColor`:{" "}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
         `tabBarItemTitleFontFamily`: &quot;Georgia&quot;{'\n'}
         `tabBarItemTitleFontSize`: &quot;12&quot;{'\n'}
         `tabBarItemTitleFontStyle`: &quot;italic&quot;{'\n'}
@@ -51,11 +44,7 @@ function FontTab() {
         {'\n'}
         {'\n'}
         When selected: title text should be visibly shifted upward relative to a
-        default-positioned label in{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
-        {'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title
-        color for unselected tabs is{' '}
-        <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
+        default-positioned label in <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title color for unselected tabs is <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
       </Text>
     </View>
   );
@@ -69,8 +58,8 @@ function LongTitleTab() {
         Tab title: &quot;A Very Long Tab Title That Should Truncate&quot;{'\n'}
         {'\n'}
         Demonstrates that `options.title` with an overly wide string is
-        truncated by the system tab bar with an ellipsis rather than wrapping or
-        overflowing.
+        truncated by the system tab bar with an ellipsis rather than wrapping
+        or overflowing.
       </Text>
     </View>
   );
@@ -121,10 +110,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
               tabBarItemTitleFontSize: 12,
               tabBarItemTitleFontStyle: 'italic',
               tabBarItemTitleFontWeight: '700',
-              tabBarItemTitlePositionAdjustment: {
-                vertical: -6,
-                horizontal: 0,
-              },
+              tabBarItemTitlePositionAdjustment: { vertical: -6, horizontal: 0 },
             },
             normal: {
               tabBarItemTitleFontColor: Colors.BlueDark100,
@@ -137,12 +123,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
 ];
 
 export function App() {
-  return (
-    <TabsContainerWithHostConfigContext
-      routeConfigs={ROUTE_CONFIGS}
-      ios={{ tabBarTintColor: Colors.GreenDark100 }}
-    />
-  );
+  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} ios={{ tabBarTintColor: Colors.GreenDark100 }} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -62,6 +62,11 @@ export interface StackHeaderBackgroundSubviewAndroid {
   render: () => ReactElement;
 }
 
+export type StackHeaderToolbarMenuItemShowAsActionAndroid =
+  | 'always'
+  | 'ifRoom'
+  | 'never';
+
 export interface StackHeaderToolbarMenuItemAndroid {
   /**
    * @summary Unique identifier of the menu item.
@@ -82,6 +87,8 @@ export interface StackHeaderToolbarMenuItemAndroid {
    * @platform android
    */
   hidden?: boolean | undefined;
+  showAsAction?: StackHeaderToolbarMenuItemShowAsActionAndroid | undefined;
+  showAsActionWithText?: boolean | undefined;
 }
 
 export type StackHeaderToolbarMenuItemClickedEvent = {

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -64,7 +64,9 @@ export interface StackHeaderBackgroundSubviewAndroid {
 
 export type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'always'
+  | 'alwaysWithText'
   | 'ifRoom'
+  | 'ifRoomWithText'
   | 'never';
 
 export interface StackHeaderToolbarMenuItemAndroid {
@@ -88,7 +90,6 @@ export interface StackHeaderToolbarMenuItemAndroid {
    */
   hidden?: boolean | undefined;
   showAsAction?: StackHeaderToolbarMenuItemShowAsActionAndroid | undefined;
-  showAsActionWithText?: boolean | undefined;
 }
 
 export type StackHeaderToolbarMenuItemClickedEvent = {

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -89,6 +89,30 @@ export interface StackHeaderToolbarMenuItemAndroid {
    * @platform android
    */
   hidden?: boolean | undefined;
+  /**
+   * @summary Specifies whether the item should be displayed as a button in the
+   * Toolbar.
+   *
+   * The following values are available:
+   * - `always` - always displays the item as a button in the Toolbar,
+   * - `alwaysWithText` - always displays the item as a button in the Toolbar,
+   *   forcing the text label to be visible even if an icon is provided,
+   * - `ifRoom` - displays the item as a button in the Toolbar only if the
+   *   system determines there is sufficient space,
+   * - `ifRoomWithText` - displays the item as a button in the Toolbar if the
+   *   system determines there is sufficient space, forcing the text label to
+   *   be visible even if an icon is provided,
+   * - `never` - never displays the item as a button in the Toolbar; it will be
+   *   placed in the overflow menu instead.
+   *
+   * @remarks
+   * Due to native limitations, the width limit for the `ifRoom` options is
+   * determined during the initial render and will not adapt to subsequent layout
+   * or orientation changes.
+   *
+   * @default never
+   * @platform android
+   */
   showAsAction?: StackHeaderToolbarMenuItemShowAsActionAndroid | undefined;
 }
 

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -26,6 +26,8 @@ export type {
   StackHeaderConfigCommandsAndroid,
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuItemClickedEvent,
+  StackHeaderToolbarMenuItemShowAsActionAndroid,
   // iOS
   StackHeaderConfigPropsIOS,
   StackHeaderConfigCommandsIOS,

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -17,7 +17,9 @@ type StackHeaderToolbarMenuItemClickedEvent = Readonly<{
 
 type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'always'
+  | 'alwaysWithText'
   | 'ifRoom'
+  | 'ifRoomWithText'
   | 'never';
 
 export interface StackHeaderToolbarMenuItemAndroid {
@@ -28,7 +30,6 @@ export interface StackHeaderToolbarMenuItemAndroid {
     StackHeaderToolbarMenuItemShowAsActionAndroid,
     'never'
   >;
-  showAsActionWithText?: CT.WithDefault<boolean, false>;
 }
 
 export interface NativeProps extends ViewProps {

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -54,6 +54,13 @@ export interface NativeProps extends ViewProps {
   onToolbarMenuItemClicked?:
     | CT.DirectEventHandler<StackHeaderToolbarMenuItemClickedEvent>
     | undefined;
+
+  // When StackHeaderToolbarMenuItemAndroid is used as an array
+  // in toolbarMenuItems, Codegen doesn't generate an enum in Props.h
+  // which causes a build failure on iOS. By adding a property where
+  // StackHeaderToolbarMenuItemAndroid is used directly, we ensure
+  // that the enum is generated.
+  DO_NOT_USE?: StackHeaderToolbarMenuItemAndroid | undefined;
 }
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -15,10 +15,20 @@ type StackHeaderToolbarMenuItemClickedEvent = Readonly<{
   id: string;
 }>;
 
+type StackHeaderToolbarMenuItemShowAsActionAndroid =
+  | 'always'
+  | 'ifRoom'
+  | 'never';
+
 export interface StackHeaderToolbarMenuItemAndroid {
   id: string;
   title?: CT.WithDefault<string, ''>;
   hidden?: CT.WithDefault<boolean, false>;
+  showAsAction?: CT.WithDefault<
+    StackHeaderToolbarMenuItemShowAsActionAndroid,
+    'never'
+  >;
+  showAsActionWithText?: CT.WithDefault<boolean, false>;
 }
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
## Description

Adds `showAsAction` property to toolbar menu items in header on Android in Stack v5. 

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1202.

### API shape

The initial API idea was:

```ts
showAsAction?: 'always' | 'ifRoom' | 'never' | undefined;
showAsActionWithText?: boolean | undefined;
```

But this turned out to be problematic on the native side. You can only set the
`showAsAction` flags, you can't read them from the `MenuItem`. If the user
changed only one of these 2 props, we wouldn't know all the flags that need to
be applied. We could add state to the `ToolbarMenuCoordinator` or `HeaderConfig`
but we would like to avoid it.

I decided to merge these 2 props into one enum. For `never`, we don't need the
`withText` modifier so there are only 5 options possible which isn't bad.

We could also use nested object but we've been trying to avoid complicated
nesting.

The final API therefore looks like this:

```ts
showAsAction?: 'always' | 'alwaysWithText' | 'ifRoom' | 'ifRoomWithText' | 'never' | undefined;
```

I'm open to suggestions though.

### Codegen problem

When adding the
`showAsAction?: CT.WithDefault<StackHeaderToolbarMenuItemShowAsActionAndroid, 'never'>;`
prop to `StackHeaderToolbarMenuItemAndroid` interface in native spec on Android,
iOS build stopped working. In `Props.h`, all types are generated (also for
Android-only components). For some reason, if we use nested object as an array
(` toolbarMenuItems?: StackHeaderToolbarMenuItemAndroid[] | undefined;`), the
enum type isn't generated which causes the build to fail. After I added
`DO_NOT_USE?: StackHeaderToolbarMenuItemAndroid | undefined;` property, the enum
is generated correctly. I assumed that it's better to add this workaround
instead of losing the typing completely.

### Limited support for `ifRoom`

`ifRoom` option doesn't react to orientation changes. The maximum width of
action items is determined on first layout and it remains that way even through
layout/orientation changes. This means that if you open the screen in portrait,
more items won't move from overflow menu to the toolbar when rotated to
landscape and if you open the screen in landscape, rotating to portrait won't
make the items move to the overflow menu, usually resulting in the title being
shrunk down. 

| portrait -> landscape | landscape -> portrait |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ef59d7f6-a171-46b9-9854-ee977989a951" /> | <video src="https://github.com/user-attachments/assets/ecc66cc1-eca0-44ef-86e1-7ad9597bf54d" /> |

This happens due to native implementation. Typically on Android, every
orientation change causes the activity to restart. The maximum width of action
menu items is evaluated only on initialization of `ActionMenuProesenter`
(`initForMenu`). If activity restarts are disabled, as is the case in
`react-native` apps, the initially set width will still apply.

> [!NOTE]
>
> By the way, this value turns out to be half of the width of the device:
> 
> ```java
> public int getEmbeddedMenuWidthLimit() {
>     return mContext.getResources().getDisplayMetrics().widthPixels / 2;
> }
> ```
> 
> This value is then made smaller by subtracting the width of the collapse icon.

I tried looking for a way to force this value to reset. Unfortunately, I didn't
find any way that wouldn't involve heavy reflection usage or completely
resetting the menu, resulting in the loss of state (i.e. changes applied via
view commands would be completely lost). I think that keeping the state is more
important in this case but I'm open for discussion here.

While testing this I also noticed some problems with handling orientation
changes for the screen. I will investigate this separately
(https://github.com/software-mansion/react-native-screens-labs/issues/1499).

https://github.com/user-attachments/assets/a6d64b67-6599-4abc-a154-92bdacfe9c72

## Changes

- add `showAsAction` prop and `StackHeaderToolbarMenuItemShowAsAction(Android)` enums
- add `DO_NOT_USE?: StackHeaderToolbarMenuItemAndroid | undefined;` to native spec to  ensure generation of enum in `Props.h` to fix build on iOS
- minor fixes:
  - expose `StackHeaderToolbarMenuItemClickedEvent`
  - make `clear`, `updateItem` internal in `ToolbarMenuCoordinator`
  - adjust `test-stack-toolbar-menu-commands` to new convention

## Visual documentation

https://github.com/user-attachments/assets/419ef60c-f7af-4a43-8f86-b62640a681bc

## Test plan

Run `test-stack-toolbar-menu-show-as-action-android` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
