### PR TITLE
feat(Android, Stack v5): toolbar menu item icon and icon tint color

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
@@ -1,0 +1,39 @@
+package com.swmansion.rnscreens.gamma.helpers
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+
+internal class IconResolver {
+    private var lastDrawableName: String? = null
+    private var lastImageUri: String? = null
+    private var lastEmittedDrawableName: String? = null
+    private var lastEmittedImageUri: String? = null
+
+    fun resolve(
+        context: Context,
+        drawableIconResourceName: String?,
+        imageIconUri: String?,
+        onResolved: (Drawable?) -> Unit,
+    ) {
+        lastDrawableName = drawableIconResourceName
+        lastImageUri = imageIconUri
+        if (drawableIconResourceName == lastEmittedDrawableName &&
+            imageIconUri == lastEmittedImageUri
+        ) {
+            return
+        }
+        lastEmittedDrawableName = drawableIconResourceName
+        lastEmittedImageUri = imageIconUri
+        when {
+            drawableIconResourceName != null ->
+                onResolved(getSystemDrawableResource(context, drawableIconResourceName))
+            imageIconUri != null ->
+                loadImage(context, imageIconUri) { drawable ->
+                    if (imageIconUri == lastImageUri && lastDrawableName == null) {
+                        onResolved(drawable)
+                    }
+                }
+            else -> onResolved(null)
+        }
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
@@ -3,37 +3,59 @@ package com.swmansion.rnscreens.gamma.helpers
 import android.content.Context
 import android.graphics.drawable.Drawable
 
+/**
+ * Outcome of [IconResolver.resolve].
+ *
+ * [Unchanged] is reported when the requested source matches the one the resolver
+ * last emitted, so the caller should keep whatever icon it already has (no reload
+ * happens). [Resolved] carries a freshly resolved drawable, or `null` when the
+ * source resolves to no icon (i.e. the icon should be cleared).
+ */
+internal sealed interface IconResolution {
+    object Unchanged : IconResolution
+
+    data class Resolved(
+        val drawable: Drawable?,
+    ) : IconResolution
+}
+
 internal class IconResolver {
     private var lastDrawableName: String? = null
     private var lastImageUri: String? = null
     private var lastEmittedDrawableName: String? = null
     private var lastEmittedImageUri: String? = null
 
+    /**
+     * Resolves an icon from a drawable resource name or an image uri and always
+     * reports the outcome via [onResult] exactly once — synchronously for drawable
+     * resources and empty sources, asynchronously for image uris.
+     */
     fun resolve(
         context: Context,
         drawableIconResourceName: String?,
         imageIconUri: String?,
-        onResolved: (Drawable?) -> Unit,
+        onResult: (IconResolution) -> Unit,
     ) {
         lastDrawableName = drawableIconResourceName
         lastImageUri = imageIconUri
         if (drawableIconResourceName == lastEmittedDrawableName &&
             imageIconUri == lastEmittedImageUri
         ) {
+            onResult(IconResolution.Unchanged)
             return
         }
         lastEmittedDrawableName = drawableIconResourceName
         lastEmittedImageUri = imageIconUri
         when {
             drawableIconResourceName != null ->
-                onResolved(getSystemDrawableResource(context, drawableIconResourceName))
+                onResult(IconResolution.Resolved(getSystemDrawableResource(context, drawableIconResourceName)))
             imageIconUri != null ->
                 loadImage(context, imageIconUri) { drawable ->
                     if (imageIconUri == lastImageUri && lastDrawableName == null) {
-                        onResolved(drawable)
+                        onResult(IconResolution.Resolved(drawable))
                     }
                 }
-            else -> onResolved(null)
+            else -> onResult(IconResolution.Resolved(null))
         }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/IconResolver.kt
@@ -26,9 +26,11 @@ internal class IconResolver {
     private var lastEmittedImageUri: String? = null
 
     /**
-     * Resolves an icon from a drawable resource name or an image uri and always
-     * reports the outcome via [onResult] exactly once — synchronously for drawable
-     * resources and empty sources, asynchronously for image uris.
+     * Resolves an icon from a drawable resource name or an image uri.
+     *
+     * The result is delivered to [onResult] synchronously for drawable resources and empty sources,
+     * and asynchronously for image uris. For image uris, the callback is only invoked if the
+     * resolved uri is still the latest requested source (stale requests are dropped).
      */
     fun resolve(
         context: Context,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -607,7 +607,7 @@ internal class StackHeaderCoordinator(
         options: StackHeaderToolbarMenuItemOptions,
     ) {
         appBarLayout?.toolbar?.let {
-            toolbarMenuCoordinator.updateItem(it.menu, id, options)
+            toolbarMenuCoordinator.updateItem(it, id, options)
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -1,11 +1,13 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
+import android.R
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 import android.util.LayoutDirection
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
+import com.swmansion.rnscreens.gamma.helpers.IconResolver
 import com.swmansion.rnscreens.gamma.helpers.getSystemDrawableResource
 import com.swmansion.rnscreens.gamma.helpers.loadImage
 import com.swmansion.rnscreens.gamma.stack.header.subview.OnStackHeaderSubviewChangeListener
@@ -56,33 +58,16 @@ class StackHeaderConfig(
     internal var backButtonDrawableIconResourceName: String? = null
     internal var backButtonImageIconUri: String? = null
 
-    private var lastResolvedDrawableIconResourceName: String? = null
-    private var lastResolvedImageIconUri: String? = null
+    private val backButtonIconResolver = IconResolver()
 
     internal fun resolveBackButtonIconIfNeeded() {
-        val name = backButtonDrawableIconResourceName
-        val uri = backButtonImageIconUri
-
-        if (name == lastResolvedDrawableIconResourceName && uri == lastResolvedImageIconUri) {
-            return
-        }
-
-        lastResolvedDrawableIconResourceName = name
-        lastResolvedImageIconUri = uri
-
-        if (name != null) {
-            backButtonIcon = getSystemDrawableResource(context, name)
-        } else if (uri != null) {
-            loadImage(context, uri) { drawable ->
-                if (uri == lastResolvedImageIconUri) {
-                    backButtonIcon = drawable
-                    // We need to call notifyConfigChanged because icons are loaded asynchronously
-                    // and regular update path might execute too early.
-                    notifyConfigChanged()
-                }
-            }
-        } else {
-            backButtonIcon = null
+        backButtonIconResolver.resolve(
+            reactContext,
+            backButtonDrawableIconResourceName,
+            backButtonImageIconUri
+        ) { drawable ->
+            backButtonIcon = drawable
+            notifyConfigChanged()
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -1,6 +1,5 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
-import android.R
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 import android.util.LayoutDirection
@@ -8,12 +7,11 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
 import com.swmansion.rnscreens.gamma.helpers.IconResolver
-import com.swmansion.rnscreens.gamma.helpers.getSystemDrawableResource
-import com.swmansion.rnscreens.gamma.helpers.loadImage
 import com.swmansion.rnscreens.gamma.stack.header.subview.OnStackHeaderSubviewChangeListener
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import java.lang.ref.WeakReference
 
@@ -57,18 +55,54 @@ class StackHeaderConfig(
     // Resolution happens in resolveBackButtonIconIfNeeded(), called from onAfterUpdateTransaction.
     internal var backButtonDrawableIconResourceName: String? = null
     internal var backButtonImageIconUri: String? = null
-
     private val backButtonIconResolver = IconResolver()
 
     internal fun resolveBackButtonIconIfNeeded() {
         backButtonIconResolver.resolve(
             reactContext,
             backButtonDrawableIconResourceName,
-            backButtonImageIconUri
+            backButtonImageIconUri,
         ) { drawable ->
             backButtonIcon = drawable
             notifyConfigChanged()
         }
+    }
+
+    internal var toolbarMenuItemIconSourceMap = mapOf<String, StackHeaderToolbarMenuItemIconSource>()
+
+    private var toolbarMenuItemIconResolvers = mapOf<String, IconResolver>()
+
+    internal fun resolveToolbarMenuItemIconsIfNeeded() {
+        val nextResolvers = mutableMapOf<String, IconResolver>()
+
+        toolbarMenuItemIconSourceMap.forEach { (id, source) ->
+            val resolver = toolbarMenuItemIconResolvers[id] ?: IconResolver()
+            nextResolvers[id] = resolver
+
+            resolver.resolve(
+                context = reactContext,
+                drawableIconResourceName = source.drawableIconResourceName,
+                imageIconUri = source.imageIconUri,
+            ) { drawable ->
+
+                val currentItems = toolbarMenuItems
+                val itemIndex = currentItems.indexOfFirst { it.id == id }
+
+                if (itemIndex != -1) {
+                    val item = currentItems[itemIndex]
+
+                    if (item.icon != drawable) {
+                        val newItems = currentItems.toMutableList()
+                        newItems[itemIndex] = item.copy(icon = drawable)
+
+                        toolbarMenuItems = newItems
+                        notifyConfigChanged()
+                    }
+                }
+            }
+        }
+
+        toolbarMenuItemIconResolvers = nextResolvers
     }
 
     override var backgroundSubview: StackHeaderSubview? = null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -80,11 +80,19 @@ class StackHeaderConfig(
 
     private var toolbarMenuItemIconResolvers = mapOf<String, IconResolver>()
 
+    // Last resolved icon per menu item id. Unlike every other field on this
+    // config — which mirrors a single prop — this cache deliberately merges
+    // resolved icons from BOTH sources that can set a menu item icon: the
+    // `toolbarMenuItems` prop array (resolveToolbarMenuItemIconsIfNeeded) and
+    // the imperative `setToolbarMenuItemOptions` view command
+    // (dispatchMenuItemUpdate). It is necessary to ensure consistency.
+    private var toolbarMenuItemIcons = mapOf<String, Drawable?>()
+
     internal fun resolveToolbarMenuItemIconsIfNeeded() {
         val nextResolvers = mutableMapOf<String, IconResolver>()
 
         toolbarMenuItemIconSourceMap.forEach { (id, source) ->
-            val resolver = IconResolver()
+            val resolver = toolbarMenuItemIconResolvers[id] ?: IconResolver()
             nextResolvers[id] = resolver
 
             resolver.resolve(
@@ -92,26 +100,39 @@ class StackHeaderConfig(
                 drawableIconResourceName = source.drawableIconResourceName,
                 imageIconUri = source.imageIconUri,
             ) { result ->
-                if (result !is IconResolution.Resolved) return@resolve
-
-                val currentItems = toolbarMenuItems
-                val itemIndex = currentItems.indexOfFirst { it.id == id }
-
-                if (itemIndex != -1) {
-                    val item = currentItems[itemIndex]
-
-                    if (item.icon != result.drawable) {
-                        val newItems = currentItems.toMutableList()
-                        newItems[itemIndex] = item.copy(icon = result.drawable)
-
-                        toolbarMenuItems = newItems
-                        notifyConfigChanged()
+                val icon =
+                    when (result) {
+                        IconResolution.Unchanged -> toolbarMenuItemIcons[id]
+                        is IconResolution.Resolved -> {
+                            toolbarMenuItemIcons = toolbarMenuItemIcons + (id to result.drawable)
+                            result.drawable
+                        }
                     }
-                }
+
+                applyToolbarMenuItemIcon(id, icon)
             }
         }
 
         toolbarMenuItemIconResolvers = nextResolvers
+        toolbarMenuItemIcons = toolbarMenuItemIcons.filterKeys { it in toolbarMenuItemIconSourceMap }
+    }
+
+    private fun applyToolbarMenuItemIcon(
+        id: String,
+        icon: Drawable?,
+    ) {
+        val currentItems = toolbarMenuItems
+        val itemIndex = currentItems.indexOfFirst { it.id == id }
+        if (itemIndex == -1) return
+
+        val item = currentItems[itemIndex]
+        if (item.icon != icon) {
+            val newItems = currentItems.toMutableList()
+            newItems[itemIndex] = item.copy(icon = icon)
+
+            toolbarMenuItems = newItems
+            notifyConfigChanged()
+        }
     }
 
     override var backgroundSubview: StackHeaderSubview? = null
@@ -197,7 +218,12 @@ class StackHeaderConfig(
             val icon =
                 when (result) {
                     IconResolution.Unchanged -> null // keep the current icon
-                    is IconResolution.Resolved -> StackHeaderToolbarUpdate.from(result.drawable)
+                    is IconResolution.Resolved -> {
+                        // Keep the cache in sync with the prop-array path: both share this
+                        // id's resolver.
+                        toolbarMenuItemIcons = toolbarMenuItemIcons + (id to result.drawable)
+                        StackHeaderToolbarUpdate.from(result.drawable)
+                    }
                 }
             delegate?.get()?.onMenuItemUpdate(id, options.copy(icon = icon))
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
+import com.swmansion.rnscreens.gamma.helpers.IconResolution
 import com.swmansion.rnscreens.gamma.helpers.IconResolver
 import com.swmansion.rnscreens.gamma.stack.header.subview.OnStackHeaderSubviewChangeListener
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
@@ -64,9 +65,14 @@ class StackHeaderConfig(
             reactContext,
             backButtonDrawableIconResourceName,
             backButtonImageIconUri,
-        ) { drawable ->
-            backButtonIcon = drawable
-            notifyConfigChanged()
+        ) { result ->
+            when (result) {
+                IconResolution.Unchanged -> Unit
+                is IconResolution.Resolved -> {
+                    backButtonIcon = result.drawable
+                    notifyConfigChanged()
+                }
+            }
         }
     }
 
@@ -85,7 +91,8 @@ class StackHeaderConfig(
                 context = reactContext,
                 drawableIconResourceName = source.drawableIconResourceName,
                 imageIconUri = source.imageIconUri,
-            ) { drawable ->
+            ) { result ->
+                if (result !is IconResolution.Resolved) return@resolve
 
                 val currentItems = toolbarMenuItems
                 val itemIndex = currentItems.indexOfFirst { it.id == id }
@@ -93,9 +100,9 @@ class StackHeaderConfig(
                 if (itemIndex != -1) {
                     val item = currentItems[itemIndex]
 
-                    if (item.icon != drawable) {
+                    if (item.icon != result.drawable) {
                         val newItems = currentItems.toMutableList()
-                        newItems[itemIndex] = item.copy(icon = drawable)
+                        newItems[itemIndex] = item.copy(icon = result.drawable)
 
                         toolbarMenuItems = newItems
                         notifyConfigChanged()
@@ -162,22 +169,37 @@ class StackHeaderConfig(
         delegate?.get()?.onConfigChange(this)
     }
 
+    /**
+     * Applies a toolbar menu item view command. When the command does not touch
+     * the icon ([iconSource] is `null`) the options are delivered immediately.
+     * Otherwise, the icon is resolved first and all options — including the icon —
+     * are delivered together in a single update, so the change is applied
+     * atomically once the (possibly async) image has loaded.
+     */
     internal fun dispatchMenuItemUpdate(
         id: String,
         options: StackHeaderToolbarMenuItemOptions,
         iconSource: StackHeaderToolbarMenuItemIconSource?,
     ) {
-        if (iconSource != null) {
-            val resolver = toolbarMenuItemIconResolvers[id]
-            if (resolver != null) {
-                resolver.resolve(reactContext, iconSource.drawableIconResourceName, iconSource.imageIconUri) { drawable ->
-                    delegate?.get()?.onMenuItemUpdate(id, options.copy(icon = StackHeaderToolbarUpdate.from(drawable)))
-                }
-            } else {
-                Log.w(TAG, "[RNScreens] Unable to find icon resolver for menu item $id.")
-            }
-        } else {
+        if (iconSource == null) {
             delegate?.get()?.onMenuItemUpdate(id, options)
+            return
+        }
+
+        val resolver = toolbarMenuItemIconResolvers[id]
+        if (resolver == null) {
+            Log.w(TAG, "[RNScreens] Unable to find icon resolver for menu item $id.")
+            delegate?.get()?.onMenuItemUpdate(id, options)
+            return
+        }
+
+        resolver.resolve(reactContext, iconSource.drawableIconResourceName, iconSource.imageIconUri) { result ->
+            val icon =
+                when (result) {
+                    IconResolution.Unchanged -> null // keep the current icon
+                    is IconResolution.Resolved -> StackHeaderToolbarUpdate.from(result.drawable)
+                }
+            delegate?.get()?.onMenuItemUpdate(id, options.copy(icon = icon))
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -76,7 +76,7 @@ class StackHeaderConfig(
         val nextResolvers = mutableMapOf<String, IconResolver>()
 
         toolbarMenuItemIconSourceMap.forEach { (id, source) ->
-            val resolver = toolbarMenuItemIconResolvers[id] ?: IconResolver()
+            val resolver = IconResolver()
             nextResolvers[id] = resolver
 
             resolver.resolve(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 import android.util.LayoutDirection
+import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
@@ -13,6 +14,7 @@ import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
 import java.lang.ref.WeakReference
 
 @SuppressLint("ViewConstructor")
@@ -163,8 +165,20 @@ class StackHeaderConfig(
     internal fun dispatchMenuItemUpdate(
         id: String,
         options: StackHeaderToolbarMenuItemOptions,
+        iconSource: StackHeaderToolbarMenuItemIconSource?,
     ) {
-        delegate?.get()?.onMenuItemUpdate(id, options)
+        if (iconSource != null) {
+            val resolver = toolbarMenuItemIconResolvers[id]
+            if (resolver != null) {
+                resolver.resolve(reactContext, iconSource.drawableIconResourceName, iconSource.imageIconUri) { drawable ->
+                    delegate?.get()?.onMenuItemUpdate(id, options.copy(icon = StackHeaderToolbarUpdate.from(drawable)))
+                }
+            } else {
+                Log.w(TAG, "[RNScreens] Unable to find icon resolver for menu item $id.")
+            }
+        } else {
+            delegate?.get()?.onMenuItemUpdate(id, options)
+        }
     }
 
     override fun onStackHeaderSubviewChange() = notifyConfigChanged()
@@ -208,4 +222,8 @@ class StackHeaderConfig(
     // The order of the subviews MUST match the order of JS StackHeaderConfig children.
     internal fun getConfigSubviewAt(index: Int): StackHeaderSubview? =
         listOfNotNull(backgroundSubview, leadingSubview, centerSubview, trailingSubview).getOrNull(index)
+
+    companion object {
+        private const val TAG = "StackHeaderConfig"
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -267,13 +267,6 @@ open class StackHeaderConfigViewManager :
     ) {
         val map = options.getMap(0) ?: return
 
-        val drawableIconResourceName = map.getString("drawableIconResourceName")
-        val imageIconUri = map.readNullableImageUriUpdate("imageIconResource", null)
-        val iconSource = if (drawableIconResourceName != null || imageIconUri != null) StackHeaderToolbarMenuItemIconSource(
-            drawableIconResourceName = drawableIconResourceName,
-            imageIconUri = imageIconUri
-        ) else null
-
         view.dispatchMenuItemUpdate(
             id,
             StackHeaderToolbarMenuItemOptions(
@@ -284,17 +277,14 @@ open class StackHeaderConfigViewManager :
                         "showAsAction",
                         StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                     ),
+                // The icon is resolved asynchronously and filled in by dispatchMenuItemUpdate.
                 icon = null,
-                iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal",
-                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL),
-                iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed",
-                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED),
-                iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused",
-                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED),
-                iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled",
-                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED)
+                iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal"),
+                iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed"),
+                iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused"),
+                iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled"),
             ),
-            iconSource
+            map.readIconSource(),
         )
     }
 
@@ -335,12 +325,10 @@ private fun ReadableMap.readShowAsActionEnum(
 private fun ReadableMap.readColor(
     key: String,
     default: Int?,
-): Int? {
-    if (!this.hasKey(key) || this.isNull(key)) {
-        return default
-    }
+): Int? = if (!this.hasKey(key) || this.isNull(key)) default else parseColor(key)
 
-    return try {
+private fun ReadableMap.parseColor(key: String): Int? =
+    try {
         when (getType(key)) {
             ReadableType.Number -> getInt(key)
             ReadableType.String -> getString(key)?.toColorInt()
@@ -350,7 +338,6 @@ private fun ReadableMap.readColor(
         Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
         null
     }
-}
 
 private fun ReadableMap.readImageUri(
     key: String,
@@ -364,9 +351,15 @@ private fun ReadableMap.readImageUri(
     return imageMap?.getString("uri") ?: default
 }
 
-// Helpers for view commands:
-// - not defined -> null (means "no update")
-// - null -> default (means "reset to default value")
+// Helpers for view commands. Each key has three states:
+// - not defined -> null         (no change)
+// - null        -> default      (reset to default)
+// - value       -> value
+//
+// A plain `T?` return can encode this only when the field's default is non-null,
+// so `null` unambiguously means "no change". Fields whose default is null (the
+// tint colors) must return `StackHeaderToolbarUpdate<T>?` instead, to tell "no
+// change" (null) apart from "reset" (Reset).
 private fun ReadableMap.readNullableStringUpdate(
     key: String,
     default: String,
@@ -400,47 +393,26 @@ private fun ReadableMap.readNullableShowAsActionEnumUpdate(
             } ?: default
     }
 
-private fun ReadableMap.readNullableColorUpdate(
-    key: String,
-    default: Int?
-): StackHeaderToolbarUpdate<Int>? =
+// Assumes null is the default color.
+private fun ReadableMap.readNullableColorUpdate(key: String): StackHeaderToolbarUpdate<Int>? =
     when {
         !this.hasKey(key) -> null
-        this.isNull(key) -> StackHeaderToolbarUpdate.from(default)
-        else -> {
-            try {
-                when (getType(key)) {
-                    ReadableType.Number -> StackHeaderToolbarUpdate.from(getInt(key))
-                    ReadableType.String -> StackHeaderToolbarUpdate.from(getString(key)?.toColorInt())
-                    else -> StackHeaderToolbarUpdate.from(default)
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
-                StackHeaderToolbarUpdate.from(default)
-            }
-        }
+        this.isNull(key) -> StackHeaderToolbarUpdate.Reset
+        else -> StackHeaderToolbarUpdate.from(parseColor(key))
     }
 
-private fun ReadableMap.readNullableImageUriUpdate(
-    key: String,
-    default: String?,
-): String? {
-    if (!this.hasKey(key)) {
+// The icon is composed of two JS keys that together form one source. It is
+// "mentioned" iff at least one key is present; mentioned but empty (both null)
+// means "clear", which the resolver turns into a Reset.
+private fun ReadableMap.readIconSource(): StackHeaderToolbarMenuItemIconSource? {
+    if (!this.hasKey("drawableIconResourceName") && !this.hasKey("imageIconResource")) {
         return null
     }
-
-    if (this.isNull(key)) {
-        return default
-    }
-
-    if (this.getType(key) != ReadableType.Map) {
-        return null
-    }
-
-    val imageMap = getMap(key)
-    return imageMap?.getString("uri") ?: default
+    return StackHeaderToolbarMenuItemIconSource(
+        drawableIconResourceName = this.getString("drawableIconResourceName"),
+        imageIconUri = this.readImageUri("imageIconResource", null),
+    )
 }
-
 
 private fun toMenuItemShowAsActionEnum(value: String): StackHeaderToolbarMenuItemShowAsAction =
     when (value) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -275,6 +275,11 @@ open class StackHeaderConfigViewManager :
                         "showAsAction",
                         StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                     ),
+                icon = null,
+                iconTintColorNormal = null,
+                iconTintColorPressed = null,
+                iconTintColorFocused = null,
+                iconTintColorDisabled = null
             ),
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -22,7 +22,8 @@ import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenu
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
-import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreenViewManager.Companion.TAG
+
+private const val TAG = "StackHeaderConfigViewManager"
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
 open class StackHeaderConfigViewManager :
@@ -220,7 +221,7 @@ open class StackHeaderConfigViewManager :
 
                     sourceMap[id] =
                         StackHeaderToolbarMenuItemIconSource(
-                            item.getString("drawableIconResourceName"),
+                            item.getString("drawableIconResourceName") ?: StackHeaderToolbarMenuItemDefaults.DRAWABLE_ICON_RESOURCE_NAME,
                             item.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
                         )
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -21,6 +21,7 @@ import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenu
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
 import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreenViewManager.Companion.TAG
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
@@ -265,6 +266,14 @@ open class StackHeaderConfigViewManager :
         options: ReadableArray,
     ) {
         val map = options.getMap(0) ?: return
+
+        val drawableIconResourceName = map.getString("drawableIconResourceName")
+        val imageIconUri = map.readNullableImageUriUpdate("imageIconResource", null)
+        val iconSource = if (drawableIconResourceName != null || imageIconUri != null) StackHeaderToolbarMenuItemIconSource(
+            drawableIconResourceName = drawableIconResourceName,
+            imageIconUri = imageIconUri
+        ) else null
+
         view.dispatchMenuItemUpdate(
             id,
             StackHeaderToolbarMenuItemOptions(
@@ -276,11 +285,16 @@ open class StackHeaderConfigViewManager :
                         StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                     ),
                 icon = null,
-                iconTintColorNormal = null,
-                iconTintColorPressed = null,
-                iconTintColorFocused = null,
-                iconTintColorDisabled = null
+                iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL),
+                iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED),
+                iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED),
+                iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED)
             ),
+            iconSource
         )
     }
 
@@ -385,6 +399,48 @@ private fun ReadableMap.readNullableShowAsActionEnumUpdate(
                 toMenuItemShowAsActionEnum(it)
             } ?: default
     }
+
+private fun ReadableMap.readNullableColorUpdate(
+    key: String,
+    default: Int?
+): StackHeaderToolbarUpdate<Int>? =
+    when {
+        !this.hasKey(key) -> null
+        this.isNull(key) -> StackHeaderToolbarUpdate.from(default)
+        else -> {
+            try {
+                when (getType(key)) {
+                    ReadableType.Number -> StackHeaderToolbarUpdate.from(getInt(key))
+                    ReadableType.String -> StackHeaderToolbarUpdate.from(getString(key)?.toColorInt())
+                    else -> StackHeaderToolbarUpdate.from(default)
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
+                StackHeaderToolbarUpdate.from(default)
+            }
+        }
+    }
+
+private fun ReadableMap.readNullableImageUriUpdate(
+    key: String,
+    default: String?,
+): String? {
+    if (!this.hasKey(key)) {
+        return null
+    }
+
+    if (this.isNull(key)) {
+        return default
+    }
+
+    if (this.getType(key) != ReadableType.Map) {
+        return null
+    }
+
+    val imageMap = getMap(key)
+    return imageMap?.getString("uri") ?: default
+}
+
 
 private fun toMenuItemShowAsActionEnum(value: String): StackHeaderToolbarMenuItemShowAsAction =
     when (value) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,9 +1,12 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
+import android.util.Log
 import android.view.View
+import androidx.core.graphics.toColorInt
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
@@ -15,8 +18,10 @@ import com.facebook.react.viewmanagers.RNSStackHeaderConfigAndroidManagerInterfa
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemDefaults
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
+import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreenViewManager.Companion.TAG
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
 open class StackHeaderConfigViewManager :
@@ -99,6 +104,7 @@ open class StackHeaderConfigViewManager :
     override fun onAfterUpdateTransaction(view: StackHeaderConfig) {
         super.onAfterUpdateTransaction(view)
         view.resolveBackButtonIconIfNeeded()
+        view.resolveToolbarMenuItemIconsIfNeeded()
         view.notifyConfigChanged()
     }
 
@@ -203,12 +209,22 @@ open class StackHeaderConfigViewManager :
         view: StackHeaderConfig,
         value: ReadableArray?,
     ) {
+        val sourceMap = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
+
         view.toolbarMenuItems =
             value?.let { array ->
                 (0 until array.size()).map { i ->
                     val item = requireNotNull(array.getMap(i))
+                    val id = item.requireNotNullString("id")
+
+                    sourceMap[id] =
+                        StackHeaderToolbarMenuItemIconSource(
+                            item.getString("drawableIconResourceName"),
+                            item.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
+                        )
+
                     StackHeaderToolbarMenuItemConfig(
-                        id = item.requireNotNullString("id"),
+                        id = id,
                         title = item.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
                         hidden = item.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
                         showAsAction =
@@ -216,9 +232,31 @@ open class StackHeaderConfigViewManager :
                                 "showAsAction",
                                 StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                             ),
+                        icon = null,
+                        iconTintColorNormal =
+                            item.readColor(
+                                "iconTintColorNormal",
+                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
+                            ),
+                        iconTintColorPressed =
+                            item.readColor(
+                                "iconTintColorPressed",
+                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
+                            ),
+                        iconTintColorFocused =
+                            item.readColor(
+                                "iconTintColorFocused",
+                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
+                            ),
+                        iconTintColorDisabled =
+                            item.readColor(
+                                "iconTintColorDisabled",
+                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
+                            ),
                     )
                 }
             } ?: emptyList()
+        view.toolbarMenuItemIconSourceMap = sourceMap
     }
 
     override fun setToolbarMenuItemOptions(
@@ -273,6 +311,38 @@ private fun ReadableMap.readShowAsActionEnum(
 ): StackHeaderToolbarMenuItemShowAsAction {
     val stringValue = this.getString(key) ?: return default
     return toMenuItemShowAsActionEnum(stringValue)
+}
+
+private fun ReadableMap.readColor(
+    key: String,
+    default: Int?,
+): Int? {
+    if (!this.hasKey(key) || this.isNull(key)) {
+        return default
+    }
+
+    return try {
+        when (getType(key)) {
+            ReadableType.Number -> getInt(key)
+            ReadableType.String -> getString(key)?.toColorInt()
+            else -> null
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
+        null
+    }
+}
+
+private fun ReadableMap.readImageUri(
+    key: String,
+    default: String?,
+): String? {
+    if (!this.hasKey(key) || this.getType(key) != ReadableType.Map) {
+        return default
+    }
+
+    val imageMap = getMap(key)
+    return imageMap?.getString("uri") ?: default
 }
 
 // Helpers for view commands:

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -159,7 +159,7 @@ internal class StackHeaderToolbarMenuCoordinator(
                 is StackHeaderToolbarUpdate.Set -> update.value
                 null ->
                     currentTintList
-                        ?.resolvedColorOrNull(intArrayOf())
+                        ?.resolvedColorOrNull(intArrayOf(-android.R.attr.state_enabled))
                         ?.takeIf { it != currentNormal }
             }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -83,7 +83,7 @@ internal class StackHeaderToolbarMenuCoordinator(
             }
         }
 
-        if (options.requiresIconTintColorUpdate) {
+        if (options.requiresIconTintColorUpdate || options.icon != null) {
             MenuItemCompat.setIconTintList(menuItem, getResolvedIconTintList(menuItem, options))
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -139,13 +139,18 @@ internal class StackHeaderToolbarMenuCoordinator(
         options: StackHeaderToolbarMenuItemOptions,
     ): ColorStateList? {
         val currentTintList = MenuItemCompat.getIconTintList(menuItem)
-        val currentDefault = currentTintList?.defaultColor
+        // The currently-applied normal (catch-all) color, if any. Used both as
+        // the "leave unchanged" value for normal and to dedup read-back
+        // overrides: when a normal entry exists every override probe also
+        // matches it, so an override equal to the current normal is the
+        // catch-all leaking through rather than an explicit override.
+        val currentNormal = currentTintList?.resolvedColorOrNull(intArrayOf(android.R.attr.state_enabled))
 
         val finalNormal =
             when (val update = options.iconTintColorNormal) {
                 StackHeaderToolbarUpdate.Reset -> null
                 is StackHeaderToolbarUpdate.Set -> update.value
-                null -> currentDefault
+                null -> currentNormal
             }
 
         val finalDisabled =
@@ -154,8 +159,8 @@ internal class StackHeaderToolbarMenuCoordinator(
                 is StackHeaderToolbarUpdate.Set -> update.value
                 null ->
                     currentTintList
-                        ?.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentDefault ?: 0)
-                        ?.takeIf { it != currentDefault }
+                        ?.resolvedColorOrNull(intArrayOf())
+                        ?.takeIf { it != currentNormal }
             }
 
         val finalPressed =
@@ -164,8 +169,8 @@ internal class StackHeaderToolbarMenuCoordinator(
                 is StackHeaderToolbarUpdate.Set -> update.value
                 null ->
                     currentTintList
-                        ?.getColorForState(intArrayOf(android.R.attr.state_pressed), currentDefault ?: 0)
-                        ?.takeIf { it != currentDefault }
+                        ?.resolvedColorOrNull(intArrayOf(android.R.attr.state_enabled, android.R.attr.state_pressed))
+                        ?.takeIf { it != currentNormal }
             }
 
         val finalFocused =
@@ -174,8 +179,8 @@ internal class StackHeaderToolbarMenuCoordinator(
                 is StackHeaderToolbarUpdate.Set -> update.value
                 null ->
                     currentTintList
-                        ?.getColorForState(intArrayOf(android.R.attr.state_focused), currentDefault ?: 0)
-                        ?.takeIf { it != currentDefault }
+                        ?.resolvedColorOrNull(intArrayOf(android.R.attr.state_enabled, android.R.attr.state_focused))
+                        ?.takeIf { it != currentNormal }
             }
 
         val states = mutableListOf<IntArray>()
@@ -208,7 +213,29 @@ internal class StackHeaderToolbarMenuCoordinator(
         }
     }
 
+    /**
+     * Resolves the color the receiver applies to [stateSet], or `null` when no
+     * state spec matches it.
+     *
+     * `getColorForState` returns the caller-supplied fallback when nothing
+     * matches, so we probe twice with two distinct sentinels: equal results
+     * mean a real spec matched (the actual color), differing results mean the
+     * slot is absent. This is robust for any color value and keeps the read-back
+     * stateless — see [getResolvedIconTintList].
+     */
+    private fun ColorStateList.resolvedColorOrNull(stateSet: IntArray): Int? {
+        val a = getColorForState(stateSet, SENTINEL_A)
+        val b = getColorForState(stateSet, SENTINEL_B)
+        return if (a == b) a else null
+    }
+
     companion object {
         private const val TAG = "StackHeaderToolbarMenuCoordinator"
+
+        // Two distinct sentinel fallbacks used to detect whether a ColorStateList
+        // actually defines a color for a given state. Their concrete values are
+        // irrelevant as long as they differ — see resolvedColorOrNull.
+        private const val SENTINEL_A = 0x00000001
+        private const val SENTINEL_B = 0x00000002
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -1,8 +1,12 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
+import android.R
+import android.content.res.ColorStateList
+import android.graphics.drawable.Drawable
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
+import androidx.core.view.MenuItemCompat
 import com.google.android.material.appbar.MaterialToolbar
 
 internal class StackHeaderToolbarMenuCoordinator(
@@ -67,6 +71,81 @@ internal class StackHeaderToolbarMenuCoordinator(
         options.title?.let { menuItem.title = it }
         options.hidden?.let { menuItem.isVisible = !it }
         options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
+
+        options.icon?.let {
+            when (it) {
+                StackHeaderToolbarUpdate.Reset -> menuItem.icon = null
+                is StackHeaderToolbarUpdate.Set<Drawable> -> menuItem.icon = it.value
+            }
+        }
+
+        if (options.requiresIconTintColorUpdate) {
+            val currentTintList = MenuItemCompat.getIconTintList(menuItem)
+            val currentDefault = currentTintList?.defaultColor
+
+            // 1. Resolve Normal State
+            val finalNormal = when (val update = options.iconTintColorNormal) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null -> currentDefault // Unchanged
+            }
+
+            // 2. Resolve Disabled State
+            val finalDisabled = when (val update = options.iconTintColorDisabled) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null -> currentTintList?.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentDefault ?: 0)
+                    ?.takeIf { it != currentDefault } // Unchanged
+            }
+
+            // 3. Resolve Pressed State
+            val finalPressed = when (val update = options.iconTintColorPressed) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null -> currentTintList?.getColorForState(intArrayOf(android.R.attr.state_pressed), currentDefault ?: 0)
+                    ?.takeIf { it != currentDefault } // Unchanged
+            }
+
+            // 4. Resolve Focused State
+            val finalFocused = when (val update = options.iconTintColorFocused) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null -> currentTintList?.getColorForState(intArrayOf(android.R.attr.state_focused), currentDefault ?: 0)
+                    ?.takeIf { it != currentDefault } // Unchanged
+            }
+
+            // 5. Build the states and colors arrays (Fallback order matters!)
+            val states = mutableListOf<IntArray>()
+            val colors = mutableListOf<Int>()
+
+            finalDisabled?.let {
+                states.add(intArrayOf(-android.R.attr.state_enabled))
+                colors.add(it)
+            }
+
+            finalPressed?.let {
+                states.add(intArrayOf(android.R.attr.state_pressed))
+                colors.add(it)
+            }
+
+            finalFocused?.let {
+                states.add(intArrayOf(android.R.attr.state_focused))
+                colors.add(it)
+            }
+
+            finalNormal?.let {
+                states.add(intArrayOf()) // Empty array acts as the default fallback
+                colors.add(it)
+            }
+
+            // 6. Apply or clear the tint list
+            if (states.isEmpty()) {
+                MenuItemCompat.setIconTintList(menuItem, null)
+            } else {
+                val colorStateList = ColorStateList(states.toTypedArray(), colors.toIntArray())
+                MenuItemCompat.setIconTintList(menuItem, colorStateList)
+            }
+        }
     }
 
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =
@@ -74,6 +153,11 @@ internal class StackHeaderToolbarMenuCoordinator(
             title = title,
             hidden = hidden,
             showAsAction = showAsAction,
+            icon = StackHeaderToolbarUpdate.from(icon),
+            iconTintColorNormal = StackHeaderToolbarUpdate.from(iconTintColorNormal),
+            iconTintColorPressed = StackHeaderToolbarUpdate.from(iconTintColorPressed),
+            iconTintColorFocused = StackHeaderToolbarUpdate.from(iconTintColorFocused),
+            iconTintColorDisabled = StackHeaderToolbarUpdate.from(iconTintColorDisabled),
         )
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
-import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.MenuItemCompat
@@ -64,7 +63,7 @@ internal class StackHeaderToolbarMenuCoordinator(
                 return
             }
 
-        applyOptions(toolbar,item, options)
+        applyOptions(toolbar, item, options)
     }
 
     private fun applyOptions(
@@ -85,71 +84,7 @@ internal class StackHeaderToolbarMenuCoordinator(
         }
 
         if (options.requiresIconTintColorUpdate) {
-            val currentTintList = MenuItemCompat.getIconTintList(menuItem)
-            val currentDefault = currentTintList?.defaultColor
-
-            // 1. Resolve Normal State
-            val finalNormal = when (val update = options.iconTintColorNormal) {
-                StackHeaderToolbarUpdate.Reset -> null
-                is StackHeaderToolbarUpdate.Set -> update.value
-                null -> currentDefault // Unchanged
-            }
-
-            // 2. Resolve Disabled State
-            val finalDisabled = when (val update = options.iconTintColorDisabled) {
-                StackHeaderToolbarUpdate.Reset -> null
-                is StackHeaderToolbarUpdate.Set -> update.value
-                null -> currentTintList?.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentDefault ?: 0)
-                    ?.takeIf { it != currentDefault } // Unchanged
-            }
-
-            // 3. Resolve Pressed State
-            val finalPressed = when (val update = options.iconTintColorPressed) {
-                StackHeaderToolbarUpdate.Reset -> null
-                is StackHeaderToolbarUpdate.Set -> update.value
-                null -> currentTintList?.getColorForState(intArrayOf(android.R.attr.state_pressed), currentDefault ?: 0)
-                    ?.takeIf { it != currentDefault } // Unchanged
-            }
-
-            // 4. Resolve Focused State
-            val finalFocused = when (val update = options.iconTintColorFocused) {
-                StackHeaderToolbarUpdate.Reset -> null
-                is StackHeaderToolbarUpdate.Set -> update.value
-                null -> currentTintList?.getColorForState(intArrayOf(android.R.attr.state_focused), currentDefault ?: 0)
-                    ?.takeIf { it != currentDefault } // Unchanged
-            }
-
-            // 5. Build the states and colors arrays (Fallback order matters!)
-            val states = mutableListOf<IntArray>()
-            val colors = mutableListOf<Int>()
-
-            finalDisabled?.let {
-                states.add(intArrayOf(-android.R.attr.state_enabled))
-                colors.add(it)
-            }
-
-            finalPressed?.let {
-                states.add(intArrayOf(android.R.attr.state_pressed))
-                colors.add(it)
-            }
-
-            finalFocused?.let {
-                states.add(intArrayOf(android.R.attr.state_focused))
-                colors.add(it)
-            }
-
-            finalNormal?.let {
-                states.add(intArrayOf()) // Empty array acts as the default fallback
-                colors.add(it)
-            }
-
-            // 6. Apply or clear the tint list
-            if (states.isEmpty()) {
-                MenuItemCompat.setIconTintList(menuItem, null)
-            } else {
-                val colorStateList = ColorStateList(states.toTypedArray(), colors.toIntArray())
-                MenuItemCompat.setIconTintList(menuItem, colorStateList)
-            }
+            MenuItemCompat.setIconTintList(menuItem, getResolvedIconTintList(menuItem, options))
         }
     }
 
@@ -171,26 +106,106 @@ internal class StackHeaderToolbarMenuCoordinator(
      *
      * Icon size source: https://m3.material.io/components/app-bars/specs - App bar icon size
      */
-    private fun getResizedDrawable(toolbar: MaterialToolbar, drawable: Drawable): Drawable {
-        val targetHeightPx = TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            24f,
-            toolbar.resources.displayMetrics
-        ).toInt()
+    private fun getResizedDrawable(
+        toolbar: MaterialToolbar,
+        drawable: Drawable,
+    ): Drawable {
+        val targetHeightPx =
+            TypedValue
+                .applyDimension(
+                    TypedValue.COMPLEX_UNIT_DIP,
+                    24f,
+                    toolbar.resources.displayMetrics,
+                ).toInt()
 
         val intrinsicWidth = drawable.intrinsicWidth
         val intrinsicHeight = drawable.intrinsicHeight
 
-        val targetWidthPx = if (intrinsicWidth > 0 && intrinsicHeight > 0) {
-            val aspectRatio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
-            (targetHeightPx * aspectRatio).toInt()
-        } else {
-            targetHeightPx
-        }
+        val targetWidthPx =
+            if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+                val aspectRatio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
+                (targetHeightPx * aspectRatio).toInt()
+            } else {
+                targetHeightPx
+            }
 
         return drawable
             .toBitmap(width = targetWidthPx, height = targetHeightPx)
             .toDrawable(toolbar.resources)
+    }
+
+    private fun getResolvedIconTintList(
+        menuItem: MenuItem,
+        options: StackHeaderToolbarMenuItemOptions,
+    ): ColorStateList? {
+        val currentTintList = MenuItemCompat.getIconTintList(menuItem)
+        val currentDefault = currentTintList?.defaultColor
+
+        val finalNormal =
+            when (val update = options.iconTintColorNormal) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null -> currentDefault
+            }
+
+        val finalDisabled =
+            when (val update = options.iconTintColorDisabled) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null ->
+                    currentTintList
+                        ?.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentDefault ?: 0)
+                        ?.takeIf { it != currentDefault }
+            }
+
+        val finalPressed =
+            when (val update = options.iconTintColorPressed) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null ->
+                    currentTintList
+                        ?.getColorForState(intArrayOf(android.R.attr.state_pressed), currentDefault ?: 0)
+                        ?.takeIf { it != currentDefault }
+            }
+
+        val finalFocused =
+            when (val update = options.iconTintColorFocused) {
+                StackHeaderToolbarUpdate.Reset -> null
+                is StackHeaderToolbarUpdate.Set -> update.value
+                null ->
+                    currentTintList
+                        ?.getColorForState(intArrayOf(android.R.attr.state_focused), currentDefault ?: 0)
+                        ?.takeIf { it != currentDefault }
+            }
+
+        val states = mutableListOf<IntArray>()
+        val colors = mutableListOf<Int>()
+
+        finalDisabled?.let {
+            states.add(intArrayOf(-android.R.attr.state_enabled))
+            colors.add(it)
+        }
+
+        finalPressed?.let {
+            states.add(intArrayOf(android.R.attr.state_pressed))
+            colors.add(it)
+        }
+
+        finalFocused?.let {
+            states.add(intArrayOf(android.R.attr.state_focused))
+            colors.add(it)
+        }
+
+        finalNormal?.let {
+            states.add(intArrayOf())
+            colors.add(it)
+        }
+
+        return if (states.isNotEmpty()) {
+            ColorStateList(states.toTypedArray(), colors.toIntArray())
+        } else {
+            null
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -1,11 +1,14 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
-import android.R
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.util.Log
+import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
+import androidx.appcompat.widget.Toolbar
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.MenuItemCompat
 import com.google.android.material.appbar.MaterialToolbar
 
@@ -33,7 +36,7 @@ internal class StackHeaderToolbarMenuCoordinator(
             reverseIdMap[nativeId] = item.id
             val menuItem = toolbar.menu.add(Menu.NONE, nativeId, index, null)
 
-            applyOptions(menuItem, item.toOptions())
+            applyOptions(toolbar, menuItem, item.toOptions())
         }
 
         toolbar.setOnMenuItemClickListener { menuItem ->
@@ -51,20 +54,21 @@ internal class StackHeaderToolbarMenuCoordinator(
     }
 
     internal fun updateItem(
-        menu: Menu,
+        toolbar: MaterialToolbar,
         id: String,
         options: StackHeaderToolbarMenuItemOptions,
     ) {
         val item =
-            forwardIdMap[id]?.let { menu.findItem(it) } ?: run {
+            forwardIdMap[id]?.let { toolbar.menu.findItem(it) } ?: run {
                 Log.e(TAG, "[RNScreens] Unable to find menu item.")
                 return
             }
 
-        applyOptions(item, options)
+        applyOptions(toolbar,item, options)
     }
 
     private fun applyOptions(
+        toolbar: MaterialToolbar,
         menuItem: MenuItem,
         options: StackHeaderToolbarMenuItemOptions,
     ) {
@@ -75,7 +79,8 @@ internal class StackHeaderToolbarMenuCoordinator(
         options.icon?.let {
             when (it) {
                 StackHeaderToolbarUpdate.Reset -> menuItem.icon = null
-                is StackHeaderToolbarUpdate.Set<Drawable> -> menuItem.icon = it.value
+                is StackHeaderToolbarUpdate.Set<Drawable> ->
+                    menuItem.icon = getResizedDrawable(toolbar, it.value)
             }
         }
 
@@ -159,6 +164,34 @@ internal class StackHeaderToolbarMenuCoordinator(
             iconTintColorFocused = StackHeaderToolbarUpdate.from(iconTintColorFocused),
             iconTintColorDisabled = StackHeaderToolbarUpdate.from(iconTintColorDisabled),
         )
+
+    /**
+     * Returns drawable resized to 24 dp height. Width is scaled proportionally to keep the aspect
+     * ratio.
+     *
+     * Icon size source: https://m3.material.io/components/app-bars/specs - App bar icon size
+     */
+    private fun getResizedDrawable(toolbar: MaterialToolbar, drawable: Drawable): Drawable {
+        val targetHeightPx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            24f,
+            toolbar.resources.displayMetrics
+        ).toInt()
+
+        val intrinsicWidth = drawable.intrinsicWidth
+        val intrinsicHeight = drawable.intrinsicHeight
+
+        val targetWidthPx = if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+            val aspectRatio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
+            (targetHeightPx * aspectRatio).toInt()
+        } else {
+            targetHeightPx
+        }
+
+        return drawable
+            .toBitmap(width = targetWidthPx, height = targetHeightPx)
+            .toDrawable(toolbar.resources)
+    }
 
     companion object {
         private const val TAG = "StackHeaderToolbarMenuCoordinator"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -1,8 +1,15 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
+import android.graphics.drawable.Drawable
+
 data class StackHeaderToolbarMenuItemConfig(
     val id: String,
     val title: String,
     val hidden: Boolean,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction,
+    val icon: Drawable?,
+    val iconTintColorNormal: Int?,
+    val iconTintColorPressed: Int?,
+    val iconTintColorFocused: Int?,
+    val iconTintColorDisabled: Int?,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -11,4 +11,10 @@ internal object StackHeaderToolbarMenuItemDefaults {
     const val TITLE: String = ""
     const val HIDDEN: Boolean = false
     val SHOW_AS_ACTION: StackHeaderToolbarMenuItemShowAsAction = StackHeaderToolbarMenuItemShowAsAction.NEVER
+    val ICON_TINT_COLOR_NORMAL: Int? = null
+    val ICON_TINT_COLOR_PRESSED: Int? = null
+    val ICON_TINT_COLOR_FOCUSED: Int? = null
+    val ICON_TINT_COLOR_DISABLED: Int? = null
+    val DRAWABLE_ICON_RESOURCE_NAME: String? = null
+    val IMAGE_ICON_URI: String? = null
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemIconSource.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemIconSource.kt
@@ -1,0 +1,6 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+data class StackHeaderToolbarMenuItemIconSource(
+    val drawableIconResourceName: String?,
+    val imageIconUri: String?,
+)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -1,5 +1,7 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
+import android.graphics.drawable.Drawable
+
 /**
  * Partial update for a toolbar menu item.
  *
@@ -10,4 +12,16 @@ data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
-)
+
+    val icon: StackHeaderToolbarUpdate<Drawable>?,
+    val iconTintColorNormal: StackHeaderToolbarUpdate<Int>?,
+    val iconTintColorPressed: StackHeaderToolbarUpdate<Int>?,
+    val iconTintColorFocused: StackHeaderToolbarUpdate<Int>?,
+    val iconTintColorDisabled: StackHeaderToolbarUpdate<Int>?,
+) {
+    val requiresIconTintColorUpdate: Boolean
+        get() = iconTintColorNormal != null ||
+                iconTintColorPressed != null ||
+                iconTintColorFocused != null ||
+                iconTintColorDisabled != null
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -5,8 +5,7 @@ import android.graphics.drawable.Drawable
 /**
  * Partial update for a toolbar menu item.
  *
- * A `null` field means "leave the current value unchanged". A non-null field
- * replaces the current value on the underlying `MenuItem`.
+ * A `null` field means "leave the current value unchanged".
  */
 data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -12,7 +12,6 @@ data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
-
     val icon: StackHeaderToolbarUpdate<Drawable>?,
     val iconTintColorNormal: StackHeaderToolbarUpdate<Int>?,
     val iconTintColorPressed: StackHeaderToolbarUpdate<Int>?,
@@ -20,7 +19,8 @@ data class StackHeaderToolbarMenuItemOptions(
     val iconTintColorDisabled: StackHeaderToolbarUpdate<Int>?,
 ) {
     val requiresIconTintColorUpdate: Boolean
-        get() = iconTintColorNormal != null ||
+        get() =
+            iconTintColorNormal != null ||
                 iconTintColorPressed != null ||
                 iconTintColorFocused != null ||
                 iconTintColorDisabled != null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
@@ -2,15 +2,17 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
 sealed interface StackHeaderToolbarUpdate<out T> {
     object Reset : StackHeaderToolbarUpdate<Nothing>
-    data class Set<T>(val value: T) : StackHeaderToolbarUpdate<T>
+
+    data class Set<T>(
+        val value: T,
+    ) : StackHeaderToolbarUpdate<T>
 
     companion object {
-        fun <T : Any> from(value: T?): StackHeaderToolbarUpdate<T> {
-            return if (value != null) {
+        fun <T : Any> from(value: T?): StackHeaderToolbarUpdate<T> =
+            if (value != null) {
                 Set(value)
             } else {
                 Reset
             }
-        }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
@@ -1,0 +1,16 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+sealed interface StackHeaderToolbarUpdate<out T> {
+    object Reset : StackHeaderToolbarUpdate<Nothing>
+    data class Set<T>(val value: T) : StackHeaderToolbarUpdate<T>
+
+    companion object {
+        fun <T : Any> from(value: T?): StackHeaderToolbarUpdate<T> {
+            return if (value != null) {
+                Set(value)
+            } else {
+                Reset
+            }
+        }
+    }
+}

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -7,6 +7,7 @@ import TestStackSubviews from './test-stack-subviews-android';
 import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
 import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
+import TestStackToolbarMenuIcon from './test-stack-toolbar-menu-icon-android';
 
 const scenarios = {
   PreventNativeDismissSingleStack,
@@ -17,6 +18,7 @@ const scenarios = {
   TestStackBackButton,
   TestStackToolbarMenuCommands,
   TestStackToolbarMenuShowAsAction,
+  TestStackToolbarMenuIcon,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -1,0 +1,375 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import type { ColorValue } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuItemAndroid,
+  type StackHeaderToolbarMenuItemOptionsAndroid,
+} from 'react-native-screens/experimental';
+import type { PlatformIconAndroid } from 'react-native-screens';
+import { scenarioDescription } from './scenario-descriptions';
+
+type IdOption = 'item-1' | 'item-2' | 'item-3';
+type IconOption = 'none' | 'imageSource' | 'drawableResource';
+type TintColorOption = 'default' | 'purple' | 'red' | 'green';
+type ShowAsActionOption = 'always' | 'never' | 'ifRoom';
+
+type CmdIconOption = 'no change' | IconOption;
+type CmdTintColorOption = 'no change' | TintColorOption;
+
+const ID_OPTIONS: IdOption[] = ['item-1', 'item-2', 'item-3'];
+const ICON_OPTIONS: IconOption[] = ['none', 'imageSource', 'drawableResource'];
+const TINT_COLOR_OPTIONS: TintColorOption[] = [
+  'default',
+  'purple',
+  'red',
+  'green',
+];
+const SHOW_AS_ACTION_OPTIONS: ShowAsActionOption[] = [
+  'always',
+  'never',
+  'ifRoom',
+];
+
+const CMD_ICON_OPTIONS: CmdIconOption[] = ['no change', ...ICON_OPTIONS];
+const CMD_TINT_COLOR_OPTIONS: CmdTintColorOption[] = [
+  'no change',
+  ...TINT_COLOR_OPTIONS,
+];
+
+interface SlotConfig {
+  include: boolean;
+  id: IdOption;
+  icon: IconOption;
+  showAsAction: ShowAsActionOption;
+  tintColorNormal: TintColorOption;
+  tintColorPressed: TintColorOption;
+  tintColorFocused: TintColorOption;
+  tintColorDisabled: TintColorOption;
+}
+
+type Slots = [SlotConfig, SlotConfig, SlotConfig];
+
+const SLOT_DEFAULTS: Omit<SlotConfig, 'id'> = {
+  include: true,
+  icon: 'imageSource',
+  showAsAction: 'always',
+  tintColorNormal: 'default',
+  tintColorPressed: 'default',
+  tintColorFocused: 'default',
+  tintColorDisabled: 'default',
+};
+
+const DEFAULT_SLOTS: Slots = [
+  { ...SLOT_DEFAULTS, id: 'item-1' },
+  { ...SLOT_DEFAULTS, id: 'item-2' },
+  { ...SLOT_DEFAULTS, id: 'item-3' },
+];
+
+const ITEM_TITLES: Record<IdOption, string> = {
+  'item-1': 'Item 1',
+  'item-2': 'Item 2',
+  'item-3': 'Item 3',
+};
+
+function resolveIcon(option: IconOption): PlatformIconAndroid | undefined {
+  switch (option) {
+    case 'imageSource':
+      return {
+        type: 'imageSource',
+        imageSource: require('@assets/search_black.png'),
+      };
+    case 'drawableResource':
+      return {
+        type: 'drawableResource',
+        name: 'sym_call_missed',
+      };
+    default:
+      return undefined;
+  }
+}
+
+function resolveTintColor(option: TintColorOption): ColorValue | undefined {
+  switch (option) {
+    case 'purple':
+      return Colors.PurpleLight100;
+    case 'red':
+      return Colors.RedLight100;
+    case 'green':
+      return Colors.GreenLight100;
+    default:
+      return undefined;
+  }
+}
+
+function buildItems(slots: Slots): StackHeaderToolbarMenuItemAndroid[] {
+  return slots
+    .filter(s => s.include)
+    .map(s => ({
+      id: s.id,
+      title: ITEM_TITLES[s.id],
+      showAsAction: s.showAsAction,
+      icon: resolveIcon(s.icon),
+      iconTintColorNormal: resolveTintColor(s.tintColorNormal),
+      iconTintColorPressed: resolveTintColor(s.tintColorPressed),
+      iconTintColorFocused: resolveTintColor(s.tintColorFocused),
+      iconTintColorDisabled: resolveTintColor(s.tintColorDisabled),
+    }));
+}
+
+function updateSlotAt(
+  slots: Slots,
+  index: number,
+  patch: Partial<SlotConfig>,
+): Slots {
+  return slots.map((s, i) => (i === index ? { ...s, ...patch } : s)) as Slots;
+}
+
+const HEADER_TITLE = 'Toolbar Menu Icon Test';
+
+export function App() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Main',
+          Component: MainScreen,
+          options: {
+            headerConfig: {
+              title: HEADER_TITLE,
+              android: { toolbarMenuItems: buildItems(DEFAULT_SLOTS) },
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function MainScreen() {
+  const [slots, setSlots] = useState<Slots>(DEFAULT_SLOTS);
+  const [lastClicked, setLastClicked] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<IdOption>('item-1');
+  const [cmdIcon, setCmdIcon] = useState<CmdIconOption>('no change');
+  const [cmdTintColorNormal, setCmdTintColorNormal] =
+    useState<CmdTintColorOption>('no change');
+  const [cmdTintColorPressed, setCmdTintColorPressed] =
+    useState<CmdTintColorOption>('no change');
+  const [cmdTintColorFocused, setCmdTintColorFocused] =
+    useState<CmdTintColorOption>('no change');
+  const [cmdTintColorDisabled, setCmdTintColorDisabled] =
+    useState<CmdTintColorOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenuItems: buildItems(DEFAULT_SLOTS),
+          onToolbarMenuItemClicked: event =>
+            setLastClicked(event.nativeEvent.id),
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey]);
+
+  const applySlots = useCallback(
+    (next: Slots) => {
+      setSlots(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenuItems: buildItems(next),
+            onToolbarMenuItemClicked: event =>
+              setLastClicked(event.nativeEvent.id),
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdIcon !== 'no change' && {
+        icon: cmdIcon === 'none' ? undefined : resolveIcon(cmdIcon),
+      }),
+      ...(cmdTintColorNormal !== 'no change' && {
+        iconTintColorNormal: resolveTintColor(cmdTintColorNormal),
+      }),
+      ...(cmdTintColorPressed !== 'no change' && {
+        iconTintColorPressed: resolveTintColor(cmdTintColorPressed),
+      }),
+      ...(cmdTintColorFocused !== 'no change' && {
+        iconTintColorFocused: resolveTintColor(cmdTintColorFocused),
+      }),
+      ...(cmdTintColorDisabled !== 'no change' && {
+        iconTintColorDisabled: resolveTintColor(cmdTintColorDisabled),
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [
+    cmdTargetId,
+    cmdIcon,
+    cmdTintColorNormal,
+    cmdTintColorPressed,
+    cmdTintColorFocused,
+    cmdTintColorDisabled,
+  ]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<IdOption>
+        label="target id"
+        value={cmdTargetId}
+        items={ID_OPTIONS}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdIconOption>
+        label="icon"
+        value={cmdIcon}
+        items={CMD_ICON_OPTIONS}
+        onValueChange={setCmdIcon}
+      />
+      <SettingsPicker<CmdTintColorOption>
+        label="tintColorNormal"
+        value={cmdTintColorNormal}
+        items={CMD_TINT_COLOR_OPTIONS}
+        onValueChange={setCmdTintColorNormal}
+      />
+      <SettingsPicker<CmdTintColorOption>
+        label="tintColorPressed"
+        value={cmdTintColorPressed}
+        items={CMD_TINT_COLOR_OPTIONS}
+        onValueChange={setCmdTintColorPressed}
+      />
+      <SettingsPicker<CmdTintColorOption>
+        label="tintColorFocused"
+        value={cmdTintColorFocused}
+        items={CMD_TINT_COLOR_OPTIONS}
+        onValueChange={setCmdTintColorFocused}
+      />
+      <SettingsPicker<CmdTintColorOption>
+        label="tintColorDisabled"
+        value={cmdTintColorDisabled}
+        items={CMD_TINT_COLOR_OPTIONS}
+        onValueChange={setCmdTintColorDisabled}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Result</Text>
+      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+
+      <Text style={styles.heading}>Menu Items — Props</Text>
+      <SlotControls
+        slots={slots}
+        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+      />
+    </ScrollView>
+  );
+}
+
+interface SlotControlsProps {
+  slots: Slots;
+  updateSlot: (index: number, patch: Partial<SlotConfig>) => void;
+}
+
+function SlotControls({ slots, updateSlot }: SlotControlsProps) {
+  return (
+    <>
+      {slots.map((slot, i) => (
+        <React.Fragment key={i}>
+          <Text style={styles.slotLabel}>
+            Slot {i + 1} ({slot.id})
+          </Text>
+          <SettingsSwitch
+            label="include"
+            value={slot.include}
+            onValueChange={v => updateSlot(i, { include: v })}
+          />
+          <SettingsPicker<IconOption>
+            label="icon"
+            value={slot.icon}
+            items={ICON_OPTIONS}
+            onValueChange={v => updateSlot(i, { icon: v })}
+          />
+          <SettingsPicker<ShowAsActionOption>
+            label="showAsAction"
+            value={slot.showAsAction}
+            items={SHOW_AS_ACTION_OPTIONS}
+            onValueChange={v => updateSlot(i, { showAsAction: v })}
+          />
+          <SettingsPicker<TintColorOption>
+            label="tintColorNormal"
+            value={slot.tintColorNormal}
+            items={TINT_COLOR_OPTIONS}
+            onValueChange={v => updateSlot(i, { tintColorNormal: v })}
+          />
+          <SettingsPicker<TintColorOption>
+            label="tintColorPressed"
+            value={slot.tintColorPressed}
+            items={TINT_COLOR_OPTIONS}
+            onValueChange={v => updateSlot(i, { tintColorPressed: v })}
+          />
+          <SettingsPicker<TintColorOption>
+            label="tintColorFocused"
+            value={slot.tintColorFocused}
+            items={TINT_COLOR_OPTIONS}
+            onValueChange={v => updateSlot(i, { tintColorFocused: v })}
+          />
+          <SettingsPicker<TintColorOption>
+            label="tintColorDisabled"
+            value={slot.tintColorDisabled}
+            items={TINT_COLOR_OPTIONS}
+            onValueChange={v => updateSlot(i, { tintColorDisabled: v })}
+          />
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  slotLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-descriptions.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Icon',
+  key: 'test-stack-toolbar-menu-icon-android',
+  details:
+    'Tests the icon and state-aware tint props on toolbar menu items, both via props and via the setToolbarMenuItemOptions view command.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -1,0 +1,331 @@
+# Test Scenario: Stack Toolbar Menu Icon
+
+## Details
+
+**Description:** Tests the `icon` and state-aware `iconTintColor*` props on
+Android toolbar menu items. Covers both the props flow (via `toolbarMenuItems`
+prop) and the imperative command flow (via `setToolbarMenuItemOptions`). The
+props flow rebuilds all items from scratch on every update and discards all
+prior command state on all items simultaneously. The command flow merges changes
+onto individual items: absent fields preserve the current value; fields set to
+`default` reset to the regular default (not to the last value received from
+props); changes to one item never touch others.
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+TBD: E2E coverage has not been determined yet.
+
+## Prerequisites
+
+- Android emulator or device
+- To test `iconTintColorFocused`: enable **Hardware Input** in the emulator
+  settings, then use arrow keys to enable keyboard focus and press **Ctrl+Tab**
+  to move keyboard focus into the header toolbar.
+
+## Note
+
+- All three items start with `showAsAction = always` and `icon = imageSource`,
+  so they appear as action buttons directly in the toolbar (not in the overflow
+  menu).
+- `imageSource` uses `search_black.png` (black icon, transparent background).
+  `drawableResource` uses `sym_call_missed` (native white-and-red colors).
+  Applying any tint color completely overrides the icon's native colors.
+- **Native platform limitation:** if `iconTintColorNormal` is left at its
+  default (undefined) but any other state tint (`Pressed`, `Focused`,
+  `Disabled`) is explicitly set, the icon becomes invisible in the normal state.
+  This is Android platform behavior, not a library bug. Always set
+  `iconTintColorNormal` alongside other state tints if you want the icon visible
+  in the normal state.
+- `iconTintColorDisabled` requires a disabled item. This isn't supported yet, so
+  that prop is not exercised here.
+
+## Steps
+
+### Baseline — initial render from props
+
+1. Launch the app and navigate to **Stack Toolbar Menu Icon**.
+
+- [ ] The header shows three action icon buttons in the toolbar. Each displays
+      the `search_black.png` icon (black on transparent background). No tint is
+      applied; all icons show their default colors.
+
+---
+
+### Props — icon type
+
+2. In **Menu Items — Props**, change Slot 1 `icon` to `drawableResource`.
+
+- [ ] Item 1 changes to the `sym_call_missed` drawable (white and red). Items 2
+      and 3 remain `search_black.png`.
+
+3. Change Slot 1 `icon` to `none`.
+
+- [ ] Item 1 shows "ITEM 1" text and no icon. Items 2 and 3 are unchanged.
+
+4. Change Slot 1 `icon` back to `imageSource`.
+
+- [ ] Item 1 returns to `search_black.png`.
+
+---
+
+### Props — tint color (Normal state)
+
+5. Change Slot 1 `tintColorNormal` to `purple`.
+
+- [ ] Item 1 icon turns purple. Items 2 and 3 are unchanged.
+
+6. Change Slot 1 `tintColorNormal` to `red`.
+
+- [ ] Item 1 icon turns red immediately.
+
+7. Change Slot 1 `tintColorNormal` back to `default`.
+
+- [ ] Item 1 icon returns to its original black color (no tint).
+
+---
+
+### Props — multiple state tints (Normal + Pressed + Focused)
+
+8. Change Slot 2 `tintColorNormal` to `purple`, then `tintColorPressed` to
+   `green`, then `tintColorFocused` to `red`.
+
+- [ ] Normal: Item 2 shows purple.
+- [ ] Pressed: Press and hold Item 2 — it turns green while pressed.
+- [ ] Focused: Use Ctrl+Tab to move keyboard focus to the toolbar, navigate to
+      Item 2 — it turns red while focused.
+
+9. Change Slot 2 `tintColorNormal`, `tintColorPressed`, and `tintColorFocused`
+   all back to `default`.
+
+- [ ] Item 2 returns to its original default appearance in all interaction
+      states.
+
+---
+
+### Props — native limitation: non-Normal tint without Normal tint
+
+10. Change Slot 3 `tintColorPressed` to `red` (leave `tintColorNormal` at
+    `default`).
+
+- [ ] Item 3 icon becomes **invisible** in the normal state (Android platform
+      behavior: setting any state-specific tint without a Normal tint causes the
+      icon to disappear at rest). The tint is visible when Item 3 is pressed.
+
+11. Change Slot 3 `tintColorNormal` to `purple`.
+
+- [ ] Item 3 icon becomes visible again, showing purple at rest and red when
+      pressed.
+
+12. Change Slot 3 `tintColorNormal` and `tintColorPressed` back to `default`.
+
+- [ ] Item 3 returns to its untinted `search_black.png` appearance.
+
+---
+
+### Props — icon removed while tint is set
+
+13. Change Slot 3 `tintColorNormal` to `green`, then change Slot 3 `icon` to
+    `none`.
+
+- [ ] Item 3 shows no icon.
+
+14. Change Slot 3 `icon` back to `imageSource`.
+
+- [ ] Item 3 shows `search_black.png` with green tint already applied. The tint
+      was preserved while the icon was absent.
+
+15. Change Slot 3 `tintColorNormal` to `default`.
+
+- [ ] Item 3 returns to untinted `search_black.png`.
+
+---
+
+### Commands — no-op
+
+16. In **Send Command**, set target id = `item-1`, all fields = `no change`. Tap
+    **Send Command**.
+
+- [ ] No visible change. All items appear exactly as before.
+
+---
+
+### Commands — single tint color change
+
+17. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 turns red. Items 2 and 3 are unchanged.
+
+18. Set target id = `item-2`, `tintColorNormal` = `purple`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 2 turns purple. Items 1 and 3 are unchanged.
+
+---
+
+### Commands — native limitation: non-Normal tint without Normal tint
+
+19. Set target id = `item-3`, `tintColorPressed` = `green`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 3 becomes **invisible** in the normal state (same platform behavior
+      as in steps 10–11). It is visible (green) when pressed.
+
+20. Set target id = `item-3`, `tintColorNormal` = `purple`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 3 becomes visible again, showing purple at rest and green when
+      pressed.
+
+---
+
+### Commands — restore single tint color to default
+
+21. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 returns to no tint (original colors).
+
+---
+
+### Commands — multiple tint colors at once (Normal + Pressed + Focused)
+
+22. Set target id = `item-3`, `tintColorNormal` = `green`, `tintColorPressed` =
+    `red`, `tintColorFocused` = `purple`, all others = `no change`. Tap **Send
+    Command**.
+
+- [ ] Normal: Item 3 shows green. Item 2 still shows purple from step 18. Item 1
+      is at default.
+- [ ] Pressed: Press and hold Item 3 — it turns red.
+- [ ] Focused: Use Ctrl+Tab and keyboard to focus Item 3 — it turns purple.
+
+---
+
+### Commands — partial restore (change one, restore another, preserve third)
+
+23. Set target id = `item-3`, `tintColorNormal` = `purple`, `tintColorPressed` =
+    `no change`, `tintColorFocused` = `no change`. Tap **Send Command**.
+
+- [ ] Item 3 normal tint changes to purple. `tintColorPressed` (red) and
+      `tintColorFocused` (purple) are preserved — they were absent from the
+      options object. Pressing Item 3 still shows red.
+
+24. Set target id = `item-3`, `tintColorNormal` = `no change`,
+    `tintColorPressed` = `default`, `tintColorFocused` = `no change`. Tap
+    **Send Command**.
+
+- [ ] Item 3 normal tint remains purple (preserved). `tintColorPressed` is
+      cleared — pressing Item 3 now shows purple (falling back to
+      `tintColorNormal`) instead of the previous red. `tintColorFocused`
+      remains purple (preserved).
+
+---
+
+### Commands — change icon only (tint colors preserved)
+
+25. Set target id = `item-2`, `icon` = `drawableResource`, all tint fields = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 2 changes to the `sym_call_missed` icon. Its `tintColorNormal`
+      remains purple from step 18 — the drawable is shown in purple.
+
+---
+
+### Commands — change icon and tint color simultaneously
+
+26. Set target id = `item-1`, `icon` = `drawableResource`, `tintColorNormal` =
+    `green`, all others = `no change`. Tap **Send Command**.
+
+- [ ] Item 1 changes to `sym_call_missed` and simultaneously turns green.
+
+---
+
+### Commands — restore tint color only (icon preserved)
+
+27. Set target id = `item-1`, `tintColorNormal` = `default`, `icon` = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 `tintColorNormal` resets to the regular default (no tint). The icon
+      remains `drawableResource` — it was not included in the options object.
+
+---
+
+### Commands — restore icon to none, then restore with stored tint
+
+28. Set target id = `item-1`, `icon` = `none`, `tintColorNormal` = `no change`.
+    Tap **Send Command**.
+
+- [ ] Item 1 shows no icon.
+
+29. Set target id = `item-1`, `tintColorNormal` = `red`, `icon` = `no change`.
+    Tap **Send Command**.
+
+- [ ] Item 1 still shows no icon. The tint is stored but invisible.
+
+30. Set target id = `item-1`, `icon` = `imageSource`, `tintColorNormal` = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 shows `search_black.png` with red tint (the `tintColorNormal` set
+      in step 29 was preserved while the icon was absent and becomes visible
+      once the icon is restored).
+
+---
+
+### Commands — props update resets all command state
+
+31. At this point all three items have command overrides applied (icon and/or
+    tint changes from steps 17–30). In **Menu Items — Props**, change Slot 1
+    `tintColorNormal` from `default` to `purple` and then immediately back to
+    `default`.
+
+- [ ] Both prop changes trigger a full menu rebuild. All command-applied
+      overrides (icon and tint changes) are discarded for all three items
+      simultaneously. Items 1, 2, and 3 all revert to their props-configured
+      state: `search_black.png`, no tint.
+
+---
+
+### Commands — restore resets to global default, not prop value
+
+32. In **Menu Items — Props**, change Slot 1 `tintColorNormal` to `purple`.
+
+- [ ] Item 1 shows purple.
+
+33. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 changes to red (command override on top of the purple prop value).
+
+34. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
+    change`. Tap **Send Command**.
+
+- [ ] Item 1 shows **no tint** — the icon returns to its original colors. This
+      is the global default, not the prop value: the prop still specifies
+      `tintColorNormal = purple` for Slot 1, but the command's `default` resets
+      to the regular default (no tint) rather than restoring purple.
+
+35. In **Menu Items — Props**, change Slot 1 `tintColorNormal` back to
+    `default`.
+
+- [ ] Item 1 remains untinted (no visible change — command already set the
+      override to the global default).
+
+---
+
+### Commands — excluded item safe targeting
+
+36. In **Menu Items — Props**, toggle Slot 2 `include` to `false`.
+
+- [ ] Item 2 disappears from the toolbar.
+
+37. Set target id = `item-2`, `icon` = `drawableResource`, `tintColorNormal` =
+    `red`. Tap **Send Command**.
+
+- [ ] No crash. Items 1 and 3 are unaffected.
+
+38. Toggle Slot 2 `include` back to `true`.
+
+- [ ] Item 2 reappears with its props-configured appearance (`search_black.png`,
+      no tint). The command from step 37 did not leak into the re-included slot.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
@@ -14,12 +14,18 @@ function TintOverrideTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Tint Override</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{" "}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
-        This tab&apos;s `tabBarItemTitleFontColor`:{" "}
-        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>{'\n'}
+        Host `tabBarTintColor`:{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
         {'\n'}
-        When selected: title text should appear <Text style={{ color: Colors.RedLight100 }}>RED</Text>{'\n'} and icon should appear <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}
+        This tab&apos;s `tabBarItemTitleFontColor`:{' '}
+        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>
+        {'\n'}
+        {'\n'}
+        When selected: title text should appear{' '}
+        <Text style={{ color: Colors.RedLight100 }}>RED</Text>
+        {'\n'} and icon should appear{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
+        {'\n'}
         {'\n'}
         Confirms `tabBarItemTitleFontColor` overrides `tabBarTintColor` for the
         label but not the icon, which should still be tinted by the host config.
@@ -33,8 +39,9 @@ function FontTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Font and Position</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{" "}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
+        Host `tabBarTintColor`:{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
+        {'\n'}
         `tabBarItemTitleFontFamily`: &quot;Georgia&quot;{'\n'}
         `tabBarItemTitleFontSize`: &quot;12&quot;{'\n'}
         `tabBarItemTitleFontStyle`: &quot;italic&quot;{'\n'}
@@ -44,7 +51,11 @@ function FontTab() {
         {'\n'}
         {'\n'}
         When selected: title text should be visibly shifted upward relative to a
-        default-positioned label in <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title color for unselected tabs is <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
+        default-positioned label in{' '}
+        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
+        {'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title
+        color for unselected tabs is{' '}
+        <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
       </Text>
     </View>
   );
@@ -58,8 +69,8 @@ function LongTitleTab() {
         Tab title: &quot;A Very Long Tab Title That Should Truncate&quot;{'\n'}
         {'\n'}
         Demonstrates that `options.title` with an overly wide string is
-        truncated by the system tab bar with an ellipsis rather than wrapping
-        or overflowing.
+        truncated by the system tab bar with an ellipsis rather than wrapping or
+        overflowing.
       </Text>
     </View>
   );
@@ -110,7 +121,10 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
               tabBarItemTitleFontSize: 12,
               tabBarItemTitleFontStyle: 'italic',
               tabBarItemTitleFontWeight: '700',
-              tabBarItemTitlePositionAdjustment: { vertical: -6, horizontal: 0 },
+              tabBarItemTitlePositionAdjustment: {
+                vertical: -6,
+                horizontal: 0,
+              },
             },
             normal: {
               tabBarItemTitleFontColor: Colors.BlueDark100,
@@ -123,7 +137,12 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
 ];
 
 export function App() {
-  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} ios={{ tabBarTintColor: Colors.GreenDark100 }} />;
+  return (
+    <TabsContainerWithHostConfigContext
+      routeConfigs={ROUTE_CONFIGS}
+      ios={{ tabBarTintColor: Colors.GreenDark100 }}
+    />
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title-ios/index.tsx
@@ -14,18 +14,12 @@ function TintOverrideTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Tint Override</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
+        Host `tabBarTintColor`:{" "}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
+        This tab&apos;s `tabBarItemTitleFontColor`:{" "}
+        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>{'\n'}
         {'\n'}
-        This tab&apos;s `tabBarItemTitleFontColor`:{' '}
-        <Text style={{ color: Colors.RedLight100 }}>RedLight100</Text>
-        {'\n'}
-        {'\n'}
-        When selected: title text should appear{' '}
-        <Text style={{ color: Colors.RedLight100 }}>RED</Text>
-        {'\n'} and icon should appear{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
-        {'\n'}
+        When selected: title text should appear <Text style={{ color: Colors.RedLight100 }}>RED</Text>{'\n'} and icon should appear <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}
         {'\n'}
         Confirms `tabBarItemTitleFontColor` overrides `tabBarTintColor` for the
         label but not the icon, which should still be tinted by the host config.
@@ -39,9 +33,8 @@ function FontTab() {
     <View style={styles.screen}>
       <Text style={styles.label}>Font and Position</Text>
       <Text style={styles.hint}>
-        Host `tabBarTintColor`:{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>
-        {'\n'}
+        Host `tabBarTintColor`:{" "}
+        <Text style={{ color: Colors.GreenDark100 }}>GreenDark100</Text>{'\n'}
         `tabBarItemTitleFontFamily`: &quot;Georgia&quot;{'\n'}
         `tabBarItemTitleFontSize`: &quot;12&quot;{'\n'}
         `tabBarItemTitleFontStyle`: &quot;italic&quot;{'\n'}
@@ -51,11 +44,7 @@ function FontTab() {
         {'\n'}
         {'\n'}
         When selected: title text should be visibly shifted upward relative to a
-        default-positioned label in{' '}
-        <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>
-        {'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title
-        color for unselected tabs is{' '}
-        <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
+        default-positioned label in <Text style={{ color: Colors.GreenDark100 }}>GREEN</Text>{'\n'}bold italic Georgia at 12 pt. For iOS 18 and lower, the title color for unselected tabs is <Text style={{ color: Colors.BlueDark100 }}>BLUE</Text>
       </Text>
     </View>
   );
@@ -69,8 +58,8 @@ function LongTitleTab() {
         Tab title: &quot;A Very Long Tab Title That Should Truncate&quot;{'\n'}
         {'\n'}
         Demonstrates that `options.title` with an overly wide string is
-        truncated by the system tab bar with an ellipsis rather than wrapping or
-        overflowing.
+        truncated by the system tab bar with an ellipsis rather than wrapping
+        or overflowing.
       </Text>
     </View>
   );
@@ -121,10 +110,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
               tabBarItemTitleFontSize: 12,
               tabBarItemTitleFontStyle: 'italic',
               tabBarItemTitleFontWeight: '700',
-              tabBarItemTitlePositionAdjustment: {
-                vertical: -6,
-                horizontal: 0,
-              },
+              tabBarItemTitlePositionAdjustment: { vertical: -6, horizontal: 0 },
             },
             normal: {
               tabBarItemTitleFontColor: Colors.BlueDark100,
@@ -137,12 +123,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
 ];
 
 export function App() {
-  return (
-    <TabsContainerWithHostConfigContext
-      routeConfigs={ROUTE_CONFIGS}
-      ios={{ tabBarTintColor: Colors.GreenDark100 }}
-    />
-  );
+  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} ios={{ tabBarTintColor: Colors.GreenDark100 }} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -261,8 +261,22 @@ function parseToolbarMenuItemOptionsToNativeProps(
         case 'icon': {
           const iconValue =
             value as StackHeaderToolbarMenuItemOptionsAndroid['icon'];
-          const parsedIcon = parseIconToNativeProps(iconValue);
-          return Object.entries(parsedIcon);
+
+          // Explicit `undefined` means "reset the icon". The native side treats
+          // an absent key as "no change", so to clear the icon we must send every
+          // native icon key explicitly as `null`.
+          if (iconValue === undefined) {
+            const noIcon: Pick<
+              NativeToolbarMenuItemOptionsAndroid,
+              'imageIconResource' | 'drawableIconResourceName'
+            > = {
+              imageIconResource: null,
+              drawableIconResourceName: null,
+            };
+            return Object.entries(noIcon);
+          }
+
+          return Object.entries(parseIconToNativeProps(iconValue));
         }
       }
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -23,7 +23,7 @@ import type {
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from './StackHeaderConfig.android.types';
-import { parseIconToNativeProps } from 'react-native-screens/components/shared';
+import { parseIconToNativeProps } from '../../../shared';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -254,7 +254,7 @@ function parseToolbarMenuItemOptionsToNativeProps(
               key,
               processColor(
                 value as StackHeaderToolbarMenuItemOptionsAndroid[typeof typedKey],
-              ),
+              ) ?? null,
             ],
           ];
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -49,9 +49,12 @@ function StackHeaderConfig(
     scrollFlagEnterAlwaysCollapsed,
     scrollFlagExitUntilCollapsed,
     scrollFlagSnap,
+    toolbarMenuItems,
     ...filteredAndroidProps
   } = android ?? {};
 
+  const parsedToolbarMenuItems =
+    parseToolbarMenuItemsToNativeProps(toolbarMenuItems);
   const backButtonIconProps = parseBackButtonIconToNativeProps(backButtonIcon);
   const scrollFlagProps = resolveScrollFlags(filteredAndroidProps.type, {
     scrollFlagScroll,
@@ -66,6 +69,7 @@ function StackHeaderConfig(
       ref={ref}
       collapsable={false}
       style={StyleSheet.absoluteFill}
+      toolbarMenuItems={parsedToolbarMenuItems}
       {...baseProps}
       {...filteredAndroidProps}
       {...backButtonIconProps}
@@ -211,7 +215,28 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
   return ref;
 }
 
-// Doesn't support nested props.
+function parseToolbarMenuItemsToNativeProps(
+  items: StackHeaderConfigPropsAndroid['toolbarMenuItems'],
+): StackHeaderConfigAndroidNativeComponentProps['toolbarMenuItems'] {
+  return items?.map(
+    ({
+      icon,
+      iconTintColorNormal,
+      iconTintColorPressed,
+      iconTintColorFocused,
+      iconTintColorDisabled,
+      ...rest
+    }) => ({
+      ...rest,
+      ...parseIconToNativeProps(icon),
+      iconTintColorNormal: processColor(iconTintColorNormal),
+      iconTintColorPressed: processColor(iconTintColorPressed),
+      iconTintColorFocused: processColor(iconTintColorFocused),
+      iconTintColorDisabled: processColor(iconTintColorDisabled),
+    }),
+  );
+}
+
 function parseToolbarMenuItemOptionsToNativeProps(
   options: StackHeaderToolbarMenuItemOptionsAndroid,
 ): NativeToolbarMenuItemOptionsAndroid[] {

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -5,7 +5,7 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image, processColor, StyleSheet } from 'react-native';
 import type {
   StackHeaderConfigProps,
   StackHeaderConfigRef,
@@ -23,6 +23,7 @@ import type {
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from './StackHeaderConfig.android.types';
+import { parseIconToNativeProps } from 'react-native-screens/components/shared';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -215,7 +216,31 @@ function parseToolbarMenuItemOptionsToNativeProps(
   options: StackHeaderToolbarMenuItemOptionsAndroid,
 ): NativeToolbarMenuItemOptionsAndroid[] {
   const nativeOptions: NativeToolbarMenuItemOptionsAndroid = Object.fromEntries(
-    Object.entries(options).map(([key, value]) => {
+    Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
+      const typedKey = key as keyof StackHeaderToolbarMenuItemOptionsAndroid;
+
+      switch (typedKey) {
+        case 'iconTintColorNormal':
+        case 'iconTintColorPressed':
+        case 'iconTintColorFocused':
+        case 'iconTintColorDisabled':
+          return [
+            [
+              key,
+              processColor(
+                value as StackHeaderToolbarMenuItemOptionsAndroid[typeof typedKey],
+              ),
+            ],
+          ];
+
+        case 'icon': {
+          const iconValue =
+            value as StackHeaderToolbarMenuItemOptionsAndroid['icon'];
+          const parsedIcon = parseIconToNativeProps(iconValue);
+          return Object.entries(parsedIcon);
+        }
+      }
+
       if (
         typeof value === 'object' &&
         value !== null &&
@@ -225,10 +250,12 @@ function parseToolbarMenuItemOptionsToNativeProps(
       }
 
       return [
-        key,
-        // We need to replace explicit `undefined` with `null`
-        // so that we're able to read that information on the native side.
-        value === undefined ? null : value,
+        [
+          key,
+          // We need to replace explicit `undefined` with `null`
+          // so that we're able to read that information on the native side.
+          value === undefined ? null : value,
+        ],
       ];
     }),
   );

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -23,7 +23,7 @@ import type {
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from './StackHeaderConfig.android.types';
-import { parseIconToNativeProps } from '../../../shared';
+import { parseAndroidIconToNativeProps } from '../../../shared';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -228,7 +228,7 @@ function parseToolbarMenuItemsToNativeProps(
       ...rest
     }) => ({
       ...rest,
-      ...parseIconToNativeProps(icon),
+      ...parseAndroidIconToNativeProps(icon),
       iconTintColorNormal: processColor(iconTintColorNormal),
       iconTintColorPressed: processColor(iconTintColorPressed),
       iconTintColorFocused: processColor(iconTintColorFocused),
@@ -276,7 +276,7 @@ function parseToolbarMenuItemOptionsToNativeProps(
             return Object.entries(noIcon);
           }
 
-          return Object.entries(parseIconToNativeProps(iconValue));
+          return Object.entries(parseAndroidIconToNativeProps(iconValue));
         }
       }
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -114,6 +114,57 @@ export interface StackHeaderToolbarMenuItemAndroid {
    * @platform android
    */
   showAsAction?: StackHeaderToolbarMenuItemShowAsActionAndroid | undefined;
+  /**
+   * @summary Specifies the icon for the menu item.
+   *
+   * Supported values:
+   * - `{ type: 'imageSource', imageSource }`
+   *   Uses an image from the provided resource.
+   *
+   *   Remarks: `imageSource` type doesn't support SVGs on Android.
+   *   For loading SVGs use `drawableResource` type.
+   *
+   * - `{ type: 'drawableResource', name }`
+   *   Uses a drawable resource with the given name.
+   *
+   *   Remarks: Requires passing a drawable to resources via Android Studio.
+   *
+   * @remarks
+   * The icon will be visible only if the menu item is shown in the Toolbar.
+   *
+   * @platform android
+   */
+  icon?: PlatformIconAndroid | undefined;
+  /**
+   * @summary Specifies the tint color to apply to the menu item icon.
+   *
+   * @platform android
+   */
+  iconTintColorNormal?: ColorValue | undefined;
+  /**
+   * @summary Specifies the tint color to apply to the menu item icon when item
+   * is pressed.
+   *
+   * @platform android
+   */
+  iconTintColorPressed?: ColorValue | undefined;
+  /**
+   * @summary Specifies the tint color to apply to the menu item icon when item
+   * is focused (e.g. by keyboard navigation).
+   *
+   * @platform android
+   */
+  iconTintColorFocused?: ColorValue | undefined;
+  /**
+   * @summary Specifies the tint color to apply to the menu item icon when item
+   * is disabled.
+   *
+   * @remarks
+   * Disabling menu item isn't currently supported.
+   *
+   * @platform android
+   */
+  iconTintColorDisabled?: ColorValue | undefined;
 }
 
 export type StackHeaderToolbarMenuItemClickedEvent = {

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -145,12 +145,20 @@ export interface StackHeaderToolbarMenuItemAndroid {
    * @summary Specifies the tint color to apply to the menu item icon when item
    * is pressed.
    *
+   * @remarks
+   * Due to native platform limitations, if you set this prop, you must also
+   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
+   *
    * @platform android
    */
   iconTintColorPressed?: ColorValue | undefined;
   /**
    * @summary Specifies the tint color to apply to the menu item icon when item
    * is focused (e.g. by keyboard navigation).
+   *
+   * @remarks
+   * Due to native platform limitations, if you set this prop, you must also
+   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
    *
    * @platform android
    */
@@ -161,6 +169,9 @@ export interface StackHeaderToolbarMenuItemAndroid {
    *
    * @remarks
    * Disabling menu item isn't currently supported.
+   *
+   * Due to native platform limitations, if you set this prop, you must also
+   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
    *
    * @platform android
    */

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,5 +1,5 @@
 import { Image, type ImageResolvedAssetSource } from 'react-native';
-import { PlatformIconAndroid } from '../../types';
+import type { PlatformIconAndroid } from '../../types';
 
 export function parseIconToNativeProps(icon: PlatformIconAndroid | undefined): {
   imageIconResource?: ImageResolvedAssetSource | undefined;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,5 +1,5 @@
-import { Image, ImageResolvedAssetSource } from 'react-native';
-import { PlatformIconAndroid } from 'react-native-screens';
+import { Image, type ImageResolvedAssetSource } from 'react-native';
+import { PlatformIconAndroid } from '../../types';
 
 export function parseIconToNativeProps(icon: PlatformIconAndroid | undefined): {
   imageIconResource?: ImageResolvedAssetSource | undefined;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,7 +1,9 @@
 import { Image, type ImageResolvedAssetSource } from 'react-native';
 import type { PlatformIconAndroid } from '../../types';
 
-export function parseIconToNativeProps(icon: PlatformIconAndroid | undefined): {
+export function parseAndroidIconToNativeProps(
+  icon: PlatformIconAndroid | undefined,
+): {
   imageIconResource?: ImageResolvedAssetSource | undefined;
   drawableIconResourceName?: string | undefined;
 } {

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,0 +1,35 @@
+import { Image, ImageResolvedAssetSource } from 'react-native';
+import { PlatformIconAndroid } from 'react-native-screens';
+
+export function parseIconToNativeProps(icon: PlatformIconAndroid | undefined): {
+  imageIconResource?: ImageResolvedAssetSource | undefined;
+  drawableIconResourceName?: string | undefined;
+} {
+  if (!icon) {
+    return {};
+  }
+
+  let parsedIconResource;
+  if (icon.type === 'imageSource') {
+    parsedIconResource = Image.resolveAssetSource(icon.imageSource);
+    if (!parsedIconResource) {
+      console.error('[RNScreens] Failed to resolve an asset.');
+    }
+
+    return {
+      // I'm keeping undefined as a fallback if `Image.resolveAssetSource` has failed for some reason.
+      // It won't render any icon, but it will prevent from crashing on the native side which is expecting
+      // ReadableMap. Passing `iconResource` directly will result in crash, because `require` API is returning
+      // double as a value.
+      imageIconResource: parsedIconResource || undefined,
+    };
+  } else if (icon.type === 'drawableResource') {
+    return {
+      drawableIconResourceName: icon.name,
+    };
+  } else {
+    throw new Error(
+      '[RNScreens] Incorrect icon format for Android. You must provide `imageSource` or `drawableResource`.',
+    );
+  }
+}

--- a/src/components/tabs/screen/TabsScreen.android.tsx
+++ b/src/components/tabs/screen/TabsScreen.android.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import {
-  Image,
   ImageResolvedAssetSource,
   StyleSheet,
   processColor,
@@ -19,6 +18,7 @@ import type {
 import type { TabsScreenProps } from '../screen/TabsScreen.types';
 import type { PlatformIconAndroid } from '../../../types';
 import { useTabsScreen } from './useTabsScreen';
+import { parseIconToNativeProps } from '../../shared';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -149,41 +149,6 @@ function parseIconsToNativeProps(
     selectedDrawableIconResourceName:
       parsedSelectedIcon.drawableIconResourceName,
   };
-}
-
-function parseIconToNativeProps(icon: PlatformIconAndroid | undefined): {
-  imageIconResource?: ImageResolvedAssetSource | undefined;
-  drawableIconResourceName?: string | undefined;
-} {
-  if (!icon) {
-    return {};
-  }
-
-  let parsedIconResource;
-  if (icon.type === 'imageSource') {
-    parsedIconResource = Image.resolveAssetSource(icon.imageSource);
-    if (!parsedIconResource) {
-      console.error(
-        '[RNScreens] failed to resolve an asset for bottom tab icon',
-      );
-    }
-
-    return {
-      // I'm keeping undefined as a fallback if `Image.resolveAssetSource` has failed for some reason.
-      // It won't render any icon, but it will prevent from crashing on the native side which is expecting
-      // ReadableMap. Passing `iconResource` directly will result in crash, because `require` API is returning
-      // double as a value.
-      imageIconResource: parsedIconResource || undefined,
-    };
-  } else if (icon.type === 'drawableResource') {
-    return {
-      drawableIconResourceName: icon.name,
-    };
-  } else {
-    throw new Error(
-      '[RNScreens] Incorrect icon format for Android. You must provide `imageSource` or `drawableResource`.',
-    );
-  }
 }
 
 export default TabsScreen;

--- a/src/components/tabs/screen/TabsScreen.android.tsx
+++ b/src/components/tabs/screen/TabsScreen.android.tsx
@@ -18,7 +18,7 @@ import type {
 import type { TabsScreenProps } from '../screen/TabsScreen.types';
 import type { PlatformIconAndroid } from '../../../types';
 import { useTabsScreen } from './useTabsScreen';
-import { parseIconToNativeProps } from '../../shared';
+import { parseAndroidIconToNativeProps } from '../../shared';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -139,8 +139,8 @@ function parseIconsToNativeProps(
   selectedImageIconResource?: ImageResolvedAssetSource | undefined;
   selectedDrawableIconResourceName?: string | undefined;
 } {
-  const parsedIcon = parseIconToNativeProps(icon);
-  const parsedSelectedIcon = parseIconToNativeProps(selectedIcon);
+  const parsedIcon = parseAndroidIconToNativeProps(icon);
+  const parsedSelectedIcon = parseAndroidIconToNativeProps(selectedIcon);
 
   return {
     imageIconResource: parsedIcon.imageIconResource,

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -5,6 +5,7 @@ import type {
   CodegenTypes as CT,
   HostComponent,
   ImageSource,
+  ProcessedColorValue,
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
@@ -32,10 +33,10 @@ export interface StackHeaderToolbarMenuItemAndroid {
   >;
   drawableIconResourceName?: string | undefined;
   imageIconResource?: ImageSource | undefined;
-  iconTintColorNormal?: ColorValue | undefined;
-  iconTintColorPressed?: ColorValue | undefined;
-  iconTintColorFocused?: ColorValue | undefined;
-  iconTintColorDisabled?: ColorValue | undefined;
+  iconTintColorNormal?: ProcessedColorValue | null | undefined;
+  iconTintColorPressed?: ProcessedColorValue | null | undefined;
+  iconTintColorFocused?: ProcessedColorValue | null | undefined;
+  iconTintColorDisabled?: ProcessedColorValue | null | undefined;
 }
 
 export interface NativeProps extends ViewProps {

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -31,8 +31,8 @@ export interface StackHeaderToolbarMenuItemAndroid {
     StackHeaderToolbarMenuItemShowAsActionAndroid,
     'never'
   >;
-  drawableIconResourceName?: string | undefined;
-  imageIconResource?: ImageSource | undefined;
+  drawableIconResourceName?: string | null | undefined;
+  imageIconResource?: ImageSource | null | undefined;
   iconTintColorNormal?: ProcessedColorValue | null | undefined;
   iconTintColorPressed?: ProcessedColorValue | null | undefined;
   iconTintColorFocused?: ProcessedColorValue | null | undefined;

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -30,6 +30,12 @@ export interface StackHeaderToolbarMenuItemAndroid {
     StackHeaderToolbarMenuItemShowAsActionAndroid,
     'never'
   >;
+  drawableIconResourceName?: string | undefined;
+  imageIconResource?: ImageSource | undefined;
+  iconTintColorNormal?: ColorValue | undefined;
+  iconTintColorPressed?: ColorValue | undefined;
+  iconTintColorFocused?: ColorValue | undefined;
+  iconTintColorDisabled?: ColorValue | undefined;
 }
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
## Description

Adds support for icons and icon tinting for toolbar menu items in Stack v5 on Android.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1207.

### Details

1. I tried not to use any additional state for color state list, that's why we have some code to read the current values from menu item state.
2. Setting tint color without `normal` leads to transparent icon - that's platform limitation. If you specify any tint, we can't use original appearance of the icon. You must specify `normal` if you want to apply any tint color.
3. Applying tint color to back button will be added in separate PR.
4. Currently, we don't support making the toolbar menu item disabled - this will be added in separate PR.
5. For view command update, if we need to load the image asynchronously, we delay applying the command until the image is loaded. I think it's reasonable - we want to avoid a flash e.g. if you change both colors and icon. This however differs from regular prop behavior where we apply all props as soon as possible. When you add multiple icons, each will force the update - I did it to simplify the logic, the runtime looks reasonable as well. If it turns out to be problematic, we can consider batching these updates but we would need to refactor image loading to ensure that *something* is always returned.
6. To test "focused" state you need to enable "Hardware input" in your emulator. Select something with keyboard focus (use arrows) and then click `Ctrl+Tab` - this will move the focus to the toolbar.

## Changes

- move `parseIconToNativeProps` to `components/shared`
- add new props and process them for native props (change undefined to null, `parseColor`/`resolveAssetSource`)
- add `StackHeaderToolbarUpdate` to handle props where `null` is the default value and "no change" needs different representation from "reset to default"
- create `IconResolver` to handle icon-related logic (diffing, handling async updates)
- handle icon and color changes for both prop and view command paths
- ensure drawable is resized to 24 dp height (default icon size according to M3 spec)
- add SFT

## Before & after - visual documentation

https://github.com/user-attachments/assets/62dcf5d7-907a-4c76-9b06-44cc58505f65

## Test plan

Run `test-stack-toolbar-menu-icon-android`. Check for regressions in `test-stack-subviews-android` and `test-stack-back-button-android`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
