### PR TITLE
chore: remove Paper and unsupported RN versions leftovers

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -162,11 +162,11 @@ android {
                 "META-INF/**",
                 "**/libjsi.so",
                 "**/libc++_shared.so",
-                "**/libreact_render*.so",
-                "**/libreactnativejni.so",
-                "**/libreact_performance_timeline.so",
-                // In 0.76 multiple react-native's libraries were merged and these are the main new artifacts we're using.
-                // Some of above lib* names could be removed after we remove support for 0.76.
+                // In 0.76 multiple react-native's libraries were merged into libreactnative.so via
+                // SoMerging-utils.cmake (target_merge_so) or OBJECT libraries. Since we require RN >= 0.82
+                // (see peerDependencies), the previously listed standalone .so artifacts
+                // (libreact_render*.so, libreactnativejni.so, libreact_performance_timeline.so) no longer
+                // exist in any supported RN version and were removed from this exclude list.
                 // https://github.com/facebook/react-native/pull/43909
                 // https://github.com/facebook/react-native/pull/46059
                 "**/libfbjni.so",
@@ -209,10 +209,4 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.13.0'
     implementation "androidx.core:core-ktx:1.17.0"
-
-    constraints {
-        implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1") {
-            because("on older React Native versions this dependency conflicts with react-native-screens")
-        }
-    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,23 +153,18 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
-        // For some reason gradle only complains about the duplicated version of libreact_render libraries
-        // while there are more libraries copied in intermediates folder of the lib build directory, we exclude
-        // only the ones that make the build fail (ideally we should only include librnscreens_modules but we
-        // are only allowed to specify exclude patterns)
+        // Several RN-provided .so are copied into this library's build intermediates and can collide when
+        // the app merges native libs. We can only specify exclude (not include) patterns, so we exclude
+        // these (ideally we'd keep only librnscreens.so).
         excludes = [
                 "META-INF",
                 "META-INF/**",
                 "**/libjsi.so",
                 "**/libc++_shared.so",
-                // In 0.76 multiple react-native's libraries were merged into libreactnative.so via
-                // SoMerging-utils.cmake (target_merge_so) or OBJECT libraries. Since we require RN >= 0.82
-                // (see peerDependencies), the previously listed standalone .so artifacts
-                // (libreact_render*.so, libreactnativejni.so, libreact_performance_timeline.so) no longer
-                // exist in any supported RN version and were removed from this exclude list.
-                // https://github.com/facebook/react-native/pull/43909
-                // https://github.com/facebook/react-native/pull/46059
                 "**/libfbjni.so",
+                // RN's renderer / jni / performance-timeline libs (libreact_render*.so, libreactnativejni.so,
+                // libreact_performance_timeline.so) are merged into libreactnative.so since RN 0.76
+                // (facebook/react-native#46059), so on supported RN (>= 0.82) only libreactnative.so needs excluding.
                 "**/libreactnative.so"
         ]
     }

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -11,7 +11,6 @@
 #import <React/RCTRootComponentView.h>
 #import <React/RCTScrollViewComponentView.h>
 #import <React/RCTSurfaceTouchHandler.h>
-#import <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -8,7 +8,6 @@
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/UIView+React.h>
 #import <ReactCommon/TurboModuleUtils.h>
-#import <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/components/image/ImageProps.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>

--- a/ios/RNSScreenStackHeaderSubview.mm
+++ b/ios/RNSScreenStackHeaderSubview.mm
@@ -3,7 +3,6 @@
 #import "RNSDefines.h"
 #import "RNSScreenStackHeaderConfig.h"
 
-#import <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -1,5 +1,4 @@
 #import <React/RCTConversions.h>
-#import <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
 #import "RNSConversions.h"
 #import "RNSDefines.h"

--- a/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
+++ b/ios/gamma/split/RNSSplitScreenShadowStateProxy.mm
@@ -3,7 +3,6 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTConversions.h>
-#import <cxxreact/ReactNativeVersion.h>
 #import <rnscreens/RNSSplitScreenShadowNode.h>
 
 namespace react = facebook::react;

--- a/ios/safe-area/RNSSafeAreaViewComponentView.mm
+++ b/ios/safe-area/RNSSafeAreaViewComponentView.mm
@@ -7,7 +7,6 @@
 #import "RNSSafeAreaProviding.h"
 #import "RNSSafeAreaViewNotifications.h"
 
-#import <cxxreact/ReactNativeVersion.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/Props.h>
 #import <rnscreens/RNSSafeAreaViewComponentDescriptor.h>

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
@@ -6,8 +6,6 @@
 
 #if defined(__cplusplus)
 
-#import <cxxreact/ReactNativeVersion.h>
-
 #endif // defined(__cplusplus)
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.h
@@ -4,10 +4,6 @@
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"
 
-#if defined(__cplusplus)
-
-#endif // defined(__cplusplus)
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSTabsBottomAccessoryContentComponentView : RNSReactBaseView

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -4,7 +4,6 @@
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 #import <React/RCTAssert.h>
-#import <cxxreact/ReactNativeVersion.h>
 
 namespace react = facebook::react;
 

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -221,7 +221,6 @@ function getPositioningStyle(
   presentation: StackPresentationTypes,
 ) {
   const isIOS = Platform.OS === 'ios';
-  const rnMinorVersion = Platform.constants.reactNativeVersion.minor;
 
   if (presentation !== 'formSheet') {
     return styles.container;
@@ -230,7 +229,6 @@ function getPositioningStyle(
   if (isIOS) {
     if (
       allowedDetents !== 'fitToContents' &&
-      rnMinorVersion >= 82 &&
       featureFlags.experiment.synchronousScreenUpdatesEnabled
     ) {
       return styles.container;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -90,9 +90,6 @@ function SearchBar(
     return View as unknown as React.ReactNode;
   }
 
-  // This is necessary only for legacy architecture (Paper).
-  const parsedProps = parseUndefinedPropsToSystemDefault(props);
-
   const {
     obscureBackground,
     hideNavigationBar,
@@ -102,7 +99,7 @@ function SearchBar(
     onCancelButtonPress,
     onChangeText,
     ...rest
-  } = parsedProps;
+  } = props;
 
   return (
     <NativeSearchBar
@@ -125,14 +122,6 @@ function SearchBar(
       onChangeText={onChangeText as CT.DirectEventHandler<ChangeTextEvent>}
     />
   );
-}
-
-// This function is necessary for legacy architecture (Paper) to ensure
-// consistent behavior for props with `systemDefault` option.
-function parseUndefinedPropsToSystemDefault(
-  props: SearchBarProps,
-): SearchBarProps {
-  return { ...props, autoCapitalize: props.autoCapitalize ?? 'systemDefault' };
 }
 
 export default React.forwardRef<SearchBarCommands, SearchBarProps>(SearchBar);

--- a/src/components/tabs/host/TabsHost.ios.tsx
+++ b/src/components/tabs/host/TabsHost.ios.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import React, { useState } from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
 import TabsHostIOSNativeComponent, {
   type NativeProps as TabsHostIOSNativeComponentProps,
 } from '../../../fabric/tabs/TabsHostIOSNativeComponent';
 import type { TabsHostProps } from './TabsHost.types';
 import { RNSLog } from '../../../private';
 import TabsBottomAccessory from '../bottom-accessory/TabsBottomAccessory';
-import { TabsBottomAccessoryEnvironment } from '../bottom-accessory/TabsBottomAccessory.types';
 import TabsBottomAccessoryContent from '../bottom-accessory/TabsBottomAccessoryContent';
 import { isIOS26OrHigher } from '../../helpers/PlatformUtils';
 import { useTabsHost } from './useTabsHost';
@@ -41,9 +40,6 @@ function TabsHost(props: TabsHostProps) {
       onTabSelected,
     });
 
-  const [bottomAccessoryEnvironment, setBottomAccessoryEnvironment] =
-    useState<TabsBottomAccessoryEnvironment>('regular');
-
   return (
     <TabsHostIOSNativeComponent
       style={styles.fillParent}
@@ -60,25 +56,16 @@ function TabsHost(props: TabsHostProps) {
       tabBarTintColor={ios?.tabBarTintColor}
       onMoreTabSelected={ios?.onMoreTabSelected}>
       {children}
-      {ios?.bottomAccessory &&
-        isIOS26OrHigher &&
-        (Platform.constants.reactNativeVersion.minor >= 82 ? (
-          <TabsBottomAccessory>
-            <TabsBottomAccessoryContent environment="regular">
-              {ios.bottomAccessory('regular')}
-            </TabsBottomAccessoryContent>
-            <TabsBottomAccessoryContent environment="inline">
-              {ios.bottomAccessory('inline')}
-            </TabsBottomAccessoryContent>
-          </TabsBottomAccessory>
-        ) : (
-          <TabsBottomAccessory
-            onEnvironmentChange={event => {
-              setBottomAccessoryEnvironment(event.nativeEvent.environment);
-            }}>
-            {ios.bottomAccessory(bottomAccessoryEnvironment)}
-          </TabsBottomAccessory>
-        ))}
+      {ios?.bottomAccessory && isIOS26OrHigher && (
+        <TabsBottomAccessory>
+          <TabsBottomAccessoryContent environment="regular">
+            {ios.bottomAccessory('regular')}
+          </TabsBottomAccessoryContent>
+          <TabsBottomAccessoryContent environment="inline">
+            {ios.bottomAccessory('inline')}
+          </TabsBottomAccessoryContent>
+        </TabsBottomAccessory>
+      )}
     </TabsHostIOSNativeComponent>
   );
 }

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -83,15 +83,11 @@ export interface TabsHostPropsIOS {
    *
    * If this prop is `undefined`, the bottom accessory will not be rendered.
    *
-   * On legacy architecture (Paper) and on new architecture (Fabric) with RN < 0.82,
-   * implementation uses DisplayLink which might result in the size of bottom
-   * accessory being updated with a delay.
-   *
-   * Starting from RN 0.82, this issue is mitigated but in order to allow accessory
-   * rendering based on environment, component is rendered 2 times for both `regular`
-   * and `inline` environments at the same time. Environment determines which component
-   * is visible at given moment. This might require implementing a solution to share
-   * state between both rendered components (e.g. usage of context).
+   * In order to allow accessory rendering based on environment, the component is
+   * rendered 2 times for both `regular` and `inline` environments at the same time.
+   * Environment determines which component is visible at given moment. This might
+   * require implementing a solution to share state between both rendered components
+   * (e.g. usage of context).
    *
    * Available starting from iOS 26.
    *


### PR DESCRIPTION
## Description

This PR removes leftovers of Paper or not supported anymore React Native versions - related code.

For `android/build.gradle` this means:
- `libreact_render*.so`, `libreactnativejni.so` and `libreact_performance_timeline.so` were dropped from `packagingOptions.excludes` — these libraries were merged into `libreactnative.so` in RN 0.76.
- the `lifecycle-viewmodel-ktx:2.5.1` constraints block was removed — it fixed a duplicate-class conflict (`androidx.lifecycle.ViewModelLazy`) on older RN versions


## Changes

- `SearchBar.tsx`: removed the Paper-only `parseUndefinedPropsToSystemDefault` which made `autoCapitalize` `'systemDefault'` if undefined
- `android/build.gradle`: modified accordingly to the description above
- `#import <cxxreact/ReactNativeVersion.h>` removed from several files
- `ScreenStackItem.tsx`, `TabsHost.ios.tsx`: removed conditions related to RN < 0.82
- `TabsHost.ios.types.ts`: updated a comment

## Before & after - visual documentation

N/A

## Test plan

Build example apps.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
