### PR TITLE
fix(iOS, Tabs): weak-capture tab bar item and screen view in async image callbacks

### DIFF
--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -92,16 +92,30 @@
   } else if (imageLoader != nil) {
     bool isTemplate = screenView.iconType == RNSTabsIconTypeTemplate;
 
+    // Weak-capture to avoid updating a tab bar item whose internal
+    // view hierarchy has been torn down (iOS 26 UIKit regression:
+    // unowned refs inside UITabBarItem._updateViewAndPositionItems:).
+    __weak UITabBarItem *weakTabBarItem = tabBarItem;
+    __weak RNSTabsScreenComponentView *weakScreenView = screenView;
+
     // Normal icon
     if (screenView.iconImageSource != nil) {
       [RNSImageLoadingHelper loadImageFromSource:screenView.iconImageSource
                                  withImageLoader:imageLoader
                                       asTemplate:isTemplate
                                  completionBlock:^(UIImage *image) {
-                                   [self updateTabBarItem:tabBarItem
+                                   UITabBarItem *strongItem = weakTabBarItem;
+                                   RNSTabsScreenComponentView *strongView = weakScreenView;
+                                   if (strongItem == nil || strongView == nil) {
+                                     return;
+                                   }
+                                   if (![strongView.controller.parentViewController isKindOfClass:[UITabBarController class]]) {
+                                     return;
+                                   }
+                                   [self updateTabBarItem:strongItem
                                                 withImage:image
                                                isSelected:NO
-                                            forScreenView:screenView];
+                                            forScreenView:strongView];
                                  }];
     } else {
       tabBarItem.image = nil;
@@ -113,10 +127,18 @@
                                  withImageLoader:imageLoader
                                       asTemplate:isTemplate
                                  completionBlock:^(UIImage *image) {
-                                   [self updateTabBarItem:tabBarItem
+                                   UITabBarItem *strongItem = weakTabBarItem;
+                                   RNSTabsScreenComponentView *strongView = weakScreenView;
+                                   if (strongItem == nil || strongView == nil) {
+                                     return;
+                                   }
+                                   if (![strongView.controller.parentViewController isKindOfClass:[UITabBarController class]]) {
+                                     return;
+                                   }
+                                   [self updateTabBarItem:strongItem
                                                 withImage:image
                                                isSelected:YES
-                                            forScreenView:screenView];
+                                            forScreenView:strongView];
                                  }];
     } else {
       tabBarItem.selectedImage = nil;

--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -104,18 +104,10 @@
                                  withImageLoader:imageLoader
                                       asTemplate:isTemplate
                                  completionBlock:^(UIImage *image) {
-                                   UITabBarItem *strongItem = weakTabBarItem;
-                                   RNSTabsScreenComponentView *strongView = weakScreenView;
-                                   if (strongItem == nil || strongView == nil) {
-                                     return;
-                                   }
-                                   if (![strongView.controller.parentViewController isKindOfClass:[UITabBarController class]]) {
-                                     return;
-                                   }
-                                   [self updateTabBarItem:strongItem
+                                   [self updateTabBarItem:weakTabBarItem
                                                 withImage:image
                                                isSelected:NO
-                                            forScreenView:strongView];
+                                            forScreenView:weakScreenView];
                                  }];
     } else {
       tabBarItem.image = nil;
@@ -127,18 +119,10 @@
                                  withImageLoader:imageLoader
                                       asTemplate:isTemplate
                                  completionBlock:^(UIImage *image) {
-                                   UITabBarItem *strongItem = weakTabBarItem;
-                                   RNSTabsScreenComponentView *strongView = weakScreenView;
-                                   if (strongItem == nil || strongView == nil) {
-                                     return;
-                                   }
-                                   if (![strongView.controller.parentViewController isKindOfClass:[UITabBarController class]]) {
-                                     return;
-                                   }
-                                   [self updateTabBarItem:strongItem
+                                   [self updateTabBarItem:weakTabBarItem
                                                 withImage:image
                                                isSelected:YES
-                                            forScreenView:strongView];
+                                            forScreenView:weakScreenView];
                                  }];
     } else {
       tabBarItem.selectedImage = nil;
@@ -148,11 +132,23 @@
   }
 }
 
-- (void)updateTabBarItem:(UITabBarItem *)tabBarItem
-               withImage:(UIImage *)image
+- (void)updateTabBarItem:(nullable UITabBarItem *)tabBarItem
+               withImage:(nullable UIImage *)image
               isSelected:(BOOL)isSelected
-           forScreenView:(RNSTabsScreenComponentView *)screenView
+           forScreenView:(nullable RNSTabsScreenComponentView *)screenView
 {
+  // This method is sometimes called from an asynchronous context and we got reports
+  // that on iOS 26+ it can happen that the tab bar item is already nullish, or the
+  // screen's controller is not attached to the UITabBarController.
+  if (tabBarItem == nil || screenView == nil) {
+    return;
+  }
+
+  UIViewController *screenParentViewController = [screenView.controller parentViewController];
+  if (screenParentViewController == nil) {
+    return;
+  }
+
   if (isSelected) {
     tabBarItem.selectedImage = image;
   } else {
@@ -164,9 +160,8 @@
   // This code handles case where image passed by the user is not
   // of appropriate size & needs to be readjusted. W/o additional
   // layout here the icon would be displayed with original dimensions.
-  UIViewController *parent = screenView.controller.parentViewController;
-  if ([parent isKindOfClass:[UITabBarController class]]) {
-    UITabBarController *tabBarVC = (UITabBarController *)parent;
+  if ([screenParentViewController isKindOfClass:[UITabBarController class]]) {
+    UITabBarController *tabBarVC = (UITabBarController *)screenParentViewController;
     [tabBarVC.tabBar setNeedsLayout];
   }
 }


### PR DESCRIPTION
## Description

Avoid updating a tab bar item whose internal view hierarchy has been
torn down. This works around an iOS 26 UIKit regression where unowned
refs inside UITabBarItem._updateViewAndPositionItems: cause crashes.

Both the normal icon and selected icon completion blocks now:
1. Weak-capture tabBarItem and screenView before the block
2. Promote to strong refs inside the block and bail if either is nil
3. Guard that the screen's controller is still parented by a UITabBarController

## Before & after - visual documentation

TBA

## Test plan

Discussed offline

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
