### PR TITLE
fix(Android): fix translucent header first layout correction

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -101,7 +101,10 @@ void RNSScreenShadowNode::appendChild(
           *std::static_pointer_cast<const RNSScreenStackHeaderConfigProps>(
               headerConfigChild->getProps());
 
-      const auto headerHeight = headerProps.hidden
+      // Translucent headers do not reserve vertical space, so applying the
+      // estimated header correction can expose the previous screen at the
+      // bottom during the first Fabric layout.
+      const auto headerHeight = (headerProps.hidden || headerProps.translucent)
           ? 0.f
           : findHeaderHeight(
                 headerProps.titleFontSize, headerProps.title.empty())


### PR DESCRIPTION
## Summary
- Skip the Android Fabric first-layout header-height correction when the header config is translucent.
- Keep translucent header layout consistent with the native/header-config behavior so the screen is not temporarily shortened during transitions.

## Root cause
On the first Fabric layout, before Android has sent the native screen dimensions back through state, `RNSScreenShadowNode` estimates the native header height and applies padding/frame corrections. Translucent headers do not reserve that vertical space on the native side, so applying the estimate can briefly shrink the screen and reveal the previous screen at the bottom during the transition.

## Validation
- `yarn check-types`
- `yarn lint-android`
- `cd FabricExample/android && ./gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a`

Fixes #3530