### PR TITLE
Fix iOS orientation updates during transitions

### DIFF
--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -97,11 +97,83 @@
 }
 #endif
 
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) && !TARGET_OS_TV && !TARGET_OS_VISION
++ (UIWindowScene *)windowSceneForOrientationUpdate
+{
+  UIWindow *keyWindow = RCTKeyWindow();
+  if (keyWindow.windowScene != nil) {
+    return keyWindow.windowScene;
+  }
+
+  // When an app supports multiple scenes (e.g. CarPlay), it is possible that
+  // UIWindowScene is not the first scene, or it may not be present at all.
+  NSArray *connectedScenes = [[[UIApplication sharedApplication] connectedScenes] allObjects];
+  for (id connectedScene in connectedScenes) {
+    if ([connectedScene isKindOfClass:[UIWindowScene class]]) {
+      return connectedScene;
+    }
+  }
+
+  return nil;
+}
+
++ (void)setNeedsUpdateOfSupportedInterfaceOrientations
+{
+  UIViewController *topController = RCTKeyWindow().rootViewController;
+  while (topController.presentedViewController) {
+    topController = topController.presentedViewController;
+  }
+
+  [topController setNeedsUpdateOfSupportedInterfaceOrientations];
+}
+
++ (void)requestGeometryUpdateForOrientationMask:(UIInterfaceOrientationMask)orientationMask
+{
+  UIWindowScene *scene = [RNSScreenWindowTraits windowSceneForOrientationUpdate];
+  if (scene == nil) {
+    return;
+  }
+
+  [RNSScreenWindowTraits setNeedsUpdateOfSupportedInterfaceOrientations];
+
+  UIWindowSceneGeometryPreferencesIOS *geometryPreferences =
+      [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientationMask];
+  [scene
+      requestGeometryUpdateWithPreferences:geometryPreferences
+                              errorHandler:^(NSError *_Nonnull error) {
+                                dispatch_async(dispatch_get_main_queue(), ^{
+                                  [RNSScreenWindowTraits setNeedsUpdateOfSupportedInterfaceOrientations];
+
+                                  UIWindowSceneGeometryPreferencesIOS *retryGeometryPreferences =
+                                      [[UIWindowSceneGeometryPreferencesIOS alloc]
+                                          initWithInterfaceOrientations:orientationMask];
+                                  [scene
+                                      requestGeometryUpdateWithPreferences:retryGeometryPreferences
+                                                              errorHandler:^(NSError *_Nonnull retryError) {
+                                                                RCTLogWarn(
+                                                                    @"[RNScreens] Failed to update interface orientation: %@",
+                                                                    retryError);
+                                                              }];
+                                });
+                              }];
+}
+#endif
+
 + (void)enforceDesiredDeviceOrientation
 {
 #if !TARGET_OS_TV && !TARGET_OS_VISION
   dispatch_async(dispatch_get_main_queue(), ^{
     UIInterfaceOrientationMask orientationMask = [RCTKeyWindow().rootViewController supportedInterfaceOrientations];
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+    if (@available(iOS 16.0, *)) {
+      // On iOS 16+ geometry updates are idempotent and should be driven by the
+      // desired mask directly. The scene's current interfaceOrientation may be
+      // stale during navigation transitions or after scene restoration.
+      [RNSScreenWindowTraits requestGeometryUpdateForOrientationMask:orientationMask];
+      return;
+    }
+#endif // Check for iOS 16
 
     UIInterfaceOrientation currentDeviceOrientation =
         [RNSScreenWindowTraits interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
@@ -128,44 +200,8 @@
       }
     }
     if (newOrientation != UIInterfaceOrientationUnknown) {
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-      if (@available(iOS 16.0, *)) {
-        NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
-
-        // when an app supports multiple scenes (e.g. CarPlay), it is possible that
-        // UIWindowScene is not the first scene, or it may not be present at all
-        UIWindowScene *scene = nil;
-        for (id connectedScene in array) {
-          if ([connectedScene isKindOfClass:[UIWindowScene class]]) {
-            scene = connectedScene;
-            break;
-          }
-        }
-
-        if (scene == nil) {
-          return;
-        }
-
-        UIWindowSceneGeometryPreferencesIOS *geometryPreferences =
-            [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientationMask];
-        [scene requestGeometryUpdateWithPreferences:geometryPreferences
-                                       errorHandler:^(NSError *_Nonnull error){
-                                       }];
-
-        // `attemptRotationToDeviceOrientation` is deprecated for modern OS versions
-        // so we need to use `setNeedsUpdateOfSupportedInterfaceOrientations`
-        UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
-        while (topController.presentedViewController) {
-          topController = topController.presentedViewController;
-        }
-
-        [topController setNeedsUpdateOfSupportedInterfaceOrientations];
-      } else
-#endif // Check for iOS 16
-      {
-        [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
-        [UIViewController attemptRotationToDeviceOrientation];
-      }
+      [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
+      [UIViewController attemptRotationToDeviceOrientation];
     }
   });
 #endif // !TARGET_TV_OS

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -98,7 +98,7 @@
 #endif
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) && !TARGET_OS_TV && !TARGET_OS_VISION
-+ (UIWindowScene *)windowSceneForOrientationUpdate
++ (UIWindowScene *)windowSceneForOrientationUpdate API_AVAILABLE(ios(16.0))
 {
   UIWindow *keyWindow = RCTKeyWindow();
   if (keyWindow.windowScene != nil) {
@@ -117,45 +117,74 @@
   return nil;
 }
 
-+ (void)setNeedsUpdateOfSupportedInterfaceOrientations
++ (UIViewController *)topViewControllerFromRootViewController:(UIViewController *)rootViewController
 {
-  UIViewController *topController = RCTKeyWindow().rootViewController;
+  UIViewController *topController = rootViewController;
   while (topController.presentedViewController) {
     topController = topController.presentedViewController;
   }
 
-  [topController setNeedsUpdateOfSupportedInterfaceOrientations];
+  return topController;
 }
 
-+ (void)requestGeometryUpdateForOrientationMask:(UIInterfaceOrientationMask)orientationMask
++ (UIViewController *)topViewControllerForOrientationUpdateInScene:(UIWindowScene *)scene API_AVAILABLE(ios(16.0))
 {
-  UIWindowScene *scene = [RNSScreenWindowTraits windowSceneForOrientationUpdate];
-  if (scene == nil) {
-    return;
+  UIWindow *keyWindow = RCTKeyWindow();
+  if (keyWindow.windowScene == scene) {
+    return [RNSScreenWindowTraits topViewControllerFromRootViewController:keyWindow.rootViewController];
   }
 
-  [RNSScreenWindowTraits setNeedsUpdateOfSupportedInterfaceOrientations];
+  for (UIWindow *window in scene.windows) {
+    if (window.isKeyWindow) {
+      return [RNSScreenWindowTraits topViewControllerFromRootViewController:window.rootViewController];
+    }
+  }
 
-  UIWindowSceneGeometryPreferencesIOS *geometryPreferences =
-      [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientationMask];
-  [scene
-      requestGeometryUpdateWithPreferences:geometryPreferences
-                              errorHandler:^(NSError *_Nonnull error) {
-                                dispatch_async(dispatch_get_main_queue(), ^{
-                                  [RNSScreenWindowTraits setNeedsUpdateOfSupportedInterfaceOrientations];
+  for (UIWindow *window in scene.windows) {
+    if (window.rootViewController != nil) {
+      return [RNSScreenWindowTraits topViewControllerFromRootViewController:window.rootViewController];
+    }
+  }
 
-                                  UIWindowSceneGeometryPreferencesIOS *retryGeometryPreferences =
-                                      [[UIWindowSceneGeometryPreferencesIOS alloc]
-                                          initWithInterfaceOrientations:orientationMask];
-                                  [scene
-                                      requestGeometryUpdateWithPreferences:retryGeometryPreferences
-                                                              errorHandler:^(NSError *_Nonnull retryError) {
-                                                                RCTLogWarn(
-                                                                    @"[RNScreens] Failed to update interface orientation: %@",
-                                                                    retryError);
-                                                              }];
-                                });
-                              }];
+  return nil;
+}
+
++ (void)requestGeometryUpdateForOrientationMask:(UIInterfaceOrientationMask)orientationMask API_AVAILABLE(ios(16.0))
+{
+  if (@available(iOS 16.0, *)) {
+    UIWindowScene *scene = [RNSScreenWindowTraits windowSceneForOrientationUpdate];
+    if (scene == nil) {
+      return;
+    }
+
+    UIViewController *topController = [RNSScreenWindowTraits topViewControllerForOrientationUpdateInScene:scene];
+    if (topController == nil) {
+      return;
+    }
+
+    [topController setNeedsUpdateOfSupportedInterfaceOrientations];
+
+    UIWindowSceneGeometryPreferencesIOS *geometryPreferences =
+        [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientationMask];
+    [scene
+        requestGeometryUpdateWithPreferences:geometryPreferences
+                                errorHandler:^(NSError *_Nonnull error) {
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                    [topController setNeedsUpdateOfSupportedInterfaceOrientations];
+
+                                    UIWindowSceneGeometryPreferencesIOS *retryGeometryPreferences =
+                                        [[UIWindowSceneGeometryPreferencesIOS alloc]
+                                            initWithInterfaceOrientations:orientationMask];
+                                    [scene
+                                        requestGeometryUpdateWithPreferences:retryGeometryPreferences
+                                                                errorHandler:^(NSError *_Nonnull retryError) {
+                                                                  RCTLogWarn(
+                                                                      @"[RNScreens] Failed to update interface orientation: %@",
+                                                                      retryError);
+                                                                }];
+                                  });
+                                }];
+  }
 }
 #endif
 


### PR DESCRIPTION
## Summary
- On iOS 16+, request orientation geometry updates from the desired supported-orientation mask directly instead of first relying on `windowScene.interfaceOrientation`.
- Refresh the top view controller's supported-orientation state before requesting geometry updates.
- Retry a failed geometry update once on the next main-queue turn and warn if UIKit still rejects it, instead of silently swallowing the failure.

## Root cause
`enforceDesiredDeviceOrientation` gated iOS 16+ `requestGeometryUpdate` behind a pre-iOS-16 heuristic that compares the current device and scene interface orientations. During navigation transitions, scene restoration, or after previous geometry updates, `windowScene.interfaceOrientation` can be stale. When the stale orientation still appears to satisfy the new mask, the method skips the iOS 16+ geometry request completely.

UIKit may also reject a transition-time request while its supported-orientation cache still reflects the outgoing screen. The previous error handler was empty, so these failed requests disappeared without another attempt.

## Reproduction
This is easiest to reproduce with the Expo repro from the issue because it exercises native-stack per-screen orientation changes during a real iOS transition.

1. `git clone https://github.com/JeanDes-Code/orientation-lock-repro`
2. `cd orientation-lock-repro`
3. `npm install`
4. Delete `patches/react-native-screens+4.23.0.patch` so the app runs against unpatched react-native-screens. The `expo-screen-orientation` patch can remain.
5. `npm install`
6. `npx expo prebuild --clean`
7. `npx expo run:ios`
8. Tap **Go to Landscape (Option C)**. This navigates to a native-stack screen with `options={{ orientation: 'landscape_right' }}`.
9. Tap **Go Back**. The app should return to portrait, but without this fix it can stay stuck in landscape.
10. Repeat the landscape/back cycle once or twice. The orientation lock can then fail in both directions.

The app-level repro is equivalent to this single-file native-stack setup:

```tsx
import React from 'react';
import { Button, View } from 'react-native';
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';

const Stack = createNativeStackNavigator();

function PortraitScreen({ navigation }) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Button
        title="Go to Landscape"
        onPress={() => navigation.push('Landscape')}
      />
    </View>
  );
}

function LandscapeScreen({ navigation }) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Button title="Go Back" onPress={() => navigation.goBack()} />
    </View>
  );
}

export default function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator screenOptions={{ orientation: 'portrait' }}>
        <Stack.Screen name="Portrait" component={PortraitScreen} />
        <Stack.Screen
          name="Landscape"
          component={LandscapeScreen}
          options={{ orientation: 'landscape_right' }}
        />
      </Stack.Navigator>
    </NavigationContainer>
  );
}
```

## Validation
- `yarn check-types`
- `yarn lint-swift`
- `xcodebuild -workspace FabricExample/ios/FabricExample.xcworkspace -scheme FabricExample -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=latest" -derivedDataPath /Users/sorincioban/Library/Developer/Xcode/DerivedData/RNScreensOSS CODE_SIGNING_ALLOWED=NO build`

Fixes #3831
