### PR TITLE
refactor(docs): update systemitem type documentation

### DIFF
--- a/src/components/tabs/screen/TabsScreen.ios.types.ts
+++ b/src/components/tabs/screen/TabsScreen.ios.types.ts
@@ -266,8 +266,11 @@ export interface TabsScreenPropsIOS {
    *
    * Uses Apple's built-in tab bar items (e.g., bookmarks, contacts, downloads) with
    * standard iOS styling and localized titles. Custom `icon` or `selectedIcon`
-   * properties will override the system icon, but the system-defined title cannot
-   * be customized.
+   * properties will override the system icon, and the system-defined title can be
+   * overridden by providing a custom `title`.
+   *
+   * @remarks
+   * On iOS 26, `systemItem: 'search'` acts as a detached tab bar item, which does not display any title (system or custom).
    *
    * @see {@link https://developer.apple.com/documentation/uikit/uitabbaritem/systemitem|UITabBarItem.SystemItem}
    *


### PR DESCRIPTION
## Description

This PR updates the documentation for the `systemItem` type in `TabsScreen.ios.types.ts`. 

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1504

## Changes

Since PR #3333, we are able to override the system-defined title.
- Updated the information regarding title customization to describe how it can be overridden (replacing the previous "cannot be customized" statement).
- Added a `@remarks` section detailing the specific behavior of `systemItem: 'search'` on iOS 26.