### PR TITLE
feat(iOS, FormSheet v5): Add support for nativeContainerStyle

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -6,6 +6,7 @@ import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index-ios';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events-ios';
+import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style-ios';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state-ios';
@@ -19,6 +20,7 @@ const scenarios = {
   TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,
   TestFormSheetLifecycleEvents,
+  TestFormSheetNativeContainerStyle,
   TestFormSheetOnDetentChanged,
   TestFormSheetPreferredCornerRadius,
   TestFormSheetPresentationState,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/index.tsx
@@ -1,0 +1,193 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ColorValue,
+} from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [nativeColor, setNativeColor] = useState<ColorValue>(
+    Colors.NavyLight100,
+  );
+
+  const handleDismiss = () => {
+    setIsOpen(false);
+  };
+
+  const colorOptions: { name: string; value: ColorValue }[] = [
+    { name: 'NAVY', value: Colors.NavyLight100 },
+    { name: 'TRANSPARENT', value: 'transparent' },
+  ];
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Native Container Style</Text>
+
+      <View style={styles.controlsContainer}>
+        <Text style={styles.controlsLabel}>
+          Select Native Background Color:
+        </Text>
+        <View style={styles.buttonRow}>
+          {colorOptions.map(option => (
+            <TouchableOpacity
+              key={option.name}
+              style={[
+                styles.optionButton,
+                nativeColor === option.value && styles.optionButtonActive,
+              ]}
+              onPress={() => setNativeColor(option.value)}>
+              <Text
+                style={[
+                  styles.optionText,
+                  nativeColor === option.value && styles.optionTextActive,
+                ]}>
+                {option.name}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.spacing} />
+
+      <Button
+        title="Open FormSheet"
+        color={Colors.primary}
+        onPress={() => setIsOpen(true)}
+      />
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={handleDismiss}
+        detents="fitToContents"
+        nativeContainerStyle={{ backgroundColor: nativeColor }}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>Native Container</Text>
+
+          <Text style={styles.description}>
+            This sheet dynamically wraps its content, but the background color
+            is applied directly to the underlying native UIView.
+          </Text>
+
+          <View style={styles.spacing} />
+
+          <Button
+            title={isExpanded ? 'Collapse Content' : 'Expand Content'}
+            color={Colors.White}
+            onPress={() => setIsExpanded(!isExpanded)}
+          />
+
+          {isExpanded && (
+            <View style={styles.extraContentBox}>
+              <Text style={styles.extraText}>
+                Notice how the native background seamlessly fills the entire
+                sheet, including the un-collapsible bottom safe area, without
+                relying on Yoga layouts.
+              </Text>
+            </View>
+          )}
+
+          <View style={styles.spacing} />
+
+          <Button
+            title="Dismiss from JS"
+            color={Colors.White}
+            onPress={handleDismiss}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  controlsContainer: {
+    paddingHorizontal: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  controlsLabel: {
+    fontSize: 14,
+    color: Colors.text,
+    marginBottom: 8,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  optionButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: Colors.primary,
+  },
+  optionButtonActive: {
+    backgroundColor: Colors.primary,
+  },
+  optionText: {
+    fontSize: 12,
+    color: Colors.primary,
+    fontWeight: '600',
+  },
+  optionTextActive: {
+    color: Colors.White,
+  },
+  sheetContent: {
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.White,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: Colors.White,
+    paddingHorizontal: 16,
+  },
+  extraContentBox: {
+    marginTop: 20,
+    padding: 16,
+    backgroundColor: Colors.WhiteTransparentDark,
+    borderRadius: 8,
+    width: '100%',
+  },
+  extraText: {
+    fontSize: 15,
+    color: Colors.Black,
+    textAlign: 'center',
+  },
+  spacing: {
+    height: 24,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/index.tsx
@@ -25,7 +25,7 @@ export function App() {
 
   const colorOptions: { name: string; value: ColorValue }[] = [
     { name: 'NAVY', value: Colors.NavyLight100 },
-    { name: 'TRANSPARENT', value: 'transparent' },
+    { name: 'PURPLE', value: Colors.PurpleDark100 },
   ];
 
   return (

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Native container style',
+  key: 'test-form-sheet-native-container-style-ios',
+  details:
+    'Allows to test the native container style properties (backgroundColor) of the FormSheet.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario.md
@@ -24,7 +24,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Verification: Applying Native Background Color
+### Applying Default Native Background Color
 
 2. Tap the "Open FormSheet" button.
 
@@ -33,7 +33,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Verification: Layout Stability
+### Layout Stability
 
 3. Tap the "Expand Content" button.
 
@@ -42,3 +42,20 @@ TBD: Planned, but will be implemented separately.
 4. Tap the "Dismiss from JS" button.
 
 - [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+
+---
+
+### Dynamic Native Background Color
+
+5. In the color selection controls, tap the **"PURPLE"** option.
+
+- [ ] The PURPLE option becomes visually active.
+
+6. Tap the "Open FormSheet" button.
+
+- [ ] The FormSheet opens smoothly.
+- [ ] The background color is now purple, extending to the bottom edge of the screen just as it did with the navy color.
+
+7. Swipe down to dismiss the FormSheet.
+
+- [ ] The FormSheet dismisses smoothly.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style-ios/scenario.md
@@ -1,0 +1,44 @@
+# Test Scenario: Native container style
+
+## Details
+
+**Description:** Verify the `nativeContainerStyle` functionality of the `FormSheet` component. This test ensures that styling properties applied to the native container (e.g. `backgroundColor`) correctly map to the underlying `UIView`, seamlessly filling the entire modal bounds including the bottom safe area.
+
+**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone with a Home Indicator (e.g., iPhone 13/14/15) to properly verify the bottom safe area coverage.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Native container style** screen.
+
+- [ ] Content with the button "Open FormSheet" and color selection controls is shown. The default selected color is "NAVY".
+
+---
+
+### Verification: Applying Native Background Color
+
+2. Tap the "Open FormSheet" button.
+
+- [ ] The FormSheet opens smoothly.
+- [ ] The navy background extends completely to the bottom edge of the screen, rendering underneath the system Home Indicator without leaving any default-colored gaps in the safe area.
+
+---
+
+### Verification: Layout Stability
+
+3. Tap the "Expand Content" button.
+
+- [ ] The FormSheet animates and expands in height to accommodate the new content. The native background seamlessly covers the new bounds without any visual flashes or white gaps during the transition.
+
+4. Tap the "Dismiss from JS" button.
+
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
@@ -90,6 +90,8 @@
     sheet.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier;
   }];
 #endif // !TARGET_OS_TV
+
+  controller.view.backgroundColor = appearanceProvider.nativeContainerBackgroundColor ?: UIColor.clearColor;
 }
 
 @end

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSInteger initialDetentIndex;
 @property (nonatomic, readonly) BOOL prefersScrollingExpandsWhenScrolledToEdge;
 @property (nonatomic, readonly) BOOL preventNativeDismiss;
+@property (nonatomic, readonly, nullable) UIColor *nativeContainerBackgroundColor;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -8,6 +8,7 @@
 #import "RNSFormSheetHostShadowStateProxy.h"
 #import "RNSFormSheetProviders.h"
 
+#import <React/RCTConversions.h>
 #import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
@@ -40,6 +41,7 @@ namespace react = facebook::react;
   NSInteger _initialDetentIndex;
   BOOL _prefersScrollingExpandsWhenScrolledToEdge;
   BOOL _preventNativeDismiss;
+  UIColor *_Nullable _nativeContainerBackgroundColor;
 
   CGFloat _reactContentsHeight;
 }
@@ -74,6 +76,7 @@ namespace react = facebook::react;
   _initialDetentIndex = 0;
   _prefersScrollingExpandsWhenScrolledToEdge = YES;
   _preventNativeDismiss = NO;
+  _nativeContainerBackgroundColor = nil;
 
   _reactContentsHeight = 0.0;
 }
@@ -273,6 +276,11 @@ namespace react = facebook::react;
 
   if (oldComponentProps.largestUndimmedDetentIndex != newComponentProps.largestUndimmedDetentIndex) {
     _largestUndimmedDetentIndex = newComponentProps.largestUndimmedDetentIndex;
+    [_controller setNeedsAppearanceUpdate];
+  }
+
+  if (oldComponentProps.nativeContainerBackgroundColor != newComponentProps.nativeContainerBackgroundColor) {
+    _nativeContainerBackgroundColor = RCTUIColorFromSharedColor(newComponentProps.nativeContainerBackgroundColor);
     [_controller setNeedsAppearanceUpdate];
   }
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetProviders.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)prefersGrabberVisible;
 - (CGFloat)preferredCornerRadius;
 - (NSInteger)largestUndimmedDetentIndex;
+- (nullable UIColor *)nativeContainerBackgroundColor;
 
 @end
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.tsx
+++ b/src/components/gamma/modals/form-sheet/FormSheet.tsx
@@ -17,6 +17,7 @@ export function FormSheet(props: FormSheetProps) {
     initialDetentIndex,
     largestUndimmedDetentIndex,
     preferredCornerRadius,
+    nativeContainerStyle,
     ...rest
   } = props;
 
@@ -44,6 +45,7 @@ export function FormSheet(props: FormSheetProps) {
       initialDetentIndex={resolvedInitialDetentIndex}
       largestUndimmedDetentIndex={resolvedUndimmedDetentIndex}
       preferredCornerRadius={nativeCornerRadius}
+      nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
       {...rest}>
       {isFitToContents ? (
         <FormSheetContentWrapperNativeComponent

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -1,4 +1,4 @@
-import type { NativeSyntheticEvent, ViewProps } from 'react-native';
+import type { ColorValue, NativeSyntheticEvent, ViewProps } from 'react-native';
 
 export type EmptyEventPayload = Record<string, never>;
 
@@ -7,6 +7,15 @@ export type FormSheetEventHandler<T> = (e: NativeSyntheticEvent<T>) => void;
 export interface FormSheetDetentChangedEvent {
   index: number;
 }
+
+export type FormSheetNativeContainerStyleProps = {
+  /**
+   * @summary Specifies the background color of the native container hosting the sheet content.
+   *
+   * @platform ios
+   */
+  backgroundColor?: ColorValue | undefined;
+};
 
 export interface FormSheetProps {
   children?: ViewProps['children'] | undefined;
@@ -119,6 +128,15 @@ export interface FormSheetProps {
    * @platform ios
    */
   preventNativeDismiss?: boolean | undefined;
+
+  /**
+   * @summary Style applied to the native container hosting the sheet content.
+   *
+   * These properties are forwarded directly to the underlying native view.
+   *
+   * @platform ios
+   */
+  nativeContainerStyle?: FormSheetNativeContainerStyleProps | undefined;
 
   // Events
 

--- a/src/components/gamma/modals/form-sheet/index.ts
+++ b/src/components/gamma/modals/form-sheet/index.ts
@@ -1,3 +1,6 @@
-export type { FormSheetProps } from './FormSheet.types';
+export type {
+  FormSheetProps,
+  FormSheetNativeContainerStyleProps,
+} from './FormSheet.types';
 
 export { FormSheet } from './FormSheet';

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { CodegenTypes as CT, ViewProps } from 'react-native';
+import type { CodegenTypes as CT, ColorValue, ViewProps } from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -20,6 +20,7 @@ interface NativeProps extends ViewProps {
   initialDetentIndex?: CT.WithDefault<CT.Int32, 0>;
   prefersScrollingExpandsWhenScrolledToEdge?: CT.WithDefault<boolean, true>;
   preventNativeDismiss?: CT.WithDefault<boolean, false>;
+  nativeContainerBackgroundColor?: ColorValue | undefined;
   // Events
   onWillAppear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onDidAppear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;


### PR DESCRIPTION
## Description

Prep for applying some styling props directly to the native container that's hosting FormSheet's content.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1512

## Changes

- Updated public API
- Added native prop application

## Before & after - visual documentation

| iOS 18 | iOS 26 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/038c96fe-1314-481f-a8a2-5a0d7cc34822" /> | <video src="https://github.com/user-attachments/assets/037eec80-efb7-40d2-959a-fcb320376c65" /> |

## Test plan

Added dedicated SFT.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
