### PR TITLE
feat(iOS, FormSheet v5): Add lifecycle events

### DIFF
--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -5,6 +5,7 @@ import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents-ios';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible-ios';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index-ios';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
+import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events-ios';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed-ios';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius-ios';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state-ios';
@@ -17,6 +18,7 @@ const scenarios = {
   TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,
+  TestFormSheetLifecycleEvents,
   TestFormSheetOnDetentChanged,
   TestFormSheetPreferredCornerRadius,
   TestFormSheetPresentationState,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/index.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { FormSheet } from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+export function App() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const addLog = (eventName: string) => {
+    const timestamp = new Date().toISOString().substring(11, 23);
+    setLogs(prev => [...prev, `[${timestamp}] ${eventName}`]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet Lifecycle Test</Text>
+
+      <View style={styles.row}>
+        <Button
+          title="Open FormSheet"
+          color={Colors.primary}
+          onPress={() => setIsOpen(true)}
+        />
+        <Button
+          title="Clear Logs"
+          color={Colors.primary}
+          onPress={() => setLogs([])}
+        />
+      </View>
+
+      <View style={styles.logsContainer}>
+        <Text style={styles.logsHeader}>Event Logs:</Text>
+        <ScrollView style={styles.scrollView}>
+          {logs.map((log, index) => (
+            <Text key={index} style={styles.logText}>
+              {log}
+            </Text>
+          ))}
+          {logs.length === 0 && (
+            <Text style={styles.emptyLogText}>No events recorded yet.</Text>
+          )}
+        </ScrollView>
+      </View>
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        onWillAppear={() => addLog('onWillAppear')}
+        onDidAppear={() => addLog('onDidAppear')}
+        onWillDisappear={() => addLog('onWillDisappear')}
+        onDidDisappear={() => addLog('onDidDisappear')}
+        detents={[0.4]}>
+        <View style={styles.sheetContent}>
+          <Text style={styles.sheetTitle}>FormSheet content</Text>
+          <View style={styles.spacing} />
+          <Button
+            title="Dismiss from JS"
+            color={Colors.primary}
+            onPress={() => setIsOpen(false)}
+          />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 60,
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+    gap: 16,
+  },
+  logsContainer: {
+    flex: 1,
+    width: '100%',
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+  },
+  logsHeader: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    borderRadius: 8,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+  },
+  logText: {
+    fontSize: 14,
+    color: Colors.text,
+    marginBottom: 4,
+    fontFamily: 'Courier',
+  },
+  emptyLogText: {
+    fontSize: 14,
+    color: 'gray',
+    fontStyle: 'italic',
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Lifecycle Events',
+  key: 'test-form-sheet-lifecycle-events-ios',
+  details:
+    'Allows to test the lifecycle events (onWillAppear, onDidAppear, onWillDisappear, onDidDisappear) of the FormSheet component.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events-ios/scenario.md
@@ -1,0 +1,52 @@
+# Test Scenario: Lifecycle Events
+
+## Details
+
+**Description:** Verify that the `FormSheet` component correctly emits lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the exact order corresponding to the underlying native modal presentation transitions.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator: iPhone
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Lifecycle Events** screen.
+
+- [ ] A UI with "Open FormSheet" and "Clear Logs" buttons is shown, along with an empty event logs area.
+
+---
+
+### Presentation (Opening)
+
+2. Tap the "Open FormSheet" button.
+3. Wait for the sheet presentation animation to finish.
+
+- [ ] The FormSheet opens smoothly.
+- [ ] The logs list updates to show exactly two new events in the following order: `onWillAppear`, `onDidAppear`
+
+---
+
+### Native Dismissal (Swiping down)
+
+4. Dismiss the FormSheet by swiping it down.
+
+- [ ] The logs list updates to show exactly two new events: `onWillDisappear`, `onDidDisappear`
+
+---
+
+### Programmatic Dismissal (JS)
+
+5. Tap "Clear Logs" to reset the list.
+6. Tap "Open FormSheet" and wait for it to open.
+7. Tap the "Dismiss from JS" button inside the FormSheet.
+
+- [ ] The FormSheet closes smoothly.
+- [ ] The final logs list contains exactly four events in total, recorded in the following chronological order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.h
@@ -16,6 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
     didChangeDetentIdentifier:(nullable NSString *)identifier;
 #endif // !TARGET_OS_TV
 - (void)sheetControllerDidPreventNativeDismiss:(RNSFormSheetContentController *)controller;
+// Lifecycle
+- (void)sheetControllerWillAppear:(RNSFormSheetContentController *)controller;
+- (void)sheetControllerDidAppear:(RNSFormSheetContentController *)controller;
+- (void)sheetControllerWillDisappear:(RNSFormSheetContentController *)controller;
+- (void)sheetControllerDidDisappear:(RNSFormSheetContentController *)controller;
 @end
 
 @interface RNSFormSheetContentController : UIViewController

--- a/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetContentController.mm
@@ -67,12 +67,30 @@
 {
   [super viewWillAppear:animated];
   [self attachBackdropTapGestureRecognizer];
+
+  [self.delegate sheetControllerWillAppear:self];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+  [super viewDidAppear:animated];
+
+  [self.delegate sheetControllerDidAppear:self];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+  [super viewWillDisappear:animated];
+
+  [self.delegate sheetControllerWillDisappear:self];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
   [self detachBackdropTapGestureRecognizer];
+
+  [self.delegate sheetControllerDidDisappear:self];
 }
 
 #pragma mark - Presentation Setup

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -158,6 +158,26 @@ namespace react = facebook::react;
 }
 #endif // !TARGET_OS_TV
 
+- (void)sheetControllerWillAppear:(RNSFormSheetContentController *)controller
+{
+  [_reactEventEmitter emitOnWillAppear];
+}
+
+- (void)sheetControllerDidAppear:(RNSFormSheetContentController *)controller
+{
+  [_reactEventEmitter emitOnDidAppear];
+}
+
+- (void)sheetControllerWillDisappear:(RNSFormSheetContentController *)controller
+{
+  [_reactEventEmitter emitOnWillDisappear];
+}
+
+- (void)sheetControllerDidDisappear:(RNSFormSheetContentController *)controller
+{
+  [_reactEventEmitter emitOnDidDisappear];
+}
+
 #pragma mark - RCTComponentViewProtocol
 
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 #if !TARGET_OS_TV
 - (BOOL)emitOnDetentChangedWithIndex:(NSInteger)index;
 #endif // !TARGET_OS_TV
+- (BOOL)emitOnWillAppear;
+- (BOOL)emitOnDidAppear;
+- (BOOL)emitOnWillDisappear;
+- (BOOL)emitOnDidDisappear;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostEventEmitter.mm
@@ -40,6 +40,52 @@
 }
 #endif // !TARGET_OS_TV
 
+#pragma mark - Lifecycle events
+
+- (BOOL)emitOnWillAppear
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onWillAppear({});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnWillAppear event emission due to nullish emitter");
+    return NO;
+  }
+}
+
+- (BOOL)emitOnDidAppear
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onDidAppear({});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnDidAppear event emission due to nullish emitter");
+    return NO;
+  }
+}
+
+- (BOOL)emitOnWillDisappear
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onWillDisappear({});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnWillDisappear event emission due to nullish emitter");
+    return NO;
+  }
+}
+
+- (BOOL)emitOnDidDisappear
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onDidDisappear({});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnDidDisappear event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 - (void)updateEventEmitter:(const std::shared_ptr<const react::RNSFormSheetHostEventEmitter> &)emitter
 {
   _reactEventEmitter = emitter;

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -1,5 +1,9 @@
 import type { NativeSyntheticEvent, ViewProps } from 'react-native';
 
+export type EmptyEventPayload = Record<string, never>;
+
+export type FormSheetEventHandler<T> = (e: NativeSyntheticEvent<T>) => void;
+
 export interface FormSheetDetentChangedEvent {
   index: number;
 }
@@ -117,6 +121,39 @@ export interface FormSheetProps {
   preventNativeDismiss?: boolean | undefined;
 
   // Events
+
+  /**
+   * @summary A callback that gets invoked when the FormSheet will appear.
+   * This is called as soon as the transition begins.
+   *
+   * @platform ios
+   */
+  onWillAppear?: FormSheetEventHandler<EmptyEventPayload> | undefined;
+
+  /**
+   * @summary A callback that gets invoked when the FormSheet did appear.
+   * This is called as soon as the transition ends.
+   *
+   * @platform ios
+   */
+  onDidAppear?: FormSheetEventHandler<EmptyEventPayload> | undefined;
+
+  /**
+   * @summary A callback that gets invoked when the FormSheet will disappear.
+   * This is called as soon as the transition begins.
+   *
+   * @platform ios
+   */
+  onWillDisappear?: FormSheetEventHandler<EmptyEventPayload> | undefined;
+
+  /**
+   * @summary A callback that gets invoked when the FormSheet did disappear.
+   * This is called as soon as the transition ends.
+   *
+   * @platform ios
+   */
+  onDidDisappear?: FormSheetEventHandler<EmptyEventPayload> | undefined;
+
   /**
    * @summary Called when the sheet is dismissed natively.
    *
@@ -125,7 +162,7 @@ export interface FormSheetProps {
    *
    * @platform ios
    */
-  onNativeDismiss?: (() => void) | undefined;
+  onNativeDismiss?: FormSheetEventHandler<EmptyEventPayload> | undefined;
 
   /**
    * @summary Called when the sheet settles at a new detent.
@@ -135,7 +172,7 @@ export interface FormSheetProps {
    * @platform ios
    */
   onDetentChanged?:
-    | ((e: NativeSyntheticEvent<FormSheetDetentChangedEvent>) => void)
+    | FormSheetEventHandler<FormSheetDetentChangedEvent>
     | undefined;
 
   /**
@@ -147,5 +184,7 @@ export interface FormSheetProps {
    *
    * @platform ios
    */
-  onNativeDismissPrevented?: (() => void) | undefined;
+  onNativeDismissPrevented?:
+    | FormSheetEventHandler<EmptyEventPayload>
+    | undefined;
 }

--- a/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
+++ b/src/fabric/gamma/modals/form-sheet/FormSheetHostNativeComponent.ts
@@ -11,6 +11,7 @@ type DetentChangedEvent = Readonly<{
 }>;
 
 interface NativeProps extends ViewProps {
+  // General
   isOpen?: CT.WithDefault<boolean, false>;
   detents?: CT.Double[] | undefined;
   prefersGrabberVisible?: CT.WithDefault<boolean, false>;
@@ -19,6 +20,11 @@ interface NativeProps extends ViewProps {
   initialDetentIndex?: CT.WithDefault<CT.Int32, 0>;
   prefersScrollingExpandsWhenScrolledToEdge?: CT.WithDefault<boolean, true>;
   preventNativeDismiss?: CT.WithDefault<boolean, false>;
+  // Events
+  onWillAppear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onDidAppear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onWillDisappear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onDidDisappear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onNativeDismiss?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onNativeDismissPrevented?:
     | CT.DirectEventHandler<GenericEmptyEvent>


### PR DESCRIPTION
## Description

Adding `on[Will|Did][Appear|Disappear]` events for FormSheet component.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1269

## Changes

- updated public types
- updated spec
- updated delegate callbacks
- added methods for event emitter

## Before & after - visual documentation

| iOS 26 |
| --- |
| <video src="https://github.com/user-attachments/assets/a01a2202-9d57-4a11-99fb-cd798ff98c12" /> |

## Test plan

Added dedicated SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
