### PR TITLE
feat(Android, Stack v5): add support for extended tinting and enforce M3 icon size for back button

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinator.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.gamma.stack.header
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.text.TextUtils
 import android.util.Log
@@ -13,6 +14,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.TextViewCompat
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
@@ -65,7 +67,9 @@ internal class StackHeaderCoordinator(
     private var lastBackgroundSubviewCollapseMode: StackHeaderSubviewCollapseMode? = null
 
     private var lastBackButtonVisible: Boolean? = null
-    private var lastBackButtonTintColor: Int? = null
+    private var lastBackButtonTintColorNormal: Int? = null
+    private var lastBackButtonTintColorPressed: Int? = null
+    private var lastBackButtonTintColorFocused: Int? = null
     private var lastBackButtonIcon: Drawable? = null
 
     private var lastScrollFlags: Int? = null
@@ -171,7 +175,9 @@ internal class StackHeaderCoordinator(
         appBarLayout = null
         managedTitleView = null
         lastBackButtonVisible = null
-        lastBackButtonTintColor = null
+        lastBackButtonTintColorNormal = null
+        lastBackButtonTintColorPressed = null
+        lastBackButtonTintColorFocused = null
         lastBackButtonIcon = null
         lastScrollFlags = null
         clearCachedRebuildTriggers()
@@ -424,13 +430,18 @@ internal class StackHeaderCoordinator(
         val visible = canNavigateBack && !config.backButtonHidden
         val visibilityChanged = visible != lastBackButtonVisible
         val iconChanged = config.backButtonIcon !== lastBackButtonIcon
-        val tintChanged = config.backButtonTintColor != lastBackButtonTintColor
+        val tintChanged =
+            config.backButtonTintColorNormal != lastBackButtonTintColorNormal ||
+                config.backButtonTintColorPressed != lastBackButtonTintColorPressed ||
+                config.backButtonTintColorFocused != lastBackButtonTintColorFocused
 
         if (!visibilityChanged && !iconChanged && !tintChanged) return
 
         lastBackButtonVisible = visible
         lastBackButtonIcon = config.backButtonIcon
-        lastBackButtonTintColor = config.backButtonTintColor
+        lastBackButtonTintColorNormal = config.backButtonTintColorNormal
+        lastBackButtonTintColorPressed = config.backButtonTintColorPressed
+        lastBackButtonTintColorFocused = config.backButtonTintColorFocused
 
         if (!visible) {
             toolbar.navigationIcon = null
@@ -438,16 +449,50 @@ internal class StackHeaderCoordinator(
             return
         }
 
-        // Clear previous tint before setting icon to ensure clean state
         toolbar.clearNavigationIconTint()
 
-        toolbar.navigationIcon = config.backButtonIcon ?: resolveDefaultBackButtonIcon()
+        val baseDrawable =
+            config.backButtonIcon
+                ?.let { getResizedDrawable(toolbar, it) }
+                ?: resolveDefaultBackButtonIcon()
 
-        config.backButtonTintColor?.let {
-            toolbar.setNavigationIconTint(it)
-        }
+        val tintList = resolveBackButtonTintList(config)
+        toolbar.navigationIcon =
+            if (tintList != null && baseDrawable != null) {
+                DrawableCompat.wrap(baseDrawable.mutate()).also {
+                    DrawableCompat.setTintList(it, tintList)
+                }
+            } else {
+                baseDrawable
+            }
 
         toolbar.setNavigationOnClickListener { onNavigationIconClick() }
+    }
+
+    private fun resolveBackButtonTintList(config: StackHeaderConfigProviding): ColorStateList? {
+        val normal = config.backButtonTintColorNormal
+        val pressed = config.backButtonTintColorPressed
+        val focused = config.backButtonTintColorFocused
+
+        if (normal == null && pressed == null && focused == null) return null
+
+        val states = mutableListOf<IntArray>()
+        val colors = mutableListOf<Int>()
+
+        pressed?.let {
+            states.add(intArrayOf(android.R.attr.state_pressed))
+            colors.add(it)
+        }
+        focused?.let {
+            states.add(intArrayOf(android.R.attr.state_focused))
+            colors.add(it)
+        }
+        normal?.let {
+            states.add(intArrayOf())
+            colors.add(it)
+        }
+
+        return ColorStateList(states.toTypedArray(), colors.toIntArray())
     }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderDrawableUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderDrawableUtils.kt
@@ -35,7 +35,7 @@ internal fun getResizedDrawable(
             targetHeightPx
         }
 
-    return drawable
-        .toBitmap(width = targetWidthPx, height = targetHeightPx)
-        .toDrawable(toolbar.resources)
+    val bitmap = drawable.toBitmap(width = targetWidthPx, height = targetHeightPx)
+    bitmap.density = toolbar.resources.displayMetrics.densityDpi
+    return bitmap.toDrawable(toolbar.resources)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderDrawableUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderDrawableUtils.kt
@@ -1,0 +1,41 @@
+package com.swmansion.rnscreens.gamma.stack.header
+
+import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.drawable.toDrawable
+import com.google.android.material.appbar.MaterialToolbar
+
+/**
+ * Returns [drawable] resized to 24 dp height. Width is scaled proportionally to keep the aspect
+ * ratio.
+ *
+ * Icon size source: https://m3.material.io/components/app-bars/specs - App bar icon size
+ */
+internal fun getResizedDrawable(
+    toolbar: MaterialToolbar,
+    drawable: Drawable,
+): Drawable {
+    val targetHeightPx =
+        TypedValue
+            .applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                24f,
+                toolbar.resources.displayMetrics,
+            ).toInt()
+
+    val intrinsicWidth = drawable.intrinsicWidth
+    val intrinsicHeight = drawable.intrinsicHeight
+
+    val targetWidthPx =
+        if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+            val aspectRatio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
+            (targetHeightPx * aspectRatio).toInt()
+        } else {
+            targetHeightPx
+        }
+
+    return drawable
+        .toBitmap(width = targetWidthPx, height = targetHeightPx)
+        .toDrawable(toolbar.resources)
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -34,7 +34,11 @@ class StackHeaderConfig(
         internal set
     override var backButtonHidden: Boolean = false
         internal set
-    override var backButtonTintColor: Int? = null
+    override var backButtonTintColorNormal: Int? = null
+        internal set
+    override var backButtonTintColorPressed: Int? = null
+        internal set
+    override var backButtonTintColorFocused: Int? = null
         internal set
     override var backButtonIcon: Drawable? = null
         internal set

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigProviding.kt
@@ -10,7 +10,9 @@ interface StackHeaderConfigProviding {
     val hidden: Boolean
     val transparent: Boolean
     val backButtonHidden: Boolean
-    val backButtonTintColor: Int?
+    val backButtonTintColorNormal: Int?
+    val backButtonTintColorPressed: Int?
+    val backButtonTintColorFocused: Int?
     val backButtonIcon: Drawable?
     val scrollFlagScroll: Boolean
     val scrollFlagEnterAlways: Boolean

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -151,11 +151,25 @@ open class StackHeaderConfigViewManager :
         view.backButtonHidden = value
     }
 
-    override fun setBackButtonTintColor(
+    override fun setBackButtonTintColorNormal(
         view: StackHeaderConfig,
         value: Int?,
     ) {
-        view.backButtonTintColor = value
+        view.backButtonTintColorNormal = value
+    }
+
+    override fun setBackButtonTintColorPressed(
+        view: StackHeaderConfig,
+        value: Int?,
+    ) {
+        view.backButtonTintColorPressed = value
+    }
+
+    override fun setBackButtonTintColorFocused(
+        view: StackHeaderConfig,
+        value: Int?,
+    ) {
+        view.backButtonTintColorFocused = value
     }
 
     override fun setBackButtonDrawableIconResourceName(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -6,8 +6,8 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.core.view.MenuItemCompat
-import com.swmansion.rnscreens.gamma.stack.header.getResizedDrawable
 import com.google.android.material.appbar.MaterialToolbar
+import com.swmansion.rnscreens.gamma.stack.header.getResizedDrawable
 
 internal class StackHeaderToolbarMenuCoordinator(
     private val onItemClicked: (id: String) -> Unit,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuCoordinator.kt
@@ -3,12 +3,10 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.util.Log
-import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
-import androidx.core.graphics.drawable.toBitmap
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.MenuItemCompat
+import com.swmansion.rnscreens.gamma.stack.header.getResizedDrawable
 import com.google.android.material.appbar.MaterialToolbar
 
 internal class StackHeaderToolbarMenuCoordinator(
@@ -99,40 +97,6 @@ internal class StackHeaderToolbarMenuCoordinator(
             iconTintColorFocused = StackHeaderToolbarUpdate.from(iconTintColorFocused),
             iconTintColorDisabled = StackHeaderToolbarUpdate.from(iconTintColorDisabled),
         )
-
-    /**
-     * Returns drawable resized to 24 dp height. Width is scaled proportionally to keep the aspect
-     * ratio.
-     *
-     * Icon size source: https://m3.material.io/components/app-bars/specs - App bar icon size
-     */
-    private fun getResizedDrawable(
-        toolbar: MaterialToolbar,
-        drawable: Drawable,
-    ): Drawable {
-        val targetHeightPx =
-            TypedValue
-                .applyDimension(
-                    TypedValue.COMPLEX_UNIT_DIP,
-                    24f,
-                    toolbar.resources.displayMetrics,
-                ).toInt()
-
-        val intrinsicWidth = drawable.intrinsicWidth
-        val intrinsicHeight = drawable.intrinsicHeight
-
-        val targetWidthPx =
-            if (intrinsicWidth > 0 && intrinsicHeight > 0) {
-                val aspectRatio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
-                (targetHeightPx * aspectRatio).toInt()
-            } else {
-                targetHeightPx
-            }
-
-        return drawable
-            .toBitmap(width = targetWidthPx, height = targetHeightPx)
-            .toDrawable(toolbar.resources)
-    }
 
     private fun getResolvedIconTintList(
         menuItem: MenuItem,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -31,13 +31,17 @@ const ICON_OPTIONS: IconOption[] = [
 
 interface Config {
   backButtonHidden: boolean;
-  tintColor: TintColorOption;
+  tintColorNormal: TintColorOption;
+  tintColorPressed: TintColorOption;
+  tintColorFocused: TintColorOption;
   icon: IconOption;
 }
 
 const DEFAULT_CONFIG: Config = {
   backButtonHidden: false,
-  tintColor: 'default',
+  tintColorNormal: 'default',
+  tintColorPressed: 'default',
+  tintColorFocused: 'default',
   icon: 'default',
 };
 
@@ -51,7 +55,7 @@ const ConfigContext = React.createContext<{
 
 function resolveTintColor(
   option: TintColorOption,
-): StackHeaderConfigPropsAndroid['backButtonTintColor'] {
+): StackHeaderConfigPropsAndroid['backButtonTintColorNormal'] {
   switch (option) {
     case 'purple':
       return Colors.PurpleLight100;
@@ -88,7 +92,9 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps {
     title: 'Back Button Test',
     backButtonHidden: config.backButtonHidden,
     android: {
-      backButtonTintColor: resolveTintColor(config.tintColor),
+      backButtonTintColorNormal: resolveTintColor(config.tintColorNormal),
+      backButtonTintColorPressed: resolveTintColor(config.tintColorPressed),
+      backButtonTintColorFocused: resolveTintColor(config.tintColorFocused),
       backButtonIcon: resolveIcon(config.icon),
     },
   };
@@ -136,9 +142,21 @@ export function ConfigControls() {
         onValueChange={v => updateConfig('backButtonHidden', v)}
       />
       <SettingsPicker<TintColorOption>
-        label="tintColor"
-        value={config.tintColor}
-        onValueChange={v => updateConfig('tintColor', v)}
+        label="tintColorNormal"
+        value={config.tintColorNormal}
+        onValueChange={v => updateConfig('tintColorNormal', v)}
+        items={TINT_COLOR_OPTIONS}
+      />
+      <SettingsPicker<TintColorOption>
+        label="tintColorPressed"
+        value={config.tintColorPressed}
+        onValueChange={v => updateConfig('tintColorPressed', v)}
+        items={TINT_COLOR_OPTIONS}
+      />
+      <SettingsPicker<TintColorOption>
+        label="tintColorFocused"
+        value={config.tintColorFocused}
+        onValueChange={v => updateConfig('tintColorFocused', v)}
         items={TINT_COLOR_OPTIONS}
       />
       <SettingsPicker<IconOption>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
@@ -12,11 +12,14 @@ changing props in runtime and ensure consistent behavior.
 
 ## E2E test
 
-TB: Automation is planned in limited scope but not yet implemented.
+TBD: Automation is planned in limited scope but not yet implemented.
 
 ## Prerequisites
 
 - Android emulator
+- To test `backButtonTintColorFocused`: enable **Hardware Input** in the
+  emulator settings, then use arrow keys to enable keyboard focus and press
+  **Ctrl+Tab** to move keyboard focus into the header toolbar.
 
 ## Note (Optional)
 
@@ -26,6 +29,13 @@ Interaction with prevent native dismiss mechanism is tested in separate tests
 
 Applying tint color to non-transparent image results in the entire image being
 covered in tint color.
+
+**Native platform limitation:** if `backButtonTintColorNormal` is left at its
+default (undefined) but `backButtonTintColorPressed` or
+`backButtonTintColorFocused` is explicitly set, the icon becomes invisible in
+the normal state. This is Android platform behavior, not a library bug. Always
+set `backButtonTintColorNormal` alongside other state tints if you want the
+icon visible in the normal state.
 
 When support for color scheme is added, we should check if default back arrow
 adapts to color scheme change.
@@ -59,21 +69,27 @@ adapts to color scheme change.
 5. Set tintColorPressed = `red`.
 
 - [ ] Back arrow appears transparent (native limitation) but turns red when
-  held down.
+      held down.
 
 6. Set tintColorNormal = `purple`.
 
 - [ ] Back arrow changes to purple immediately. When pressed, it turns red.
 
-7. Set tintColorPressed = `default`.
+7. Set tintColorFocused = `green`.
 
-- [ ] When pressed, back arrow turns purple.
+- [ ] Enable keyboard navigation using arrow keys. Use Ctrl+Tab to move keyboard
+      focus to the toolbar and focus the back button — it turns green while
+      focused.
 
-8. Toggle backButtonHidden = `true`.
+8. Set tintColorPressed = `default`, set tintColorFocused = `default`.
+
+- [ ] Pressed and focused states return to the normal purple tint.
+
+9. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears from the header.
 
-9. Toggle backButtonHidden = `false`.
+10. Toggle backButtonHidden = `false`.
 
 - [ ] Back button reappears with default icon and purple tint.
 
@@ -81,32 +97,32 @@ adapts to color scheme change.
 
 ### Icon: `imageSource` and changes when hidden
 
-10. Set tintColorNormal = `default` and icon = `imageSource`.
+11. Set tintColorNormal = `default` and icon = `imageSource`.
 
 - [ ] Back button changes to the custom image — white background
       with a black arrow, no tint applied.
 - [ ] The custom image is scaled to approximately 24 dp height,
       visually similar in size to the default back arrow.
 
-11. Set tintColorNormal = `red`.
+12. Set tintColorNormal = `red`.
 
 - [ ] The entire image is covered in red (non-transparent image is
       fully tinted).
 
-12. Set tintColorNormal = `default`.
+13. Set tintColorNormal = `default`.
 
 - [ ] Custom image returns to its original appearance (white
       background, black arrow).
 
-13. Toggle backButtonHidden = `true`.
+14. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears.
 
-14. Set tintColorNormal = `green`.
+15. Set tintColorNormal = `green`.
 
 - [ ] No visible change (back button is hidden).
 
-15. Toggle backButtonHidden = `false`.
+16. Toggle backButtonHidden = `false`.
 
 - [ ] Back button reappears with `imageSource` icon and green tint
       already applied.
@@ -115,25 +131,25 @@ adapts to color scheme change.
 
 ### Icon: `drawableResource`
 
-16. Set tintColorNormal = `default`, set icon = `drawableResource`.
+17. Set tintColorNormal = `default`, set icon = `drawableResource`.
 
 - [ ] Back button changes to `sym_call_missed` drawable — white
       and red (its native colors).
 - [ ] The drawable icon is scaled to approximately 24 dp height.
 
-17. Set tintColorNormal = `purple`.
+18. Set tintColorNormal = `purple`.
 
 - [ ] Drawable icon changes to purple.
 
-18. Set tintColorNormal = `default`.
+19. Set tintColorNormal = `default`.
 
 - [ ] Drawable icon returns to its native white and red appearance.
 
-19. Toggle backButtonHidden = `true`.
+20. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears.
 
-20. Toggle backButtonHidden = `false`.
+21. Toggle backButtonHidden = `false`.
 
 - [ ] Back button reappears with `drawableResource` icon and
       default tint.
@@ -142,12 +158,12 @@ adapts to color scheme change.
 
 ### Config applied before push
 
-21. Go back to the root screen. Set icon = `imageSource`,
-  tintColorNormal = `purple`.
+22. Go back to the root screen. Set icon = `imageSource`,
+    tintColorNormal = `purple`.
 
 - [ ] Root screen is shown. No back button visible (root screen).
 
-22. Tap **Push screen**.
+23. Tap **Push screen**.
 
 - [ ] Pushed screen appears with the `imageSource` icon and purple
       tint already applied.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
@@ -2,13 +2,17 @@
 
 ## Details
 
-**Description:** This test focuses on back button in the header on Android. Back button should be visible on screens that are not a root screen of the stack, unless it's explicitly disabled. Back button allows customization via custom icon and tint color. Focus on changing props in runtime and ensure consistent behavior.
+**Description:** This test focuses on back button in the header on Android.
+Back button should be visible on screens that are not a root screen of the
+stack, unless it's explicitly disabled. Back button allows customization via
+custom icon and tint color (normal, pressed, and focused states). Focus on
+changing props in runtime and ensure consistent behavior.
 
 **OS test creation version:** API 36
 
 ## E2E test
 
-Other - the automation is planned (in limited scope) but not implemented yet.
+TB: Automation is planned in limited scope but not yet implemented.
 
 ## Prerequisites
 
@@ -16,11 +20,15 @@ Other - the automation is planned (in limited scope) but not implemented yet.
 
 ## Note (Optional)
 
-Interaction with prevent native dismiss mechanism is tested in separate tests (`prevent-native-dismiss-single-stack` and `prevent-native-dismiss-nested-stack`).
+Interaction with prevent native dismiss mechanism is tested in separate tests
+(`prevent-native-dismiss-single-stack` and
+`prevent-native-dismiss-nested-stack`).
 
-Applying tint color to non-transparent image results in the entire image being covered in tint color.
+Applying tint color to non-transparent image results in the entire image being
+covered in tint color.
 
-When support for color scheme is added, we should check if default back arrow adapts to color scheme change.
+When support for color scheme is added, we should check if default back arrow
+adapts to color scheme change.
 
 ## Steps
 
@@ -28,92 +36,118 @@ When support for color scheme is added, we should check if default back arrow ad
 
 1. Launch the app and navigate to the **Stack Back Button** screen.
 
-- [ ] Root screen is shown. No back button is visible in the header (root screen has no predecessor).
+- [ ] Root screen is shown. No back button is visible in the header
+      (root screen has no predecessor).
 
 2. Tap **Push screen**.
 
-- [ ] Pushed screen is shown. A default back button (default arrow icon, default tint) is visible in the header.
+- [ ] Pushed screen is shown. A default back button (default arrow
+      icon, default tint) is visible in the header.
 
 ---
 
 ### Icon: `default`
 
-3. Set tintColor = `purple`.
+3. Set tintColorNormal = `purple`.
 
 - [ ] Back arrow changes to purple immediately.
 
-4. Set tintColor = `default`.
+4. Set tintColorNormal = `default`.
 
 - [ ] Back arrow returns to default tint.
 
-5. Toggle backButtonHidden = `true`.
+5. Set tintColorPressed = `red`.
+
+- [ ] Back arrow appears transparent (native limitation) but turns red when
+  held down.
+
+6. Set tintColorNormal = `purple`.
+
+- [ ] Back arrow changes to purple immediately. When pressed, it turns red.
+
+7. Set tintColorPressed = `default`.
+
+- [ ] When pressed, back arrow turns purple.
+
+8. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears from the header.
 
-6. Toggle backButtonHidden = `false`.
+9. Toggle backButtonHidden = `false`.
 
-- [ ] Back button reappears with default icon and default tint.
+- [ ] Back button reappears with default icon and purple tint.
 
 ---
 
 ### Icon: `imageSource` and changes when hidden
 
-7. Set icon = `imageSource`.
+10. Set tintColorNormal = `default` and icon = `imageSource`.
 
-- [ ] Back button changes to the custom image — white background with a black arrow, no tint applied.
+- [ ] Back button changes to the custom image — white background
+      with a black arrow, no tint applied.
+- [ ] The custom image is scaled to approximately 24 dp height,
+      visually similar in size to the default back arrow.
 
-8. Set tintColor = `red`.
+11. Set tintColorNormal = `red`.
 
-- [ ] The entire image is covered in red (non-transparent image is fully tinted).
+- [ ] The entire image is covered in red (non-transparent image is
+      fully tinted).
 
-9. Set tintColor = `default`.
+12. Set tintColorNormal = `default`.
 
-- [ ] Custom image returns to its original appearance (white background, black arrow).
+- [ ] Custom image returns to its original appearance (white
+      background, black arrow).
 
-10. Toggle backButtonHidden = `true`.
+13. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears.
 
-11. Set tintColor = `green`.
+14. Set tintColorNormal = `green`.
 
 - [ ] No visible change (back button is hidden).
 
-12. Toggle backButtonHidden = `false`.
+15. Toggle backButtonHidden = `false`.
 
-- [ ] Back button reappears with `imageSource` icon and green tint already applied.
+- [ ] Back button reappears with `imageSource` icon and green tint
+      already applied.
 
 ---
 
 ### Icon: `drawableResource`
 
-13. Set tintColor = `default`, set icon = `drawableResource`.
+16. Set tintColorNormal = `default`, set icon = `drawableResource`.
 
-- [ ] Back button changes to `sym_call_missed` drawable — white and red (its native colors).
+- [ ] Back button changes to `sym_call_missed` drawable — white
+      and red (its native colors).
+- [ ] The drawable icon is scaled to approximately 24 dp height.
 
-14. Set tintColor = `purple`.
+17. Set tintColorNormal = `purple`.
 
 - [ ] Drawable icon changes to purple.
 
-15. Set tintColor = `default`.
+18. Set tintColorNormal = `default`.
 
 - [ ] Drawable icon returns to its native white and red appearance.
 
-16. Toggle backButtonHidden = `true`.
+19. Toggle backButtonHidden = `true`.
 
 - [ ] Back button disappears.
 
-17. Toggle backButtonHidden = `false`.
+20. Toggle backButtonHidden = `false`.
 
-- [ ] Back button reappears with `drawableResource` icon and default tint.
+- [ ] Back button reappears with `drawableResource` icon and
+      default tint.
 
 ---
 
 ### Config applied before push
 
-18. Go back to the root screen. Set icon = `imageSource`, tintColor = `purple`.
+21. Go back to the root screen. Set icon = `imageSource`,
+  tintColorNormal = `purple`.
 
 - [ ] Root screen is shown. No back button visible (root screen).
 
-19. Tap **Push screen**.
+22. Tap **Push screen**.
 
-- [ ] Pushed screen appears with the `imageSource` icon and purple tint already applied.
+- [ ] Pushed screen appears with the `imageSource` icon and purple
+      tint already applied.

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -250,7 +250,7 @@ export interface StackHeaderConfigPropsAndroid {
    */
   trailingSubview?: StackHeaderToolbarSubviewAndroid | undefined;
   /**
-   * @summary Tint color applied to the back button icon.
+   * @summary Tint color applied to the back button icon in its normal state.
    *
    * When `undefined`, the default tint color is used. This applies to the
    * native back arrow and `drawableResource` icons that have an associated
@@ -258,7 +258,30 @@ export interface StackHeaderConfigPropsAndroid {
    *
    * @platform android
    */
-  backButtonTintColor?: ColorValue | undefined;
+  backButtonTintColorNormal?: ColorValue | undefined;
+  /**
+   * @summary Tint color applied to the back button icon when it is pressed.
+   *
+   * @remarks
+   * Due to native platform limitations, if you set this prop, you must also
+   * provide `backButtonTintColorNormal`. Otherwise, the icon will become
+   * transparent.
+   *
+   * @platform android
+   */
+  backButtonTintColorPressed?: ColorValue | undefined;
+  /**
+   * @summary Tint color applied to the back button icon when it is focused
+   * (e.g. by keyboard navigation).
+   *
+   * @remarks
+   * Due to native platform limitations, if you set this prop, you must also
+   * provide `backButtonTintColorNormal`. Otherwise, the icon will become
+   * transparent.
+   *
+   * @platform android
+   */
+  backButtonTintColorFocused?: ColorValue | undefined;
   /**
    * @summary Custom icon for the back button.
    *

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -48,7 +48,9 @@ export interface NativeProps extends ViewProps {
   // Android-specific props
   type?: CT.WithDefault<StackHeaderTypeAndroid, 'small'>;
 
-  backButtonTintColor?: ColorValue | undefined;
+  backButtonTintColorNormal?: ColorValue | undefined;
+  backButtonTintColorPressed?: ColorValue | undefined;
+  backButtonTintColorFocused?: ColorValue | undefined;
   backButtonDrawableIconResourceName?: string | undefined;
   backButtonImageIconResource?: ImageSource | undefined;
 


### PR DESCRIPTION
## Description

Adds support for customizing `pressed`, `focused` tint color for back button. Enforces M3 spec back button icon size. Fixes scaling logic to handle both custom images and drawable resources.

## Changes

- add `backButtonTintColor{Pressed,Focused}`, rename previous prop to `...Normal`
- handle prop changes
- extract scaling logic and use it for back button
- fix scaling logic to handle both regular icons and drawable resources

## Before & after - visual documentation

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/5e5ad3d7-8ba1-435f-9414-166e59490c2e" /> | <video src="https://github.com/user-attachments/assets/78e0d471-9d6b-405f-a803-c088ee146f94" /> |

## Test plan

Run `test-stack-back-button-android`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
