### PR TITLE
feat(tabs): add iOS search toolbar items

### DIFF
--- a/apps/src/tests/issue-tests/Test3168.tsx
+++ b/apps/src/tests/issue-tests/Test3168.tsx
@@ -197,6 +197,7 @@ function TabsStackComponent() {
   const [config, setConfig] = React.useState<Configuration>(
     DEFAULT_GLOBAL_CONFIGURATION,
   );
+  const [activeFilterCount, setActiveFilterCount] = useState(2);
   const { searchBarConfig } = useSearchBarConfig();
 
   const TAB_CONFIGS: TabRouteConfig[] = [
@@ -237,6 +238,24 @@ function TabsStackComponent() {
             name: 'magnifyingglass',
           },
           systemItem: searchBarConfig.useSystemItem ? 'search' : undefined,
+          toolbarItems: [
+            {
+              type: 'button',
+              icon: {
+                type: 'sfSymbol',
+                name: 'line.3.horizontal.decrease',
+              },
+              accessibilityLabel: 'Filters',
+              accessibilityHint: 'Updates active filters count',
+              badge: {
+                value: String(activeFilterCount),
+              },
+              onPress: () =>
+                setActiveFilterCount(currentFilterCount =>
+                  currentFilterCount + 1,
+                ),
+            },
+          ],
         },
       },
     },

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -22,6 +22,7 @@
 #import "RNSDefines.h"
 #import "RNSScreen.h"
 #import "RNSSearchBar.h"
+#import "RNSTabBarController.h"
 #import "UINavigationBar+RNSUtility.h"
 
 namespace react = facebook::react;
@@ -626,6 +627,11 @@ RNS_IGNORE_SUPER_CALL_END
 #if !TARGET_OS_TV
   if (!searchBarPresent) {
     navitem.searchController = nil;
+  }
+  if ([vc.tabBarController isKindOfClass:RNSTabBarController.class]) {
+    RNSTabBarController *tabBarController = static_cast<RNSTabBarController *>(vc.tabBarController);
+    tabBarController.needsUpdateOfSearchToolbarItems = true;
+    [tabBarController updateSearchToolbarItemsIfNeeded];
   }
 #endif /* !TARGET_OS_TV */
 

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -227,6 +227,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateTabBarAppearance;
 
 /**
+ * Updates native toolbar items associated with the selected search tab.
+ */
+- (void)updateSearchToolbarItemsIfNeeded;
+
+/**
+ * Updates native toolbar items associated with the selected search tab.
+ */
+- (void)updateSearchToolbarItems;
+
+/**
  * Updates the interface orientation based on selected tab screen and its children.
  *
  * This method does nothing if the update has not been previously requested.
@@ -286,6 +296,11 @@ NS_ASSUME_NONNULL_BEGIN
  * appearance requires update.
  */
 @property (nonatomic, readwrite) bool needsUpdateOfTabBarAppearance;
+
+/**
+ * Tell the controller that toolbar items associated with the selected search tab need an update.
+ */
+@property (nonatomic, readwrite) bool needsUpdateOfSearchToolbarItems;
 
 /**
  * Tell the controller that some configuration regarding interface orientation has changed & it

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -7,6 +7,7 @@
 #import "NSString+RNSUtility.h"
 #import "RNSLog.h"
 #import "RNSScreenWindowTraits.h"
+#import "RNSTabsHostComponentView+RNSImageLoader.h"
 #import "RNSTabsHostComponentView.h"
 #import "RNSTabsNavigationStateObserverRegistry.h"
 
@@ -97,6 +98,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
     _navigationState = nil;
     _pendingStateUpdate = nil;
     _shouldProgressStateOnMoreNavigationControllerPush = NO;
+    _needsUpdateOfSearchToolbarItems = false;
     _observerRegistry = [RNSTabsNavigationStateObserverRegistry new];
 
     // Delegate field retains weakly, no risk of cycle.
@@ -250,6 +252,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   _isHandlingExplicitSelectionUpdate = NO;
 
   [self updateTabBarAppearanceIfNeeded];
+  [self updateSearchToolbarItemsIfNeeded];
   [self updateTabBarA11yIfNeeded];
   [self updateOrientationIfNeeded];
 }
@@ -280,10 +283,12 @@ static void rns_pushViewController(__unsafe_unretained id self,
   [self progressNavigationState:screenKey withOrigin:actionOrigin];
 
   if (currSelectedViewController == nextSelectedViewController) {
+    self.needsUpdateOfSearchToolbarItems = true;
     return YES;
   }
 
   [self setSelectedViewController:nextSelectedViewController];
+  self.needsUpdateOfSearchToolbarItems = true;
   return YES;
 }
 
@@ -342,6 +347,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
                                                                            actionOrigin:RNSTabsActionOriginUser];
     [_observerRegistry emitDidUpdateStateTo:_navigationState withContext:updateContext sender:self];
   }
+  self.needsUpdateOfSearchToolbarItems = true;
+  [self updateSearchToolbarItemsIfNeeded];
 }
 
 - (void)onDidPreventUserFromSelectingViewControllerWithKey:(nonnull NSString *)screenKey
@@ -580,6 +587,32 @@ static void rns_pushViewController(__unsafe_unretained id self,
                                    withHostComponentView:self.tabsHostComponentView
                                     tabScreenControllers:_tabScreenControllers
                                              imageLoader:[self.tabsHostComponentView reactImageLoader]];
+}
+
+- (void)updateSearchToolbarItemsIfNeeded
+{
+  if (_needsUpdateOfSearchToolbarItems) {
+    [self updateSearchToolbarItems];
+  }
+}
+
+- (void)updateSearchToolbarItems
+{
+  _needsUpdateOfSearchToolbarItems = false;
+
+  RNSTabsScreenViewController *selectedScreenViewController = nil;
+  if (![self isSelectedViewControllerTheMoreNavigationController] &&
+      [self.selectedViewController isKindOfClass:RNSTabsScreenViewController.class]) {
+    selectedScreenViewController = [self selectedScreenViewController];
+  }
+
+  for (RNSTabsScreenViewController *screenViewController in _tabScreenControllers) {
+    if (screenViewController != selectedScreenViewController) {
+      [screenViewController clearSearchToolbarItems];
+    }
+  }
+
+  [selectedScreenViewController updateSearchToolbarItemsWithImageLoader:[self.tabsHostComponentView reactImageLoader]];
 }
 
 - (void)updateTabBarA11yIfNeeded

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -70,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL tabBarItemNeedsA11yUpdate;
 
 @property (nonatomic, readonly) RNSTabsScreenSystemItem systemItem;
+@property (nonatomic, copy, readonly, nullable) NSArray<NSDictionary<NSString *, id> *> *searchToolbarItems;
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -1,6 +1,7 @@
 #import "RNSTabsScreenComponentView.h"
 #import "NSString+RNSUtility.h"
 #import "RNSConversions.h"
+#import "RNSConvert.h"
 #import "RNSDefines.h"
 #import "RNSLog.h"
 #import "RNSSafeAreaViewNotifications.h"
@@ -80,6 +81,7 @@ namespace react = facebook::react;
   _selectedIconResourceName = nil;
 
   _systemItem = RNSTabsScreenSystemItemNone;
+  _searchToolbarItems = nil;
 
   _userInterfaceStyle = UIUserInterfaceStyleUnspecified;
 }
@@ -338,6 +340,22 @@ RNS_IGNORE_SUPER_CALL_END
     _systemItem =
         rnscreens::conversion::RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(newComponentProps.systemItem);
     tabBarItemNeedsRecreation = YES;
+    RNSTabBarController *tabBarController = [self findTabBarController];
+    tabBarController.needsUpdateOfSearchToolbarItems = true;
+  }
+
+  if (newComponentProps.toolbarItems != oldComponentProps.toolbarItems) {
+    const auto &vec = newComponentProps.toolbarItems;
+    NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
+    for (const auto &item : vec) {
+      NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
+      if ([dict isKindOfClass:NSDictionary.class]) {
+        [array addObject:dict];
+      }
+    }
+    _searchToolbarItems = array;
+    RNSTabBarController *tabBarController = [self findTabBarController];
+    tabBarController.needsUpdateOfSearchToolbarItems = true;
   }
 
   if (newComponentProps.userInterfaceStyle != oldComponentProps.userInterfaceStyle) {

--- a/ios/tabs/screen/RNSTabsScreenEventEmitter.h
+++ b/ios/tabs/screen/RNSTabsScreenEventEmitter.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)emitOnDidAppear;
 - (BOOL)emitOnWillDisappear;
 - (BOOL)emitOnDidDisappear;
+- (BOOL)emitOnPressToolbarItem:(NSString *)buttonId;
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenEventEmitter.mm
+++ b/ios/tabs/screen/RNSTabsScreenEventEmitter.mm
@@ -4,6 +4,8 @@
 #import <React/RCTLog.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 
+namespace react = facebook::react;
+
 @implementation RNSTabsScreenEventEmitter {
   std::shared_ptr<const react::RNSTabsScreenIOSEventEmitter> _reactEventEmitter;
 }
@@ -48,6 +50,18 @@
     return YES;
   } else {
     RCTLogWarn(@"[RNScreens] Skipped OnDidDisappear event emission due to nullish emitter");
+    return NO;
+  }
+}
+
+- (BOOL)emitOnPressToolbarItem:(NSString *)buttonId
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onPressToolbarItem(
+        react::RNSTabsScreenIOSEventEmitter::OnPressToolbarItem{.buttonId = std::string([buttonId UTF8String])});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnPressToolbarItem event emission due to nullish emitter");
     return NO;
   }
 }

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#import <React/RCTImageLoader.h>
 #import <UIKit/UIKit.h>
 #import "RNSTabsScreenComponentView.h"
 #import "RNSTabsSpecialEffectsSupporting.h"
@@ -27,6 +28,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Tell the controller that the tab screen it owns has got its react-props-orientation changed.
  */
 - (void)tabScreenOrientationHasChanged;
+
+/**
+ * Updates native toolbar items associated with this tab screen's search item.
+ */
+- (void)updateSearchToolbarItemsWithImageLoader:(nullable RCTImageLoader *)imageLoader;
+
+/**
+ * Restores toolbar items previously replaced by this tab screen.
+ */
+- (void)clearSearchToolbarItems;
 
 /**
  * Tell the controller that the tab item related to this controller has been selected again after being presented.

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -1,10 +1,15 @@
 #import "RNSTabsScreenViewController.h"
+#import "RNSBarButtonItem.h"
+#import "RNSDefines.h"
 #import "RNSLog.h"
 #import "RNSScrollViewFinder.h"
 #import "RNSTabBarController.h"
 #import "UIScrollView+RNScreens.h"
 
-@implementation RNSTabsScreenViewController
+@implementation RNSTabsScreenViewController {
+  __weak UIViewController *_searchToolbarItemsOwner;
+  NSArray<UIBarButtonItem *> *_searchToolbarItemsOwnerBaseItems;
+}
 
 - (nullable RNSTabBarController *)findTabBarController
 {
@@ -26,6 +31,104 @@
   [[self findTabBarController] setNeedsOrientationUpdate:true];
 }
 
+- (void)clearSearchToolbarItems
+{
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+  if (@available(iOS 26.0, *)) {
+    if (_searchToolbarItemsOwner != nil) {
+      [_searchToolbarItemsOwner setToolbarItems:_searchToolbarItemsOwnerBaseItems animated:YES];
+      _searchToolbarItemsOwner = nil;
+      _searchToolbarItemsOwnerBaseItems = nil;
+    }
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+}
+
+- (void)updateSearchToolbarItemsWithImageLoader:(nullable RCTImageLoader *)imageLoader
+{
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+  if (@available(iOS 26.0, *)) {
+    RNSTabsScreenComponentView *screenView = self.tabScreenComponentView;
+    UIViewController *toolbarOwner = [self activeSearchToolbarViewController];
+    UINavigationItem *navigationItem = toolbarOwner.navigationItem;
+    UIBarButtonItem *searchBarItem = navigationItem.searchBarPlacementBarButtonItem;
+
+    if (screenView.systemItem != RNSTabsScreenSystemItemSearch || screenView.searchToolbarItems.count == 0 ||
+        navigationItem.searchController == nil || !navigationItem.searchBarPlacementAllowsToolbarIntegration ||
+        searchBarItem == nil) {
+      [self clearSearchToolbarItems];
+      return;
+    }
+
+    NSArray<UIBarButtonItem *> *baseItems = nil;
+    if (_searchToolbarItemsOwner == toolbarOwner) {
+      baseItems = _searchToolbarItemsOwnerBaseItems ?: @[];
+    } else {
+      [self clearSearchToolbarItems];
+      _searchToolbarItemsOwner = toolbarOwner;
+      _searchToolbarItemsOwnerBaseItems = toolbarOwner.toolbarItems ?: @[];
+      baseItems = _searchToolbarItemsOwnerBaseItems;
+    }
+
+    NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithArray:baseItems ?: @[]];
+    [items addObject:searchBarItem];
+    [items addObjectsFromArray:[self toolbarButtonItemsFromConfigs:screenView.searchToolbarItems
+                                                       imageLoader:imageLoader]];
+    [toolbarOwner setToolbarItems:items animated:YES];
+  }
+#else
+  [self clearSearchToolbarItems];
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+}
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+- (UIViewController *)activeSearchToolbarViewController API_AVAILABLE(ios(26.0))
+{
+  UIViewController *controller = self;
+  while (true) {
+    if ([controller isKindOfClass:UINavigationController.class]) {
+      UINavigationController *navigationController = static_cast<UINavigationController *>(controller);
+      UIViewController *visibleViewController =
+          navigationController.visibleViewController ?: navigationController.topViewController;
+      if (visibleViewController == nil || visibleViewController == controller) {
+        return controller;
+      }
+      controller = visibleViewController;
+      continue;
+    }
+
+    UIViewController *childViewController = controller.childViewControllers.lastObject;
+    if (childViewController == nil) {
+      return controller;
+    }
+    controller = childViewController;
+  }
+}
+
+- (NSArray<UIBarButtonItem *> *)toolbarButtonItemsFromConfigs:(NSArray<NSDictionary<NSString *, id> *> *)dicts
+                                                  imageLoader:(nullable RCTImageLoader *)imageLoader
+    API_AVAILABLE(ios(26.0))
+{
+  NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithCapacity:dicts.count];
+  __weak RNSTabsScreenViewController *weakSelf = self;
+  for (NSDictionary<NSString *, id> *dict in dicts) {
+    if (dict[@"buttonId"] == nil) {
+      continue;
+    }
+
+    RNSBarButtonItem *item = [[RNSBarButtonItem alloc]
+        initWithConfig:dict
+                action:^(NSString *buttonId) {
+                  [weakSelf.tabScreenComponentView.reactEventEmitter emitOnPressToolbarItem:buttonId];
+                }
+            menuAction:nil
+           imageLoader:imageLoader];
+    [items addObject:item];
+  }
+  return items;
+}
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
@@ -36,6 +139,9 @@
 {
   [super viewDidAppear:animated];
   [self.tabScreenComponentView.reactEventEmitter emitOnDidAppear];
+  RNSTabBarController *tabBarController = [self findTabBarController];
+  tabBarController.needsUpdateOfSearchToolbarItems = true;
+  [tabBarController updateSearchToolbarItemsIfNeeded];
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -9,6 +9,7 @@
 @implementation RNSTabsScreenViewController {
   __weak UIViewController *_searchToolbarItemsOwner;
   NSArray<UIBarButtonItem *> *_searchToolbarItemsOwnerBaseItems;
+  BOOL _searchToolbarItemsOwnerHadHiddenToolbar;
 }
 
 - (nullable RNSTabBarController *)findTabBarController
@@ -37,8 +38,11 @@
   if (@available(iOS 26.0, *)) {
     if (_searchToolbarItemsOwner != nil) {
       [_searchToolbarItemsOwner setToolbarItems:_searchToolbarItemsOwnerBaseItems animated:YES];
+      [_searchToolbarItemsOwner.navigationController setToolbarHidden:_searchToolbarItemsOwnerHadHiddenToolbar
+                                                              animated:YES];
       _searchToolbarItemsOwner = nil;
       _searchToolbarItemsOwnerBaseItems = nil;
+      _searchToolbarItemsOwnerHadHiddenToolbar = NO;
     }
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
@@ -67,6 +71,7 @@
       [self clearSearchToolbarItems];
       _searchToolbarItemsOwner = toolbarOwner;
       _searchToolbarItemsOwnerBaseItems = toolbarOwner.toolbarItems ?: @[];
+      _searchToolbarItemsOwnerHadHiddenToolbar = toolbarOwner.navigationController.toolbarHidden;
       baseItems = _searchToolbarItemsOwnerBaseItems;
     }
 
@@ -75,6 +80,7 @@
     [items addObjectsFromArray:[self toolbarButtonItemsFromConfigs:screenView.searchToolbarItems
                                                        imageLoader:imageLoader]];
     [toolbarOwner setToolbarItems:items animated:YES];
+    [toolbarOwner.navigationController setToolbarHidden:NO animated:YES];
   }
 #else
   [self clearSearchToolbarItems];

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -6,6 +6,10 @@
 #import "RNSTabBarController.h"
 #import "UIScrollView+RNScreens.h"
 
+static constexpr CGFloat RNSSearchToolbarDefaultLeadingReservedWidth = 80.0;
+static constexpr CGFloat RNSSearchToolbarLeadingReservedPadding = 4.0;
+static constexpr CGFloat RNSSearchToolbarMaxCompactTabControlWidth = 72.0;
+
 @implementation RNSTabsScreenViewController {
   __weak UIViewController *_searchToolbarItemsOwner;
   NSArray<UIBarButtonItem *> *_searchToolbarItemsOwnerBaseItems;
@@ -76,6 +80,10 @@
     }
 
     NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithArray:baseItems ?: @[]];
+    CGFloat leadingReservedWidth = [self searchToolbarLeadingReservedWidth];
+    if (leadingReservedWidth > 0.0) {
+      [items addObject:[UIBarButtonItem fixedSpaceItemOfWidth:leadingReservedWidth]];
+    }
     [items addObject:searchBarItem];
     [items addObjectsFromArray:[self toolbarButtonItemsFromConfigs:screenView.searchToolbarItems
                                                        imageLoader:imageLoader]];
@@ -88,6 +96,33 @@
 }
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
+- (CGFloat)searchToolbarLeadingReservedWidth API_AVAILABLE(ios(26.0))
+{
+  UITabBar *tabBar = self.tabBarController.tabBar;
+  if (tabBar == nil || CGRectIsEmpty(tabBar.bounds)) {
+    return self.tabBarController.selectedIndex == 0 ? 0.0 : RNSSearchToolbarDefaultLeadingReservedWidth;
+  }
+
+  CGFloat tabBarMidX = CGRectGetMidX(tabBar.bounds);
+  CGFloat leadingMaxX = 0.0;
+  for (UIView *subview in tabBar.subviews) {
+    CGRect frame = subview.frame;
+    CGFloat width = CGRectGetWidth(frame);
+    if (subview.hidden || subview.alpha < 0.01 || CGRectIsEmpty(frame) ||
+        width > RNSSearchToolbarMaxCompactTabControlWidth || CGRectGetMidX(frame) >= tabBarMidX) {
+      continue;
+    }
+
+    leadingMaxX = MAX(leadingMaxX, CGRectGetMaxX(frame));
+  }
+
+  if (leadingMaxX > 0.0) {
+    return leadingMaxX + RNSSearchToolbarLeadingReservedPadding;
+  }
+
+  return self.tabBarController.selectedIndex == 0 ? 0.0 : RNSSearchToolbarDefaultLeadingReservedWidth;
+}
+
 - (UIViewController *)activeSearchToolbarViewController API_AVAILABLE(ios(26.0))
 {
   UIViewController *controller = self;

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -34,6 +34,7 @@ export type {
   // iOS
   TabsScreenBlurEffect,
   TabsScreenSystemItem,
+  TabsScreenToolbarItemIOS,
   TabsScreenAppearanceIOS,
   TabsScreenItemAppearanceIOS,
   TabsScreenItemStateAppearanceIOS,

--- a/src/components/tabs/screen/TabsScreen.ios.tsx
+++ b/src/components/tabs/screen/TabsScreen.ios.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import {
   ImageResolvedAssetSource,
+  NativeSyntheticEvent,
   StyleSheet,
   processColor,
   type ImageSourcePropType,
@@ -21,6 +22,7 @@ import type {
 } from './TabsScreen.ios.types';
 import type { TabsScreenProps } from './TabsScreen.types';
 import type { PlatformIconIOS } from '../../../types';
+import { prepareHeaderBarButtonItems } from '../../helpers/prepareHeaderBarButtonItems';
 import { useTabsScreen } from './useTabsScreen';
 
 /**
@@ -55,6 +57,30 @@ function TabsScreen(props: TabsScreenProps) {
     });
 
   const iconProps = parseIconsToNativeProps(ios?.icon, ios?.selectedIcon);
+  const toolbarItems = React.useMemo(
+    () =>
+      ios?.toolbarItems
+        ? prepareHeaderBarButtonItems(ios.toolbarItems, 'right')
+        : undefined,
+    [ios?.toolbarItems],
+  );
+  const onPressToolbarItem = toolbarItems
+    ? (event: NativeSyntheticEvent<{ buttonId: string }>) => {
+        const pressedItem = toolbarItems.find(
+          item =>
+            item &&
+            'buttonId' in item &&
+            item.buttonId === event.nativeEvent.buttonId,
+        );
+        if (
+          pressedItem &&
+          pressedItem.type === 'button' &&
+          pressedItem.onPress
+        ) {
+          pressedItem.onPress();
+        }
+      }
+    : undefined;
 
   return (
     <TabsScreenIOSNativeComponent
@@ -75,6 +101,8 @@ function TabsScreen(props: TabsScreenProps) {
       )}
       userInterfaceStyle={ios?.experimental_userInterfaceStyle}
       systemItem={ios?.systemItem}
+      toolbarItems={toolbarItems}
+      onPressToolbarItem={onPressToolbarItem}
       overrideScrollViewContentInsetAdjustmentBehavior={
         ios?.overrideScrollViewContentInsetAdjustmentBehavior
       }>

--- a/src/components/tabs/screen/TabsScreen.ios.types.ts
+++ b/src/components/tabs/screen/TabsScreen.ios.types.ts
@@ -1,6 +1,9 @@
 import type { ColorValue, TextStyle } from 'react-native';
 import type { UserInterfaceStyle, BlurEffect } from '../../shared/types';
-import type { PlatformIconIOS } from '../../../types';
+import type {
+  HeaderBarButtonItemWithAction,
+  PlatformIconIOS,
+} from '../../../types';
 
 export type TabsScreenBlurEffect = BlurEffect | 'systemDefault';
 
@@ -17,6 +20,8 @@ export type TabsScreenSystemItem =
   | 'recents'
   | 'search'
   | 'topRated';
+
+export type TabsScreenToolbarItemIOS = HeaderBarButtonItemWithAction;
 
 export interface TabsScreenAppearanceIOS {
   /**
@@ -277,6 +282,17 @@ export interface TabsScreenPropsIOS {
    * @platform ios
    */
   systemItem?: TabsScreenSystemItem | undefined;
+  /**
+   * @summary Native toolbar items displayed next to the integrated search item.
+   *
+   * On iOS 26 and later, when this screen uses `systemItem: 'search'` and the active
+   * nested screen has a search controller integrated into the toolbar, these items are
+   * appended after `UINavigationItem.searchBarPlacementBarButtonItem`.
+   *
+   * @platform ios
+   * @supported iOS 26 or higher
+   */
+  toolbarItems?: TabsScreenToolbarItemIOS[] | undefined;
   /**
    * @summary Specifies if `contentInsetAdjustmentBehavior` of first ScrollView
    * in first descendant chain from tab screen should be overridden back from `never`

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -14,6 +14,7 @@ import { UnsafeMixed } from './codegenUtils';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type GenericEmptyEvent = Readonly<{}>;
+type OnPressToolbarItemEvent = Readonly<{ buttonId: string }>;
 
 // #endregion General helpers
 
@@ -115,6 +116,9 @@ export interface NativeProps extends ViewProps {
   onDidAppear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onWillDisappear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
   onDidDisappear?: CT.DirectEventHandler<GenericEmptyEvent> | undefined;
+  onPressToolbarItem?:
+    | CT.DirectEventHandler<OnPressToolbarItemEvent>
+    | undefined;
 
   // Control
   screenKey: string;
@@ -145,6 +149,7 @@ export interface NativeProps extends ViewProps {
   // Tab config
   isTitleUndefined?: CT.WithDefault<boolean, true>;
   systemItem?: CT.WithDefault<SystemItem, 'none'>;
+  toolbarItems?: CT.UnsafeMixed[] | undefined;
 
   // Appearance
   standardAppearance?: UnsafeMixed<Appearance> | undefined;


### PR DESCRIPTION
## Description

Adds the native `react-native-screens` primitive needed to render UIKit toolbar items next to the integrated iOS 26 search control in native tabs.

The motivation is to support downstream APIs, including Expo Router native tabs, without replacing the native tab bar or search control with a custom JavaScript bar. This keeps UIKit rendering, native search expansion, toolbar minimization, and accessibility semantics intact.

Companion Expo Router PR: expo/expo#46617.

## Changes

- Adds `ios.toolbarItems` to native tabs screen props, reusing the existing header bar button item shape.
- Adds an `onPressToolbarItem` event and dispatches the matching item `onPress` handler from JS.
- Composes the custom toolbar items with `navigationItem.searchBarPlacementBarButtonItem` when the selected iOS tab uses `systemItem: 'search'` and search toolbar integration is available.
- Reserves the visible leading compact tab controls so the integrated search field does not render underneath them when toolbar items are present.
- Refreshes search toolbar items when the selected tab, tab item configuration, or native-stack search config changes.
- Clears the injected toolbar composition when the active tab is no longer eligible.

## Before & after - visual documentation

The screenshot below was captured from `FabricExample` running on an iOS 26.5 simulator. It shows the native integrated search field with a trailing SF Symbol toolbar item rendered by UIKit.

![iOS 26 native search toolbar item](https://github.com/marcodejongh/react-native-screens/releases/download/codex-ios-search-toolbar-screenshot-f99f1097/rns-search-toolbar-leading-reserve-helper.png)

## Test plan

Tested locally:

- `yarn check-types`
- `xcodebuild -quiet -workspace FabricExample/ios/FabricExample.xcworkspace -scheme FabricExample -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/rns-fabric-example-derived-data CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -quiet -workspace FabricExample/ios/FabricExample.xcworkspace -scheme FabricExample -configuration Debug -sdk iphonesimulator -destination 'id=BB8A37F1-DDBE-4344-9B98-6526C6B17566' -derivedDataPath /private/tmp/rns-fabric-example-final-derived-data CODE_SIGNING_ALLOWED=NO build`
- Installed/launched `FabricExample` on iOS 26.5 simulator and captured `/private/tmp/rns-search-toolbar-leading-reserve-helper.png`.
- `git diff --check`

Also tried `yarn test:unit --no-watchman`; it fails before reaching relevant tests because `TVOSExample/__tests__/App.test.tsx` cannot resolve `react-native-screens` in the current local setup.

Minimal usage example:

```tsx
const TAB_CONFIGS: TabRouteConfig[] = [
  {
    name: 'Search',
    Component: SearchStack,
    options: {
      title: 'Search',
      ios: {
        systemItem: 'search',
        toolbarItems: [
          {
            type: 'button',
            icon: { type: 'sfSymbol', name: 'line.3.horizontal.decrease' },
            accessibilityLabel: 'Filters',
            accessibilityHint: 'Opens search filters',
            badge: { value: String(activeFilterCount) },
            onPress: openFilters,
          },
        ],
      },
    },
  },
];
```

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
