### PR TITLE
fix(Tabs): re-export TabSelectionPreventedEvent from package root

### DIFF
--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -6,6 +6,7 @@ export type {
   TabSelectedEvent,
   TabSelectionRejectedEvent,
   TabSelectionRejectionReason,
+  TabSelectionPreventedEvent,
   TabsHostColorScheme,
   TabsHostDirection,
   TabsHostNativeContainerStyleProps,


### PR DESCRIPTION
## Description

`TabSelectionPreventedEvent` was exported from the `host` barrel but never re-exported from the package root, so consumers like `expo-router` couldn't import it and had to derive the payload from the `onTabSelectionPrevented` prop instead.

## Changes

Add `TabSelectionPreventedEvent` to the `export type { ... } from './host'` list in `src/components/tabs/index.ts`.

## Test plan

`yarn check-types` passes. The type can now be imported from the package root:

```ts
import { type TabSelectionPreventedEvent } from 'react-native-screens';
```
