### PR TITLE
chore: add RNS_USE_CXXBRIDGE to compile out legacy code

### DIFF
--- a/RNScreens.podspec
+++ b/RNScreens.podspec
@@ -4,6 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 gamma_project_enabled = ENV['RNS_GAMMA_ENABLED'] == '1'
 debug_logging_enabled = ENV['RNS_DEBUG_LOGGING'] == '1'
+use_cxxbridge = ENV['RNS_USE_CXXBRIDGE'] == '1'
 
 
 source_files_exts = '{h,m,mm,cpp,swift}'
@@ -21,6 +22,7 @@ if debug_logging_enabled
   rnscreens_swift_flags << "-DRNS_DEBUG_LOGGING"
 end
 rnscreens_cpp_flags << "-DRNS_GAMMA_ENABLED=1" if gamma_project_enabled
+rnscreens_cpp_flags << "-DRNS_USE_CXXBRIDGE=1" if use_cxxbridge
 
 rnscreens_config  =  {
   'OTHER_CPLUSPLUSFLAGS' => rnscreens_cpp_flags.join(" "),

--- a/ios/RNSModule.mm
+++ b/ios/RNSModule.mm
@@ -1,5 +1,7 @@
 #import "RNSModule.h"
+#if RNS_USE_CXXBRIDGE
 #import <React/RCTBridge+Private.h>
+#endif // RNS_USE_CXXBRIDGE
 #import <React/RCTBridge.h>
 #import <React/RCTUtils.h>
 #include <jsi/jsi.h>
@@ -120,7 +122,8 @@ RCT_EXPORT_MODULE()
 {
   /*
    installHostObject method is called from constantsToExport and getTurboModule.
-*/
+  */
+#if RNS_USE_CXXBRIDGE
   RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
   if (cxxBridge != nil) {
     auto jsiRuntime = (jsi::Runtime *)cxxBridge.runtime;
@@ -149,6 +152,7 @@ RCT_EXPORT_MODULE()
           runtime, RNScreens::RNScreensTurboModule::MODULE_NAME, std::move(rnScreensModuleHostObject));
     }
   }
+#endif // RNS_USE_CXXBRIDGE
 }
 
 @end


### PR DESCRIPTION
## Description

Due to removal of legacy arch in `react-native` core, `RCTCxxBridge` has been compiled out (https://github.com/react/react-native/pull/56837). This causes `react-native-screens` to fail to build with latest `react-native` nightlies.

We decided to compile out the code that uses `RCTCxxBridge` with `RNS_USE_CXXBRIDGE` env variable. If you need to bring this back, use `RNS_USE_CXXBRIDGE=1` when installing pods. This however won't work with react-native 0.87.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1508.

## Changes

- add `RNS_USE_CXXBRIDGE`
- compile out `RCTCxxBridge` usage if `RNS_USE_CXXBRIDGE` is not defined to `1`

## Before & after - visual documentation
### Before

<img width="2274" height="768" alt="before" src="https://github.com/user-attachments/assets/8f22bba1-d2bc-49be-ae9a-0cfb53ebc7a0" />

### After

https://github.com/user-attachments/assets/bb3b04b1-d9c4-4d3e-bd2e-22797506e7fd

## Test plan

Create brand new react-native app with one of the most recent nightlies (e.g. `npx @react-native-community/cli@latest init rn87 --version 0.87.0-nightly-20260608-2ff3b81dc`). Use `screens` from this PR. The app should build correctly.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] Ensured that CI passes
