### PR TITLE
chore(Android): Remove explicit versions setting in `build.gradle`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        if (isRunningInContextOfScreensRepo()) {
+        if (project == rootProject) {
             classpath('com.android.tools.build:gradle:8.2.1')
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,9 +20,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:8.2.1')
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        if (project == rootProject) {
+            classpath('com.android.tools.build:gradle:8.2.1')
+            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
+            classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        if (project == rootProject) {
+        if (isRunningInContextOfScreensRepo()) {
             classpath('com.android.tools.build:gradle:8.2.1')
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,3 @@
-import com.android.Version
-import groovy.json.JsonSlurper
-
 buildscript {
     ext {
         rnsDefaultTargetSdkVersion = 34

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        if (project == rootProject) {
+        def isRunningInContextOfScreensRepo = project == rootProject
+        if (isRunningInContextOfScreensRepo) {
             classpath('com.android.tools.build:gradle:8.2.1')
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', rnsDefaultKotlinVersion)}"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

This PR is a follow up for the [PR from Gesture Handler side](https://github.com/software-mansion/react-native-gesture-handler/pull/4248). In [this issue](https://github.com/software-mansion/react-native-gesture-handler/issues/2307) in our repository it was stated that there are warnings during build phase, namely both, Screens and Gesture Handler try to load their pinned versions of Kotlin.

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

To address aforementioned issue, I've added simple `if` statement that adds pinned versions to classpath only if Screens is the root project (e.g. when running `spotless`). Both, `gradle` and `kotlin-gradle-plugin` are shipped with React Native apps ([see template](https://github.com/react-native-community/template/blob/816967c82f535cacc0f7a5c28688e884ecc3bdd9/template/android/build.gradle#L14)) so it is not necessary to declare them. This could break before RN 0.70, but I don't think that it is relevant at this point.

## Test plan

Tested that `FabricExample` and standalone app with Screens added from generated package build correctly.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
