### PR TITLE
feat: Handle onPress in iOS Menu

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,
@@ -9,24 +9,31 @@ import { Button, ScrollView } from 'react-native';
 import LongText from '@apps/shared/LongText';
 import { scenarioDescription } from './scenario-description';
 import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
+import { ToastProvider, useToast } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
 
 const DEFAULT_TRAILING_ITEMS_COUNT = 2;
 
 export function App() {
   return (
-    <StackContainer
-      routeConfigs={[
-        {
-          name: 'Home',
-          Component: ConfigScreen,
-          options: {},
-        },
-      ]}
-    />
+    <ToastProvider>
+      <StackContainer
+        routeConfigs={[
+          {
+            name: 'Home',
+            Component: ConfigScreen,
+            options: {},
+          },
+        ]}
+      />
+    </ToastProvider>
   );
 }
 
-function buildHeaderConfig(trailingItemsCount: number): StackHeaderConfigProps {
+function buildHeaderConfig(
+  trailingItemsCount: number,
+  showToast: (text: string) => void,
+): StackHeaderConfigProps {
   const trailingItems: NonNullable<
     StackHeaderConfigProps['ios']
   >['trailingItems'] = Array.from({ length: trailingItemsCount }).map(
@@ -42,15 +49,37 @@ function buildHeaderConfig(trailingItemsCount: number): StackHeaderConfigProps {
       }),
       menu: {
         type: 'menu',
+        menuElementId: `menu-${i}`,
         children: [
-          { type: 'menuItem', title: `Item ${i}.1` },
-          { type: 'menuItem', title: `Item ${i}.2` },
           {
+            menuElementId: `subitem-${i}-1`,
+            type: 'menuItem',
+            title: `Item ${i}.1`,
+            onPress: () => showToast(`Clicked Item ${i}.1`),
+          },
+          {
+            menuElementId: `subitem-${i}-2`,
+            type: 'menuItem',
+            title: `Item ${i}.2`,
+            onPress: () => showToast(`Clicked Item ${i}.2`),
+          },
+          {
+            menuElementId: `submenu-${i}`,
             type: 'menu',
             title: `Submenu ${i}`,
             children: [
-              { type: 'menuItem', title: `Nested ${i}.1` },
-              { type: 'menuItem', title: `Nested ${i}.2` },
+              {
+                menuElementId: `subsubitem-${i}-1`,
+                type: 'menuItem',
+                title: `Nested ${i}.1`,
+                onPress: () => showToast(`Clicked Nested ${i}.1`),
+              },
+              {
+                menuElementId: `subsubitem-${i}-2`,
+                type: 'menuItem',
+                title: `Nested ${i}.2`,
+                onPress: () => showToast(`Clicked Nested ${i}.2`),
+              },
             ],
           },
         ],
@@ -68,14 +97,22 @@ function buildHeaderConfig(trailingItemsCount: number): StackHeaderConfigProps {
 
 function ConfigScreen() {
   const navigation = useStackNavigationContext();
+  const toast = useToast();
   const [trailingItemsCount, setTrailingItemsCount] = useState<number>(
     DEFAULT_TRAILING_ITEMS_COUNT,
   );
 
+  const showToast = useCallback(
+    (text: string) => {
+      toast.push({ backgroundColor: Colors.GreenDark120, message: text });
+    },
+    [toast],
+  );
+
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(
-    () => buildHeaderConfig(trailingItemsCount),
-    [trailingItemsCount],
+    () => buildHeaderConfig(trailingItemsCount, showToast),
+    [trailingItemsCount, showToast],
   );
 
   useEffect(() => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -49,33 +49,33 @@ function buildHeaderConfig(
       }),
       menu: {
         type: 'menu',
-        menuElementId: `menu-${i}`,
+        id: `menu-${i}`,
         children: [
           {
-            menuElementId: `subitem-${i}-1`,
+            id: `subitem-${i}-1`,
             type: 'menuItem',
             title: `Item ${i}.1`,
             onPress: () => showToast(`Clicked Item ${i}.1`),
           },
           {
-            menuElementId: `subitem-${i}-2`,
+            id: `subitem-${i}-2`,
             type: 'menuItem',
             title: `Item ${i}.2`,
             onPress: () => showToast(`Clicked Item ${i}.2`),
           },
           {
-            menuElementId: `submenu-${i}`,
+            id: `submenu-${i}`,
             type: 'menu',
             title: `Submenu ${i}`,
             children: [
               {
-                menuElementId: `subsubitem-${i}-1`,
+                id: `subsubitem-${i}-1`,
                 type: 'menuItem',
                 title: `Nested ${i}.1`,
                 onPress: () => showToast(`Clicked Nested ${i}.1`),
               },
               {
-                menuElementId: `subsubitem-${i}-2`,
+                id: `subsubitem-${i}-2`,
                 type: 'menuItem',
                 title: `Nested ${i}.2`,
                 onPress: () => showToast(`Clicked Nested ${i}.2`),

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -24,18 +24,18 @@ TBD
 2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
 3. Click on the Menu 1 item
   - [ ] The bubble morphs into a menu with two items and a submenu
-  - [ ] Clicking on Item 1.1 triggers a Toast "Item 1.1 clicked"
-  - [ ] Clicking on Item 1.2 triggers a Toast "Item 1.2 clicked"
+  - [ ] Clicking on Item 1.1 triggers a Toast "Clicked Item 1.1"
+  - [ ] Clicking on Item 1.2 triggers a Toast "Clicked Item 1.2"
 4. While the menu is opened, click on the Submenu 1
   - [ ] A nested menu appears, containing two items
-  - [ ] Clicking on Nested 1.1 triggers a Toast "Nested 1.1 clicked"
-  - [ ] Clicking on Nested 1.2 triggers a Toast "Nested 1.2 clicked"
+  - [ ] Clicking on Nested 1.1 triggers a Toast "Clicked Nested 1.1"
+  - [ ] Clicking on Nested 1.2 triggers a Toast "Clicked Nested 1.2"
 5. Click on "Toggle trailing items count" 2 times to get 4 items
-3. Click on the Menu 3 item
+6. Click on the Menu 3 item
   - [ ] The bubble morphs into a menu with two items and a submenu
-  - [ ] Clicking on Item 3.1 triggers a Toast "Item 3.1 clicked"
-  - [ ] Clicking on Item 3.2 triggers a Toast "Item 3.2 clicked"
-4. While the menu is opened, click on the Submenu 3
+  - [ ] Clicking on Item 3.1 triggers a Toast "Clicked Item 3.1"
+  - [ ] Clicking on Item 3.2 triggers a Toast "Clicked Item 3.2"
+7. While the menu is opened, click on the Submenu 3
   - [ ] A nested menu appears, containing two items
-  - [ ] Clicking on Nested 3.1 triggers a Toast "Nested 3.1 clicked"
-  - [ ] Clicking on Nested 3.2 triggers a Toast "Nested 3.2 clicked"
+  - [ ] Clicking on Nested 3.1 triggers a Toast "Clicked Nested 3.1"
+  - [ ] Clicking on Nested 3.2 triggers a Toast "Clicked Nested 3.2"

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -24,5 +24,18 @@ TBD
 2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
 3. Click on the Menu 1 item
   - [ ] The bubble morphs into a menu with two items and a submenu
+  - [ ] Clicking on Item 1.1 triggers a Toast "Item 1.1 clicked"
+  - [ ] Clicking on Item 1.2 triggers a Toast "Item 1.2 clicked"
 4. While the menu is opened, click on the Submenu 1
   - [ ] A nested menu appears, containing two items
+  - [ ] Clicking on Nested 1.1 triggers a Toast "Nested 1.1 clicked"
+  - [ ] Clicking on Nested 1.2 triggers a Toast "Nested 1.2 clicked"
+5. Click on "Toggle trailing items count" 2 times to get 4 items
+3. Click on the Menu 3 item
+  - [ ] The bubble morphs into a menu with two items and a submenu
+  - [ ] Clicking on Item 3.1 triggers a Toast "Item 3.1 clicked"
+  - [ ] Clicking on Item 3.2 triggers a Toast "Item 3.2 clicked"
+4. While the menu is opened, click on the Submenu 3
+  - [ ] A nested menu appears, containing two items
+  - [ ] Clicking on Nested 3.1 triggers a Toast "Nested 3.1 clicked"
+  - [ ] Clicking on Nested 3.2 triggers a Toast "Nested 3.2 clicked"

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -125,9 +125,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
 #pragma mark - RNSStackHeaderMenuEventsDelegate
 
-- (void)didPressMenuElement:(NSString *)menuElementId
+- (void)didPressMenuItem:(NSString *)menuElementId
 {
-  [_reactEventEmitter emitOnPressMenuItem:menuElementId];
+  [_reactEventEmitter emitOnMenuItemPress:menuElementId];
 }
 
 #pragma mark - RNSViewFrameChangeDelegate

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -1,11 +1,13 @@
 #import "RNSStackHeaderConfigComponentView.h"
 #import "RNSLog.h"
+#import "RNSStackHeaderConfigEventEmitter.h"
 #import "RNSStackHeaderConfigShadowStateProxy.h"
 #import "RNSStackHeaderContentFactory.h"
 #import "RNSStackHeaderData.h"
 #import "RNSStackHeaderItemComponentView.h"
 #import "RNSStackHeaderItemInvalidationDelegate.h"
 #import "RNSStackHeaderItemSpacerComponentView.h"
+#import "RNSStackHeaderMenuEventsDelegate.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackScreenComponentView.h"
 #import "RNSStackScreenController.h"
@@ -28,7 +30,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
             RNSStackHeaderItemSpacerComponentView.class);
 }
 
-@interface RNSStackHeaderConfigComponentView () <RNSStackHeaderItemInvalidationDelegate>
+@interface RNSStackHeaderConfigComponentView () <RNSStackHeaderItemInvalidationDelegate,
+                                                 RNSStackHeaderMenuEventsDelegate>
 @end
 
 @implementation RNSStackHeaderConfigComponentView {
@@ -43,6 +46,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
   std::shared_ptr<const react::RNSStackHeaderConfigShadowNode::ConcreteState> _state;
   RNSStackHeaderConfigShadowStateProxy *_Nonnull _shadowStateProxy;
+  RNSStackHeaderConfigEventEmitter *_Nonnull _reactEventEmitter;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -52,6 +56,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     _props = defaultProps;
     _children = [NSMutableArray new];
     _shadowStateProxy = [[RNSStackHeaderConfigShadowStateProxy alloc] initWithHeaderConfigView:self];
+    _reactEventEmitter = [RNSStackHeaderConfigEventEmitter new];
     [self resetProps];
   }
   return self;
@@ -111,11 +116,18 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   [self submitCurrentDataIfMounted];
 }
 
-#pragma mark RNSStackHeaderItemInvalidationDelegate
+#pragma mark - RNSStackHeaderItemInvalidationDelegate
 
 - (void)headerItemDidInvalidate
 {
   [self submitCurrentDataIfMounted];
+}
+
+#pragma mark - RNSStackHeaderMenuEventsDelegate
+
+- (void)didPressMenuElement:(NSString *)menuElementId
+{
+  [_reactEventEmitter emitOnPressMenuItem:menuElementId];
 }
 
 #pragma mark - RNSViewFrameChangeDelegate
@@ -193,6 +205,13 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   return NO;
 }
 
+- (void)updateEventEmitter:(const facebook::react::EventEmitter::Shared &)eventEmitter
+{
+  [super updateEventEmitter:eventEmitter];
+  [_reactEventEmitter
+      updateEventEmitter:std::static_pointer_cast<const react::RNSStackHeaderConfigIOSEventEmitter>(eventEmitter)];
+}
+
 #pragma mark - Private
 
 - (void)submitCurrentDataIfMounted
@@ -244,11 +263,13 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
       switch (item.placement) {
         case RNSHeaderItemPlacementLeading:
           [leadingItems addObject:[RNSStackHeaderContentFactory barButtonItemForHeaderItem:item
-                                                                   withFrameChangeDelegate:self]];
+                                                                   withFrameChangeDelegate:self
+                                                                    withMenuEventsDelegate:self]];
           break;
         case RNSHeaderItemPlacementTrailing:
           [trailingItems addObject:[RNSStackHeaderContentFactory barButtonItemForHeaderItem:item
-                                                                    withFrameChangeDelegate:self]];
+                                                                    withFrameChangeDelegate:self
+                                                                     withMenuEventsDelegate:self]];
           break;
         case RNSHeaderItemPlacementTitle:
           if (item.customView != nil) {

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -125,9 +125,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
 #pragma mark - RNSStackHeaderMenuEventsDelegate
 
-- (void)didPressMenuItem:(NSString *)menuElementId
+- (void)didPressMenuItem:(NSString *)menuItemId
 {
-  [_reactEventEmitter emitOnMenuItemPress:menuElementId];
+  [_reactEventEmitter emitOnMenuItemPress:menuItemId];
 }
 
 #pragma mark - RNSViewFrameChangeDelegate

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSStackHeaderConfigEventEmitter : NSObject
 
-- (BOOL)emitOnPressMenuItem:(NSString *)menuElementId;
+- (BOOL)emitOnMenuItemPress:(NSString *)menuElementId;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+// Hide C++ symbols from C compiler used when building Swift module
+#if defined(__cplusplus)
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+
+namespace react = facebook::react;
+#endif // __cplusplus
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSStackHeaderConfigEventEmitter : NSObject
+
+- (BOOL)emitOnPressMenuItem:(NSString *)menuElementId;
+
+@end
+
+#pragma mark - Hidden from Swift
+
+#if defined(__cplusplus)
+
+@interface RNSStackHeaderConfigEventEmitter ()
+
+- (void)updateEventEmitter:(const std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> &)emitter;
+
+@end
+
+#endif // __cplusplus
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSStackHeaderConfigEventEmitter : NSObject
 
-- (BOOL)emitOnMenuItemPress:(NSString *)menuElementId;
+- (BOOL)emitOnMenuItemPress:(NSString *)menuItemId;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -1,4 +1,5 @@
 #import "RNSStackHeaderConfigEventEmitter.h"
+#import <React/RCTConversions.h>
 #import <React/RCTLog.h>
 
 @implementation RNSStackHeaderConfigEventEmitter {
@@ -8,7 +9,7 @@
 - (BOOL)emitOnMenuItemPress:(NSString *)menuElementId
 {
   if (_reactEventEmitter != nullptr) {
-    _reactEventEmitter->onMenuItemPress({.menuElementId = menuElementId.cString});
+    _reactEventEmitter->onMenuItemPress({.menuElementId = RCTStringFromNSString(menuElementId)});
     return YES;
   } else {
     RCTLogWarn(@"[RNScreens] Skipped OnMenuItemPress event emission due to nullish emitter");

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -1,0 +1,24 @@
+#import "RNSStackHeaderConfigEventEmitter.h"
+#import <React/RCTLog.h>
+
+@implementation RNSStackHeaderConfigEventEmitter {
+  std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> _reactEventEmitter;
+}
+
+- (BOOL)emitOnPressMenuItem:(NSString *)menuElementId
+{
+  if (_reactEventEmitter != nullptr) {
+    _reactEventEmitter->onPressMenuItem({.menuElementId = menuElementId.cString});
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnPressMenuItem event emission due to nullish emitter");
+    return NO;
+  }
+}
+
+- (void)updateEventEmitter:(const std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> &)emitter
+{
+  _reactEventEmitter = emitter;
+}
+
+@end

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -6,10 +6,10 @@
   std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> _reactEventEmitter;
 }
 
-- (BOOL)emitOnMenuItemPress:(NSString *)menuElementId
+- (BOOL)emitOnMenuItemPress:(NSString *)menuItemId
 {
   if (_reactEventEmitter != nullptr) {
-    _reactEventEmitter->onMenuItemPress({.menuElementId = RCTStringFromNSString(menuElementId)});
+    _reactEventEmitter->onMenuItemPress({.menuItemId = RCTStringFromNSString(menuItemId)});
     return YES;
   } else {
     RCTLogWarn(@"[RNScreens] Skipped OnMenuItemPress event emission due to nullish emitter");

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -5,13 +5,13 @@
   std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> _reactEventEmitter;
 }
 
-- (BOOL)emitOnPressMenuItem:(NSString *)menuElementId
+- (BOOL)emitOnMenuItemPress:(NSString *)menuElementId
 {
   if (_reactEventEmitter != nullptr) {
-    _reactEventEmitter->onPressMenuItem({.menuElementId = menuElementId.cString});
+    _reactEventEmitter->onMenuItemPress({.menuElementId = menuElementId.cString});
     return YES;
   } else {
-    RCTLogWarn(@"[RNScreens] Skipped OnPressMenuItem event emission due to nullish emitter");
+    RCTLogWarn(@"[RNScreens] Skipped OnMenuItemPress event emission due to nullish emitter");
     return NO;
   }
 }

--- a/ios/gamma/stack/header/RNSStackHeaderContentFactory.h
+++ b/ios/gamma/stack/header/RNSStackHeaderContentFactory.h
@@ -4,6 +4,7 @@
 
 #import "RNSStackHeaderItemDataProviding.h"
 #import "RNSStackHeaderItemSpacerDataProviding.h"
+#import "RNSStackHeaderMenuEventsDelegate.h"
 #import "RNSViewFrameChangeDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -11,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderContentFactory : NSObject
 
 + (UIBarButtonItem *)barButtonItemForHeaderItem:(id<RNSStackHeaderItemDataProviding>)item
-                        withFrameChangeDelegate:(id<RNSViewFrameChangeDelegate>)delegate;
+                        withFrameChangeDelegate:(id<RNSViewFrameChangeDelegate>)delegate
+                         withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)menuEventsDelegate;
 
 + (UIView *)wrappedViewForHeaderItem:(id<RNSStackHeaderItemDataProviding>)item
                  frameChangeDelegate:(id<RNSViewFrameChangeDelegate>)delegate;

--- a/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
@@ -7,11 +7,14 @@
 
 + (UIBarButtonItem *)barButtonItemForHeaderItem:(id<RNSStackHeaderItemDataProviding>)item
                         withFrameChangeDelegate:(id<RNSViewFrameChangeDelegate>)delegate
+                         withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)menuEventsDelegate
 {
   UIBarButtonItem *barButtonItem = [RNSStackHeaderContentFactory internalBarButtonItemForHeaderItem:item
                                                                             withFrameChangeDelegate:delegate];
   if (item.menu != nil) {
-    [RNSStackHeaderMenuCoordinator applyMenu:item.menu toBarButtonItem:barButtonItem];
+    [RNSStackHeaderMenuCoordinator applyMenu:item.menu
+                             toBarButtonItem:barButtonItem
+                      withMenuEventsDelegate:menuEventsDelegate];
   }
 
   return barButtonItem;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
@@ -2,12 +2,15 @@
 
 #import <UIKit/UIKit.h>
 #import "RNSStackHeaderMenuData.h"
+#import "RNSStackHeaderMenuEventsDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSStackHeaderMenuCoordinator : NSObject
 
-+ (void)applyMenu:(nonnull RNSStackHeaderMenuData *)data toBarButtonItem:(nonnull UIBarButtonItem *)item;
++ (void)applyMenu:(RNSStackHeaderMenuData *)data
+           toBarButtonItem:(UIBarButtonItem *)item
+    withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -41,7 +41,7 @@
                                image:nil
                           identifier:nil
                              handler:^(__kindof UIAction *_Nonnull action) {
-                               [weakDelegate didPressMenuElement:itemData.menuElementId];
+                               [weakDelegate didPressMenuItem:itemData.menuElementId];
                              }];
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -2,20 +2,23 @@
 
 @implementation RNSStackHeaderMenuCoordinator
 
-+ (void)applyMenu:(nonnull RNSStackHeaderMenuData *)data toBarButtonItem:(nonnull UIBarButtonItem *)item
++ (void)applyMenu:(RNSStackHeaderMenuData *)data
+           toBarButtonItem:(UIBarButtonItem *)item
+    withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
 {
 #if !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
   if (@available(tvOS 17.0, *)) {
-    item.menu = [self buildMenuFromData:data];
+    item.menu = [self buildMenuFromData:data withMenuEventsDelegate:delegate];
   }
 #endif // !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
 }
 
 + (UIMenu *)buildMenuFromData:(RNSStackHeaderMenuData *)data
+       withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
 {
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
   for (id<RNSStackHeaderMenuElement> child in data.children) {
-    UIMenuElement *element = [self buildElementFromData:child];
+    UIMenuElement *element = [self buildElementFromData:child withMenuEventsDelegate:delegate];
     if (element != nil) {
       [elements addObject:element];
     }
@@ -25,18 +28,20 @@
 }
 
 + (nullable UIMenuElement *)buildElementFromData:(id<RNSStackHeaderMenuElement>)element
+                          withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
 {
   if ([element isKindOfClass:[RNSStackHeaderMenuData class]]) {
-    return [self buildMenuFromData:(RNSStackHeaderMenuData *)element];
+    return [self buildMenuFromData:(RNSStackHeaderMenuData *)element withMenuEventsDelegate:delegate];
   }
 
   if ([element isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
     RNSStackHeaderMenuItemData *itemData = (RNSStackHeaderMenuItemData *)element;
+    __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
     return [UIAction actionWithTitle:itemData.title
                                image:nil
                           identifier:nil
-                             handler:^(__kindof UIAction *_Nonnull action){
-                                 // noop
+                             handler:^(__kindof UIAction *_Nonnull action) {
+                               [weakDelegate didPressMenuElement:itemData.menuElementId];
                              }];
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -5,13 +5,16 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSStackHeaderMenuElement <NSObject>
+
+@property (nonatomic, copy, readonly) NSString *menuElementId;
+
 @end
 
 @interface RNSStackHeaderMenuItemData : NSObject <RNSStackHeaderMenuElement>
 
 @property (nonatomic, copy, readonly, nullable) NSString *title;
 
-- (instancetype)initWithTitle:(nullable NSString *)title;
+- (instancetype)initWithId:(NSString *)menuElementId title:(nullable NSString *)title;
 
 @end
 
@@ -20,7 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly, nullable) NSString *title;
 @property (nonatomic, copy, readonly) NSArray<id<RNSStackHeaderMenuElement>> *children;
 
-- (instancetype)initWithTitle:(nullable NSString *)title children:(NSArray<id<RNSStackHeaderMenuElement>> *)children;
+- (instancetype)initWithId:(NSString *)menuElementId
+                     title:(nullable NSString *)title
+                  children:(NSArray<id<RNSStackHeaderMenuElement>> *)children;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
@@ -2,9 +2,12 @@
 
 @implementation RNSStackHeaderMenuItemData
 
-- (instancetype)initWithTitle:(nullable NSString *)title
+@synthesize menuElementId = _menuElementId;
+
+- (instancetype)initWithId:(NSString *)menuElementId title:(nullable NSString *)title
 {
   if (self = [super init]) {
+    _menuElementId = [menuElementId copy];
     _title = [title copy];
   }
   return self;
@@ -14,9 +17,14 @@
 
 @implementation RNSStackHeaderMenuData
 
-- (instancetype)initWithTitle:(nullable NSString *)title children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
+@synthesize menuElementId = _menuElementId;
+
+- (instancetype)initWithId:(NSString *)menuElementId
+                     title:(nullable NSString *)title
+                  children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
 {
   if (self = [super init]) {
+    _menuElementId = [menuElementId copy];
     _title = [title copy];
     _children = [children copy];
   }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSStackHeaderMenuEventsDelegate <NSObject>
 
-- (void)didPressMenuElement:(NSString *)menuElementId;
+- (void)didPressMenuItem:(NSString *)menuElementId;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSStackHeaderMenuEventsDelegate <NSObject>
 
-- (void)didPressMenuItem:(NSString *)menuElementId;
+- (void)didPressMenuItem:(NSString *)menuItemId;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSStackHeaderMenuEventsDelegate <NSObject>
+
+- (void)didPressMenuElement:(NSString *)menuElementId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -29,7 +29,9 @@
     }
   }
 
-  return [[RNSStackHeaderMenuData alloc] initWithTitle:[self stringForKey:@"title" in:dict] children:children];
+  return [[RNSStackHeaderMenuData alloc] initWithId:[self stringForKey:@"menuElementId" in:dict]
+                                              title:[self stringForKey:@"title" in:dict]
+                                           children:children];
 }
 
 + (nullable id<RNSStackHeaderMenuElement>)elementFromDictionary:(nullable id)dictionary
@@ -44,7 +46,8 @@
     return [self menuFromDictionary:dict];
   } else if ([type isEqual:@"menuItem"]) {
     [RNSStackHeaderMenuMapper validateMenuItemKeys:dict];
-    return [[RNSStackHeaderMenuItemData alloc] initWithTitle:[self stringForKey:@"title" in:dict]];
+    return [[RNSStackHeaderMenuItemData alloc] initWithId:[self stringForKey:@"menuElementId" in:dict]
+                                                    title:[self stringForKey:@"title" in:dict]];
   }
 
   return nil;
@@ -55,20 +58,23 @@
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"type"] || [key isEqualToString:@"title"] || [key isEqualToString:@"children"],
+    RCTAssert([key isEqualToString:@"menuElementId"] || [key isEqualToString:@"type"] ||
+                  [key isEqualToString:@"title"] || [key isEqualToString:@"children"],
               @"[RNScreens] Invalid key \"%@\" found in menu",
               key);
   }
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
+  RCTAssert(dict[@"menuElementId"], @"[RNScreens] missing menuElementId on one of menu elements");
 }
 
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"type"] || [key isEqualToString:@"title"],
+    RCTAssert([key isEqualToString:@"menuElementId"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"],
               @"[RNScreens] Invalid key \"%@\" found in menu item",
               key);
   }
+  RCTAssert(dict[@"menuElementId"], @"[RNScreens] missing menuElementId on one of menu elements");
 }
 
 + (nullable NSString *)stringForKey:(NSString *)key in:(NSDictionary *)dict

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -29,7 +29,7 @@
     }
   }
 
-  return [[RNSStackHeaderMenuData alloc] initWithId:[self stringForKey:@"menuElementId" in:dict]
+  return [[RNSStackHeaderMenuData alloc] initWithId:[self stringForKey:@"id" in:dict]
                                               title:[self stringForKey:@"title" in:dict]
                                            children:children];
 }
@@ -46,7 +46,7 @@
     return [self menuFromDictionary:dict];
   } else if ([type isEqual:@"menuItem"]) {
     [RNSStackHeaderMenuMapper validateMenuItemKeys:dict];
-    return [[RNSStackHeaderMenuItemData alloc] initWithId:[self stringForKey:@"menuElementId" in:dict]
+    return [[RNSStackHeaderMenuItemData alloc] initWithId:[self stringForKey:@"id" in:dict]
                                                     title:[self stringForKey:@"title" in:dict]];
   }
 
@@ -58,23 +58,23 @@
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"menuElementId"] || [key isEqualToString:@"type"] ||
-                  [key isEqualToString:@"title"] || [key isEqualToString:@"children"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
+                  [key isEqualToString:@"children"],
               @"[RNScreens] Invalid key \"%@\" found in menu",
               key);
   }
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
-  RCTAssert(dict[@"menuElementId"], @"[RNScreens] missing menuElementId on one of menu elements");
+  RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"menuElementId"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"],
               @"[RNScreens] Invalid key \"%@\" found in menu item",
               key);
   }
-  RCTAssert(dict[@"menuElementId"], @"[RNScreens] missing menuElementId on one of menu elements");
+  RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 
 + (nullable NSString *)stringForKey:(NSString *)key in:(NSDictionary *)dict

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -41,7 +41,6 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
       );
-      console.log(event.nativeEvent.menuItemId);
       const menuElement = findMenuElementByIdInItems(
         items,
         event.nativeEvent.menuItemId,

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -41,9 +41,10 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
       );
+      console.log(event.nativeEvent.menuItemId);
       const menuElement = findMenuElementByIdInItems(
         items,
-        event.nativeEvent.menuElementId,
+        event.nativeEvent.menuItemId,
       );
       if (menuElement && menuElement.type === 'menuItem') {
         menuElement.onPress?.();

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
 import StackHeaderConfigIOSNativeComponent, {
-  PressMenuItemEvent,
+  MenuItemPressEvent,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
 import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
@@ -35,18 +35,18 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     largeTitleEnabled,
   } = ios ?? {};
 
-  const handleMenuPress = useCallback(
-    (event: NativeSyntheticEvent<PressMenuItemEvent>) => {
+  const handleMenuItemPress = useCallback(
+    (event: NativeSyntheticEvent<MenuItemPressEvent>) => {
       const items = Array.of(
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
       );
-      const menu = findMenuElementByIdInItems(
+      const menuElement = findMenuElementByIdInItems(
         items,
         event.nativeEvent.menuElementId,
       );
-      if (menu && menu.type === 'menuItem') {
-        menu.onPress?.();
+      if (menuElement && menuElement.type === 'menuItem') {
+        menuElement.onPress?.();
       }
     },
     [leadingItems, trailingItems],
@@ -60,7 +60,7 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
       style={styles.config}
-      onPressMenuItem={handleMenuPress}>
+      onMenuItemPress={handleMenuItemPress}>
       {leadingItems?.map(item => makeItemViewFromItem(item, 'leading'))}
       {titleItem && makeItemViewFromItem(titleItem, 'title')}
       {subtitleItem && makeItemViewFromItem(subtitleItem, 'subtitle')}

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
-import StackHeaderConfigIOSNativeComponent from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
+import StackHeaderConfigIOSNativeComponent, {
+  PressMenuItemEvent,
+} from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
 import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
 import StackHeaderItemSpacer from './ios/StackHeaderItemSpacer.ios';
 import StackHeaderItem from './ios/StackHeaderItem.ios';
-import { StyleSheet } from 'react-native';
+import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import type {
   StackHeaderInlineCustomItemIOS,
   StackHeaderInlineItemIOS,
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
+import { findMenuElementByIdInItems } from './utils';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -32,6 +35,23 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     largeTitleEnabled,
   } = ios ?? {};
 
+  const handleMenuPress = useCallback(
+    (event: NativeSyntheticEvent<PressMenuItemEvent>) => {
+      const items = Array.of(
+        ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
+        ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
+      );
+      const menu = findMenuElementByIdInItems(
+        items,
+        event.nativeEvent.menuElementId,
+      );
+      if (menu && menu.type === 'menuItem') {
+        menu.onPress?.();
+      }
+    },
+    [leadingItems, trailingItems],
+  );
+
   return (
     <StackHeaderConfigIOSNativeComponent
       {...restProps}
@@ -39,7 +59,8 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       largeTitle={largeTitle}
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
-      style={styles.config}>
+      style={styles.config}
+      onPressMenuItem={handleMenuPress}>
       {leadingItems?.map(item => makeItemViewFromItem(item, 'leading'))}
       {titleItem && makeItemViewFromItem(titleItem, 'title')}
       {subtitleItem && makeItemViewFromItem(subtitleItem, 'subtitle')}

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -6,16 +6,20 @@ export interface StackHeaderBaseItemIOS {
   label?: string | undefined;
 }
 
-export interface StackHeaderInlineItemIOS extends StackHeaderBaseItemIOS {
-  type: 'item';
+export interface SupportsMenuIOS {
   menu?: StackHeaderMenu | undefined;
 }
 
-export interface StackHeaderInlineCustomItemIOS {
+export interface StackHeaderInlineItemIOS
+  extends StackHeaderBaseItemIOS,
+    SupportsMenuIOS {
+  type: 'item';
+}
+
+export interface StackHeaderInlineCustomItemIOS extends SupportsMenuIOS {
   key: string;
   type: 'item';
   render: () => ReactElement;
-  menu?: StackHeaderMenu | undefined;
 }
 
 interface StackHeaderFixedSpacerItemIOS {

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import type { StackHeaderMenu } from './ios/StackHeaderMenu.ios.types';
+import type { StackHeaderMenuIOS } from './ios/StackHeaderMenu.ios.types';
 
 export interface StackHeaderBaseItemIOS {
   key: string;
@@ -7,7 +7,7 @@ export interface StackHeaderBaseItemIOS {
 }
 
 export interface SupportsMenuIOS {
-  menu?: StackHeaderMenu | undefined;
+  menu?: StackHeaderMenuIOS | undefined;
 }
 
 export interface StackHeaderInlineItemIOS

--- a/src/components/gamma/stack/header/index.ts
+++ b/src/components/gamma/stack/header/index.ts
@@ -4,3 +4,5 @@ export type * from './StackHeaderConfig.types';
 
 export type * from './StackHeaderConfig.android.types';
 export type * from './StackHeaderConfig.ios.types';
+
+export type * from './ios/StackHeaderMenu.ios.types';

--- a/src/components/gamma/stack/header/ios/StackHeaderItem.ios.tsx
+++ b/src/components/gamma/stack/header/ios/StackHeaderItem.ios.tsx
@@ -5,6 +5,11 @@ import { StyleSheet } from 'react-native';
 
 export default function StackHeaderItem(props: StackHeaderItemProps) {
   const { render, ...rest } = props;
+
+  // `rest.menu` includes some JS callback within nested menu specification
+  // codegen strips JS functions and replaces them with NULLT and keys of such type
+  // are omitted inside RNSConvertFollyDynamicToId so we can safely pass `rest.menu` as-is
+
   return (
     <StackHeaderItemIOSNativeComponent {...rest} style={styles.config}>
       {render?.()}

--- a/src/components/gamma/stack/header/ios/StackHeaderItem.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderItem.ios.types.ts
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import type { StackHeaderMenu } from './StackHeaderMenu.ios.types';
+import type { StackHeaderMenuIOS } from './StackHeaderMenu.ios.types';
 
 export type StackHeaderItemPlacement =
   | 'leading'
@@ -12,5 +12,5 @@ export type StackHeaderItemProps = {
   placement: StackHeaderItemPlacement;
   label?: string | undefined;
   render?: (() => ReactElement) | undefined;
-  menu?: StackHeaderMenu | undefined;
+  menu?: StackHeaderMenuIOS | undefined;
 };

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -2,7 +2,7 @@ export interface StackHeaderMenuItem {
   menuElementId: string;
   type: 'menuItem';
   title?: string | undefined;
-  onPress?: () => void;
+  onPress?: () => void | undefined;
 }
 
 export interface StackHeaderMenu {

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -1,15 +1,17 @@
-export interface StackHeaderMenuItem {
+export interface StackHeaderMenuItemIOS {
   id: string;
   type: 'menuItem';
   title?: string | undefined;
   onPress?: () => void | undefined;
 }
 
-export interface StackHeaderMenu {
+export interface StackHeaderMenuIOS {
   id: string;
   type: 'menu';
   title?: string | undefined;
-  children: StackHeaderMenuElement[];
+  children: StackHeaderMenuElementIOS[];
 }
 
-export type StackHeaderMenuElement = StackHeaderMenu | StackHeaderMenuItem;
+export type StackHeaderMenuElementIOS =
+  | StackHeaderMenuIOS
+  | StackHeaderMenuItemIOS;

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -1,9 +1,12 @@
 export interface StackHeaderMenuItem {
+  menuElementId: string;
   type: 'menuItem';
   title?: string | undefined;
+  onPress?: () => void;
 }
 
 export interface StackHeaderMenu {
+  menuElementId: string;
   type: 'menu';
   title?: string | undefined;
   children: StackHeaderMenuElement[];

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -1,12 +1,12 @@
 export interface StackHeaderMenuItem {
-  menuElementId: string;
+  id: string;
   type: 'menuItem';
   title?: string | undefined;
   onPress?: () => void | undefined;
 }
 
 export interface StackHeaderMenu {
-  menuElementId: string;
+  id: string;
   type: 'menu';
   title?: string | undefined;
   children: StackHeaderMenuElement[];

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -1,10 +1,10 @@
-import { StackHeaderMenuElement } from './ios/StackHeaderMenu.ios.types';
+import { StackHeaderMenuElementIOS } from './ios/StackHeaderMenu.ios.types';
 import { SupportsMenuIOS } from './StackHeaderConfig.ios.types';
 
 export function findMenuElementByIdInItems(
   items: SupportsMenuIOS[],
   id: string,
-): StackHeaderMenuElement | null {
+): StackHeaderMenuElementIOS | null {
   for (const item of items) {
     if (item.menu === undefined) {
       continue;
@@ -20,9 +20,9 @@ export function findMenuElementByIdInItems(
 }
 
 export function findMenuElementById(
-  menu: StackHeaderMenuElement,
+  menu: StackHeaderMenuElementIOS,
   id: string,
-): StackHeaderMenuElement | null {
+): StackHeaderMenuElementIOS | null {
   if (menu.id === id) {
     return menu;
   }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -27,10 +27,9 @@ export function findMenuElementById(
     return menu;
   }
 
-  let result;
   if (menu.type === 'menu') {
     for (const child of menu.children) {
-      result = findMenuElementById(child, menuElementId);
+      const result = findMenuElementById(child, menuElementId);
       if (result !== null) {
         return result;
       }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -3,14 +3,14 @@ import { SupportsMenuIOS } from './StackHeaderConfig.ios.types';
 
 export function findMenuElementByIdInItems(
   items: SupportsMenuIOS[],
-  menuElementId: string,
+  id: string,
 ): StackHeaderMenuElement | null {
   for (const item of items) {
     if (item.menu === undefined) {
       continue;
     }
 
-    const menu = findMenuElementById(item.menu, menuElementId);
+    const menu = findMenuElementById(item.menu, id);
     if (menu !== null) {
       return menu;
     }
@@ -21,15 +21,15 @@ export function findMenuElementByIdInItems(
 
 export function findMenuElementById(
   menu: StackHeaderMenuElement,
-  menuElementId: string,
+  id: string,
 ): StackHeaderMenuElement | null {
-  if (menu.menuElementId === menuElementId) {
+  if (menu.id === id) {
     return menu;
   }
 
   if (menu.type === 'menu') {
     for (const child of menu.children) {
-      const result = findMenuElementById(child, menuElementId);
+      const result = findMenuElementById(child, id);
       if (result !== null) {
         return result;
       }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -1,0 +1,41 @@
+import { StackHeaderMenuElement } from './ios/StackHeaderMenu.ios.types';
+import { SupportsMenuIOS } from './StackHeaderConfig.ios.types';
+
+export function findMenuElementByIdInItems(
+  items: SupportsMenuIOS[],
+  menuElementId: string,
+): StackHeaderMenuElement | null {
+  for (const item of items) {
+    if (item.menu === undefined) {
+      continue;
+    }
+
+    const menu = findMenuElementById(item.menu, menuElementId);
+    if (menu !== null) {
+      return menu;
+    }
+  }
+
+  return null;
+}
+
+export function findMenuElementById(
+  menu: StackHeaderMenuElement,
+  menuElementId: string,
+): StackHeaderMenuElement | null {
+  if (menu.menuElementId === menuElementId) {
+    return menu;
+  }
+
+  let result;
+  if (menu.type === 'menu') {
+    for (const child of menu.children) {
+      result = findMenuElementById(child, menuElementId);
+      if (result !== null) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -35,6 +35,9 @@ export type {
   StackHeaderTitleCustomItemIOS,
   StackHeaderSpacerItemIOS,
   StackHeaderConfigCommandsIOS,
+  StackHeaderMenuIOS,
+  StackHeaderMenuItemIOS,
+  StackHeaderMenuElementIOS,
 } from './header';
 
 /**

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -3,7 +3,7 @@
 import type { CodegenTypes as CT, ViewProps } from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
-export type PressMenuItemEvent = Readonly<{ menuElementId: string }>;
+export type MenuItemPressEvent = Readonly<{ menuElementId: string }>;
 
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
@@ -17,7 +17,7 @@ export interface NativeProps extends ViewProps {
   largeSubtitle?: string | undefined;
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
 
-  onPressMenuItem?: CT.DirectEventHandler<PressMenuItemEvent> | undefined;
+  onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSStackHeaderConfigIOS', {

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -3,6 +3,8 @@
 import type { CodegenTypes as CT, ViewProps } from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
+export type PressMenuItemEvent = Readonly<{ menuElementId: string }>;
+
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
   subtitle?: string | undefined;
@@ -14,6 +16,8 @@ export interface NativeProps extends ViewProps {
   largeTitle?: string | undefined;
   largeSubtitle?: string | undefined;
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
+
+  onPressMenuItem?: CT.DirectEventHandler<PressMenuItemEvent> | undefined;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSStackHeaderConfigIOS', {

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -3,7 +3,7 @@
 import type { CodegenTypes as CT, ViewProps } from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
-export type MenuItemPressEvent = Readonly<{ menuElementId: string }>;
+export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
 export interface NativeProps extends ViewProps {
   title?: string | undefined;

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -12,13 +12,13 @@ export type Placement =
   | 'largeSubtitle';
 
 export type StackHeaderMenuItem = {
-  menuElementId: string;
+  id: string;
   type: 'menuItem';
   title?: string | undefined;
 };
 
 export type StackHeaderMenu = {
-  menuElementId: string;
+  id: string;
   type: 'menu';
   title?: string | undefined;
   children: StackHeaderMenuElement[];

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -11,25 +11,27 @@ export type Placement =
   | 'subtitle'
   | 'largeSubtitle';
 
-export type StackHeaderMenuItem = {
+export type StackHeaderMenuItemIOS = {
   id: string;
   type: 'menuItem';
   title?: string | undefined;
 };
 
-export type StackHeaderMenu = {
+export type StackHeaderMenuIOS = {
   id: string;
   type: 'menu';
   title?: string | undefined;
-  children: StackHeaderMenuElement[];
+  children: StackHeaderMenuElementIOS[];
 };
 
-export type StackHeaderMenuElement = StackHeaderMenuItem | StackHeaderMenu;
+export type StackHeaderMenuElementIOS =
+  | StackHeaderMenuItemIOS
+  | StackHeaderMenuIOS;
 
 export interface NativeProps extends ViewProps {
   placement?: CT.WithDefault<Placement, 'trailing'>;
   label?: string | undefined;
-  menu?: UnsafeMixed<StackHeaderMenu> | undefined;
+  menu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSStackHeaderItemIOS', {

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -12,11 +12,13 @@ export type Placement =
   | 'largeSubtitle';
 
 export type StackHeaderMenuItem = {
+  menuElementId: string;
   type: 'menuItem';
   title?: string | undefined;
 };
 
 export type StackHeaderMenu = {
+  menuElementId: string;
   type: 'menu';
   title?: string | undefined;
   children: StackHeaderMenuElement[];


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1521

## Description

This PR adds support for `onPress` in iOS Stack v5 header.

## Changes

- added required `id` for all menuElements, currently used for `onPress` in menu items
- added optional `onPress` for menu item - a callback defined per menu item

## Before & after - visual documentation

N/A

## Test plan

Use `test-stack-header-menu-ios`, follow the scenario.md

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
