### PR TITLE
fix(iOS, Tabs): make bottom accessory content switching robust and survive window detach

### DIFF
--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
@@ -49,9 +49,37 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   if (self.window != nil) {
+    // The helper & shadow proxy are torn down below whenever the accessory
+    // leaves the window (e.g. a full-screen push covering the tab bar), so
+    // they must be recreated on re-entry — previously
+    // `registerForAccessoryFrameChanges` was messaged at nil here and all
+    // trait/frame callbacks and content-view switching stayed permanently
+    // dead after the first full-screen push, freezing the accessory on
+    // whichever content copy was last visible. The content views' own
+    // `didMoveToWindow` runs after this one (window changes propagate
+    // top-down), so they re-register into the fresh helper.
+    if (@available(iOS 26, *)) {
+      if (_helper == nil) {
+        _helper = [[RNSTabsBottomAccessoryHelper alloc] initWithBottomAccessoryView:self];
+      }
+      if (_shadowStateProxy == nil) {
+        _shadowStateProxy = [[RNSTabsBottomAccessoryShadowStateProxy alloc] initWithBottomAccessoryView:self];
+      }
+    }
     [_helper registerForAccessoryFrameChanges];
   } else {
-    [self invalidate];
+    // Lighter teardown than `invalidate` — keep the Fabric `_state` alive
+    // across a detach/reattach cycle. Only React can re-deliver the state
+    // (via `updateState` on a commit), so resetting it on a mere window
+    // detach would leave the recreated shadow proxy unable to publish
+    // accessory frame updates until an unrelated commit happens to arrive.
+    // True unmount still fully invalidates via RNSTabsHostComponentView.
+    if (@available(iOS 26, *)) {
+      [_helper invalidate];
+      _helper = nil;
+      [_shadowStateProxy invalidate];
+      _shadowStateProxy = nil;
+    }
   }
 }
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.mm
@@ -39,11 +39,6 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 
 #pragma mark - Content view switching workaround
 
-- (BOOL)isContentViewSwitchingWorkaroundActive
-{
-  return _regularContentView != nil && _inlineContentView != nil;
-}
-
 - (void)setContentView:(RNSTabsBottomAccessoryContentComponentView *)contentView
         forEnvironment:(RNSTabsBottomAccessoryEnvironment)environment
 {
@@ -65,20 +60,29 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
 
 - (void)handleContentViewVisibilityForEnvironmentIfNeeded
 {
-  if (!self.isContentViewSwitchingWorkaroundActive) {
-    return;
-  }
+  // `hidden` is used as the sole carrier of invisibility, with alpha
+  // normalized to 1.0 on both content views:
+  // - `RCTViewComponentView.invalidateLayer` unconditionally resets
+  //   `layer.opacity` to the React props value on arbitrary commits, which
+  //   used to re-show the off-environment copy. It never touches `hidden`,
+  //   and with alpha kept at 1.0 the reset becomes a no-op by construction.
+  // - The off-environment copy is mounted absoluteFill ON TOP of the active
+  //   one (later sibling); when it regained opacity it also captured all
+  //   hit-testing, making the accessory unresponsive to taps. Hidden views
+  //   are excluded from hit-testing.
+  // Applied to whichever content views are registered (messages to nil are
+  // no-ops) — the previous both-registered early-return left a lone
+  // registered view fully visible until its sibling registered.
+  BOOL isInline =
+      self->_bottomAccessoryView.traitCollection.tabAccessoryEnvironment == UITabAccessoryEnvironmentInline;
 
-  switch (self->_bottomAccessoryView.traitCollection.tabAccessoryEnvironment) {
-    case UITabAccessoryEnvironmentInline:
-      _regularContentView.layer.opacity = 0.0;
-      _inlineContentView.layer.opacity = 1.0;
-      break;
-    default:
-      _regularContentView.layer.opacity = 1.0;
-      _inlineContentView.layer.opacity = 0.0;
-      break;
-  }
+  UIView *viewToShow = isInline ? _inlineContentView : _regularContentView;
+  UIView *viewToHide = isInline ? _regularContentView : _inlineContentView;
+
+  viewToShow.hidden = NO;
+  viewToShow.alpha = 1.0;
+  viewToHide.hidden = YES;
+  viewToHide.alpha = 1.0;
 }
 
 #pragma mark - Observing environment changes
@@ -149,6 +153,15 @@ static void *RNSTabsBottomAccessoryNativeWrapperViewContext = &RNSTabsBottomAcce
   // We use self.nativeWrapperView because it has both the size and the origin
   // that we want to send to the ShadowNode.
   [_bottomAccessoryView.shadowStateProxy updateShadowStateWithFrame:self.nativeWrapperView.frame];
+
+  // The wrapper frame changes on every regular <-> inline move, so re-evaluate
+  // content-view visibility here as well. The one-shot
+  // UITraitTabAccessoryEnvironment registration callback is occasionally
+  // missed during the minimize transition, which left the wrong copy visible
+  // inside the inline accessory (or vice versa); this KVO fires reliably on
+  // each transition (and once on registration via
+  // NSKeyValueObservingOptionInitial) and self-corrects that.
+  [self handleContentViewVisibilityForEnvironmentIfNeeded];
 }
 
 #pragma mark - Invalidation


### PR DESCRIPTION
Note: The code / PR is made by Claude Fable, however I've manually tested and confirmed with my app on simulator and device.

## Description

The bottom accessory's dual-content-view switching (the "content view switching workaround") has three failure modes we root-caused on a physical iOS 26 device in a production app (RN 0.85, new arch):

1. **`RCTViewComponentView.invalidateLayer` resets `layer.opacity`** to the React props value on arbitrary commits, re-showing the off-environment copy (the bug reported in #3798). Because that copy is mounted `absoluteFill` as the **later sibling**, it sits on top of the active copy and also **captures all hit-testing** — every tap on the accessory goes dead, not just "wrong content shown".
2. **The `UITraitTabAccessoryEnvironment` registration callback is occasionally missed** during the minimize transition, leaving the wrong copy visible until the next trait change.
3. **The helper dies permanently after any full-screen push.** `didMoveToWindow` invalidates and nils `_helper` + `_shadowStateProxy` when the accessory leaves the window, but nothing recreated them on re-entry — `registerForAccessoryFrameChanges` was messaged at `nil`, so all callbacks and content switching stayed dead and the accessory froze on whichever copy was last visible. This likely explains the "full-screen modal dismissal also causes bottom accessory glitches" report in the #3798 thread.

Closes #3798.

## Changes

- `RNSTabsBottomAccessoryHelper`:
  - `handleContentViewVisibilityForEnvironmentIfNeeded` now uses **`hidden` as the sole carrier of invisibility, with alpha normalized to 1.0 on both copies**. `invalidateLayer` never touches `hidden`, and with alpha kept at 1.0 its opacity reset becomes a no-op by construction (no reliance on the private `invalidateLayer`, no KVO loops). Hidden views are also excluded from hit-testing, fixing the dead-taps half. Applied to whichever content views are registered (nil messages are no-ops) — the both-registered early-return previously left a lone registered view fully visible.
  - `notifyWrapperViewFrameHasChanged` re-evaluates visibility: the wrapper-frame KVO fires reliably on every regular↔inline move (and once at registration via `NSKeyValueObservingOptionInitial`), so a missed trait callback self-corrects.
  - Removed the now-unused `isContentViewSwitchingWorkaroundActive`.
- `RNSTabsBottomAccessoryComponentView.didMoveToWindow`:
  - Recreates the helper + shadow proxy on window re-entry.
  - Window-leave does a lighter teardown that preserves the Fabric `_state` — only React can re-deliver it (`updateState` on a commit), so resetting it on a mere detach left the recreated shadow proxy unable to publish accessory frame updates. True unmount still fully invalidates via `RNSTabsHostComponentView`.

## Test plan

Tested in a production Expo SDK 56 app (RN 0.85, new arch, Fabric) on a physical iOS 26 device, with these changes applied to 4.25.2 via package patching (identical code paths — this area is unchanged between 4.25.2 and `main` apart from the removed RN < 0.82 guards):

- Repeated scroll-driven minimize/expand cycles across multiple tabs: correct copy visible in every environment, no stuck/overlaid content, accessory taps always responsive.
- Full-screen push covering the tab bar → pop: content switching keeps working afterwards (previously permanently dead).
- Accessory mount/unmount cycles (conditionally rendered accessory) and app backgrounding.

Reproduction shape for the original bugs: a `NativeTabs` (expo-router) app with a `BottomAccessory` whose content differs per placement, scroll-minimizing tab bars, and any full-screen push — see #3798 for the opacity repro.

## Checklist

- [ ] Included code example that can be used to test this change.
- [x] For API changes, updated relevant public types. *(No public API changes.)*
- [ ] Ensured that CI passes
