### PR TITLE
fix(iOS, Tabs): resolve content scroll view for tabBarMinimizeBehavior in real-world RN hierarchies

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1538,6 +1538,25 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   _shouldNotify = YES;
 }
 
+// See RNSTabsScreenViewController: when a tab hosts a nested stack, UIKit may
+// resolve the bottom-edge content scroll view (which drives iOS 26
+// `tabBarMinimizeBehavior`) against the visible stack screen's view
+// controller rather than the tab root. UIKit's automatic detection cannot
+// reach UIScrollViews nested in a React Native screen tree, so fall back to a
+// breadth-first search. Restricted to the bottom edge so top-edge
+// (navigation bar) resolution is unaffected.
+- (UIScrollView *)contentScrollViewForEdge:(NSDirectionalRectEdge)edge
+{
+  UIScrollView *scrollView = [super contentScrollViewForEdge:edge];
+  if (scrollView != nil) {
+    return scrollView;
+  }
+  if (edge == NSDirectionalRectEdgeBottom) {
+    return [RNSScrollViewFinder findScrollViewBreadthFirstFrom:self.view];
+  }
+  return nil;
+}
+
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];

--- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
+++ b/ios/helpers/scroll-view/RNSScrollViewFinder.h
@@ -25,4 +25,18 @@
  */
 + (nullable UIScrollView *)findContentScrollViewWithDelegatingToProvider:(nullable UIView *)view;
 
+/**
+ * Breadth-first search for the first vertically-scrollable UIScrollView
+ * descendant. Unlike the first-descendant-chain walk, this finds scroll views
+ * in real-world screen trees (styled wrapper views, headers, virtualized
+ * lists such as FlashList/LegendList, nested stack navigators), which
+ * UIKit's automatic content-scroll-view detection cannot reach.
+ * Horizontal-only scrollers (e.g. carousels) are skipped, so behaviors driven
+ * by the result (such as `tabBarMinimizeBehavior`) track vertical scrolling.
+ * The search is bounded so a pathological tree cannot stall the main thread.
+ *
+ * When `view == nil`, it returns `nil`.
+ */
++ (nullable UIScrollView *)findScrollViewBreadthFirstFrom:(nullable UIView *)view;
+
 @end

--- a/ios/helpers/scroll-view/RNSScrollViewFinder.mm
+++ b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
@@ -41,4 +41,37 @@
   return nil;
 }
 
++ (nullable UIScrollView *)findScrollViewBreadthFirstFrom:(nullable UIView *)view
+{
+  if (view == nil) {
+    return nil;
+  }
+
+  static const NSUInteger kMaxVisitedViews = 2000;
+  NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:view];
+  NSUInteger index = 0;
+
+  while (index < queue.count && queue.count < kMaxVisitedViews) {
+    UIView *current = queue[index++];
+
+    if ([current isKindOfClass:UIScrollView.class]) {
+      UIScrollView *scrollView = static_cast<UIScrollView *>(current);
+      // Skip horizontal-only scrollers (carousels). Unmeasured scroll views
+      // (zero contentSize) pass, since the main list may not be laid out yet
+      // when UIKit first resolves the content scroll view.
+      BOOL isHorizontalOnly = scrollView.contentSize.width > scrollView.bounds.size.width &&
+          scrollView.contentSize.height <= scrollView.bounds.size.height;
+      if (!isHorizontalOnly) {
+        return scrollView;
+      }
+      // Do not descend into a skipped horizontal scroller.
+      continue;
+    }
+
+    [queue addObjectsFromArray:current.subviews];
+  }
+
+  return nil;
+}
+
 @end

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -105,6 +105,26 @@
   return false;
 }
 
+// UIKit resolves the scroll view that drives `tabBarMinimizeBehavior`
+// (iOS 26 tab-bar minimize + inline bottom accessory) by asking the selected
+// tab's view controller for its bottom-edge content scroll view. UIKit's
+// automatic detection cannot find UIScrollViews nested inside a typical
+// React Native screen tree (styled wrappers, headers, virtualized lists,
+// nested stack navigators), so minimize never engages. Fall back to a
+// breadth-first search of the currently attached content. Restricted to the
+// bottom edge so top-edge (navigation bar) resolution is unaffected.
+- (UIScrollView *)contentScrollViewForEdge:(NSDirectionalRectEdge)edge
+{
+  UIScrollView *scrollView = [super contentScrollViewForEdge:edge];
+  if (scrollView != nil) {
+    return scrollView;
+  }
+  if (edge == NSDirectionalRectEdgeBottom) {
+    return [RNSScrollViewFinder findScrollViewBreadthFirstFrom:self.view];
+  }
+  return nil;
+}
+
 #if !TARGET_OS_TV
 
 - (RNSOrientation)evaluateOrientation


### PR DESCRIPTION
Note: The code / PR is made by Claude Fable, however I've manually tested and confirmed with my app on simulator and device.

## Description

On iOS 26, `tabBarMinimizeBehavior: 'onScrollDown'` never engages when a tab's content is a **nested (native stack) navigator** and/or the scrolling content is a **virtualized list** (FlashList, LegendList) or any `UIScrollView` behind styled wrapper views — i.e. the common shape of a production app. The tab bar never minimizes and a bottom accessory never reaches its inline placement.

UIKit resolves the scroll view that drives minimize by asking the selected tab's view controller for its **bottom-edge content scroll view** (`contentScrollView(for:)` / automatic detection). UIKit's automatic detection cannot find a `UIScrollView` nested inside a React Native screen tree. The `collapsable={false}` workaround from #3954 only addresses the trivial single-styled-wrapper case — it cannot help when the first-descendant chain runs through a nested stack host or a virtualized list's wrappers.

Closes #4145.

## Changes

- `RNSScrollViewFinder`: new `findScrollViewBreadthFirstFrom:` — a bounded breadth-first search (2000-view visit cap) that skips horizontal-only scrollers (carousels), so behaviors driven by the result track the vertical list. The existing first-descendant-chain walk is exactly what fails on real screens.
- `RNSTabsScreenViewController` + `RNSScreen`: implement `contentScrollViewForEdge:` (UIKit's documented override point), covering whichever controller UIKit queries (the tab root, or the visible nested-stack screen). UIKit's own resolution is tried first; the BFS is only a fallback, and only for the **bottom** edge so top-edge (navigation bar) resolution is unaffected.

Open questions for maintainers:
- The `RNSScreen` override applies to all stack screens, not only tab-hosted ones. We saw no regressions (bottom edge only), but it could be gated to tab-hosted screens or behind a prop if preferred.
- An alternative shape would be extending the existing `RNSContentScrollViewProviding` delegation so the BFS lives behind the provider protocol.

## Test plan

Tested in a production Expo SDK 56 app (RN 0.85, new arch) on a physical iOS 26 device, with these changes applied to 4.25.2 via package patching (this area is unchanged between 4.25.2 and `main`):

- Tabs each hosting a nested native stack whose screens render LegendList content behind styled wrappers/headers: scrolling down now minimizes the tab bar and moves the bottom accessory to its inline placement on every tab; scrolling up restores it. Previously minimize never engaged anywhere.
- Screens with a horizontal carousel near the top: minimize still tracks the vertical list (carousel skipped by the finder).
- Navigation-bar / top-edge behaviors unaffected (override restricted to the bottom edge).

Reproduction shape:

```
NativeTabs (tabBarMinimizeBehavior: onScrollDown)
└─ Tab
   └─ native stack navigator
      └─ screen
         └─ styled wrappers / headers
            └─ FlashList / LegendList / ScrollView
```

Same class of issue reported against react-native-bottom-tabs (callstack/react-native-bottom-tabs#496), where swizzling `contentScrollView(for:)` is the community fix; this PR uses the documented override point instead.

## Checklist

- [ ] Included code example that can be used to test this change.
- [x] For API changes, updated relevant public types. *(No public API changes; new method is internal.)*
- [ ] Ensured that CI passes
