### PR TITLE
fix(iOS, Tabs): remove `invalidate` call in `RNSTabsBottomAccessoryComponentView.didMoveToWindow`

### DIFF
--- a/apps/src/tests/issue-tests/Test4155.tsx
+++ b/apps/src/tests/issue-tests/Test4155.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  Button,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { TabsBottomAccessoryEnvironment } from 'react-native-screens';
 import {
   StackContainer,
@@ -29,12 +22,7 @@ export function AccessoryContent(environment: TabsBottomAccessoryEnvironment) {
 }
 
 export function HomeTab() {
-  const { push } = useStackNavigationContext();
-  return (
-    <View style={styles.centered}>
-      <Button title="Go to test" onPress={() => push('Test')} />
-    </View>
-  );
+  return <View style={styles.centered} />;
 }
 
 export function ExploreTab() {

--- a/apps/src/tests/issue-tests/Test4155.tsx
+++ b/apps/src/tests/issue-tests/Test4155.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import {
+  Button,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type { TabsBottomAccessoryEnvironment } from 'react-native-screens';
+import {
+  StackContainer,
+  type StackRouteConfig,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import {
+  TabsContainer,
+  type TabRouteConfig,
+  DEFAULT_TAB_ROUTE_OPTIONS,
+} from '@apps/shared/gamma/containers/tabs';
+
+export function AccessoryContent(environment: TabsBottomAccessoryEnvironment) {
+  return (
+    <View style={styles.accessory}>
+      <Text>Bottom Accessory</Text>
+      {environment === 'inline' && <Text>Inline</Text>}
+    </View>
+  );
+}
+
+export function HomeTab() {
+  const { push } = useStackNavigationContext();
+  return (
+    <View style={styles.centered}>
+      <Button title="Go to test" onPress={() => push('Test')} />
+    </View>
+  );
+}
+
+export function ExploreTab() {
+  const { push } = useStackNavigationContext();
+  return (
+    <ScrollView
+      style={styles.container}
+      contentInsetAdjustmentBehavior="automatic">
+      {Array.from({ length: 150 }, (_, i) => (
+        <Pressable
+          key={i}
+          onPress={() => push('Test')}
+          style={[
+            styles.scrollItem,
+            { backgroundColor: i % 2 ? 'black' : 'white' },
+          ]}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'Home',
+    Component: HomeTab,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Home',
+    },
+  },
+  {
+    name: 'Explore',
+    Component: ExploreTab,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Explore',
+    },
+  },
+];
+
+export function TabsScreen() {
+  return (
+    <TabsContainer
+      routeConfigs={TAB_ROUTE_CONFIGS}
+      ios={{
+        bottomAccessory: AccessoryContent,
+        tabBarMinimizeBehavior: 'onScrollDown',
+      }}
+    />
+  );
+}
+
+export function TestScreen() {
+  return <View />;
+}
+
+const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
+  {
+    name: 'Tabs',
+    Component: TabsScreen,
+    options: {},
+  },
+  {
+    name: 'Test',
+    Component: TestScreen,
+    options: {
+      headerConfig: {
+        title: 'Test',
+      },
+    },
+  },
+];
+
+export default function App() {
+  return <StackContainer routeConfigs={STACK_ROUTE_CONFIGS} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  accessory: {
+    flex: 1,
+    backgroundColor: 'rgba(255,0,0,0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 16,
+  },
+  scrollItem: {
+    width: '100%',
+    height: 50,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -194,6 +194,8 @@ export { default as Test3885 } from './Test3885';
 export { default as Test3910 } from './Test3910';
 export { default as Test4027 } from './Test4027';
 export { default as Test4064 } from './Test4064';
+export { default as Test4090 } from './Test4090';
+export { default as Test4155 } from './Test4155';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold
@@ -214,4 +216,3 @@ export { default as TestScreenStack } from './TestScreenStack';
 export { default as TestSplit } from './TestSplit';
 export { default as TestSafeAreaViewIOS } from './TestSafeAreaViewIOS';
 export { default as TestStackNesting } from './TestStackNesting';
-export { default as Test4090 } from './Test4090';

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
@@ -50,8 +50,6 @@ namespace react = facebook::react;
 {
   if (self.window != nil) {
     [_helper registerForAccessoryFrameChanges];
-  } else {
-    [self invalidate];
   }
 }
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryComponentView.mm
@@ -50,6 +50,8 @@ namespace react = facebook::react;
 {
   if (self.window != nil) {
     [_helper registerForAccessoryFrameChanges];
+  } else {
+    [_helper unregisterForAccessoryFrameChanges];
   }
 }
 

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryContentComponentView.mm
@@ -27,11 +27,15 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
+  if (self.window == nil) {
+    return;
+  }
+
   if ([self.superview isKindOfClass:[RNSTabsBottomAccessoryComponentView class]]) {
     RNSTabsBottomAccessoryComponentView *accessoryView =
         static_cast<RNSTabsBottomAccessoryComponentView *>(self.superview);
     _accessoryView = accessoryView;
-    [_accessoryView.helper setContentView:(self.window != nil ? self : nil) forEnvironment:_environment];
+    [_accessoryView.helper setContentView:self forEnvironment:_environment];
   } else {
     [_accessoryView.helper setContentView:nil forEnvironment:_environment];
     _accessoryView = nil;

--- a/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h
+++ b/ios/tabs/bottom-accessory/RNSTabsBottomAccessoryHelper.h
@@ -28,6 +28,10 @@ API_AVAILABLE(ios(26.0))
  */
 - (void)registerForAccessoryFrameChanges;
 /**
+ * Removes the KVO registration set up by `registerForAccessoryFrameChanges`.
+ */
+- (void)unregisterForAccessoryFrameChanges;
+/**
  * Invalidates observers, display link (if it is used); resets internal properties.
  */
 - (void)invalidate;


### PR DESCRIPTION
## Description

`RNSTabsBottomAccessoryComponentView.didMoveToWindow` called `[self invalidate]` - this approach nilled `_helper` and `_shadowStateProxy` and also reset the state  while the component was still alive. Removing this line of code is correct because React calls invalidate itself via the `RCTComponentViewProtocol` callback when the component is actually torn down. 

Instead of that, we add `[_helper unregisterForAccessoryFrameChanges]`:
`An object that calls this method must also (...) unregister the observer when participating in KVO.`
https://developer.apple.com/documentation/objectivec/nsobject-swift.class/observevalue(forkeypath:of:change:context:)?language=objc

We also update `RNSTabsBottomAccessoryContentComponentView.didMoveToWindow` so it returns early if `self.window == nil`.

This PR fixes https://github.com/software-mansion/react-native-screens/issues/3798#issuecomment-4633259225:

After [self invalidate] nils `_helper` (and nothing recreates it), `RNSTabsBottomAccessoryContentComponentView.didMoveToWindow` ends up calling `setContentView:forEnvironment`: on a nil helper, so `handleContentViewVisibilityForEnvironmentIfNeeded` never runs to restore the correct opacities, and both copies stay visible.

>NOTE:
We've decided to set a KVO for `_regularContentView.layer.opacity`/`_inlineContentView.layer.opacity` so that if UIKit updates it on its own for any reason, we can detect it. It will be handled in a separate PR.
Issue link: https://github.com/software-mansion/react-native-screens-labs/issues/1527

## Changes

- `RNSTabsBottomAccessoryComponentView.didMoveToWindow` updated
- `RNSTabsBottomAccessoryContentComponentView.didMoveToWindow` updated
- issue test added

## Before & after - visual documentation

|  Before |  After  |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/057323c6-00ea-426d-8153-5b2530d6c4ef"></video> | <video src="https://github.com/user-attachments/assets/9e9390ea-f0b8-45bb-a5a8-3409cd7352bb"></video> |








## Test plan

Run `Test4155.tsx`:
On the Explore tab, scroll and tap to push a new screen, then go back. Verify that the Bottom Accessory and the Bottom Accessory Inline do not overlap.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
