### PR TITLE
fix(Android): guard against re-adding an attached fragment in ScreenStack.onUpdate

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -269,6 +269,12 @@ class ScreenStack(
                 screenWrappers
                     .asSequence()
                     .dropWhile { it !== visibleBottom } // ignore all screens beneath the visible bottom
+                    // Skip fragments that are still attached, otherwise the transaction throws
+                    // "Fragment already added" - e.g. when visibleBottom's fragment got detached
+                    // while fragments above it stayed attached. Dismissed wrappers are exempt:
+                    // their removal is queued earlier in this transaction, so adding them back
+                    // is the legal remove + add re-attach path.
+                    .filter { !it.fragment.isAdded || dismissedWrappers.contains(it) }
                     .forEach { wrapper ->
                         // TODO: It should be enough to dispatch this on commit action once.
                         transaction.add(id, wrapper.fragment).runOnCommit {

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStack.kt
@@ -282,6 +282,12 @@ class ScreenStack(
                 screenWrappers
                     .asSequence()
                     .dropWhile { it !== visibleBottom } // ignore all screens beneath the visible bottom
+                    // Skip fragments that are still attached, otherwise the transaction throws
+                    // "Fragment already added" - e.g. when visibleBottom's fragment got detached
+                    // while fragments above it stayed attached. Dismissed wrappers are exempt:
+                    // their removal is queued earlier in this transaction, so adding them back
+                    // is the legal remove + add re-attach path.
+                    .filter { !it.fragment.isAdded || dismissedWrappers.contains(it) }
                     .forEach { wrapper ->
                         // TODO: It should be enough to dispatch this on commit action once.
                         transaction.add(id, wrapper.fragment).runOnCommit {


### PR DESCRIPTION
## Description

Fixes an `IllegalStateException: Fragment already added: ScreenStackFragment` crash in `ScreenStack.onUpdate`.

When the top screen is translucent and `visibleBottom`'s fragment is not added, the re-attach loop adds every wrapper from `visibleBottom` upward without checking whether it is already attached. If a fragment above `visibleBottom` is still attached — we hit this in production after background/resume cycles with a `transparentModal` on top and `enableFreeze(true)` — the `add` throws on commit.

Closes #4156.

## Changes

- Skip wrappers whose fragment is already added in the re-attach loop, mirroring the `!newTop.fragment.isAdded` guard in the sibling branch below.
- Wrappers in `dismissedWrappers` are exempt from the skip: their removal is queued earlier in the same transaction, so remove + add is the existing (legal) re-attach path and behavior there is unchanged.

The guard only changes behavior in states that currently throw — for any wrapper that isn't attached, the transaction is identical to before.

## Test plan

- No deterministic repro, it's a race around fragment attachment state (details in #4156).
- `:react-native-screens:compileDebugKotlin` passes with the change.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
