### PR TITLE
fix(Android): use per-display density for px→dp conversion in FabricEnabledViewGroup.updateState

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt
@@ -28,9 +28,16 @@ abstract class FabricEnabledViewGroup(
         height: Int,
         headerHeight: Int,
     ) {
-        val realWidth: Float = PixelUtil.toDIPFromPixel(width.toFloat())
-        val realHeight: Float = PixelUtil.toDIPFromPixel(height.toFloat())
-        val realHeaderHeight: Float = PixelUtil.toDIPFromPixel(headerHeight.toFloat())
+        // Use the density of the display this view is attached to, not the process-global one
+        // captured from the device's main display (PixelUtil). Fabric mounts views using the
+        // per-display density, so converting back with the global density shrinks/inflates the
+        // frame pushed to the Shadow Tree whenever the app runs on a display with a different
+        // density (Samsung DeX, freeform multi-window, external monitors). Both densities are
+        // identical on single-display devices, so this is a no-op there. See #4159.
+        val density = context.resources.displayMetrics.density
+        val realWidth: Float = if (density > 0f) width / density else PixelUtil.toDIPFromPixel(width.toFloat())
+        val realHeight: Float = if (density > 0f) height / density else PixelUtil.toDIPFromPixel(height.toFloat())
+        val realHeaderHeight: Float = if (density > 0f) headerHeight / density else PixelUtil.toDIPFromPixel(headerHeight.toFloat())
 
         // Check incoming state values. If they're already the correct value, return early to prevent
         // infinite UpdateState/SetState loop.

--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledViewGroup.kt
@@ -5,8 +5,8 @@ import androidx.annotation.UiThread
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.swmansion.rnscreens.utils.pxToDp
 import kotlin.math.abs
 
 abstract class FabricEnabledViewGroup(
@@ -28,16 +28,12 @@ abstract class FabricEnabledViewGroup(
         height: Int,
         headerHeight: Int,
     ) {
-        // Use the density of the display this view is attached to, not the process-global one
-        // captured from the device's main display (PixelUtil). Fabric mounts views using the
-        // per-display density, so converting back with the global density shrinks/inflates the
-        // frame pushed to the Shadow Tree whenever the app runs on a display with a different
-        // density (Samsung DeX, freeform multi-window, external monitors). Both densities are
-        // identical on single-display devices, so this is a no-op there. See #4159.
-        val density = context.resources.displayMetrics.density
-        val realWidth: Float = if (density > 0f) width / density else PixelUtil.toDIPFromPixel(width.toFloat())
-        val realHeight: Float = if (density > 0f) height / density else PixelUtil.toDIPFromPixel(height.toFloat())
-        val realHeaderHeight: Float = if (density > 0f) headerHeight / density else PixelUtil.toDIPFromPixel(headerHeight.toFloat())
+        // Convert px->dp with this view's own display density (see pxToDp): the global density
+        // mis-scales the frame pushed to the Shadow Tree on displays whose density differs from
+        // the device's main one (Samsung DeX, freeform multi-window, external monitors). See #4159.
+        val realWidth: Float = pxToDp(width.toFloat())
+        val realHeight: Float = pxToDp(height.toFloat())
+        val realHeaderHeight: Float = pxToDp(headerHeight.toFloat())
 
         // Check incoming state values. If they're already the correct value, return early to prevent
         // infinite UpdateState/SetState loop.

--- a/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt
@@ -2,6 +2,29 @@ package com.swmansion.rnscreens.utils
 
 import android.content.Context
 import android.util.TypedValue
+import android.view.View
+import com.facebook.react.uimanager.PixelUtil
+
+/**
+ * Converts a pixel value to dp using the density of the display this [View] is attached
+ * to — not the process-global density that [PixelUtil] reads from the device's main
+ * display. Fabric mounts views with the per-display density, so state pushed back to the
+ * Shadow Tree must be converted with that same density; the global one mis-scales the
+ * frame on any display whose density differs from the main one (Samsung DeX, freeform
+ * multi-window, external monitors). On single-display devices the two are equal, so this
+ * is a no-op there. See #4159.
+ *
+ * [android.util.DisplayMetrics.density] (`densityDpi / DENSITY_DEFAULT(160)`) is strictly
+ * positive for the resources of any attached view; it is `0` only for a default-constructed
+ * [android.util.DisplayMetrics] that was never populated — which should not happen for a
+ * live view. The `density > 0f` guard exists solely so a degenerate `0` cannot turn the
+ * division into Infinity/NaN and corrupt the pushed state; in that case we fall back to the
+ * global conversion, which is at least well-defined.
+ */
+internal fun View.pxToDp(px: Float): Float {
+    val density = resources.displayMetrics.density
+    return if (density > 0f) px / density else PixelUtil.toDIPFromPixel(px)
+}
 
 internal fun resolveDimensionAttr(
     context: Context,


### PR DESCRIPTION
## Description

Fabric mounts views using the density of the display the surface is attached to, but `FabricEnabledViewGroup.updateState` converts the natively measured **px** size back to **dp** with the process-global density (`PixelUtil`), captured once from the device's main display.

On a display whose density differs from the main one (Samsung DeX, freeform multi-window, external monitors), every `Screen` pushes `windowSize ÷ mainDisplayDensity` into the Shadow Tree — all stack/tab content collapses into a 1/density-sized top-left box, while plain RN views outside screens track the window correctly.

Closes #4159.

## Changes

- `FabricEnabledViewGroup.updateState` (Android, Fabric): convert px→dp using the view's own context density (`context.resources.displayMetrics.density`), with a defensive fallback to `PixelUtil.toDIPFromPixel` if the density is not positive.
- On single-display devices the context density equals the global density, so behavior there is unchanged.

## Before & after - visual documentation

| Before — content in a `1/density` box | After — content fills the window |
| --- | --- |
| ![before](https://cdn.avarlabs.com/7a7085a6-5b4c-4e01-b5b4-bec8944d5831.jpg) | ![after](https://cdn.avarlabs.com/4fc044b2-5aa0-40ba-987c-b43c036a4625.jpg) |

(The dark card is a diagnostic overlay that instruments `updateState` pushes. In the "after" screenshot the visible text rendering is correct because the app also applies a workaround for a *separate* react-native core bug — stale global density in text sp→px conversion — which is out of scope for this PR and reported to facebook/react-native.)

Measured `updateState` pushes on a Galaxy S25 Ultra (main display density **2.8125**) in DeX, window resized 6 times:

| window (dp) | pushed state before fix | pushed state after fix |
|---|---|---|
| 394 × 702 | 140 × 235 | 394 × 662 |
| 497 × 730 | 177 × 245 | — |
| 737 × 794 | 262 × 268 | — |
| 421 × 788 | 150 × 266 | 421 × 748 |
| 338 × 727 | — | 338 × 687 |
| 429 × 790 | — | 429 × 750 |

Before the fix every push equals `window ÷ 2.8125`; after the fix it equals the window content size at every tested window size.

## Test plan

- Minimal reproducer (RN 0.86, New Architecture, based on the official reproducer template): https://github.com/ziponia/rn-multidisplay-density-repro — shows live on-screen measurements (outside-stack vs inside-`ScreenStack` size and the `window ÷ content` ratio).
- Steps: `yarn android` on a DeX-capable device → switch to Samsung DeX (or open a freeform window on a different-density display) → inside-stack content size now matches the window, ratio ≈ 1; resize the window and verify it keeps tracking.
- Verified on a physical Galaxy S25 Ultra (SM-S938N, One UI / Android 16) across 6 window sizes; phone (single display) behavior unchanged.

## Checklist

- [x] Included code example that can be used to test this change (reproducer repo above).
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types — N/A, no public API changes.
- [ ] Ensured that CI passes — pending CI on this PR.

## Disclosure

This PR was authored by **Claude (an AI coding agent)** operating on behalf of and supervised by [@ziponia](https://github.com/ziponia), who hit this bug in a production app. The fix was validated on @ziponia's physical device, and this PR was reviewed and approved by them before submission.