### PR TITLE
fix(iOS): FullWindowOverlay leaks its container when a child has a reanimated layout animation

### DIFF
--- a/ios/RNSFullWindowOverlay.mm
+++ b/ios/RNSFullWindowOverlay.mm
@@ -92,6 +92,16 @@
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+  // The window-attached `_container` is normally removed in -didMoveToSuperview
+  // (when superview becomes nil) and -prepareForRecycle. Those paths can be
+  // bypassed when the overlay's subtree removal is deferred by a
+  // react-native-reanimated layout animation on a descendant, which leaves
+  // `_container` (and its now-orphaned child) stranded on the UIWindow forever.
+  // Remove it here as a final safety net so the overlay never outlives itself.
+  if (_container != nil) {
+    [_container removeFromSuperview];
+    [_touchHandler detachFromView:_container];
+  }
 }
 
 - (void)setAccessibilityContainerViewIsModal:(BOOL)accessibilityContainerViewIsModal


### PR DESCRIPTION
<!-- DRAFT / work-in-progress — see the open question on the fix below. -->

## Summary

On iOS / New Architecture (Fabric), a `FullWindowOverlay` does **not** remove its
native `RNSFullWindowOverlayContainer` from the `UIWindow` when it unmounts **if a
descendant has a `react-native-reanimated` layout animation** (`layout` /
`LinearTransition`, or `entering`/`exiting` paired with `layout`).

Each mount/unmount cycle leaks one full-screen `RNSFullWindowOverlayContainer`
that stays attached to the window forever (it survives a JS reload — only a full
process restart clears it). The leaked container keeps its child view, which keeps
capturing touches, so the region it covers becomes permanently unresponsive.

**Real-world impact:** `sonner-native` renders toasts inside a `FullWindowOverlay`
with a `layout` animation, so every toast leaks a full-screen container whose child
swallows touches — the top of the screen (e.g. a navigation back button) goes dead
after a few toasts.

## Repro

- **Snack (SDK 56):** https://snack.expo.dev/UuaAipOBuu1iHJVRWgGJ9
- **Repo:** https://github.com/PierreCapo/fwo-leak-repro

Steps:
1. Tap **Show overlay** a few times (each mounts a `FullWindowOverlay`, then
   auto-unmounts it ~1.2s later, like a toast).
2. Capture the view hierarchy in Xcode and count `RNSFullWindowOverlayContainer`
   under the `UIWindow` → one extra per cycle, never removed.

## This is specific to `FullWindowOverlay`, not a generic reanimated leak

The exact same `<Animated.View layout={LinearTransition}>` mounted/unmounted in the
ordinary view tree (not inside a `FullWindowOverlay`) is removed cleanly — verified
by searching the native hierarchy for the marker before/after unmount.

| Overlay child                                                       | Container after unmount |
| ------------------------------------------------------------------- | ----------------------- |
| `<View>` (plain)                                                    | removed ✅               |
| `<Animated.View exiting={FadeOut}>` (no `layout`)                   | removed ✅               |
| `<Animated.View layout={LinearTransition}>`                         | **stranded ❌**          |
| same layout-animated view in the **ordinary tree** (no overlay)     | removed ✅               |

So reanimated tears down a `layout`-animated view correctly in the normal case;
the leak appears only under `FullWindowOverlay`, whose container is attached
directly to the `UIWindow`, outside the normal view hierarchy.

## Root cause

`RNSFullWindowOverlay` attaches its `_container` directly to the `UIWindow`
(`maybeShow` → `[window addSubview:_container]`) and removes it only via
`-didMoveToSuperview` (when `superview == nil`) and `-prepareForRecycle`. When the
overlay's subtree removal is deferred by reanimated's layout-animation machinery,
those UIKit-lifecycle paths are bypassed and `_container` (with its now-orphaned
child) is stranded on the window. `-dealloc` currently only removes the
`NSNotificationCenter` observer — not the container.

## Proposed change

Remove the window-attached container in `-dealloc` as a final safety net.

## ⚠️ Open question (why this is a draft)

This only triggers if `RNSFullWindowOverlay` is actually **deallocated** when the
node is removed. The runtime evidence suggests reanimated may keep the overlay's
component view *retained* (the leak persists indefinitely), in which case
`-dealloc` would not fire and a different hook is needed — e.g. removing the
container in `-didMoveToWindow` when `self.window == nil`, or a fix on the
reanimated side that finalises the native unmount of a `FullWindowOverlay` subtree.

I couldn't compile-test the patch in this environment. Adding an `NSLog` in
`-dealloc` / `-prepareForRecycle` / `-didMoveToWindow` during one repro cycle will
show which hook actually fires when reanimated owns the removal — happy to follow
the maintainers' guidance on the right place for the fix, and to add an
example-app test.

## Environment

- react-native 0.85.3 (New Architecture)
- react-native-screens 4.25.2
- react-native-reanimated 4.3.1
- iOS 26 simulator + device
