### PR TITLE
fix(Android): route all px→dp Shadow Tree state pushes through per-display density

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderConfigViewGroup.kt
@@ -5,8 +5,8 @@ import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.swmansion.rnscreens.utils.pxToDp
 import kotlin.math.abs
 
 abstract class FabricEnabledHeaderConfigViewGroup(
@@ -39,10 +39,12 @@ abstract class FabricEnabledHeaderConfigViewGroup(
         paddingStart: Int,
         paddingEnd: Int,
     ) {
-        val realWidth: Float = PixelUtil.toDIPFromPixel(width.toFloat())
-        val realHeight: Float = PixelUtil.toDIPFromPixel(height.toFloat())
-        val realPaddingStart: Float = PixelUtil.toDIPFromPixel(paddingStart.toFloat())
-        val realPaddingEnd: Float = PixelUtil.toDIPFromPixel(paddingEnd.toFloat())
+        // Convert px->dp with this view's own display density (see pxToDp); the global density
+        // mis-scales the frame pushed to the Shadow Tree on a non-main-density display. See #4159.
+        val realWidth: Float = pxToDp(width.toFloat())
+        val realHeight: Float = pxToDp(height.toFloat())
+        val realPaddingStart: Float = pxToDp(paddingStart.toFloat())
+        val realPaddingEnd: Float = pxToDp(paddingEnd.toFloat())
 
         // Check incoming state values. If they're already the correct value, return early to prevent
         // infinite UpdateState/SetState loop.

--- a/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/FabricEnabledHeaderSubviewViewGroup.kt
@@ -5,8 +5,8 @@ import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.swmansion.rnscreens.utils.pxToDp
 import kotlin.math.abs
 
 abstract class FabricEnabledHeaderSubviewViewGroup(
@@ -39,10 +39,12 @@ abstract class FabricEnabledHeaderSubviewViewGroup(
         offsetX: Int,
         offsetY: Int,
     ) {
-        val realWidth: Float = PixelUtil.toDIPFromPixel(width.toFloat())
-        val realHeight: Float = PixelUtil.toDIPFromPixel(height.toFloat())
-        val offsetXDip: Float = PixelUtil.toDIPFromPixel(offsetX.toFloat())
-        val offsetYDip: Float = PixelUtil.toDIPFromPixel(offsetY.toFloat())
+        // Convert px->dp with this view's own display density (see pxToDp); the global density
+        // mis-scales the frame pushed to the Shadow Tree on a non-main-density display. See #4159.
+        val realWidth: Float = pxToDp(width.toFloat())
+        val realHeight: Float = pxToDp(height.toFloat())
+        val offsetXDip: Float = pxToDp(offsetX.toFloat())
+        val offsetYDip: Float = pxToDp(offsetY.toFloat())
 
         // Check incoming state values. If they're already the correct value, return early to prevent
         // infinite UpdateState/SetState loop.

--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -38,6 +38,7 @@ import com.swmansion.rnscreens.events.HeaderHeightChangeEvent
 import com.swmansion.rnscreens.events.SheetDetentChangedEvent
 import com.swmansion.rnscreens.ext.asScreenStackFragment
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
+import com.swmansion.rnscreens.utils.pxToDp
 import kotlin.math.max
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
@@ -517,7 +518,7 @@ class Screen(
                 HeaderHeightChangeEvent(
                     surfaceId,
                     id,
-                    PixelUtil.toDIPFromPixel(headerHeight.toFloat()).toDouble(),
+                    pxToDp(headerHeight.toFloat()).toDouble(),
                 ),
             )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/ShadowStateProxy.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/ShadowStateProxy.kt
@@ -1,8 +1,8 @@
 package com.swmansion.rnscreens.gamma.common
 
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.swmansion.rnscreens.utils.pxToDp
 import kotlin.math.abs
 
 internal class ShadowStateProxy(
@@ -16,15 +16,18 @@ internal class ShadowStateProxy(
     private var lastContentOffsetYInDp: Float = 0f
 
     fun updateStateIfNeeded(
+        // The display density is supplied per call (not captured once) so it stays correct
+        // when the owning view moves between displays of differing density. See pxToDp / #4159.
+        density: Float,
         frameWidth: Int? = null,
         frameHeight: Int? = null,
         contentOffsetX: Int? = null,
         contentOffsetY: Int? = null,
     ) {
-        val widthInDp = frameWidth?.let { PixelUtil.toDIPFromPixel(it.toFloat()) } ?: lastFrameWidthInDp
-        val heightInDp = frameHeight?.let { PixelUtil.toDIPFromPixel(it.toFloat()) } ?: lastFrameHeightInDp
-        val offsetXInDp = contentOffsetX?.let { PixelUtil.toDIPFromPixel(it.toFloat()) } ?: lastContentOffsetXInDp
-        val offsetYInDp = contentOffsetY?.let { PixelUtil.toDIPFromPixel(it.toFloat()) } ?: lastContentOffsetYInDp
+        val widthInDp = frameWidth?.let { pxToDp(it.toFloat(), density) } ?: lastFrameWidthInDp
+        val heightInDp = frameHeight?.let { pxToDp(it.toFloat(), density) } ?: lastFrameHeightInDp
+        val offsetXInDp = contentOffsetX?.let { pxToDp(it.toFloat(), density) } ?: lastContentOffsetXInDp
+        val offsetYInDp = contentOffsetY?.let { pxToDp(it.toFloat(), density) } ?: lastContentOffsetYInDp
 
         if (
             abs(lastFrameWidthInDp - widthInDp) < DELTA &&

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -112,6 +112,7 @@ class StackHeaderConfig(
         contentOffsetY: Int,
     ) {
         shadowStateProxy.updateStateIfNeeded(
+            density = resources.displayMetrics.density,
             frameWidth = width,
             frameHeight = height,
             contentOffsetY = contentOffsetY,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/subview/StackHeaderSubview.kt
@@ -35,7 +35,11 @@ class StackHeaderSubview(
         x: Int,
         y: Int,
     ) {
-        shadowStateProxy.updateStateIfNeeded(contentOffsetX = x, contentOffsetY = y)
+        shadowStateProxy.updateStateIfNeeded(
+            density = resources.displayMetrics.density,
+            contentOffsetX = x,
+            contentOffsetY = y,
+        )
     }
 
     internal var onStackHeaderSubviewChangeListener: WeakReference<OnStackHeaderSubviewChangeListener>? = null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
@@ -63,6 +63,7 @@ class StackScreen(
         width: Int? = null,
         height: Int? = null,
     ) = shadowStateProxy.updateStateIfNeeded(
+        density = resources.displayMetrics.density,
         contentOffsetX = x,
         contentOffsetY = y,
         frameWidth = width,
@@ -120,7 +121,11 @@ class StackScreen(
         r: Int,
         b: Int,
     ) {
-        shadowStateProxy.updateStateIfNeeded(frameWidth = r - l, frameHeight = b - t)
+        shadowStateProxy.updateStateIfNeeded(
+            density = resources.displayMetrics.density,
+            frameWidth = r - l,
+            frameHeight = b - t,
+        )
     }
 
     override fun getAssociatedFragment(): Fragment? =

--- a/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/safearea/SafeAreaView.kt
@@ -11,10 +11,10 @@ import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
+import com.swmansion.rnscreens.utils.pxToDp
 import java.lang.ref.WeakReference
 
 @SuppressLint("ViewConstructor") // Should never be recreated
@@ -165,10 +165,10 @@ class SafeAreaView(
         val stateWrapper = getStateWrapper()
         if (stateWrapper != null) {
             val insets = Arguments.createMap()
-            insets.putDouble("left", PixelUtil.toDIPFromPixel(safeAreaInsets.left).toDouble())
-            insets.putDouble("top", PixelUtil.toDIPFromPixel(safeAreaInsets.top).toDouble())
-            insets.putDouble("right", PixelUtil.toDIPFromPixel(safeAreaInsets.right).toDouble())
-            insets.putDouble("bottom", PixelUtil.toDIPFromPixel(safeAreaInsets.bottom).toDouble())
+            insets.putDouble("left", pxToDp(safeAreaInsets.left).toDouble())
+            insets.putDouble("top", pxToDp(safeAreaInsets.top).toDouble())
+            insets.putDouble("right", pxToDp(safeAreaInsets.right).toDouble())
+            insets.putDouble("bottom", pxToDp(safeAreaInsets.bottom).toDouble())
 
             val newState = Arguments.createMap()
             newState.putMap("insets", insets)

--- a/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/DimensionUtils.kt
@@ -6,13 +6,12 @@ import android.view.View
 import com.facebook.react.uimanager.PixelUtil
 
 /**
- * Converts a pixel value to dp using the density of the display this [View] is attached
- * to — not the process-global density that [PixelUtil] reads from the device's main
- * display. Fabric mounts views with the per-display density, so state pushed back to the
- * Shadow Tree must be converted with that same density; the global one mis-scales the
- * frame on any display whose density differs from the main one (Samsung DeX, freeform
- * multi-window, external monitors). On single-display devices the two are equal, so this
- * is a no-op there. See #4159.
+ * Converts a pixel value to dp using the given display [density] — not the process-global
+ * density that [PixelUtil] reads from the device's main display. Fabric mounts views with
+ * the per-display density, so state pushed back to the Shadow Tree must be converted with
+ * that same density; the global one mis-scales the frame on any display whose density
+ * differs from the main one (Samsung DeX, freeform multi-window, external monitors). On
+ * single-display devices the two are equal, so this is a no-op there. See #4159.
  *
  * [android.util.DisplayMetrics.density] (`densityDpi / DENSITY_DEFAULT(160)`) is strictly
  * positive for the resources of any attached view; it is `0` only for a default-constructed
@@ -21,10 +20,17 @@ import com.facebook.react.uimanager.PixelUtil
  * division into Infinity/NaN and corrupt the pushed state; in that case we fall back to the
  * global conversion, which is at least well-defined.
  */
-internal fun View.pxToDp(px: Float): Float {
-    val density = resources.displayMetrics.density
-    return if (density > 0f) px / density else PixelUtil.toDIPFromPixel(px)
-}
+internal fun pxToDp(
+    px: Float,
+    density: Float,
+): Float = if (density > 0f) px / density else PixelUtil.toDIPFromPixel(px)
+
+/**
+ * Converts a pixel value to dp using the density of the display this [View] is attached to.
+ * Reads the density fresh on every call, so it stays correct if the view moves between
+ * displays of differing density. See [pxToDp].
+ */
+internal fun View.pxToDp(px: Float): Float = pxToDp(px, resources.displayMetrics.density)
 
 internal fun resolveDimensionAttr(
     context: Context,


### PR DESCRIPTION
## Description

Follow-up that **completes and refactors** the per-display px→dp conversion fix for Android Fabric. 🥞 **Stacked on #4160** — land that first, then this.

`Fabric` mounts views using the density of the display the surface is attached to, but the screens library converts the natively-measured **px** back to **dp** with the process-global density (`PixelUtil`), captured once from the device's main display. On a display whose density differs (Samsung DeX, freeform multi-window, external monitors), every state pushed to the Shadow Tree (and the header-height event) is mis-scaled. #4160 fixes the first call site (`FabricEnabledViewGroup.updateState`); this PR extracts that into a reusable helper and routes **every remaining px→dp state push** through it.

Closes #4159 (together with #4160).


## Changes

- **`utils/DimensionUtils.kt`**: add an `internal` per-display conversion helper — a context-free core `pxToDp(px, density)` plus a `View.pxToDp(px)` extension that reads the view's own display density fresh on every call (so it stays correct if a view moves between displays of differing density). Documents the `density > 0f` guard and its relationship to `DisplayMetrics.density`.
- Route the remaining Shadow Tree / JS state pushes through the helper:
  - `FabricEnabledViewGroup` (refactor of #4160's inline conversion), `FabricEnabledHeaderConfigViewGroup`, `FabricEnabledHeaderSubviewViewGroup` — header/frame state.
  - `safearea/SafeAreaView` — inset values.
  - `gamma/common/ShadowStateProxy` — gamma stack/header state. Has no `View`, so it takes a **required `density` parameter supplied per call** by its owning views (`StackScreen`, `StackHeaderConfig`, `StackHeaderSubview`).
  - `Screen.notifyHeaderHeightChange` — the header-height event dispatched to JS.

## Before & after - visual documentation

N/A — no visible change on single-display devices, where the per-display density equals the global one (the conversion is a no-op there). The fix only affects rendering on a display whose density differs from the device's main display; that path is validated on hardware in #4160 (Galaxy S25 Ultra in DeX).

## Test plan

- `./gradlew :app:assembleDebug` (FabricExample) — **BUILD SUCCESSFUL**; Kotlin compile + codegen pass with all changed files.
- Ran FabricExample on an emulator (Pixel 9 Pro, API 36) and verified basic navigation has no regression on the single-display (no-op) path: stack push/pop (Simple Native Stack → Detail → back) and bottom-tabs switching all render full-window with correct headers.
- Multi-display behaviour (the actual bug): covered by #4160's on-device validation and reproducer — https://github.com/ziponia/rn-multidisplay-density-repro.

## Checklist

- [x] Included code example that can be used to test this change (reproducer in #4160).
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. — N/A
- [x] For API changes, updated relevant public types. — N/A, only `internal` helpers + an `internal` parameter.
- [ ] Ensured that CI passes — pending.
