### PR TITLE
chore(test): e2e: test-tabs-item-badge 

### DIFF
--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
@@ -16,7 +16,6 @@ const tabBarBadgeViewType = isIOSVersionAtLeast('26.0')
   ? '_UIBarBadgeView'
   : '_UIBadgeView';
 
-const tabBarBagdeViewType = tabBarBadgeViewType;
 describeIfiOS('Tab Bar Item Badge', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -31,22 +30,22 @@ describeIfiOS('Tab Bar Item Badge', () => {
 
     await expect(
       element(
-        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-1')),
+        by.type(tabBarBadgeViewType).withAncestor(by.id('tab-badge-item-1')),
       ),
     ).toHaveText('1');
     await expect(
       element(
-        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-2')),
+        by.type(tabBarBadgeViewType).withAncestor(by.id('tab-badge-item-2')),
       ),
     ).toHaveText('1234567890');
     await expect(
       element(
-        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-3')),
+        by.type(tabBarBadgeViewType).withAncestor(by.id('tab-badge-item-3')),
       ),
     ).toHaveText('NEW!');
     await expect(
       element(
-        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-4')),
+        by.type(tabBarBadgeViewType).withAncestor(by.id('tab-badge-item-4')),
       ),
     ).toHaveText('⚠️');
   });

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
@@ -1,5 +1,20 @@
 import { device, expect, element, by } from 'detox';
 import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
+import isVersionEqualOrHigherThan from '../../helpers/isVersionEqualOrHigherThan';
+const {
+  getIOSVersionNumber,
+} = require('../../../../scripts/e2e/ios-devices.js');
+
+function isIOSVersionAtLeast(version: string): boolean {
+  return (
+    device.getPlatform() === 'ios' &&
+    isVersionEqualOrHigherThan(getIOSVersionNumber(), version)
+  );
+}
+
+const tabBarBagdeViewType = isIOSVersionAtLeast('26.0')
+  ? '_UIBarBadgeView'
+  : '_UIBadgeView';
 
 describeIfiOS('Tab Bar Item Badge', () => {
   beforeAll(async () => {
@@ -15,22 +30,22 @@ describeIfiOS('Tab Bar Item Badge', () => {
 
     await expect(
       element(
-        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-1')),
+        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-1')),
       ),
     ).toHaveText('1');
     await expect(
       element(
-        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-2')),
+        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-2')),
       ),
     ).toHaveText('1234567890');
     await expect(
       element(
-        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-3')),
+        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-3')),
       ),
     ).toHaveText('NEW!');
     await expect(
       element(
-        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-4')),
+        by.type(tabBarBagdeViewType).withAncestor(by.id('tab-badge-item-4')),
       ),
     ).toHaveText('⚠️');
   });

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
@@ -12,10 +12,11 @@ function isIOSVersionAtLeast(version: string): boolean {
   );
 }
 
-const tabBarBagdeViewType = isIOSVersionAtLeast('26.0')
+const tabBarBadgeViewType = isIOSVersionAtLeast('26.0')
   ? '_UIBarBadgeView'
   : '_UIBadgeView';
 
+const tabBarBagdeViewType = tabBarBadgeViewType;
 describeIfiOS('Tab Bar Item Badge', () => {
   beforeAll(async () => {
     await device.reloadReactNative();

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
@@ -1,0 +1,37 @@
+import { device, expect, element, by } from 'detox';
+import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
+
+describeIfiOS('Tab Bar Item Badge', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen('Tabs', 'test-tabs-item-badge');
+  });
+
+  it('should display all four tab bar items with correct badge values', async () => {
+    await expect(element(by.id('tab-badge-item-1'))).toExist();
+    await expect(element(by.id('tab-badge-item-2'))).toExist();
+    await expect(element(by.id('tab-badge-item-3'))).toExist();
+    await expect(element(by.id('tab-badge-item-4'))).toExist();
+
+    await expect(
+      element(
+        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-1')),
+      ),
+    ).toHaveText('1');
+    await expect(
+      element(
+        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-2')),
+      ),
+    ).toHaveText('1234567890');
+    await expect(
+      element(
+        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-3')),
+      ),
+    ).toHaveText('NEW!');
+    await expect(
+      element(
+        by.type('_UIBarBadgeView').withAncestor(by.id('tab-badge-item-4')),
+      ),
+    ).toHaveText('⚠️');
+  });
+});

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
@@ -190,7 +190,6 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
       title: 'Tab1',
       badgeValue: Platform.OS === 'ios' ? '1' : '',
       tabBarItemTestID: 'tab-badge-item-1',
-      tabBarItemAccessibilityLabel: 'tab-badge-item-1-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
       },
@@ -209,7 +208,6 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
       title: 'Tab2',
       badgeValue: '1234567890',
       tabBarItemTestID: 'tab-badge-item-2',
-      tabBarItemAccessibilityLabel: 'tab-badge-item-2-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {
@@ -240,7 +238,6 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
       title: 'Tab3',
       badgeValue: 'NEW!',
       tabBarItemTestID: 'tab-badge-item-3',
-      tabBarItemAccessibilityLabel: 'tab-badge-item-3-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {
@@ -267,7 +264,6 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
       title: 'Tab4',
       badgeValue: '⚠️',
       tabBarItemTestID: 'tab-badge-item-4',
-      tabBarItemAccessibilityLabel: 'tab-badge-item-4-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Platform, PlatformColor, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Platform,
+  PlatformColor,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
@@ -15,20 +22,32 @@ function Tab1Screen() {
       <Text style={styles.label}>Default badge appearance</Text>
       {Platform.OS === 'ios' ? (
         <Text style={styles.hint}>
-          `badgeValue`: "1"{'\n'}{'\n'}
-          `standardAppearance` and `scrollEdgeAppearance` are not defined.{'\n'}{'\n'}
+          `badgeValue`: "1"{'\n'}
+          {'\n'}
+          `standardAppearance` and `scrollEdgeAppearance` are not defined.{'\n'}
+          {'\n'}
           Badges render with the default iOS appearance:
           `tabBarItemBadgeBackgroundColor`{' '}
-          <Text style={{ color: PlatformColor('systemRed'), fontWeight: 'bold' }}>RED</Text> with white text.
+          <Text
+            style={{ color: PlatformColor('systemRed'), fontWeight: 'bold' }}>
+            RED
+          </Text>{' '}
+          with white text.
         </Text>
       ) : (
         <Text style={styles.hint}>
           `badgeValue`: ""{'\n'}
-          An empty string badge value renders as a "small dot" using the color defined in `tabBarItemBadgeBackgroundColor`, or the system default if not set.{'\n'}{'\n'}
-          Badge appearance is not defined.{'\n'}{'\n'}
-          Badges render with the default system appearance:
-          background{' '}
-          <Text style={{ color: Colors.RedDark120, fontWeight: 'bold' }}>DARK RED</Text> with white text.
+          An empty string badge value renders as a "small dot" using the color
+          defined in `tabBarItemBadgeBackgroundColor`, or the system default if
+          not set.{'\n'}
+          {'\n'}
+          Badge appearance is not defined.{'\n'}
+          {'\n'}
+          Badges render with the default system appearance: background{' '}
+          <Text style={{ color: Colors.RedDark120, fontWeight: 'bold' }}>
+            DARK RED
+          </Text>{' '}
+          with white text.
         </Text>
       )}
     </View>
@@ -43,31 +62,44 @@ function Tab2Screen() {
         {Platform.OS === 'ios' ? (
           <>
             <Text style={styles.hint}>
-              `badgeValue`: "1234567890"{'\n'}{'\n'}
+              `badgeValue`: "1234567890"{'\n'}
+              {'\n'}
               `standardAppearance`{'\n'}
               `tabBarItemBadgeBackgroundColor`:{' '}
-              <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>BLUE</Text>
-              {'\n'}{'\n'}
+              <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>
+                BLUE
+              </Text>
+              {'\n'}
+              {'\n'}
               `scrollEdgeAppearance`{'\n'}
               `tabBarItemBadgeBackgroundColor`:{' '}
-              <Text style={{ color: Colors.YellowDark100, fontWeight: 'bold' }}>YELLOW</Text>
-              {'\n'}{'\n'}
+              <Text style={{ color: Colors.YellowDark100, fontWeight: 'bold' }}>
+                YELLOW
+              </Text>
+              {'\n'}
+              {'\n'}
             </Text>
             <View style={styles.spacer} />
             <Text style={styles.hint}>
-              Scroll all the way down so the list edge meets the tab bar to apply
-              `scrollEdgeAppearance`. Scroll back up to restore `standardAppearance`.
+              Scroll all the way down so the list edge meets the tab bar to
+              apply `scrollEdgeAppearance`. Scroll back up to restore
+              `standardAppearance`.
             </Text>
             <View style={styles.spacer} />
           </>
         ) : (
           <Text style={styles.hint}>
-            `badgeValue`: "1234567890" displayed as "999+"{'\n'}{'\n'}
+            `badgeValue`: "1234567890" displayed as "999+"{'\n'}
+            {'\n'}
             `tabBarItemBadgeBackgroundColor`:{' '}
-            <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>BLUE</Text>
+            <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>
+              BLUE
+            </Text>
             {'\n'}
             `tabBarItemBadgeTextColor`:{' '}
-            <Text style={{ color: Colors.YellowDark100, fontWeight: 'bold' }}>YELLOW</Text>
+            <Text style={{ color: Colors.YellowDark100, fontWeight: 'bold' }}>
+              YELLOW
+            </Text>
           </Text>
         )}
       </View>
@@ -81,22 +113,34 @@ function Tab3Screen() {
       <Text style={styles.label}>String Badge Value</Text>
       {Platform.OS === 'ios' ? (
         <Text style={styles.hint}>
-          `badgeValue`: "NEW!"{'\n'}{'\n'}
+          `badgeValue`: "NEW!"{'\n'}
+          {'\n'}
           selected: `tabBarItemBadgeBackgroundColor`:{' '}
-          <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>BLUE</Text>
-          {'\n'}{'\n'}
+          <Text style={{ color: Colors.BlueDark100, fontWeight: 'bold' }}>
+            BLUE
+          </Text>
+          {'\n'}
+          {'\n'}
           normal: `tabBarItemBadgeBackgroundColor`:{' '}
-          <Text style={{ color: Colors.PurpleDark100, fontWeight: 'bold' }}>PURPLE</Text>
-          {'\n'}{'\n'}
+          <Text style={{ color: Colors.PurpleDark100, fontWeight: 'bold' }}>
+            PURPLE
+          </Text>
+          {'\n'}
+          {'\n'}
         </Text>
       ) : (
         <Text style={styles.hint}>
-          `badgeValue`: "NEW!"{'\n'}{'\n'}
+          `badgeValue`: "NEW!"{'\n'}
+          {'\n'}
           `tabBarItemBadgeBackgroundColor`:{' '}
-          <Text style={{ color: Colors.PurpleDark100, fontWeight: 'bold' }}>PURPLE</Text>
+          <Text style={{ color: Colors.PurpleDark100, fontWeight: 'bold' }}>
+            PURPLE
+          </Text>
           {'\n'}
           `tabBarItemBadgeTextColor`:{' '}
-          <Text style={{ color: Colors.NavyLight100, fontWeight: 'bold' }}>NAVY</Text>
+          <Text style={{ color: Colors.NavyLight100, fontWeight: 'bold' }}>
+            NAVY
+          </Text>
         </Text>
       )}
     </View>
@@ -109,19 +153,29 @@ function Tab4Screen() {
       <Text style={styles.label}>Transparent badge background</Text>
       {Platform.OS === 'ios' ? (
         <Text style={styles.hint}>
-          `badgeValue`: "⚠️"{'\n'}{'\n'}
-          Badge appearance is defined only for selected tab: setting background to `transparent` value.{'\n'}{'\n'}
-          Unselected badges render with the default system appearance:
-          badge background{' '}
-          <Text style={{ color: PlatformColor('systemRed'), fontWeight: 'bold' }}>RED</Text> with white text.
+          `badgeValue`: "⚠️"{'\n'}
+          {'\n'}
+          Badge appearance is defined only for selected tab: setting background
+          to `transparent` value.{'\n'}
+          {'\n'}
+          Unselected badges render with the default system appearance: badge
+          background{' '}
+          <Text
+            style={{ color: PlatformColor('systemRed'), fontWeight: 'bold' }}>
+            RED
+          </Text>{' '}
+          with white text.
         </Text>
       ) : (
         <Text style={styles.hint}>
-          `badgeValue`: "⚠️"{'\n'}{'\n'}
+          `badgeValue`: "⚠️"{'\n'}
+          {'\n'}
           `tabBarItemBadgeBackgroundColor`: `transparent`
           {'\n'}
           `tabBarItemBadgeTextColor`:{' '}
-          <Text style={{ color: Colors.RedLight100, fontWeight: 'bold' }}>RED</Text>
+          <Text style={{ color: Colors.RedLight100, fontWeight: 'bold' }}>
+            RED
+          </Text>
         </Text>
       )}
     </View>
@@ -135,6 +189,8 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       title: 'Tab1',
       badgeValue: Platform.OS === 'ios' ? '1' : '',
+      tabBarItemTestID: 'tab-badge-item-1',
+      tabBarItemAccessibilityLabel: 'tab-badge-item-1-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
       },
@@ -152,6 +208,8 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       title: 'Tab2',
       badgeValue: '1234567890',
+      tabBarItemTestID: 'tab-badge-item-2',
+      tabBarItemAccessibilityLabel: 'tab-badge-item-2-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {
@@ -181,6 +239,8 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       title: 'Tab3',
       badgeValue: 'NEW!',
+      tabBarItemTestID: 'tab-badge-item-3',
+      tabBarItemAccessibilityLabel: 'tab-badge-item-3-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {
@@ -206,12 +266,14 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       title: 'Tab4',
       badgeValue: '⚠️',
+      tabBarItemTestID: 'tab-badge-item-4',
+      tabBarItemAccessibilityLabel: 'tab-badge-item-4-label',
       ios: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
         standardAppearance: {
           stacked: {
             selected: { tabBarItemBadgeBackgroundColor: 'transparent' },
-          }
+          },
         },
       },
       android: {
@@ -236,7 +298,6 @@ const styles = StyleSheet.create({
     margin: 24,
     padding: 24,
     gap: 12,
-
   },
   spacer: {
     height: 220,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -14,8 +14,11 @@ customisation is driven by `standardAppearance`.
 
 ## E2E test
 
-Incomplete: Only step 1 for iOS is automated. The E2E test asserts badge text values for all four
-tabs at baseline.
+Incomplete: Only step 1 for iOS is automated. The E2E test asserts the badge text
+values for all four tabs at baseline. A single suite can be run on both iOS
+versions with version-specific conditions: the tab bar badge view class name
+resolves dynamically (_UIBadgeView on iOS 18 and lower vs.
+_UIBarBadgeView on iOS 26).
 
 Not covered:
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -14,11 +14,16 @@ customisation is driven by `standardAppearance`.
 
 ## E2E test
 
-Incomplete: Not automated. All observable
-outcomes are purely visual (badge color, text color, displayed string).
-Detox does not expose color or text-content attributes of native tab bar
-badge items, so automated assertion requires a screenshot-diff approach
-not yet in place.
+Incomplete: Only step 1 for iOS is automated. The E2E test asserts badge text values for all four
+tabs at baseline.
+
+Not covered:
+
+- Android - no automated coverage; all badge behavior on Android remains
+  manual-only.
+- Badge background color and badge text color (all tabs, all states) -
+  Detox does not expose color attributes of native tab bar badge views,
+  so color assertions require a screenshot-diff approach not yet in place.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -22,11 +22,10 @@ _UIBarBadgeView on iOS 26).
 
 Not covered:
 
-- Android - no automated coverage; all badge behavior on Android remains
-  manual-only.
-- Badge background color and badge text color (all tabs, all states) -
-  Detox does not expose color attributes of native tab bar badge views,
-  so color assertions require a screenshot-diff approach not yet in place.
+- All steps for Android, and most iOS steps except for the initial badge text validation.
+- Badge background and text colors (all tabs, all states). Detox does not expose color 
+  attributes for native tab bar badge views, meaning color validation requires a 
+  screenshot-diff approach that is not yet implemented.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

This PR adds a new test scenario screen and a Detox e2e test that exercise the `badgeValue` prop on `TabsScreen`, covering default badge appearance, a long numeric string, a custom string badge, and an emoji badge. The e2e test is iOS-only (wrapped in `describeIfiOS`) because badge text content is introspectable via `_UIBarBadgeView` on iOS but not on Android; the scenario screen itself is cross-platform and documents Android behavior as well. To enable Detox assertions, `tabBarItemTestID` is added to each of the four tab route configs, exposing the tab bar items via `by.id()`. The overall `e2eCoverage` is marked `incomplete` because badge color and text color attributes are not yet assertable without a screenshot-diff approach.

Closes:https://github.com/software-mansion/react-native-screens-labs/issues/1415

## Changes

- **FabricExample/e2e**: Added `test-tabs-item-badge.e2e.ts` — Detox iOS-only suite using `describeIfiOS` that asserts badge text on all four tabs via `_UIBarBadgeView` ancestor queries
- **apps/src**: Added `test-tabs-item-badge/` scenario directory with `index.tsx` (cross-platform screen covering four badge cases), `scenario-description.ts`, and `scenario.md` (manual steps for iOS and Android including known iOS 26 badge color regression KI-1072)
- **apps/src/tests/single-feature-tests/tabs/index.ts**: Registered `TestTabsItemBadge` in the scenario map
- **Tabs/testID**: Set `tabBarItemTestID` on all four tab route configs to expose tab bar items as Detox targets