### PR TITLE
refactor(test): remove "Expected:" prefix from scenario step assertions

### DIFF
--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -25,7 +25,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **FormSheet with Nested Stack v5** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown
+- [ ] Content with the button "Open FormSheet" is shown
 
 ---
 
@@ -33,12 +33,12 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). The "Home Screen" text is visible and centered within the sheet. The light blue background completely covers the FormSheet content area.
+- [ ] The FormSheet opens at the initial lower detent (0.6). The "Home Screen" text is visible and centered within the sheet. The light blue background completely covers the FormSheet content area.
 
 
 3. Tap the "Push A" button to push Screen A.
 
-- [ ] Expected: The stack navigates to "Screen A". The "Screen A" text is centered. The light yellow background completely covers the FormSheet content area.
+- [ ] The stack navigates to "Screen A". The "Screen A" text is centered. The light yellow background completely covers the FormSheet content area.
 
 ---
 
@@ -46,7 +46,7 @@ TBD: Planned, but will be implemented separately.
 
 4. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] Expected: The FormSheet expands to take up the maximum available height (respecting the top inset). The layout adapts dynamically - the light yellow background stretches to cover the new full height, and the "Screen A" text dynamically re-centers itself within the newly expanded view area.
+- [ ] The FormSheet expands to take up the maximum available height (respecting the top inset). The layout adapts dynamically - the light yellow background stretches to cover the new full height, and the "Screen A" text dynamically re-centers itself within the newly expanded view area.
 
 ---
 
@@ -54,7 +54,7 @@ TBD: Planned, but will be implemented separately.
 
 5. Swipe down on the FormSheet to dismiss it, then tap the "Open FormSheet" button again.
 
-- [ ] Expected: The FormSheet re-opens at the initial lower detent (0.6). The stack's navigation state has been kept - the sheet immediately displays "Screen A" (with the yellow background and centered text) rather than resetting back to the Home Screen.
+- [ ] The FormSheet re-opens at the initial lower detent (0.6). The stack's navigation state has been kept - the sheet immediately displays "Screen A" (with the yellow background and centered text) rather than resetting back to the Home Screen.
 
 ---
 
@@ -62,7 +62,7 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap the "Pop" button (or native header back button) to pop Screen A.
 
-- [ ] Expected: The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered, and the light blue background completely covers the FormSheet content area.
+- [ ] The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered, and the light blue background completely covers the FormSheet content area.
 
 ## Steps - iPad
 
@@ -70,7 +70,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **FormSheet with Nested Stack v5** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown.
+- [ ] Content with the button "Open FormSheet" is shown.
 
 ---
 
@@ -78,11 +78,11 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "Home Screen" text is visible and centered within the panel. The light blue background completely covers the FormSheet content area.
+- [ ] The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "Home Screen" text is visible and centered within the panel. The light blue background completely covers the FormSheet content area.
 
 3. Tap the "Push A" button to push Screen A.
 
-- [ ] Expected: The stack navigates to "Screen A". The "Screen A" text is centered within the floating panel. The light yellow background completely covers the FormSheet content area.
+- [ ] The stack navigates to "Screen A". The "Screen A" text is centered within the floating panel. The light yellow background completely covers the FormSheet content area.
 
 ---
 
@@ -90,7 +90,7 @@ TBD: Planned, but will be implemented separately.
 
 4. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] Expected: The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The layout adapts dynamically - the light yellow background stretches to cover the new full height, and the "Screen A" text dynamically re-centers itself within the newly expanded panel.
+- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The layout adapts dynamically - the light yellow background stretches to cover the new full height, and the "Screen A" text dynamically re-centers itself within the newly expanded panel.
 
 ---
 
@@ -98,7 +98,7 @@ TBD: Planned, but will be implemented separately.
 
 5. Swipe down on the FormSheet to dismiss it, then tap the "Open FormSheet" button again.
 
-- [ ] Expected: The FormSheet re-opens as a centered floating panel at the initial lower detent (0.6). The stack's navigation state has been kept - the panel immediately displays "Screen A" (with the yellow background and centered text) rather than resetting back to the Home Screen.
+- [ ] The FormSheet re-opens as a centered floating panel at the initial lower detent (0.6). The stack's navigation state has been kept - the panel immediately displays "Screen A" (with the yellow background and centered text) rather than resetting back to the Home Screen.
 
 ---
 
@@ -106,4 +106,4 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap the "Pop" button (or native header back button) to pop Screen A.
 
-- [ ] Expected: The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered within the panel, and the light blue background completely covers the FormSheet content area.
+- [ ] The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered within the panel, and the light blue background completely covers the FormSheet content area.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base-ios/scenario.md
@@ -25,7 +25,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Basic functionality** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown
+- [ ] Content with the button "Open FormSheet" is shown
 
 ---
 
@@ -33,7 +33,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered both vertically and horizontally within the sheet.
+- [ ] The FormSheet opens at the initial lower detent (0.6). The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered both vertically and horizontally within the sheet.
 
 ---
 
@@ -41,7 +41,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] Expected: The FormSheet expands to take up the maximum available height (respecting the top inset). The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded view area.
+- [ ] The FormSheet expands to take up the maximum available height (respecting the top inset). The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded view area.
 
 ---
 
@@ -49,7 +49,7 @@ TBD: Planned, but will be implemented separately.
 
 4. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.
 
 ## Steps - iPad
 
@@ -57,7 +57,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Basic functionality** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown.
+- [ ] Content with the button "Open FormSheet" is shown.
 
 ---
 
@@ -65,7 +65,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered within the panel.
+- [ ] The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered within the panel.
 
 ---
 
@@ -73,7 +73,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] Expected: The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded panel.
+- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded panel.
 
 ---
 
@@ -81,4 +81,4 @@ TBD: Planned, but will be implemented separately.
 
 4. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -26,17 +26,17 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Expand when scrolled to edge** screen.
 
-- [ ] Expected: A status text indicating the current prop value ("Expands on edge scroll: ON"), a switch, and an "Open FormSheet" button are shown.
+- [ ] A status text indicating the current prop value ("Expands on edge scroll: ON"), a switch, and an "Open FormSheet" button are shown.
 
 ### Expansion enabled (Default)
 
 2. Ensure the toggle is set to `ON`. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.5). The "Drag Here to Expand" header and a scrollable list of items are visible.
+- [ ] The FormSheet opens at the initial lower detent (0.5). The "Drag Here to Expand" header and a scrollable list of items are visible.
 
 3. Swipe up on the scrollable list content.
 
-- [ ] Expected: The FormSheet expands to the maximum detent (1.0). The list content does not scroll until the sheet has finished expanding to the maximum detent.
+- [ ] The FormSheet expands to the maximum detent (1.0). The list content does not scroll until the sheet has finished expanding to the maximum detent.
 
 4. Dismiss the sheet by tapping "Dismiss from JS" or swiping down on the drag indicator.
 
@@ -46,12 +46,12 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+- [ ] The FormSheet opens at the initial lower detent (0.5).
 
 7. Swipe up on the scrollable list content (ensure you are starting from the very top edge of the ScrollView).
 
-- [ ] Expected: The list scrolls normally to reveal lower items. The FormSheet **does not** expand to the maximum detent and remains at 0.5. 
+- [ ] The list scrolls normally to reveal lower items. The FormSheet **does not** expand to the maximum detent and remains at 0.5. 
 
 8. Grab the "Drag Here to Expand" header area above the list and drag it up.
 
-- [ ] Expected: The FormSheet expands to the maximum detent (1.0), verifying that manual sheet expansion is still possible outside the ScrollView area.
+- [ ] The FormSheet expands to the maximum detent (1.0), verifying that manual sheet expansion is still possible outside the ScrollView area.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents-ios/scenario.md
@@ -25,7 +25,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Fit to contents** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown.
+- [ ] Content with the button "Open FormSheet" is shown.
 
 ---
 
@@ -33,7 +33,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens smoothly. Its height is matched to its internal content (on iPhone, it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
+- [ ] The FormSheet opens smoothly. Its height is matched to its internal content (on iPhone, it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
 
 ---
 
@@ -41,7 +41,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Expand Content" button inside the FormSheet.
 
-- [ ] Expected: The extra text box appears. The native FormSheet smoothly animates and grows in height to fully accommodate the newly added content without any visual glitches.
+- [ ] The extra text box appears. The native FormSheet smoothly animates and grows in height to fully accommodate the newly added content without any visual glitches.
 
 ---
 
@@ -49,7 +49,7 @@ TBD: Planned, but will be implemented separately.
 
 4. Tap the "Collapse Content" button.
 
-- [ ] Expected: The extra text box disappears. The native FormSheet smoothly animates and shrinks back to its original, smaller height.
+- [ ] The extra text box disappears. The native FormSheet smoothly animates and shrinks back to its original, smaller height.
 
 ---
 
@@ -57,4 +57,4 @@ TBD: Planned, but will be implemented separately.
 
 5. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible-ios/scenario.md
@@ -20,7 +20,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Grabber visibility** screen.
 
-- [ ] Expected: Content with the "prefersGrabberVisible" toggle (switched off by default) and the "Open FormSheet" button is shown.
+- [ ] Content with the "prefersGrabberVisible" toggle (switched off by default) and the "Open FormSheet" button is shown.
 
 ---
 
@@ -28,11 +28,11 @@ TBD: Planned, but will be implemented separately.
 
 2. Without flipping the toggle, tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). No grabber indicator is shown at the top of the sheet.
+- [ ] The FormSheet opens at the initial lower detent (0.6). No grabber indicator is shown at the top of the sheet.
 
 3. Dismiss the FormSheet by swiping it down.
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
 
 ---
 
@@ -42,7 +42,7 @@ TBD: Planned, but will be implemented separately.
 
 5. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.6). A grabber indicator is visible at the top of the sheet.
+- [ ] The FormSheet opens at the initial lower detent (0.6). A grabber indicator is visible at the top of the sheet.
 
 6. Dismiss the FormSheet by swiping it down.
 
@@ -50,7 +50,7 @@ TBD: Planned, but will be implemented separately.
 
 8. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens with no grabber indicator visible at the top of the sheet.
+- [ ] The FormSheet opens with no grabber indicator visible at the top of the sheet.
 
 9. Dismiss the FormSheet by swiping it down.
 
@@ -60,16 +60,16 @@ TBD: Planned, but will be implemented separately.
 
 10. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens with no grabber indicator visible at the top of the sheet. The "prefersGrabberVisible" toggle inside the sheet is switched off and reflects the same state as the toggle on the main screen.
+- [ ] The FormSheet opens with no grabber indicator visible at the top of the sheet. The "prefersGrabberVisible" toggle inside the sheet is switched off and reflects the same state as the toggle on the main screen.
 
 11. Flip the "prefersGrabberVisible" toggle inside the FormSheet to **on**.
 
-- [ ] Expected: The grabber indicator appears at the top of the sheet without dismissing or re-presenting the sheet.
+- [ ] The grabber indicator appears at the top of the sheet without dismissing or re-presenting the sheet.
 
 12. Flip the "prefersGrabberVisible" toggle inside the FormSheet back to **off**.
 
-- [ ] Expected: The grabber indicator disappears from the top of the sheet without dismissing or re-presenting the sheet.
+- [ ] The grabber indicator disappears from the top of the sheet without dismissing or re-presenting the sheet.
 
 13. Tap the "Dismiss from JS" button.
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "prefersGrabberVisible" toggle on the main screen reflects the last value set inside the sheet (off).
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "prefersGrabberVisible" toggle on the main screen reflects the last value set inside the sheet (off).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index-ios/scenario.md
@@ -22,15 +22,15 @@ TBD: Planned, but will be implemented separately.
 2. Ensure "Selected Initial Detent: 0" is displayed.
 3. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens and snaps immediately to the lowest detent (0.3 detent).
+- [ ] The FormSheet opens and snaps immediately to the lowest detent (0.3 detent).
 
 ### Re-render Validation
 
 4. While the sheet is open at the 0.3 detent, drag it up to the middle detent (0.6).
 5. Tap the "Force Re-render" button inside the sheet.
 
-- [ ] Expected: The button's counter updates (confirming a React render cycle occurred).
-- [ ] Expected: The sheet remains at the 0.6 detent.
+- [ ] The button's counter updates (confirming a React render cycle occurred).
+- [ ] The sheet remains at the 0.6 detent.
 
 6. Dismiss the sheet by swiping down or tapping "Dismiss from JS".
 
@@ -41,7 +41,7 @@ TBD: Planned, but will be implemented separately.
 7. On the main screen, tap "Set Initial to 1 (0.6)".
 8. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens directly at the middle detent (0.6 detent).
+- [ ] The FormSheet opens directly at the middle detent (0.6 detent).
 
 9. Dismiss the sheet.
 
@@ -52,6 +52,6 @@ TBD: Planned, but will be implemented separately.
 10. On the main screen, tap "Set Initial to 'last' (1.0)".
 11. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens and snaps directly to the maximum height (1.0 detent).
+- [ ] The FormSheet opens and snaps directly to the maximum height (1.0 detent).
 
 12. Dismiss the sheet.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 1. Launch the app and navigate to the **Sheet largest undimmed detent index** screen.
 2. Tap the "Increment Background Counter" button at the top of the screen a few times.
 
-- [ ] Expected: The counter increases successfully.
+- [ ] The counter increases successfully.
 
 ---
 
@@ -29,8 +29,8 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the first detent (0.3). The background behind the sheet immediately becomes dimmed. 
-- [ ] Expected: Tapping the "Increment Background Counter" button does **not** work (the tap is intercepted by the dimming view and it dismisses the sheet).
+- [ ] The FormSheet opens at the first detent (0.3). The background behind the sheet immediately becomes dimmed. 
+- [ ] Tapping the "Increment Background Counter" button does **not** work (the tap is intercepted by the dimming view and it dismisses the sheet).
 
 ---
 
@@ -38,12 +38,12 @@ TBD: Planned, but will be implemented separately.
 
 4. Inside the sheet, tap the "Set 0 (0.3 height)" button.
 
-- [ ] Expected: The background is undimmed immediately.
-- [ ] Expected: Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.3.
+- [ ] The background is undimmed immediately.
+- [ ] Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.3.
 
 5. Grab the top of the sheet and drag it up to the middle detent (0.6).
 
-- [ ] Expected: As the sheet transitions to index 1 (0.6), the background is dimmed again. The background counter button is no longer pressable.
+- [ ] As the sheet transitions to index 1 (0.6), the background is dimmed again. The background counter button is no longer pressable.
 
 ---
 
@@ -51,9 +51,9 @@ TBD: Planned, but will be implemented separately.
 
 6. Inside the sheet, tap the "Set 'last'" button.
 
-- [ ] Expected: The background is undimmed for lower detents (0.3 and 0.6).
-- [ ] Expected: Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
-- [ ] Expected: Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
+- [ ] The background is undimmed for lower detents (0.3 and 0.6).
+- [ ] Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
+- [ ] Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
 
 ---
 
@@ -61,7 +61,7 @@ TBD: Planned, but will be implemented separately.
 
 7. Inside the sheet, tap the "Set 'none'" button.
 
-- [ ] Expected: The background dims immediately. Interaction with the background counter is blocked.
+- [ ] The background dims immediately. Interaction with the background counter is blocked.
 
 ---
 
@@ -69,4 +69,4 @@ TBD: Planned, but will be implemented separately.
 
 8. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly. The background counter button becomes pressable again.
+- [ ] The FormSheet dismisses smoothly. The background counter button becomes pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed-ios/scenario.md
@@ -20,26 +20,26 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **OnDetentChanged** screen.
 
-- [ ] Expected: A status text "Current Detent Index: 0" and an "Open FormSheet" button are shown.
+- [ ] A status text "Current Detent Index: 0" and an "Open FormSheet" button are shown.
 
 ### Track Detent Changes
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the smallest initial detent (0.4). The textbox inside the sheet displays `0`.
+- [ ] The FormSheet opens at the smallest initial detent (0.4). The textbox inside the sheet displays `0`.
 
 3. Grab the drag indicator and swipe up until the sheet snaps to the middle detent (0.7).
 
-- [ ] Expected: The sheet settles in the middle of the screen. The textbox inside the sheet updates to `1`.
+- [ ] The sheet settles in the middle of the screen. The textbox inside the sheet updates to `1`.
 
 4. Swipe up again to expand the sheet to the maximum detent (1.0).
 
-- [ ] Expected: The sheet expands to fill the available screen height. The textbox inside the sheet updates to `2`.
+- [ ] The sheet expands to fill the available screen height. The textbox inside the sheet updates to `2`.
 
 5. Swipe down to collapse the sheet back to the smallest detent (0.4).
 
-- [ ] Expected: The sheet shrinks back to the smallest size. The textbox inside the sheet updates back to `0`.
+- [ ] The sheet shrinks back to the smallest size. The textbox inside the sheet updates back to `0`.
 
 6. Tap the "Dismiss from JS" button or swipe the sheet all the way down to dismiss it.
 
-- [ ] Expected: The FormSheet dismisses successfully.
+- [ ] The FormSheet dismisses successfully.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius-ios/scenario.md
@@ -27,7 +27,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
+- [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 
 ---
 
@@ -35,7 +35,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens. The top corners (iOS 18) or all corners (iOS 26) of the sheet display the standard, system-default rounded appearance.
+- [ ] The FormSheet opens. The top corners (iOS 18) or all corners (iOS 26) of the sheet display the standard, system-default rounded appearance.
 
 ---
 
@@ -43,15 +43,15 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Sharp (0)" button.
 
-- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, becoming sharp.
+- [ ] The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, becoming sharp.
 
 4. Tap the "Small (10)" button.
 
-- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) update to a slightly rounded curve.
+- [ ] The top corners (iOS 18) or all corners (iOS 26) update to a slightly rounded curve.
 
 5. Tap the "Large (50)" button.
 
-- [ ] Expected: The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, displaying deeply rounded curve.
+- [ ] The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, displaying deeply rounded curve.
 
 ---
 
@@ -59,7 +59,7 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly. Pressables on the main screen remain active.
+- [ ] The FormSheet dismisses smoothly. Pressables on the main screen remain active.
 
 ## Steps - iPad
 
@@ -67,7 +67,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
+- [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 
 ---
 
@@ -75,7 +75,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens as a centered floating panel. All four corners of the panel display the standard, system-default rounded appearance.
+- [ ] The FormSheet opens as a centered floating panel. All four corners of the panel display the standard, system-default rounded appearance.
 
 ---
 
@@ -83,15 +83,15 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Sharp (0)" button.
 
-- [ ] Expected: All four corners of the sheet update dynamically, becoming sharp.
+- [ ] All four corners of the sheet update dynamically, becoming sharp.
 
 4. Tap the "Small (10)" button.
 
-- [ ] Expected: All four corners update to a slightly rounded curve.
+- [ ] All four corners update to a slightly rounded curve.
 
 5. Tap the "Large (50)" button.
 
-- [ ] Expected: All four corners of the sheet update dynamically, displaying deeply rounded curve.
+- [ ] All four corners of the sheet update dynamically, displaying deeply rounded curve.
 
 ---
 
@@ -99,4 +99,4 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap the "Dismiss from JS" button (or swipe down completely).
 
-- [ ] Expected: The FormSheet dismisses smoothly. Pressables on the main screen remain active.
+- [ ] The FormSheet dismisses smoothly. Pressables on the main screen remain active.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state-ios/scenario.md
@@ -20,7 +20,7 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Presentation state** screen.
 
-- [ ] Expected: Content with the button "Open FormSheet" is shown.
+- [ ] Content with the button "Open FormSheet" is shown.
 
 ---
 
@@ -28,7 +28,7 @@ Other: Planned, but will be implemented separately.
 
 2. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens smoothly and displays its content.
+- [ ] The FormSheet opens smoothly and displays its content.
 
 ---
 
@@ -36,7 +36,7 @@ Other: Planned, but will be implemented separately.
 
 3. Tap the "Quickly dismiss & present" button.
 
-- [ ] Expected: The FormSheet should begin the dismissal animation. As soon as the dismissal animation finishes, the FormSheet should immediately automatically re-present itself. The final state should be opened FormSheet.
+- [ ] The FormSheet should begin the dismissal animation. As soon as the dismissal animation finishes, the FormSheet should immediately automatically re-present itself. The final state should be opened FormSheet.
 
 ---
 
@@ -44,4 +44,4 @@ Other: Planned, but will be implemented separately.
 
 4. Grab the top edge of the FormSheet and swipe down completely to natively dismiss it.
 
-- [ ] Expected: The FormSheet dismisses and returns the user to the underlying main screen. The native state is synchronized, and tapping "Open FormSheet" again works correctly.
+- [ ] The FormSheet dismisses and returns the user to the underlying main screen. The native state is synchronized, and tapping "Open FormSheet" again works correctly.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss-ios/scenario.md
@@ -20,41 +20,41 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **PreventNativeDismiss** screen.
 
-- [ ] Expected: A status text indicating the current prop value (e.g., "Prevent Native Dismiss: ON"), a switch component, and an "Open FormSheet" button are shown.
+- [ ] A status text indicating the current prop value (e.g., "Prevent Native Dismiss: ON"), a switch component, and an "Open FormSheet" button are shown.
 
 ### Native Dismissal Prevented & Event Fired
 
 2. Ensure the switch is set to ON. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+- [ ] The FormSheet opens at the initial lower detent (0.5).
 
 3. Swipe up to expand the sheet to the maximum detent (1.0).
 
-- [ ] Expected: The sheet expands successfully. 
+- [ ] The sheet expands successfully. 
 
 4. Swipe down on the sheet to collapse it back to the lower detent (0.5).
 
-- [ ] Expected: The sheet collapses successfully.
+- [ ] The sheet collapses successfully.
 
 5. Swipe down on the sheet to attempt to dismiss it completely.
 
-- [ ] Expected: The FormSheet **does not** dismiss. It resists the gesture and bounces back to the 0.5 detent. An alert with the title "Dismissal Prevented" appears.
+- [ ] The FormSheet **does not** dismiss. It resists the gesture and bounces back to the 0.5 detent. An alert with the title "Dismissal Prevented" appears.
 
 6. Tap "OK" on the alert.
 
-- [ ] Expected: The alert closes and the FormSheet remains open.
+- [ ] The alert closes and the FormSheet remains open.
 
 7. Tap the backdrop (the dimmed area behind/above the sheet).
 
-- [ ] Expected: The FormSheet **does not** dismiss. An alert with the title "Dismissal Prevented" appears again.
+- [ ] The FormSheet **does not** dismiss. An alert with the title "Dismissal Prevented" appears again.
 
 8. Tap "OK" on the alert.
 
-- [ ] Expected: The alert closes and the FormSheet remains open.
+- [ ] The alert closes and the FormSheet remains open.
 
 9. Tap the "Dismiss from JS" button.
 
-- [ ] Expected: The FormSheet dismisses successfully.
+- [ ] The FormSheet dismisses successfully.
 
 ### Native Dismissal Allowed
 
@@ -62,16 +62,16 @@ Other: Planned, but will be implemented separately.
 
 11. Tap the "Open FormSheet" button.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+- [ ] The FormSheet opens at the initial lower detent (0.5).
 
 12. Swipe down on the sheet to attempt to dismiss it completely.
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
 
 13. Tap the "Open FormSheet" button again.
 
-- [ ] Expected: The FormSheet opens at the initial lower detent (0.5).
+- [ ] The FormSheet opens at the initial lower detent (0.5).
 
 14. Tap the backdrop.
 
-- [ ] Expected: The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
+- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.

--- a/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/split/test-split-color-scheme-ios/scenario.md
@@ -35,7 +35,7 @@ Assumption:
 
 1. Launch the app with the **Split Color Scheme** scenario injected as the root.
 
-- [ ] Expected: Pickers default to `unspecified` for RN and `inherit` for SplitHost.
+- [ ] Pickers default to `unspecified` for RN and `inherit` for SplitHost.
 
 ---
 
@@ -43,11 +43,11 @@ Assumption:
 
 2. Set system/RN to **light**, SplitHost colorScheme = `inherit`
 
-- [ ] Expected: The split view and its background appear **light**
+- [ ] The split view and its background appear **light**
 
 3. Set system/RN to **dark**, keep SplitHost colorScheme = `inherit`
 
-- [ ] Expected: The split view appears **dark** — SplitHost defers to RN/system
+- [ ] The split view appears **dark** — SplitHost defers to RN/system
 
 ---
 
@@ -55,15 +55,15 @@ Assumption:
 
 4. Set system/RN to **dark**, set SplitHost colorScheme = `light`
 
-- [ ] Expected: The split view appears **light** — SplitHost overrides dark from RN/system
+- [ ] The split view appears **light** — SplitHost overrides dark from RN/system
 
 5. Set system/RN to **light**, keep SplitHost colorScheme = `light`
 
-- [ ] Expected: The split view stays **light**
+- [ ] The split view stays **light**
 
 6. Cycle through `inherit` → `dark` → `light` → `dark` → `inherit`
 
-- [ ] Expected: Split view color scheme updates immediately with each change, no crash or layout freeze
+- [ ] Split view color scheme updates immediately with each change, no crash or layout freeze
 
 ---
 
@@ -71,15 +71,15 @@ Assumption:
 
 7. Set system/RN to **light**, set SplitHost colorScheme = `dark`
 
-- [ ] Expected: The split view appears **dark** — SplitHost overrides light from RN/system
+- [ ] The split view appears **dark** — SplitHost overrides light from RN/system
 
 8. Set system/RN to **dark**, keep SplitHost colorScheme = `dark`
 
-- [ ] Expected: The split view stays **dark**
+- [ ] The split view stays **dark**
 
 9. Cycle through `inherit` → `light` → `dark` → `light` → `inherit`
 
-- [ ] Expected: Split view color scheme updates immediately with each change, no crash or layout freeze
+- [ ] Split view color scheme updates immediately with each change, no crash or layout freeze
 
 ---
 
@@ -87,4 +87,4 @@ Assumption:
 
 10. Switch focus to the `TextInput` in the right column, open the keyboard (or `Cmd+K` on iOS simulator)
 
-- [ ] Expected: Keyboard appearance matches the currently active, resolved color scheme of the `SplitHost` (e.g., if SplitHost forces `dark` while the system is `light`, the keyboard must be dark). Verify for both light and dark values.
+- [ ] Keyboard appearance matches the currently active, resolved color scheme of the `SplitHost` (e.g., if SplitHost forces `dark` while the system is `light`, the keyboard must be dark). Verify for both light and dark values.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/scenario.md
@@ -28,11 +28,11 @@ When support for color scheme is added, we should check if default back arrow ad
 
 1. Launch the app and navigate to the **Stack Back Button** screen.
 
-- [ ] Expected: Root screen is shown. No back button is visible in the header (root screen has no predecessor).
+- [ ] Root screen is shown. No back button is visible in the header (root screen has no predecessor).
 
 2. Tap **Push screen**.
 
-- [ ] Expected: Pushed screen is shown. A default back button (default arrow icon, default tint) is visible in the header.
+- [ ] Pushed screen is shown. A default back button (default arrow icon, default tint) is visible in the header.
 
 ---
 
@@ -40,19 +40,19 @@ When support for color scheme is added, we should check if default back arrow ad
 
 3. Set tintColor = `purple`.
 
-- [ ] Expected: Back arrow changes to purple immediately.
+- [ ] Back arrow changes to purple immediately.
 
 4. Set tintColor = `default`.
 
-- [ ] Expected: Back arrow returns to default tint.
+- [ ] Back arrow returns to default tint.
 
 5. Toggle backButtonHidden = `true`.
 
-- [ ] Expected: Back button disappears from the header.
+- [ ] Back button disappears from the header.
 
 6. Toggle backButtonHidden = `false`.
 
-- [ ] Expected: Back button reappears with default icon and default tint.
+- [ ] Back button reappears with default icon and default tint.
 
 ---
 
@@ -60,27 +60,27 @@ When support for color scheme is added, we should check if default back arrow ad
 
 7. Set icon = `imageSource`.
 
-- [ ] Expected: Back button changes to the custom image — white background with a black arrow, no tint applied.
+- [ ] Back button changes to the custom image — white background with a black arrow, no tint applied.
 
 8. Set tintColor = `red`.
 
-- [ ] Expected: The entire image is covered in red (non-transparent image is fully tinted).
+- [ ] The entire image is covered in red (non-transparent image is fully tinted).
 
 9. Set tintColor = `default`.
 
-- [ ] Expected: Custom image returns to its original appearance (white background, black arrow).
+- [ ] Custom image returns to its original appearance (white background, black arrow).
 
 10. Toggle backButtonHidden = `true`.
 
-- [ ] Expected: Back button disappears.
+- [ ] Back button disappears.
 
 11. Set tintColor = `green`.
 
-- [ ] Expected: No visible change (back button is hidden).
+- [ ] No visible change (back button is hidden).
 
 12. Toggle backButtonHidden = `false`.
 
-- [ ] Expected: Back button reappears with `imageSource` icon and green tint already applied.
+- [ ] Back button reappears with `imageSource` icon and green tint already applied.
 
 ---
 
@@ -88,23 +88,23 @@ When support for color scheme is added, we should check if default back arrow ad
 
 13. Set tintColor = `default`, set icon = `drawableResource`.
 
-- [ ] Expected: Back button changes to `sym_call_missed` drawable — white and red (its native colors).
+- [ ] Back button changes to `sym_call_missed` drawable — white and red (its native colors).
 
 14. Set tintColor = `purple`.
 
-- [ ] Expected: Drawable icon changes to purple.
+- [ ] Drawable icon changes to purple.
 
 15. Set tintColor = `default`.
 
-- [ ] Expected: Drawable icon returns to its native white and red appearance.
+- [ ] Drawable icon returns to its native white and red appearance.
 
 16. Toggle backButtonHidden = `true`.
 
-- [ ] Expected: Back button disappears.
+- [ ] Back button disappears.
 
 17. Toggle backButtonHidden = `false`.
 
-- [ ] Expected: Back button reappears with `drawableResource` icon and default tint.
+- [ ] Back button reappears with `drawableResource` icon and default tint.
 
 ---
 
@@ -112,8 +112,8 @@ When support for color scheme is added, we should check if default back arrow ad
 
 18. Go back to the root screen. Set icon = `imageSource`, tintColor = `purple`.
 
-- [ ] Expected: Root screen is shown. No back button visible (root screen).
+- [ ] Root screen is shown. No back button visible (root screen).
 
 19. Tap **Push screen**.
 
-- [ ] Expected: Pushed screen appears with the `imageSource` icon and purple tint already applied.
+- [ ] Pushed screen appears with the `imageSource` icon and purple tint already applied.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -45,17 +45,17 @@ Other — automation is not implemented yet.
 
 1. Launch the app and navigate to **Stack Toolbar Menu Commands**.
 
-- [ ] Expected: Header title reads "Toolbar Menu Commands Test". The
+- [ ] Header title reads "Toolbar Menu Commands Test". The
       toolbar overflow menu shows three items in order: "Title A",
       "Title B", "Title C", all visible.
 
 2. Open the menu and tap "Title A".
 
-- [ ] Expected: Menu closes. "Last clicked" updates to `item-1`.
+- [ ] Menu closes. "Last clicked" updates to `item-1`.
 
 3. Open the menu and tap "Title C".
 
-- [ ] Expected: "Last clicked" updates to `item-3`.
+- [ ] "Last clicked" updates to `item-3`.
 
 ---
 
@@ -64,7 +64,7 @@ Other — automation is not implemented yet.
 4. In the **Send Command** section, set target id = `item-1`,
    title = `no change`, hidden = `no change`. Tap **Send Command**.
 
-- [ ] Expected: No visible change. Menu still shows "Title A",
+- [ ] No visible change. Menu still shows "Title A",
       "Title B", "Title C".
 
 ---
@@ -74,12 +74,12 @@ Other — automation is not implemented yet.
 5. Set target id = `item-2`, title = `Changed`, hidden = `no change`.
    Tap **Send Command**.
 
-- [ ] Expected: Item 2 in the menu now reads "Changed". Items 1
+- [ ] Item 2 in the menu now reads "Changed". Items 1
       ("Title A") and 3 ("Title C") are unchanged.
 
 6. Tap "Changed" in the menu.
 
-- [ ] Expected: "Last clicked" updates to `item-2` (id is stable across
+- [ ] "Last clicked" updates to `item-2` (id is stable across
       title changes).
 
 ---
@@ -89,13 +89,13 @@ Other — automation is not implemented yet.
 7. Set target id = `item-2`, title = `no change`, hidden = `true`.
    Tap **Send Command**.
 
-- [ ] Expected: Item 2 disappears from the menu. Only "Title A" and
+- [ ] Item 2 disappears from the menu. Only "Title A" and
       "Title C" remain.
 
 8. Set target id = `item-2`, title = `no change`, hidden = `false`.
    Tap **Send Command**.
 
-- [ ] Expected: Item 2 reappears and still reads "Changed" (the title
+- [ ] Item 2 reappears and still reads "Changed" (the title
       set in step 5 was preserved because `title` was absent from both
       step 7 and step 8 options).
 
@@ -106,13 +106,13 @@ Other — automation is not implemented yet.
 9. Set target id = `item-1`, title = `no change`, hidden = `true`.
    Tap **Send Command**.
 
-- [ ] Expected: Item 1 ("Title A") disappears. Menu shows "Changed" and
+- [ ] Item 1 ("Title A") disappears. Menu shows "Changed" and
       "Title C".
 
 10. Set target id = `item-1`, title = `no change`, hidden = `undefined`.
     Tap **Send Command**.
 
-- [ ] Expected: Item 1 reappears with "Title A". The `hidden` override
+- [ ] Item 1 reappears with "Title A". The `hidden` override
       is cleared and the prop falls back to its regular default
       (visible). Note this is the regular default, not the value
       previously received from props — they happen to coincide in this
@@ -125,13 +125,13 @@ Other — automation is not implemented yet.
 11. Set target id = `item-1`, title = `Long Title`, hidden = `no change`.
     Tap **Send Command**.
 
-- [ ] Expected: Item 1 reads "Long Title". Item 2 still reads "Changed"
+- [ ] Item 1 reads "Long Title". Item 2 still reads "Changed"
       (carried over from step 5 / step 8). Item 3 reads "Title C".
 
 12. In **Menu Items — Props**, change Slot 3 title from `Title C` to
     `Long Title`.
 
-- [ ] Expected: Item 3 reads "Long Title" (direct props change). At the
+- [ ] Item 3 reads "Long Title" (direct props change). At the
       same time, Item 1 reverts to its props-configured "Title A"
       (losing the "Long Title" override applied in step 11) and Item 2
       reverts to its props-configured "Title B" (losing the "Changed"
@@ -139,7 +139,7 @@ Other — automation is not implemented yet.
 
 13. Change Slot 3 title back to `Title C`.
 
-- [ ] Expected: Item 3 reads "Title C". Items 1 and 2 still show their
+- [ ] Item 3 reads "Title C". Items 1 and 2 still show their
       props-configured titles ("Title A", "Title B").
 
 ---
@@ -148,17 +148,17 @@ Other — automation is not implemented yet.
 
 14. In **Menu Items — Props**, toggle Slot 3 `include = false`.
 
-- [ ] Expected: Item 3 ("Title C") disappears. Menu shows "Title A" and
+- [ ] Item 3 ("Title C") disappears. Menu shows "Title A" and
       "Title B".
 
 15. Set command target id = `item-3`, title = `Changed`,
     hidden = `false`. Tap **Send Command**.
 
-- [ ] Expected: No visible change. No crash. Items 1 and 2 are
+- [ ] No visible change. No crash. Items 1 and 2 are
       unaffected.
 
 16. Toggle Slot 3 `include = true`.
 
-- [ ] Expected: Item 3 reappears with "Title C" (the props-configured
+- [ ] Item 3 reappears with "Title C" (the props-configured
       title), NOT "Changed". The command from step 15 did not leak
       into the re-included slot.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
@@ -39,18 +39,18 @@ promote additional items.
 
 1. Launch the app and navigate to **Stack Toolbar Menu Show As Action**.
 
-- [ ] Expected: Header title reads "Show As Action Test". The toolbar
+- [ ] Header title reads "Show As Action Test". The toolbar
       shows only the overflow (⋮) icon — no items appear as direct
       action buttons. Open the overflow menu: three items are listed
       ("I1", "Item 2", "Item Number Three").
 
 2. Open the overflow menu and tap "I1".
 
-- [ ] Expected: Menu closes. "Last clicked" updates to `item-1`.
+- [ ] Menu closes. "Last clicked" updates to `item-1`.
 
 3. Open the overflow menu and tap "Item Number Three".
 
-- [ ] Expected: "Last clicked" updates to `item-3`.
+- [ ] "Last clicked" updates to `item-3`.
 
 ---
 
@@ -59,7 +59,7 @@ promote additional items.
 4. In **Menu Items — Props**, change Slot 1 `showAsAction` from
    `undefined` to `never`.
 
-- [ ] Expected: Item 1 remains in the overflow menu — identical to the
+- [ ] Item 1 remains in the overflow menu — identical to the
       default behaviour.
 
 ---
@@ -68,13 +68,13 @@ promote additional items.
 
 5. Change Slot 1 `showAsAction` to `always`.
 
-- [ ] Expected: "I1" appears directly in the toolbar as a text
+- [ ] "I1" appears directly in the toolbar as a text
       action button. The overflow menu now contains only "Item 2" and
       "Item Number Three".
 
 6. Tap the "I1" action button in the toolbar.
 
-- [ ] Expected: "Last clicked" updates to `item-1`.
+- [ ] "Last clicked" updates to `item-1`.
 
 ---
 
@@ -86,7 +86,7 @@ promote additional items.
 
 7. Change Slot 1 `showAsAction` to `alwaysWithText`.
 
-- [ ] Expected: "I1" still appears directly in the toolbar. Visually
+- [ ] "I1" still appears directly in the toolbar. Visually
       indistinguishable from `always` without an icon.
 
 ---
@@ -95,7 +95,7 @@ promote additional items.
 
 8. Change all three slots to `ifRoom` (Slot 1, Slot 2, Slot 3).
 
-- [ ] Expected: Items that fit within the available toolbar space appear
+- [ ] Items that fit within the available toolbar space appear
       as action buttons; the rest fall back to the overflow menu. Exact
       count depends on screen width.
 
@@ -108,7 +108,7 @@ promote additional items.
 
 9. Change all three slots to `ifRoomWithText`.
 
-- [ ] Expected: Behaviour matches `ifRoom` — items appear in the toolbar
+- [ ] Behaviour matches `ifRoom` — items appear in the toolbar
       when there is room, otherwise in overflow.
 
 ---
@@ -122,7 +122,7 @@ promote additional items.
 11. In **Send Command**, set target id = `item-1`,
     showAsAction = `always`. Tap **Send Command**.
 
-- [ ] Expected: "I1" immediately moves from the overflow menu to the
+- [ ] "I1" immediately moves from the overflow menu to the
       toolbar as an action button without any prop change.
 
 ---
@@ -132,7 +132,7 @@ promote additional items.
 12. Set target id = `item-1`, showAsAction = `never`. Tap
     **Send Command**.
 
-- [ ] Expected: "I1" moves back to the overflow menu.
+- [ ] "I1" moves back to the overflow menu.
 
 ---
 
@@ -141,11 +141,11 @@ promote additional items.
 13. Set target id = `item-2`, showAsAction = `always`. Tap
     **Send Command**.
 
-- [ ] Expected: "Item 2" appears as a toolbar action button.
+- [ ] "Item 2" appears as a toolbar action button.
 
 14. Set target id = `item-2`, showAsAction = `undefined`. Tap
     **Send Command**.
 
-- [ ] Expected: "Item 2" returns to the overflow menu. The
+- [ ] "Item 2" returns to the overflow menu. The
       `showAsAction` override is cleared and falls back to the regular
       default (`never`).

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
@@ -48,14 +48,14 @@ is not applied to the full-size app.
 
 1. Launch the app and navigate to the **Bottom Accessory** screen.
 
-- [ ] Expected: Three tabs are visible - **Config**, **ScrollDown**,
+- [ ] Three tabs are visible - **Config**, **ScrollDown**,
   **ScrollUp**. The **Config** tab is selected. Five variant cards are
   displayed in a scrollable list; the first card (**Upper Left**) has a blue
   border indicating it is selected.
 
 2. Observe the area below the tab content and above the tab bar.
 
-- [ ] Expected: A bottom accessory is rendered showing the **Upper Left**
+- [ ] A bottom accessory is rendered showing the **Upper Left**
   variant - a green-highlighted label aligned to the top-left corner of the
   accessory area.
 
@@ -65,31 +65,31 @@ is not applied to the full-size app.
 
 3. Confirm the first card (**Upper Left**) is selected (blue border).
 
-- [ ] Expected: The accessory displays the green `Upper Left` label aligned
+- [ ] The accessory displays the green `Upper Left` label aligned
   to the top-left of the accessory slot.
 
 4. Tap the **Center** card on the **Config** tab.
 
-- [ ] Expected: The card border changes to blue. The accessory updates
+- [ ] The card border changes to blue. The accessory updates
   immediately to show the green `Center` label aligned to the center of the
   accessory slot.
 
 5. Tap the **Lower Right** card on the **Config** tab.
 
-- [ ] Expected: The card border changes to blue. The accessory updates
+- [ ] The card border changes to blue. The accessory updates
   immediately to show the green `Lower Right` label aligned to the
   bottom-right of the accessory slot.
 
 6. Tap the **Long** card with 'Lorem ipsum(...)' text on the **Config** tab.
 
-- [ ] Expected: The card border changes to blue. The accessory updates to
+- [ ] The card border changes to blue. The accessory updates to
   a view that stretches to fill the available accessory area and displays
   long body text. The tab bar and content area are not obscured beyond the
   designated accessory slot.
 
 7. Tap the **RGB** card with three strips on the **Config** tab.
 
-- [ ] Expected: The card border changes to blue. The accessory updates to
+- [ ] The card border changes to blue. The accessory updates to
   show three equal vertical strips: red, green,
   and blue, filling the full width of the accessory slot.
 
@@ -99,12 +99,12 @@ is not applied to the full-size app.
 
 8. With the **Center** variant selected, tap the **ScrollDown** tab.
 
-- [ ] Expected: The **ScrollDown** tab content (a 40-row list) is displayed.
+- [ ] The **ScrollDown** tab content (a 40-row list) is displayed.
   The Center accessory remains visible below the content and above tab bar.
 
 9.  Tap the **Config** tab.
 
-- [ ] Expected: The **Config** tab is displayed. The Center accessory is still
+- [ ] The **Config** tab is displayed. The Center accessory is still
   visible. The **Center** card still has a blue border.
 
 ---
@@ -113,18 +113,18 @@ is not applied to the full-size app.
 
 10. Tap the **ScrollDown** tab.
 
-- [ ] Expected: The tab bar is fully visible. The Center accessory is visible in
+- [ ] The tab bar is fully visible. The Center accessory is visible in
 its `regular` position above the tab bar.
 
 11.  Scroll the list **down** on the **ScrollDown** tab.
 
-- [ ] Expected: The tab bar minimizes as content scrolls down. The accessory
+- [ ] The tab bar minimizes as content scrolls down. The accessory
   transitions to the `inline` environment layout (rendered inside the
   collapsed tab bar area).
 
 12. Scroll the list back **up** on the **ScrollDown** tab.
 
-- [ ] Expected: The tab bar expands again. The accessory transitions back to
+- [ ] The tab bar expands again. The accessory transitions back to
   the `regular` environment layout above the tab bar.
 
 ---
@@ -133,17 +133,17 @@ its `regular` position above the tab bar.
 
 13. Tap the **ScrollUp** tab.
 
-- [ ] Expected: The tab bar is fully visible. The accessory is visible in
+- [ ] The tab bar is fully visible. The accessory is visible in
   its `regular` position.
 
 14. Scroll the list **up** (toward the top) on the **ScrollUp** tab.
 
-- [ ] Expected: The tab bar minimizes. The accessory transitions to the
+- [ ] The tab bar minimizes. The accessory transitions to the
   `inline` layout inside the collapsed tab bar.
 
 15. Scroll the list back **down** on the **ScrollUp** tab.
 
-- [ ] Expected: The tab bar expands. The accessory returns to the `regular`
+- [ ] The tab bar expands. The accessory returns to the `regular`
   layout above the tab bar.
 
 ---
@@ -152,22 +152,22 @@ its `regular` position above the tab bar.
 
 16.  Scroll the **ScrollUp** tab so the tab bar minimizes.
 
-- [ ] Expected: The tab bar collapses. The bottom accessory transitions to
+- [ ] The tab bar collapses. The bottom accessory transitions to
 the `inline` layout inside the collapsed bar.  
 
 17. Tap on the collapsed tab bar to expand it.
 
-- [ ] Expected: The tab bar expands back to its full height. The bottom
+- [ ] The tab bar expands back to its full height. The bottom
 accessory transitions back to the `regular` layout above the tab bar.
 
 18. Tap the **Config** tab from the now-expanded tab bar.
 
-- [ ] Expected: The **Config** tab is shown. The currently selected variant card
+- [ ] The **Config** tab is shown. The currently selected variant card
 still has a blue border.
 
 19. Tap a different variant card (e.g., **RGB**).
 
-- [ ] Expected: The accessory updates immediately to the new variant.
+- [ ] The accessory updates immediately to the new variant.
 
 ---
 
@@ -175,5 +175,5 @@ still has a blue border.
 
 20.  Resize app to full-size and perform steps 1-7.
 
-- [ ] Expected: Tab bar is displayed at the top of screen. Different bottom
+- [ ] Tab bar is displayed at the top of screen. Different bottom
 accessory content variants should be displayed correctly at the bottom of the screen.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario.md
@@ -54,7 +54,7 @@ Not automated:
 
 1. Launch the app and navigate to **Tabs lifecycle events**.
 
-- [ ] Expected: Three tabs are visible in the tab bar: **Tab A**, **Tab B**,
+- [ ] Three tabs are visible in the tab bar: **Tab A**, **Tab B**,
   and **Tab C**. **Tab A** is selected. Two toasts
   appear for the initial Tab A appearance:
   - `TabA: onWillAppear`
@@ -66,7 +66,7 @@ Not automated:
 
 2. Tap **Tab B** in the tab bar.
 
-- [ ] Expected: The content area switches to show "TabB". Four toasts
+- [ ] The content area switches to show "TabB". Four toasts
   appear in the following platform-specific order:
 
   **iOS:**
@@ -87,7 +87,7 @@ Not automated:
 
 3. Tap **Tab C** in the tab bar.
 
-- [ ] Expected: The content area switches to show "TabC". Four toasts
+- [ ] The content area switches to show "TabC". Four toasts
   appear in the following platform-specific order:
 
   **iOS:**
@@ -108,7 +108,7 @@ Not automated:
 
 4. Tap **Tab A** in the tab bar.
 
-- [ ] Expected: The content area switches to show "TabA". Four toasts
+- [ ] The content area switches to show "TabA". Four toasts
   appear in the following platform-specific order:
 
   **iOS:**
@@ -129,7 +129,7 @@ Not automated:
 
 5. With **Tab A** selected, tap **Tab A** again in the tab bar.
 
-- [ ] Expected: The content area does not change. No toast notifications
+- [ ] The content area does not change. No toast notifications
   appear. No lifecycle events fire for a tap on the already-active tab.
 
 ---
@@ -139,7 +139,7 @@ Not automated:
 6. Tap **Tab B**, then immediately tap **Tab C** before the toasts from
    the previous step have finished dismissing.
 
-- [ ] Expected: Both transitions complete. Toasts from the B→C transition
+- [ ] Both transitions complete. Toasts from the B→C transition
   appear after the A→B toasts. The final selected
   tab is **Tab C** and its content area shows "TabC". No events are
   missing or duplicated — all eight toasts from both transitions are
@@ -151,7 +151,7 @@ Not automated:
 
 7. From **Tab C**, tap **Tab A**, then **Tab B**, then **Tab C**.
 
-- [ ] Expected: Each tab switch produces exactly four toasts (will/did
+- [ ] Each tab switch produces exactly four toasts (will/did
   disappear for the leaving tab, will/did appear for the arriving tab).
   After three switches, twelve toasts in total have been fired. The final
   selected tab is **Tab C**.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
@@ -26,7 +26,7 @@ TBD: Ongoing research.
 
 1. Launch the app and navigate to the **More navigation controller** scenario.
 
-- [ ] Expected: Tab bar shows **First**, **Second**, **Third**, **Fourth**, and **More**. The **First** tab is selected. The content area displays `First` as the route key.
+- [ ] Tab bar shows **First**, **Second**, **Third**, **Fourth**, and **More**. The **First** tab is selected. The content area displays `First` as the route key.
 
 ---
 
@@ -34,31 +34,31 @@ TBD: Ongoing research.
 
 2. Tap the **More** tab in the tab bar.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. A green toast appears at the bottom with the message `onMoreTabSelected`.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. A green toast appears at the bottom with the message `onMoreTabSelected`.
 
 3. Tap **Fifth** in the More screen list.
 
-- [ ] Expected: The **Fifth** tab content is shown. The route key label reads `Fifth`. The **More** tab remains selected in the tab bar.
+- [ ] The **Fifth** tab content is shown. The route key label reads `Fifth`. The **More** tab remains selected in the tab bar.
 
 4. Tap **Third** tab in the tab bar.
 
-- [ ] Expected: **Third** tab becomes active. Tab bar selection updates, and the route key label reads `Third`.
+- [ ] **Third** tab becomes active. Tab bar selection updates, and the route key label reads `Third`.
 
 5. Tap the **More** tab in the tab bar.
 
-- [ ] Expected: The Fifth tab content is displayed, and the route key label reads `Fifth`. The Tab Bar updates to show that the **More** tab is selected.
+- [ ] The Fifth tab content is displayed, and the route key label reads `Fifth`. The Tab Bar updates to show that the **More** tab is selected.
 
 6. Tap the **More** tab again.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
 
 7. Tap the **More** tab few more times.
 
-- [ ] Expected: The native More screen remains open, listing "Fifth" and "Sixth" as available tabs. No new green toast appears with an `onMoreTabSelected` message.
+- [ ] The native More screen remains open, listing "Fifth" and "Sixth" as available tabs. No new green toast appears with an `onMoreTabSelected` message.
 
 8. Tap **Sixth** in the More screen list.
 
-- [ ] Expected: The **Sixth** tab content is shown. The route key label reads `Sixth`.
+- [ ] The **Sixth** tab content is shown. The route key label reads `Sixth`.
 
 ---
 
@@ -66,19 +66,19 @@ TBD: Ongoing research.
 
 9. Tap **"Select Fourth"**.
 
-- [ ] Expected: **Fourth** tab becomes active. Tab bar selection updates, and the route key label reads `Fourth`.
+- [ ] **Fourth** tab becomes active. Tab bar selection updates, and the route key label reads `Fourth`.
 
 10. Tap **"Select Fifth"**.
 
-- [ ] Expected: **Fifth** tab content is shown, and the route key label reads `Fifth`. The **More** tab is selected in the tab bar. No crash or blank screen.
+- [ ] **Fifth** tab content is shown, and the route key label reads `Fifth`. The **More** tab is selected in the tab bar. No crash or blank screen.
 
 11. Tap **"Select First"**.
 
-- [ ] Expected: **First** tab becomes active. Tab bar selection updates, and the route key label reads `First`.
+- [ ] **First** tab becomes active. Tab bar selection updates, and the route key label reads `First`.
 
 12. Tap **"Select Sixth"**.
 
-- [ ] Expected: **Sixth** tab content is shown, and the route key label reads `Sixth`. The **More** tab is selected in the tab bar.
+- [ ] **Sixth** tab content is shown, and the route key label reads `Sixth`. The **More** tab is selected in the tab bar.
 
 ## Steps - iPad
 
@@ -86,15 +86,15 @@ TBD: Ongoing research.
 
 1. Open app on iPad in full size and navigate to the **More navigation controller** scenario. Open DevTools.
 
-- [ ] Expected: Tab bar shows all six tabs. The **First** tab is selected. The content area displays `First` as the route key.
+- [ ] Tab bar shows all six tabs. The **First** tab is selected. The content area displays `First` as the route key.
 
 2. Navigate between tabs using tab items from tab bar.
 
-- [ ] Expected: Each transition updates the route key label and tab bar selection correctly. No visual glitches or stale route key labels.
+- [ ] Each transition updates the route key label and tab bar selection correctly. No visual glitches or stale route key labels.
 
 3. Navigate between tabs using buttons from screen.
 
-- [ ] Expected: Each transition updates the route key label and tab bar selection correctly. No visual glitches or stale route key labels.
+- [ ] Each transition updates the route key label and tab bar selection correctly. No visual glitches or stale route key labels.
 
 ---
 
@@ -102,60 +102,60 @@ TBD: Ongoing research.
 
 4. Select `First` tab and resize app to iPhone size view.
 
-- [ ] Expected: Tab bar shows **First**, **Second**, **Third**, **Fourth**, and **More**. The **First** tab is selected. The content area displays `First` as the route key.
+- [ ] Tab bar shows **First**, **Second**, **Third**, **Fourth**, and **More**. The **First** tab is selected. The content area displays `First` as the route key.
 
 5. Tap the **More** tab in the tab bar.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. A green toast appears at the bottom with the message `onMoreTabSelected`.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. A green toast appears at the bottom with the message `onMoreTabSelected`.
 
 6. Tap **Fifth** in the More screen list.
 
-- [ ] Expected: The **Fifth** tab content is shown. The route key label reads `Fifth`. The **More** tab remains selected in the tab bar.
+- [ ] The **Fifth** tab content is shown. The route key label reads `Fifth`. The **More** tab remains selected in the tab bar.
 
 7. Tap **Third** tab in the tab bar.
 
-- [ ] Expected: **Third** tab becomes active. Tab bar selection updates, and the route key label reads `Third`.
+- [ ] **Third** tab becomes active. Tab bar selection updates, and the route key label reads `Third`.
 
 8. Tap the **More** tab in the tab bar.
 
-- [ ] Expected: The **Fifth** tab content is shown. The route key label reads `Fifth`. Tab bar selection updates - **More** tab is selected.
+- [ ] The **Fifth** tab content is shown. The route key label reads `Fifth`. Tab bar selection updates - **More** tab is selected.
 
 9. Tap the **More** tab again.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
 
 10. Tap the **More** tab few more times.
 
-- [ ] Expected: The native More screen remains open, listing "Fifth" and "Sixth" as available tabs. No new green toast appears with an `onMoreTabSelected` message.
+- [ ] The native More screen remains open, listing "Fifth" and "Sixth" as available tabs. No new green toast appears with an `onMoreTabSelected` message.
 
 11. Tap **Second** tab in the tab bar.
 
-- [ ] Expected: **Second** tab becomes active. Tab bar selection updates, and the route key label reads `Second`. A blue toast appears at the bottom with the message `onTabSelected:"Second"`.
+- [ ] **Second** tab becomes active. Tab bar selection updates, and the route key label reads `Second`. A blue toast appears at the bottom with the message `onTabSelected:"Second"`.
 
 12.  Tap **"More"** tab bar item and select **"Sixth"** from the More list.
 
-- [ ] Expected: **Sixth** tab content is shown, and the route key label reads `Sixth`. The **More** tab is selected in the tab bar. No crash or blank screen.
+- [ ] **Sixth** tab content is shown, and the route key label reads `Sixth`. The **More** tab is selected in the tab bar. No crash or blank screen.
 
 13. Tap the **More** tab again.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
 
 14. Resize app to full size.
 
-- [ ] Expected: The **More** tab disappears, and the tab bar shows all six tabs at the top of the screen. The **Second** tab becomes active, and the route key label reads `Second`.
+- [ ] The **More** tab disappears, and the tab bar shows all six tabs at the top of the screen. The **Second** tab becomes active, and the route key label reads `Second`.
 
 15. Select **Third** tab and switch to **Fifth**
 
-- [ ] Expected: **Fifth** tab is selected, and the route key label reads `Fifth`.
+- [ ] **Fifth** tab is selected, and the route key label reads `Fifth`.
 
 16. Resize app to iPhone size view.
 
-- [ ] Expected: **More** tab appears and becomes active, and the route key label reads `Fifth`.
+- [ ] **More** tab appears and becomes active, and the route key label reads `Fifth`.
 
 17. Tap the **More** tab again.
 
-- [ ] Expected: The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
+- [ ] The native More screen opens, listing **Fifth** and **Sixth** as available tabs. New green toast appear with `onMoreTabSelected` message.
 
 18. Resize app to full size.
 
-- [ ] Expected: **More** tab disappear, tab bar shows all six tabs on top of the screen. **Fifth** tab becomes active, and the route key label reads `Fifth`.
+- [ ] **More** tab disappear, tab bar shows all six tabs on top of the screen. **Fifth** tab becomes active, and the route key label reads `Fifth`.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/scenario.md
@@ -42,7 +42,7 @@ Full: Covers all manual scenario steps.
 1. Launch the app and navigate to the
    **Override Scroll View Content Inset** screen.
 
-- [ ] Expected: Three tabs are displayed in the tab bar: **False**,
+- [ ] Three tabs are displayed in the tab bar: **False**,
   **True**, and **Default**. The **False** tab is selected and shows
   a scrollable list of 30 items.
 
@@ -52,13 +52,13 @@ Full: Covers all manual scenario steps.
 
 2. Confirm the **False** tab is active and scroll the list to the bottom.
 
-- [ ] Expected: The last item in the list is partially or fully
+- [ ] The last item in the list is partially or fully
   obscured behind the tab bar, confirming that no bottom inset is
   applied.
 
 3. Scroll the list to the top.
 
-- [ ] Expected: The text label
+- [ ] The text label
   `overrideScrollViewContentInsetAdjustmentBehavior: false` at
   the top of the scroll content is partially or fully obscured
   behind the navigation bar, because
@@ -72,17 +72,17 @@ Full: Covers all manual scenario steps.
 
 4. Tap the **True** tab.
 
-- [ ] Expected: The **True** tab becomes active and shows a
+- [ ] The **True** tab becomes active and shows a
   scrollable list of 30 items.
 
 5. Scroll the list to the bottom.
 
-- [ ] Expected: The last item is fully visible and is not obscured by
+- [ ] The last item is fully visible and is not obscured by
   the tab bar. The scroll view respects the bottom inset.
 
 6. Scroll the list to the top.
 
-- [ ] Expected: The text label
+- [ ] The text label
   `overrideScrollViewContentInsetAdjustmentBehavior: true`
   at the top of the scroll content is fully visible below the
   navigation bar and not obscured behind it. The scroll view
@@ -95,17 +95,17 @@ Full: Covers all manual scenario steps.
 
 7. Tap the **Default** tab.
 
-- [ ] Expected: The **Default** tab becomes active and shows a
+- [ ] The **Default** tab becomes active and shows a
   scrollable list of 30 items.
 
 8. Scroll the list to the bottom.
 
-- [ ] Expected: The last item is fully visible and not obscured by
+- [ ] The last item is fully visible and not obscured by
   the tab bar — identical behavior to the **True** tab.
 
 9. Scroll the list to the top.
 
-- [ ] Expected: The text label
+- [ ] The text label
   `overrideScrollViewContentInsetAdjustmentBehavior:
   (not set, defaults to true)` at the top of the scroll content
   is fully visible below the navigation bar and not obscured
@@ -118,7 +118,7 @@ Full: Covers all manual scenario steps.
 10. Switch between the **True** tab and the **Default** tab several
     times while keeping each list scrolled to the top.
 
-- [ ] Expected: Both tabs show the text label
+- [ ] Both tabs show the text label
   `overrideScrollViewContentInsetAdjustmentBehavior:` with value `true`
   or `(not set, defaults to true)` at the top of the scroll content
   is fully visible below the navigation bar and not obscured
@@ -128,6 +128,6 @@ Full: Covers all manual scenario steps.
 11. Switch to the **False** tab and scroll to the top, then
     immediately switch to the **True** tab.
 
-- [ ] Expected: The **True** tab correctly shows the text label
+- [ ] The **True** tab correctly shows the text label
   inset from the navigation bar. No crash or blank screen occurs
   during the switch.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
@@ -52,7 +52,7 @@ is blocked.
 
 1. Launch the app and navigate to **Prevent native selection**.
 
-- [ ] Expected: On Android — six tabs visible in the tab bar. On iOS — four tabs
+- [ ] On Android — six tabs visible in the tab bar. On iOS — four tabs
 and a **More** item visible.The **First** tab is selected
 and displays `preventNativeSelection: false` under its name on the screen.
 
@@ -62,21 +62,21 @@ and displays `preventNativeSelection: false` under its name on the screen.
 
 2. While on the **First** tab, tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: The label updates to `preventNativeSelection: true`.
+- [ ] The label updates to `preventNativeSelection: true`.
 
 3. Tap the **Second** tab item in the tab bar.
 
-- [ ] Expected: **Second** tab is selected normally. `preventNativeSelection` is
+- [ ] **Second** tab is selected normally. `preventNativeSelection` is
 `false` on Second.
 
 4. Tap the **First** tab item in the tab bar.
 
-- [ ] Expected: The tab does not change. A toast appears with
+- [ ] The tab does not change. A toast appears with
 `onTabSelectionPrevented: First`.
 
 5. Tap **Select First** button (programmatic navigation).
 
-- [ ] Expected: Navigation switches to the **First** tab normally — programmatic
+- [ ] Navigation switches to the **First** tab normally — programmatic
 navigation is not blocked by `preventNativeSelection`.
 
 ---
@@ -86,11 +86,11 @@ navigation is not blocked by `preventNativeSelection`.
 6. While on the **First** tab (with `preventNativeSelection: true`), tap
 **Toggle preventNativeSelection**.
 
-- [ ] Expected: The label updates back to `preventNativeSelection: false`.
+- [ ] The label updates back to `preventNativeSelection: false`.
 
 7. Navigate to a different tab and then tap the **First** tab item in the tab bar.
 
-- [ ] Expected: Tab switches normally. No toast appears.
+- [ ] Tab switches normally. No toast appears.
 
 ---
 
@@ -98,21 +98,21 @@ navigation is not blocked by `preventNativeSelection`.
 
 8. Navigate to the **Third** tab and tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: Third tab label shows `preventNativeSelection: true`.
+- [ ] Third tab label shows `preventNativeSelection: true`.
 
 9. Navigate to  the **Fourth** tab and tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: Fourth tab label shows `preventNativeSelection: true`.
+- [ ] Fourth tab label shows `preventNativeSelection: true`.
 
 10. Tap the **Third** tab item in the tab bar.
 
-- [ ] Expected: Tab does not switch. Toast appears with
+- [ ] Tab does not switch. Toast appears with
 `onTabSelectionPrevented: Third`.
 
 11. Navigate to the **First** tab and confirm its `preventNativeSelection` is
 still `false`.
 
-- [ ] Expected: First tab label shows `preventNativeSelection: false`. Tapping it
+- [ ] First tab label shows `preventNativeSelection: false`. Tapping it
 from another tab works normally.
 
 ---
@@ -121,68 +121,68 @@ from another tab works normally.
 
 12. Navigate to the **Fifth** tab via the **Select Fifth** button (programmatic).
 
-- [ ] Expected: **Fifth** tab is displayed normally.
+- [ ] **Fifth** tab is displayed normally.
 
 13. Tap **Toggle preventNativeSelection** on the **Fifth** tab.
 
-- [ ] Expected: Label updates to `preventNativeSelection: true`.
+- [ ] Label updates to `preventNativeSelection: true`.
 
 14. Tap **Select Sixth**, then tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: Label updates to `preventNativeSelection: true`.
+- [ ] Label updates to `preventNativeSelection: true`.
 
 15. Tap **Select First**, then tap **More** in the tab bar.
 
-- [ ] Expected: Navigation to **Sixth** is blocked. Toast appears with
+- [ ] Navigation to **Sixth** is blocked. Toast appears with
 `onTabSelectionPrevented: Sixth`. The More list is displayed.
 
 16. Tap **Fifth** in the More list.
 
-- [ ] Expected: Navigation to **Fifth** is blocked. Toast appears with `onTabSelectionPrevented: Fifth`. The More list remains displayed.
+- [ ] Navigation to **Fifth** is blocked. Toast appears with `onTabSelectionPrevented: Fifth`. The More list remains displayed.
 
 17. Tap **Fourth** tab and navigate to **Fifth** via **Select Fifth**, tap
 **Toggle preventNativeSelection** to disable it.
 
-- [ ] Expected: Fifth tab label shows `preventNativeSelection: false`.
+- [ ] Fifth tab label shows `preventNativeSelection: false`.
 
 18. Navigate away, then tap **More**.
 
-- [ ] Expected: Navigation to **Fifth** proceeds normally. No toast appears.
+- [ ] Navigation to **Fifth** proceeds normally. No toast appears.
 
 19. Tap **More** again and tap **Fifth** from list.
 
-- [ ] Expected: Navigation to **Fifth** proceeds normally. No toast appears.
+- [ ] Navigation to **Fifth** proceeds normally. No toast appears.
 
 ### iPad only - Sidebar behavior
 
 20. Resize app to full screen width.
 
-- [ ] Expected: More tab disappear. **Fifth** tab is selected.
+- [ ] More tab disappear. **Fifth** tab is selected.
 
 21. Open Sidebar and select **Sixth** from the list.
 
-- [ ] Expected: Navigation to **Sixth** is blocked. Toast appears with
+- [ ] Navigation to **Sixth** is blocked. Toast appears with
 `onTabSelectionPrevented: Sixth`.
 The **Fifth** tab is selected and its content remains displayed.
 
 22. Open Sidebar.
 
-- [ ] Expected: **Fifth** tab is selected.
+- [ ] **Fifth** tab is selected.
 
 23. Tap **Second** from Sidebar list and tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: Label updates to `preventNativeSelection: true`.
+- [ ] Label updates to `preventNativeSelection: true`.
 
 24. Tap **Select Sixth** and tap **Toggle preventNativeSelection**.
 
-- [ ] Expected: Label updates to `preventNativeSelection: false`.
+- [ ] Label updates to `preventNativeSelection: false`.
 
 25. Tap **Fourth** and then from the Sidebar tap **Sixth**.
 
-- [ ] Expected: Tab switches normally. No toast appears.
+- [ ] Tab switches normally. No toast appears.
 
 26. Tap **Second** from tab bar.
 
-- [ ] Expected: Navigation to **Second** is blocked. Toast appears with
+- [ ] Navigation to **Second** is blocked. Toast appears with
 `onTabSelectionPrevented: Second`.
 The **Sixth** tab is selected and its content remains displayed.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario.md
@@ -30,60 +30,60 @@ list of 50 items.
 
 1. Launch the app and navigate to the screen **Tabs special effect scroll to top**.
 
-- [ ] Expected: Three tabs (Tab1, Tab2, Tab3) are visible in the tab bar.
+- [ ] Three tabs (Tab1, Tab2, Tab3) are visible in the tab bar.
 Tab1 is active and displays a scrollable list of items.
 
 2. Scroll down several items in Tab1.
 
-- [ ] Expected: The list scrolls down; items above the fold are no longer visible.
+- [ ] The list scrolls down; items above the fold are no longer visible.
 
 3. Re-tap Tab1 (the already-active tab).
 
-- [ ] Expected: The list animates back to the top of the scroll position
+- [ ] The list animates back to the top of the scroll position
 (item 1 is visible).
 
 ### scrollToTop: false
 
 4. Tap Tab2.
 
-- [ ] Expected: Tab2 becomes active and displays a scrollable list of items.
+- [ ] Tab2 becomes active and displays a scrollable list of items.
 
 5. Scroll down several items in Tab2.
 
-- [ ] Expected: The list scrolls down; items above the fold are no longer visible.
+- [ ] The list scrolls down; items above the fold are no longer visible.
 
 6. Re-tap Tab2 (the already-active tab).
 
-- [ ] Expected: The list does **not** scroll back to the top; scroll position is
+- [ ] The list does **not** scroll back to the top; scroll position is
 preserved.
 
 ### no specialEffects (default)
 
 7. Tap Tab3.
 
-- [ ] Expected: Tab3 becomes active and displays a scrollable list of items.
+- [ ] Tab3 becomes active and displays a scrollable list of items.
 
 8. Scroll down several items in Tab3.
 
-- [ ] Expected: The list scrolls down; items above the fold are no longer visible.
+- [ ] The list scrolls down; items above the fold are no longer visible.
 
 9. Re-tap Tab3 (the already-active tab).
 
-- [ ] Expected: Observe and note the default behavior - back to the top of the
+- [ ] Observe and note the default behavior - back to the top of the
 scroll position (item 1 is visible).
 
 ### scrollToTop: true — switching away and back (not a repeated tap)
 
 10. Tap Tab1 and scroll down several items.
 
-- [ ] Expected: Tab1 becomes active. The list scrolls down;
+- [ ] Tab1 becomes active. The list scrolls down;
 items above the fold are no longer visible.
 
 11. Tap Tab3 to switch away from Tab1.
 
-- [ ] Expected: Tab3 becomes active and displays its scrollable list.
+- [ ] Tab3 becomes active and displays its scrollable list.
 
 12. Tap Tab1 again.
 
-- [ ] Expected: Tab1 becomes active and the scroll position is **preserved** -
+- [ ] Tab1 becomes active and the scroll position is **preserved** -
 the list does not scroll back to the top.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/scenario.md
@@ -49,7 +49,7 @@ Ensure the app's behavior strictly matches the expected results at each transiti
 
 1. Launch the app and navigate to **Stale update rejection**.
 
-- [ ] Expected: The **First** tab is selected. The content area shows
+- [ ] The **First** tab is selected. The content area shows
   `heavyRender: false` and `rejectStaleNavStateUpdates: true`.
   No toast is visible.
 
@@ -60,14 +60,14 @@ Ensure the app's behavior strictly matches the expected results at each transiti
 2. Tap the **Third** tab in the native tab bar to navigate to it. Tap
    **Toggle heavyRender** on the Third tab to enable heavy render.
 
-- [ ] Expected: The label updates to `heavyRender: true`. No toast
+- [ ] The label updates to `heavyRender: true`. No toast
   appears.
 
 3. Tap the **First** tab bar item to go back to the First tab. Tap
    **Select Third** (JS dispatches a navigation update to Third), then
    immediately tap the **Second** tab bar item.
 
-- [ ] Expected: The tab bar changes to **Second** immediately. After
+- [ ] The tab bar changes to **Second** immediately. After
   the heavy render on Third finishes, a toast labeled
   `onTabSelectionRejected: Third` appears. The final active tab is
   **Second**, not Third.
@@ -79,23 +79,23 @@ Ensure the app's behavior strictly matches the expected results at each transiti
 4. Navigate to the **Third** tab (heavy render still enabled). Tap
    **Toggle rejectStaleNavStateUpdates** to disable it.
 
-- [ ] Expected: The label updates to `rejectStaleNavStateUpdates:
+- [ ] The label updates to `rejectStaleNavStateUpdates:
   false`. No toast fires from this action.
 
 5. Navigate back to **First**. Tap **Select Third**, then immediately
    tap **Second** in the tab bar before the heavy render ends.
 
-- [ ] Expected: No `onTabSelectionRejected` toast appears. Tab Second is selected
+- [ ] No `onTabSelectionRejected` toast appears. Tab Second is selected
   immediately but after the 3 000 ms block, the final active tab is
   **Third**.
 
 6. Tap **Toggle rejectStaleNavStateUpdates** to re-enable it.
 
-- [ ] Expected: Label updates to `rejectStaleNavStateUpdates: true`.
+- [ ] Label updates to `rejectStaleNavStateUpdates: true`.
 
 7. Repeat the actions from step 5.
 
-- [ ] Expected: The tab bar changes to **Second** immediately. After
+- [ ] The tab bar changes to **Second** immediately. After
   the heavy render on Third finishes, a toast labeled
   `onTabSelectionRejected: Third` appears. The final active tab is
   **Second**, not Third.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
@@ -33,7 +33,7 @@ Assumption:
 
 1. Launch the app and navigate to the **Tab Bar Color Scheme** screen.
    
-- [ ] Expected: Config tab is shown. Pickers default to `unspecified` / `inherit`
+- [ ] Config tab is shown. Pickers default to `unspecified` / `inherit`
 
 ---
 
@@ -41,11 +41,11 @@ Assumption:
 
 2. Set system/RN to **light**, TabsHost colorScheme = `inherit`
    
-- [ ] Expected: Tab bar appears **light**
+- [ ] Tab bar appears **light**
 
 3. Set system/RN to **dark**, keep TabsHost colorScheme = `inherit`
    
-- [ ] Expected: Tab bar appears **dark** — TabsHost defers to RN/system
+- [ ] Tab bar appears **dark** — TabsHost defers to RN/system
 
 ---
 
@@ -53,15 +53,15 @@ Assumption:
 
 4. Set system/RN to **dark**, set TabsHost colorScheme = `light`
    
-- [ ] Expected: Tab bar appears **light** — TabsHost overrides dark from RN/system
+- [ ] Tab bar appears **light** — TabsHost overrides dark from RN/system
 
 5. Set system/RN to **light**, keep TabsHost colorScheme = `light`
    
-- [ ] Expected: Tab bar stays **light**
+- [ ] Tab bar stays **light**
 
 6. Cycle through `inherit` → `dark` → `light` → `dark` → `inherit`
    
-- [ ] Expected: Tab bar color scheme updates immediately with each change, no crash or layout freeze
+- [ ] Tab bar color scheme updates immediately with each change, no crash or layout freeze
 
 ---
 
@@ -69,11 +69,11 @@ Assumption:
 
 7. Set system/RN to **light**, set TabsHost colorScheme = `dark`
    
-- [ ] Expected: Tab bar appears **dark** — TabsHost overrides light from RN/system
+- [ ] Tab bar appears **dark** — TabsHost overrides light from RN/system
 
 8. Set system/RN to **dark**, keep TabsHost colorScheme = `dark`
    
-- [ ] Expected: Tab bar stays **dark**
+- [ ] Tab bar stays **dark**
 
 9. Cycle through `inherit` → `light` → `dark` → `light` → `inherit`
 
@@ -83,4 +83,4 @@ Assumption:
 
 10. Switch to the **Keyboard** tab, open the keyboard via TextInput (or Cmd+K on iOS simulator)
    
-- [ ] Expected: Keyboard appearance matches the currently active color scheme — verify for both light and dark values.
+- [ ] Keyboard appearance matches the currently active color scheme — verify for both light and dark values.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario.md
@@ -20,46 +20,46 @@ TBD: E2E test only makes sense on iPad to verify sidebar visibility. Research in
 
 1. Launch the app and navigate to the **Tab Bar Controller Mode** screen.
 
-- [ ] Expected: Tab bar displayed at the top with Tab1 and Tab2. Picker defaults to `automatic`
+- [ ] Tab bar displayed at the top with Tab1 and Tab2. Picker defaults to `automatic`
 
 2. Ensure that tabBarControllerMode = `automatic`
 
-- [ ] Expected: Tab bar displayed according to iPadOS default behavior for current orientation
+- [ ] Tab bar displayed according to iPadOS default behavior for current orientation
 
 3. Change app window size to correspond to iPhone view.
 
-- [ ] Expected: Tab bar displayed at the **bottom**
+- [ ] Tab bar displayed at the **bottom**
 
 4. Resize app to full screen.
    Set tabBarControllerMode = `tabBar`
 
-- [ ] Expected: Tab bar displayed without sidebar option - even if iPadOS would default do it
+- [ ] Tab bar displayed without sidebar option - even if iPadOS would default do it
 
 5. Change app window size to correspond to iPhone view.
 
-- [ ] Expected: Tab bar displayed at the **bottom**
+- [ ] Tab bar displayed at the **bottom**
 
 6. Resize app to full screen.
    Set tabBarControllerMode = `tabSidebar`, test on **iPad landscape** orientation
 
-- [ ] Expected: Navigation displayed as a **sidebar** on the leading edge
+- [ ] Navigation displayed as a **sidebar** on the leading edge
 
 7. Keep tabBarControllerMode = `tabSidebar`, test on **iPad portrait**
 
-- [ ] Expected: Sidebar adapts or collapses — tab items still accessible
+- [ ] Sidebar adapts or collapses — tab items still accessible
 
 8. Change app window size to correspond to iPhone view.
 
-- [ ] Expected: Tab bar displayed at the **bottom** without sidebar option.
+- [ ] Tab bar displayed at the **bottom** without sidebar option.
 
 9. Resize app to full screen.
    Cycle through `automatic` → `tabBar` → `tabSidebar` → `automatic`
 
-- [ ] Expected: UI transitions immediately with each change, no crash or layout freeze
+- [ ] UI transitions immediately with each change, no crash or layout freeze
 
 10. Switch tabs (Tab1 ↔ Tab2) while cycling through all modes.
 
-- [ ] Expected: Tab switching works correctly in all three modes.
+- [ ] Tab switching works correctly in all three modes.
 
 ---
 
@@ -67,16 +67,16 @@ TBD: E2E test only makes sense on iPad to verify sidebar visibility. Research in
 
 11. Launch the app and navigate to the **Tab Bar Controller Mode** screen.
 
-- [ ] Expected: Tab bar displayed at the bottom with Tab1 and Tab2. Picker defaults to `automatic`
+- [ ] Tab bar displayed at the bottom with Tab1 and Tab2. Picker defaults to `automatic`
 
 12.   Set tabBarControllerMode = `automatic`
 
-- [ ] Expected: Tab bar displayed at the **bottom**
+- [ ] Tab bar displayed at the **bottom**
 
 13.  Set tabBarControllerMode = `tabBar`
 
-- [ ] Expected: Tab bar displayed at the **bottom**
+- [ ] Tab bar displayed at the **bottom**
 
 14.  Set tabBarControllerMode = `tabSidebar`
 
-- [ ] Expected: Tab bar displayed at the **bottom**
+- [ ] Tab bar displayed at the **bottom**

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
@@ -24,40 +24,40 @@ Occasional flashes of the back button in the header are expected behavior and ar
 
 1. Launch the app and set system appearance to **light**.
 
-- [ ] Expected: App is displayed in light mode.
+- [ ] App is displayed in light mode.
 
 2. Navigate to the **Tab Bar Experimental UIStyle** screen.
 
-- [ ] Expected: `Home` screen is shown with two buttons `Dark` and `Light`.
+- [ ] `Home` screen is shown with two buttons `Dark` and `Light`.
 
 ### Light system mode & dark screen style
 
 3. On `Home` screen click `Dark` button.
 
-  - [ ] Expected: Screen is shown with a black background. A single button to push the screen with dark style is visible.
+  - [ ] Screen is shown with a black background. A single button to push the screen with dark style is visible.
  
 4. Tap **"Push screen with style: dark"** and observe tab bar.
 
-- [ ] Expected: The dark-styled tab screen is pushed, showing **Tab1** and **Tab2**. The tab bar reflects a **dark** style and appears without flash, flicker, or reversion to light style.
+- [ ] The dark-styled tab screen is pushed, showing **Tab1** and **Tab2**. The tab bar reflects a **dark** style and appears without flash, flicker, or reversion to light style.
 
 5. Switch between **Tab1** and **Tab2** on the pushed screen.
 
-- [ ] Expected: Both tabs maintain the dark interface style. No flash, flicker, or reversion to light style on tab switch.
+- [ ] Both tabs maintain the dark interface style. No flash, flicker, or reversion to light style on tab switch.
 
 1. Pop back to previous `Dark` screen and then pop back to the `Home` screen.
 
-- [ ] Expected: `Home` screen is shown with two buttons `Dark` and `Light`.
+- [ ] `Home` screen is shown with two buttons `Dark` and `Light`.
 
 ### Dark system mode & light screen style
 
 7. Set system appearance to **dark**. Click `Light` button.
 
-  - [ ] Expected: Screen is shown with a white background. A single button to push the screen with light style is visible.
+  - [ ] Screen is shown with a white background. A single button to push the screen with light style is visible.
 
 8. Push **"Push screen with style: light"** and observe tab bar.
 
-- [ ] Expected: `LightScreen` is pushed. The tab bar reflects a **light** style and appears without flash, flicker, or reversion to light style.
+- [ ] `LightScreen` is pushed. The tab bar reflects a **light** style and appears without flash, flicker, or reversion to light style.
 
 9. Switch between **Tab1** and **Tab2** on the pushed screen.
 
-- [ ] Expected: Both tabs maintain the light interface style. No flash, flicker, or reversion to dark style on tab switch.
+- [ ] Both tabs maintain the light interface style. No flash, flicker, or reversion to dark style on tab switch.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
@@ -19,12 +19,12 @@ Full: Covers all manual scenario steps.
 
 1. Launch the app and navigate to the screen Tab Bar Hidden.
 
-- [ ] Expected: Screen with one Tab in tab bar should be displayed.
+- [ ] Screen with one Tab in tab bar should be displayed.
 
 2. Toggle `tabBarHidden` to `true`.
 
-- [ ] Expected: Tab bar should disappear immediately.
+- [ ] Tab bar should disappear immediately.
 
 3. Toggle back to `false`.
 
-- [ ] Expected: Tab bar should reappear.
+- [ ] Tab bar should reappear.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -77,7 +77,7 @@ localization file, e.g. an empty `ar.lproj/InfoPlist.strings`).
 
 1. Launch the app and navigate to the **Layout Direction** scenario.
 
-- [ ] Expected: Tab1 and Tab2 are shown in LTR order. Tab1 is the leftmost
+- [ ] Tab1 and Tab2 are shown in LTR order. Tab1 is the leftmost
   item. Controls default to `forceRTL = false`, `allowRTL = true`, and
   `TabsHost direction = ltr`. The `I18nManager.isRTL == false` label
   is shown.
@@ -91,21 +91,21 @@ localization file, e.g. an empty `ar.lproj/InfoPlist.strings`).
 
 2. Set `TabsHost direction = inherit`.
 
-- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
+- [ ] Tab bar is in LTR order. Tab1 is the leftmost item.
 
 3. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar remains in LTR order. Tab1 is the leftmost item.
+- [ ] Tab bar remains in LTR order. Tab1 is the leftmost item.
 
 4. Set `TabsHost direction = rtl`.
 
-- [ ] Expected: Tab bar switches to RTL order. Tab2 becomes the leftmost
+- [ ] Tab bar switches to RTL order. Tab2 becomes the leftmost
   item.
 
 5. Cycle `TabsHost direction` through
    `inherit` → `rtl` → `ltr` → `rtl` → `inherit` rapidly.
 
-- [ ] Expected: Tab bar direction updates immediately with each change with
+- [ ] Tab bar direction updates immediately with each change with
   the result described as expected above.
 
 ---
@@ -117,22 +117,22 @@ localization file, e.g. an empty `ar.lproj/InfoPlist.strings`).
 
 6. Set `TabsHost direction = inherit`.
 
-- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
+- [ ] Tab bar is in RTL order. Tab2 is the leftmost item.
 
 7. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar displays in LTR order on both platforms. Tab1 is
+- [ ] Tab bar displays in LTR order on both platforms. Tab1 is
   the leftmost item.
 
 8. Set `TabsHost direction = rtl`.
 
-- [ ] Expected: Tab bar displays in RTL order on both platforms. Tab2 is
+- [ ] Tab bar displays in RTL order on both platforms. Tab2 is
   the leftmost item.
 
 9. Cycle `TabsHost direction` through
    `inherit` → `ltr` → `rtl` → `ltr` → `inherit` rapidly.
 
-- [ ] Expected: Tab bar direction updates immediately with each change with
+- [ ] Tab bar direction updates immediately with each change with
 result described as expected above.
 
 ---
@@ -144,22 +144,22 @@ result described as expected above.
 
 10. Set `TabsHost direction = inherit`.
 
-- [ ] Expected: Tab bar is in RTL order. Tab2 is the leftmost item.
+- [ ] Tab bar is in RTL order. Tab2 is the leftmost item.
 
 11. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar displays in LTR order. Tab1 is
+- [ ] Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
 12. Set `TabsHost direction = rtl`.
 
-- [ ] Expected: Tab bar displays in RTL order. Tab2 is
+- [ ] Tab bar displays in RTL order. Tab2 is
   the leftmost item.
 
 13. Cycle `TabsHost direction` through
    `inherit` → `ltr` → `rtl` → `ltr` → `inherit` rapidly.
 
-- [ ] Expected: Tab bar direction updates immediately with each change with
+- [ ] Tab bar direction updates immediately with each change with
 result described as expected above.
 
 ---
@@ -171,20 +171,20 @@ result described as expected above.
 
 14. Set `TabsHost direction = inherit`.
 
-- [ ] Expected: Tab bar is in LTR order. Tab1 is the leftmost item.
+- [ ] Tab bar is in LTR order. Tab1 is the leftmost item.
 
 15. Set `TabsHost direction = ltr`.
 
-- [ ] Expected: Tab bar displays in LTR order. Tab1 is
+- [ ] Tab bar displays in LTR order. Tab1 is
   the leftmost item.
 
 16. Set `TabsHost direction = rtl`.
 
-- [ ] Expected: Tab bar displays in RTL order. Tab2 is
+- [ ] Tab bar displays in RTL order. Tab2 is
   the leftmost item.
 
 17. Cycle `TabsHost direction` through
 `inherit` → `rtl` → `ltr` → `rtl` → `inherit` rapidly.
 
-- [ ] Expected: Tab bar direction updates immediately with each change with
+- [ ] Tab bar direction updates immediately with each change with
 result described as expected above.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
@@ -27,7 +27,7 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 1. Launch the app and navigate to the **Tab Bar Minimize Behavior** screen.
 
-- [ ] Expected: **Tab1** is selected. The `tabBarMinimizeBehavior` picker defaults to `automatic`.
+- [ ] **Tab1** is selected. The `tabBarMinimizeBehavior` picker defaults to `automatic`.
 
 ---
 
@@ -35,11 +35,11 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 2. Ensure `tabBarMinimizeBehavior` is set to `automatic`. Switch to **Tab2** and scroll **down** through the list.
 
-- [ ] Expected: Tab bar behave according to the system default behavior - typically remains fully visible throughout.
+- [ ] Tab bar behave according to the system default behavior - typically remains fully visible throughout.
 
 3. Scroll back **up** on **Tab2**.
 
-- [ ] Expected: Tab bar behave according to the system default behavior - typically remains fully visible throughout.
+- [ ] Tab bar behave according to the system default behavior - typically remains fully visible throughout.
 
 ---
 
@@ -47,11 +47,11 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 4. Switch to **Tab1**, set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2** and scroll **down**.
 
-- [ ] Expected: Tab bar minimizes as the user scrolls down.
+- [ ] Tab bar minimizes as the user scrolls down.
 
 5. Scroll back **up** on **Tab2**.
 
-- [ ] Expected: Tab bar reappears when scrolling up.
+- [ ] Tab bar reappears when scrolling up.
 
 ---
 
@@ -59,11 +59,11 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 6. Switch to **Tab1**, set `tabBarMinimizeBehavior` = `onScrollUp`. Switch to **Tab2** and scroll **up** (toward the top of the list).
 
-- [ ] Expected: Tab bar minimizes/hides as the user scrolls up.
+- [ ] Tab bar minimizes/hides as the user scrolls up.
 
 7. Scroll **down** on **Tab2**.
 
-- [ ] Expected: Tab bar reappears when scrolling down.
+- [ ] Tab bar reappears when scrolling down.
 
 ---
 
@@ -71,11 +71,11 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 8. Switch to **Tab1**, set `tabBarMinimizeBehavior` = `never`. Switch to **Tab2** and scroll **down** through the entire list.
 
-- [ ] Expected: Tab bar remains fully visible throughout — it does not minimize or hide at any point.
+- [ ] Tab bar remains fully visible throughout — it does not minimize or hide at any point.
 
 9. Scroll **up** through the entire list on **Tab2**.
 
-- [ ] Expected: Tab bar remains fully visible — still no minimization.
+- [ ] Tab bar remains fully visible — still no minimization.
 
 ---
 
@@ -83,8 +83,8 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 10.  Set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2**, scroll down so the tab bar minimizes. Then tap minimized tab bar.
 
-- [ ] Expected: Tab bar should reappeaer with two tabs.
+- [ ] Tab bar should reappeaer with two tabs.
 
 11.  Navigate to **Tab1** and switch back to **Tab2**.
 
-- [ ] Expected: **Tab2** scroll position is preserved — no crash or blank screen.
+- [ ] **Tab2** scroll position is preserved — no crash or blank screen.


### PR DESCRIPTION
## Description

This PR refactors all existing `scenario.md` files across the test suite to align with a formatting convention agreed upon in the RFC. Each expected-outcome checkbox item previously used the redundant label `- [ ] Expected: <description>`, which was verbose and inconsistent with how checklists are typically read in Markdown. The label is removed so that steps now read as plain `- [ ] <description>` items, making the scenario files cleaner and easier to scan. 

No test logic, step order, or content was altered - this is a pure formatting change across 28 scenario files spanning form-sheet, split, stack-v5, and tabs test areas.

## Changes

- **Scenarios/form-sheet**: Removed `Expected:` prefix from all expected-outcome checkboxes in 11 form-sheet scenario files (single-feature and component-integration tests)
- **Scenarios/split**: Removed `Expected:` prefix from expected-outcome checkboxes in the `test-split-color-scheme-ios` scenario
- **Scenarios/stack-v5**: Removed `Expected:` prefix from expected-outcome checkboxes in 3 stack-v5 Android scenario files (back button, toolbar menu commands, toolbar menu show-as-action)
- **Scenarios/tabs**: Removed `Expected:` prefix from expected-outcome checkboxes in 13 tabs scenario files covering layout, lifecycle, navigation, selection, scroll, color scheme, and tab bar behavior