### PR TITLE
chore(test): add @smoke tag to tabs e2e test suites

### DIFF
--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-prevent-native-selection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-prevent-native-selection.e2e.ts
@@ -1,7 +1,7 @@
 import { device, expect, element, by } from 'detox';
 import { selectSingleFeatureTestsScreen } from '../../e2e-utils';
 
-describe('Tabs: preventNativeSelection @smoke', () => {
+describe('@smoke Tabs: preventNativeSelection', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-prevent-native-selection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-prevent-native-selection.e2e.ts
@@ -1,7 +1,7 @@
 import { device, expect, element, by } from 'detox';
 import { selectSingleFeatureTestsScreen } from '../../e2e-utils';
 
-describe('Tabs: preventNativeSelection', () => {
+describe('Tabs: preventNativeSelection @smoke', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
@@ -22,7 +22,7 @@ async function dismissToast(message: string) {
 // separate runs with a full JS reload in between. No further effort was made
 // to fix these runtime state transitions in Detox.
 
-describe('Stale update rejection - rejectStaleNavStateUpdates:true', () => {
+describe('Stale update rejection - rejectStaleNavStateUpdates:true @smoke', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(
@@ -87,7 +87,7 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:true', () => {
   });
 });
 
-describe('Stale update rejection - rejectStaleNavStateUpdates:false', () => {
+describe('Stale update rejection - rejectStaleNavStateUpdates:false @smoke', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-stale-update-rejection.e2e.ts
@@ -22,7 +22,7 @@ async function dismissToast(message: string) {
 // separate runs with a full JS reload in between. No further effort was made
 // to fix these runtime state transitions in Detox.
 
-describe('Stale update rejection - rejectStaleNavStateUpdates:true @smoke', () => {
+describe('@smoke Stale update rejection - rejectStaleNavStateUpdates:true', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(
@@ -87,7 +87,7 @@ describe('Stale update rejection - rejectStaleNavStateUpdates:true @smoke', () =
   });
 });
 
-describe('Stale update rejection - rejectStaleNavStateUpdates:false @smoke', () => {
+describe('@smoke Stale update rejection - rejectStaleNavStateUpdates:false', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -12,8 +12,8 @@
     "build-e2e-android": "detox build --configuration android.emu.release",
     "test-e2e-ios": "detox test --configuration ios.sim.release --take-screenshots failing",
     "test-e2e-android": "detox test --configuration android.emu.release --take-screenshots failing",
-    "test-e2e-ios-smoke": "detox test --configuration ios.sim.release --take-screenshots failing -t '@smoke'",
-    "test-e2e-android-smoke": "detox test --configuration android.emu.release --take-screenshots failing -t '@smoke'",
+    "test-e2e-ios-smoke": "detox test --configuration ios.sim.release --take-screenshots failing -- -t '@smoke'",
+    "test-e2e-android-smoke": "detox test --configuration android.emu.release --take-screenshots failing -- -t '@smoke'",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -12,6 +12,8 @@
     "build-e2e-android": "detox build --configuration android.emu.release",
     "test-e2e-ios": "detox test --configuration ios.sim.release --take-screenshots failing",
     "test-e2e-android": "detox test --configuration android.emu.release --take-screenshots failing",
+    "test-e2e-ios-smoke": "detox test --configuration ios.sim.release --take-screenshots failing -t '@smoke'",
+    "test-e2e-android-smoke": "detox test --configuration android.emu.release --take-screenshots failing -t '@smoke'",
     "postinstall": "patch-package"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

This PR introduces `@smoke` tagging to Detox e2e test suites that have been identified as belonging to the smoke test subset for the Tabs component. The `@smoke` suffix is appended to `describe` block names, which allows a Detox test runner configuration to filter and execute only the smoke subset via a `--testNamePattern` or equivalent flag — without any changes to the test logic itself.

The two tagged test files cover critical Tabs behaviour: prevention of programmatic native tab selection, and rejection of stale navigation-state updates. Both already had `smokeTest: true` set in their corresponding `scenario-description.ts` files, so this change brings the Detox tags into alignment with that metadata.

## Changes

- **E2E / Tabs**: Added `@smoke` to the `describe` block in `test-tabs-prevent-native-selection.e2e.ts` and  to both `describe` blocks in `test-tabs-stale-update-rejection.e2e.ts`
- **package.json**: Added two scripts to run smoke test: `test-e2e-android-smoke` and `test-e2e-ios-smoke`
