### PR TITLE
feat: Adopt AGP v9

### DIFF
--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -130,7 +130,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
 
             // Detox-specific additions to pro-guard
             proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"

--- a/FabricExample/android/gradle.properties
+++ b/FabricExample/android/gradle.properties
@@ -48,3 +48,8 @@ rnsDebugLogsEnabled=true
 
 # Use this property to enable V5-specific code
 rnsGammaEnabled=true
+
+# Opt out of built-in kotlin and new DSL behavior that ships with AGP 9.
+# Starting from AGP 10.x these opt outs will be removed.
+android.builtInKotlin=false
+android.newDsl=false

--- a/FabricExample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/FabricExample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,22 @@ if (isRunningInContextOfScreensRepo()) {
     apply plugin: "com.facebook.react"
 }
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def shouldEnableAgpFallback() {
+    def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpMajorVersion <= 8) {
+        return true
+    }
+
+    def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+    def isBuiltInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+
+    return !isBuiltInKotlinEnabled
+}
+
+if (shouldEnableAgpFallback()) {
+    apply plugin: 'kotlin-android'
+}
 
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
@@ -170,16 +185,15 @@ android {
     }
     sourceSets.main {
         ext.androidResDir = "src/main/res"
-        java {
-            srcDirs += [
-                "src/fabric/java",
-            ]
+        kotlin {
+            directories.add("src/fabric/java")
         }
         res {
             if (safeExtGet(['compileSdkVersion', 'compileSdk'], rnsDefaultCompileSdkVersion) >= 33) {
-                srcDirs = ["${androidResDir}/base", "${androidResDir}/v33"]
+                directories.add("${androidResDir}/base")
+                directories.add("${androidResDir}/v33")
             } else {
-                srcDirs = ["${androidResDir}/base"]
+                directories.add("${androidResDir}/base")
             }
         }
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

This PR is rasied following the second phase of the RFC around AGP v9 adoption:

RFC: https://github.com/react-native-community/discussions-and-proposals/pull/1006

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

The gist of this PR is to make RNScreens AGP v9 compliant with backward compatibility. The main scope of changes is the `react-native-screens/android/build.gradle`. The rest of the changes can be considered temporary.

The rest changes include:

- Making Fabric Example App AGP9 compliant
- Upgrade `Gradle` to `v9.4.1`
- Use `proguard-android-optimize` proguard file
- Enable opt outs in the `gradle.properties`

Ideally, we should not enable the opt outs and leverage the AGP 9 built-in kotlin and newDSL. However, if we do not do it, then other libraries which are not yet AGP v9 compliant starts to fail. Hence, we need to keep the opt outs enabled for a while. For the context, react-native starting from 0.87.x will ship with AGP v9 and opt outs enabled by default for the new apps, which is the first phase of AGP v9 adoption.

With the second phase when the libraries starts adoption AGP v9, we can eventually remove the opt outs from Fabric Example.

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

To test this PR, we need to do a few steps:

- Set the `agp` version to `9.2.1` and `kotlin` to `2.2.0` in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
+++ b/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.12.0"
+agp = "9.2.1"
 gson = "2.8.9"

-kotlin = "2.1.20"
+kotlin = "2.2.0"
 assertj = "3.25.1"
```

- Comment out the following functions in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
+++ b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
@@ -1,10 +1,10 @@
      configureBuildTypesForApp(project)
    }

    // Library Only Configuration
-    configureBuildConfigFieldsForLibraries(project)
-    configureNamespaceForLibraries(project)
+    // configureBuildConfigFieldsForLibraries(project)
+    // configureNamespaceForLibraries(project)
    project.pluginManager.withPlugin("com.android.library") {
```

These step is only required because we have RN version on 0.85.2 and `AGP` + `kotlin` bump will be shipped with 0.87.x.

<details>
<summary>Verified by locally patching reanimated, safe-area, etc and making those AGP v9 compliant and removing the opt outs to test the changes in the PR </summary>


https://github.com/user-attachments/assets/51bfcd17-2df8-4fe7-b55a-d05d2401a04a


</details>

<details>
<summary>Verified these changes work with AGP 8 </summary>

https://github.com/user-attachments/assets/50929b54-6f0d-4ce9-975f-5fa1ded992e7


</details>

## Checklist

- [X] Included code example that can be used to test this change.
- [ ] Ensured that CI passes
