### PR TITLE
refactor(CI, Android): bust AVD cache when emulator profile changes

### DIFF
--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       WORKING_DIRECTORY: FabricExample
       API_LEVEL: 34
+      AVD_PROFILE: pixel_8
       RNS_GAMMA_ENABLED: 1
     concurrency:
       group: android-e2e-fabric-${{ github.ref }}
@@ -86,7 +87,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}
+          key: avd-${{ env.API_LEVEL }}-${{ env.AVD_PROFILE }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -94,7 +95,7 @@ jobs:
         with:
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_8
+          profile: ${{ env.AVD_PROFILE }}
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false
@@ -110,7 +111,7 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           api-level: ${{ env.API_LEVEL }}
           target: default
-          profile: pixel_8
+          profile: ${{ env.AVD_PROFILE }}
           ram-size: '4096M'
           disk-size: '10G'
           disable-animations: false

--- a/.github/workflows/android-e2e-test-fabric.yml
+++ b/.github/workflows/android-e2e-test-fabric.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       WORKING_DIRECTORY: FabricExample
       API_LEVEL: 34
-      AVD_PROFILE: pixel_8
+      AVD_PROFILE: pixel_7
       RNS_GAMMA_ENABLED: 1
     concurrency:
       group: android-e2e-fabric-${{ github.ref }}

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
@@ -8,7 +8,7 @@ describe('Tab Bar Hidden', () => {
   });
 
   it('screen should be displayed', async () => {
-    await expect(element(by.id('tab-bar-hidden-switch'))).toBeVisible();
+    await expect(element(by.id('tab-bar-hidden-switch'))).not.toBeVisible();
     await expect(element(by.id('tab-bar-hidden-scrollview'))).toBeVisible();
   });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
@@ -8,7 +8,7 @@ describe('Tab Bar Hidden', () => {
   });
 
   it('screen should be displayed', async () => {
-    await expect(element(by.id('tab-bar-hidden-switch'))).not.toBeVisible();
+    await expect(element(by.id('tab-bar-hidden-switch'))).toBeVisible();
     await expect(element(by.id('tab-bar-hidden-scrollview'))).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

The Android e2e (Fabric) workflow was setting the profile to `pixel_8`, but CI runs were still using a `pixel_2` emulator. This PR fixes the root cause: a stale AVD cache that was never invalidated when the profile changed. Since `pixel_8` is **not available** on the runner, the AVD couldn't build initially. The device has been updated to `pixel_7`, which is available on the runner, allowing the AVD to build correctly and the tests to run on the configured device.

## Root cause

- In CI, Detox resolves the emulator to the AVD named `e2e_emulator` (`DEFAULT_CI_AVD_NAME` in `scripts/e2e/android-devices.js`) — i.e. the AVD the workflow manages. Its hardware profile is whatever it was *created* with.
- The AVD cache key was `avd-${API_LEVEL}` (`avd-34`) and never included the device profile.
- "Create AVD and generate snapshot" only runs on a cache miss, and the run step uses `force-avd-creation: false`.
- The profile evolved `pixel_2` → `pixel_9` → `pixel_8` while `API_LEVEL` stayed `34`, so the key never changed. The original `pixel_2` snapshot kept being restored and the profile edits had no effect.

## Fix

- Add an `AVD_PROFILE: pixel_7` job env var.
- Reference it from both `profile:` fields and fold it into the cache key (`avd-${API_LEVEL}-${AVD_PROFILE}`).

This self-busts the cache whenever the profile changes, so the two can never drift apart again.

## Impact

- One-time cache miss on the next run rebuilds the AVD with the `pixel_7` profile (a few minutes, once); subsequent runs restore from cache as before. No added steady-state cost.
- The cache step has no `restore-keys`, so the new key won't fall back to the stale `pixel_2` snapshot — it's a clean rebuild.

## Changelog

- `.github/workflows/android-e2e-test-fabric.yml`: add `AVD_PROFILE` env var, use it for both `profile:` fields and include it in the AVD cache key.
