### PR TITLE
feat(Android, Tabs): integrate with ScrollViewMarker for special effects

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewFinder.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ViewFinder.kt
@@ -4,14 +4,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import androidx.core.view.isNotEmpty
+import androidx.core.widget.NestedScrollView
 import com.swmansion.rnscreens.ScreenStack
 
 object ViewFinder {
-    fun findScrollViewInFirstDescendantChain(view: View): ScrollView? {
+    fun findScrollViewInFirstDescendantChain(view: View): ViewGroup? {
         var currentView: View? = view
 
         while (currentView != null) {
-            if (currentView is ScrollView) {
+            if (currentView is ScrollView || currentView is NestedScrollView) {
                 return currentView
             } else if (currentView is ViewGroup && currentView.isNotEmpty()) {
                 currentView = currentView.getChildAt(0)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarker.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarker.kt
@@ -5,24 +5,28 @@ import android.view.ViewGroup
 import android.widget.ScrollView
 import androidx.core.view.children
 import androidx.core.widget.NestedScrollView
-import com.facebook.react.bridge.UIManager
-import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.views.view.ReactViewGroup
-import com.swmansion.rnscreens.gamma.helpers.getFabricUIManagerNotNull
 
 @OptIn(UnstableReactNativeAPI::class)
 @SuppressLint("ViewConstructor") // Should never be inflated / restored
 class ScrollViewMarker(
     private val reactContext: ThemedReactContext,
-) : ReactViewGroup(reactContext),
-    UIManagerListener {
-    init {
-        // We're adding ourselves during a batch, therefore we expect to receive its finalization callbacks
-        UIManagerHelper.getFabricUIManagerNotNull(reactContext).addUIManagerEventListener(this)
+) : ReactViewGroup(reactContext) {
+    // region Base override
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        maybeRegisterWithSeekingAncestor()
     }
+
+    override fun onDetachedFromWindow() {
+        hasAttemptedRegistration = false
+        super.onDetachedFromWindow()
+    }
+
+    // endregion
 
     private var hasAttemptedRegistration: Boolean = false
 
@@ -71,21 +75,5 @@ class ScrollViewMarker(
         hasAttemptedRegistration = true
     }
 
-    // UIManagerListener
-
-    override fun didMountItems(uiManager: UIManager) {
-        maybeRegisterWithSeekingAncestor()
-    }
-
-    override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
-
-    override fun willMountItems(uiManager: UIManager) = Unit
-
-    override fun didDispatchMountItems(uiManager: UIManager) = Unit
-
-    override fun didScheduleMountItems(uiManager: UIManager) = Unit
-
-    internal fun onViewManagerDropViewInstance() {
-        UIManagerHelper.getFabricUIManagerNotNull(reactContext).removeUIManagerEventListener(this)
-    }
+    internal fun onViewManagerDropViewInstance() = Unit
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -6,13 +6,16 @@ import android.content.res.Configuration
 import android.view.Gravity
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowInsets
 import android.widget.FrameLayout
+import android.widget.ScrollView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.graphics.Insets
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.core.view.size
+import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -59,17 +62,40 @@ class TabsContainer internal constructor(
     private inner class SpecialEffectsHandler {
         fun handleRepeatedTabSelection(): Boolean {
             val contentView = this@TabsContainer.contentView
-            val selectedTabFragment = this@TabsContainer.selectedTab
-            if (selectedTabFragment.tabsScreen.shouldUseRepeatedTabSelectionPopToRootSpecialEffect) {
+            val selectedTabScreen = this@TabsContainer.selectedTab.tabsScreen
+
+            if (selectedTabScreen.shouldUseRepeatedTabSelectionPopToRootSpecialEffect) {
                 val screenStack = ViewFinder.findScreenStackInFirstDescendantChain(contentView)
                 if (screenStack != null && screenStack.popToRoot()) {
                     return true
                 }
             }
-            if (selectedTabFragment.tabsScreen.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
-                val scrollView = ViewFinder.findScrollViewInFirstDescendantChain(contentView)
-                if (scrollView != null && scrollView.scrollY > 0) {
-                    scrollView.smoothScrollTo(scrollView.scrollX, 0)
+            if (selectedTabScreen.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
+                val scrollView = resolveContentScrollViewForScreen(selectedTabScreen)
+                scrollView?.let { return trySmoothScrollToTop(it) }
+            }
+            return false
+        }
+
+        private fun resolveContentScrollViewForScreen(tabsScreen: TabsScreen): ViewGroup? {
+            tabsScreen.contentScrollView()?.let { return it }
+            ViewFinder.findScrollViewInFirstDescendantChain(tabsScreen)?.let { return it }
+            return null
+        }
+
+        /**
+         * Attempts to scroll to top if the passed view is a `ScrollView` or `NestedScrollView`
+         */
+        private fun trySmoothScrollToTop(maybeScrollView: ViewGroup): Boolean {
+            if (maybeScrollView is ScrollView) {
+                if (maybeScrollView.scrollY > 0) {
+                    maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
+                    return true
+                }
+            }
+            if (maybeScrollView is NestedScrollView) {
+                if (maybeScrollView.scrollY > 0) {
+                    maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
                     return true
                 }
             }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -61,11 +61,10 @@ class TabsContainer internal constructor(
 
     private inner class SpecialEffectsHandler {
         fun handleRepeatedTabSelection(): Boolean {
-            val contentView = this@TabsContainer.contentView
             val selectedTabScreen = this@TabsContainer.selectedTab.tabsScreen
 
             if (selectedTabScreen.shouldUseRepeatedTabSelectionPopToRootSpecialEffect) {
-                val screenStack = ViewFinder.findScreenStackInFirstDescendantChain(contentView)
+                val screenStack = ViewFinder.findScreenStackInFirstDescendantChain(selectedTabScreen)
                 if (screenStack != null && screenStack.popToRoot()) {
                     return true
                 }
@@ -87,19 +86,13 @@ class TabsContainer internal constructor(
          * Attempts to scroll to top if the passed view is a `ScrollView` or `NestedScrollView`
          */
         private fun trySmoothScrollToTop(maybeScrollView: ViewGroup): Boolean {
-            if (maybeScrollView is ScrollView) {
-                if (maybeScrollView.scrollY > 0) {
-                    maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
-                    return true
-                }
+            if (maybeScrollView.scrollY <= 0) return false
+            when (maybeScrollView) {
+                is ScrollView -> maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
+                is NestedScrollView -> maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
+                else -> return false
             }
-            if (maybeScrollView is NestedScrollView) {
-                if (maybeScrollView.scrollY > 0) {
-                    maybeScrollView.smoothScrollTo(maybeScrollView.scrollX, 0)
-                    return true
-                }
-            }
-            return false
+            return true
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -7,6 +7,8 @@ import androidx.fragment.app.Fragment
 import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
 import com.swmansion.rnscreens.gamma.helpers.getSystemDrawableResource
+import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewMarker
+import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewSeeking
 import com.swmansion.rnscreens.gamma.tabs.appearance.TabsAppearance
 import com.swmansion.rnscreens.utils.RNSLog
 import java.lang.ref.WeakReference
@@ -18,16 +20,11 @@ import kotlin.properties.Delegates
 class TabsScreen(
     val reactContext: ThemedReactContext,
 ) : ViewGroup(reactContext),
-    FragmentProviding {
-    override fun onLayout(
-        changed: Boolean,
-        l: Int,
-        t: Int,
-        r: Int,
-        b: Int,
-    ) = Unit
+    FragmentProviding,
+    ScrollViewSeeking {
 
     private var tabsScreenDelegate: WeakReference<TabsScreenDelegate> = WeakReference(null)
+    private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
 
     internal lateinit var eventEmitter: TabsScreenEventEmitter
 
@@ -110,6 +107,14 @@ class TabsScreen(
         super.onAttachedToWindow()
     }
 
+    override fun onLayout(
+        changed: Boolean,
+        l: Int,
+        t: Int,
+        r: Int,
+        b: Int,
+    ) = Unit
+
     internal fun setTabsScreenDelegate(delegate: TabsScreenDelegate?) {
         tabsScreenDelegate = WeakReference(delegate)
     }
@@ -138,6 +143,16 @@ class TabsScreen(
     ) {
         tabsScreenDelegate.get()?.onFragmentConfigurationChange(this, config)
     }
+
+    // ScrollViewSeeking
+    override fun registerScrollView(
+        marker: ScrollViewMarker,
+        scrollView: ViewGroup
+    ) {
+        contentScrollView = WeakReference(scrollView)
+    }
+
+    internal fun contentScrollView(): ViewGroup? = contentScrollView.get()
 
     companion object {
         const val TAG = "TabsScreen"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -44,7 +44,7 @@ class TabsScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
-    // Appearance
+    // region Appearance
 
     internal var appearance: TabsAppearance? by Delegates.observable(null) { _, oldValue, newValue ->
         if (oldValue != newValue) {
@@ -52,12 +52,17 @@ class TabsScreen(
         }
     }
 
-    // Badge
+    // endregion
+
+    // region Badge
+
     var badgeValue: String? by Delegates.observable(null) { _, oldValue, newValue ->
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
-    // Accessibility
+    // endregion
+
+    // region Accessibility
     var tabBarItemTestID: String? by Delegates.observable(null) { _, oldValue, newValue ->
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
@@ -66,7 +71,9 @@ class TabsScreen(
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
 
-    // Icon
+    // endregion
+
+    // region Icon
     var drawableIconResourceName: String? by Delegates.observable(null) { _, oldValue, newValue ->
         if (newValue != oldValue) {
             icon = getSystemDrawableResource(reactContext, newValue)
@@ -86,6 +93,8 @@ class TabsScreen(
     var selectedIcon: Drawable? by Delegates.observable(null) { _, oldValue, newValue ->
         updateMenuItemAttributesIfNeeded(oldValue, newValue)
     }
+
+    // endregion
 
     var shouldUseRepeatedTabSelectionScrollToTopSpecialEffect: Boolean = true
     var shouldUseRepeatedTabSelectionPopToRootSpecialEffect: Boolean = true
@@ -143,7 +152,7 @@ class TabsScreen(
         tabsScreenDelegate.get()?.onFragmentConfigurationChange(this, config)
     }
 
-    // ScrollViewSeeking
+    // region ScrollViewSeeking
     override fun registerScrollView(
         marker: ScrollViewMarker,
         scrollView: ViewGroup,
@@ -152,6 +161,8 @@ class TabsScreen(
     }
 
     internal fun contentScrollView(): ViewGroup? = contentScrollView.get()
+
+    // endregion
 
     companion object {
         const val TAG = "TabsScreen"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -22,7 +22,6 @@ class TabsScreen(
 ) : ViewGroup(reactContext),
     FragmentProviding,
     ScrollViewSeeking {
-
     private var tabsScreenDelegate: WeakReference<TabsScreenDelegate> = WeakReference(null)
     private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
 
@@ -147,7 +146,7 @@ class TabsScreen(
     // ScrollViewSeeking
     override fun registerScrollView(
         marker: ScrollViewMarker,
-        scrollView: ViewGroup
+        scrollView: ViewGroup,
     ) {
         contentScrollView = WeakReference(scrollView)
     }


### PR DESCRIPTION
## Description

Repeated selection of the already-active tab runs "special effects" — pop the
stack to root and/or scroll the content to the top. Until now the scroll view
backing the scroll-to-top effect was located purely by walking the first
descendant of the tab content, which is fragile and only ever matched
`android.widget.ScrollView`.

This PR integrates that lookup with the `ScrollViewMarker` mechanism: a marker
mounted around the content's scroll view registers it with the nearest seeking
ancestor, giving the tab a reliable handle to the correct scroll view instead
of relying solely on tree traversal. It also adds `NestedScrollView` support.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1538
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1423

> [!note]
> The pop-to-root is not-yet-implemented due to modal constraints. It requires changes in the tabs model (simplifying here). 

## Changes

- `TabsScreen` now implements `ScrollViewSeeking`; it stores the scroll view
  registered by a `ScrollViewMarker` in a `WeakReference` and exposes it via
  `contentScrollView()`.
- `SpecialEffectsHandler` resolves the content scroll view from the registered
  marker first, falling back to the descendant-chain search. Both
  repeated-selection effects (pop-to-root and scroll-to-top) now anchor on the
  selected `TabsScreen` rather than the container content view.
- Scroll-to-top now handles both `ScrollView` and `NestedScrollView`.
- `ViewFinder.findScrollViewInFirstDescendantChain` widened to return
  `ViewGroup?` and match `NestedScrollView`, so the fallback path can resolve
  it too.

## Visual docs

| before | after |
| -- | -- | 
| <video src="https://github.com/user-attachments/assets/eb0a9e7a-f37c-4178-a15c-a777c63163c3" alt="android-tabs-special-effects-before" /> | <video src="https://github.com/user-attachments/assets/555b03b1-01b0-4864-ba79-69b35e051902" alt="android-tabs-special-effects-after" /> |

## Test plan

Tested on Android via the example app scenario:
`apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/`

Steps:
1. Open the scenario, select a tab, scroll its content down and/or push screens
   onto the stack.
2. Tap the already-selected tab again.
3. Verify the stack pops to root and the content smoothly scrolls to the top,
   for both `ScrollView`- and `NestedScrollView`-backed content.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
