### PR TITLE
fix(ios): block screen touches while header UIMenu is open

### DIFF
--- a/ios/RNSBarButtonItem.h
+++ b/ios/RNSBarButtonItem.h
@@ -5,12 +5,14 @@
 
 typedef void (^RNSBarButtonItemAction)(NSString *buttonId);
 typedef void (^RNSBarButtonMenuItemAction)(NSString *menuId);
+typedef void (^RNSBarButtonMenuPresentedCallback)(void);
 
 @interface RNSBarButtonItem : UIBarButtonItem
 
 - (instancetype)initWithConfig:(NSDictionary<NSString *, id> *)dict
                         action:(RNSBarButtonItemAction)action
                     menuAction:(RNSBarButtonMenuItemAction)menuAction
+                menuPresented:(RNSBarButtonMenuPresentedCallback)menuPresented
                    imageLoader:(RCTImageLoader *)imageLoader;
 
 @end

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -14,6 +14,7 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
 - (instancetype)initWithConfig:(NSDictionary<NSString *, id> *)dict
                         action:(RNSBarButtonItemAction)action
                     menuAction:(RNSBarButtonMenuItemAction)menuAction
+                menuPresented:(RNSBarButtonMenuPresentedCallback)menuPresented
                    imageLoader:(RCTImageLoader *)imageLoader
 {
   self = [super init];
@@ -115,7 +116,31 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
   if (@available(tvOS 17.0, *)) {
     NSDictionary *menu = dict[@"menu"];
     if (menu) {
-      self.menu = [[self class] initUIMenuWithDict:menu menuAction:menuAction imageLoader:imageLoader];
+      UIMenu *builtMenu = [[self class] initUIMenuWithDict:menu menuAction:menuAction imageLoader:imageLoader];
+
+#if !TARGET_OS_TV
+      if (menuPresented && builtMenu) {
+        if (@available(iOS 15.0, *)) {
+          NSArray<UIMenuElement *> *children = builtMenu.children;
+          UIDeferredMenuElement *sentinel =
+              [UIDeferredMenuElement elementWithUncachedProvider:^(void (^completion)(NSArray<UIMenuElement *> *)) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                  if (menuPresented) {
+                    menuPresented();
+                  }
+                  completion(children);
+                });
+              }];
+          builtMenu = [UIMenu menuWithTitle:builtMenu.title
+                                      image:builtMenu.image
+                                 identifier:builtMenu.identifier
+                                    options:builtMenu.options
+                                   children:@[sentinel]];
+        }
+      }
+#endif // !TARGET_OS_TV
+
+      self.menu = builtMenu;
     }
   }
 #endif

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateScreenTransition:(double)progress;
 - (void)finishScreenTransition:(BOOL)canceled;
 
+- (void)headerMenuWillPresent;
+- (void)headerMenuDidDismiss;
+
 @property (nonatomic) BOOL customAnimation;
 @property (nonatomic) BOOL disableSwipeBack;
 

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -167,6 +167,41 @@ namespace react = facebook::react;
 @end
 #endif
 
+@interface RNSScreenStackView (RNSHeaderMenuPrivate)
+- (void)cancelTouchesInParent;
+@end
+
+@interface RNSMenuDismissGestureRecognizer : UIGestureRecognizer
+@property (nonatomic, weak) RNSScreenStackView *stackView;
+@property (nonatomic, weak) UINavigationBar *navigationBar;
+@end
+
+@implementation RNSMenuDismissGestureRecognizer
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesBegan:touches withEvent:event];
+
+  UITouch *touch = touches.anyObject;
+  if (!touch) {
+    self.state = UIGestureRecognizerStateFailed;
+    return;
+  }
+
+  CGPoint point = [touch locationInView:self.stackView];
+
+  if (self.navigationBar && CGRectContainsPoint(self.navigationBar.frame, point)) {
+    self.state = UIGestureRecognizerStateFailed;
+    return;
+  }
+
+  [self.stackView cancelTouchesInParent];
+  self.state = UIGestureRecognizerStateRecognized;
+  [self.stackView headerMenuDidDismiss];
+}
+
+@end
+
 @implementation RNSScreenStackView {
   UINavigationController *_controller;
   NSMutableArray<RNSScreenView *> *_reactSubviews;
@@ -175,6 +210,8 @@ namespace react = facebook::react;
   RNSPercentDrivenInteractiveTransition *_interactionController;
   __weak RNSScreenStackManager *_manager;
   BOOL _updateScheduled;
+  BOOL _isMenuPresented;
+  RNSMenuDismissGestureRecognizer *_menuDismissGestureRecognizer;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -779,6 +816,38 @@ RNS_IGNORE_SUPER_CALL_END
   // gesture and onPress may fire when we release the finger.
 
   [[self rnscreens_findTouchHandlerInAncestorChain] rnscreens_cancelTouches];
+}
+
+- (void)headerMenuWillPresent
+{
+  if (_isMenuPresented) {
+    return;
+  }
+  _isMenuPresented = YES;
+
+  [self cancelTouchesInParent];
+  _controller.topViewController.view.userInteractionEnabled = NO;
+
+  _menuDismissGestureRecognizer = [[RNSMenuDismissGestureRecognizer alloc] initWithTarget:nil action:nil];
+  _menuDismissGestureRecognizer.stackView = self;
+  _menuDismissGestureRecognizer.navigationBar = _controller.navigationBar;
+  _menuDismissGestureRecognizer.cancelsTouchesInView = YES;
+  [self addGestureRecognizer:_menuDismissGestureRecognizer];
+}
+
+- (void)headerMenuDidDismiss
+{
+  if (!_isMenuPresented) {
+    return;
+  }
+  _isMenuPresented = NO;
+
+  _controller.topViewController.view.userInteractionEnabled = YES;
+
+  if (_menuDismissGestureRecognizer) {
+    [self removeGestureRecognizer:_menuDismissGestureRecognizer];
+    _menuDismissGestureRecognizer = nil;
+  }
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -21,6 +21,7 @@
 #import "RNSConvert.h"
 #import "RNSDefines.h"
 #import "RNSScreen.h"
+#import "RNSScreenStack.h"
 #import "RNSSearchBar.h"
 #import "UINavigationBar+RNSUtility.h"
 
@@ -777,6 +778,10 @@ RNS_IGNORE_SUPER_CALL_END
   for (NSUInteger i = 0; i < dicts.count; i++) {
     NSDictionary *dict = dicts[i];
     if (dict[@"buttonId"] || dict[@"menu"]) {
+      UIView *stackCandidate = self.screenView.controller.navigationController.view.superview;
+      __weak RNSScreenStackView *weakStackView =
+          [stackCandidate isKindOfClass:RNSScreenStackView.class] ? (RNSScreenStackView *)stackCandidate : nil;
+
       RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithConfig:dict
           action:^(NSString *buttonId) {
             auto eventEmitter = std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigEventEmitter>(
@@ -788,6 +793,8 @@ RNS_IGNORE_SUPER_CALL_END
             }
           }
           menuAction:^(NSString *menuId) {
+            [weakStackView headerMenuDidDismiss];
+
             auto eventEmitter = std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigEventEmitter>(
                 self->_eventEmitter);
             if (eventEmitter && menuId) {
@@ -795,6 +802,9 @@ RNS_IGNORE_SUPER_CALL_END
                   facebook::react::RNSScreenStackHeaderConfigEventEmitter::OnPressHeaderBarButtonMenuItem{
                       .menuId = std::string([menuId UTF8String])});
             }
+          }
+          menuPresented:^{
+            [weakStackView headerMenuWillPresent];
           }
           imageLoader:_imageLoader];
       NSNumber *index = dict[@"index"];


### PR DESCRIPTION
## Summary
- Block RN screen content from receiving touches while a native stack header `UIMenu` is open
- Restore interaction when the menu is dismissed (outside tap) or a menu item is selected
- Fixes #4139
## Problem
On iOS, when using `unstable_headerRightItems` with `type: 'menu'`, taps on screen content (e.g. `Pressable`) still fired while the menu was open. Native apps block those touches.
## Solution
- `RNSBarButtonItem`: wrap menu children in `UIDeferredMenuElement` and invoke a `menuPresented` callback before the menu appears (dispatched on main queue)
- `RNSScreenStackHeaderConfig`: wire callback to `RNSScreenStackView`
- `RNSScreenStack`: while menu is open, disable top screen content interaction and install a one-shot gesture recognizer to intercept outside-dismiss taps before Fabric's touch handler
## Test plan
- [ ] Run repro: https://github.com/ferrannp/menu-header-screens (or local `rn-screens-menu-repro`)
- [ ] Open header menu (⋯)
- [ ] While menu is open, tap **Increment counter** → should **not** increment
- [ ] Dismiss menu by tapping outside → tap **Increment counter** → should increment
- [ ] Dismiss menu by selecting an item → screen touches work again
- [ ] Verify left header button and back navigation still work
