### PR TITLE
feat: Add toggling items with managed flow to menu

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2234,7 +2234,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 688bade2cc6ee3de2ba9a411c85c21fd908af3bc
-  hermes-engine: fc4041028bae4b951c12520f2b2532dc4f15fe74
+  hermes-engine: 8e030a220f5a02ad155f2781b1297dba8d34696b
   RCTDeprecation: 8f1dc8057e54ea6fd01df47d0d29487adc92c1a9
   RCTRequired: 9d02105f758490fab48d77fead2599a449321ab7
   RCTSwiftUI: 714ca60953e8b7779821eea889ebdc891851682b
@@ -2310,7 +2310,7 @@ SPEC CHECKSUMS:
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RNGestureHandler: 26e6be4110bc311cbe4d54078580f5bff48b728d
   RNReanimated: c33fac69da816f409cfb51cf5aaf7288feb9f64a
-  RNScreens: 9711e6ad2dfb716ce6f61bae2479cf5727d020cf
+  RNScreens: 60f2260949e6f9cc35cd76c506a3475bec919ca6
   RNWorklets: fc903041108e66eac7b164d98eb4ce76acf03feb
   Yoga: 18b7c3b4ad4df70f7c1f90871213fd001e6c3528
 

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2234,7 +2234,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 688bade2cc6ee3de2ba9a411c85c21fd908af3bc
-  hermes-engine: 8e030a220f5a02ad155f2781b1297dba8d34696b
+  hermes-engine: fc4041028bae4b951c12520f2b2532dc4f15fe74
   RCTDeprecation: 8f1dc8057e54ea6fd01df47d0d29487adc92c1a9
   RCTRequired: 9d02105f758490fab48d77fead2599a449321ab7
   RCTSwiftUI: 714ca60953e8b7779821eea889ebdc891851682b
@@ -2310,7 +2310,7 @@ SPEC CHECKSUMS:
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RNGestureHandler: 26e6be4110bc311cbe4d54078580f5bff48b728d
   RNReanimated: c33fac69da816f409cfb51cf5aaf7288feb9f64a
-  RNScreens: 60f2260949e6f9cc35cd76c506a3475bec919ca6
+  RNScreens: 9711e6ad2dfb716ce6f61bae2479cf5727d020cf
   RNWorklets: fc903041108e66eac7b164d98eb4ce76acf03feb
   Yoga: 18b7c3b4ad4df70f7c1f90871213fd001e6c3528
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -82,7 +82,7 @@ function buildHeaderConfig(
             title: `Submenu with Radio`,
             singleSelection: true,
             onSelectionChanged: selection =>
-              showToast(`Selected unique: ${selection}`),
+              showToast(`Selected unique "${selection}"`),
             children: [
               {
                 id: `radio-${i}-1`,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -50,6 +50,8 @@ function buildHeaderConfig(
       menu: {
         type: 'menu',
         id: `menu-${i}`,
+        onSelectionChanged: selection =>
+          showToast('Selected "' + selection.join('", "') + '"'),
         children: [
           {
             id: `subitem-${i}-1`,
@@ -65,13 +67,13 @@ function buildHeaderConfig(
             title: `Toggle ${i}-1`,
           },
           {
-            menuElementId: `toggle-${i}-2`,
+            id: `toggle-${i}-2`,
             type: 'menuItem',
             itemType: 'toggle',
             title: `Toggle ${i}-2`,
           },
           {
-            menuElementId: `toggle-${i}-3`,
+            id: `toggle-${i}-3`,
             type: 'menuItem',
             itemType: 'toggle',
             title: `Toggle ${i}-3`,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -50,7 +50,7 @@ function buildHeaderConfig(
       menu: {
         type: 'menu',
         id: `menu-${i}`,
-        onSelectionChanged: selection =>
+        onSelectionChange: selection =>
           showToast('Selected "' + selection.join('", "') + '"'),
         children: [
           {
@@ -83,7 +83,7 @@ function buildHeaderConfig(
             type: 'menu',
             title: `Submenu with Radio`,
             singleSelection: true,
-            onSelectionChanged: selection =>
+            onSelectionChange: selection =>
               showToast(`Selected unique "${selection}"`),
             children: [
               {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -94,8 +94,6 @@ function buildHeaderConfig(
                 id: `subsubmenu-${i}`,
                 type: 'menu',
                 title: `SubSubMenu with Radio`,
-                onSelectionChanged: selection =>
-                  showToast(`Selected unique: ${selection}`),
                 children: [
                   {
                     id: `radio-${i}-2`,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -54,31 +54,60 @@ function buildHeaderConfig(
           {
             id: `subitem-${i}-1`,
             type: 'menuItem',
-            title: `Item ${i}.1`,
-            onPress: () => showToast(`Clicked Item ${i}.1`),
+            itemType: 'action',
+            title: `Action ${i}-1`,
+            onPress: () => showToast(`Clicked Action ${i}-1`),
           },
           {
-            id: `subitem-${i}-2`,
+            id: `toggle-${i}-1`,
             type: 'menuItem',
-            title: `Item ${i}.2`,
-            onPress: () => showToast(`Clicked Item ${i}.2`),
+            itemType: 'toggle',
+            title: `Toggle ${i}-1`,
+          },
+          {
+            menuElementId: `toggle-${i}-2`,
+            type: 'menuItem',
+            itemType: 'toggle',
+            title: `Toggle ${i}-2`,
+          },
+          {
+            menuElementId: `toggle-${i}-3`,
+            type: 'menuItem',
+            itemType: 'toggle',
+            title: `Toggle ${i}-3`,
           },
           {
             id: `submenu-${i}`,
             type: 'menu',
-            title: `Submenu ${i}`,
+            title: `Submenu with Radio`,
+            singleSelection: true,
+            onSelectionChanged: selection =>
+              showToast(`Selected unique: ${selection}`),
             children: [
               {
-                id: `subsubitem-${i}-1`,
+                id: `radio-${i}-1`,
                 type: 'menuItem',
-                title: `Nested ${i}.1`,
-                onPress: () => showToast(`Clicked Nested ${i}.1`),
+                title: `Radio ${i}-1`,
+                initialToggleState: true,
               },
               {
-                id: `subsubitem-${i}-2`,
-                type: 'menuItem',
-                title: `Nested ${i}.2`,
-                onPress: () => showToast(`Clicked Nested ${i}.2`),
+                id: `subsubmenu-${i}`,
+                type: 'menu',
+                title: `SubSubMenu with Radio`,
+                onSelectionChanged: selection =>
+                  showToast(`Selected unique: ${selection}`),
+                children: [
+                  {
+                    id: `radio-${i}-2`,
+                    type: 'menuItem',
+                    title: `Radio ${i}-2`,
+                  },
+                  {
+                    id: `radio-${i}-3`,
+                    type: 'menuItem',
+                    title: `Radio ${i}-3`,
+                  },
+                ],
               },
             ],
           },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
@@ -3,7 +3,8 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Header Menu (iOS)',
   key: 'test-stack-header-menu-ios',
-  details: 'Tests header item menus with nesting.',
+  details:
+    'Tests header item menus: action items, toggle items, singleSelection, and nested menus.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -24,18 +24,26 @@ TBD
 2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
 3. Click on the Menu 1 item
   - [ ] The bubble morphs into a menu with two items and a submenu
-  - [ ] Clicking on Item 1.1 triggers a Toast "Clicked Item 1.1"
-  - [ ] Clicking on Item 1.2 triggers a Toast "Clicked Item 1.2"
-4. While the menu is opened, click on the Submenu 1
-  - [ ] A nested menu appears, containing two items
-  - [ ] Clicking on Nested 1.1 triggers a Toast "Clicked Nested 1.1"
-  - [ ] Clicking on Nested 1.2 triggers a Toast "Clicked Nested 1.2"
-5. Click on "Toggle trailing items count" 2 times to get 4 items
-6. Click on the Menu 3 item
-  - [ ] The bubble morphs into a menu with two items and a submenu
-  - [ ] Clicking on Item 3.1 triggers a Toast "Clicked Item 3.1"
-  - [ ] Clicking on Item 3.2 triggers a Toast "Clicked Item 3.2"
-7. While the menu is opened, click on the Submenu 3
-  - [ ] A nested menu appears, containing two items
-  - [ ] Clicking on Nested 3.1 triggers a Toast "Clicked Nested 3.1"
-  - [ ] Clicking on Nested 3.2 triggers a Toast "Clicked Nested 3.2"
+4. Click on Action 1-1
+  - [ ] A toast "Clicked Action 1-1" is displayed
+5. Click on Toggle 1-1 inside Menu
+  - [ ] Menu is hidden
+  - [ ] A toast "Selected "toggle 1-1"" is displayed
+  - [ ] When Menu 1 is reopened, a checkmark is displayed next to Toggle 1-1
+6. Click on Toggle 1-3 inside Menu
+  - [ ] Menu is hidden
+  - [ ] A toast "Selected "toggle 1-1", "toggle 1-3"" is displayed
+  - [ ] When Menu 1 is reopened, a checkmark is displayed next to Toggle 1-1 and Toggle 1-3
+7. Click on Toggle 1-1 inside Menu again
+  - [ ] Menu is hidden
+  - [ ] A toast "Selected "toggle 1-3"" is displayed
+  - [ ] When Menu 1 is reopened, a checkmark is displayed only next to Toggle 1-3
+8. Click on Submenu with Radio
+  - [ ] Radio 1-1 is selected by default
+9. Click on Radio 1-1 again
+  - [ ] No toast is displayed
+10. Click on SubSubmenu with Radio, click on Radio 1-2
+  - [ ] Whole menu is hidden
+  - [ ] A toast "Selected unique Radio 1-2" is displayed
+  - [ ] When Menu 1, Submenu with Radio is reopened, Radio 1-1 is no longer checked
+  - [ ] When Menu 1, Submenu with Radio, SubSubmenu with Radio is reopened, Radio 1-2 is checked

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -44,6 +44,6 @@ TBD
   - [ ] No toast is displayed
 10. Click on SubSubmenu with Radio, click on Radio 1-2
   - [ ] Whole menu is hidden
-  - [ ] A toast "Selected unique Radio 1-2" is displayed
+  - [ ] A toast "Selected unique "radio 1-2"" is displayed
   - [ ] When Menu 1 > Submenu with Radio is reopened, Radio 1-1 is no longer checked
   - [ ] When Menu 1 > Submenu with Radio > SubSubmenu with Radio is reopened, Radio 1-2 is checked

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -45,5 +45,5 @@ TBD
 10. Click on SubSubmenu with Radio, click on Radio 1-2
   - [ ] Whole menu is hidden
   - [ ] A toast "Selected unique Radio 1-2" is displayed
-  - [ ] When Menu 1, Submenu with Radio is reopened, Radio 1-1 is no longer checked
-  - [ ] When Menu 1, Submenu with Radio, SubSubmenu with Radio is reopened, Radio 1-2 is checked
+  - [ ] When Menu 1 > Submenu with Radio is reopened, Radio 1-1 is no longer checked
+  - [ ] When Menu 1 > Submenu with Radio > SubSubmenu with Radio is reopened, Radio 1-2 is checked

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -132,7 +132,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
 - (void)didChangeSelectionForMenu:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
-  [_reactEventEmitter emitOnMenuSelectionChanged:menuId selectedMenuItemIds:selectedIds];
+  [_reactEventEmitter emitOnMenuSelectionChange:menuId selectedMenuItemIds:selectedIds];
   // UIKit doesn't update UIAction.state after tap — rebuild menu so tracker state is reflected
   [self submitCurrentDataIfMounted];
 }

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -130,9 +130,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   [_reactEventEmitter emitOnMenuItemPress:menuItemId];
 }
 
-- (void)didChangeSelectionForMenu:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds
+- (void)didChangeSelectionForMenu:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
-  [_reactEventEmitter emitOnMenuSelectionChanged:menuElementId selectedMenuElementIds:selectedIds];
+  [_reactEventEmitter emitOnMenuSelectionChanged:menuId selectedMenuItemIds:selectedIds];
   // UIKit doesn't update UIAction.state after tap — rebuild menu so tracker state is reflected
   [self submitCurrentDataIfMounted];
 }

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -130,6 +130,13 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   [_reactEventEmitter emitOnMenuItemPress:menuItemId];
 }
 
+- (void)didChangeSelectionForMenu:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds
+{
+  [_reactEventEmitter emitOnMenuSelectionChanged:menuElementId selectedMenuElementIds:selectedIds];
+  // UIKit doesn't update UIAction.state after tap — rebuild menu so tracker state is reflected
+  [self submitCurrentDataIfMounted];
+}
+
 #pragma mark - RNSViewFrameChangeDelegate
 
 - (void)viewFrameDidChange:(nonnull UINavigationBar *)navigationBar

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)emitOnMenuItemPress:(NSString *)menuItemId;
 
+- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds;
+
 @end
 
 #pragma mark - Hidden from Swift

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)emitOnMenuItemPress:(NSString *)menuItemId;
 
-- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds;
+- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)emitOnMenuItemPress:(NSString *)menuItemId;
 
-- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds;
+- (BOOL)emitOnMenuSelectionChange:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -17,7 +17,7 @@
   }
 }
 
-- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds
+- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
   if (_reactEventEmitter != nullptr) {
     std::vector<std::string> stringIds;
@@ -25,8 +25,8 @@
       stringIds.push_back(RCTStringFromNSString(sid));
     }
     _reactEventEmitter->onMenuSelectionChanged({
-        .menuElementId = RCTStringFromNSString(menuElementId),
-        .selectedMenuElementIds = std::move(stringIds),
+        .menuId = RCTStringFromNSString(menuId),
+        .selectedMenuItemIds = std::move(stringIds),
     });
     return YES;
   } else {

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -17,6 +17,24 @@
   }
 }
 
+- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds
+{
+  if (_reactEventEmitter != nullptr) {
+    std::vector<std::string> stringIds;
+    for (NSString *sid in selectedIds) {
+      stringIds.push_back(sid.cString);
+    }
+    _reactEventEmitter->onMenuSelectionChanged({
+        .menuElementId = menuElementId.cString,
+        .selectedMenuElementIds = std::move(stringIds),
+    });
+    return YES;
+  } else {
+    RCTLogWarn(@"[RNScreens] Skipped OnMenuSelectionChanged event emission due to nullish emitter");
+    return NO;
+  }
+}
+
 - (void)updateEventEmitter:(const std::shared_ptr<const react::RNSStackHeaderConfigIOSEventEmitter> &)emitter
 {
   _reactEventEmitter = emitter;

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -22,10 +22,10 @@
   if (_reactEventEmitter != nullptr) {
     std::vector<std::string> stringIds;
     for (NSString *sid in selectedIds) {
-      stringIds.push_back(sid.cString);
+      stringIds.push_back(RCTStringFromNSString(sid));
     }
     _reactEventEmitter->onMenuSelectionChanged({
-        .menuElementId = menuElementId.cString,
+        .menuElementId = RCTStringFromNSString(menuElementId),
         .selectedMenuElementIds = std::move(stringIds),
     });
     return YES;

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -20,9 +20,9 @@
 - (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
   if (_reactEventEmitter != nullptr) {
-    std::vector<std::string> stringIds;
-    for (NSString *sid in selectedIds) {
-      stringIds.push_back(RCTStringFromNSString(sid));
+    std::vector<std::string> stringIds([selectedIds count]);
+    for (int i = 0; i < [selectedIds count]; i++) {
+      stringIds[i] = RCTStringFromNSString(selectedIds[i]);
     }
     _reactEventEmitter->onMenuSelectionChanged({
         .menuId = RCTStringFromNSString(menuId),

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -17,7 +17,7 @@
   }
 }
 
-- (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
+- (BOOL)emitOnMenuSelectionChange:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
   if (_reactEventEmitter != nullptr) {
     std::vector<std::string> stringIds;
@@ -25,13 +25,13 @@
     for (NSString *sid in selectedIds) {
       stringIds.push_back(RCTStringFromNSString(sid));
     }
-    _reactEventEmitter->onMenuSelectionChanged({
+    _reactEventEmitter->onMenuSelectionChange({
         .menuId = RCTStringFromNSString(menuId),
         .selectedMenuItemIds = std::move(stringIds),
     });
     return YES;
   } else {
-    RCTLogWarn(@"[RNScreens] Skipped OnMenuSelectionChanged event emission due to nullish emitter");
+    RCTLogWarn(@"[RNScreens] Skipped OnMenuSelectionChange event emission due to nullish emitter");
     return NO;
   }
 }

--- a/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigEventEmitter.mm
@@ -20,9 +20,10 @@
 - (BOOL)emitOnMenuSelectionChanged:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds
 {
   if (_reactEventEmitter != nullptr) {
-    std::vector<std::string> stringIds([selectedIds count]);
-    for (int i = 0; i < [selectedIds count]; i++) {
-      stringIds[i] = RCTStringFromNSString(selectedIds[i]);
+    std::vector<std::string> stringIds;
+    stringIds.reserve([selectedIds count]);
+    for (NSString *sid in selectedIds) {
+      stringIds.push_back(RCTStringFromNSString(sid));
     }
     _reactEventEmitter->onMenuSelectionChanged({
         .menuId = RCTStringFromNSString(menuId),

--- a/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
@@ -14,7 +14,8 @@
   if (item.menu != nil) {
     [RNSStackHeaderMenuCoordinator applyMenu:item.menu
                              toBarButtonItem:barButtonItem
-                      withMenuEventsDelegate:menuEventsDelegate];
+                      withMenuEventsDelegate:menuEventsDelegate
+                                stateTracker:item.menuToggleStateTracker];
   }
 
   return barButtonItem;

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) RNSHeaderItemPlacement placement;
 @property (nonatomic, readonly, nullable) NSString *label;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuToggleStateTracker *menuToggleStateTracker;
 @property (nonatomic, readonly, nullable) UIView *customView;
 
 @property (nonatomic, weak, nullable) id<RNSStackHeaderItemInvalidationDelegate> invalidationDelegate;

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
@@ -157,7 +157,7 @@ RNS_IGNORE_SUPER_CALL_END
   if (oldItemProps.menu != newItemProps.menu) {
     _menu = [RNSStackHeaderMenuMapper
         menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.menu)];
-    _menuToggleStateTracker = _menu != nil ? [[RNSStackHeaderMenuToggleStateTracker alloc] init] : nil;
+    _menuToggleStateTracker = _menu != nil ? [RNSStackHeaderMenuToggleStateTracker new] : nil;
     needsUpdate = YES;
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
@@ -5,6 +5,7 @@
 #import "RNSStackHeaderItemShadowStateProxy.h"
 #import "RNSStackHeaderMenuData.h"
 #import "RNSStackHeaderMenuMapper.h"
+#import "RNSStackHeaderMenuToggleStateTracker.h"
 
 #import <React/RCTConversions.h>
 #import <React/RCTLog.h>
@@ -44,6 +45,7 @@ namespace react = facebook::react;
 {
   _label = nil;
   _menu = nil;
+  _menuToggleStateTracker = nil;
   _placement = RNSHeaderItemPlacementTrailing;
   _didSetHeaderItemPlacement = NO;
 }
@@ -155,6 +157,7 @@ RNS_IGNORE_SUPER_CALL_END
   if (oldItemProps.menu != newItemProps.menu) {
     _menu = [RNSStackHeaderMenuMapper
         menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.menu)];
+    _menuToggleStateTracker = _menu != nil ? [[RNSStackHeaderMenuToggleStateTracker alloc] init] : nil;
     needsUpdate = YES;
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
@@ -4,6 +4,7 @@
 
 #import "RNSHeaderItemPlacement.h"
 #import "RNSStackHeaderMenuData.h"
+#import "RNSStackHeaderMenuToggleStateTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *label;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) UIView *customView;
+
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuToggleStateTracker *menuToggleStateTracker;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) UIView *customView;
 
-@property (nonatomic, readonly, nullable) RNSStackHeaderMenuToggleStateTracker *menuToggleStateTracker;
+@property (nonatomic, readonly) RNSStackHeaderMenuToggleStateTracker *menuToggleStateTracker;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
@@ -3,6 +3,7 @@
 #import <UIKit/UIKit.h>
 #import "RNSStackHeaderMenuData.h"
 #import "RNSStackHeaderMenuEventsDelegate.h"
+#import "RNSStackHeaderMenuToggleStateTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)applyMenu:(RNSStackHeaderMenuData *)data
            toBarButtonItem:(UIBarButtonItem *)item
-    withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate;
+    withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+              stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -91,7 +91,6 @@
     // to be a direct parent
     // we don't send press event for toggle by design
     if (effectiveType == RNSMenuItemTypeToggle) {
-      // JS side should have sanitized this, but assert as a safety net.
       if (insideSingleSelection && itemData.initialToggleState) {
         RCTAssert(
             !*initialSingleSelectionStateClaimed,
@@ -124,6 +123,8 @@
                                   [selectedIds addObject:itemId];
                                 }
                               }
+
+                              // the state might be unchanged if user e.g. clicks on the same selected radio
                               if ([tracker toggleStateChanged]) {
                                 [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuElementIds:selectedIds];
                                 [tracker setToggleStateChanged:NO];
@@ -134,7 +135,7 @@
       return toggleAction;
     }
 
-    // it the type is not 'toggle', then it is a regular action button that triggers onPress instead
+    // it effective type is not 'toggle', then it is a regular action button that triggers onPress instead
     return [UIAction actionWithTitle:itemData.title
                                image:nil
                           identifier:nil
@@ -162,7 +163,6 @@
   for (id<RNSStackHeaderMenuElement> child in menu.children) {
     if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
       RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
-      // For direct-parent-only collection, check parent's singleSelection
       RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:menu.singleSelection];
       if (effective == RNSMenuItemTypeToggle) {
         [ids addObject:item.menuElementId];
@@ -186,7 +186,6 @@
   for (id<RNSStackHeaderMenuElement> child in menu.children) {
     if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
       RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
-      // Inside singleSelection hierarchy insideSingleSelection is always YES
       RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:insideSingleSelection];
       if (effective == RNSMenuItemTypeToggle) {
         [ids addObject:item.menuElementId];

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -126,34 +126,34 @@
 
   __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
 
-  UIAction *toggleAction =
-      [UIAction actionWithTitle:data.title
-                          image:nil
-                     identifier:nil
-                        handler:^(__kindof UIAction *_Nonnull action) {
-                          NSArray<NSString *> *toggleItemsIds = insideSingleSelection
-                              ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
-                              : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
-                          if (insideSingleSelection) {
-                            [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
-                          } else {
-                            [tracker toggleItemWithId:data.menuElementId];
-                          }
+  UIAction *toggleAction = [UIAction
+      actionWithTitle:data.title
+                image:nil
+           identifier:nil
+              handler:^(__kindof UIAction *_Nonnull action) {
+                NSArray<NSString *> *toggleItemsIds = insideSingleSelection
+                    ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInSingleSelectionHierarchy:singleSelectionRoot]
+                    : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
+                if (insideSingleSelection) {
+                  [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
+                } else {
+                  [tracker toggleItemWithId:data.menuElementId];
+                }
 
-                          NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
-                          for (NSString *itemId in toggleItemsIds) {
-                            if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
-                              [selectedIds addObject:itemId];
-                            }
-                          }
+                NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
+                for (NSString *itemId in toggleItemsIds) {
+                  if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
+                    [selectedIds addObject:itemId];
+                  }
+                }
 
-                          // the state might be unchanged if user e.g. clicks on the same selected
-                          // radio
-                          if ([tracker toggleStateChanged]) {
-                            [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
-                            [tracker setToggleStateChanged:NO];
-                          }
-                        }];
+                // the state might be unchanged if user e.g. clicks on the same selected
+                // radio
+                if ([tracker toggleStateChanged]) {
+                  [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
+                  [tracker setToggleStateChanged:NO];
+                }
+              }];
   toggleAction.state = isItemToggledOn ? UIMenuElementStateOn : UIMenuElementStateOff;
 
   return toggleAction;
@@ -185,20 +185,20 @@
 + (NSArray<NSString *> *)getToggleItemsIdsInMenu:(RNSStackHeaderMenuData *)menu
 {
   NSMutableArray<NSString *> *ids = [NSMutableArray new];
-  [self collectToggleItemsIdsFromMenu:menu intoArray:ids recursive:NO];
+  [self collectToggleItemsIdsFromMenu:menu intoArray:ids insideSingleSelection:NO];
   return ids;
 }
 
-+ (NSArray<NSString *> *)getAllToggleItemsIdsInHierarchy:(RNSStackHeaderMenuData *)menu
++ (NSArray<NSString *> *)getAllToggleItemsIdsInSingleSelectionHierarchy:(RNSStackHeaderMenuData *)menu
 {
   NSMutableArray<NSString *> *ids = [NSMutableArray new];
-  [self collectToggleItemsIdsFromMenu:menu intoArray:ids recursive:YES];
+  [self collectToggleItemsIdsFromMenu:menu intoArray:ids insideSingleSelection:YES];
   return ids;
 }
 
 + (void)collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)menu
                             intoArray:(NSMutableArray<NSString *> *)ids
-                            recursive:(bool)insideSingleSelection
+                insideSingleSelection:(bool)insideSingleSelection
 {
   for (id<RNSStackHeaderMenuElement> child in menu.children) {
     if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
@@ -211,7 +211,7 @@
     } else if (insideSingleSelection && [child isKindOfClass:[RNSStackHeaderMenuData class]]) {
       [self collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)child
                                 intoArray:ids
-                                recursive:insideSingleSelection];
+                    insideSingleSelection:insideSingleSelection];
     }
   }
 }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -89,7 +89,7 @@
     // but when singleSelection is set somewhere in the parent *chain*, only one toggle in the whole hierarchy
     // can be turned on at any point in time, and the single selection root is notified, which doesn't need
     // to be a direct parent
-    // we don't send press event for toggle by desing
+    // we don't send press event for toggle by design
     if (effectiveType == RNSMenuItemTypeToggle) {
       // JS side should have sanitized this, but assert as a safety net.
       if (insideSingleSelection && itemData.initialToggleState) {

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -82,14 +82,6 @@
               @"[RNScreens] 'action' itemType is disallowed in singleSelection menus (id: %@)",
               itemData.menuElementId);
 
-    __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
-
-    // toggle works differently with singleSelection and without it
-    // normally, each toggle is separate and changing one triggers selection change event on direct parent
-    // but when singleSelection is set somewhere in the parent *chain*, only one toggle in the whole hierarchy
-    // can be turned on at any point in time, and the single selection root is notified, which doesn't need
-    // to be a direct parent
-    // we don't send press event for toggle by design
     if (effectiveType == RNSMenuItemTypeToggle) {
       if (insideSingleSelection && itemData.initialToggleState) {
         RCTAssert(
@@ -98,53 +90,88 @@
             singleSelectionRoot.menuElementId);
         *initialSingleSelectionStateClaimed = YES;
       }
-      BOOL isOn = [tracker getToggleStateForItemWithId:itemData.menuElementId initialState:itemData.initialToggleState];
-
-      NSArray<NSString *> *toggleItemsIds = insideSingleSelection
-          ? [self getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
-          : [self getToggleItemsIdsInMenu:parentMenu];
-
-      NSString *eventMenuId = insideSingleSelection ? singleSelectionRoot.menuElementId : parentMenu.menuElementId;
-
-      UIAction *toggleAction =
-          [UIAction actionWithTitle:itemData.title
-                              image:nil
-                         identifier:nil
-                            handler:^(__kindof UIAction *_Nonnull action) {
-                              if (insideSingleSelection) {
-                                [tracker selectItemWithId:itemData.menuElementId fromIds:toggleItemsIds];
-                              } else {
-                                [tracker toggleItemWithId:itemData.menuElementId];
-                              }
-
-                              NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
-                              for (NSString *itemId in toggleItemsIds) {
-                                if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
-                                  [selectedIds addObject:itemId];
-                                }
-                              }
-
-                              // the state might be unchanged if user e.g. clicks on the same selected radio
-                              if ([tracker toggleStateChanged]) {
-                                [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
-                                [tracker setToggleStateChanged:NO];
-                              }
-                            }];
-      toggleAction.state = isOn ? UIMenuElementStateOn : UIMenuElementStateOff;
-
-      return toggleAction;
+      return [self buildToggleFromData:itemData
+                        withParentMenu:parentMenu
+                   singleSelectionRoot:singleSelectionRoot
+                    toggleStateTracker:tracker
+                    menuEventsDelegate:delegate];
     }
 
     // it effective type is not 'toggle', then it is a regular action button that triggers onPress instead
-    return [UIAction actionWithTitle:itemData.title
-                               image:nil
-                          identifier:nil
-                             handler:^(__kindof UIAction *_Nonnull action) {
-                               [weakDelegate didPressMenuItem:itemData.menuElementId];
-                             }];
+    return [self buildActionFromData:itemData withMenuEventsDelegate:delegate];
   }
 
   return nil;
+}
+
+/**
+ Builds item which can be toggled on / off.
+
+ Toggle works differently with singleSelection and without it. Normally, each toggle is separate and changing one
+ triggers selection change event on direct parent, but when singleSelection is set somewhere in the parent *chain*,
+ only one toggle in the whole hierarchy can be turned on at any point in time, and the single selection root,
+ which doesn't need to be a direct parent, is notified.
+
+ We don't send press event for toggle by design.
+ */
++ (nullable UIMenuElement *)buildToggleFromData:(RNSStackHeaderMenuItemData *)data
+                                 withParentMenu:(RNSStackHeaderMenuData *)parentMenu
+                            singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
+                             toggleStateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                             menuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+{
+  BOOL isOn = [tracker getToggleStateForItemWithId:data.menuElementId initialState:data.initialToggleState];
+  BOOL insideSingleSelection = singleSelectionRoot != nil;
+
+  NSArray<NSString *> *toggleItemsIds = insideSingleSelection
+      ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
+      : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
+
+  NSString *eventMenuId = insideSingleSelection ? singleSelectionRoot.menuElementId : parentMenu.menuElementId;
+
+  __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
+
+  UIAction *toggleAction = [UIAction actionWithTitle:data.title
+                                               image:nil
+                                          identifier:nil
+                                             handler:^(__kindof UIAction *_Nonnull action) {
+                                               if (insideSingleSelection) {
+                                                 [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
+                                               } else {
+                                                 [tracker toggleItemWithId:data.menuElementId];
+                                               }
+
+                                               NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
+                                               for (NSString *itemId in toggleItemsIds) {
+                                                 if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
+                                                   [selectedIds addObject:itemId];
+                                                 }
+                                               }
+
+                                               // the state might be unchanged if user e.g. clicks on the same selected
+                                               // radio
+                                               if ([tracker toggleStateChanged]) {
+                                                 [weakDelegate didChangeSelectionForMenu:eventMenuId
+                                                                     selectedMenuItemIds:selectedIds];
+                                                 [tracker setToggleStateChanged:NO];
+                                               }
+                                             }];
+  toggleAction.state = isOn ? UIMenuElementStateOn : UIMenuElementStateOff;
+
+  return toggleAction;
+}
+
++ (nullable UIMenuElement *)buildActionFromData:(RNSStackHeaderMenuItemData *)data
+                         withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+{
+  __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
+
+  return [UIAction actionWithTitle:data.title
+                             image:nil
+                        identifier:nil
+                           handler:^(__kindof UIAction *_Nonnull action) {
+                             [weakDelegate didPressMenuItem:data.menuElementId];
+                           }];
 }
 
 #pragma mark - Helpers

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -123,39 +123,38 @@
   BOOL isItemToggledOn = [tracker getToggleStateForItemWithId:data.menuElementId initialState:data.initialToggleState];
   BOOL insideSingleSelection = singleSelectionRoot != nil;
 
-  NSArray<NSString *> *toggleItemsIds = insideSingleSelection
-      ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
-      : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
-
   NSString *eventMenuId = insideSingleSelection ? singleSelectionRoot.menuElementId : parentMenu.menuElementId;
 
   __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
 
-  UIAction *toggleAction = [UIAction actionWithTitle:data.title
-                                               image:nil
-                                          identifier:nil
-                                             handler:^(__kindof UIAction *_Nonnull action) {
-                                               if (insideSingleSelection) {
-                                                 [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
-                                               } else {
-                                                 [tracker toggleItemWithId:data.menuElementId];
-                                               }
+  UIAction *toggleAction =
+      [UIAction actionWithTitle:data.title
+                          image:nil
+                     identifier:nil
+                        handler:^(__kindof UIAction *_Nonnull action) {
+                          NSArray<NSString *> *toggleItemsIds = insideSingleSelection
+                              ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
+                              : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
+                          if (insideSingleSelection) {
+                            [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
+                          } else {
+                            [tracker toggleItemWithId:data.menuElementId];
+                          }
 
-                                               NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
-                                               for (NSString *itemId in toggleItemsIds) {
-                                                 if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
-                                                   [selectedIds addObject:itemId];
-                                                 }
-                                               }
+                          NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
+                          for (NSString *itemId in toggleItemsIds) {
+                            if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
+                              [selectedIds addObject:itemId];
+                            }
+                          }
 
-                                               // the state might be unchanged if user e.g. clicks on the same selected
-                                               // radio
-                                               if ([tracker toggleStateChanged]) {
-                                                 [weakDelegate didChangeSelectionForMenu:eventMenuId
-                                                                     selectedMenuItemIds:selectedIds];
-                                                 [tracker setToggleStateChanged:NO];
-                                               }
-                                             }];
+                          // the state might be unchanged if user e.g. clicks on the same selected
+                          // radio
+                          if ([tracker toggleStateChanged]) {
+                            [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
+                            [tracker setToggleStateChanged:NO];
+                          }
+                        }];
   toggleAction.state = isItemToggledOn ? UIMenuElementStateOn : UIMenuElementStateOff;
 
   return toggleAction;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -12,27 +12,33 @@
 #if !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
   if (@available(tvOS 17.0, *)) {
     item.menu = [self buildMenuFromData:data
-                 withMenuEventsDelegate:delegate
-                           stateTracker:tracker
-                    singleSelectionRoot:nil];
+                    withMenuEventsDelegate:delegate
+                              stateTracker:tracker
+                       singleSelectionRoot:nil
+        initialSingleSelectionStateClaimed:NULL];
   }
 #endif // !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
 }
 
 + (UIMenu *)buildMenuFromData:(RNSStackHeaderMenuData *)data
-       withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
-                 stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
-          singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
+                withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+                          stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                   singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
+    initialSingleSelectionStateClaimed:(BOOL *)initialSingleSelectionStateClaimed
 {
   // Resolve singleSelection root: first menu in hierarchy with singleSelection becomes the root.
   // Once inside a singleSelection hierarchy, all descendants inherit it.
   // Only the root is set the singleSelection option - less things to check if sth goes wrong
   // and it shouldn't change the behavior
+  // There can be at most one element with initialToggleState and we're checking that with
+  // initialSingleSelectionStateClaimed
   UIMenuOptions options = 0;
   RNSStackHeaderMenuData *resolvedRoot = singleSelectionRoot;
+  BOOL newInitialSingleSelectionStateClaimed = NO;
   if (resolvedRoot == nil && data.singleSelection) {
     options |= UIMenuOptionsSingleSelection;
     resolvedRoot = data;
+    initialSingleSelectionStateClaimed = &newInitialSingleSelectionStateClaimed;
   }
 
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
@@ -41,7 +47,8 @@
                                  withMenuEventsDelegate:delegate
                                            stateTracker:tracker
                                              parentMenu:data
-                                    singleSelectionRoot:resolvedRoot];
+                                    singleSelectionRoot:resolvedRoot
+                     initialSingleSelectionStateClaimed:initialSingleSelectionStateClaimed];
     if (element != nil) {
       [elements addObject:element];
     }
@@ -55,12 +62,14 @@
                                     stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
                                       parentMenu:(RNSStackHeaderMenuData *)parentMenu
                              singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
+              initialSingleSelectionStateClaimed:(BOOL *)initialSingleSelectionStateClaimed
 {
   if ([element isKindOfClass:[RNSStackHeaderMenuData class]]) {
     return [self buildMenuFromData:(RNSStackHeaderMenuData *)element
-            withMenuEventsDelegate:delegate
-                      stateTracker:tracker
-               singleSelectionRoot:singleSelectionRoot];
+                    withMenuEventsDelegate:delegate
+                              stateTracker:tracker
+                       singleSelectionRoot:singleSelectionRoot
+        initialSingleSelectionStateClaimed:initialSingleSelectionStateClaimed];
   }
 
   if ([element isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
@@ -82,6 +91,14 @@
     // to be a direct parent
     // we don't send press event for toggle by desing
     if (effectiveType == RNSMenuItemTypeToggle) {
+      // JS side should have sanitized this, but assert as a safety net.
+      if (insideSingleSelection && itemData.initialToggleState) {
+        RCTAssert(
+            !*initialSingleSelectionStateClaimed,
+            @"[RNScreens] Multiple items with initialToggleState=YES in singleSelection menu hierarchy starting from \"%@\".",
+            singleSelectionRoot.menuElementId);
+        *initialSingleSelectionStateClaimed = YES;
+      }
       BOOL isOn = [tracker getToggleStateForItemWithId:itemData.menuElementId initialState:itemData.initialToggleState];
 
       NSArray<NSString *> *toggleItemsIds = insideSingleSelection

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -79,7 +79,7 @@
                                     insideSingleSelection:insideSingleSelection];
 
     RCTAssert(!(insideSingleSelection && effectiveType == RNSMenuItemTypeAction),
-              @"[RNScreens] 'action' itemType is disallowed in singleSelection menus (menuElementId: %@)",
+              @"[RNScreens] 'action' itemType is disallowed in singleSelection menus (id: %@)",
               itemData.menuElementId);
 
     __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
@@ -126,7 +126,7 @@
 
                               // the state might be unchanged if user e.g. clicks on the same selected radio
                               if ([tracker toggleStateChanged]) {
-                                [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuElementIds:selectedIds];
+                                [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
                                 [tracker setToggleStateChanged:NO];
                               }
                             }];

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -1,42 +1,123 @@
 #import "RNSStackHeaderMenuCoordinator.h"
 
+#import <React/RCTAssert.h>
+
 @implementation RNSStackHeaderMenuCoordinator
 
 + (void)applyMenu:(RNSStackHeaderMenuData *)data
            toBarButtonItem:(UIBarButtonItem *)item
     withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+              stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
 {
 #if !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
   if (@available(tvOS 17.0, *)) {
-    item.menu = [self buildMenuFromData:data withMenuEventsDelegate:delegate];
+    item.menu = [self buildMenuFromData:data
+                 withMenuEventsDelegate:delegate
+                           stateTracker:tracker
+                    singleSelectionRoot:nil];
   }
 #endif // !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
 }
 
 + (UIMenu *)buildMenuFromData:(RNSStackHeaderMenuData *)data
        withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+                 stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+          singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
 {
+  // Resolve singleSelection root: first menu in hierarchy with singleSelection becomes the root.
+  // Once inside a singleSelection hierarchy, all descendants inherit it.
+  // Only the root is set the singleSelection option - less things to check if sth goes wrong
+  // and it shouldn't change the behavior
+  UIMenuOptions options = 0;
+  RNSStackHeaderMenuData *resolvedRoot = singleSelectionRoot;
+  if (resolvedRoot == nil && data.singleSelection) {
+    options |= UIMenuOptionsSingleSelection;
+    resolvedRoot = data;
+  }
+
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
   for (id<RNSStackHeaderMenuElement> child in data.children) {
-    UIMenuElement *element = [self buildElementFromData:child withMenuEventsDelegate:delegate];
+    UIMenuElement *element = [self buildElementFromData:child
+                                 withMenuEventsDelegate:delegate
+                                           stateTracker:tracker
+                                             parentMenu:data
+                                    singleSelectionRoot:resolvedRoot];
     if (element != nil) {
       [elements addObject:element];
     }
   }
 
-  return [UIMenu menuWithTitle:data.title children:elements];
+  return [UIMenu menuWithTitle:data.title image:nil identifier:nil options:options children:elements];
 }
 
 + (nullable UIMenuElement *)buildElementFromData:(id<RNSStackHeaderMenuElement>)element
                           withMenuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
+                                    stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                                      parentMenu:(RNSStackHeaderMenuData *)parentMenu
+                             singleSelectionRoot:(nullable RNSStackHeaderMenuData *)singleSelectionRoot
 {
   if ([element isKindOfClass:[RNSStackHeaderMenuData class]]) {
-    return [self buildMenuFromData:(RNSStackHeaderMenuData *)element withMenuEventsDelegate:delegate];
+    return [self buildMenuFromData:(RNSStackHeaderMenuData *)element
+            withMenuEventsDelegate:delegate
+                      stateTracker:tracker
+               singleSelectionRoot:singleSelectionRoot];
   }
 
   if ([element isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
     RNSStackHeaderMenuItemData *itemData = (RNSStackHeaderMenuItemData *)element;
+    BOOL insideSingleSelection = singleSelectionRoot != nil;
+    RNSMenuItemType effectiveType = [self resolveItemType:itemData.itemType
+                                    insideSingleSelection:insideSingleSelection];
+
+    RCTAssert(!(insideSingleSelection && effectiveType == RNSMenuItemTypeAction),
+              @"[RNScreens] 'action' itemType is disallowed in singleSelection menus (menuElementId: %@)",
+              itemData.menuElementId);
+
     __weak id<RNSStackHeaderMenuEventsDelegate> weakDelegate = delegate;
+
+    // toggle works differently with singleSelection and without it
+    // normally, each toggle is separate and changing one triggers selection change event on direct parent
+    // but when singleSelection is set somewhere in the parent *chain*, only one toggle in the whole hierarchy
+    // can be turned on at any point in time, and the single selection root is notified, which doesn't need
+    // to be a direct parent
+    // we don't send press event for toggle by desing
+    if (effectiveType == RNSMenuItemTypeToggle) {
+      BOOL isOn = [tracker getToggleStateForItemWithId:itemData.menuElementId initialState:itemData.initialToggleState];
+
+      NSArray<NSString *> *toggleItemsIds = insideSingleSelection
+          ? [self getAllToggleItemsIdsInHierarchy:singleSelectionRoot]
+          : [self getToggleItemsIdsInMenu:parentMenu];
+
+      NSString *eventMenuId = insideSingleSelection ? singleSelectionRoot.menuElementId : parentMenu.menuElementId;
+
+      UIAction *toggleAction =
+          [UIAction actionWithTitle:itemData.title
+                              image:nil
+                         identifier:nil
+                            handler:^(__kindof UIAction *_Nonnull action) {
+                              if (insideSingleSelection) {
+                                [tracker selectItemWithId:itemData.menuElementId fromIds:toggleItemsIds];
+                              } else {
+                                [tracker toggleItemWithId:itemData.menuElementId];
+                              }
+
+                              NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
+                              for (NSString *itemId in toggleItemsIds) {
+                                if ([tracker getToggleStateForItemWithId:itemId initialState:NO]) {
+                                  [selectedIds addObject:itemId];
+                                }
+                              }
+                              if ([tracker toggleStateChanged]) {
+                                [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuElementIds:selectedIds];
+                                [tracker setToggleStateChanged:NO];
+                              }
+                            }];
+      toggleAction.state = isOn ? UIMenuElementStateOn : UIMenuElementStateOff;
+
+      return toggleAction;
+    }
+
+    // it the type is not 'toggle', then it is a regular action button that triggers onPress instead
     return [UIAction actionWithTitle:itemData.title
                                image:nil
                           identifier:nil
@@ -46,6 +127,59 @@
   }
 
   return nil;
+}
+
+#pragma mark - Helpers
+
++ (RNSMenuItemType)resolveItemType:(RNSMenuItemType)itemType insideSingleSelection:(BOOL)insideSingleSelection
+{
+  if (itemType == RNSMenuItemTypeInherit) {
+    return insideSingleSelection ? RNSMenuItemTypeToggle : RNSMenuItemTypeAction;
+  }
+  return itemType;
+}
+
++ (NSArray<NSString *> *)getToggleItemsIdsInMenu:(RNSStackHeaderMenuData *)menu
+{
+  NSMutableArray<NSString *> *ids = [NSMutableArray new];
+  for (id<RNSStackHeaderMenuElement> child in menu.children) {
+    if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
+      RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
+      // For direct-parent-only collection, check parent's singleSelection
+      RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:menu.singleSelection];
+      if (effective == RNSMenuItemTypeToggle) {
+        [ids addObject:item.menuElementId];
+      }
+    }
+  }
+  return ids;
+}
+
++ (NSArray<NSString *> *)getAllToggleItemsIdsInHierarchy:(RNSStackHeaderMenuData *)menu
+{
+  NSMutableArray<NSString *> *ids = [NSMutableArray new];
+  [self collectToggleItemsIdsFromMenu:menu intoArray:ids insideSingleSelection:menu.singleSelection];
+  return ids;
+}
+
++ (void)collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)menu
+                            intoArray:(NSMutableArray<NSString *> *)ids
+                insideSingleSelection:(bool)insideSingleSelection
+{
+  for (id<RNSStackHeaderMenuElement> child in menu.children) {
+    if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
+      RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
+      // Inside singleSelection hierarchy insideSingleSelection is always YES
+      RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:insideSingleSelection];
+      if (effective == RNSMenuItemTypeToggle) {
+        [ids addObject:item.menuElementId];
+      }
+    } else if ([child isKindOfClass:[RNSStackHeaderMenuData class]]) {
+      [self collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)child
+                                intoArray:ids
+                    insideSingleSelection:insideSingleSelection];
+    }
+  }
 }
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -27,7 +27,6 @@
     initialSingleSelectionStateClaimed:(BOOL *)initialSingleSelectionStateClaimed
 {
   // Resolve singleSelection root: first menu in hierarchy with singleSelection becomes the root.
-  // Once inside a singleSelection hierarchy, all descendants inherit it.
   // Only the root is set the singleSelection option - less things to check if sth goes wrong
   // and it shouldn't change the behavior
   // There can be at most one element with initialToggleState and we're checking that with
@@ -177,7 +176,7 @@
 
 + (RNSMenuItemType)resolveItemType:(RNSMenuItemType)itemType insideSingleSelection:(BOOL)insideSingleSelection
 {
-  if (itemType == RNSMenuItemTypeInherit) {
+  if (itemType == RNSMenuItemTypeAutomatic) {
     return insideSingleSelection ? RNSMenuItemTypeToggle : RNSMenuItemTypeAction;
   }
   return itemType;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -75,14 +75,14 @@
   if ([element isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
     RNSStackHeaderMenuItemData *itemData = (RNSStackHeaderMenuItemData *)element;
     BOOL insideSingleSelection = singleSelectionRoot != nil;
-    RNSMenuItemType effectiveType = [self resolveItemType:itemData.itemType
-                                    insideSingleSelection:insideSingleSelection];
+    RNSMenuItemType effectiveItemType = [self resolveItemType:itemData.itemType
+                                        insideSingleSelection:insideSingleSelection];
 
-    RCTAssert(!(insideSingleSelection && effectiveType == RNSMenuItemTypeAction),
+    RCTAssert(!(insideSingleSelection && effectiveItemType == RNSMenuItemTypeAction),
               @"[RNScreens] 'action' itemType is disallowed in singleSelection menus (id: %@)",
               itemData.menuElementId);
 
-    if (effectiveType == RNSMenuItemTypeToggle) {
+    if (effectiveItemType == RNSMenuItemTypeToggle) {
       if (insideSingleSelection && itemData.initialToggleState) {
         RCTAssert(
             !*initialSingleSelectionStateClaimed,
@@ -120,7 +120,7 @@
                              toggleStateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
                              menuEventsDelegate:(id<RNSStackHeaderMenuEventsDelegate>)delegate
 {
-  BOOL isOn = [tracker getToggleStateForItemWithId:data.menuElementId initialState:data.initialToggleState];
+  BOOL isItemToggledOn = [tracker getToggleStateForItemWithId:data.menuElementId initialState:data.initialToggleState];
   BOOL insideSingleSelection = singleSelectionRoot != nil;
 
   NSArray<NSString *> *toggleItemsIds = insideSingleSelection
@@ -156,7 +156,7 @@
                                                  [tracker setToggleStateChanged:NO];
                                                }
                                              }];
-  toggleAction.state = isOn ? UIMenuElementStateOn : UIMenuElementStateOff;
+  toggleAction.state = isItemToggledOn ? UIMenuElementStateOn : UIMenuElementStateOff;
 
   return toggleAction;
 }
@@ -187,40 +187,33 @@
 + (NSArray<NSString *> *)getToggleItemsIdsInMenu:(RNSStackHeaderMenuData *)menu
 {
   NSMutableArray<NSString *> *ids = [NSMutableArray new];
-  for (id<RNSStackHeaderMenuElement> child in menu.children) {
-    if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
-      RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
-      RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:menu.singleSelection];
-      if (effective == RNSMenuItemTypeToggle) {
-        [ids addObject:item.menuElementId];
-      }
-    }
-  }
+  [self collectToggleItemsIdsFromMenu:menu intoArray:ids recursive:NO];
   return ids;
 }
 
 + (NSArray<NSString *> *)getAllToggleItemsIdsInHierarchy:(RNSStackHeaderMenuData *)menu
 {
   NSMutableArray<NSString *> *ids = [NSMutableArray new];
-  [self collectToggleItemsIdsFromMenu:menu intoArray:ids insideSingleSelection:menu.singleSelection];
+  [self collectToggleItemsIdsFromMenu:menu intoArray:ids recursive:YES];
   return ids;
 }
 
 + (void)collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)menu
                             intoArray:(NSMutableArray<NSString *> *)ids
-                insideSingleSelection:(bool)insideSingleSelection
+                            recursive:(bool)insideSingleSelection
 {
   for (id<RNSStackHeaderMenuElement> child in menu.children) {
     if ([child isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
       RNSStackHeaderMenuItemData *item = (RNSStackHeaderMenuItemData *)child;
-      RNSMenuItemType effective = [self resolveItemType:item.itemType insideSingleSelection:insideSingleSelection];
-      if (effective == RNSMenuItemTypeToggle) {
+      RNSMenuItemType effectiveItemType = [self resolveItemType:item.itemType
+                                          insideSingleSelection:insideSingleSelection];
+      if (effectiveItemType == RNSMenuItemTypeToggle) {
         [ids addObject:item.menuElementId];
       }
-    } else if ([child isKindOfClass:[RNSStackHeaderMenuData class]]) {
+    } else if (insideSingleSelection && [child isKindOfClass:[RNSStackHeaderMenuData class]]) {
       [self collectToggleItemsIdsFromMenu:(RNSStackHeaderMenuData *)child
                                 intoArray:ids
-                    insideSingleSelection:insideSingleSelection];
+                                recursive:insideSingleSelection];
     }
   }
 }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -4,6 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, RNSMenuItemType) {
+  RNSMenuItemTypeInherit = 0,
+  RNSMenuItemTypeAction,
+  RNSMenuItemTypeToggle,
+};
+
 @protocol RNSStackHeaderMenuElement <NSObject>
 
 @property (nonatomic, copy, readonly) NSString *menuElementId;
@@ -13,18 +19,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderMenuItemData : NSObject <RNSStackHeaderMenuElement>
 
 @property (nonatomic, copy, readonly, nullable) NSString *title;
+@property (nonatomic, readonly) RNSMenuItemType itemType;
+@property (nonatomic, readonly) BOOL initialToggleState;
 
-- (instancetype)initWithId:(NSString *)menuElementId title:(nullable NSString *)title;
+- (instancetype)initWithId:(NSString *)menuElementId
+                     title:(nullable NSString *)title
+                  itemType:(RNSMenuItemType)itemType
+        initialToggleState:(BOOL)initialToggleState;
 
 @end
 
 @interface RNSStackHeaderMenuData : NSObject <RNSStackHeaderMenuElement>
 
 @property (nonatomic, copy, readonly, nullable) NSString *title;
+@property (nonatomic, readonly) BOOL singleSelection;
 @property (nonatomic, copy, readonly) NSArray<id<RNSStackHeaderMenuElement>> *children;
 
 - (instancetype)initWithId:(NSString *)menuElementId
                      title:(nullable NSString *)title
+           singleSelection:(BOOL)singleSelection
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children;
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, RNSMenuItemType) {
-  RNSMenuItemTypeInherit = 0,
+  RNSMenuItemTypeAutomatic = 0,
   RNSMenuItemTypeAction,
   RNSMenuItemTypeToggle,
 };

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
@@ -4,11 +4,16 @@
 
 @synthesize menuElementId = _menuElementId;
 
-- (instancetype)initWithId:(NSString *)menuElementId title:(nullable NSString *)title
+- (instancetype)initWithId:(NSString *)menuElementId
+                     title:(nullable NSString *)title
+                  itemType:(RNSMenuItemType)itemType
+        initialToggleState:(BOOL)initialToggleState
 {
   if (self = [super init]) {
     _menuElementId = [menuElementId copy];
     _title = [title copy];
+    _itemType = itemType;
+    _initialToggleState = initialToggleState;
   }
   return self;
 }
@@ -21,11 +26,13 @@
 
 - (instancetype)initWithId:(NSString *)menuElementId
                      title:(nullable NSString *)title
+           singleSelection:(BOOL)singleSelection
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
 {
   if (self = [super init]) {
     _menuElementId = [menuElementId copy];
     _title = [title copy];
+    _singleSelection = singleSelection;
     _children = [children copy];
   }
   return self;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didPressMenuItem:(NSString *)menuItemId;
 
-- (void)didChangeSelectionForMenu:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds;
+- (void)didChangeSelectionForMenu:(NSString *)menuId selectedMenuItemIds:(NSArray<NSString *> *)selectedIds;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuEventsDelegate.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didPressMenuItem:(NSString *)menuItemId;
 
+- (void)didChangeSelectionForMenu:(NSString *)menuElementId selectedMenuElementIds:(NSArray<NSString *> *)selectedIds;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -29,8 +29,11 @@
     }
   }
 
+  BOOL singleSelection = [self boolForKey:@"singleSelection" in:dict];
+
   return [[RNSStackHeaderMenuData alloc] initWithId:[self stringForKey:@"id" in:dict]
                                               title:[self stringForKey:@"title" in:dict]
+                                    singleSelection:singleSelection
                                            children:children];
 }
 
@@ -46,8 +49,14 @@
     return [self menuFromDictionary:dict];
   } else if ([type isEqual:@"menuItem"]) {
     [RNSStackHeaderMenuMapper validateMenuItemKeys:dict];
+
+    RNSMenuItemType itemType = [self itemTypeFromString:[self stringForKey:@"itemType" in:dict]];
+    BOOL initialToggleState = [self boolForKey:@"initialToggleState" in:dict];
+
     return [[RNSStackHeaderMenuItemData alloc] initWithId:[self stringForKey:@"id" in:dict]
-                                                    title:[self stringForKey:@"title" in:dict]];
+                                                    title:[self stringForKey:@"title" in:dict]
+                                                 itemType:itemType
+                                       initialToggleState:initialToggleState];
   }
 
   return nil;
@@ -58,8 +67,9 @@
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
-                  [key isEqualToString:@"children"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] ||
+                  [key isEqualToString:@"title"] || [key isEqualToString:@"children"] ||
+                  [key isEqualToString:@"singleSelection"],
               @"[RNScreens] Invalid key \"%@\" found in menu",
               key);
   }
@@ -70,7 +80,9 @@
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] ||
+                  [key isEqualToString:@"title"] || [key isEqualToString:@"itemType"] ||
+                  [key isEqualToString:@"initialToggleState"],
               @"[RNScreens] Invalid key \"%@\" found in menu item",
               key);
   }
@@ -81,6 +93,22 @@
 {
   id value = dict[key];
   return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
++ (BOOL)boolForKey:(NSString *)key in:(NSDictionary *)dict
+{
+  id value = dict[key];
+  return [value isKindOfClass:[NSNumber class]] ? [value boolValue] : NO;
+}
+
++ (RNSMenuItemType)itemTypeFromString:(nullable NSString *)string
+{
+  if ([string isEqualToString:@"action"]) {
+    return RNSMenuItemTypeAction;
+  } else if ([string isEqualToString:@"toggle"]) {
+    return RNSMenuItemTypeToggle;
+  }
+  return RNSMenuItemTypeInherit;
 }
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -104,7 +104,7 @@
   } else if ([string isEqualToString:@"toggle"]) {
     return RNSMenuItemTypeToggle;
   }
-  return RNSMenuItemTypeInherit;
+  return RNSMenuItemTypeAutomatic;
 }
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -50,13 +50,11 @@
   } else if ([type isEqual:@"menuItem"]) {
     [RNSStackHeaderMenuMapper validateMenuItemKeys:dict];
 
-    RNSMenuItemType itemType = [self itemTypeFromString:[self stringForKey:@"itemType" in:dict]];
-    BOOL initialToggleState = [self boolForKey:@"initialToggleState" in:dict];
-
     return [[RNSStackHeaderMenuItemData alloc] initWithId:[self stringForKey:@"id" in:dict]
                                                     title:[self stringForKey:@"title" in:dict]
-                                                 itemType:itemType
-                                       initialToggleState:initialToggleState];
+                                                 itemType:[self itemTypeFromString:[self stringForKey:@"itemType"
+                                                                                                   in:dict]]
+                                       initialToggleState:[self boolForKey:@"initialToggleState" in:dict]];
   }
 
   return nil;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -67,9 +67,8 @@
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] ||
-                  [key isEqualToString:@"title"] || [key isEqualToString:@"children"] ||
-                  [key isEqualToString:@"singleSelection"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
+                  [key isEqualToString:@"children"] || [key isEqualToString:@"singleSelection"],
               @"[RNScreens] Invalid key \"%@\" found in menu",
               key);
   }
@@ -80,9 +79,8 @@
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] ||
-                  [key isEqualToString:@"title"] || [key isEqualToString:@"itemType"] ||
-                  [key isEqualToString:@"initialToggleState"],
+    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
+                  [key isEqualToString:@"itemType"] || [key isEqualToString:@"initialToggleState"],
               @"[RNScreens] Invalid key \"%@\" found in menu item",
               key);
   }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
@@ -10,9 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)getToggleStateForItemWithId:(NSString *)menuItemId initialState:(BOOL)initialState;
 
-- (BOOL)toggleItemWithId:(NSString *)menuId;
+- (BOOL)toggleItemWithId:(NSString *)menuItemId;
 
-- (void)selectItemWithId:(NSString *)menuId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
+- (void)selectItemWithId:(NSString *)menuItemId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign, readwrite) BOOL toggleStateChanged;
 
-- (BOOL)getToggleStateForItemWithId:(NSString *)menuElementId initialState:(BOOL)initialState;
+- (BOOL)getToggleStateForItemWithId:(NSString *)menuItemId initialState:(BOOL)initialState;
 
-- (BOOL)toggleItemWithId:(NSString *)menuElementId;
+- (BOOL)toggleItemWithId:(NSString *)menuId;
 
-- (void)selectItemWithId:(NSString *)menuElementId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
+- (void)selectItemWithId:(NSString *)menuId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSStackHeaderMenuToggleStateTracker : NSObject
+
+@property (nonatomic, assign, readwrite) BOOL toggleStateChanged;
+
+- (BOOL)getToggleStateForItemWithId:(NSString *)menuElementId initialState:(BOOL)initialState;
+
+- (BOOL)toggleItemWithId:(NSString *)menuElementId;
+
+- (void)selectItemWithId:(NSString *)menuElementId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -1,0 +1,53 @@
+#import "RNSStackHeaderMenuToggleStateTracker.h"
+#import <React/RCTAssert.h>
+
+@implementation RNSStackHeaderMenuToggleStateTracker {
+  NSMutableDictionary<NSString *, NSNumber *> *_states;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _states = [NSMutableDictionary new];
+    _toggleStateChanged = NO;
+  }
+  return self;
+}
+
+- (BOOL)getToggleStateForItemWithId:(NSString *)menuElementId initialState:(BOOL)initialState
+{
+  NSNumber *existing = _states[menuElementId];
+  if (existing != nil) {
+    return existing.boolValue;
+  }
+  _states[menuElementId] = @(initialState);
+  return initialState;
+}
+
+- (BOOL)toggleItemWithId:(NSString *)menuElementId
+{
+  NSNumber *existing = _states[menuElementId];
+  BOOL newValue = !(existing != nil ? existing.boolValue : NO);
+  _states[menuElementId] = @(newValue);
+  _toggleStateChanged = YES;
+  return newValue;
+}
+
+- (void)selectItemWithId:(NSString *)menuElementId fromIds:(NSArray<NSString *> *)allItemIdsInMenu
+{
+  BOOL givenItemIsSelected = NO;
+  _toggleStateChanged = ![_states[menuElementId] boolValue];
+  for (NSString *itemId in allItemIdsInMenu) {
+    if ([itemId isEqualToString:menuElementId]) {
+      _states[itemId] = @(YES);
+      givenItemIsSelected = YES;
+    } else {
+      _states[itemId] = @(NO);
+    }
+  }
+
+  RCTAssert(
+      givenItemIsSelected, @"[RNScreens] Attempt to select item \"%@\" that is not present in the list", menuElementId);
+}
+
+@end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -43,10 +43,10 @@
   _toggleStateChanged = ![_states[menuItemId] boolValue];
   for (NSString *itemId in allItemIdsInMenu) {
     if ([itemId isEqualToString:menuItemId]) {
-      _states[itemId] = @(YES);
+      _states[itemId] = @YES;
       givenItemIsSelected = YES;
     } else {
-      _states[itemId] = @(NO);
+      _states[itemId] = @NO;
     }
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -14,6 +14,10 @@
   return self;
 }
 
+/**
+ For singleSelection menus, only one item should have initialState set to true.
+ This is enforced by JS-side and validated by an RCTAssert in RNSStackHeaderMenuCoordinator during menu build.
+ */
 - (BOOL)getToggleStateForItemWithId:(NSString *)menuElementId initialState:(BOOL)initialState
 {
   NSNumber *existing = _states[menuElementId];

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -18,31 +18,31 @@
  For singleSelection menus, only one item should have initialState set to true.
  This is enforced by JS-side and validated by an RCTAssert in RNSStackHeaderMenuCoordinator during menu build.
  */
-- (BOOL)getToggleStateForItemWithId:(NSString *)menuElementId initialState:(BOOL)initialState
+- (BOOL)getToggleStateForItemWithId:(NSString *)menuId initialState:(BOOL)initialState
 {
-  NSNumber *existing = _states[menuElementId];
+  NSNumber *existing = _states[menuId];
   if (existing != nil) {
     return existing.boolValue;
   }
-  _states[menuElementId] = @(initialState);
+  _states[menuId] = @(initialState);
   return initialState;
 }
 
-- (BOOL)toggleItemWithId:(NSString *)menuElementId
+- (BOOL)toggleItemWithId:(NSString *)menuItemId
 {
-  NSNumber *existing = _states[menuElementId];
+  NSNumber *existing = _states[menuItemId];
   BOOL newValue = !(existing != nil ? existing.boolValue : NO);
-  _states[menuElementId] = @(newValue);
+  _states[menuItemId] = @(newValue);
   _toggleStateChanged = YES;
   return newValue;
 }
 
-- (void)selectItemWithId:(NSString *)menuElementId fromIds:(NSArray<NSString *> *)allItemIdsInMenu
+- (void)selectItemWithId:(NSString *)menuItemId fromIds:(NSArray<NSString *> *)allItemIdsInMenu
 {
   BOOL givenItemIsSelected = NO;
-  _toggleStateChanged = ![_states[menuElementId] boolValue];
+  _toggleStateChanged = ![_states[menuItemId] boolValue];
   for (NSString *itemId in allItemIdsInMenu) {
-    if ([itemId isEqualToString:menuElementId]) {
+    if ([itemId isEqualToString:menuItemId]) {
       _states[itemId] = @(YES);
       givenItemIsSelected = YES;
     } else {
@@ -51,7 +51,7 @@
   }
 
   RCTAssert(
-      givenItemIsSelected, @"[RNScreens] Attempt to select item \"%@\" that is not present in the list", menuElementId);
+      givenItemIsSelected, @"[RNScreens] Attempt to select item \"%@\" that is not present in the list", menuItemId);
 }
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -18,13 +18,13 @@
  For singleSelection menus, only one item should have initialState set to true.
  This is enforced by JS-side and validated by an RCTAssert in RNSStackHeaderMenuCoordinator during menu build.
  */
-- (BOOL)getToggleStateForItemWithId:(NSString *)menuId initialState:(BOOL)initialState
+- (BOOL)getToggleStateForItemWithId:(NSString *)menuItemId initialState:(BOOL)initialState
 {
-  NSNumber *existing = _states[menuId];
+  NSNumber *existing = _states[menuItemId];
   if (existing != nil) {
     return existing.boolValue;
   }
-  _states[menuId] = @(initialState);
+  _states[menuItemId] = @(initialState);
   return initialState;
 }
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -66,8 +66,7 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       );
       const menu = findMenuElementByIdInItems(items, menuId);
       if (menu && menu.type === 'menu') {
-        console.log(menu.id);
-        menu.onSelectionChanged?.(selectedMenuItemIds as string[]);
+        menu.onSelectionChanged?.(selectedMenuItemIds);
       }
     },
     [leadingItems, trailingItems],

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -15,7 +15,11 @@ import type {
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
-import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
+import {
+  findMenuElementByIdInItems,
+  sanitizeMenuInitialToggleStates,
+  validateMenuCallbacks,
+} from './utils';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -68,15 +72,25 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     [leadingItems, trailingItems],
   );
 
+  // Sanitize before render so native component receives correct initial toggle states.
+  // Must run before JSX return — useEffect would be too late.
+  const allMenuItems = [
+    ...(leadingItems ?? []),
+    ...(trailingItems ?? []),
+  ].filter(it => it && it.type === 'item');
+  for (const item of allMenuItems) {
+    if ('menu' in item && item.menu) {
+      sanitizeMenuInitialToggleStates(item.menu);
+    }
+  }
+
   useEffect(() => {
-    const allItems = [...(leadingItems ?? []), ...(trailingItems ?? [])].filter(
-      it => it && it.type === 'item',
-    );
-    for (const item of allItems) {
+    for (const item of allMenuItems) {
       if ('menu' in item && item.menu) {
         validateMenuCallbacks(item.menu);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leadingItems, trailingItems]);
 
   return (

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
 import StackHeaderConfigIOSNativeComponent, {
   MenuItemPressEvent,
+  MenuSelectionChangedEvent,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
 import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
@@ -14,7 +15,7 @@ import type {
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
-import { findMenuElementByIdInItems } from './utils';
+import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -52,6 +53,32 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     [leadingItems, trailingItems],
   );
 
+  const handleSelectionChanged = useCallback(
+    (event: NativeSyntheticEvent<MenuSelectionChangedEvent>) => {
+      const { menuElementId, selectedMenuElementIds } = event.nativeEvent;
+      const items = Array.of(
+        ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
+        ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
+      );
+      const menu = findMenuElementByIdInItems(items, menuElementId);
+      if (menu && menu.type === 'menu') {
+        menu.onSelectionChanged?.(selectedMenuElementIds as string[]);
+      }
+    },
+    [leadingItems, trailingItems],
+  );
+
+  useEffect(() => {
+    const allItems = [...(leadingItems ?? []), ...(trailingItems ?? [])].filter(
+      it => it && it.type === 'item',
+    );
+    for (const item of allItems) {
+      if ('menu' in item && item.menu) {
+        validateMenuCallbacks(item.menu);
+      }
+    }
+  }, [leadingItems, trailingItems]);
+
   return (
     <StackHeaderConfigIOSNativeComponent
       {...restProps}
@@ -60,7 +87,8 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
       style={styles.config}
-      onMenuItemPress={handleMenuItemPress}>
+      onMenuItemPress={handleMenuItemPress}
+      onMenuSelectionChanged={handleSelectionChanged}>
       {leadingItems?.map(item => makeItemViewFromItem(item, 'leading'))}
       {titleItem && makeItemViewFromItem(titleItem, 'title')}
       {subtitleItem && makeItemViewFromItem(subtitleItem, 'subtitle')}

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
 import StackHeaderConfigIOSNativeComponent, {
   MenuItemPressEvent,
-  MenuSelectionChangedEvent,
+  MenuSelectionChangeEvent,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
 import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
@@ -53,8 +53,8 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     [leadingItems, trailingItems],
   );
 
-  const handleSelectionChanged = useCallback(
-    (event: NativeSyntheticEvent<MenuSelectionChangedEvent>) => {
+  const handleSelectionChange = useCallback(
+    (event: NativeSyntheticEvent<MenuSelectionChangeEvent>) => {
       const { menuId, selectedMenuItemIds } = event.nativeEvent;
       const items = [
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
@@ -62,7 +62,7 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       ];
       const menu = findMenuElementByIdInItems(items, menuId);
       if (menu && menu.type === 'menu') {
-        menu.onSelectionChanged?.(selectedMenuItemIds);
+        menu.onSelectionChange?.(selectedMenuItemIds);
       }
     },
     [leadingItems, trailingItems],
@@ -91,7 +91,7 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
       largeTitleEnabled={!!largeTitleEnabled}
       style={styles.config}
       onMenuItemPress={handleMenuItemPress}
-      onMenuSelectionChanged={handleSelectionChanged}>
+      onMenuSelectionChange={handleSelectionChange}>
       {leadingItems?.map(item => makeItemViewFromItem(item, 'leading'))}
       {titleItem && makeItemViewFromItem(titleItem, 'title')}
       {subtitleItem && makeItemViewFromItem(subtitleItem, 'subtitle')}

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -53,25 +53,21 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     [leadingItems, trailingItems],
   );
 
-  const handleSelectionChange = useCallback(
-    (event: NativeSyntheticEvent<MenuSelectionChangeEvent>) => {
-      const { menuId, selectedMenuItemIds } = event.nativeEvent;
-      const items = [
-        ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
-        ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
-      ];
-      const menu = findMenuElementByIdInItems(items, menuId);
-      if (menu && menu.type === 'menu') {
-        menu.onSelectionChange?.(selectedMenuItemIds);
-      }
-    },
-    [leadingItems, trailingItems],
-  );
-
   const allMenuItems = [
     ...(leadingItems ?? []),
     ...(trailingItems ?? []),
   ].filter(it => it && it.type === 'item');
+
+  const handleSelectionChange = useCallback(
+    (event: NativeSyntheticEvent<MenuSelectionChangeEvent>) => {
+      const { menuId, selectedMenuItemIds } = event.nativeEvent;
+      const menu = findMenuElementByIdInItems(allMenuItems, menuId);
+      if (menu && menu.type === 'menu') {
+        menu.onSelectionChange?.(selectedMenuItemIds);
+      }
+    },
+    [allMenuItems],
+  );
 
   useEffect(() => {
     for (const item of allMenuItems) {

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -15,11 +15,7 @@ import type {
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
-import {
-  findMenuElementByIdInItems,
-  sanitizeMenuInitialToggleStates,
-  validateMenuCallbacks,
-} from './utils';
+import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -60,10 +56,10 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
   const handleSelectionChanged = useCallback(
     (event: NativeSyntheticEvent<MenuSelectionChangedEvent>) => {
       const { menuId, selectedMenuItemIds } = event.nativeEvent;
-      const items = Array.of(
+      const items = [
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
-      );
+      ];
       const menu = findMenuElementByIdInItems(items, menuId);
       if (menu && menu.type === 'menu') {
         menu.onSelectionChanged?.(selectedMenuItemIds);
@@ -72,17 +68,10 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     [leadingItems, trailingItems],
   );
 
-  // Sanitize before render so native component receives correct initial toggle states.
-  // Must run before JSX return — useEffect would be too late.
   const allMenuItems = [
     ...(leadingItems ?? []),
     ...(trailingItems ?? []),
   ].filter(it => it && it.type === 'item');
-  for (const item of allMenuItems) {
-    if ('menu' in item && item.menu) {
-      sanitizeMenuInitialToggleStates(item.menu);
-    }
-  }
 
   useEffect(() => {
     for (const item of allMenuItems) {

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -59,14 +59,15 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
 
   const handleSelectionChanged = useCallback(
     (event: NativeSyntheticEvent<MenuSelectionChangedEvent>) => {
-      const { menuElementId, selectedMenuElementIds } = event.nativeEvent;
+      const { menuId, selectedMenuItemIds } = event.nativeEvent;
       const items = Array.of(
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
       );
-      const menu = findMenuElementByIdInItems(items, menuElementId);
+      const menu = findMenuElementByIdInItems(items, menuId);
       if (menu && menu.type === 'menu') {
-        menu.onSelectionChanged?.(selectedMenuElementIds as string[]);
+        console.log(menu.id);
+        menu.onSelectionChanged?.(selectedMenuItemIds as string[]);
       }
     },
     [leadingItems, trailingItems],

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -2,50 +2,196 @@ import type { ReactElement } from 'react';
 import type { StackHeaderMenuIOS } from './ios/StackHeaderMenu.ios.types';
 
 export interface StackHeaderBaseItemIOS {
+  /**
+   * @summary A unique identifier within the screen header.
+   *
+   * @platform iOS
+   */
   key: string;
+  /**
+   * @summary A label for the item that is displayed in the header.
+   *
+   * @platform iOS
+   */
   label?: string | undefined;
 }
 
 export interface SupportsMenuIOS {
+  /**
+   * @summary Menu definition for the context menu that appears when item is tapped.
+   *
+   * @platform iOS
+   */
   menu?: StackHeaderMenuIOS | undefined;
 }
 
+/**
+ * @summary Native header item with text label.
+ *
+ * @platform iOS
+ */
 export interface StackHeaderInlineItemIOS
   extends StackHeaderBaseItemIOS,
     SupportsMenuIOS {
+  /**
+   * @summary Marks this object as a header item definition.
+   *
+   * @platform iOS
+   */
   type: 'item';
 }
 
+/**
+ * @summary Header item with custom view.
+ *
+ * @platform iOS
+ */
 export interface StackHeaderInlineCustomItemIOS extends SupportsMenuIOS {
+  /**
+   * @summary A unique identifier within the screen header.
+   *
+   * @platform iOS
+   */
   key: string;
+  /**
+   * @summary Marks this object as a header item definition.
+   *
+   * @platform iOS
+   */
   type: 'item';
+  /**
+   * @summary A function that renders the custom view.
+   *
+   * @description
+   * The subview is sized by React Native's layout engine but positioned by the
+   * platform native layout. Each item's size is calculated independently and will
+   * not respect flex layout. Use static width and height for best results.
+   *
+   * @platform iOS
+   */
   render: () => ReactElement;
 }
 
+/**
+ * @summary A spacer item for visual separation of items.
+ *
+ * @description Separates items defined in {@link StackHeaderConfigPropsIOS.leadingItems | leadingItems}
+ * and {@link StackHeaderConfigPropsIOS.trailingItems | trailingItems}. The fixed size spacing works
+ * for iOS 18 and below, for iOS 26 it only splits liquid glass bubble for two adjacent items.
+ *
+ * @platform iOS
+ */
 interface StackHeaderFixedSpacerItemIOS {
+  /**
+   * @summary A unique identifier within the screen header.
+   *
+   * @platform iOS
+   */
   key: string;
+  /**
+   * @summary Marks this object as a spacer definition.
+   *
+   * @platform iOS
+   */
   type: 'spacer';
+  /**
+   * @summary Marks this object as a fixed-size spacer definition.
+   *
+   * @platform iOS
+   */
   sizing: 'fixed';
+  /**
+   * @summary Specifies space width between adjacent header items.
+   *
+   * @platform iOS
+   */
   width: number;
 }
 
+/**
+ * @summary A spacer item for visual separation of items.
+ *
+ * @description Separates items defined in {@link StackHeaderConfigPropsIOS.leadingItems | leadingItems}
+ * and {@link StackHeaderConfigPropsIOS.trailingItems | trailingItems}.
+ * For iOS 26 it splits liquid glass bubble for two adjacent items.
+ *
+ * @platform iOS
+ */
 interface StackHeaderFlexibleSpacerItemIOS {
+  /**
+   * @summary A unique identifier within the screen header.
+   *
+   * @platform iOS
+   */
   key: string;
+  /**
+   * @summary Marks this object as a spacer definition.
+   *
+   * @platform iOS
+   */
   type: 'spacer';
+  /**
+   * @summary Marks this object as a flexible-size spacer definition.
+   *
+   * @platform iOS
+   */
   sizing: 'flexible';
 }
 
+/**
+ * @summary A header spacer item type
+ */
 export type StackHeaderSpacerItemIOS =
   | StackHeaderFixedSpacerItemIOS
   | StackHeaderFlexibleSpacerItemIOS;
 
 export interface StackHeaderTitleCustomItemIOS {
+  /**
+   * @summary A unique identifier within the screen header.
+   *
+   * @platform iOS
+   */
   key: string;
+  /**
+   * @summary A function that renders the custom view.
+   *
+   * @description
+   * The subview is sized by React Native's layout engine but positioned by the
+   * platform native layout. Each item's size is calculated independently and will
+   * not respect flex layout. Use static width and height for best results.
+   *
+   * Note: Due to layout process limitations, text view will not resize and
+   * ellipsize to fit available space without manually setting desired view
+   * width. For text-only elements that should ellipsize it is recommended to
+   * use regular `title` instead.
+   *
+   * @platform iOS
+   */
   render: () => ReactElement;
 }
 
 export interface StackHeaderConfigPropsIOS {
+  /**
+   * @summary Custom item to display as a subtitle.
+   *
+   * @description Takes precedence over subtitle text.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 26 and higher
+   */
   subtitleItem?: StackHeaderTitleCustomItemIOS | undefined;
+  /**
+   * @summary A list of items placed starting from the leading edge.
+   *
+   * @description Items are placed next to the back button, if present. If there
+   * is not enough space to fit all leading items at once, they are all moved to
+   * overflow menu. This differs from trailing items, which are moved one by one.
+   *
+   * Note: Custom items are not put into the overflow menu, but are removed entirely.
+   *
+   * @platform iOS
+   */
   leadingItems?:
     | (
         | StackHeaderInlineItemIOS
@@ -53,7 +199,22 @@ export interface StackHeaderConfigPropsIOS {
         | StackHeaderSpacerItemIOS
       )[]
     | undefined;
+  /**
+   * @summary Custom item to display as a title.
+   *
+   * @description Takes precedence over title text.
+   *
+   * @platform iOS
+   */
   titleItem?: StackHeaderTitleCustomItemIOS | undefined;
+  /**
+   * @summary A list of items placed starting from the trailing edge.
+   * If there is not enough space to fit some items, they are moved to the overflow menu, one by one.
+   *
+   * Note: Custom items are not put into the overflow menu, but are removed entirely.
+   *
+   * @platform iOS
+   */
   trailingItems?:
     | (
         | StackHeaderInlineItemIOS
@@ -61,9 +222,41 @@ export interface StackHeaderConfigPropsIOS {
         | StackHeaderSpacerItemIOS
       )[]
     | undefined;
+  /**
+   * @summary Large title text, displayed when `largeTitleEnabled = true`.
+   *
+   * @description When ScrollView is present on the screen, large header is displayed only when
+   * fully scrolled to top, otherwise it collapses to regular header. If `largeTitle` is not defined,
+   * it falls back to regular title.
+   *
+   * @platform iOS
+   */
   largeTitle?: string | undefined;
+  /**
+   * @summary Specifies if the header should display the large title. It collapses to a regular header when scrolling.
+   *
+   * @platform iOS
+   */
   largeTitleEnabled?: boolean | undefined;
+  /**
+   * @summary Large subtitle text, displayed when `largeTitleEnabled = true`.
+   *
+   * @description When ScrollView is present on the screen, large header is displayed only when
+   * fully scrolled to top, otherwise it collapses to regular header. If `largeSubititle` is not defined,
+   * it falls back to regular subtitle.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 26 and higher
+   */
   largeSubtitle?: string | undefined;
+  /**
+   * @summary Custom item to display as a subtitle for large header. Takes precedence over largeSubtitle text.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 26 and higher
+   */
   largeSubtitleItem?: StackHeaderTitleCustomItemIOS | undefined;
 }
 

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -1,21 +1,172 @@
+/**
+ * @summary Represents a single actionable item inside a {@link StackHeaderMenuIOS} menu.
+ *
+ * @description
+ * A menu item is a leaf element that the user can interact with.
+ * Depending on its {@link StackHeaderMenuItemIOS.itemType | itemType}, the item
+ * behaves as a one-shot action or a stateful toggle.
+ *
+ * @platform ios
+ */
 export interface StackHeaderMenuItemIOS {
+  /**
+   * @summary Unique identifier of the menu item.
+   *
+   * @description
+   * Used to locate the item inside a menu tree and to identify selected items
+   * in {@link StackHeaderMenuIOS.onSelectionChanged} callback.
+   *
+   * @platform ios
+   */
   id: string;
+  /**
+   * @summary Marks this object as a menu item definition.
+   *
+   * @platform ios
+   */
   type: 'menuItem';
+  /**
+   * @summary Title displayed for the menu item.
+   *
+   * @platform ios
+   */
   title?: string | undefined;
+  /**
+   * @summary Determines the behavior of the menu item.
+   *
+   * @description
+   * The following values are available:
+   * - `action` - a button that fires {@link StackHeaderMenuItemIOS.onPress | onPress}
+   *   when tapped. Cannot be used inside a `singleSelection` menu.
+   * - `toggle` - a stateful item whose on/off state is tracked automatically.
+   *   Toggle items do not fire `onPress`; instead, parent menu
+   *   (or Single Selection Root in case of {@link StackHeaderMenuIOS.singleSelection | singleSelection})
+   *   is passed currently selected items with {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged}
+   * - `automatic` - resolved at render time: becomes `toggle` when the item is
+   *   under `singleSelection` hierarchy, `action` otherwise.
+   *
+   * @default automatic
+   *
+   * @platform ios
+   */
   itemType?: 'action' | 'toggle' | 'automatic' | undefined;
+  /**
+   * @summary Initial on/off state of a toggle item.
+   *
+   * @description
+   * Only meaningful when {@link StackHeaderMenuItemIOS.itemType | itemType}
+   * resolves to `toggle`. Inside a `singleSelection` hierarchy, at most one
+   * item can set this to `true`.
+   *
+   * @default false
+   *
+   * @platform ios
+   */
   initialToggleState?: boolean | undefined;
+  /**
+   * @summary Callback invoked when the menu item is pressed.
+   *
+   * @description
+   * Fires only for items whose effective type is `action`. For toggle items,
+   * this callback will not fire — use
+   * {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged} on the
+   * parent menu instead.
+   *
+   * @platform ios
+   */
   onPress?: () => void | undefined;
 }
 
+/**
+ * @summary Represents a menu (or submenu) that groups
+ * {@link StackHeaderMenuElementIOS} children.
+ *
+ * @description
+ * A menu is a container that can hold both leaf items
+ * ({@link StackHeaderMenuItemIOS}) and nested menus. Set
+ * {@link StackHeaderMenuIOS.singleSelection | singleSelection} to `true` to
+ * make the menu behave like radio group across its entire hierarchy.
+ *
+ * Note: The topmost menu that enables this prop becomes Single Selection Root.
+ * Only the root receives {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged}
+ * event, with exactly one item id passed to the callback. Only one item may be selected,
+ * across the whole hierarchy under Single Selection Root (even when mixing items and nested menus).
+ * Previously selected item is deselected automatically.
+ * Multiple Single Selection Roots may exist only if their hierarchy is completely separate.
+ *
+ * @platform ios
+ */
 export interface StackHeaderMenuIOS {
+  /**
+   * @summary Unique identifier of the menu.
+   *
+   * @description
+   * Used to locate the menu inside a tree and as the reference when querying or
+   * manipulating menu state.
+   *
+   * @platform ios
+   */
   id: string;
+  /**
+   * @summary Marks this object as a menu definition.
+   *
+   * @platform ios
+   */
   type: 'menu';
+  /**
+   * @summary Title displayed for the menu.
+   *
+   * @platform ios
+   */
   title?: string | undefined;
+  /**
+   * @summary Enables single selection mode for this menu and its descendants.
+   *
+   * @description
+   * The topmost menu with `singleSelection` enabled becomes Single Selection Root.
+   * At most one toggle item in the entire hierarchy rooted at this
+   * menu can be selected at a time.
+   *
+   * Items with `itemType` set to `automatic` are resolved to `toggle` inside a
+   * `singleSelection` hierarchy. `action` items are disallowed.
+   *
+   * @default false
+   * @platform ios
+   */
   singleSelection?: boolean | undefined;
+  /**
+   * @summary Child elements of this menu.
+   *
+   * @description
+   * Each child is either a {@link StackHeaderMenuItemIOS} (leaf) or another
+   * {@link StackHeaderMenuIOS}, allowing arbitrarily nested menu trees.
+   *
+   * @platform ios
+   */
   children: StackHeaderMenuElementIOS[];
+  /**
+   * @summary Callback invoked when the set of selected toggle items changes.
+   *
+   * @description
+   * Receives an array of IDs of all currently selected toggle items in this
+   * menu's hierarchy. For Single Selection Root, always returns one item.
+   * When defined below Single Selection Root, the callback doesn't fire.
+   * In regular non-single-selection case, only changes to direct children are reflected.
+   *
+   * @platform ios
+   */
   onSelectionChanged?: (selectedMenuElementIds: string[]) => void;
 }
 
+/**
+ * @summary A menu element type.
+ *
+ * @description
+ * A menu element is either a {@link StackHeaderMenuIOS | menu} (container with
+ * children) or a {@link StackHeaderMenuItemIOS | menu item} (actionable leaf).
+ *
+ * @platform ios
+ */
 export type StackHeaderMenuElementIOS =
   | StackHeaderMenuIOS
   | StackHeaderMenuItemIOS;

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -2,6 +2,8 @@ export interface StackHeaderMenuItemIOS {
   id: string;
   type: 'menuItem';
   title?: string | undefined;
+  itemType?: 'action' | 'toggle' | 'inherit' | undefined;
+  initialToggleState?: boolean | undefined;
   onPress?: () => void | undefined;
 }
 
@@ -9,7 +11,9 @@ export interface StackHeaderMenuIOS {
   id: string;
   type: 'menu';
   title?: string | undefined;
+  singleSelection?: boolean | undefined;
   children: StackHeaderMenuElementIOS[];
+  onSelectionChanged?: (selectedMenuElementIds: string[]) => void;
 }
 
 export type StackHeaderMenuElementIOS =

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -14,7 +14,7 @@ export interface StackHeaderMenuItemIOS {
    *
    * @description
    * Used to locate the item inside a menu tree and to identify selected items
-   * in {@link StackHeaderMenuIOS.onSelectionChanged} callback.
+   * in {@link StackHeaderMenuIOS.onSelectionChange} callback.
    *
    * @platform ios
    */
@@ -41,7 +41,7 @@ export interface StackHeaderMenuItemIOS {
    * - `toggle` - a stateful item whose on/off state is tracked automatically.
    *   Toggle items do not fire `onPress`; instead, parent menu
    *   (or Single Selection Root in case of {@link StackHeaderMenuIOS.singleSelection | singleSelection})
-   *   is passed currently selected items with {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged}
+   *   is passed currently selected items with {@link StackHeaderMenuIOS.onSelectionChange | onSelectionChange}
    * - `automatic` - resolved at render time: becomes `toggle` when the item is
    *   under `singleSelection` hierarchy, `action` otherwise.
    *
@@ -69,7 +69,7 @@ export interface StackHeaderMenuItemIOS {
    * @description
    * Fires only for items whose effective type is `action`. For toggle items,
    * this callback will not fire — use
-   * {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged} on the
+   * {@link StackHeaderMenuIOS.onSelectionChange | onSelectionChange} on the
    * parent menu instead.
    *
    * @platform ios
@@ -88,7 +88,7 @@ export interface StackHeaderMenuItemIOS {
  * make the menu behave like radio group across its entire hierarchy.
  *
  * Note: The topmost menu that enables this prop becomes Single Selection Root.
- * Only the root receives {@link StackHeaderMenuIOS.onSelectionChanged | onSelectionChanged}
+ * Only the root receives {@link StackHeaderMenuIOS.onSelectionChange | onSelectionChange}
  * event, with exactly one item id passed to the callback. Only one item may be selected,
  * across the whole hierarchy under Single Selection Root (even when mixing items and nested menus).
  * Previously selected item is deselected automatically.
@@ -155,7 +155,7 @@ export interface StackHeaderMenuIOS {
    *
    * @platform ios
    */
-  onSelectionChanged?: (selectedMenuElementIds: string[]) => void;
+  onSelectionChange?: (selectedMenuElementIds: string[]) => void;
 }
 
 /**

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -2,7 +2,7 @@ export interface StackHeaderMenuItemIOS {
   id: string;
   type: 'menuItem';
   title?: string | undefined;
-  itemType?: 'action' | 'toggle' | 'inherit' | undefined;
+  itemType?: 'action' | 'toggle' | 'automatic' | undefined;
   initialToggleState?: boolean | undefined;
   onPress?: () => void | undefined;
 }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -38,3 +38,39 @@ export function findMenuElementById(
 
   return null;
 }
+
+export function validateMenuCallbacks(menu: StackHeaderMenu): void {
+  walkMenuTreeAndValidateCallbacks(menu, false);
+}
+
+function walkMenuTreeAndValidateCallbacks(
+  menu: StackHeaderMenu,
+  insideSingleSelection: boolean,
+): void {
+  // If this menu starts a singleSelection hierarchy, mark it.
+  // If already inside one, stay inside.
+  const isInsideSingleSelection = insideSingleSelection || menu.singleSelection;
+
+  for (const child of menu.children) {
+    if (child.type === 'menuItem') {
+      if (child.itemType === 'toggle') {
+        console.warn(
+          `[RNScreens] onPress on menu item "${child.menuElementId}" will not fire ` +
+            'because it is a toggle. Use onSelectionChanged on parent menu instead.',
+        );
+      }
+    }
+
+    if (child.type === 'menu') {
+      if (isInsideSingleSelection && child.onSelectionChanged) {
+        console.warn(
+          `[RNScreens] onSelectionChanged on menu "${child.menuElementId}" will not fire ` +
+            'because it is nested inside a singleSelection hierarchy. ' +
+            'Place onSelectionChanged on the topmost singleSelection menu instead.',
+        );
+      }
+
+      walkMenuTreeAndValidateCallbacks(child, isInsideSingleSelection ?? false);
+    }
+  }
+}

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -65,17 +65,17 @@ function walkMenuTreeAndValidateCallbacks(
       ) {
         console.warn(
           `[RNScreens] onPress on menu item "${child.id}" will not fire ` +
-            'because it is a toggle. Use onSelectionChanged on parent menu instead.',
+            'because it is a toggle. Use onSelectionChange on parent menu instead.',
         );
       }
     }
 
     if (child.type === 'menu') {
-      if (isInsideSingleSelection && child.onSelectionChanged) {
+      if (isInsideSingleSelection && child.onSelectionChange) {
         console.warn(
-          `[RNScreens] onSelectionChanged on menu "${child.id}" will not fire ` +
+          `[RNScreens] onSelectionChange on menu "${child.id}" will not fire ` +
             'because it is nested inside a singleSelection hierarchy. ' +
-            'Place onSelectionChanged on the topmost singleSelection menu instead.',
+            'Place onSelectionChange on the topmost singleSelection menu instead.',
         );
       }
 

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -1,4 +1,7 @@
-import { StackHeaderMenuElementIOS } from './ios/StackHeaderMenu.ios.types';
+import {
+  StackHeaderMenuElementIOS,
+  StackHeaderMenuIOS,
+} from './ios/StackHeaderMenu.ios.types';
 import { SupportsMenuIOS } from './StackHeaderConfig.ios.types';
 
 export function findMenuElementByIdInItems(
@@ -39,7 +42,7 @@ export function findMenuElementById(
   return null;
 }
 
-export function validateMenuCallbacks(menu: StackHeaderMenu): void {
+export function validateMenuCallbacks(menu: StackHeaderMenuIOS): void {
   walkMenuTreeAndValidateCallbacks(menu, false);
 }
 
@@ -51,12 +54,14 @@ export function validateMenuCallbacks(menu: StackHeaderMenu): void {
  *
  * Must be called before the menu data reaches the native component.
  */
-export function sanitizeMenuInitialToggleStates(menu: StackHeaderMenu): void {
+export function sanitizeMenuInitialToggleStates(
+  menu: StackHeaderMenuIOS,
+): void {
   walkMenuTreeAndSanitizeInitialToggleStates(menu, false, null);
 }
 
 function walkMenuTreeAndValidateCallbacks(
-  menu: StackHeaderMenu,
+  menu: StackHeaderMenuIOS,
   insideSingleSelection: boolean,
 ): void {
   // If this menu starts a singleSelection hierarchy, mark it.
@@ -72,7 +77,7 @@ function walkMenuTreeAndValidateCallbacks(
         child.onPress
       ) {
         console.warn(
-          `[RNScreens] onPress on menu item "${child.menuElementId}" will not fire ` +
+          `[RNScreens] onPress on menu item "${child.id}" will not fire ` +
             'because it is a toggle. Use onSelectionChanged on parent menu instead.',
         );
       }
@@ -81,7 +86,7 @@ function walkMenuTreeAndValidateCallbacks(
     if (child.type === 'menu') {
       if (isInsideSingleSelection && child.onSelectionChanged) {
         console.warn(
-          `[RNScreens] onSelectionChanged on menu "${child.menuElementId}" will not fire ` +
+          `[RNScreens] onSelectionChanged on menu "${child.id}" will not fire ` +
             'because it is nested inside a singleSelection hierarchy. ' +
             'Place onSelectionChanged on the topmost singleSelection menu instead.',
         );
@@ -93,7 +98,7 @@ function walkMenuTreeAndValidateCallbacks(
 }
 
 function walkMenuTreeAndSanitizeInitialToggleStates(
-  menu: StackHeaderMenu,
+  menu: StackHeaderMenuIOS,
   insideSingleSelection: boolean,
   initialSingleSelectionStateClaimed: { claimed: boolean } | null,
 ): void {
@@ -116,7 +121,7 @@ function walkMenuTreeAndSanitizeInitialToggleStates(
           console.warn(
             `[RNScreens] Multiple items with initialToggleState: true in singleSelection ` +
               `menu. Only the first one will be honored. ` +
-              `Item "${child.menuElementId}" will be initialized as off.`,
+              `Item "${child.id}" will be initialized as off.`,
           );
           child.initialToggleState = false;
         } else {

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -43,6 +43,18 @@ export function validateMenuCallbacks(menu: StackHeaderMenu): void {
   walkMenuTreeAndValidateCallbacks(menu, false);
 }
 
+/**
+ * In a singleSelection hierarchy, only one item can have initialToggleState: true.
+ * UIKit honors only the first one and native code asserts that this is the case.
+ * This function enforces the constraint by keeping only the first
+ * initialToggleState: true per singleSelection root and warning about the rest.
+ *
+ * Must be called before the menu data reaches the native component.
+ */
+export function sanitizeMenuInitialToggleStates(menu: StackHeaderMenu): void {
+  walkMenuTreeAndSanitizeInitialToggleStates(menu, false, null);
+}
+
 function walkMenuTreeAndValidateCallbacks(
   menu: StackHeaderMenu,
   insideSingleSelection: boolean,
@@ -71,6 +83,49 @@ function walkMenuTreeAndValidateCallbacks(
       }
 
       walkMenuTreeAndValidateCallbacks(child, isInsideSingleSelection ?? false);
+    }
+  }
+}
+
+function walkMenuTreeAndSanitizeInitialToggleStates(
+  menu: StackHeaderMenu,
+  insideSingleSelection: boolean,
+  initialSingleSelectionStateClaimed: { claimed: boolean } | null,
+): void {
+  // When entering a new singleSelection root, create a fresh flag.
+  // Multiple independent singleSelection roots each get their own.
+  let resolvedInitialSingleSelectionStateClaimed =
+    initialSingleSelectionStateClaimed;
+  if (!insideSingleSelection && menu.singleSelection) {
+    resolvedInitialSingleSelectionStateClaimed = { claimed: false };
+  }
+  const isInsideSingleSelection = insideSingleSelection || menu.singleSelection;
+
+  for (const child of menu.children) {
+    if (child.type === 'menuItem') {
+      if (
+        resolvedInitialSingleSelectionStateClaimed != null &&
+        child.initialToggleState
+      ) {
+        if (resolvedInitialSingleSelectionStateClaimed.claimed) {
+          console.warn(
+            `[RNScreens] Multiple items with initialToggleState: true in singleSelection ` +
+              `menu. Only the first one will be honored. ` +
+              `Item "${child.menuElementId}" will be initialized as off.`,
+          );
+          child.initialToggleState = false;
+        } else {
+          resolvedInitialSingleSelectionStateClaimed.claimed = true;
+        }
+      }
+    }
+
+    if (child.type === 'menu') {
+      walkMenuTreeAndSanitizeInitialToggleStates(
+        child,
+        isInsideSingleSelection ?? false,
+        resolvedInitialSingleSelectionStateClaimed,
+      );
     }
   }
 }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -61,11 +61,16 @@ function walkMenuTreeAndValidateCallbacks(
 ): void {
   // If this menu starts a singleSelection hierarchy, mark it.
   // If already inside one, stay inside.
-  const isInsideSingleSelection = insideSingleSelection || menu.singleSelection;
+  const isInsideSingleSelection =
+    insideSingleSelection || !!menu.singleSelection;
 
   for (const child of menu.children) {
     if (child.type === 'menuItem') {
-      if (child.itemType === 'toggle') {
+      if (
+        (child.itemType === 'toggle' ||
+          (isInsideSingleSelection && child.itemType === 'inherit')) &&
+        child.onPress
+      ) {
         console.warn(
           `[RNScreens] onPress on menu item "${child.menuElementId}" will not fire ` +
             'because it is a toggle. Use onSelectionChanged on parent menu instead.',

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -73,7 +73,8 @@ function walkMenuTreeAndValidateCallbacks(
     if (child.type === 'menuItem') {
       if (
         (child.itemType === 'toggle' ||
-          (isInsideSingleSelection && child.itemType === 'inherit')) &&
+          (isInsideSingleSelection &&
+            (child.itemType ?? 'inherit') === 'inherit')) &&
         child.onPress
       ) {
         console.warn(

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -46,20 +46,6 @@ export function validateMenuCallbacks(menu: StackHeaderMenuIOS): void {
   walkMenuTreeAndValidateCallbacks(menu, false);
 }
 
-/**
- * In a singleSelection hierarchy, only one item can have initialToggleState: true.
- * UIKit honors only the first one and native code asserts that this is the case.
- * This function enforces the constraint by keeping only the first
- * initialToggleState: true per singleSelection root and warning about the rest.
- *
- * Must be called before the menu data reaches the native component.
- */
-export function sanitizeMenuInitialToggleStates(
-  menu: StackHeaderMenuIOS,
-): void {
-  walkMenuTreeAndSanitizeInitialToggleStates(menu, false, null);
-}
-
 function walkMenuTreeAndValidateCallbacks(
   menu: StackHeaderMenuIOS,
   insideSingleSelection: boolean,
@@ -93,50 +79,7 @@ function walkMenuTreeAndValidateCallbacks(
         );
       }
 
-      walkMenuTreeAndValidateCallbacks(child, isInsideSingleSelection ?? false);
-    }
-  }
-}
-
-function walkMenuTreeAndSanitizeInitialToggleStates(
-  menu: StackHeaderMenuIOS,
-  insideSingleSelection: boolean,
-  initialSingleSelectionStateClaimed: { claimed: boolean } | null,
-): void {
-  // When entering a new singleSelection root, create a fresh flag.
-  // Multiple independent singleSelection roots each get their own.
-  let resolvedInitialSingleSelectionStateClaimed =
-    initialSingleSelectionStateClaimed;
-  if (!insideSingleSelection && menu.singleSelection) {
-    resolvedInitialSingleSelectionStateClaimed = { claimed: false };
-  }
-  const isInsideSingleSelection = insideSingleSelection || menu.singleSelection;
-
-  for (const child of menu.children) {
-    if (child.type === 'menuItem') {
-      if (
-        resolvedInitialSingleSelectionStateClaimed != null &&
-        child.initialToggleState
-      ) {
-        if (resolvedInitialSingleSelectionStateClaimed.claimed) {
-          console.warn(
-            `[RNScreens] Multiple items with initialToggleState: true in singleSelection ` +
-              `menu. Only the first one will be honored. ` +
-              `Item "${child.id}" will be initialized as off.`,
-          );
-          child.initialToggleState = false;
-        } else {
-          resolvedInitialSingleSelectionStateClaimed.claimed = true;
-        }
-      }
-    }
-
-    if (child.type === 'menu') {
-      walkMenuTreeAndSanitizeInitialToggleStates(
-        child,
-        isInsideSingleSelection ?? false,
-        resolvedInitialSingleSelectionStateClaimed,
-      );
+      walkMenuTreeAndValidateCallbacks(child, isInsideSingleSelection);
     }
   }
 }

--- a/src/components/gamma/stack/header/utils.ts
+++ b/src/components/gamma/stack/header/utils.ts
@@ -60,7 +60,7 @@ function walkMenuTreeAndValidateCallbacks(
       if (
         (child.itemType === 'toggle' ||
           (isInsideSingleSelection &&
-            (child.itemType ?? 'inherit') === 'inherit')) &&
+            (child.itemType ?? 'automatic') === 'automatic')) &&
         child.onPress
       ) {
         console.warn(

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -5,7 +5,7 @@ import { codegenNativeComponent } from 'react-native';
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
-export type MenuSelectionChangedEvent = Readonly<{
+export type MenuSelectionChangeEvent = Readonly<{
   menuId: string;
   selectedMenuItemIds: string[];
 }>;
@@ -23,8 +23,8 @@ export interface NativeProps extends ViewProps {
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
 
   onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;
-  onMenuSelectionChanged?:
-    | CT.DirectEventHandler<MenuSelectionChangedEvent>
+  onMenuSelectionChange?:
+    | CT.DirectEventHandler<MenuSelectionChangeEvent>
     | undefined;
 }
 

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -6,8 +6,8 @@ import { codegenNativeComponent } from 'react-native';
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
 export type MenuSelectionChangedEvent = Readonly<{
-  menuElementId: string;
-  selectedMenuElementIds: string[];
+  menuId: string;
+  selectedMenuItemIds: string[];
 }>;
 
 export interface NativeProps extends ViewProps {

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -5,6 +5,11 @@ import { codegenNativeComponent } from 'react-native';
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
+export type MenuSelectionChangedEvent = Readonly<{
+  menuElementId: string;
+  selectedMenuElementIds: string[];
+}>;
+
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
   subtitle?: string | undefined;
@@ -18,6 +23,9 @@ export interface NativeProps extends ViewProps {
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
 
   onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;
+  onMenuSelectionChanged?:
+    | CT.DirectEventHandler<MenuSelectionChangedEvent>
+    | undefined;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSStackHeaderConfigIOS', {


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1187
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1137
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1188

## Description

This PR adds support for toggleable items with optional singleSelection flag.
- by default, items are actions that can be passed an `onPress` callback
- when `itemType` is set to `'toggle'`, then it doesn't react to `onPress` but rather its parent menu sends an `onSelectionChanged` callback for all child items of toggle type (this means that menu can contain both actions and toggles, and `onSelectionChanged` sends only the ids of toggles)
- when menu is set to singleSelection, then the whole hierarchy below acts as a one big radio group
  - each child is `toggle` by default and **cannot** be set to `action` (issues a warning)
  - only one child in one nested menu can be selected at any point in time
  - only one child can have initialToggleState set to true
  - `onSelectionChanged` is triggered only when selected value changes, clicking on the same item does nothing

## Changes

- added `itemType: 'action' | 'toggle' | 'automatic' | undefined` prop, `automatic` by default, which gives `toggle` for `singleSelection` menus and `action` otherwise
- added `initialToggleState` for toggles (for `singleSelection`, user is warned for setting it to true for multiple items, only first is applied)
- added `onSelectionChanged` callback to menu

## Before & after - visual documentation

<img width="340" height="228" alt="image" src="https://github.com/user-attachments/assets/036c1d0e-e3b6-4bd3-959e-04fa345e6b11" />


## Test plan

See test-stack-header-menu-ios SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
