### PR TITLE
refactor(test, iOS): resolve Detox simulator target so device name and OS version stay in sync

### DIFF
--- a/scripts/e2e/detox-utils.cjs
+++ b/scripts/e2e/detox-utils.cjs
@@ -39,13 +39,13 @@ const testButlerApkPath = isRunningCI
  *
  * * `RNS_IOS_VERSION` env var can be specified to request particular iOS version
  * for the given simulator. Note that required SDK & simulators must be installed.
- * Example: RNS_IOS_VERSION="iOS 26.1"
+ * Example: RNS_IOS_VERSION="26.1"
  *
  * * Remember:
  * Device versions are assigned to iOS versions.
  * That means running a version that has never been available
  * on a given device will result in an error.
- * Example: `RNS_IOS_VERSION="iOS 18.6" RNS_APPLE_SIM_NAME="iPhone 17 Pro" yarn test-e2e-ios` will fail
+ * Example: `RNS_IOS_VERSION="18.6" RNS_APPLE_SIM_NAME="iPhone 17 Pro" yarn test-e2e-ios` will fail
  * as iPhone 17 Pro was released with iOS 26
  *
  * @param {string} applicationName name (FabricExample)

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -1,46 +1,212 @@
+const { getCommandLineResponse } = require('./command-line-helpers');
+
 const DEFAULT_APPLE_SIMULATOR_NAME = 'iPhone 17';
 const DEFAULT_IOS_VERSION = 'iOS 26.2';
+
+const envVarKeys = /** @type {const} */ ({
+  simName: 'RNS_APPLE_SIM_NAME',
+  iosVersion: 'RNS_IOS_VERSION',
+});
+
+/**
+ * @return {string | undefined} validated simulator name from env, or undefined
+ */
+function readSimulatorNameEnv() {
+  const passedDevice = process.env[envVarKeys.simName];
+  if (!passedDevice) {
+    return undefined;
+  }
+  if (/^(iPhone|iPad)\s.+/.test(passedDevice)) {
+    return passedDevice;
+  }
+  throw new Error(
+    `Environment variable ${envVarKeys.simName} should be "iPhone xyz" or "iPad xyz".`,
+  );
+}
+
+/**
+ * @return {`iOS ${string}` | undefined} validated iOS version from env, or undefined
+ */
+function readIOSVersionEnv() {
+  const passedVersion = process.env[envVarKeys.iosVersion];
+  if (!passedVersion) {
+    return undefined;
+  }
+  if (/^iOS\s\S+/.test(passedVersion)) {
+    return /** @type {`iOS ${string}`} */ (passedVersion);
+  }
+  throw new Error(
+    `Environment variable ${envVarKeys.iosVersion} should be "iOS xyz".`,
+  );
+}
+
+/**
+ * Maps a CoreSimulator runtime identifier to a human iOS version string.
+ * "com.apple.CoreSimulator.SimRuntime.iOS-26-2" -> "iOS 26.2"
+ * @param {string} runtimeId
+ * @return {`iOS ${string}` | undefined}
+ */
+function runtimeIdToIOSVersion(runtimeId) {
+  const match = /SimRuntime\.iOS-(\d+(?:-\d+)*)$/.exec(runtimeId);
+  if (!match) {
+    return undefined;
+  }
+  return /** @type {`iOS ${string}`} */ (`iOS ${match[1].replace(/-/g, '.')}`);
+}
+
+/**
+ * @typedef {{ name: string, os: `iOS ${string}` }} SimulatorTarget
+ */
+
+/**
+ * Queries `simctl` for currently booted, available iOS simulators.
+ * @return {SimulatorTarget[]}
+ */
+function listBootedAppleSimulators() {
+  let parsed;
+  try {
+    parsed = JSON.parse(
+      getCommandLineResponse('xcrun simctl list devices booted --json'),
+    );
+  } catch (error) {
+    console.warn(
+      `Could not query booted iOS simulators, falling back to defaults. Cause:\n${error}`,
+    );
+    return [];
+  }
+  const devicesByRuntime = parsed.devices ?? {};
+  /** @type {SimulatorTarget[]} */
+  const booted = [];
+  for (const [runtimeId, devices] of Object.entries(devicesByRuntime)) {
+    const os = runtimeIdToIOSVersion(runtimeId);
+    if (!os) {
+      continue;
+    }
+    for (const device of /** @type {any[]} */ (devices)) {
+      if (device.state === 'Booted' && device.isAvailable !== false) {
+        booted.push({ name: device.name, os });
+      }
+    }
+  }
+  return booted;
+}
+
+/**
+ * Reads the active Detox configuration name from the `--configuration <name>`
+ * CLI flag or the `DETOX_CONFIGURATION` env var (Detox sets the latter in the
+ * worker processes it spawns). Returns undefined when neither is present, so
+ * callers can fall back to scanning argv for indirect invocations.
+ * @return {string | undefined}
+ */
+function readDetoxConfigName() {
+  const fromEnv = process.env.DETOX_CONFIGURATION;
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const flagIndex = process.argv.indexOf('--configuration');
+  if (flagIndex !== -1 && flagIndex + 1 < process.argv.length) {
+    return process.argv[flagIndex + 1];
+  }
+  return undefined;
+}
+
+/** @type {SimulatorTarget | undefined} */
+let cachedTarget;
+
+/**
+ * Resolves a single simulator target so that the device name and iOS version
+ * always come from the same simulator.
+ *
+ * Resolution order:
+ * 1. `RNS_APPLE_SIM_NAME` / `RNS_IOS_VERSION` env vars (explicit intent).
+ * 2. The default device/version, if it is already booted.
+ * 3. The first booted simulator, so tests can run on whatever is available.
+ * 4. The defaults, so Detox boots one when nothing is running.
+ *
+ * @return {SimulatorTarget}
+ */
+function resolveSimulatorTarget() {
+  if (cachedTarget !== undefined) {
+    return cachedTarget;
+  }
+
+  const envName = readSimulatorNameEnv();
+  const envVersion = readIOSVersionEnv();
+
+  // Explicit selection via env var(s) wins and disables auto-detection.
+  if (envName || envVersion) {
+    cachedTarget = {
+      name: envName ?? DEFAULT_APPLE_SIMULATOR_NAME,
+      os: envVersion ?? DEFAULT_IOS_VERSION,
+    };
+    return cachedTarget;
+  }
+
+  // Only probe `simctl` for iOS simulator configurations - mirrors the Android
+  // side guarding on the active Detox configuration. Prefer the resolved
+  // configuration name (flag/env) and fall back to scanning argv so indirect
+  // invocations that don't surface the name still work.
+  const detoxConfig = readDetoxConfigName();
+  const isIOSSimulatorConfig =
+    detoxConfig !== undefined
+      ? detoxConfig.includes('ios.sim')
+      : process.argv.some(runtimeArg => runtimeArg.includes('ios.sim'));
+  if (!isIOSSimulatorConfig) {
+    cachedTarget = {
+      name: DEFAULT_APPLE_SIMULATOR_NAME,
+      os: DEFAULT_IOS_VERSION,
+    };
+    return cachedTarget;
+  }
+
+  const booted = listBootedAppleSimulators();
+
+  const defaultBooted = booted.find(
+    sim =>
+      sim.name === DEFAULT_APPLE_SIMULATOR_NAME &&
+      sim.os === DEFAULT_IOS_VERSION,
+  );
+
+  if (defaultBooted) {
+    // Preferred default is booted - use it.
+    cachedTarget = defaultBooted;
+  } else if (booted.length > 0) {
+    // Fall back to whatever is booted so the test run can start.
+    cachedTarget = booted[0];
+    console.log(
+      `Default simulator "${DEFAULT_APPLE_SIMULATOR_NAME}" (${DEFAULT_IOS_VERSION}) is not booted. ` +
+        `Using booted simulator "${cachedTarget.name}" (${cachedTarget.os}) instead.`,
+    );
+  } else {
+    // Nothing booted - keep defaults so Detox boots one.
+    cachedTarget = {
+      name: DEFAULT_APPLE_SIMULATOR_NAME,
+      os: DEFAULT_IOS_VERSION,
+    };
+  }
+  return cachedTarget;
+}
 
 /**
  * @return {string}
  */
 function resolveAppleSimulatorName() {
-  const envVariableKey = 'RNS_APPLE_SIM_NAME';
-  const passedDevice = process.env[envVariableKey];
-  if (passedDevice) {
-    if (/^(iPhone|iPad)\s.+/.test(passedDevice)) {
-      return passedDevice;
-    } else {
-      throw new Error(
-        `Environment variable ${envVariableKey} should be "iPhone xyz" or "iPad xyz".`,
-      );
-    }
-  }
-  return DEFAULT_APPLE_SIMULATOR_NAME;
+  return resolveSimulatorTarget().name;
 }
+
 /**
  * @return {`iOS ${string}`} requested version of ios, or default if not specified
  */
 function getIOSVersion() {
-  const envVariableKey = 'RNS_IOS_VERSION';
-  const passedVersion = process.env[envVariableKey];
-  if (passedVersion) {
-    if (/^(iOS)\s.+/.test(passedVersion)) {
-      return /** @type {`iOS ${string}`} */ (passedVersion);
-    } else {
-      throw new Error(
-        `Environment variable ${envVariableKey} should be "iOS xyz".`,
-      );
-    }
-  }
-  return DEFAULT_IOS_VERSION;
+  return resolveSimulatorTarget().os;
 }
 
 /**
  * @return { string } iOS version number (e.g. 26.2)
  */
 function getIOSVersionNumber() {
-  return getIOSVersion().replace('iOS', '').trim();
+  // getIOSVersion() always returns "iOS <version>" per the SimulatorTarget type.
+  return getIOSVersion().slice('iOS '.length);
 }
 
 module.exports = {

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -41,57 +41,6 @@ function readIOSVersionEnv() {
 }
 
 /**
- * Maps a CoreSimulator runtime identifier to a human iOS version string.
- * "com.apple.CoreSimulator.SimRuntime.iOS-26-2" -> "iOS 26.2"
- * @param {string} runtimeId
- * @return {`iOS ${string}` | undefined}
- */
-function runtimeIdToIOSVersion(runtimeId) {
-  const match = /SimRuntime\.iOS-(\d+(?:-\d+)*)$/.exec(runtimeId);
-  if (!match) {
-    return undefined;
-  }
-  return /** @type {`iOS ${string}`} */ (`iOS ${match[1].replace(/-/g, '.')}`);
-}
-
-/**
- * @typedef {{ name: string, os: `iOS ${string}` }} SimulatorTarget
- */
-
-/**
- * Queries `simctl` for currently booted, available iOS simulators.
- * @return {SimulatorTarget[]}
- */
-function listBootedAppleSimulators() {
-  let parsed;
-  try {
-    parsed = JSON.parse(
-      getCommandLineResponse('xcrun simctl list devices booted --json'),
-    );
-  } catch (error) {
-    console.warn(
-      `Could not query booted iOS simulators, falling back to defaults. Cause:\n${error}`,
-    );
-    return [];
-  }
-  const devicesByRuntime = parsed.devices ?? {};
-  /** @type {SimulatorTarget[]} */
-  const booted = [];
-  for (const [runtimeId, devices] of Object.entries(devicesByRuntime)) {
-    const os = runtimeIdToIOSVersion(runtimeId);
-    if (!os) {
-      continue;
-    }
-    for (const device of /** @type {any[]} */ (devices)) {
-      if (device.state === 'Booted' && device.isAvailable !== false) {
-        booted.push({ name: device.name, os });
-      }
-    }
-  }
-  return booted;
-}
-
-/**
  * Reads the active Detox configuration name from the `--configuration <name>`
  * CLI flag or the `DETOX_CONFIGURATION` env var (Detox sets the latter in the
  * worker processes it spawns). Returns undefined when neither is present, so
@@ -110,6 +59,147 @@ function readDetoxConfigName() {
   return undefined;
 }
 
+/**
+ * @return {boolean} whether the active Detox configuration targets an iOS
+ * simulator. When unknown we assume it does, so the iOS resolution still runs.
+ */
+function isIOSSimulatorConfig() {
+  const detoxConfig = readDetoxConfigName();
+  if (detoxConfig !== undefined) {
+    return detoxConfig.includes('ios.sim');
+  }
+  // Fall back to scanning argv for indirect invocations that don't surface the
+  // configuration name.
+  return process.argv.some(runtimeArg => runtimeArg.includes('ios.sim'));
+}
+
+/**
+ * Maps a CoreSimulator runtime identifier to a human iOS version string.
+ * "com.apple.CoreSimulator.SimRuntime.iOS-26-2" -> "iOS 26.2"
+ * @param {string} runtimeId
+ * @return {`iOS ${string}` | undefined}
+ */
+function runtimeIdToIOSVersion(runtimeId) {
+  const match = /SimRuntime\.iOS-(\d+(?:-\d+)*)$/.exec(runtimeId);
+  if (!match) {
+    return undefined;
+  }
+  return /** @type {`iOS ${string}`} */ (`iOS ${match[1].replace(/-/g, '.')}`);
+}
+
+/**
+ * @typedef {{ name: string, os: `iOS ${string}`, booted: boolean }} InstalledSimulator
+ */
+
+/** @type {InstalledSimulator[] | undefined} */
+let cachedSimulators;
+
+/**
+ * Queries `simctl` once for created, available simulator instances. Results are
+ * memoized for the process lifetime.
+ *
+ * Note: only instances that actually exist are returned, because Detox finds
+ * devices through `applesimutils`, which matches existing simulators and does
+ * NOT create new ones from a device type + runtime pairing.
+ * @return {InstalledSimulator[]}
+ */
+function listInstalledSimulators() {
+  if (cachedSimulators !== undefined) {
+    return cachedSimulators;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(
+      getCommandLineResponse('xcrun simctl list devices available --json'),
+    );
+  } catch (error) {
+    console.warn(
+      `Could not query iOS simulators, falling back to defaults. Cause:\n${error}`,
+    );
+    cachedSimulators = [];
+    return cachedSimulators;
+  }
+
+  /** @type {InstalledSimulator[]} */
+  const simulators = [];
+  const devicesByRuntime = parsed.devices ?? {};
+  for (const [runtimeId, devices] of Object.entries(devicesByRuntime)) {
+    const os = runtimeIdToIOSVersion(runtimeId);
+    if (!os) {
+      continue;
+    }
+    for (const device of /** @type {any[]} */ (devices)) {
+      if (device.isAvailable === false) {
+        continue;
+      }
+      simulators.push({
+        name: device.name,
+        os,
+        booted: device.state === 'Booted',
+      });
+    }
+  }
+
+  cachedSimulators = simulators;
+  return cachedSimulators;
+}
+
+/**
+ * Compares two "iOS x.y[.z]" strings numerically. Returns a positive number when
+ * `a` is newer than `b`.
+ * @param {`iOS ${string}`} a
+ * @param {`iOS ${string}`} b
+ * @return {number}
+ */
+function compareIOSVersions(a, b) {
+  const toParts = (/** @type {string} */ value) =>
+    value
+      .replace(/^iOS\s+/, '')
+      .split('.')
+      .map(part => Number.parseInt(part, 10) || 0);
+  const aParts = toParts(a);
+  const bParts = toParts(b);
+  const length = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < length; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Picks the preferred simulator from a non-empty list: newest iOS version
+ * first, then iPhone models over others, keeping `simctl` order as the final
+ * tiebreak.
+ * @param {InstalledSimulator[]} simulators non-empty list
+ * @return {InstalledSimulator}
+ */
+function pickPreferredSimulator(simulators) {
+  return simulators.reduce((best, sim) => {
+    const osDiff = compareIOSVersions(sim.os, best.os);
+    if (osDiff > 0) {
+      return sim;
+    }
+    if (osDiff < 0) {
+      return best;
+    }
+    // Same OS - prefer an iPhone over any other device family.
+    const simIsIPhone = sim.name.startsWith('iPhone');
+    const bestIsIPhone = best.name.startsWith('iPhone');
+    if (simIsIPhone && !bestIsIPhone) {
+      return sim;
+    }
+    return best;
+  });
+}
+
+/**
+ * @typedef {{ name: string, os: `iOS ${string}` }} SimulatorTarget
+ */
+
 /** @type {SimulatorTarget | undefined} */
 let cachedTarget;
 
@@ -117,11 +207,13 @@ let cachedTarget;
  * Resolves a single simulator target so that the device name and iOS version
  * always come from the same simulator.
  *
- * Resolution order:
- * 1. `RNS_APPLE_SIM_NAME` / `RNS_IOS_VERSION` env vars (explicit intent).
- * 2. The default device/version, if it is already booted.
- * 3. The first booted simulator, so tests can run on whatever is available.
- * 4. The defaults, so Detox boots one when nothing is running.
+ * Resolution order (descending priority):
+ * 1. User input (`RNS_APPLE_SIM_NAME` / `RNS_IOS_VERSION`). Either may be given
+ *    on its own: a lone model picks its latest installed OS, a lone version
+ *    picks the first installed device on that OS.
+ * 2. An already-booted simulator.
+ * 3. The default hardcoded device/version, when an instance of it is installed.
+ * 4. The newest installed simulator (preferring iPhone models).
  *
  * @return {SimulatorTarget}
  */
@@ -129,64 +221,97 @@ function resolveSimulatorTarget() {
   if (cachedTarget !== undefined) {
     return cachedTarget;
   }
+  cachedTarget = computeSimulatorTarget();
+  return cachedTarget;
+}
 
+/**
+ * @return {SimulatorTarget}
+ */
+function computeSimulatorTarget() {
   const envName = readSimulatorNameEnv();
   const envVersion = readIOSVersionEnv();
 
-  // Explicit selection via env vars must be consistent.
-  if (envName || envVersion) {
-    if (!envName || !envVersion) {
-      throw new Error(
-        `Environment variables ${envVarKeys.simName} and ${envVarKeys.iosVersion} must be set together to avoid mismatched simulator targets.`,
-      );
-    }
-    cachedTarget = { name: envName, os: envVersion };
-    return cachedTarget;
+  // 1a. Both provided - honor verbatim, no probing needed.
+  if (envName && envVersion) {
+    return { name: envName, os: envVersion };
   }
 
-  // Only probe `simctl` for iOS simulator configurations - mirrors the Android
-  // side guarding on the active Detox configuration. Prefer the resolved
-  // configuration name (flag/env) and fall back to scanning argv so indirect
-  // invocations that don't surface the name still work.
-  const detoxConfig = readDetoxConfigName();
-  const isIOSSimulatorConfig =
-    detoxConfig !== undefined
-      ? detoxConfig.includes('ios.sim')
-      : process.argv.some(runtimeArg => runtimeArg.includes('ios.sim'));
-  if (!isIOSSimulatorConfig) {
-    cachedTarget = {
-      name: DEFAULT_APPLE_SIMULATOR_NAME,
-      os: DEFAULT_IOS_VERSION,
+  // For non-iOS configurations the returned values are unused by Detox, so we
+  // avoid shelling out to `simctl` and just echo defaults/env pieces.
+  if (!isIOSSimulatorConfig()) {
+    return {
+      name: envName ?? DEFAULT_APPLE_SIMULATOR_NAME,
+      os: envVersion ?? DEFAULT_IOS_VERSION,
     };
-    return cachedTarget;
   }
 
-  const booted = listBootedAppleSimulators();
+  const simulators = listInstalledSimulators();
 
-  const defaultBooted = booted.find(
+  // 1b. Model only - pick its latest installed OS, else fall back to default OS.
+  if (envName) {
+    const matches = simulators.filter(sim => sim.name === envName);
+    if (matches.length > 0) {
+      const latest = matches.reduce((newest, sim) =>
+        compareIOSVersions(sim.os, newest.os) > 0 ? sim : newest,
+      );
+      return { name: envName, os: latest.os };
+    }
+    return { name: envName, os: DEFAULT_IOS_VERSION };
+  }
+
+  // 1c. Version only - first installed device on that OS (preferring a booted
+  // one), else fall back to the default device.
+  if (envVersion) {
+    const matches = simulators.filter(sim => sim.os === envVersion);
+    const chosen = matches.find(sim => sim.booted) ?? matches[0];
+    return {
+      name: chosen ? chosen.name : DEFAULT_APPLE_SIMULATOR_NAME,
+      os: envVersion,
+    };
+  }
+
+  // 2. An already-booted simulator (prefer the default when it is booted).
+  const booted = simulators.filter(sim => sim.booted);
+  if (booted.length > 0) {
+    const defaultBooted = booted.find(
+      sim =>
+        sim.name === DEFAULT_APPLE_SIMULATOR_NAME &&
+        sim.os === DEFAULT_IOS_VERSION,
+    );
+    if (defaultBooted) {
+      return { name: defaultBooted.name, os: defaultBooted.os };
+    }
+    console.log(
+      `Default simulator "${DEFAULT_APPLE_SIMULATOR_NAME}" (${DEFAULT_IOS_VERSION}) is not booted. ` +
+        `Using booted simulator "${booted[0].name}" (${booted[0].os}) instead.`,
+    );
+    return { name: booted[0].name, os: booted[0].os };
+  }
+
+  // 3. The default hardcoded device/version, when an instance of it actually
+  // exists - `applesimutils` (used by Detox) only matches existing simulators.
+  const defaultInstalled = simulators.some(
     sim =>
       sim.name === DEFAULT_APPLE_SIMULATOR_NAME &&
       sim.os === DEFAULT_IOS_VERSION,
   );
-
-  if (defaultBooted) {
-    // Preferred default is booted - use it.
-    cachedTarget = defaultBooted;
-  } else if (booted.length > 0) {
-    // Fall back to whatever is booted so the test run can start.
-    cachedTarget = booted[0];
-    console.log(
-      `Default simulator "${DEFAULT_APPLE_SIMULATOR_NAME}" (${DEFAULT_IOS_VERSION}) is not booted. ` +
-        `Using booted simulator "${cachedTarget.name}" (${cachedTarget.os}) instead.`,
-    );
-  } else {
-    // Nothing booted - keep defaults so Detox boots one.
-    cachedTarget = {
-      name: DEFAULT_APPLE_SIMULATOR_NAME,
-      os: DEFAULT_IOS_VERSION,
-    };
+  if (defaultInstalled) {
+    return { name: DEFAULT_APPLE_SIMULATOR_NAME, os: DEFAULT_IOS_VERSION };
   }
-  return cachedTarget;
+
+  // 4. The newest installed simulator, preferring iPhone models.
+  if (simulators.length > 0) {
+    const fallback = pickPreferredSimulator(simulators);
+    console.log(
+      `Default simulator "${DEFAULT_APPLE_SIMULATOR_NAME}" (${DEFAULT_IOS_VERSION}) is not installed. ` +
+        `Using installed simulator "${fallback.name}" (${fallback.os}) instead.`,
+    );
+    return { name: fallback.name, os: fallback.os };
+  }
+
+  // Nothing installed - keep defaults and let Detox surface the error.
+  return { name: DEFAULT_APPLE_SIMULATOR_NAME, os: DEFAULT_IOS_VERSION };
 }
 
 /**

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -197,6 +197,22 @@ function pickPreferredSimulator(simulators) {
 }
 
 /**
+ * Lists installed OS versions for a device name (for validation errors).
+ * @param {InstalledSimulator[]} simulators
+ * @param {string} name
+ * @return {string}
+ */
+function describeAvailabilityForName(simulators, name) {
+  const versions = [
+    ...new Set(simulators.filter(sim => sim.name === name).map(sim => sim.os)),
+  ].sort((a, b) => compareIOSVersions(a, b));
+  if (versions.length > 0) {
+    return `"${name}" is installed with: ${versions.join(', ')}.`;
+  }
+  return `No installed simulator is named "${name}".`;
+}
+
+/**
  * @typedef {{ name: string, os: `iOS ${string}` }} SimulatorTarget
  */
 
@@ -232,11 +248,6 @@ function computeSimulatorTarget() {
   const envName = readSimulatorNameEnv();
   const envVersion = readIOSVersionEnv();
 
-  // 1a. Both provided - honor verbatim, no probing needed.
-  if (envName && envVersion) {
-    return { name: envName, os: envVersion };
-  }
-
   // For non-iOS configurations the returned values are unused by Detox, so we
   // avoid shelling out to `simctl` and just echo defaults/env pieces.
   if (!isIOSSimulatorConfig()) {
@@ -247,6 +258,22 @@ function computeSimulatorTarget() {
   }
 
   const simulators = listInstalledSimulators();
+
+  // 1a. Both provided - validate the exact device + OS instance exists, since
+  // Detox (via applesimutils) only matches existing simulators.
+  if (envName && envVersion) {
+    const exists = simulators.some(
+      sim => sim.name === envName && sim.os === envVersion,
+    );
+    if (!exists && simulators.length > 0) {
+      throw new Error(
+        `Requested simulator "${envName}" (${envVersion}) is not installed. ` +
+          `${describeAvailabilityForName(simulators, envName)} ` +
+          `List devices with: xcrun simctl list devices available`,
+      );
+    }
+    return { name: envName, os: envVersion };
+  }
 
   // 1b. Model only - pick its latest installed OS, else fall back to default OS.
   if (envName) {

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -12,11 +12,12 @@ const envVarKeys = /** @type {const} */ ({
  * @return {string | undefined} validated simulator name from env, or undefined
  */
 function readSimulatorNameEnv() {
-  const passedDevice = process.env[envVarKeys.simName];
+  const passedDevice = process.env[envVarKeys.simName]?.trim();
   if (!passedDevice) {
     return undefined;
   }
-  if (/^(iPhone|iPad)\s.+/.test(passedDevice)) {
+  // Require at least one non-whitespace character after the family prefix.
+  if (/^(iPhone|iPad)\s\S.*/.test(passedDevice)) {
     return passedDevice;
   }
   throw new Error(
@@ -28,11 +29,12 @@ function readSimulatorNameEnv() {
  * @return {`iOS ${string}` | undefined} validated iOS version from env, or undefined
  */
 function readIOSVersionEnv() {
-  const passedVersion = process.env[envVarKeys.iosVersion];
+  const passedVersion = process.env[envVarKeys.iosVersion]?.trim();
   if (!passedVersion) {
     return undefined;
   }
-  if (/^iOS\s\S+/.test(passedVersion)) {
+  // Accept only "iOS <digits>(.<digits>)*" so typos fail here, not downstream.
+  if (/^iOS\s\d+(\.\d+)*$/.test(passedVersion)) {
     return /** @type {`iOS ${string}`} */ (passedVersion);
   }
   throw new Error(
@@ -261,12 +263,22 @@ function computeSimulatorTarget() {
     const exists = simulators.some(
       sim => sim.name === envName && sim.os === envVersion,
     );
-    if (!exists && simulators.length > 0) {
-      throw new Error(
-        `Requested simulator "${envName}" (${envVersion}) is not installed. ` +
-          `${describeAvailabilityForName(simulators, envName)} ` +
-          `List devices with: xcrun simctl list devices available`,
-      );
+    if (!exists) {
+      if (simulators.length === 0) {
+        // simctl failed or no simulators are installed, so we cannot validate.
+        // Warn and proceed rather than swallowing the problem silently - Detox
+        // will surface an error if the target does not exist.
+        console.warn(
+          `Could not validate simulator "${envName}" (${envVersion}): ` +
+            `simctl returned no simulators. Proceeding anyway.`,
+        );
+      } else {
+        throw new Error(
+          `Requested simulator "${envName}" (${envVersion}) is not installed. ` +
+            `${describeAvailabilityForName(simulators, envName)} ` +
+            `List devices with: xcrun simctl list devices available`,
+        );
+      }
     }
     return { name: envName, os: envVersion };
   }

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -211,7 +211,7 @@ let cachedTarget;
  * 1. User input (`RNS_APPLE_SIM_NAME` / `RNS_IOS_VERSION`). Either may be given
  *    on its own: a lone model picks its latest installed OS, a lone version
  *    picks the first installed device on that OS.
- * 2. An already-booted simulator.
+ * 2. An already-booted simulator (the newest version when several are booted).
  * 3. The default hardcoded device/version, when an instance of it is installed.
  * 4. The newest installed simulator (preferring iPhone models).
  *
@@ -271,22 +271,21 @@ function computeSimulatorTarget() {
     };
   }
 
-  // 2. An already-booted simulator (prefer the default when it is booted).
+  // 2. An already-booted simulator. When several are booted, use the one with
+  // the newest iOS version (preferring iPhone on a tie) - a newer booted
+  // simulator wins even over the default.
   const booted = simulators.filter(sim => sim.booted);
   if (booted.length > 0) {
-    const defaultBooted = booted.find(
-      sim =>
-        sim.name === DEFAULT_APPLE_SIMULATOR_NAME &&
-        sim.os === DEFAULT_IOS_VERSION,
-    );
-    if (defaultBooted) {
-      return { name: defaultBooted.name, os: defaultBooted.os };
+    const chosen = pickPreferredSimulator(booted);
+    const isDefault =
+      chosen.name === DEFAULT_APPLE_SIMULATOR_NAME &&
+      chosen.os === DEFAULT_IOS_VERSION;
+    if (!isDefault) {
+      console.log(
+        `Using booted simulator "${chosen.name}" (${chosen.os}).`,
+      );
     }
-    console.log(
-      `Default simulator "${DEFAULT_APPLE_SIMULATOR_NAME}" (${DEFAULT_IOS_VERSION}) is not booted. ` +
-        `Using booted simulator "${booted[0].name}" (${booted[0].os}) instead.`,
-    );
-    return { name: booted[0].name, os: booted[0].os };
+    return { name: chosen.name, os: chosen.os };
   }
 
   // 3. The default hardcoded device/version, when an instance of it actually

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -1,7 +1,7 @@
 const { getCommandLineResponse } = require('./command-line-helpers');
 
 const DEFAULT_APPLE_SIMULATOR_NAME = 'iPhone 17';
-const DEFAULT_IOS_VERSION = 'iOS 26.2';
+const DEFAULT_IOS_VERSION = '26.2';
 
 const envVarKeys = /** @type {const} */ ({
   simName: 'RNS_APPLE_SIM_NAME',
@@ -26,19 +26,20 @@ function readSimulatorNameEnv() {
 }
 
 /**
- * @return {`iOS ${string}` | undefined} validated iOS version from env, or undefined
+ * @return {string | undefined} validated iOS version from env, or undefined
  */
 function readIOSVersionEnv() {
   const passedVersion = process.env[envVarKeys.iosVersion]?.trim();
   if (!passedVersion) {
     return undefined;
   }
-  // Accept only "iOS <digits>(.<digits>)*" so typos fail here, not downstream.
-  if (/^iOS\s\d+(\.\d+)*$/.test(passedVersion)) {
-    return /** @type {`iOS ${string}`} */ (passedVersion);
+  // Accept only a bare "<digits>(.<digits>)*" version, so typos fail here, not
+  // downstream.
+  if (/^\d+(\.\d+)*$/.test(passedVersion)) {
+    return passedVersion;
   }
   throw new Error(
-    `Environment variable ${envVarKeys.iosVersion} should be "iOS xyz".`,
+    `Environment variable ${envVarKeys.iosVersion} should be a version like "26.2".`,
   );
 }
 
@@ -46,6 +47,11 @@ function readIOSVersionEnv() {
  * Reads the active Detox configuration name from the `--configuration <name>`
  * CLI flag or the `DETOX_CONFIGURATION` env var (Detox sets the latter in its
  * worker processes), or undefined when neither is present.
+ *
+ * Accepted values are the `configurations` keys defined in
+ * `scripts/e2e/detox-utils.cjs` (`commonDetoxConfigFactory`):
+ * `ios.sim.debug`, `ios.sim.release`, `android.att.debug`,
+ * `android.att.release`, `android.emu.debug`, `android.emu.release`.
  * @return {string | undefined}
  */
 function readDetoxConfigName() {
@@ -75,21 +81,21 @@ function isIOSSimulatorConfig() {
 }
 
 /**
- * Maps a CoreSimulator runtime identifier to a human iOS version string.
- * "com.apple.CoreSimulator.SimRuntime.iOS-26-2" -> "iOS 26.2"
+ * Maps a CoreSimulator runtime identifier to a bare iOS version string.
+ * "com.apple.CoreSimulator.SimRuntime.iOS-26-2" -> "26.2"
  * @param {string} runtimeId
- * @return {`iOS ${string}` | undefined}
+ * @return {string | undefined}
  */
 function runtimeIdToIOSVersion(runtimeId) {
   const match = /SimRuntime\.iOS-(\d+(?:-\d+)*)$/.exec(runtimeId);
   if (!match) {
     return undefined;
   }
-  return /** @type {`iOS ${string}`} */ (`iOS ${match[1].replace(/-/g, '.')}`);
+  return match[1].replace(/-/g, '.');
 }
 
 /**
- * @typedef {{ name: string, os: `iOS ${string}`, booted: boolean }} InstalledSimulator
+ * @typedef {{ name: string, os: string, booted: boolean }} InstalledSimulator
  */
 
 /** @type {InstalledSimulator[] | undefined} */
@@ -146,18 +152,15 @@ function listInstalledSimulators() {
 }
 
 /**
- * Compares two "iOS x.y[.z]" strings numerically. Returns a positive number when
- * `a` is newer than `b`.
- * @param {`iOS ${string}`} a
- * @param {`iOS ${string}`} b
+ * Compares two bare "x.y[.z]" version strings numerically. Returns a positive
+ * number when `a` is newer than `b`.
+ * @param {string} a
+ * @param {string} b
  * @return {number}
  */
 function compareIOSVersions(a, b) {
   const toParts = (/** @type {string} */ value) =>
-    value
-      .replace(/^iOS\s+/, '')
-      .split('.')
-      .map(part => Number.parseInt(part, 10) || 0);
+    value.split('.').map(part => Number.parseInt(part, 10) || 0);
   const aParts = toParts(a);
   const bParts = toParts(b);
   const length = Math.max(aParts.length, bParts.length);
@@ -213,7 +216,7 @@ function describeAvailabilityForName(simulators, name) {
 }
 
 /**
- * @typedef {{ name: string, os: `iOS ${string}` }} SimulatorTarget
+ * @typedef {{ name: string, os: string }} SimulatorTarget
  */
 
 /** @type {SimulatorTarget | undefined} */
@@ -355,18 +358,21 @@ function resolveAppleSimulatorName() {
 }
 
 /**
- * @return {`iOS ${string}`} requested version of ios, or default if not specified
+ * @return {string} bare iOS version (e.g. "26.2"), or default if not specified.
+ * Used directly as Detox's `device.os`, which `applesimutils --byOS` matches
+ * against a bare version.
  */
 function getIOSVersion() {
   return resolveSimulatorTarget().os;
 }
 
 /**
- * @return { string } iOS version number (e.g. 26.2)
+ * @return {string} iOS version number (e.g. "26.2"). Kept as a named accessor
+ * for the e2e specs that read it for version comparisons; identical to
+ * {@link getIOSVersion} now that versions are stored without the "iOS " prefix.
  */
 function getIOSVersionNumber() {
-  // getIOSVersion() always returns "iOS <version>" per the SimulatorTarget type.
-  return getIOSVersion().slice('iOS '.length);
+  return getIOSVersion();
 }
 
 module.exports = {

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -133,12 +133,14 @@ function resolveSimulatorTarget() {
   const envName = readSimulatorNameEnv();
   const envVersion = readIOSVersionEnv();
 
-  // Explicit selection via env var(s) wins and disables auto-detection.
+  // Explicit selection via env vars must be consistent.
   if (envName || envVersion) {
-    cachedTarget = {
-      name: envName ?? DEFAULT_APPLE_SIMULATOR_NAME,
-      os: envVersion ?? DEFAULT_IOS_VERSION,
-    };
+    if (!envName || !envVersion) {
+      throw new Error(
+        `Environment variables ${envVarKeys.simName} and ${envVarKeys.iosVersion} must be set together to avoid mismatched simulator targets.`,
+      );
+    }
+    cachedTarget = { name: envName, os: envVersion };
     return cachedTarget;
   }
 

--- a/scripts/e2e/ios-devices.js
+++ b/scripts/e2e/ios-devices.js
@@ -42,9 +42,8 @@ function readIOSVersionEnv() {
 
 /**
  * Reads the active Detox configuration name from the `--configuration <name>`
- * CLI flag or the `DETOX_CONFIGURATION` env var (Detox sets the latter in the
- * worker processes it spawns). Returns undefined when neither is present, so
- * callers can fall back to scanning argv for indirect invocations.
+ * CLI flag or the `DETOX_CONFIGURATION` env var (Detox sets the latter in its
+ * worker processes), or undefined when neither is present.
  * @return {string | undefined}
  */
 function readDetoxConfigName() {
@@ -61,15 +60,15 @@ function readDetoxConfigName() {
 
 /**
  * @return {boolean} whether the active Detox configuration targets an iOS
- * simulator. When unknown we assume it does, so the iOS resolution still runs.
+ * simulator. When it can't be determined, we assume it does not and skip
+ * `simctl` probing.
  */
 function isIOSSimulatorConfig() {
   const detoxConfig = readDetoxConfigName();
   if (detoxConfig !== undefined) {
     return detoxConfig.includes('ios.sim');
   }
-  // Fall back to scanning argv for indirect invocations that don't surface the
-  // configuration name.
+  // No configuration name surfaced (indirect invocation) - scan argv instead.
   return process.argv.some(runtimeArg => runtimeArg.includes('ios.sim'));
 }
 
@@ -95,12 +94,11 @@ function runtimeIdToIOSVersion(runtimeId) {
 let cachedSimulators;
 
 /**
- * Queries `simctl` once for created, available simulator instances. Results are
- * memoized for the process lifetime.
+ * Queries `simctl` once (memoized) for created, available simulator instances.
  *
- * Note: only instances that actually exist are returned, because Detox finds
- * devices through `applesimutils`, which matches existing simulators and does
- * NOT create new ones from a device type + runtime pairing.
+ * Only existing instances are returned: Detox finds devices via `applesimutils`,
+ * which matches existing simulators and never creates new ones from a device
+ * type + runtime pairing.
  * @return {InstalledSimulator[]}
  */
 function listInstalledSimulators() {
@@ -248,8 +246,7 @@ function computeSimulatorTarget() {
   const envName = readSimulatorNameEnv();
   const envVersion = readIOSVersionEnv();
 
-  // For non-iOS configurations the returned values are unused by Detox, so we
-  // avoid shelling out to `simctl` and just echo defaults/env pieces.
+  // Non-iOS config: values are unused, so skip `simctl` and echo defaults/env.
   if (!isIOSSimulatorConfig()) {
     return {
       name: envName ?? DEFAULT_APPLE_SIMULATOR_NAME,
@@ -259,8 +256,7 @@ function computeSimulatorTarget() {
 
   const simulators = listInstalledSimulators();
 
-  // 1a. Both provided - validate the exact device + OS instance exists, since
-  // Detox (via applesimutils) only matches existing simulators.
+  // 1a. Both provided - validate the exact device + OS instance exists.
   if (envName && envVersion) {
     const exists = simulators.some(
       sim => sim.name === envName && sim.os === envVersion,
@@ -315,8 +311,7 @@ function computeSimulatorTarget() {
     return { name: chosen.name, os: chosen.os };
   }
 
-  // 3. The default hardcoded device/version, when an instance of it actually
-  // exists - `applesimutils` (used by Detox) only matches existing simulators.
+  // 3. The default hardcoded device/version, when an instance of it exists.
   const defaultInstalled = simulators.some(
     sim =>
       sim.name === DEFAULT_APPLE_SIMULATOR_NAME &&


### PR DESCRIPTION
## Description

Detox iOS e2e runs previously resolved the simulator **device name** and **iOS version** independently, each reading its own env var, with nothing guaranteeing the resulting pair belonged to the same — or even an existing — simulator.

This PR unifies resolution into a single `SimulatorTarget` (`{ name, os }`) so both values always come from the same simulator. Either env var can now be supplied on its own — a lone model resolves to its latest installed OS, a lone version to the first installed device on that OS — and it adds simulator auto-detection (querying what is installed and booted) so local runs adapt to whatever is already available.

Discussion was updated adding subsection:`How the target simulator is chosen`
https://github.com/software-mansion/react-native-screens-labs/discussions/572

## Changelog

`scripts/e2e/ios-devices.js`:

- **Unified resolution** — introduces `resolveSimulatorTarget()`, returning a single `{ name, os }` so the device name and iOS version can never come from different simulators. `resolveAppleSimulatorName()` and `getIOSVersion()` now derive from it. The resolved target is memoized for the process lifetime.
- **Resolution order:**
  1. `RNS_APPLE_SIM_NAME` / `RNS_IOS_VERSION` env vars. Either may be given on its own:
     - both provided → the exact `name` + `os` instance is validated against the installed simulators. If the combination doesn't exist — e.g. `iPhone 15` with `iOS 26` (a runtime that model can't run) — the script **throws a clear error** listing the OS versions that model is actually installed with, instead of letting Detox/`applesimutils` fail later. (When `simctl` returns nothing — failed or no simulators installed — validation can't run, so the script **warns** and returns the pair verbatim, letting Detox surface any error.)
     - model only → its latest installed OS, else the default OS;
     - version only → the first installed device on that OS (preferring a booted one), else the default device.
  2. An already-booted simulator — when several are booted, the newest iOS version wins (preferring iPhone models on a tie), even over the default device.
  3. The default hardcoded device/version, when an instance of it is actually installed.
  4. The newest installed simulator (preferring iPhone models) when the default isn't installed. Falls back to the defaults when nothing is installed, letting Detox surface the error.
- **`simctl` probing** — `listInstalledSimulators()` queries `xcrun simctl list devices available --json` (memoized) and maps CoreSimulator runtime ids (`...SimRuntime.iOS-26-2`) to human versions (`iOS 26.2`). Only created, available instances are returned, because Detox matches existing simulators through `applesimutils` and does **not** create them from a device-type + runtime pairing. Degrades gracefully to defaults (with a warning) if `xcrun` is unavailable.
- **Config guard** — the `simctl` probe only runs for iOS simulator configurations. The active Detox config is read from the `--configuration` flag and the `DETOX_CONFIGURATION` env var, with an argv-scan fallback for indirect invocations.
- **Validation & types** — env-var formats are validated (`iPhone|iPad …`, `iOS …`) and, when both are given, the device + OS combination is checked for existence before use; JSDoc uses the `` `iOS ${string}` `` template-literal type so callers can't drop the prefix.

## Test:
Check if script follows the order of simulator and requirements mentioned in comment:

- [x] Run script with user input
      -   provide iPhone model and os version - different than default   
      -  provide iPhone model and os version not supported on that model
      -  iPhone model provided w/o version - take the latest OS version if feasible
      -  iOS provided w/o iPhone model - select something with appropriate SDK from the top of the list - first match.
 - [x] Run simulator other than default one and run script without args when default simulator is installed
 - [x] Run simulator other than default one and run script without args when default simulator is booted -> booted device with the newest version is taken
 - [x] Make sure default simulator is installed and no simulators are booted, run script without args -> default device is run
 - [x]  Make sure default simulator is NOT installed and no simulator are booted and run script without args -> iPhone with newest version is run

