### PR TITLE
fix(Android, Stack v5): set `needsCustomLayoutForChildren` to `true` for `StackHost`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackHostViewManager.kt
@@ -61,6 +61,15 @@ class StackHostViewManager :
         super.onDropViewInstance(view)
     }
 
+    /**
+     * StackScreens need to be positioned by **native** layout **initiated by** StackHost's layout
+     * from Yoga but **not by using the dimensions provided to StackScreen by Yoga directly**.
+     * Otherwise, we receive outdated layout from Yoga, e.g. after an orientation change.
+     * If we set this flag to true, we receive incorrect measure but layout won't be called. Next
+     * native layout traversal will remeasure the view and apply correct layout.
+     */
+    override fun needsCustomLayoutForChildren() = true
+
     companion object {
         const val REACT_CLASS = "RNSStackHost"
     }


### PR DESCRIPTION
## Description

Disables layout from Yoga for children of `StackHost`. Fixes a nondeterministic bug with incorrect screen size on orientation change.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1499.

### Details

On orientation change, sometimes measure & layout from Yoga was applied with incorrect measurements. This is very likely connected to https://github.com/software-mansion/react-native-screens-labs/discussions/543, https://github.com/software-mansion/react-native-screens/pull/3295 but I didn't investigate further why we receive the outdated measurements.

In order to mitigate this, I decided to use similar strategy to `StackHeaderConfig`. By enabling `needsCustomLayoutForChildren` in `StackHostViewManager`, we will still receive `measure` with incorrect width & height from Yoga but `layout` won't be called. This way, incorrect measurements won't be applied and next native layout will remeasure & apply correct layout. Ultimately, we want the screen to be laid out fully by native layout, not by Yoga, so this is the desired behavior. If anything changes, `StackHost` receives new measurement from Yoga and will trigger native layout pass for `StackScreen`.

## Changes

- set `needsCustomLayoutForChildren=true` in `StackHostViewManager`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/737b9b88-4749-439a-a970-271edeff051a" /> | <video src="https://github.com/user-attachments/assets/7c14be70-4a00-42c0-aba2-aea8d793cb2f" /> |

## Test plan

Run `test-stack-toolbar-menu-show-as-action`. Change orientation portrait -> landscape -> portrait multiple times. The content of the screen should be laid out correctly.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
