### PR TITLE
fix(Android, Stack, Tabs): fix crash on simple navigation with stack nested in tabs

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -540,7 +540,7 @@ class TabsContainer internal constructor(
         if (navState.isEmpty()) {
             check(isInExternalOperationContext && pendingStateUpdateRequest != null)
             initNavigationState(nextSelectedFragment.requireScreenKey)
-            applyInitialStateToFragmentManager(nextSelectedFragment)
+            applyInitialStateToFragmentManagerSync(nextSelectedFragment)
             return true
         }
 
@@ -552,11 +552,11 @@ class TabsContainer internal constructor(
         }
 
         progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
-        applyNextSelectedFragmentToFragmentManager(currentSelectedFragment, nextSelectedFragment)
+        applyNextSelectedFragmentToFragmentManagerSync(currentSelectedFragment, nextSelectedFragment)
         return true
     }
 
-    private fun applyInitialStateToFragmentManager(nextSelectedFragment: TabsScreenFragment) {
+    private fun applyInitialStateToFragmentManagerSync(nextSelectedFragment: TabsScreenFragment) {
         requireFragmentManager
             .createTransactionWithReordering()
             .let {
@@ -568,7 +568,7 @@ class TabsContainer internal constructor(
             }.commitNowAllowingStateLoss()
     }
 
-    private fun applyNextSelectedFragmentToFragmentManager(
+    private fun applyNextSelectedFragmentToFragmentManagerSync(
         currSelectedFragment: TabsScreenFragment,
         nextSelectedFragment: TabsScreenFragment,
     ) {
@@ -665,13 +665,15 @@ class TabsContainer internal constructor(
                 .filter { it in tabsModel }
                 .toList()
 
-        if (currentFragments.size == 1 && currentFragments[0] === selectedTab) {
+        val fragmentsWithAttachedUI = currentFragments.filterNot { it.isDetached }
+
+        if (currentFragments.size == tabsModel.size &&
+            fragmentsWithAttachedUI.size == 1 &&
+            fragmentsWithAttachedUI.first() === selectedTab
+        ) {
             return
         } else if (currentFragments.isEmpty()) {
-            requireFragmentManager
-                .createTransactionWithReordering()
-                .add(contentView.id, selectedTab)
-                .commitNowAllowingStateLoss()
+            applyInitialStateToFragmentManagerSync(selectedTab)
         } else {
             error("[RNScreens] Unexpected fragment manager state.")
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -533,17 +533,14 @@ class TabsContainer internal constructor(
         }
     }
 
-    private fun updateSelectedFragment(
+    private fun updateNavigationStateAndSelectedFragment(
         nextSelectedFragment: TabsScreenFragment,
         actionOrigin: TabsActionOrigin,
     ): Boolean {
         if (navState.isEmpty()) {
             check(isInExternalOperationContext && pendingStateUpdateRequest != null)
-            navState = TabsNavigationState(nextSelectedFragment.requireScreenKey, 0)
-            requireFragmentManager
-                .createTransactionWithReordering()
-                .add(contentView.id, nextSelectedFragment)
-                .commitNowAllowingStateLoss()
+            initNavigationState(nextSelectedFragment.requireScreenKey)
+            applyInitialStateToFragmentManager(nextSelectedFragment)
             return true
         }
 
@@ -555,14 +552,37 @@ class TabsContainer internal constructor(
         }
 
         progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
+        applyNextSelectedFragmentToFragmentManager(currentSelectedFragment, nextSelectedFragment)
+        return true
+    }
+
+    private fun applyInitialStateToFragmentManager(nextSelectedFragment: TabsScreenFragment) {
         requireFragmentManager
             .createTransactionWithReordering()
             .let {
-                it.remove(currentSelectedFragment)
-                it.add(contentView.id, nextSelectedFragment)
+                tabsModel.forEach { fragment ->
+                    it.add(contentView.id, fragment)
+                    it.detach(fragment)
+                }
+                it.attach(nextSelectedFragment)
             }.commitNowAllowingStateLoss()
+    }
 
-        return true
+    private fun applyNextSelectedFragmentToFragmentManager(
+        currSelectedFragment: TabsScreenFragment,
+        nextSelectedFragment: TabsScreenFragment,
+    ) {
+        requireFragmentManager
+            .createTransactionWithReordering()
+            .let {
+                it.detach(currSelectedFragment)
+                it.attach(nextSelectedFragment)
+            }.commitNowAllowingStateLoss()
+    }
+
+    private fun initNavigationState(selectedScreenKey: String) {
+        check(navState.isEmpty()) { "[RNScreens] Navigation state is already initialized!" }
+        navState = TabsNavigationState(selectedScreenKey, 0)
     }
 
     private fun progressNavigationState(
@@ -595,11 +615,14 @@ class TabsContainer internal constructor(
 
         // If this is user action we test whether it should be prevented before we progress the state.
         if (!isRepeated && actionOrigin == TabsActionOrigin.USER && nextSelectedFragment.isPreventNativeSelectionEnabled) {
-            observerRegistry.emitOnNavigationStateUpdatePrevented(navState, nextSelectedFragment.requireScreenKey)
+            observerRegistry.emitOnNavigationStateUpdatePrevented(
+                navState,
+                nextSelectedFragment.requireScreenKey,
+            )
             return false
         }
 
-        val stateChanged = updateSelectedFragment(nextSelectedFragment, actionOrigin)
+        val stateChanged = updateNavigationStateAndSelectedFragment(nextSelectedFragment, actionOrigin)
 
         val hasTriggeredSpecialEffect =
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/index.ts
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/index.ts
@@ -1,7 +1,11 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TabsInStackStableEnterTransition from './test-stack-tabs-tabs-in-stack-stable-enter-transition';
+import { default as TestStackTabsStackInTabsBaseNavigation } from './test-stack-tabs-stack-in-tabs-base-navigation';
 
-const scenarios = { TabsInStackStableEnterTransition };
+const scenarios = {
+  TabsInStackStableEnterTransition,
+  TestStackTabsStackInTabsBaseNavigation,
+};
 
 const StackTabsScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {
   name: 'Stack V5 & Native Tabs Integration Tests',

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
@@ -10,11 +10,12 @@ import {
   StackContainer,
   type StackRouteConfig,
 } from '@apps/shared/gamma/containers/stack';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 import { StackRouteInformation } from '@apps/tests/shared/components/stack-v5/StackRouteInformation';
 import { TabsRouteInformation } from '@apps/tests/shared/components/tabs/TabsRouteInformation';
 import { StackNavigationButtons } from '@apps/tests/shared/components/stack-v5/StackNavigationButtons';
+import { Colors } from '@apps/shared/styling';
 
 const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
@@ -115,10 +116,17 @@ function GenericStackScreenContents() {
   }, []);
 
   return (
-    <CenteredLayoutView style={[styles.flexContainer]}>
-      <StackRouteInformation />
-      <StackNavigationButtons routeNames={routeNames} isPopEnabled />
-    </CenteredLayoutView>
+    <View
+      style={[
+        styles.flexContainer,
+        styles.fillParent,
+        { backgroundColor: Colors.BlueLight40 },
+      ]}>
+      <CenteredLayoutView style={[styles.flexContainer]}>
+        <StackRouteInformation />
+        <StackNavigationButtons routeNames={routeNames} isPopEnabled />
+      </CenteredLayoutView>
+    </View>
   );
 }
 

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { scenarioDescription } from './scenario-description';
+import {
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  type TabRouteConfig,
+  TabsContainer,
+} from '@apps/shared/gamma/containers/tabs';
+import {
+  StackContainer,
+  type StackRouteConfig,
+} from '@apps/shared/gamma/containers/stack';
+import { StyleSheet } from 'react-native';
+import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
+import { StackRouteInformation } from '@apps/tests/shared/components/stack-v5/StackRouteInformation';
+import { TabsRouteInformation } from '@apps/tests/shared/components/tabs/TabsRouteInformation';
+import { StackNavigationButtons } from '@apps/tests/shared/components/stack-v5/StackNavigationButtons';
+
+const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'First',
+    Component: FirstTabScreen,
+    options: {
+      title: 'First',
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+    },
+  },
+  {
+    name: 'Second',
+    Component: SecondTabScreen,
+    options: {
+      title: 'Second',
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+    },
+  },
+  {
+    name: 'Stack',
+    Component: StackTabScreen,
+    options: {
+      title: 'Stack',
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+    },
+  },
+];
+
+const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
+  {
+    name: 'First',
+    Component: FirstStackScreen,
+    options: {},
+  },
+  {
+    name: 'Second',
+    Component: SecondStackScreen,
+    options: {},
+  },
+  {
+    name: 'Third',
+    Component: ThirdStackScreen,
+    options: {},
+  },
+];
+
+export function TestStackTabsStackInTabsBaseNavigation() {
+  return <App />;
+}
+
+function App() {
+  return <TabsNavigation />;
+}
+
+function TabsNavigation() {
+  return <TabsContainer routeConfigs={TABS_ROUTE_CONFIGS} />;
+}
+
+function StackNavigation() {
+  return <StackContainer routeConfigs={STACK_ROUTE_CONFIGS} />;
+}
+
+function FirstTabScreen() {
+  return <GenericTabsScreenContents />;
+}
+
+function SecondTabScreen() {
+  return <GenericTabsScreenContents />;
+}
+
+function StackTabScreen() {
+  return <StackNavigation />;
+}
+
+function FirstStackScreen() {
+  return <GenericStackScreenContents />;
+}
+
+function SecondStackScreen() {
+  return <GenericStackScreenContents />;
+}
+
+function ThirdStackScreen() {
+  return <GenericStackScreenContents />;
+}
+
+function GenericTabsScreenContents() {
+  return (
+    <CenteredLayoutView style={[styles.flexContainer]}>
+      <TabsRouteInformation />
+    </CenteredLayoutView>
+  );
+}
+
+function GenericStackScreenContents() {
+  const routeNames = React.useMemo(() => {
+    return STACK_ROUTE_CONFIGS.map(value => value.name);
+  }, []);
+
+  return (
+    <CenteredLayoutView style={[styles.flexContainer]}>
+      <StackRouteInformation />
+      <StackNavigationButtons routeNames={routeNames} isPopEnabled />
+    </CenteredLayoutView>
+  );
+}
+
+export default createScenario(
+  TestStackTabsStackInTabsBaseNavigation,
+  scenarioDescription,
+);
+
+const styles = StyleSheet.create({
+  flexContainer: {
+    flex: 1,
+  },
+  fillParent: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack in Tabs - basic navigation scenarios',
+  key: 'test-stack-tabs-stack-in-tabs-base-navigation',
+  details: 'Test common navigation flows in Stack in Tabs configuration',
+  platforms: ['android', 'ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
@@ -1,11 +1,10 @@
-# Test Scenario: Tabs in Stack - stable enter transition
+# Test Scenario: Stack in Tabs - basic navigation scenarios
 
 ## Details
 
-**Description:** Verify that pushing a `StackContainer` screen that has a
-nested `TabsContainer` plays a stable enter transition (without any visual content jumps).
+**Description:** Test common navigation flows in Stack in Tabs configuration
 
-**OS test creation version:** TBD
+**OS test creation version:** Android SDK 36, iOS 26.5
 
 ## E2E test
 
@@ -19,32 +18,39 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Tabs in Stack - stable enter
-   transition** screen.
+1. Launch the app and navigate to the test screen.
 
-- [ ] The "First stack screen" is shown on a light blue background
-      with a "Go to nested tabs" button.
-
----
-
-### Enter transition
-
-2. Tap the "Go to nested tabs" button.
-
-- [ ] The stack pushes the second screen ("Nested Tabs") with a
-      standard push animation. The nested tabs content ("Home tab" with its
-      `tab routeKey`) and the tab bar (Home / Settings) are already correctly
-      laid out as the screen slides in. There is **no** flicker, no flash of an
-      empty/white screen, no layout jump, and no momentary mis-position of the
-      tab bar or tab content during the transition.
+- [ ] A tab navigation bar is visible with three destinations: *First*, *Second*, *Stack*.
+- [ ] *First* is selected.
 
 ---
 
-### Tab switching after transition
+### Tab navigation
 
-3. Once the transition finishes, switch between the "Home" and "Settings" tabs.
+2. Navigate to the *Second* tab.
 
-- [ ] Both tabs render their content centered ("Home tab" /
-      "Settings tab") together with the corresponding `tab routeKey`. Switching
-      tab runs a slide-in animation for the active indicator and the label
-      of the selected tab.
+- [ ] Second tab is selected correctly.
+
+3. Navigate to the *Stack* tab.
+
+- [ ] *First* route there is displayed correctly.
+
+4. Toggle between *First* and *Stack* tabs.
+
+- [ ] Tabs do change "normally", there is no crash.
+
+---
+
+### Nested container state preservation 
+
+1. Navigate to the *Stack* tab.
+
+2. Push *Second* screen.
+
+3. Push *Third* screen.
+
+- [ ] Both *Second* and *Third* are pushed onto the stack.
+
+4. Toggle between *First* and *Stack* tabs.
+
+- [ ] *Stack* tab displays nested stack with *Third* route on top.

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
@@ -1,0 +1,50 @@
+# Test Scenario: Tabs in Stack - stable enter transition
+
+## Details
+
+**Description:** Verify that pushing a `StackContainer` screen that has a
+nested `TabsContainer` plays a stable enter transition (without any visual content jumps).
+
+**OS test creation version:** TBD
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS or Android device / simulator.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Tabs in Stack - stable enter
+   transition** screen.
+
+- [ ] The "First stack screen" is shown on a light blue background
+      with a "Go to nested tabs" button.
+
+---
+
+### Enter transition
+
+2. Tap the "Go to nested tabs" button.
+
+- [ ] The stack pushes the second screen ("Nested Tabs") with a
+      standard push animation. The nested tabs content ("Home tab" with its
+      `tab routeKey`) and the tab bar (Home / Settings) are already correctly
+      laid out as the screen slides in. There is **no** flicker, no flash of an
+      empty/white screen, no layout jump, and no momentary mis-position of the
+      tab bar or tab content during the transition.
+
+---
+
+### Tab switching after transition
+
+3. Once the transition finishes, switch between the "Home" and "Settings" tabs.
+
+- [ ] Both tabs render their content centered ("Home tab" /
+      "Settings tab") together with the corresponding `tab routeKey`. Switching
+      tab runs a slide-in animation for the active indicator and the label
+      of the selected tab.

--- a/apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx
+++ b/apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useStackNavigationContext } from '@apps/shared/gamma/containers/stack';
+import { StyleSheet, Text, View } from 'react-native';
+
+export function StackRouteInformation(props: { routeName?: string }) {
+  const routeKey = useStackNavigationContext().routeKey;
+
+  return (
+    <View>
+      {props.routeName ? (
+        <Text style={styles.routeInformation}>Name: {props.routeName}</Text>
+      ) : null}
+      <Text style={styles.routeInformation}>Key: {routeKey}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  routeInformation: {
+    color: 'black',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/src/tests/shared/components/tabs/TabsRouteInformation.tsx
+++ b/apps/src/tests/shared/components/tabs/TabsRouteInformation.tsx
@@ -1,0 +1,24 @@
+import { useTabsNavigationContext } from '@apps/shared/gamma/containers/tabs';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export function TabsRouteInformation(props: { routeName?: string }) {
+  const routeKey = useTabsNavigationContext().routeKey;
+
+  return (
+    <View>
+      {props.routeName ? (
+        <Text style={styles.routeInformation}>Name: {props.routeName}</Text>
+      ) : null}
+      <Text style={styles.routeInformation}>Key: {routeKey}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  routeInformation: {
+    color: 'black',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Description

This PR touches only the Android side. iOS is yet untested.

Closes <https://github.com/software-mansion/react-native-screens-labs/issues/1543>

> [!caution]
> This PR requires careful testing! It touches core `TabsContainer` update logic.

The error mechanism is straightforward. When we tap back on the First
tab, the `TabsContainer` removes the `TabsScreenFragment` associated
with the `Stack` tab from *FragmentManager* and this forces the
*childFragmentManager* and its children (including
`StackScreenFragment`) to be destroyed. `StackScreenFragment` emits
`onDismiss(isNative=true)` from its `onDestroy` lifecycle callback,
which is obviously triggered -> this forces an undesired state update in
JS leading to an empty Stack & later crash.

The desired behavior here is to have the nested stack (nested container
in general) state preserved between tab switches. One way to achieve
this is to actually not remove the `TabsScreenFragment` from
*FragmentManager* entirely as we do now. Instead, we can just detach it
and re-attach it later. Such change shouldn't be that much intrusive,
since we keep all the tab fragments allocated anyway, so having them
attached to the *FragmentManager* should be painful. When we do so, tab
change no longer forces destruction of fragments in
*childFragmentManager* - effectively preserving the state of the nested
stack on the native side.

Alternative here is to keep the current behavior, but:

1. Somehow prevent changes of state in native stack (state should be
   left unmodified),
2. Create fragment manager state reconstruction mechanism that will
   re-apply the state preserved in navigation state back to the
   *FragmentManager*.

For now I decide to go with attach/detach on tabs fragment. This change
however requires careful testing.

> [!important]
> This patch fixes the problem only in this particular scenario. 
> Consider a stack nested in yet another stack - if we decide to unmount the screen
> with nested stack inside - the nested stack will still lose state.
> Similarly, in any case where the fragment hierarchy is being restored (e.g. after backgrounding the app?) this won't work. We still are in need of proper state restoration mechanism. This is however outside of scope of this PR. 

## Changes

`TabsContainer` now does not add/remove a single fragment per tab change. Now it initially adds all the fragments as "detached", and then only attaches & detaches appropriate fragments. 

I've also updated the code responsible for state restoration after window re-attachment added in: https://github.com/software-mansion/react-native-screens/pull/4035.
I've tested the `Test4027` it continues to work correctly. 

## Before & after - visual documentation

| before | after | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b84e57cd-a9e6-451a-a26b-4e6ad36b750c" alt="before" /> | <video src="https://github.com/user-attachments/assets/6ae71cd5-4f89-4b2b-9691-3f03123d5dc5" alt="after" /> |

## Test plan

See `test-stack-tabs-stack-in-tabs-base-navigation` and scenario description there.

`Test4027` for regression. 

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
