### PR TITLE
feat: Rename label and key to title and id in Stack v5 header items

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -39,8 +39,8 @@ function buildHeaderConfig(
   >['trailingItems'] = Array.from({ length: trailingItemsCount }).map(
     (_, i) => ({
       type: 'item',
-      key: `trailing-${i}`,
-      label: `Menu ${i}`,
+      id: `trailing-${i}`,
+      title: `Menu ${i}`,
       // every second item is custom
       ...(i % 2 === 0 && {
         render: () => (

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -169,13 +169,13 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       length: config.leadingItemsCount,
     }).map((_, i) => ({
       type: 'item',
-      key: `leading-${i}`,
+      id: `leading-${i}`,
       render: () => <ResizingItem />,
     }));
   if (leadingItems.length > 1) {
     leadingItems.splice(1, 0, {
       type: 'spacer',
-      key: 'spacer-leading-1',
+      id: 'spacer-leading-1',
       sizing: 'fixed',
       width: 100,
     });
@@ -186,14 +186,14 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
   >['trailingItems'] = Array.from({ length: config.trailingItemsCount }).map(
     (_, i) => ({
       type: 'item',
-      key: `trailing-${i}`,
+      id: `trailing-${i}`,
       render: () => <ResizingItem />,
     }),
   );
   if (trailingItems.length > 1) {
     trailingItems.splice(1, 0, {
       type: 'spacer',
-      key: 'spacer-trailing-1',
+      id: 'spacer-trailing-1',
       sizing: 'fixed',
       width: 100,
     });
@@ -210,21 +210,21 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       titleItem:
         config.title === 'view'
           ? {
-              key: 'title',
+              id: 'title',
               render: () => <LargeHorizontalItem />,
             }
           : undefined,
       subtitleItem:
         config.subtitle === 'view'
           ? {
-              key: 'subtitle',
+              id: 'subtitle',
               render: () => <SmallHorizontalItem />,
             }
           : undefined,
       largeSubtitleItem:
         config.largeSubtitle === 'view'
           ? {
-              key: 'largeSubtitle',
+              id: 'largeSubtitle',
               render: () => <LargeHorizontalItem />,
             }
           : undefined,

--- a/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
@@ -36,7 +36,7 @@
                                                                   frameChangeDelegate:delegate]];
   }
 
-  return [[UIBarButtonItem alloc] initWithTitle:item.label style:UIBarButtonItemStylePlain target:nil action:nil];
+  return [[UIBarButtonItem alloc] initWithTitle:item.title style:UIBarButtonItemStylePlain target:nil action:nil];
 }
 
 + (UIView *)wrappedViewForHeaderItem:(id<RNSStackHeaderItemDataProviding>)item

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderItemComponentView : RNSReactBaseView <RNSStackHeaderItemDataProviding>
 
 @property (nonatomic, readonly) RNSHeaderItemPlacement placement;
-@property (nonatomic, readonly, nullable) NSString *label;
+@property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuToggleStateTracker *menuToggleStateTracker;
 @property (nonatomic, readonly, nullable) UIView *customView;

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
@@ -43,7 +43,7 @@ namespace react = facebook::react;
 
 - (void)resetProps
 {
-  _label = nil;
+  _title = nil;
   _menu = nil;
   _menuToggleStateTracker = nil;
   _placement = RNSHeaderItemPlacementTrailing;
@@ -149,8 +149,8 @@ RNS_IGNORE_SUPER_CALL_END
   }
   _didSetHeaderItemPlacement = YES;
 
-  if (oldItemProps.label != newItemProps.label) {
-    _label = RCTNSStringFromStringNilIfEmpty(newItemProps.label);
+  if (oldItemProps.title != newItemProps.title) {
+    _title = RCTNSStringFromStringNilIfEmpty(newItemProps.title);
     needsUpdate = YES;
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemDataProviding.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol RNSStackHeaderItemDataProviding <NSObject>
 
 @property (nonatomic, readonly) RNSHeaderItemPlacement placement;
-@property (nonatomic, readonly, nullable) NSString *label;
+@property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) UIView *customView;
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -107,7 +107,7 @@ function makeItemViewFromItem(
   placement: StackHeaderItemPlacement,
 ) {
   if ('type' in item && item.type === 'spacer') {
-    const { key, ...rest } = item;
+    const { id, ...rest } = item;
 
     if (!(placement === 'leading' || placement === 'trailing')) {
       console.warn(
@@ -118,16 +118,16 @@ function makeItemViewFromItem(
 
     return (
       <StackHeaderItemSpacer
-        key={key}
+        key={id}
         placement={placement as StackHeaderItemSpacerPlacement}
         {...rest}
       />
     );
   }
 
-  const { key, ...rest } = item;
+  const { id, ...rest } = item;
 
-  return <StackHeaderItem key={key} placement={placement} {...rest} />;
+  return <StackHeaderItem key={id} placement={placement} {...rest} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -7,13 +7,13 @@ export interface StackHeaderBaseItemIOS {
    *
    * @platform iOS
    */
-  key: string;
+  id: string;
   /**
-   * @summary A label for the item that is displayed in the header.
+   * @summary A title for the item that is displayed in the header.
    *
    * @platform iOS
    */
-  label?: string | undefined;
+  title?: string | undefined;
 }
 
 export interface SupportsMenuIOS {
@@ -26,7 +26,7 @@ export interface SupportsMenuIOS {
 }
 
 /**
- * @summary Native header item with text label.
+ * @summary Native header item with text title.
  *
  * @platform iOS
  */
@@ -52,7 +52,7 @@ export interface StackHeaderInlineCustomItemIOS extends SupportsMenuIOS {
    *
    * @platform iOS
    */
-  key: string;
+  id: string;
   /**
    * @summary Marks this object as a header item definition.
    *
@@ -87,7 +87,7 @@ interface StackHeaderFixedSpacerItemIOS {
    *
    * @platform iOS
    */
-  key: string;
+  id: string;
   /**
    * @summary Marks this object as a spacer definition.
    *
@@ -123,7 +123,7 @@ interface StackHeaderFlexibleSpacerItemIOS {
    *
    * @platform iOS
    */
-  key: string;
+  id: string;
   /**
    * @summary Marks this object as a spacer definition.
    *
@@ -151,7 +151,7 @@ export interface StackHeaderTitleCustomItemIOS {
    *
    * @platform iOS
    */
-  key: string;
+  id: string;
   /**
    * @summary A function that renders the custom view.
    *

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -26,7 +26,7 @@ export interface SupportsMenuIOS {
 }
 
 /**
- * @summary Native header item with text title.
+ * @summary Native header item with text label.
  *
  * @platform iOS
  */

--- a/src/components/gamma/stack/header/ios/StackHeaderItem.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderItem.ios.types.ts
@@ -10,7 +10,7 @@ export type StackHeaderItemPlacement =
 
 export type StackHeaderItemProps = {
   placement: StackHeaderItemPlacement;
-  label?: string | undefined;
+  title?: string | undefined;
   render?: (() => ReactElement) | undefined;
   menu?: StackHeaderMenuIOS | undefined;
 };

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -30,7 +30,7 @@ export type StackHeaderMenuElementIOS =
 
 export interface NativeProps extends ViewProps {
   placement?: CT.WithDefault<Placement, 'trailing'>;
-  label?: string | undefined;
+  title?: string | undefined;
   menu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
 }
 


### PR DESCRIPTION
https://github.com/software-mansion/react-native-screens-labs/issues/1528

## Description

This PR renames label and key props on header items with title and id, respectively. The new prop names better match other API elements.

## Changes

- renamed header item label with title
- renamed header item/spacer key with id

## Before & after - visual documentation

n/a

## Test plan

Use test-stack-header-menu-ios. See that the label is still there.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
