### PR TITLE
feat(Android, Stack v5): add support for nested menus in toolbar menu

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
@@ -1,0 +1,88 @@
+package com.swmansion.rnscreens.gamma.helpers
+
+import android.util.Log
+import androidx.core.graphics.toColorInt
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+
+private const val TAG = "ReadableMapExt"
+
+// region Nullable variants
+
+internal fun ReadableMap.readOptionalString(key: String): String? {
+    if (!hasKey(key) || isNull(key)) return null
+    return if (getType(key) == ReadableType.String) getString(key) else null
+}
+
+internal fun ReadableMap.readOptionalBoolean(key: String): Boolean? {
+    if (!hasKey(key) || isNull(key)) return null
+    return if (getType(key) == ReadableType.Boolean) getBoolean(key) else null
+}
+
+internal fun ReadableMap.readOptionalFloat(key: String): Float? {
+    if (!hasKey(key) || isNull(key)) return null
+    return if (getType(key) == ReadableType.Number) getDouble(key).toFloat() else null
+}
+
+internal fun ReadableMap.readOptionalColor(key: String): Int? {
+    if (!hasKey(key) || isNull(key)) return null
+    return parseColor(key)
+}
+
+// endregion
+
+// region Default-value variants
+
+internal fun ReadableMap.readString(
+    key: String,
+    default: String,
+): String = readOptionalString(key) ?: default
+
+internal fun ReadableMap.readBoolean(
+    key: String,
+    default: Boolean,
+): Boolean = readOptionalBoolean(key) ?: default
+
+internal fun ReadableMap.readColor(
+    key: String,
+    default: Int?,
+): Int? = if (!hasKey(key) || isNull(key)) default else parseColor(key)
+
+internal fun ReadableMap.readImageUri(
+    key: String,
+    default: String?,
+): String? {
+    if (!hasKey(key) || getType(key) != ReadableType.Map) {
+        return default
+    }
+
+    val imageMap = getMap(key)
+    return imageMap?.getString("uri") ?: default
+}
+
+// endregion
+
+// region Validation
+
+internal fun ReadableMap.requireNotNullString(key: String): String =
+    requireNotNull(this.getString(key)) {
+        "[RNScreens] $key property must not be null."
+    }
+
+// endregion
+
+// region Building blocks
+
+internal fun ReadableMap.parseColor(key: String): Int? =
+    try {
+        when (getType(key)) {
+            ReadableType.Number -> getInt(key)
+            ReadableType.String -> getString(key)?.toColorInt()
+            else -> null
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
+        null
+    }
+
+// endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -29,6 +29,8 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.swmansion.rnscreens.ext.detachFromCurrentParent
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfigurationProviding
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
@@ -246,41 +248,67 @@ internal class StackHeaderApplicator(
 
     // region Toolbar menu
 
-    fun generateToolbarMenuItemMappings(items: List<StackHeaderToolbarMenuItemConfig>): Pair<Map<String, Int>, Map<Int, String>> {
+    fun generateToolbarMenuItemMappings(menuConfig: StackHeaderToolbarMenuConfig): Pair<Map<String, Int>, Map<Int, String>> {
         val forwardIdMap = mutableMapOf<String, Int>()
         val reverseIdMap = mutableMapOf<Int, String>()
-
-        items.forEachIndexed { index, item ->
-            // We use IDs > 0 because 0 is Menu.NONE.
-            val nativeId = index + 1
-            forwardIdMap[item.id] = nativeId
-            reverseIdMap[nativeId] = item.id
-        }
-
+        var counter = 1
+        assignElementIds(menuConfig.children, forwardIdMap, reverseIdMap) { counter++ }
         return Pair(forwardIdMap.toMap(), reverseIdMap.toMap())
+    }
+
+    private fun assignElementIds(
+        elements: List<StackHeaderToolbarMenuElementConfig>,
+        forwardIdMap: MutableMap<String, Int>,
+        reverseIdMap: MutableMap<Int, String>,
+        nextId: () -> Int,
+    ) {
+        for (element in elements) {
+            val nativeId = nextId()
+            forwardIdMap[element.item.id] = nativeId
+            reverseIdMap[nativeId] = element.item.id
+            if (element is StackHeaderToolbarMenuElementConfig.Menu) {
+                assignElementIds(element.children, forwardIdMap, reverseIdMap, nextId)
+            }
+        }
     }
 
     fun rebuildToolbarMenu(
         toolbar: MaterialToolbar,
-        items: List<StackHeaderToolbarMenuItemConfig>,
+        menuConfig: StackHeaderToolbarMenuConfig,
         forwardIdMap: Map<String, Int>,
         reverseIdMap: Map<Int, String>,
         onItemClicked: (id: String) -> Unit,
     ) {
         toolbar.menu.clear()
-
-        items.forEachIndexed { index, item ->
-            val itemId = forwardIdMap[item.id]
-            require(itemId != null) {
-                "[RNScreens] Invalid forwardIdMap received. Missing item: $item."
-            }
-            val menuItem = toolbar.menu.add(Menu.NONE, itemId, index, null)
-            applyMenuItemOptions(toolbar, menuItem, item.toOptions())
-        }
-
+        addElements(toolbar, toolbar.menu, menuConfig.children, forwardIdMap)
         toolbar.setOnMenuItemClickListener { menuItem ->
             reverseIdMap[menuItem.itemId]?.let(onItemClicked)
             true
+        }
+    }
+
+    private fun addElements(
+        toolbar: MaterialToolbar,
+        menu: Menu,
+        elements: List<StackHeaderToolbarMenuElementConfig>,
+        forwardIdMap: Map<String, Int>,
+    ) {
+        elements.forEachIndexed { index, element ->
+            val itemId =
+                requireNotNull(forwardIdMap[element.item.id]) {
+                    "[RNScreens] Invalid forwardIdMap received. Missing item: ${element.item}."
+                }
+            when (element) {
+                is StackHeaderToolbarMenuElementConfig.MenuItem -> {
+                    val menuItem = menu.add(Menu.NONE, itemId, index, null)
+                    applyMenuItemOptions(toolbar, menuItem, element.item.toOptions())
+                }
+                is StackHeaderToolbarMenuElementConfig.Menu -> {
+                    val subMenu = menu.addSubMenu(Menu.NONE, itemId, index, null)
+                    applyMenuItemOptions(toolbar, subMenu.item, element.item.toOptions())
+                    addElements(toolbar, subMenu, element.children, forwardIdMap)
+                }
+            }
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -266,8 +266,8 @@ internal class StackHeaderApplicator(
             val nativeId = nextId()
             forwardIdMap[element.item.id] = nativeId
             reverseIdMap[nativeId] = element.item.id
-            if (element is StackHeaderToolbarMenuElementConfig.Menu) {
-                assignElementIds(element.children, forwardIdMap, reverseIdMap, nextId)
+            if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
+                assignElementIds(element.menu.children, forwardIdMap, reverseIdMap, nextId)
             }
         }
     }
@@ -303,10 +303,10 @@ internal class StackHeaderApplicator(
                     val menuItem = menu.add(Menu.NONE, itemId, index, null)
                     applyMenuItemOptions(toolbar, menuItem, element.item.toOptions())
                 }
-                is StackHeaderToolbarMenuElementConfig.Menu -> {
+                is StackHeaderToolbarMenuElementConfig.Submenu -> {
                     val subMenu = menu.addSubMenu(Menu.NONE, itemId, index, null)
                     applyMenuItemOptions(toolbar, subMenu.item, element.item.toOptions())
-                    addElements(toolbar, subMenu, element.children, forwardIdMap)
+                    addElements(toolbar, subMenu, element.menu.children, forwardIdMap)
                 }
             }
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -209,12 +209,12 @@ internal class StackHeaderCoordinatorLayout(
             if (provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TOOLBAR_MENU)) {
                 val (forwardIdMap, reverseIdMap) =
                     applicator.generateToolbarMenuItemMappings(
-                        provider.toolbarMenuItems,
+                        provider.toolbarMenu,
                     )
 
                 applicator.rebuildToolbarMenu(
                     appBar.toolbar,
-                    provider.toolbarMenuItems,
+                    provider.toolbarMenu,
                     forwardIdMap,
                     reverseIdMap,
                 ) { id -> currentDelegate?.onMenuItemClicked(id) }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -17,7 +17,7 @@ import com.swmansion.rnscreens.gamma.helpers.getFabricUIManagerNotNull
 import com.swmansion.rnscreens.gamma.stack.header.subview.OnStackHeaderSubviewChangeListener
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewType
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
@@ -139,8 +139,8 @@ class StackHeaderConfig(
     }
         internal set
 
-    override var toolbarMenuItems: List<StackHeaderToolbarMenuItemConfig>
-        by Delegates.observable(emptyList()) { _, old, new ->
+    override var toolbarMenu: StackHeaderToolbarMenuConfig
+        by Delegates.observable(StackHeaderToolbarMenuConfig(emptyList())) { _, old, new ->
             if (old != new) invalidate(StackHeaderInvalidationFlags.TOOLBAR_MENU)
         }
         internal set
@@ -187,7 +187,7 @@ class StackHeaderConfig(
 
     // Last resolved icon per menu item id. Unlike every other field on this config — which
     // mirrors a single prop — this cache deliberately merges resolved icons from BOTH sources
-    // that can set a menu item icon: the `toolbarMenuItems` prop array
+    // that can set a menu item icon: the `toolbarMenu` prop
     // (resolveToolbarMenuItemIconsIfNeeded) and the imperative `setToolbarMenuItemOptions`
     // view command (dispatchMenuItemUpdate). It is necessary to ensure consistency.
     private var toolbarMenuItemIcons = mapOf<String, Drawable?>()
@@ -225,15 +225,10 @@ class StackHeaderConfig(
         id: String,
         icon: Drawable?,
     ) {
-        val currentItems = toolbarMenuItems
-        val itemIndex = currentItems.indexOfFirst { it.id == id }
-        if (itemIndex == -1) return
-
-        val item = currentItems[itemIndex]
-        if (item.icon != icon) {
-            val newItems = currentItems.toMutableList()
-            newItems[itemIndex] = item.copy(icon = icon)
-            toolbarMenuItems = newItems
+        val currentMenu = toolbarMenu
+        val updated = currentMenu.updateItemIcon(id, icon)
+        if (updated !== currentMenu) {
+            toolbarMenu = updated
             if (!isInsideMountTransaction) {
                 flushUpdates()
             }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -26,7 +26,7 @@ import kotlin.properties.Delegates
 
 @OptIn(UnstableReactNativeAPI::class)
 @SuppressLint("ViewConstructor")
-class StackHeaderConfig(
+internal class StackHeaderConfig(
     val reactContext: ThemedReactContext,
 ) : ReactViewGroup(reactContext),
     StackHeaderConfigurationProviding,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -323,7 +323,7 @@ internal class StackHeaderConfig(
     }
 
     override fun onMenuItemClicked(id: String) {
-        eventEmitter.emitOnToolbarMenuItemClicked(id)
+        eventEmitter.emitOnToolbarMenuItemPress(id)
     }
 
     override fun onSubviewOriginChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigEventEmitter.kt
@@ -2,15 +2,15 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 
 import com.facebook.react.bridge.ReactContext
 import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.event.StackHeaderToolbarMenuItemClickedEvent
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.event.StackHeaderToolbarMenuItemPressEvent
 
 internal class StackHeaderConfigEventEmitter(
     reactContext: ReactContext,
     viewTag: Int,
 ) : BaseEventEmitter(reactContext, viewTag) {
-    internal fun emitOnToolbarMenuItemClicked(id: String) {
+    internal fun emitOnToolbarMenuItemPress(id: String) {
         reactEventDispatcher.dispatchEvent(
-            StackHeaderToolbarMenuItemClickedEvent(surfaceId, viewTag, id),
+            StackHeaderToolbarMenuItemPressEvent(surfaceId, viewTag, id),
         )
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
 import android.view.View
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -12,19 +13,8 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHeaderConfigAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHeaderConfigAndroidManagerInterface
-import com.swmansion.rnscreens.gamma.helpers.parseColor
-import com.swmansion.rnscreens.gamma.helpers.readBoolean
-import com.swmansion.rnscreens.gamma.helpers.readColor
-import com.swmansion.rnscreens.gamma.helpers.readImageUri
-import com.swmansion.rnscreens.gamma.helpers.readString
-import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemDefaults
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuMapper
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
 open class StackHeaderConfigViewManager :
@@ -226,58 +216,12 @@ open class StackHeaderConfigViewManager :
         view.scrollFlagSnap = value
     }
 
-    override fun setToolbarMenuItems(
+    override fun setToolbarMenu(
         view: StackHeaderConfig,
-        value: ReadableArray?,
+        value: Dynamic,
     ) {
-        val sourceMap = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
-
-        view.toolbarMenuItems =
-            value?.let { array ->
-                (0 until array.size()).map { i ->
-                    val item = requireNotNull(array.getMap(i))
-                    val id = item.requireNotNullString("id")
-
-                    sourceMap[id] =
-                        StackHeaderToolbarMenuItemIconSource(
-                            item.getString("drawableIconResourceName") ?: StackHeaderToolbarMenuItemDefaults.DRAWABLE_ICON_RESOURCE_NAME,
-                            item.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
-                        )
-
-                    StackHeaderToolbarMenuItemConfig(
-                        id = id,
-                        title = item.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
-                        hidden = item.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
-                        showAsAction =
-                            item.readShowAsActionEnum(
-                                "showAsAction",
-                                StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
-                            ),
-                        icon = null,
-                        iconTintColorNormal =
-                            item.readColor(
-                                "iconTintColorNormal",
-                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
-                            ),
-                        iconTintColorPressed =
-                            item.readColor(
-                                "iconTintColorPressed",
-                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
-                            ),
-                        iconTintColorFocused =
-                            item.readColor(
-                                "iconTintColorFocused",
-                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
-                            ),
-                        iconTintColorDisabled =
-                            item.readColor(
-                                "iconTintColorDisabled",
-                                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
-                            ),
-                    )
-                }
-            } ?: emptyList()
-        view.toolbarMenuItemIconSourceMap = sourceMap
+        view.toolbarMenu = StackHeaderToolbarMenuMapper.parseMenu(value)
+        view.toolbarMenuItemIconSourceMap = StackHeaderToolbarMenuMapper.collectIconSources(value)
     }
 
     override fun setToolbarMenuItemOptions(
@@ -286,115 +230,14 @@ open class StackHeaderConfigViewManager :
         options: ReadableArray,
     ) {
         val map = options.getMap(0) ?: return
-
         view.dispatchMenuItemUpdate(
             id,
-            StackHeaderToolbarMenuItemOptions(
-                title = map.readNullableStringUpdate("title", StackHeaderToolbarMenuItemDefaults.TITLE),
-                hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
-                showAsAction =
-                    map.readNullableShowAsActionEnumUpdate(
-                        "showAsAction",
-                        StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
-                    ),
-                // The icon is resolved asynchronously and filled in by dispatchMenuItemUpdate.
-                icon = null,
-                iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal"),
-                iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed"),
-                iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused"),
-                iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled"),
-            ),
-            map.readIconSource(),
+            StackHeaderToolbarMenuMapper.parseMenuItemOptions(map),
+            StackHeaderToolbarMenuMapper.parseMenuItemIconSource(map),
         )
     }
-
-    override fun setDO_NOT_USE(
-        view: StackHeaderConfig,
-        value: ReadableMap?,
-    ) = Unit
 
     companion object {
         const val REACT_CLASS = "RNSStackHeaderConfigAndroid"
     }
 }
-
-private fun ReadableMap.readShowAsActionEnum(
-    key: String,
-    default: StackHeaderToolbarMenuItemShowAsAction,
-): StackHeaderToolbarMenuItemShowAsAction {
-    val stringValue = this.getString(key) ?: return default
-    return toMenuItemShowAsActionEnum(stringValue)
-}
-
-// Helpers for view commands. Each key has three states:
-// - not defined -> null         (no change)
-// - null        -> default      (reset to default)
-// - value       -> value
-//
-// A plain `T?` return can encode this only when the field's default is non-null,
-// so `null` unambiguously means "no change". Fields whose default is null (the
-// tint colors) must return `StackHeaderToolbarUpdate<T>?` instead, to tell "no
-// change" (null) apart from "reset" (Reset).
-private fun ReadableMap.readNullableStringUpdate(
-    key: String,
-    default: String,
-): String? =
-    when {
-        !this.hasKey(key) -> null
-        this.isNull(key) -> default
-        else -> this.getString(key) ?: default
-    }
-
-private fun ReadableMap.readNullableBooleanUpdate(
-    key: String,
-    default: Boolean,
-): Boolean? =
-    when {
-        !this.hasKey(key) -> null
-        this.isNull(key) -> default
-        else -> this.getBoolean(key)
-    }
-
-private fun ReadableMap.readNullableShowAsActionEnumUpdate(
-    key: String,
-    default: StackHeaderToolbarMenuItemShowAsAction,
-): StackHeaderToolbarMenuItemShowAsAction? =
-    when {
-        !this.hasKey(key) -> null
-        this.isNull(key) -> default
-        else ->
-            this.getString(key)?.let {
-                toMenuItemShowAsActionEnum(it)
-            } ?: default
-    }
-
-// Assumes null is the default color.
-private fun ReadableMap.readNullableColorUpdate(key: String): StackHeaderToolbarUpdate<Int>? =
-    when {
-        !this.hasKey(key) -> null
-        this.isNull(key) -> StackHeaderToolbarUpdate.Reset
-        else -> StackHeaderToolbarUpdate.from(parseColor(key))
-    }
-
-// The icon is composed of two JS keys that together form one source. It is
-// "mentioned" iff at least one key is present; mentioned but empty (both null)
-// means "clear", which the resolver turns into a Reset.
-private fun ReadableMap.readIconSource(): StackHeaderToolbarMenuItemIconSource? {
-    if (!this.hasKey("drawableIconResourceName") && !this.hasKey("imageIconResource")) {
-        return null
-    }
-    return StackHeaderToolbarMenuItemIconSource(
-        drawableIconResourceName = this.getString("drawableIconResourceName"),
-        imageIconUri = this.readImageUri("imageIconResource", null),
-    )
-}
-
-private fun toMenuItemShowAsActionEnum(value: String): StackHeaderToolbarMenuItemShowAsAction =
-    when (value) {
-        "always" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS
-        "alwaysWithText" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS_WITH_TEXT
-        "ifRoom" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM
-        "ifRoomWithText" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM_WITH_TEXT
-        "never" -> StackHeaderToolbarMenuItemShowAsAction.NEVER
-        else -> throw JSApplicationIllegalArgumentException("[RNScreens] Invalid value for StackHeaderToolbarMenuItemShowAsAction: $value.")
-    }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -17,7 +17,7 @@ import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuMapper
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
-open class StackHeaderConfigViewManager :
+internal open class StackHeaderConfigViewManager :
     ViewGroupManager<StackHeaderConfig>(),
     RNSStackHeaderConfigAndroidManagerInterface<StackHeaderConfig> {
     private val delegate: ViewManagerDelegate<StackHeaderConfig>

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,12 +1,9 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
-import android.util.Log
 import android.view.View
-import androidx.core.graphics.toColorInt
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
@@ -15,6 +12,12 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHeaderConfigAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHeaderConfigAndroidManagerInterface
+import com.swmansion.rnscreens.gamma.helpers.parseColor
+import com.swmansion.rnscreens.gamma.helpers.readBoolean
+import com.swmansion.rnscreens.gamma.helpers.readColor
+import com.swmansion.rnscreens.gamma.helpers.readImageUri
+import com.swmansion.rnscreens.gamma.helpers.readString
+import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemDefaults
@@ -22,8 +25,6 @@ import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenu
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemShowAsAction
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
-
-private const val TAG = "StackHeaderConfigViewManager"
 
 @ReactModule(name = StackHeaderConfigViewManager.REACT_CLASS)
 open class StackHeaderConfigViewManager :
@@ -317,57 +318,12 @@ open class StackHeaderConfigViewManager :
     }
 }
 
-private fun ReadableMap.requireNotNullString(key: String): String =
-    requireNotNull(this.getString(key)) {
-        "[RNScreens] toolbarMenuItem $key property must not be null."
-    }
-
-// Helpers for regular props (null/not defined -> default)
-private fun ReadableMap.readString(
-    key: String,
-    default: String,
-): String = if (!this.hasKey(key) || this.isNull(key)) default else this.getString(key) ?: default
-
-private fun ReadableMap.readBoolean(
-    key: String,
-    default: Boolean,
-): Boolean = if (!this.hasKey(key) || this.isNull(key)) default else this.getBoolean(key)
-
 private fun ReadableMap.readShowAsActionEnum(
     key: String,
     default: StackHeaderToolbarMenuItemShowAsAction,
 ): StackHeaderToolbarMenuItemShowAsAction {
     val stringValue = this.getString(key) ?: return default
     return toMenuItemShowAsActionEnum(stringValue)
-}
-
-private fun ReadableMap.readColor(
-    key: String,
-    default: Int?,
-): Int? = if (!this.hasKey(key) || this.isNull(key)) default else parseColor(key)
-
-private fun ReadableMap.parseColor(key: String): Int? =
-    try {
-        when (getType(key)) {
-            ReadableType.Number -> getInt(key)
-            ReadableType.String -> getString(key)?.toColorInt()
-            else -> null
-        }
-    } catch (e: Exception) {
-        Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
-        null
-    }
-
-private fun ReadableMap.readImageUri(
-    key: String,
-    default: String?,
-): String? {
-    if (!this.hasKey(key) || this.getType(key) != ReadableType.Map) {
-        return default
-    }
-
-    val imageMap = getMap(key)
-    return imageMap?.getString("uri") ?: default
 }
 
 // Helpers for view commands. Each key has three states:

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationObserver.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 
-interface StackHeaderConfigurationObserver {
+internal interface StackHeaderConfigurationObserver {
     fun onConfigChanged(config: StackHeaderConfigurationProviding)
 
     fun onMenuItemUpdated(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 
 import android.graphics.drawable.Drawable
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewProviding
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
 
 interface StackHeaderConfigurationProviding {
     val type: StackHeaderType
@@ -23,7 +23,7 @@ interface StackHeaderConfigurationProviding {
     val centerSubview: StackHeaderSubviewProviding?
     val trailingSubview: StackHeaderSubviewProviding?
     val backgroundSubview: StackHeaderSubviewProviding?
-    val toolbarMenuItems: List<StackHeaderToolbarMenuItemConfig>
+    val toolbarMenu: StackHeaderToolbarMenuConfig
     val isRTL: Boolean
 
     val invalidationFlags: StackHeaderInvalidationFlags

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -4,7 +4,7 @@ import android.graphics.drawable.Drawable
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewProviding
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
 
-interface StackHeaderConfigurationProviding {
+internal interface StackHeaderConfigurationProviding {
     val type: StackHeaderType
     val title: String
     val hidden: Boolean

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderDelegate.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewType
 
-interface StackHeaderDelegate {
+internal interface StackHeaderDelegate {
     fun onHeaderFrameChanged(
         width: Int,
         height: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderInvalidationFlags.kt
@@ -1,7 +1,7 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
 @JvmInline
-value class StackHeaderInvalidationFlags(
+internal value class StackHeaderInvalidationFlags(
     val raw: Int,
 ) {
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderType.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderType.kt
@@ -1,6 +1,6 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
-enum class StackHeaderType {
+internal enum class StackHeaderType {
     SMALL,
     MEDIUM,
     LARGE,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
@@ -2,68 +2,55 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
 import android.graphics.drawable.Drawable
 
-data class StackHeaderToolbarMenuConfig(
+internal data class StackHeaderToolbarMenuConfig(
     val children: List<StackHeaderToolbarMenuElementConfig>,
 ) {
-    fun updateItemIcon(
+    internal fun updateItemIcon(
         id: String,
         icon: Drawable?,
     ): StackHeaderToolbarMenuConfig {
         val updated = updateChildrenIcon(children, id, icon)
-        return if (updated !== children) StackHeaderToolbarMenuConfig(updated) else this
+        return if (updated !== children) copy(children = updated) else this
     }
-}
 
-sealed interface StackHeaderToolbarMenuElementConfig {
-    val item: StackHeaderToolbarMenuItemConfig
+    private fun updateChildrenIcon(
+        children: List<StackHeaderToolbarMenuElementConfig>,
+        id: String,
+        icon: Drawable?,
+    ): List<StackHeaderToolbarMenuElementConfig> {
+        var changed = false
+        val result =
+            children.map { element ->
+                val updated = updateElementIcon(element, id, icon)
+                if (updated !== element) changed = true
+                updated
+            }
+        return if (changed) result else children
+    }
 
-    data class MenuItem(
-        override val item: StackHeaderToolbarMenuItemConfig,
-    ) : StackHeaderToolbarMenuElementConfig
-
-    data class Menu(
-        override val item: StackHeaderToolbarMenuItemConfig,
-        val children: List<StackHeaderToolbarMenuElementConfig>,
-    ) : StackHeaderToolbarMenuElementConfig
-}
-
-private fun updateChildrenIcon(
-    children: List<StackHeaderToolbarMenuElementConfig>,
-    id: String,
-    icon: Drawable?,
-): List<StackHeaderToolbarMenuElementConfig> {
-    var changed = false
-    val result =
-        children.map { element ->
-            val updated = updateElementIcon(element, id, icon)
-            if (updated !== element) changed = true
-            updated
+    private fun updateElementIcon(
+        element: StackHeaderToolbarMenuElementConfig,
+        id: String,
+        icon: Drawable?,
+    ): StackHeaderToolbarMenuElementConfig {
+        if (element.item.id == id) {
+            val newItem = element.item.copy(icon = icon)
+            if (newItem.icon !== element.item.icon) {
+                return when (element) {
+                    is StackHeaderToolbarMenuElementConfig.MenuItem -> element.copy(item = newItem)
+                    is StackHeaderToolbarMenuElementConfig.Submenu -> element.copy(item = newItem)
+                }
+            }
+            return element
         }
-    return if (changed) result else children
-}
 
-private fun updateElementIcon(
-    element: StackHeaderToolbarMenuElementConfig,
-    id: String,
-    icon: Drawable?,
-): StackHeaderToolbarMenuElementConfig {
-    if (element.item.id == id) {
-        val newItem = element.item.copy(icon = icon)
-        if (newItem.icon !== element.item.icon) {
-            return when (element) {
-                is StackHeaderToolbarMenuElementConfig.MenuItem -> element.copy(item = newItem)
-                is StackHeaderToolbarMenuElementConfig.Menu -> element.copy(item = newItem)
+        if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
+            val updatedChildren = updateChildrenIcon(element.menu.children, id, icon)
+            if (updatedChildren !== element.menu.children) {
+                return element.copy(menu = element.menu.copy(children = updatedChildren))
             }
         }
+
         return element
     }
-
-    if (element is StackHeaderToolbarMenuElementConfig.Menu) {
-        val updatedChildren = updateChildrenIcon(element.children, id, icon)
-        if (updatedChildren !== element.children) {
-            return element.copy(children = updatedChildren)
-        }
-    }
-
-    return element
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
@@ -1,0 +1,69 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+import android.graphics.drawable.Drawable
+
+data class StackHeaderToolbarMenuConfig(
+    val children: List<StackHeaderToolbarMenuElementConfig>,
+) {
+    fun updateItemIcon(
+        id: String,
+        icon: Drawable?,
+    ): StackHeaderToolbarMenuConfig {
+        val updated = updateChildrenIcon(children, id, icon)
+        return if (updated !== children) StackHeaderToolbarMenuConfig(updated) else this
+    }
+}
+
+sealed interface StackHeaderToolbarMenuElementConfig {
+    val item: StackHeaderToolbarMenuItemConfig
+
+    data class MenuItem(
+        override val item: StackHeaderToolbarMenuItemConfig,
+    ) : StackHeaderToolbarMenuElementConfig
+
+    data class Menu(
+        override val item: StackHeaderToolbarMenuItemConfig,
+        val children: List<StackHeaderToolbarMenuElementConfig>,
+    ) : StackHeaderToolbarMenuElementConfig
+}
+
+private fun updateChildrenIcon(
+    children: List<StackHeaderToolbarMenuElementConfig>,
+    id: String,
+    icon: Drawable?,
+): List<StackHeaderToolbarMenuElementConfig> {
+    var changed = false
+    val result =
+        children.map { element ->
+            val updated = updateElementIcon(element, id, icon)
+            if (updated !== element) changed = true
+            updated
+        }
+    return if (changed) result else children
+}
+
+private fun updateElementIcon(
+    element: StackHeaderToolbarMenuElementConfig,
+    id: String,
+    icon: Drawable?,
+): StackHeaderToolbarMenuElementConfig {
+    if (element.item.id == id) {
+        val newItem = element.item.copy(icon = icon)
+        if (newItem.icon !== element.item.icon) {
+            return when (element) {
+                is StackHeaderToolbarMenuElementConfig.MenuItem -> element.copy(item = newItem)
+                is StackHeaderToolbarMenuElementConfig.Menu -> element.copy(item = newItem)
+            }
+        }
+        return element
+    }
+
+    if (element is StackHeaderToolbarMenuElementConfig.Menu) {
+        val updatedChildren = updateChildrenIcon(element.children, id, icon)
+        if (updatedChildren !== element.children) {
+            return element.copy(children = updatedChildren)
+        }
+    }
+
+    return element
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
@@ -2,6 +2,10 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
 import android.graphics.drawable.Drawable
 
+// Immutable tree of data classes. Updates walk the tree recursively and use
+// reference comparison (!==) to detect actual changes — only the path from
+// the changed leaf to the root is copied; unchanged subtrees keep their
+// original instances.
 internal data class StackHeaderToolbarMenuConfig(
     val children: List<StackHeaderToolbarMenuElementConfig>,
 ) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
@@ -18,14 +18,13 @@ internal data class StackHeaderToolbarMenuConfig(
         id: String,
         icon: Drawable?,
     ): List<StackHeaderToolbarMenuElementConfig> {
-        var changed = false
-        val result =
-            children.map { element ->
-                val updated = updateElementIcon(element, id, icon)
-                if (updated !== element) changed = true
-                updated
+        for ((index, element) in children.withIndex()) {
+            val updated = updateElementIcon(element, id, icon)
+            if (updated !== element) {
+                return children.toMutableList().apply { set(index, updated) }
             }
-        return if (changed) result else children
+        }
+        return children
     }
 
     private fun updateElementIcon(
@@ -34,8 +33,8 @@ internal data class StackHeaderToolbarMenuConfig(
         icon: Drawable?,
     ): StackHeaderToolbarMenuElementConfig {
         if (element.item.id == id) {
-            val newItem = element.item.copy(icon = icon)
-            if (newItem.icon !== element.item.icon) {
+            if (icon !== element.item.icon) {
+                val newItem = element.item.copy(icon = icon)
                 return when (element) {
                     is StackHeaderToolbarMenuElementConfig.MenuItem -> element.copy(item = newItem)
                     is StackHeaderToolbarMenuElementConfig.Submenu -> element.copy(item = newItem)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementConfig.kt
@@ -1,0 +1,14 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+internal sealed interface StackHeaderToolbarMenuElementConfig {
+    val item: StackHeaderToolbarMenuItemConfig
+
+    data class MenuItem(
+        override val item: StackHeaderToolbarMenuItemConfig,
+    ) : StackHeaderToolbarMenuElementConfig
+
+    data class Submenu(
+        override val item: StackHeaderToolbarMenuItemConfig,
+        val menu: StackHeaderToolbarMenuConfig,
+    ) : StackHeaderToolbarMenuElementConfig
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
 import android.graphics.drawable.Drawable
 
-data class StackHeaderToolbarMenuItemConfig(
+internal data class StackHeaderToolbarMenuItemConfig(
     val id: String,
     val title: String,
     val hidden: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemIconSource.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemIconSource.kt
@@ -1,6 +1,6 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
-data class StackHeaderToolbarMenuItemIconSource(
+internal data class StackHeaderToolbarMenuItemIconSource(
     val drawableIconResourceName: String?,
     val imageIconUri: String?,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -7,7 +7,7 @@ import android.graphics.drawable.Drawable
  *
  * A `null` field means "leave the current value unchanged".
  */
-data class StackHeaderToolbarMenuItemOptions(
+internal data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemShowAsAction.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemShowAsAction.kt
@@ -5,7 +5,7 @@ import android.view.MenuItem.SHOW_AS_ACTION_IF_ROOM
 import android.view.MenuItem.SHOW_AS_ACTION_NEVER
 import android.view.MenuItem.SHOW_AS_ACTION_WITH_TEXT
 
-enum class StackHeaderToolbarMenuItemShowAsAction {
+internal enum class StackHeaderToolbarMenuItemShowAsAction {
     ALWAYS,
     ALWAYS_WITH_TEXT,
     IF_ROOM,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -63,21 +63,27 @@ internal object StackHeaderToolbarMenuMapper {
 
     private fun parseChildren(map: ReadableMap): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
-        return (0 until array.size()).mapNotNull { i ->
-            val child = array.getMap(i) ?: return@mapNotNull null
+        return (0 until array.size()).map { i ->
+            val child =
+                requireNotNull(array.getMap(i)) {
+                    "[RNScreens] Menu children array must contain objects."
+                }
             parseElement(child)
         }
     }
 
-    private fun parseElement(map: ReadableMap): StackHeaderToolbarMenuElementConfig? =
-        when (map.readOptionalString("type")) {
+    private fun parseElement(map: ReadableMap): StackHeaderToolbarMenuElementConfig =
+        when (val type = map.readOptionalString("type")) {
             "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = parseItemConfig(map))
             "menu" ->
                 StackHeaderToolbarMenuElementConfig.Submenu(
                     item = parseItemConfig(map),
                     menu = StackHeaderToolbarMenuConfig(parseChildren(map)),
                 )
-            else -> null
+            else ->
+                throw JSApplicationIllegalArgumentException(
+                    "[RNScreens] Unknown toolbar menu element type: $type.",
+                )
         }
 
     private fun parseItemConfig(map: ReadableMap): StackHeaderToolbarMenuItemConfig =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -1,0 +1,206 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.swmansion.rnscreens.gamma.helpers.parseColor
+import com.swmansion.rnscreens.gamma.helpers.readBoolean
+import com.swmansion.rnscreens.gamma.helpers.readColor
+import com.swmansion.rnscreens.gamma.helpers.readImageUri
+import com.swmansion.rnscreens.gamma.helpers.readOptionalString
+import com.swmansion.rnscreens.gamma.helpers.readString
+import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
+
+internal object StackHeaderToolbarMenuMapper {
+    // region Menu prop parsing
+
+    fun parseMenu(value: Dynamic): StackHeaderToolbarMenuConfig {
+        val map = value.asMapOrNull() ?: return StackHeaderToolbarMenuConfig(emptyList())
+        return StackHeaderToolbarMenuConfig(parseChildren(map))
+    }
+
+    fun collectIconSources(value: Dynamic): Map<String, StackHeaderToolbarMenuItemIconSource> {
+        val map = value.asMapOrNull() ?: return emptyMap()
+        val result = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
+        collectIconSourcesFromChildren(map, result)
+        return result
+    }
+
+    // endregion
+
+    // region Menu item command parsing
+
+    fun parseMenuItemOptions(map: ReadableMap): StackHeaderToolbarMenuItemOptions =
+        StackHeaderToolbarMenuItemOptions(
+            title = map.readNullableStringUpdate("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+            showAsAction =
+                map.readNullableShowAsActionEnumUpdate(
+                    "showAsAction",
+                    StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
+                ),
+            icon = null,
+            iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal"),
+            iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed"),
+            iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused"),
+            iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled"),
+        )
+
+    fun parseMenuItemIconSource(map: ReadableMap): StackHeaderToolbarMenuItemIconSource? {
+        if (!map.hasKey("drawableIconResourceName") && !map.hasKey("imageIconResource")) {
+            return null
+        }
+        return StackHeaderToolbarMenuItemIconSource(
+            drawableIconResourceName = map.getString("drawableIconResourceName"),
+            imageIconUri = map.readImageUri("imageIconResource", null),
+        )
+    }
+
+    // endregion
+
+    // region Menu tree parsing
+
+    private fun parseChildren(map: ReadableMap): List<StackHeaderToolbarMenuElementConfig> {
+        val array = map.getArray("children") ?: return emptyList()
+        return (0 until array.size()).mapNotNull { i ->
+            val child = array.getMap(i) ?: return@mapNotNull null
+            parseElement(child)
+        }
+    }
+
+    private fun parseElement(map: ReadableMap): StackHeaderToolbarMenuElementConfig? =
+        when (map.readOptionalString("type")) {
+            "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = parseItemConfig(map))
+            "menu" ->
+                StackHeaderToolbarMenuElementConfig.Menu(
+                    item = parseItemConfig(map),
+                    children = parseChildren(map),
+                )
+            else -> null
+        }
+
+    private fun parseItemConfig(map: ReadableMap): StackHeaderToolbarMenuItemConfig =
+        StackHeaderToolbarMenuItemConfig(
+            id = map.requireNotNullString("id"),
+            title = map.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            hidden = map.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+            showAsAction = map.readShowAsActionEnum("showAsAction", StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION),
+            icon = null,
+            iconTintColorNormal = map.readColor("iconTintColorNormal", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL),
+            iconTintColorPressed = map.readColor("iconTintColorPressed", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED),
+            iconTintColorFocused = map.readColor("iconTintColorFocused", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED),
+            iconTintColorDisabled = map.readColor("iconTintColorDisabled", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED),
+        )
+
+    // endregion
+
+    // region Icon source collection
+
+    private fun collectIconSourcesFromChildren(
+        map: ReadableMap,
+        result: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
+    ) {
+        val array = map.getArray("children") ?: return
+        for (i in 0 until array.size()) {
+            val child = array.getMap(i) ?: continue
+            val type = child.readOptionalString("type") ?: continue
+            val id = child.getString("id") ?: continue
+
+            result[id] =
+                StackHeaderToolbarMenuItemIconSource(
+                    drawableIconResourceName =
+                        child.getString("drawableIconResourceName")
+                            ?: StackHeaderToolbarMenuItemDefaults.DRAWABLE_ICON_RESOURCE_NAME,
+                    imageIconUri =
+                        child.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
+                )
+
+            if (type == "menu") {
+                collectIconSourcesFromChildren(child, result)
+            }
+        }
+    }
+
+    // endregion
+
+    // region Enum helpers
+
+    private fun ReadableMap.readShowAsActionEnum(
+        key: String,
+        default: StackHeaderToolbarMenuItemShowAsAction,
+    ): StackHeaderToolbarMenuItemShowAsAction {
+        val stringValue = this.getString(key) ?: return default
+        return toShowAsActionEnum(stringValue)
+    }
+
+    private fun toShowAsActionEnum(value: String): StackHeaderToolbarMenuItemShowAsAction =
+        when (value) {
+            "always" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS
+            "alwaysWithText" -> StackHeaderToolbarMenuItemShowAsAction.ALWAYS_WITH_TEXT
+            "ifRoom" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM
+            "ifRoomWithText" -> StackHeaderToolbarMenuItemShowAsAction.IF_ROOM_WITH_TEXT
+            "never" -> StackHeaderToolbarMenuItemShowAsAction.NEVER
+            else ->
+                throw JSApplicationIllegalArgumentException(
+                    "[RNScreens] Invalid value for StackHeaderToolbarMenuItemShowAsAction: $value.",
+                )
+        }
+
+    // endregion
+
+    // region Update helpers (3-state semantics for view commands)
+
+    // Each key has three states:
+    // - not defined -> null         (no change)
+    // - null        -> default      (reset to default)
+    // - value       -> value
+    //
+    // A plain `T?` return can encode this only when the field's default is non-null,
+    // so `null` unambiguously means "no change". Fields whose default is null (the
+    // tint colors) must return `StackHeaderToolbarUpdate<T>?` instead, to tell "no
+    // change" (null) apart from "reset" (Reset).
+    private fun ReadableMap.readNullableStringUpdate(
+        key: String,
+        default: String,
+    ): String? =
+        when {
+            !this.hasKey(key) -> null
+            this.isNull(key) -> default
+            else -> this.getString(key) ?: default
+        }
+
+    private fun ReadableMap.readNullableBooleanUpdate(
+        key: String,
+        default: Boolean,
+    ): Boolean? =
+        when {
+            !this.hasKey(key) -> null
+            this.isNull(key) -> default
+            else -> this.getBoolean(key)
+        }
+
+    private fun ReadableMap.readNullableShowAsActionEnumUpdate(
+        key: String,
+        default: StackHeaderToolbarMenuItemShowAsAction,
+    ): StackHeaderToolbarMenuItemShowAsAction? =
+        when {
+            !this.hasKey(key) -> null
+            this.isNull(key) -> default
+            else ->
+                this.getString(key)?.let {
+                    toShowAsActionEnum(it)
+                } ?: default
+        }
+
+    private fun ReadableMap.readNullableColorUpdate(key: String): StackHeaderToolbarUpdate<Int>? =
+        when {
+            !this.hasKey(key) -> null
+            this.isNull(key) -> StackHeaderToolbarUpdate.Reset
+            else -> StackHeaderToolbarUpdate.from(parseColor(key))
+        }
+
+    // endregion
+}
+
+private fun Dynamic.asMapOrNull(): ReadableMap? = if (!isNull && type == ReadableType.Map) asMap() else null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -16,7 +16,12 @@ internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
     fun parseMenu(value: Dynamic): StackHeaderToolbarMenuConfig {
-        val map = value.asMapOrNull() ?: return StackHeaderToolbarMenuConfig(emptyList())
+        if (value.isNull) return StackHeaderToolbarMenuConfig(emptyList())
+        val map =
+            value.asMapOrNull()
+                ?: throw JSApplicationIllegalArgumentException(
+                    "[RNScreens] toolbarMenu must be an object.",
+                )
         return StackHeaderToolbarMenuConfig(parseChildren(map))
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -73,9 +73,9 @@ internal object StackHeaderToolbarMenuMapper {
         when (map.readOptionalString("type")) {
             "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = parseItemConfig(map))
             "menu" ->
-                StackHeaderToolbarMenuElementConfig.Menu(
+                StackHeaderToolbarMenuElementConfig.Submenu(
                     item = parseItemConfig(map),
-                    children = parseChildren(map),
+                    menu = StackHeaderToolbarMenuConfig(parseChildren(map)),
                 )
             else -> null
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
@@ -1,6 +1,6 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
-sealed interface StackHeaderToolbarUpdate<out T> {
+internal sealed interface StackHeaderToolbarUpdate<out T> {
     object Reset : StackHeaderToolbarUpdate<Nothing>
 
     data class Set<T>(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuItemClickedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuItemClickedEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
 
-class StackHeaderToolbarMenuItemClickedEvent(
+internal class StackHeaderToolbarMenuItemClickedEvent(
     surfaceId: Int,
     viewTag: Int,
     private val id: String,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuItemPressEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuItemPressEvent.kt
@@ -4,11 +4,11 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
 
-internal class StackHeaderToolbarMenuItemClickedEvent(
+internal class StackHeaderToolbarMenuItemPressEvent(
     surfaceId: Int,
     viewTag: Int,
     private val id: String,
-) : Event<StackHeaderToolbarMenuItemClickedEvent>(surfaceId, viewTag),
+) : Event<StackHeaderToolbarMenuItemPressEvent>(surfaceId, viewTag),
     NamingAwareEventType {
     override fun getEventName() = EVENT_NAME
 
@@ -19,8 +19,8 @@ internal class StackHeaderToolbarMenuItemClickedEvent(
     override fun getEventData() = Arguments.createMap().apply { putString(EK_ID, id) }
 
     companion object : NamingAwareEventType {
-        const val EVENT_NAME = "topToolbarMenuItemClicked"
-        const val EVENT_REGISTRATION_NAME = "onToolbarMenuItemClicked"
+        const val EVENT_NAME = "topToolbarMenuItemPress"
+        const val EVENT_REGISTRATION_NAME = "onToolbarMenuItemPress"
 
         private const val EK_ID = "id"
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -1,9 +1,6 @@
 package com.swmansion.rnscreens.gamma.tabs.screen
 
-import android.util.Log
-import androidx.core.graphics.toColorInt
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
@@ -12,9 +9,12 @@ import com.facebook.react.viewmanagers.RNSTabsScreenAndroidManagerDelegate
 import com.facebook.react.viewmanagers.RNSTabsScreenAndroidManagerInterface
 import com.swmansion.rnscreens.gamma.helpers.loadImage
 import com.swmansion.rnscreens.gamma.helpers.makeEventRegistrationInfo
+import com.swmansion.rnscreens.gamma.helpers.readOptionalBoolean
+import com.swmansion.rnscreens.gamma.helpers.readOptionalColor
+import com.swmansion.rnscreens.gamma.helpers.readOptionalFloat
+import com.swmansion.rnscreens.gamma.helpers.readOptionalString
 import com.swmansion.rnscreens.gamma.tabs.appearance.ItemStateAppearance
 import com.swmansion.rnscreens.gamma.tabs.appearance.TabsAppearance
-import com.swmansion.rnscreens.gamma.tabs.screen.TabsScreenViewManager.Companion.TAG
 import com.swmansion.rnscreens.gamma.tabs.screen.event.TabsScreenDidAppearEvent
 import com.swmansion.rnscreens.gamma.tabs.screen.event.TabsScreenDidDisappearEvent
 import com.swmansion.rnscreens.gamma.tabs.screen.event.TabsScreenWillAppearEvent
@@ -172,63 +172,33 @@ class TabsScreenViewManager :
 
     private fun parseAndroidTabsAppearance(appearance: ReadableMap): TabsAppearance =
         TabsAppearance(
-            tabBarBackgroundColor = appearance.getOptionalColor("tabBarBackgroundColor"),
-            tabBarItemRippleColor = appearance.getOptionalColor("tabBarItemRippleColor"),
-            tabBarItemLabelVisibilityMode = appearance.getOptionalString("tabBarItemLabelVisibilityMode"),
+            tabBarBackgroundColor = appearance.readOptionalColor("tabBarBackgroundColor"),
+            tabBarItemRippleColor = appearance.readOptionalColor("tabBarItemRippleColor"),
+            tabBarItemLabelVisibilityMode = appearance.readOptionalString("tabBarItemLabelVisibilityMode"),
             normal = if (appearance.hasKey("normal")) parseItemStateAppearance(appearance.getMap("normal")) else null,
             selected = if (appearance.hasKey("selected")) parseItemStateAppearance(appearance.getMap("selected")) else null,
             focused = if (appearance.hasKey("focused")) parseItemStateAppearance(appearance.getMap("focused")) else null,
             disabled = if (appearance.hasKey("disabled")) parseItemStateAppearance(appearance.getMap("disabled")) else null,
-            tabBarItemActiveIndicatorColor = appearance.getOptionalColor("tabBarItemActiveIndicatorColor"),
-            tabBarItemActiveIndicatorEnabled = appearance.getOptionalBoolean("tabBarItemActiveIndicatorEnabled"),
-            tabBarItemTitleFontFamily = appearance.getOptionalString("tabBarItemTitleFontFamily"),
-            tabBarItemTitleSmallLabelFontSize = appearance.getOptionalFloat("tabBarItemTitleSmallLabelFontSize"),
-            tabBarItemTitleLargeLabelFontSize = appearance.getOptionalFloat("tabBarItemTitleLargeLabelFontSize"),
-            tabBarItemTitleFontWeight = appearance.getOptionalString("tabBarItemTitleFontWeight"),
-            tabBarItemTitleFontStyle = appearance.getOptionalString("tabBarItemTitleFontStyle"),
-            tabBarItemBadgeBackgroundColor = appearance.getOptionalColor("tabBarItemBadgeBackgroundColor"),
-            tabBarItemBadgeTextColor = appearance.getOptionalColor("tabBarItemBadgeTextColor"),
+            tabBarItemActiveIndicatorColor = appearance.readOptionalColor("tabBarItemActiveIndicatorColor"),
+            tabBarItemActiveIndicatorEnabled = appearance.readOptionalBoolean("tabBarItemActiveIndicatorEnabled"),
+            tabBarItemTitleFontFamily = appearance.readOptionalString("tabBarItemTitleFontFamily"),
+            tabBarItemTitleSmallLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleSmallLabelFontSize"),
+            tabBarItemTitleLargeLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleLargeLabelFontSize"),
+            tabBarItemTitleFontWeight = appearance.readOptionalString("tabBarItemTitleFontWeight"),
+            tabBarItemTitleFontStyle = appearance.readOptionalString("tabBarItemTitleFontStyle"),
+            tabBarItemBadgeBackgroundColor = appearance.readOptionalColor("tabBarItemBadgeBackgroundColor"),
+            tabBarItemBadgeTextColor = appearance.readOptionalColor("tabBarItemBadgeTextColor"),
         )
 
     private fun parseItemStateAppearance(itemStateAppearance: ReadableMap?): ItemStateAppearance? {
         if (itemStateAppearance == null) return null
         return ItemStateAppearance(
-            tabBarItemIconColor = itemStateAppearance.getOptionalColor("tabBarItemIconColor"),
-            tabBarItemTitleFontColor = itemStateAppearance.getOptionalColor("tabBarItemTitleFontColor"),
+            tabBarItemIconColor = itemStateAppearance.readOptionalColor("tabBarItemIconColor"),
+            tabBarItemTitleFontColor = itemStateAppearance.readOptionalColor("tabBarItemTitleFontColor"),
         )
     }
 
     companion object {
         const val REACT_CLASS = "RNSTabsScreenAndroid"
-        const val TAG = "TabsScreenViewManager"
-    }
-}
-
-private fun ReadableMap.getOptionalBoolean(key: String): Boolean? {
-    if (!hasKey(key) || isNull(key)) return null
-    return if (getType(key) == ReadableType.Boolean) getBoolean(key) else null
-}
-
-private fun ReadableMap.getOptionalString(key: String): String? {
-    if (!hasKey(key) || isNull(key)) return null
-    return if (getType(key) == ReadableType.String) getString(key) else null
-}
-
-private fun ReadableMap.getOptionalFloat(key: String): Float? {
-    if (!hasKey(key) || isNull(key)) return null
-    return if (getType(key) == ReadableType.Number) getDouble(key).toFloat() else null
-}
-
-private fun ReadableMap.getOptionalColor(key: String): Int? {
-    if (!hasKey(key) || isNull(key)) return null
-    return try {
-        when (getType(key)) {
-            ReadableType.Number -> getInt(key)
-            ReadableType.String -> getString(key)?.toColorInt()
-            else -> null
-        }
-    } catch (e: Exception) {
-        Log.w(TAG, "[RNScreens] Could not parse color for key '$key': ${e.message}")
-        null
     }
 }

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -10,6 +10,7 @@ import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
 import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
 import TestStackToolbarMenuIcon from './test-stack-toolbar-menu-icon-android';
+import TestStackToolbarNestedMenu from './test-stack-toolbar-nested-menu-android';
 
 const scenarios = {
   PreventNativeDismissSingleStack,
@@ -23,6 +24,7 @@ const scenarios = {
   TestStackToolbarMenuCommands,
   TestStackToolbarMenuShowAsAction,
   TestStackToolbarMenuIcon,
+  TestStackToolbarNestedMenu,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -14,29 +14,25 @@ import type {
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-descriptions';
 
-type IdOption = 'item-1' | 'item-2' | 'item-3';
-type TitleOption =
-  | 'Title A'
-  | 'Title B'
-  | 'Title C'
-  | 'Long Title'
-  | 'Changed'
-  | 'undefined';
-type HiddenOption = 'true' | 'false' | 'undefined';
+const ID_OPTIONS = ['item-1', 'item-2', 'item-3'] as const;
+type IdOption = (typeof ID_OPTIONS)[number];
 
-type CmdTitleOption = TitleOption | 'no change';
-type CmdHiddenOption = HiddenOption | 'no change';
-
-const ID_OPTIONS: IdOption[] = ['item-1', 'item-2', 'item-3'];
-const TITLE_OPTIONS: TitleOption[] = [
+const TITLE_OPTIONS = [
   'Title A',
   'Title B',
   'Title C',
   'Long Title',
   'Changed',
   'undefined',
-];
-const HIDDEN_OPTIONS: HiddenOption[] = ['true', 'false', 'undefined'];
+] as const;
+type TitleOption = (typeof TITLE_OPTIONS)[number];
+
+const HIDDEN_OPTIONS = ['true', 'false', 'undefined'] as const;
+type HiddenOption = (typeof HIDDEN_OPTIONS)[number];
+
+type CmdTitleOption = TitleOption | 'no change';
+type CmdHiddenOption = HiddenOption | 'no change';
+
 const CMD_TITLE_OPTIONS: CmdTitleOption[] = ['no change', ...TITLE_OPTIONS];
 const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = ['no change', ...HIDDEN_OPTIONS];
 
@@ -172,7 +168,7 @@ function MainScreen() {
       <SettingsPicker<IdOption>
         label="target id"
         value={cmdTargetId}
-        items={ID_OPTIONS}
+        items={[...ID_OPTIONS]}
         onValueChange={setCmdTargetId}
       />
       <SettingsPicker<CmdTitleOption>
@@ -222,13 +218,13 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
           <SettingsPicker<TitleOption>
             label="title"
             value={slot.title}
-            items={TITLE_OPTIONS}
+            items={[...TITLE_OPTIONS]}
             onValueChange={v => updateSlot(i, { title: v })}
           />
           <SettingsPicker<HiddenOption>
             label="hidden"
             value={slot.hidden}
-            items={HIDDEN_OPTIONS}
+            items={[...HIDDEN_OPTIONS]}
             onValueChange={v => updateSlot(i, { hidden: v })}
           />
         </React.Fragment>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -7,9 +7,10 @@ import {
 } from '@apps/shared/gamma/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import {
-  type StackHeaderConfigRef,
-  type StackHeaderToolbarMenuItemOptionsAndroid,
+import type {
+  StackHeaderToolbarMenuElementAndroid,
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuItemOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-descriptions';
 
@@ -62,11 +63,11 @@ function resolveHidden(h: HiddenOption): boolean | undefined {
   return h === 'undefined' ? undefined : h === 'true';
 }
 
-function buildItems(slots: Slots) {
+function buildItems(slots: Slots): StackHeaderToolbarMenuElementAndroid[] {
   return slots
     .filter(s => s.include)
     .map(({ id, title, hidden }) => ({
-      type: 'menuItem' as const,
+      type: 'menuItem',
       id,
       title: resolveTitle(title),
       hidden: resolveHidden(hidden),

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -66,10 +66,21 @@ function buildItems(slots: Slots) {
   return slots
     .filter(s => s.include)
     .map(({ id, title, hidden }) => ({
+      type: 'menuItem' as const,
       id,
       title: resolveTitle(title),
       hidden: resolveHidden(hidden),
     }));
+}
+
+function withOnPress(
+  items: ReturnType<typeof buildItems>,
+  onPress: (id: string) => void,
+) {
+  return items.map(item => ({
+    ...item,
+    onPress: () => onPress(item.id),
+  }));
 }
 
 function updateSlotAt(
@@ -92,7 +103,7 @@ export function App() {
           options: {
             headerConfig: {
               title: HEADER_TITLE,
-              android: { toolbarMenuItems: buildItems(DEFAULT_SLOTS) },
+              android: { toolbarMenu: { children: buildItems(DEFAULT_SLOTS) } },
             },
           },
         },
@@ -117,9 +128,9 @@ function MainScreen() {
       headerConfig: {
         title: HEADER_TITLE,
         android: {
-          toolbarMenuItems: buildItems(DEFAULT_SLOTS),
-          onToolbarMenuItemClicked: event =>
-            setLastClicked(event.nativeEvent.id),
+          toolbarMenu: {
+            children: withOnPress(buildItems(DEFAULT_SLOTS), setLastClicked),
+          },
         },
       },
       headerConfigRef,
@@ -133,9 +144,9 @@ function MainScreen() {
         headerConfig: {
           title: HEADER_TITLE,
           android: {
-            toolbarMenuItems: buildItems(next),
-            onToolbarMenuItemClicked: event =>
-              setLastClicked(event.nativeEvent.id),
+            toolbarMenu: {
+              children: withOnPress(buildItems(next), setLastClicked),
+            },
           },
         },
       });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -16,27 +16,20 @@ import type {
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-descriptions';
 
-type IdOption = 'item-1' | 'item-2' | 'item-3';
-type IconOption = 'none' | 'imageSource' | 'drawableResource';
-type TintColorOption = 'default' | 'purple' | 'red' | 'green';
-type ShowAsActionOption = 'always' | 'never' | 'ifRoom';
+const ID_OPTIONS = ['item-1', 'item-2', 'item-3'] as const;
+type IdOption = (typeof ID_OPTIONS)[number];
+
+const ICON_OPTIONS = ['none', 'imageSource', 'drawableResource'] as const;
+type IconOption = (typeof ICON_OPTIONS)[number];
+
+const TINT_COLOR_OPTIONS = ['default', 'purple', 'red', 'green'] as const;
+type TintColorOption = (typeof TINT_COLOR_OPTIONS)[number];
+
+const SHOW_AS_ACTION_OPTIONS = ['always', 'never', 'ifRoom'] as const;
+type ShowAsActionOption = (typeof SHOW_AS_ACTION_OPTIONS)[number];
 
 type CmdIconOption = 'no change' | IconOption;
 type CmdTintColorOption = 'no change' | TintColorOption;
-
-const ID_OPTIONS: IdOption[] = ['item-1', 'item-2', 'item-3'];
-const ICON_OPTIONS: IconOption[] = ['none', 'imageSource', 'drawableResource'];
-const TINT_COLOR_OPTIONS: TintColorOption[] = [
-  'default',
-  'purple',
-  'red',
-  'green',
-];
-const SHOW_AS_ACTION_OPTIONS: ShowAsActionOption[] = [
-  'always',
-  'never',
-  'ifRoom',
-];
 
 const CMD_ICON_OPTIONS: CmdIconOption[] = ['no change', ...ICON_OPTIONS];
 const CMD_TINT_COLOR_OPTIONS: CmdTintColorOption[] = [
@@ -250,7 +243,7 @@ function MainScreen() {
       <SettingsPicker<IdOption>
         label="target id"
         value={cmdTargetId}
-        items={ID_OPTIONS}
+        items={[...ID_OPTIONS]}
         onValueChange={setCmdTargetId}
       />
       <SettingsPicker<CmdIconOption>
@@ -318,37 +311,37 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
           <SettingsPicker<IconOption>
             label="icon"
             value={slot.icon}
-            items={ICON_OPTIONS}
+            items={[...ICON_OPTIONS]}
             onValueChange={v => updateSlot(i, { icon: v })}
           />
           <SettingsPicker<ShowAsActionOption>
             label="showAsAction"
             value={slot.showAsAction}
-            items={SHOW_AS_ACTION_OPTIONS}
+            items={[...SHOW_AS_ACTION_OPTIONS]}
             onValueChange={v => updateSlot(i, { showAsAction: v })}
           />
           <SettingsPicker<TintColorOption>
             label="tintColorNormal"
             value={slot.tintColorNormal}
-            items={TINT_COLOR_OPTIONS}
+            items={[...TINT_COLOR_OPTIONS]}
             onValueChange={v => updateSlot(i, { tintColorNormal: v })}
           />
           <SettingsPicker<TintColorOption>
             label="tintColorPressed"
             value={slot.tintColorPressed}
-            items={TINT_COLOR_OPTIONS}
+            items={[...TINT_COLOR_OPTIONS]}
             onValueChange={v => updateSlot(i, { tintColorPressed: v })}
           />
           <SettingsPicker<TintColorOption>
             label="tintColorFocused"
             value={slot.tintColorFocused}
-            items={TINT_COLOR_OPTIONS}
+            items={[...TINT_COLOR_OPTIONS]}
             onValueChange={v => updateSlot(i, { tintColorFocused: v })}
           />
           <SettingsPicker<TintColorOption>
             label="tintColorDisabled"
             value={slot.tintColorDisabled}
-            items={TINT_COLOR_OPTIONS}
+            items={[...TINT_COLOR_OPTIONS]}
             onValueChange={v => updateSlot(i, { tintColorDisabled: v })}
           />
         </React.Fragment>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -8,10 +8,10 @@ import {
 } from '@apps/shared/gamma/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import {
-  type StackHeaderConfigRef,
-  type StackHeaderToolbarMenuItemAndroid,
-  type StackHeaderToolbarMenuItemOptionsAndroid,
+import type {
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuItemAndroid,
+  StackHeaderToolbarMenuItemOptionsAndroid,
 } from 'react-native-screens/experimental';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-descriptions';
@@ -113,7 +113,7 @@ function buildItems(slots: Slots): StackHeaderToolbarMenuItemAndroid[] {
   return slots
     .filter(s => s.include)
     .map(s => ({
-      type: 'menuItem' as const,
+      type: 'menuItem',
       id: s.id,
       title: ITEM_TITLES[s.id],
       showAsAction: s.showAsAction,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -113,6 +113,7 @@ function buildItems(slots: Slots): StackHeaderToolbarMenuItemAndroid[] {
   return slots
     .filter(s => s.include)
     .map(s => ({
+      type: 'menuItem' as const,
       id: s.id,
       title: ITEM_TITLES[s.id],
       showAsAction: s.showAsAction,
@@ -122,6 +123,16 @@ function buildItems(slots: Slots): StackHeaderToolbarMenuItemAndroid[] {
       iconTintColorFocused: resolveTintColor(s.tintColorFocused),
       iconTintColorDisabled: resolveTintColor(s.tintColorDisabled),
     }));
+}
+
+function withOnPress(
+  items: ReturnType<typeof buildItems>,
+  onPress: (id: string) => void,
+) {
+  return items.map(item => ({
+    ...item,
+    onPress: () => onPress(item.id),
+  }));
 }
 
 function updateSlotAt(
@@ -144,7 +155,7 @@ export function App() {
           options: {
             headerConfig: {
               title: HEADER_TITLE,
-              android: { toolbarMenuItems: buildItems(DEFAULT_SLOTS) },
+              android: { toolbarMenu: { children: buildItems(DEFAULT_SLOTS) } },
             },
           },
         },
@@ -176,9 +187,9 @@ function MainScreen() {
       headerConfig: {
         title: HEADER_TITLE,
         android: {
-          toolbarMenuItems: buildItems(DEFAULT_SLOTS),
-          onToolbarMenuItemClicked: event =>
-            setLastClicked(event.nativeEvent.id),
+          toolbarMenu: {
+            children: withOnPress(buildItems(DEFAULT_SLOTS), setLastClicked),
+          },
         },
       },
       headerConfigRef,
@@ -192,9 +203,9 @@ function MainScreen() {
         headerConfig: {
           title: HEADER_TITLE,
           android: {
-            toolbarMenuItems: buildItems(next),
-            onToolbarMenuItemClicked: event =>
-              setLastClicked(event.nativeEvent.id),
+            toolbarMenu: {
+              children: withOnPress(buildItems(next), setLastClicked),
+            },
           },
         },
       });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -16,29 +16,26 @@ import type {
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-descriptions';
 
-type IdOption = 'item-1' | 'item-2' | 'item-3';
-type ShowAsActionOption =
-  | 'undefined'
-  | 'never'
-  | 'always'
-  | 'alwaysWithText'
-  | 'ifRoom'
-  | 'ifRoomWithText';
-type IconOption = 'undefined' | 'searchIcon';
-type CmdIconOption = 'no change' | IconOption;
-type CmdShowAsActionOption = 'no change' | ShowAsActionOption;
+const ID_OPTIONS = ['item-1', 'item-2', 'item-3'] as const;
+type IdOption = (typeof ID_OPTIONS)[number];
 
-const ID_OPTIONS: IdOption[] = ['item-1', 'item-2', 'item-3'];
-const ICON_OPTIONS: IconOption[] = ['undefined', 'searchIcon'];
-const CMD_ICON_OPTIONS: CmdIconOption[] = ['no change', ...ICON_OPTIONS];
-const SHOW_AS_ACTION_OPTIONS: ShowAsActionOption[] = [
+const ICON_OPTIONS = ['undefined', 'searchIcon'] as const;
+type IconOption = (typeof ICON_OPTIONS)[number];
+
+const SHOW_AS_ACTION_OPTIONS = [
   'undefined',
   'never',
   'always',
   'alwaysWithText',
   'ifRoom',
   'ifRoomWithText',
-];
+] as const;
+type ShowAsActionOption = (typeof SHOW_AS_ACTION_OPTIONS)[number];
+
+type CmdIconOption = 'no change' | IconOption;
+type CmdShowAsActionOption = 'no change' | ShowAsActionOption;
+
+const CMD_ICON_OPTIONS: CmdIconOption[] = ['no change', ...ICON_OPTIONS];
 const CMD_SHOW_AS_ACTION_OPTIONS: CmdShowAsActionOption[] = [
   'no change',
   ...SHOW_AS_ACTION_OPTIONS,
@@ -198,7 +195,7 @@ function MainScreen() {
       <SettingsPicker<IdOption>
         label="target id"
         value={cmdTargetId}
-        items={ID_OPTIONS}
+        items={[...ID_OPTIONS]}
         onValueChange={setCmdTargetId}
       />
       <SettingsPicker<CmdIconOption>
@@ -248,13 +245,13 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
           <SettingsPicker<IconOption>
             label="icon"
             value={slot.icon}
-            items={ICON_OPTIONS}
+            items={[...ICON_OPTIONS]}
             onValueChange={v => updateSlot(i, { icon: v })}
           />
           <SettingsPicker<ShowAsActionOption>
             label="showAsAction"
             value={slot.showAsAction}
-            items={SHOW_AS_ACTION_OPTIONS}
+            items={[...SHOW_AS_ACTION_OPTIONS]}
             onValueChange={v => updateSlot(i, { showAsAction: v })}
           />
         </React.Fragment>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -7,10 +7,11 @@ import {
 } from '@apps/shared/gamma/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import {
-  type StackHeaderConfigRef,
-  type StackHeaderToolbarMenuItemOptionsAndroid,
-  type StackHeaderToolbarMenuItemShowAsActionAndroid,
+import type {
+  StackHeaderToolbarMenuElementAndroid,
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuItemShowAsActionAndroid,
 } from 'react-native-screens/experimental';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-descriptions';
@@ -82,11 +83,11 @@ const ITEM_TITLES: Record<IdOption, string> = {
   'item-3': 'Item Number Three',
 };
 
-function buildItems(slots: Slots) {
+function buildItems(slots: Slots): StackHeaderToolbarMenuElementAndroid[] {
   return slots
     .filter(s => s.include)
     .map(({ id, icon, showAsAction }) => ({
-      type: 'menuItem' as const,
+      type: 'menuItem',
       id,
       title: ITEM_TITLES[id],
       icon: resolveIcon(icon),

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -86,11 +86,22 @@ function buildItems(slots: Slots) {
   return slots
     .filter(s => s.include)
     .map(({ id, icon, showAsAction }) => ({
+      type: 'menuItem' as const,
       id,
       title: ITEM_TITLES[id],
       icon: resolveIcon(icon),
       showAsAction: resolveShowAsAction(showAsAction),
     }));
+}
+
+function withOnPress(
+  items: ReturnType<typeof buildItems>,
+  onPress: (id: string) => void,
+) {
+  return items.map(item => ({
+    ...item,
+    onPress: () => onPress(item.id),
+  }));
 }
 
 function updateSlotAt(
@@ -113,7 +124,7 @@ export function App() {
           options: {
             headerConfig: {
               title: HEADER_TITLE,
-              android: { toolbarMenuItems: buildItems(DEFAULT_SLOTS) },
+              android: { toolbarMenu: { children: buildItems(DEFAULT_SLOTS) } },
             },
           },
         },
@@ -139,9 +150,9 @@ function MainScreen() {
       headerConfig: {
         title: HEADER_TITLE,
         android: {
-          toolbarMenuItems: buildItems(DEFAULT_SLOTS),
-          onToolbarMenuItemClicked: event =>
-            setLastClicked(event.nativeEvent.id),
+          toolbarMenu: {
+            children: withOnPress(buildItems(DEFAULT_SLOTS), setLastClicked),
+          },
         },
       },
       headerConfigRef,
@@ -155,9 +166,9 @@ function MainScreen() {
         headerConfig: {
           title: HEADER_TITLE,
           android: {
-            toolbarMenuItems: buildItems(next),
-            onToolbarMenuItemClicked: event =>
-              setLastClicked(event.nativeEvent.id),
+            toolbarMenu: {
+              children: withOnPress(buildItems(next), setLastClicked),
+            },
           },
         },
       });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -1,0 +1,325 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuItemOptionsAndroid,
+} from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+
+type AllIds =
+  | 'item-top'
+  | 'submenu-1'
+  | 'sub-1-1'
+  | 'sub-1-2'
+  | 'submenu-2'
+  | 'sub-2-1'
+  | 'deep-menu'
+  | 'deep-1';
+
+type TitleOption = 'Title X' | 'undefined';
+type HiddenOption = 'true' | 'false' | 'undefined';
+
+type CmdTitleOption = TitleOption | 'no change';
+type CmdHiddenOption = HiddenOption | 'no change';
+
+type Submenu1TitleOption = 'Submenu A' | 'Changed' | 'undefined';
+
+const ALL_IDS: AllIds[] = [
+  'item-top',
+  'submenu-1',
+  'sub-1-1',
+  'sub-1-2',
+  'submenu-2',
+  'sub-2-1',
+  'deep-menu',
+  'deep-1',
+];
+const CMD_TITLE_OPTIONS: CmdTitleOption[] = [
+  'no change',
+  'Title X',
+  'undefined',
+];
+const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = [
+  'no change',
+  'true',
+  'false',
+  'undefined',
+];
+const SUBMENU1_TITLE_OPTIONS: Submenu1TitleOption[] = [
+  'Submenu A',
+  'Changed',
+  'undefined',
+];
+
+function resolveTitle(t: TitleOption | Submenu1TitleOption): string | undefined {
+  return t === 'undefined' ? undefined : t;
+}
+
+function resolveHidden(h: HiddenOption): boolean | undefined {
+  return h === 'undefined' ? undefined : h === 'true';
+}
+
+interface MenuConfig {
+  includeSubmenu1: boolean;
+  submenu1Title: Submenu1TitleOption;
+  addExtraItem: boolean;
+  includeSubmenu2: boolean;
+}
+
+const DEFAULT_CONFIG: MenuConfig = {
+  includeSubmenu1: true,
+  submenu1Title: 'Submenu A',
+  addExtraItem: false,
+  includeSubmenu2: true,
+};
+
+function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
+  const children: Array<
+    | { type: 'menuItem'; id: string; title: string; onPress: () => void }
+    | {
+        type: 'menu';
+        id: string;
+        title: string | undefined;
+        children: Array<any>;
+      }
+  > = [];
+
+  children.push({
+    type: 'menuItem',
+    id: 'item-top',
+    title: 'Top Item',
+    onPress: () => onPress('item-top'),
+  });
+
+  if (config.includeSubmenu1) {
+    const sub1Children = [
+      {
+        type: 'menuItem' as const,
+        id: 'sub-1-1',
+        title: 'Sub A.1',
+        onPress: () => onPress('sub-1-1'),
+      },
+      {
+        type: 'menuItem' as const,
+        id: 'sub-1-2',
+        title: 'Sub A.2',
+        onPress: () => onPress('sub-1-2'),
+      },
+    ];
+    if (config.addExtraItem) {
+      sub1Children.push({
+        type: 'menuItem' as const,
+        id: 'sub-1-3',
+        title: 'Sub A.3',
+        onPress: () => onPress('sub-1-3'),
+      });
+    }
+    children.push({
+      type: 'menu',
+      id: 'submenu-1',
+      title: resolveTitle(config.submenu1Title),
+      children: sub1Children,
+    });
+  }
+
+  if (config.includeSubmenu2) {
+    children.push({
+      type: 'menu',
+      id: 'submenu-2',
+      title: 'Submenu B',
+      children: [
+        {
+          type: 'menuItem' as const,
+          id: 'sub-2-1',
+          title: 'Sub B.1',
+          onPress: () => onPress('sub-2-1'),
+        },
+        {
+          type: 'menu' as const,
+          id: 'deep-menu',
+          title: 'Deep',
+          children: [
+            {
+              type: 'menuItem' as const,
+              id: 'deep-1',
+              title: 'Deep.1',
+              onPress: () => onPress('deep-1'),
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  return children;
+}
+
+const HEADER_TITLE = 'Toolbar Nested Menu Test';
+
+export function App() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Main',
+          Component: MainScreen,
+          options: {
+            headerConfig: {
+              title: HEADER_TITLE,
+              android: {
+                toolbarMenu: {
+                  children: buildMenu(DEFAULT_CONFIG, () => {}),
+                },
+              },
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function MainScreen() {
+  const [config, setConfig] = useState<MenuConfig>(DEFAULT_CONFIG);
+  const [lastClicked, setLastClicked] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<AllIds>('item-top');
+  const [cmdTitle, setCmdTitle] = useState<CmdTitleOption>('no change');
+  const [cmdHidden, setCmdHidden] = useState<CmdHiddenOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenu: {
+            children: buildMenu(DEFAULT_CONFIG, setLastClicked),
+          },
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey]);
+
+  const applyConfig = useCallback(
+    (next: MenuConfig) => {
+      setConfig(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenu: {
+              children: buildMenu(next, setLastClicked),
+            },
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdTitle !== 'no change' && { title: resolveTitle(cmdTitle) }),
+      ...(cmdHidden !== 'no change' && {
+        hidden: resolveHidden(cmdHidden),
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [cmdTargetId, cmdTitle, cmdHidden]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Result</Text>
+      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<AllIds>
+        label="target id"
+        value={cmdTargetId}
+        items={ALL_IDS}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdTitleOption>
+        label="title"
+        value={cmdTitle}
+        items={CMD_TITLE_OPTIONS}
+        onValueChange={setCmdTitle}
+      />
+      <SettingsPicker<CmdHiddenOption>
+        label="hidden"
+        value={cmdHidden}
+        items={CMD_HIDDEN_OPTIONS}
+        onValueChange={setCmdHidden}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Menu Structure — Props</Text>
+      <SettingsSwitch
+        label="include submenu-1"
+        value={config.includeSubmenu1}
+        onValueChange={v =>
+          applyConfig({ ...config, includeSubmenu1: v })
+        }
+      />
+      <SettingsPicker<Submenu1TitleOption>
+        label="submenu-1 title"
+        value={config.submenu1Title}
+        items={SUBMENU1_TITLE_OPTIONS}
+        onValueChange={v =>
+          applyConfig({ ...config, submenu1Title: v })
+        }
+      />
+      <SettingsSwitch
+        label="add extra item to submenu-1"
+        value={config.addExtraItem}
+        onValueChange={v =>
+          applyConfig({ ...config, addExtraItem: v })
+        }
+      />
+      <SettingsSwitch
+        label="include submenu-2"
+        value={config.includeSubmenu2}
+        onValueChange={v =>
+          applyConfig({ ...config, includeSubmenu2: v })
+        }
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -14,25 +14,7 @@ import {
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
 
-type AllIds =
-  | 'item-top'
-  | 'submenu-1'
-  | 'sub-1-1'
-  | 'sub-1-2'
-  | 'submenu-2'
-  | 'sub-2-1'
-  | 'deep-menu'
-  | 'deep-1';
-
-type TitleOption = 'Title X' | 'undefined';
-type HiddenOption = 'true' | 'false' | 'undefined';
-
-type CmdTitleOption = TitleOption | 'no change';
-type CmdHiddenOption = HiddenOption | 'no change';
-
-type Submenu1TitleOption = 'Submenu A' | 'Changed' | 'undefined';
-
-const ALL_IDS: AllIds[] = [
+const ALL_IDS = [
   'item-top',
   'submenu-1',
   'sub-1-1',
@@ -41,7 +23,18 @@ const ALL_IDS: AllIds[] = [
   'sub-2-1',
   'deep-menu',
   'deep-1',
-];
+] as const;
+type AllIds = (typeof ALL_IDS)[number];
+
+type TitleOption = 'Title X' | 'undefined';
+type HiddenOption = 'true' | 'false' | 'undefined';
+
+type CmdTitleOption = TitleOption | 'no change';
+type CmdHiddenOption = HiddenOption | 'no change';
+
+const SUBMENU1_TITLE_OPTIONS = ['Submenu A', 'Changed', 'undefined'] as const;
+type Submenu1TitleOption = (typeof SUBMENU1_TITLE_OPTIONS)[number];
+
 const CMD_TITLE_OPTIONS: CmdTitleOption[] = [
   'no change',
   'Title X',
@@ -51,11 +44,6 @@ const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = [
   'no change',
   'true',
   'false',
-  'undefined',
-];
-const SUBMENU1_TITLE_OPTIONS: Submenu1TitleOption[] = [
-  'Submenu A',
-  'Changed',
   'undefined',
 ];
 
@@ -248,7 +236,7 @@ function MainScreen() {
       <SettingsPicker<AllIds>
         label="target id"
         value={cmdTargetId}
-        items={ALL_IDS}
+        items={[...ALL_IDS]}
         onValueChange={setCmdTargetId}
       />
       <SettingsPicker<CmdTitleOption>
@@ -274,7 +262,7 @@ function MainScreen() {
       <SettingsPicker<Submenu1TitleOption>
         label="submenu-1 title"
         value={config.submenu1Title}
-        items={SUBMENU1_TITLE_OPTIONS}
+        items={[...SUBMENU1_TITLE_OPTIONS]}
         onValueChange={v => applyConfig({ ...config, submenu1Title: v })}
       />
       <SettingsSwitch

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -83,7 +83,10 @@ const DEFAULT_CONFIG: MenuConfig = {
   includeSubmenu2: true,
 };
 
-function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
+function buildMenu(
+  config: MenuConfig,
+  onPress: (id: string) => void,
+): StackHeaderToolbarMenuElementAndroid[] {
   const children: StackHeaderToolbarMenuElementAndroid[] = [];
 
   children.push({
@@ -94,15 +97,15 @@ function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
   });
 
   if (config.includeSubmenu1) {
-    const sub1Children = [
+    const sub1Children: StackHeaderToolbarMenuElementAndroid[] = [
       {
-        type: 'menuItem' as const,
+        type: 'menuItem',
         id: 'sub-1-1',
         title: 'Sub A.1',
         onPress: () => onPress('sub-1-1'),
       },
       {
-        type: 'menuItem' as const,
+        type: 'menuItem',
         id: 'sub-1-2',
         title: 'Sub A.2',
         onPress: () => onPress('sub-1-2'),
@@ -110,7 +113,7 @@ function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
     ];
     if (config.addExtraItem) {
       sub1Children.push({
-        type: 'menuItem' as const,
+        type: 'menuItem',
         id: 'sub-1-3',
         title: 'Sub A.3',
         onPress: () => onPress('sub-1-3'),
@@ -131,18 +134,18 @@ function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
       title: 'Submenu B',
       children: [
         {
-          type: 'menuItem' as const,
+          type: 'menuItem',
           id: 'sub-2-1',
           title: 'Sub B.1',
           onPress: () => onPress('sub-2-1'),
         },
         {
-          type: 'menu' as const,
+          type: 'menu',
           id: 'deep-menu',
           title: 'Deep',
           children: [
             {
-              type: 'menuItem' as const,
+              type: 'menuItem',
               id: 'deep-1',
               title: 'Deep.1',
               onPress: () => onPress('deep-1'),

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -9,6 +9,7 @@ import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
 import {
   type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuElementAndroid,
   type StackHeaderToolbarMenuItemOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
@@ -58,7 +59,9 @@ const SUBMENU1_TITLE_OPTIONS: Submenu1TitleOption[] = [
   'undefined',
 ];
 
-function resolveTitle(t: TitleOption | Submenu1TitleOption): string | undefined {
+function resolveTitle(
+  t: TitleOption | Submenu1TitleOption,
+): string | undefined {
   return t === 'undefined' ? undefined : t;
 }
 
@@ -81,15 +84,7 @@ const DEFAULT_CONFIG: MenuConfig = {
 };
 
 function buildMenu(config: MenuConfig, onPress: (id: string) => void) {
-  const children: Array<
-    | { type: 'menuItem'; id: string; title: string; onPress: () => void }
-    | {
-        type: 'menu';
-        id: string;
-        title: string | undefined;
-        children: Array<any>;
-      }
-  > = [];
+  const children: StackHeaderToolbarMenuElementAndroid[] = [];
 
   children.push({
     type: 'menuItem',
@@ -271,31 +266,23 @@ function MainScreen() {
       <SettingsSwitch
         label="include submenu-1"
         value={config.includeSubmenu1}
-        onValueChange={v =>
-          applyConfig({ ...config, includeSubmenu1: v })
-        }
+        onValueChange={v => applyConfig({ ...config, includeSubmenu1: v })}
       />
       <SettingsPicker<Submenu1TitleOption>
         label="submenu-1 title"
         value={config.submenu1Title}
         items={SUBMENU1_TITLE_OPTIONS}
-        onValueChange={v =>
-          applyConfig({ ...config, submenu1Title: v })
-        }
+        onValueChange={v => applyConfig({ ...config, submenu1Title: v })}
       />
       <SettingsSwitch
         label="add extra item to submenu-1"
         value={config.addExtraItem}
-        onValueChange={v =>
-          applyConfig({ ...config, addExtraItem: v })
-        }
+        onValueChange={v => applyConfig({ ...config, addExtraItem: v })}
       />
       <SettingsSwitch
         label="include submenu-2"
         value={config.includeSubmenu2}
-        onValueChange={v =>
-          applyConfig({ ...config, includeSubmenu2: v })
-        }
+        onValueChange={v => applyConfig({ ...config, includeSubmenu2: v })}
       />
     </ScrollView>
   );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario-description.ts
@@ -1,0 +1,13 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Nested Menu',
+  key: 'test-stack-toolbar-nested-menu-android',
+  details:
+    'Tests toolbar menu submenus: rendering nested menus, click handling ' +
+    'at all nesting levels, imperative commands targeting items inside ' +
+    'submenus and submenu containers, and props-update rebuild semantics.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
@@ -1,0 +1,216 @@
+# Test Scenario: Stack Toolbar Nested Menu
+
+## Details
+
+**Description:** This test focuses on the Android toolbar menu submenu
+support on the gamma stack header. It verifies that submenus render
+correctly as expandable groups in the overflow menu, that `onPress`
+fires with the correct id for items at every nesting level (including
+deeply nested submenus), that imperative `setToolbarMenuItemOptions`
+commands work on both leaf items inside submenus and on submenu
+containers themselves, and that any props update rebuilds the entire
+menu tree — discarding all prior command-applied state at every level.
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+TBD — automation is possible and planned but not yet implemented.
+
+## Prerequisites
+
+- Android emulator or device
+
+## Note
+
+- The initial menu structure is:
+  - `item-top`: "Top Item" (regular menu item)
+  - `submenu-1`: "Submenu A" (submenu containing):
+    - `sub-1-1`: "Sub A.1"
+    - `sub-1-2`: "Sub A.2"
+  - `submenu-2`: "Submenu B" (submenu containing):
+    - `sub-2-1`: "Sub B.1"
+    - `deep-menu`: "Deep" (submenu containing):
+      - `deep-1`: "Deep.1"
+- Submenus appear as items with a disclosure indicator (arrow).
+  Tapping a submenu opens a nested menu instead of firing `onPress`.
+- `setToolbarMenuItemOptions` targets elements by `id`. It works on
+  both leaf items and submenu containers at any nesting depth.
+
+## Steps
+
+### Baseline — initial render and submenu structure
+
+1. Launch the app and navigate to **Stack Toolbar Nested Menu**.
+
+- [ ] Header title reads "Toolbar Nested Menu Test". The toolbar
+      overflow menu shows three entries: "Top Item", "Submenu A"
+      (with a disclosure indicator), "Submenu B" (with a disclosure
+      indicator).
+
+2. Tap "Submenu A" in the overflow menu.
+
+- [ ] A nested menu opens showing two items: "Sub A.1" and
+      "Sub A.2".
+
+3. Go back to the top-level menu. Tap "Submenu B".
+
+- [ ] A nested menu opens showing two entries: "Sub B.1" and
+      "Deep" (with a disclosure indicator).
+
+4. Tap "Deep" in the Submenu B menu.
+
+- [ ] A nested menu opens showing one item: "Deep.1".
+
+---
+
+### Click handling — items at all nesting levels
+
+5. Open the overflow menu and tap "Top Item".
+
+- [ ] "Last clicked" updates to `item-top`.
+
+6. Open the overflow menu, tap "Submenu A", then tap "Sub A.1".
+
+- [ ] "Last clicked" updates to `sub-1-1`.
+
+7. Open the overflow menu, tap "Submenu A", then tap "Sub A.2".
+
+- [ ] "Last clicked" updates to `sub-1-2`.
+
+8. Open the overflow menu, tap "Submenu B", then tap "Sub B.1".
+
+- [ ] "Last clicked" updates to `sub-2-1`.
+
+9. Open the overflow menu, tap "Submenu B", tap "Deep", then tap
+   "Deep.1".
+
+- [ ] "Last clicked" updates to `deep-1`.
+
+---
+
+### Imperative command — change a leaf item inside a submenu
+
+10. In **Send Command**, set target id = `sub-1-1`,
+    title = `Title X`, hidden = `no change`. Tap **Send Command**.
+
+- [ ] Open "Submenu A": item 1 now reads "Title X". Item 2 still
+      reads "Sub A.2".
+
+11. Tap "Title X" in the submenu.
+
+- [ ] "Last clicked" updates to `sub-1-1` (id is stable across
+      title changes).
+
+---
+
+### Imperative command — hide and show a leaf item inside a submenu
+
+12. Set target id = `sub-1-2`, title = `no change`,
+    hidden = `true`. Tap **Send Command**.
+
+- [ ] Open "Submenu A": only "Title X" is visible. "Sub A.2" is
+      hidden.
+
+13. Set target id = `sub-1-2`, title = `no change`,
+    hidden = `false`. Tap **Send Command**.
+
+- [ ] Open "Submenu A": "Sub A.2" reappears alongside "Title X".
+
+---
+
+### Imperative command — change a submenu container
+
+14. Set target id = `submenu-1`, title = `Title X`,
+    hidden = `no change`. Tap **Send Command**.
+
+- [ ] In the overflow menu, the submenu previously labeled
+      "Submenu A" now reads "Title X". Its children are unchanged
+      ("Title X" from step 10 and "Sub A.2").
+
+15. Set target id = `submenu-1`, title = `no change`,
+    hidden = `true`. Tap **Send Command**.
+
+- [ ] The submenu disappears from the overflow menu. Only
+      "Top Item" and "Submenu B" remain.
+
+16. Set target id = `submenu-1`, title = `no change`,
+    hidden = `false`. Tap **Send Command**.
+
+- [ ] The submenu reappears with the title "Title X" (preserved
+      from step 14).
+
+---
+
+### Props update drops all command state
+
+17. In **Menu Structure — Props**, toggle the "add extra item to
+    submenu-1" switch ON.
+
+- [ ] Open "Submenu A" (which reverts to its prop-configured title
+      "Submenu A" because the props update rebuilt the menu). It now
+      shows three items: "Sub A.1" (reverted from "Title X"),
+      "Sub A.2", and "Sub A.3". All command state is gone.
+
+---
+
+### Props update — structural changes
+
+18. Toggle the "add extra item to submenu-1" switch OFF.
+
+- [ ] Open "Submenu A": "Sub A.3" disappears. Two items remain:
+      "Sub A.1" and "Sub A.2".
+
+19. Change the "submenu-1 title" picker to `Changed`.
+
+- [ ] The submenu now reads "Changed" in the overflow menu. Its
+      children are unchanged.
+
+20. Change the "submenu-1 title" picker back to `Submenu A`.
+
+- [ ] The submenu reads "Submenu A" again.
+
+21. Toggle the "include submenu-1" switch OFF.
+
+- [ ] "Submenu A" disappears from the overflow menu. Only
+      "Top Item" and "Submenu B" remain.
+
+22. Toggle the "include submenu-1" switch ON.
+
+- [ ] "Submenu A" reappears with its default children ("Sub A.1"
+      and "Sub A.2").
+
+23. Toggle the "include submenu-2" switch OFF.
+
+- [ ] "Submenu B" disappears. Only "Top Item" and "Submenu A"
+      remain.
+
+24. Toggle the "include submenu-2" switch ON.
+
+- [ ] "Submenu B" reappears with "Sub B.1" and "Deep" (containing
+      "Deep.1").
+
+---
+
+### Deeply nested submenu — commands at depth
+
+25. Set target id = `deep-1`, title = `Title X`,
+    hidden = `no change`. Tap **Send Command**.
+
+- [ ] Open Submenu B > Deep: the item now reads "Title X".
+
+26. Tap "Title X".
+
+- [ ] "Last clicked" updates to `deep-1`.
+
+27. Set target id = `deep-menu`, title = `Title X`,
+    hidden = `no change`. Tap **Send Command**.
+
+- [ ] Open Submenu B: the nested submenu now reads "Title X"
+      instead of "Deep".
+
+28. In **Menu Structure — Props**, toggle "include submenu-2" OFF
+    and back ON.
+
+- [ ] Open Submenu B: "Deep" is restored (props rebuild). Open
+      Deep: "Deep.1" is restored.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
@@ -32,7 +32,7 @@ TBD — automation is possible and planned but not yet implemented.
     - `sub-2-1`: "Sub B.1"
     - `deep-menu`: "Deep" (submenu containing):
       - `deep-1`: "Deep.1"
-- Submenus appear as items with a disclosure indicator (arrow).
+- Submenus appear as items with a submenu indicator (caret/arrow icon).
   Tapping a submenu opens a nested menu instead of firing `onPress`.
 - `setToolbarMenuItemOptions` targets elements by `id`. It works on
   both leaf items and submenu containers at any nesting depth.
@@ -45,7 +45,7 @@ TBD — automation is possible and planned but not yet implemented.
 
 - [ ] Header title reads "Toolbar Nested Menu Test". The toolbar
       overflow menu shows three entries: "Top Item", "Submenu A"
-      (with a disclosure indicator), "Submenu B" (with a disclosure
+      (with a submenu indicator), "Submenu B" (with a submenu
       indicator).
 
 2. Tap "Submenu A" in the overflow menu.
@@ -56,7 +56,7 @@ TBD — automation is possible and planned but not yet implemented.
 3. Go back to the top-level menu. Tap "Submenu B".
 
 - [ ] A nested menu opens showing two entries: "Sub B.1" and
-      "Deep" (with a disclosure indicator).
+      "Deep" (with a submenu indicator).
 
 4. Tap "Deep" in the Submenu B menu.
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -22,14 +22,17 @@ import StackHeaderConfigAndroidNativeComponent, {
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import type {
   NativeProps as StackHeaderConfigAndroidNativeComponentProps,
+  StackHeaderToolbarMenuBaseAndroid as NativeToolbarMenuBaseAndroid,
+  StackHeaderToolbarMenuElementAndroid as NativeToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemClickedEventAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid as NativeToolbarMenuItemOptionsAndroid,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
 import type {
   StackHeaderConfigPropsAndroid,
-  StackHeaderToolbarMenuAndroid,
+  StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
+  StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from './StackHeaderConfig.android.types';
@@ -63,9 +66,7 @@ function StackHeaderConfig(
     ...filteredAndroidProps
   } = android ?? {};
 
-  const parsedToolbarMenuItems = parseToolbarMenuItemsToNativeProps(
-    toolbarMenu?.children,
-  );
+  const parsedToolbarMenu = parseToolbarMenuToNativeProps(toolbarMenu);
   const onPressMap = useToolbarMenuOnPressMap(toolbarMenu);
   const handleToolbarMenuItemClicked = useCallback(
     (
@@ -89,7 +90,7 @@ function StackHeaderConfig(
       ref={ref}
       collapsable={false}
       style={StyleSheet.absoluteFill}
-      toolbarMenuItems={parsedToolbarMenuItems}
+      toolbarMenu={parsedToolbarMenu}
       onToolbarMenuItemClicked={handleToolbarMenuItemClicked}
       {...baseProps}
       {...filteredAndroidProps}
@@ -237,7 +238,7 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
 }
 
 function useToolbarMenuOnPressMap(
-  menu: StackHeaderToolbarMenuAndroid | undefined,
+  menu: StackHeaderToolbarMenuBaseAndroid | undefined,
 ): Map<string, () => void> {
   return useMemo(() => {
     const map = new Map<string, () => void>();
@@ -254,34 +255,62 @@ function collectOnPressCallbacks(
   map: Map<string, () => void>,
 ) {
   for (const element of elements) {
-    if (element.onPress) {
+    if (element.type === 'menuItem' && element.onPress) {
       map.set(element.id, element.onPress);
+    }
+    if (element.type === 'menu' && element.children) {
+      collectOnPressCallbacks(element.children, map);
     }
   }
 }
 
-function parseToolbarMenuItemsToNativeProps(
-  items: StackHeaderToolbarMenuAndroid['children'],
-): StackHeaderConfigAndroidNativeComponentProps['toolbarMenuItems'] {
-  return items?.map(
-    ({
-      type: _type,
-      onPress: _onPress,
-      icon,
-      iconTintColorNormal,
-      iconTintColorPressed,
-      iconTintColorFocused,
-      iconTintColorDisabled,
-      ...rest
-    }) => ({
-      ...rest,
-      ...parseAndroidIconToNativeProps(icon),
-      iconTintColorNormal: processColor(iconTintColorNormal),
-      iconTintColorPressed: processColor(iconTintColorPressed),
-      iconTintColorFocused: processColor(iconTintColorFocused),
-      iconTintColorDisabled: processColor(iconTintColorDisabled),
-    }),
-  );
+function parseToolbarMenuToNativeProps(
+  menu: StackHeaderToolbarMenuBaseAndroid | undefined,
+): NativeToolbarMenuBaseAndroid | undefined {
+  if (!menu?.children?.length) {
+    return undefined;
+  }
+  return {
+    children: menu.children.map(parseElementToNativeProps),
+  };
+}
+
+function parseElementToNativeProps(
+  element: StackHeaderToolbarMenuElementAndroid,
+): NativeToolbarMenuElementAndroid {
+  if (element.type === 'menu') {
+    const { type, children, ...baseProps } = element;
+    return {
+      type,
+      ...parseBaseItemToNativeProps(baseProps),
+      children: children?.map(parseElementToNativeProps),
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { type, onPress, ...baseProps } = element;
+  return {
+    type,
+    ...parseBaseItemToNativeProps(baseProps),
+  };
+}
+
+function parseBaseItemToNativeProps({
+  icon,
+  iconTintColorNormal,
+  iconTintColorPressed,
+  iconTintColorFocused,
+  iconTintColorDisabled,
+  ...rest
+}: StackHeaderToolbarMenuItemBaseAndroid) {
+  return {
+    ...rest,
+    ...parseAndroidIconToNativeProps(icon),
+    iconTintColorNormal: processColor(iconTintColorNormal),
+    iconTintColorPressed: processColor(iconTintColorPressed),
+    iconTintColorFocused: processColor(iconTintColorFocused),
+    iconTintColorDisabled: processColor(iconTintColorDisabled),
+  };
 }
 
 function parseToolbarMenuItemOptionsToNativeProps(

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -2,9 +2,7 @@ import React, {
   ComponentRef,
   forwardRef,
   Ref,
-  useCallback,
   useImperativeHandle,
-  useMemo,
   useRef,
 } from 'react';
 import {
@@ -67,15 +65,17 @@ function StackHeaderConfig(
   } = android ?? {};
 
   const parsedToolbarMenu = parseToolbarMenuToNativeProps(toolbarMenu);
-  const onPressMap = useToolbarMenuOnPressMap(toolbarMenu);
-  const handleToolbarMenuItemClicked = useCallback(
-    (
-      event: NativeSyntheticEvent<StackHeaderToolbarMenuItemClickedEventAndroid>,
-    ) => {
-      onPressMap.get(event.nativeEvent.id)?.();
-    },
-    [onPressMap],
-  );
+  const handleToolbarMenuItemClicked = (
+    event: NativeSyntheticEvent<StackHeaderToolbarMenuItemClickedEventAndroid>,
+  ) => {
+    const element = findToolbarMenuElementById(
+      toolbarMenu?.children,
+      event.nativeEvent.id,
+    );
+    if (element?.type === 'menuItem') {
+      element.onPress?.();
+    }
+  };
   const backButtonIconProps = parseBackButtonIconToNativeProps(backButtonIcon);
   const scrollFlagProps = resolveScrollFlags(filteredAndroidProps.type, {
     scrollFlagScroll,
@@ -237,31 +237,25 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
   return ref;
 }
 
-function useToolbarMenuOnPressMap(
-  menu: StackHeaderToolbarMenuBaseAndroid | undefined,
-): Map<string, () => void> {
-  return useMemo(() => {
-    const map = new Map<string, () => void>();
-    if (!menu?.children) {
-      return map;
-    }
-    collectOnPressCallbacks(menu.children, map);
-    return map;
-  }, [menu]);
-}
-
-function collectOnPressCallbacks(
-  elements: StackHeaderToolbarMenuElementAndroid[],
-  map: Map<string, () => void>,
-) {
+function findToolbarMenuElementById(
+  elements: StackHeaderToolbarMenuElementAndroid[] | undefined,
+  id: string,
+): StackHeaderToolbarMenuElementAndroid | null {
+  if (!elements) {
+    return null;
+  }
   for (const element of elements) {
-    if (element.type === 'menuItem' && element.onPress) {
-      map.set(element.id, element.onPress);
+    if (element.id === id) {
+      return element;
     }
-    if (element.type === 'menu' && element.children) {
-      collectOnPressCallbacks(element.children, map);
+    if (element.type === 'menu') {
+      const found = findToolbarMenuElementById(element.children, id);
+      if (found) {
+        return found;
+      }
     }
   }
+  return null;
 }
 
 function parseToolbarMenuToNativeProps(

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -22,7 +22,7 @@ import type {
   NativeProps as StackHeaderConfigAndroidNativeComponentProps,
   StackHeaderToolbarMenuBaseAndroid as NativeToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid as NativeToolbarMenuElementAndroid,
-  StackHeaderToolbarMenuItemClickedEventAndroid,
+  StackHeaderToolbarMenuItemPressEventAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid as NativeToolbarMenuItemOptionsAndroid,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
@@ -65,8 +65,8 @@ function StackHeaderConfig(
   } = android ?? {};
 
   const parsedToolbarMenu = parseToolbarMenuToNativeProps(toolbarMenu);
-  const handleToolbarMenuItemClicked = (
-    event: NativeSyntheticEvent<StackHeaderToolbarMenuItemClickedEventAndroid>,
+  const handleToolbarMenuItemPress = (
+    event: NativeSyntheticEvent<StackHeaderToolbarMenuItemPressEventAndroid>,
   ) => {
     const element = findToolbarMenuElementById(
       toolbarMenu?.children,
@@ -91,7 +91,7 @@ function StackHeaderConfig(
       collapsable={false}
       style={StyleSheet.absoluteFill}
       toolbarMenu={parsedToolbarMenu}
-      onToolbarMenuItemClicked={handleToolbarMenuItemClicked}
+      onToolbarMenuItemPress={handleToolbarMenuItemPress}
       {...baseProps}
       {...filteredAndroidProps}
       {...backButtonIconProps}

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -2,10 +2,17 @@ import React, {
   ComponentRef,
   forwardRef,
   Ref,
+  useCallback,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
-import { Image, processColor, StyleSheet } from 'react-native';
+import {
+  Image,
+  type NativeSyntheticEvent,
+  processColor,
+  StyleSheet,
+} from 'react-native';
 import type {
   StackHeaderConfigProps,
   StackHeaderConfigRef,
@@ -15,11 +22,14 @@ import StackHeaderConfigAndroidNativeComponent, {
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import type {
   NativeProps as StackHeaderConfigAndroidNativeComponentProps,
+  StackHeaderToolbarMenuItemClickedEventAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid as NativeToolbarMenuItemOptionsAndroid,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
 import type {
   StackHeaderConfigPropsAndroid,
+  StackHeaderToolbarMenuAndroid,
+  StackHeaderToolbarMenuElementAndroid,
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from './StackHeaderConfig.android.types';
@@ -49,12 +59,22 @@ function StackHeaderConfig(
     scrollFlagEnterAlwaysCollapsed,
     scrollFlagExitUntilCollapsed,
     scrollFlagSnap,
-    toolbarMenuItems,
+    toolbarMenu,
     ...filteredAndroidProps
   } = android ?? {};
 
-  const parsedToolbarMenuItems =
-    parseToolbarMenuItemsToNativeProps(toolbarMenuItems);
+  const parsedToolbarMenuItems = parseToolbarMenuItemsToNativeProps(
+    toolbarMenu?.children,
+  );
+  const onPressMap = useToolbarMenuOnPressMap(toolbarMenu);
+  const handleToolbarMenuItemClicked = useCallback(
+    (
+      event: NativeSyntheticEvent<StackHeaderToolbarMenuItemClickedEventAndroid>,
+    ) => {
+      onPressMap.get(event.nativeEvent.id)?.();
+    },
+    [onPressMap],
+  );
   const backButtonIconProps = parseBackButtonIconToNativeProps(backButtonIcon);
   const scrollFlagProps = resolveScrollFlags(filteredAndroidProps.type, {
     scrollFlagScroll,
@@ -70,6 +90,7 @@ function StackHeaderConfig(
       collapsable={false}
       style={StyleSheet.absoluteFill}
       toolbarMenuItems={parsedToolbarMenuItems}
+      onToolbarMenuItemClicked={handleToolbarMenuItemClicked}
       {...baseProps}
       {...filteredAndroidProps}
       {...backButtonIconProps}
@@ -215,11 +236,37 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
   return ref;
 }
 
+function useToolbarMenuOnPressMap(
+  menu: StackHeaderToolbarMenuAndroid | undefined,
+): Map<string, () => void> {
+  return useMemo(() => {
+    const map = new Map<string, () => void>();
+    if (!menu?.children) {
+      return map;
+    }
+    collectOnPressCallbacks(menu.children, map);
+    return map;
+  }, [menu]);
+}
+
+function collectOnPressCallbacks(
+  elements: StackHeaderToolbarMenuElementAndroid[],
+  map: Map<string, () => void>,
+) {
+  for (const element of elements) {
+    if (element.onPress) {
+      map.set(element.id, element.onPress);
+    }
+  }
+}
+
 function parseToolbarMenuItemsToNativeProps(
-  items: StackHeaderConfigPropsAndroid['toolbarMenuItems'],
+  items: StackHeaderToolbarMenuAndroid['children'],
 ): StackHeaderConfigAndroidNativeComponentProps['toolbarMenuItems'] {
   return items?.map(
     ({
+      type: _type,
+      onPress: _onPress,
       icon,
       iconTintColorNormal,
       iconTintColorPressed,

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import type { ColorValue, NativeSyntheticEvent } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type { StackHeaderSubviewCollapseModeAndroid } from './android/StackHeaderSubview.android.types';
 import type { PlatformIconAndroid } from '../../../../types';
 
@@ -70,6 +70,12 @@ export type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'never';
 
 export interface StackHeaderToolbarMenuItemAndroid {
+  /**
+   * @summary Marks this object as menu item definition.
+   *
+   * @platform android
+   */
+  type: 'menuItem';
   /**
    * @summary Unique identifier of the menu item.
    *
@@ -176,17 +182,28 @@ export interface StackHeaderToolbarMenuItemAndroid {
    * @platform android
    */
   iconTintColorDisabled?: ColorValue | undefined;
+  /**
+   * @summary Callback invoked when the menu item is clicked.
+   *
+   * @platform android
+   */
+  onPress?: (() => void) | undefined;
 }
 
-export type StackHeaderToolbarMenuItemClickedEvent = {
+export type StackHeaderToolbarMenuElementAndroid =
+  StackHeaderToolbarMenuItemAndroid;
+
+export interface StackHeaderToolbarMenuAndroid {
   /**
-   * @summary ID of the clicked menu item.
+   * @summary Menu elements displayed in the toolbar menu.
+   *
+   * @platform android
    */
-  id: string;
-};
+  children?: StackHeaderToolbarMenuElementAndroid[];
+}
 
 export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
-  Omit<StackHeaderToolbarMenuItemAndroid, 'id'>
+  Omit<StackHeaderToolbarMenuItemAndroid, 'id' | 'type' | 'onPress'>
 >;
 
 export interface StackHeaderConfigCommandsAndroid {
@@ -378,9 +395,9 @@ export interface StackHeaderConfigPropsAndroid {
    */
   scrollFlagSnap?: boolean | undefined;
   /**
-   * @summary Menu items displayed in the toolbar menu.
+   * @summary Toolbar menu configuration.
    *
-   * This prop serves as initial configuration of the toolbar menu items. If you
+   * This prop serves as initial configuration of the toolbar menu. If you
    * want to change some property in runtime, use `setToolbarMenuItemOptions`
    * view command.
    *
@@ -389,15 +406,5 @@ export interface StackHeaderConfigPropsAndroid {
    *
    * @platform android
    */
-  toolbarMenuItems?: StackHeaderToolbarMenuItemAndroid[] | undefined;
-  /**
-   * @summary Callback invoked when a toolbar menu item is clicked.
-   *
-   * @platform android
-   */
-  onToolbarMenuItemClicked?:
-    | ((
-        event: NativeSyntheticEvent<StackHeaderToolbarMenuItemClickedEvent>,
-      ) => void)
-    | undefined;
+  toolbarMenu?: StackHeaderToolbarMenuAndroid | undefined;
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -69,59 +69,54 @@ export type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'ifRoomWithText'
   | 'never';
 
-export interface StackHeaderToolbarMenuItemAndroid {
+export interface StackHeaderToolbarMenuItemBaseAndroid {
   /**
-   * @summary Marks this object as menu item definition.
-   *
-   * @platform android
-   */
-  type: 'menuItem';
-  /**
-   * @summary Unique identifier of the menu item.
+   * @summary Unique identifier of the menu element.
    *
    * @platform android
    */
   id: string;
   /**
-   * @summary Title of the menu item.
+   * @summary Title of the menu element.
    *
    * @platform android
    */
   title?: string | undefined;
   /**
-   * @summary Specifies if the menu item should be hidden.
+   * @summary Specifies if the menu element should be hidden.
    *
    * @default false
    * @platform android
    */
   hidden?: boolean | undefined;
   /**
-   * @summary Specifies whether the item should be displayed as a button in the
-   * Toolbar.
+   * @summary Specifies whether the element should be displayed as a button in
+   * the Toolbar.
    *
    * The following values are available:
-   * - `always` - always displays the item as a button in the Toolbar,
-   * - `alwaysWithText` - always displays the item as a button in the Toolbar,
-   *   forcing the text label to be visible even if an icon is provided,
-   * - `ifRoom` - displays the item as a button in the Toolbar only if the
+   * - `always` - always displays the element as a button in the Toolbar,
+   * - `alwaysWithText` - always displays the element as a button in the
+   *   Toolbar, forcing the text label to be visible even if an icon is
+   *   provided,
+   * - `ifRoom` - displays the element as a button in the Toolbar only if the
    *   system determines there is sufficient space,
-   * - `ifRoomWithText` - displays the item as a button in the Toolbar if the
-   *   system determines there is sufficient space, forcing the text label to
-   *   be visible even if an icon is provided,
-   * - `never` - never displays the item as a button in the Toolbar; it will be
-   *   placed in the overflow menu instead.
+   * - `ifRoomWithText` - displays the element as a button in the Toolbar if
+   *   the system determines there is sufficient space, forcing the text label
+   *   to be visible even if an icon is provided,
+   * - `never` - never displays the element as a button in the Toolbar; it
+   *   will be placed in the overflow menu instead.
    *
    * @remarks
    * Due to native limitations, the width limit for the `ifRoom` options is
-   * determined during the initial render and will not adapt to subsequent layout
-   * or orientation changes.
+   * determined during the initial render and will not adapt to subsequent
+   * layout or orientation changes.
    *
    * @default never
    * @platform android
    */
   showAsAction?: StackHeaderToolbarMenuItemShowAsActionAndroid | undefined;
   /**
-   * @summary Specifies the icon for the menu item.
+   * @summary Specifies the icon for the menu element.
    *
    * Supported values:
    * - `{ type: 'imageSource', imageSource }`
@@ -136,52 +131,66 @@ export interface StackHeaderToolbarMenuItemAndroid {
    *   Remarks: Requires passing a drawable to resources via Android Studio.
    *
    * @remarks
-   * The icon will be visible only if the menu item is shown in the Toolbar.
+   * The icon will be visible only if the menu element is shown in the
+   * Toolbar.
    *
    * @platform android
    */
   icon?: PlatformIconAndroid | undefined;
   /**
-   * @summary Specifies the tint color to apply to the menu item icon.
+   * @summary Specifies the tint color to apply to the menu element icon.
    *
    * @platform android
    */
   iconTintColorNormal?: ColorValue | undefined;
   /**
-   * @summary Specifies the tint color to apply to the menu item icon when item
-   * is pressed.
+   * @summary Specifies the tint color to apply to the menu element icon when
+   * it is pressed.
    *
    * @remarks
    * Due to native platform limitations, if you set this prop, you must also
-   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
+   * provide `iconTintColorNormal`. Otherwise, the icon will become
+   * transparent.
    *
    * @platform android
    */
   iconTintColorPressed?: ColorValue | undefined;
   /**
-   * @summary Specifies the tint color to apply to the menu item icon when item
-   * is focused (e.g. by keyboard navigation).
+   * @summary Specifies the tint color to apply to the menu element icon when
+   * it is focused (e.g. by keyboard navigation).
    *
    * @remarks
    * Due to native platform limitations, if you set this prop, you must also
-   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
+   * provide `iconTintColorNormal`. Otherwise, the icon will become
+   * transparent.
    *
    * @platform android
    */
   iconTintColorFocused?: ColorValue | undefined;
   /**
-   * @summary Specifies the tint color to apply to the menu item icon when item
-   * is disabled.
+   * @summary Specifies the tint color to apply to the menu element icon when
+   * it is disabled.
    *
    * @remarks
-   * Disabling menu item isn't currently supported.
+   * Disabling menu elements isn't currently supported.
    *
    * Due to native platform limitations, if you set this prop, you must also
-   * provide `iconTintColorNormal`. Otherwise, the icon will become transparent.
+   * provide `iconTintColorNormal`. Otherwise, the icon will become
+   * transparent.
    *
    * @platform android
    */
   iconTintColorDisabled?: ColorValue | undefined;
+}
+
+export interface StackHeaderToolbarMenuItemAndroid
+  extends StackHeaderToolbarMenuItemBaseAndroid {
+  /**
+   * @summary Marks this object as a menu item.
+   *
+   * @platform android
+   */
+  type: 'menuItem';
   /**
    * @summary Callback invoked when the menu item is clicked.
    *
@@ -190,10 +199,7 @@ export interface StackHeaderToolbarMenuItemAndroid {
   onPress?: (() => void) | undefined;
 }
 
-export type StackHeaderToolbarMenuElementAndroid =
-  StackHeaderToolbarMenuItemAndroid;
-
-export interface StackHeaderToolbarMenuAndroid {
+export interface StackHeaderToolbarMenuBaseAndroid {
   /**
    * @summary Menu elements displayed in the toolbar menu.
    *
@@ -202,8 +208,23 @@ export interface StackHeaderToolbarMenuAndroid {
   children?: StackHeaderToolbarMenuElementAndroid[];
 }
 
+export interface StackHeaderToolbarMenuAndroid
+  extends StackHeaderToolbarMenuItemBaseAndroid,
+    StackHeaderToolbarMenuBaseAndroid {
+  /**
+   * @summary Marks this object as a submenu.
+   *
+   * @platform android
+   */
+  type: 'menu';
+}
+
+export type StackHeaderToolbarMenuElementAndroid =
+  | StackHeaderToolbarMenuItemAndroid
+  | StackHeaderToolbarMenuAndroid;
+
 export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
-  Omit<StackHeaderToolbarMenuItemAndroid, 'id' | 'type' | 'onPress'>
+  Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
 >;
 
 export interface StackHeaderConfigCommandsAndroid {
@@ -406,5 +427,5 @@ export interface StackHeaderConfigPropsAndroid {
    *
    * @platform android
    */
-  toolbarMenu?: StackHeaderToolbarMenuAndroid | undefined;
+  toolbarMenu?: StackHeaderToolbarMenuBaseAndroid | undefined;
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -12,6 +12,7 @@ export interface StackHeaderToolbarSubviewAndroid {
   /**
    * @summary Render callback for the React element placed in this toolbar slot.
    *
+   * @description
    * The subview is sized by React Native's layout engine but positioned by the
    * platform native layout. Each subview is placed independently — subviews do
    * not participate in a shared flex layout and cannot influence each other's
@@ -33,6 +34,7 @@ export interface StackHeaderBackgroundSubviewAndroid {
    * @summary Controls how the background subview behaves when the app bar
    * collapses.
    *
+   * @description
    * The following values are available:
    * - `off` - the subview scrolls away with the app bar,
    * - `parallax` - the subview scrolls at a slower rate, creating a parallax
@@ -93,6 +95,7 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    * @summary Specifies whether the element should be displayed as a button in
    * the Toolbar.
    *
+   * @description
    * The following values are available:
    * - `always` - always displays the element as a button in the Toolbar,
    * - `alwaysWithText` - always displays the element as a button in the
@@ -118,6 +121,7 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
   /**
    * @summary Specifies the icon for the menu element.
    *
+   * @description
    * Supported values:
    * - `{ type: 'imageSource', imageSource }`
    *   Uses an image from the provided resource.
@@ -247,6 +251,7 @@ export interface StackHeaderConfigPropsAndroid {
   /**
    * @summary Specifies the type of the Material 3 app bar.
    *
+   * @description
    * The following values are available:
    * - `small` - small app bar with fixed title,
    * - `medium` - medium app bar with collapsing title,
@@ -290,6 +295,7 @@ export interface StackHeaderConfigPropsAndroid {
   /**
    * @summary Tint color applied to the back button icon in its normal state.
    *
+   * @description
    * When `undefined`, the default tint color is used. This applies to the
    * native back arrow and `drawableResource` icons that have an associated
    * tint. For `imageSource` icons, no tint is applied by default.
@@ -323,6 +329,7 @@ export interface StackHeaderConfigPropsAndroid {
   /**
    * @summary Custom icon for the back button.
    *
+   * @description
    * When `undefined`, the native back arrow (`homeAsUpIndicator`) is used.
    *
    * Supported values:
@@ -344,6 +351,7 @@ export interface StackHeaderConfigPropsAndroid {
    * @summary Whether the header reacts to nested scroll. Required for any
    * other `scrollFlag*` prop to take effect.
    *
+   * @description
    * When `undefined`, falls back to the type-specific default:
    * - `small` -> `false`
    * - `medium` / `large` -> `true`
@@ -362,6 +370,7 @@ export interface StackHeaderConfigPropsAndroid {
    * scroll position. Without this flag, the header only begins expanding once
    * the list has reached the top of its content. Requires `scrollFlagScroll`.
    *
+   * @description
    * When `undefined`, falls back to the type-specific default (`false` for
    * all types).
    *
@@ -374,6 +383,7 @@ export interface StackHeaderConfigPropsAndroid {
    * expands only after the ScrollView reaches the top of its content. Requires
    * `scrollFlagEnterAlways`.
    *
+   * @description
    * When `undefined`, falls back to the type-specific default (`false` for
    * all types).
    *
@@ -388,6 +398,7 @@ export interface StackHeaderConfigPropsAndroid {
    * (the toolbar) remains pinned at the top. Without this flag, the entire
    * header scrolls off the screen. Requires `scrollFlagScroll`.
    *
+   * @description
    * When `undefined`, falls back to the type-specific default:
    * - `small` -> `false`
    * - `medium` / `large` -> `true`
@@ -408,6 +419,7 @@ export interface StackHeaderConfigPropsAndroid {
    * after a scroll gesture ends, instead of resting partway. Requires
    * `scrollFlagScroll`.
    *
+   * @description
    * When `undefined`, falls back to the type-specific default:
    * - `small` -> `false`
    * - `medium` / `large` -> `true`
@@ -418,6 +430,7 @@ export interface StackHeaderConfigPropsAndroid {
   /**
    * @summary Toolbar menu configuration.
    *
+   * @description
    * This prop serves as initial configuration of the toolbar menu. If you
    * want to change some property in runtime, use `setToolbarMenuItemOptions`
    * view command.

--- a/src/components/gamma/stack/header/StackHeaderConfig.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.types.ts
@@ -27,6 +27,7 @@ export interface StackHeaderConfigPropsBase {
   /**
    * @summary Specifies if the content should be rendered behind the header.
    *
+   * @description
    * When `true`, content is rendered behind the header instead of starting
    * below it.
    *
@@ -43,6 +44,7 @@ export interface StackHeaderConfigPropsBase {
   /**
    * @summary Specifies if the back button should be hidden.
    *
+   * @description
    * This prop does not apply to the root screen of the stack for which the back
    * button is always hidden.
    *

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -25,8 +25,10 @@ export type {
   StackHeaderConfigPropsAndroid,
   StackHeaderConfigCommandsAndroid,
   StackHeaderToolbarMenuAndroid,
+  StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemAndroid,
+  StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
   // iOS

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -24,9 +24,10 @@ export type {
   StackHeaderBackgroundSubviewAndroid,
   StackHeaderConfigPropsAndroid,
   StackHeaderConfigCommandsAndroid,
+  StackHeaderToolbarMenuAndroid,
+  StackHeaderToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
-  StackHeaderToolbarMenuItemClickedEvent,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
   // iOS
   StackHeaderConfigPropsIOS,

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -12,7 +12,7 @@ import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
 
 type StackHeaderTypeAndroid = 'small' | 'medium' | 'large';
 
-type StackHeaderToolbarMenuItemClickedEvent = Readonly<{
+export type StackHeaderToolbarMenuItemClickedEventAndroid = Readonly<{
   id: string;
 }>;
 
@@ -62,7 +62,7 @@ export interface NativeProps extends ViewProps {
 
   toolbarMenuItems?: StackHeaderToolbarMenuItemAndroid[] | undefined;
   onToolbarMenuItemClicked?:
-    | CT.DirectEventHandler<StackHeaderToolbarMenuItemClickedEvent>
+    | CT.DirectEventHandler<StackHeaderToolbarMenuItemClickedEventAndroid>
     | undefined;
 
   // When StackHeaderToolbarMenuItemAndroid is used as an array

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -13,7 +13,7 @@ import type { UnsafeMixed } from '../../codegenUtils';
 
 type StackHeaderTypeAndroid = 'small' | 'medium' | 'large';
 
-export type StackHeaderToolbarMenuItemClickedEventAndroid = Readonly<{
+export type StackHeaderToolbarMenuItemPressEventAndroid = Readonly<{
   id: string;
 }>;
 
@@ -80,8 +80,8 @@ export interface NativeProps extends ViewProps {
   scrollFlagSnap?: CT.WithDefault<boolean, false>;
 
   toolbarMenu?: UnsafeMixed<StackHeaderToolbarMenuBaseAndroid> | undefined;
-  onToolbarMenuItemClicked?:
-    | CT.DirectEventHandler<StackHeaderToolbarMenuItemClickedEventAndroid>
+  onToolbarMenuItemPress?:
+    | CT.DirectEventHandler<StackHeaderToolbarMenuItemPressEventAndroid>
     | undefined;
 }
 

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -9,6 +9,7 @@ import type {
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
+import type { UnsafeMixed } from '../../codegenUtils';
 
 type StackHeaderTypeAndroid = 'small' | 'medium' | 'large';
 
@@ -23,7 +24,7 @@ type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'ifRoomWithText'
   | 'never';
 
-export interface StackHeaderToolbarMenuItemAndroid {
+export interface StackHeaderToolbarMenuItemBaseAndroid {
   id: string;
   title?: CT.WithDefault<string, ''>;
   hidden?: CT.WithDefault<boolean, false>;
@@ -38,6 +39,24 @@ export interface StackHeaderToolbarMenuItemAndroid {
   iconTintColorFocused?: ProcessedColorValue | null | undefined;
   iconTintColorDisabled?: ProcessedColorValue | null | undefined;
 }
+
+type StackHeaderToolbarMenuItemAndroid =
+  StackHeaderToolbarMenuItemBaseAndroid & {
+    type: 'menuItem';
+  };
+
+export type StackHeaderToolbarMenuBaseAndroid = {
+  children?: StackHeaderToolbarMenuElementAndroid[] | undefined;
+};
+
+type StackHeaderToolbarMenuAndroid = StackHeaderToolbarMenuItemBaseAndroid &
+  StackHeaderToolbarMenuBaseAndroid & {
+    type: 'menu';
+  };
+
+export type StackHeaderToolbarMenuElementAndroid =
+  | StackHeaderToolbarMenuItemAndroid
+  | StackHeaderToolbarMenuAndroid;
 
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
@@ -60,23 +79,16 @@ export interface NativeProps extends ViewProps {
   scrollFlagExitUntilCollapsed?: CT.WithDefault<boolean, false>;
   scrollFlagSnap?: CT.WithDefault<boolean, false>;
 
-  toolbarMenuItems?: StackHeaderToolbarMenuItemAndroid[] | undefined;
+  toolbarMenu?: UnsafeMixed<StackHeaderToolbarMenuBaseAndroid> | undefined;
   onToolbarMenuItemClicked?:
     | CT.DirectEventHandler<StackHeaderToolbarMenuItemClickedEventAndroid>
     | undefined;
-
-  // When StackHeaderToolbarMenuItemAndroid is used as an array
-  // in toolbarMenuItems, Codegen doesn't generate an enum in Props.h
-  // which causes a build failure on iOS. By adding a property where
-  // StackHeaderToolbarMenuItemAndroid is used directly, we ensure
-  // that the enum is generated.
-  DO_NOT_USE?: StackHeaderToolbarMenuItemAndroid | undefined;
 }
 
 type ComponentType = HostComponent<NativeProps>;
 
 export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
-  Omit<StackHeaderToolbarMenuItemAndroid, 'id'>
+  Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
 >;
 
 export interface NativeCommands {


### PR DESCRIPTION
## Description

Adds support for nested menus in toolbar menu.

> [!IMPORTANT]
> Even though the Android documentation (`Menu.addSubMenu`) states:
>
> > Note that you can only have one level of sub-menus, i.e. you cannnot add a subMenu to a subMenu: An UnsupportedOperationException will be thrown if you try.
>
> Nested submenus work without any problems. I tested API 36.1 and API 25 - no problems observed. I guess that Material's implementation handles nesting without any problems even if the original interface states otherwise.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1201.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1531.

## Changes

- extract common prop parsing methods to `ReadableMapExt`
- add `onPress` callback per-item instead of global callback
- refactor JS structure to support nesting menus:
  - header config accepts `MenuBase`
  - `MenuBase` has children of `MenuElement` which can be `MenuItem` or `Menu`
  - `Menu` is `MenuBase` + `MenuItemBase` because it has corresponding menu item on the native side
  - use `UnsafeMixed`/`Dynamic` to handle complex menu structure, remove `DO_NOT_USE` prop workaround
- handle new structure on the native side:
  - extract creating menu items from view manager to `MenuMapper`
  - create `MenuConfig` and use it with `MenuItemConfig` for `MenuElementConfig`
  - update `Applicator` to handle submenus 
- make header-related classes internal
- add SFT

## Visual documentation

https://github.com/user-attachments/assets/74fb6d6b-3fce-4a53-81c0-f651344ad7e4


## Test plan

Run `test-stack-toolbar-nested-menu` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
