### PR TITLE
feat(iOS, gamma): build gamma as separate ObjC/Swift modules for SwiftPM

### DIFF
--- a/ios/bridging/Swift-Bridging.h
+++ b/ios/bridging/Swift-Bridging.h
@@ -1,7 +1,10 @@
 #pragma once
 
+// `RNScreens-Swift.h` (the generated ObjC interface of the Swift half) only exists
+// in a single mixed-language module (CocoaPods `DEFINES_MODULE`). Under separate
+// SwiftPM targets it's absent, so `__has_include` makes this header a no-op.
 #if __has_include(<RNScreens/RNScreens-Swift.h>)
 #import <RNScreens/RNScreens-Swift.h>
-#else
+#elif __has_include("RNScreens-Swift.h")
 #import "RNScreens-Swift.h"
 #endif

--- a/ios/gamma/split/RNSSplitHostComponentView.h
+++ b/ios/gamma/split/RNSSplitHostComponentView.h
@@ -7,8 +7,25 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RNSSplitHostController;
+@class RNSSplitHostComponentView;
 @class RNSSplitScreenComponentView;
+
+// ObjC-facing surface of the Swift `RNSSplitHostController`, resolved at runtime
+// via NSClassFromString. Lets the ObjC sources drive the controller without
+// importing `RNScreens-Swift.h`, so ObjC and Swift can build as separate SwiftPM
+// targets (SwiftPM has no mixed-language target).
+@protocol RNSSplitHostControlling <NSObject>
+- (instancetype)initWithSplitHostComponentView:(RNSSplitHostComponentView *)splitHostComponentView
+                                numberOfColumns:(NSInteger)numberOfColumns;
+- (void)setNeedsAppearanceUpdate;
+- (void)setNeedsDisplayModeUpdate;
+- (void)setNeedsSecondaryScreenNavBarUpdate;
+- (void)setNeedsOrientationUpdate;
+- (void)setNeedsUpdateOfChildViewControllers;
+- (void)reactMountingTransactionWillMount;
+- (void)reactMountingTransactionDidMount;
+- (void)showColumnNamed:(NSString *)columnName;
+@end
 
 /**
  * @class RNSSplitHostComponentView
@@ -21,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nonnull NSMutableArray<RNSSplitScreenComponentView *> *)reactSubviews;
 
-@property (nonatomic, nonnull, strong, readonly) RNSSplitHostController *splitHostController;
+@property (nonatomic, nonnull, strong, readonly) UISplitViewController<RNSSplitHostControlling> *splitHostController;
 
 @end
 

--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -8,7 +8,6 @@
 #import "RNSConversions.h"
 #import "RNSDefines.h"
 #import "RNSSplitScreenComponentView.h"
-#import "Swift-Bridging.h"
 
 namespace react = facebook::react;
 
@@ -22,7 +21,7 @@ static const CGFloat epsilon = 1e-6;
 
 @implementation RNSSplitHostComponentView {
   RNSSplitHostComponentEventEmitter *_Nonnull _reactEventEmitter;
-  RNSSplitHostController *_Nonnull _controller;
+  UISplitViewController<RNSSplitHostControlling> *_Nonnull _controller;
   NSMutableArray<RNSSplitScreenComponentView *> *_Nonnull _reactSubviews;
 
   bool _hasModifiedReactSubviewsInCurrentTransaction;
@@ -115,7 +114,16 @@ static const CGFloat epsilon = 1e-6;
   if (_controller == nil) {
     int numberOfColumns = [self getNumberOfColumns];
 
-    _controller = [[RNSSplitHostController alloc] initWithSplitHostComponentView:self numberOfColumns:numberOfColumns];
+    // Resolved at runtime to avoid a compile-time dependency on the Swift module.
+    Class controllerClass = NSClassFromString(@"RNSSplitHostController");
+    if (controllerClass == nil) {
+      [NSException raise:NSInternalInconsistencyException
+                  format:@"[RNScreens] The RNSSplitHostController Swift class could not be resolved at runtime. "
+                         @"Make sure the gamma Swift sources are compiled and linked into the build."];
+    }
+    _controller = [(UISplitViewController<RNSSplitHostControlling> *)[controllerClass alloc]
+        initWithSplitHostComponentView:self
+                       numberOfColumns:numberOfColumns];
   }
 }
 
@@ -154,7 +162,7 @@ RNS_IGNORE_SUPER_CALL_BEGIN
 }
 RNS_IGNORE_SUPER_CALL_END
 
-- (nonnull RNSSplitHostController *)splitHostController
+- (nonnull UISplitViewController<RNSSplitHostControlling> *)splitHostController
 {
   RCTAssert(_controller != nil, @"[RNScreens] Controller must not be nil");
   return _controller;

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -6,9 +6,9 @@ import UIKit
 ///
 /// Manages a collection of RNSSplitScreenComponentView instances,
 /// synchronizes appearance settings with props, observes component lifecycle, and emits events.
-@objc
+@objc(RNSSplitHostController)
 public class RNSSplitHostController: UISplitViewController, ReactMountingTransactionObserving,
-  RNSOrientationProvidingSwift
+  RNSOrientationProvidingSwift, RNSSplitHostControlling
 {
   private var needsChildViewControllersUpdate = false
 
@@ -44,7 +44,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
   /// @param splitHostComponentView The view managed by this controller.
   /// @param numberOfColumns Expected number of visible columns.
   ///
-  @objc public init(
+  @objc public required init(
     splitHostComponentView: RNSSplitHostComponentView,
     numberOfColumns: Int
   ) {

--- a/ios/gamma/split/RNSSplitScreenComponentView.h
+++ b/ios/gamma/split/RNSSplitScreenComponentView.h
@@ -8,8 +8,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RNSSplitScreenComponentView;
 @class RNSSplitHostComponentView;
-@class RNSSplitScreenController;
+
+// ObjC-facing surface of the Swift `RNSSplitScreenController`, resolved at runtime
+// via NSClassFromString. Lets the ObjC sources drive the controller without
+// importing `RNScreens-Swift.h`, so ObjC and Swift can build as separate SwiftPM
+// targets (SwiftPM has no mixed-language target).
+@protocol RNSSplitScreenControlling <NSObject>
+- (instancetype)initWithSplitScreenComponentView:(RNSSplitScreenComponentView *)splitScreenComponentView;
+- (BOOL)isInSplitHostSubtree;
+@end
 
 /**
  * @class RNSSplitScreenComponentView
@@ -20,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface RNSSplitScreenComponentView : RNSReactBaseView <RNSSafeAreaProviding>
 
-@property (nonatomic, strong, readonly, nonnull) RNSSplitScreenController *controller;
+@property (nonatomic, strong, readonly, nonnull) UIViewController<RNSSplitScreenControlling> *controller;
 @property (nonatomic, weak, readwrite, nullable) RNSSplitHostComponentView *splitHost;
 
 @end

--- a/ios/gamma/split/RNSSplitScreenComponentView.mm
+++ b/ios/gamma/split/RNSSplitScreenComponentView.mm
@@ -5,19 +5,17 @@
 #import "RNSConversions.h"
 #import "RNSSafeAreaViewNotifications.h"
 
-#import "Swift-Bridging.h"
-
 namespace react = facebook::react;
 
 @implementation RNSSplitScreenComponentView {
   RNSSplitScreenComponentEventEmitter *_Nonnull _reactEventEmitter;
-  RNSSplitScreenController *_Nullable _controller;
+  UIViewController<RNSSplitScreenControlling> *_Nullable _controller;
   RNSSplitScreenShadowStateProxy *_Nonnull _shadowStateProxy;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
   NSMutableSet<UIView *> *_viewsForFrameCorrection;
 }
 
-- (RNSSplitScreenController *)controller
+- (UIViewController<RNSSplitScreenControlling> *)controller
 {
   RCTAssert(
       _controller != nil,
@@ -48,7 +46,15 @@ namespace react = facebook::react;
 
 - (void)setupController
 {
-  _controller = [[RNSSplitScreenController alloc] initWithSplitScreenComponentView:self];
+  // Resolved at runtime to avoid a compile-time dependency on the Swift module.
+  Class controllerClass = NSClassFromString(@"RNSSplitScreenController");
+  if (controllerClass == nil) {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"[RNScreens] The RNSSplitScreenController Swift class could not be resolved at runtime. "
+                       @"Make sure the gamma Swift sources are compiled and linked into the build."];
+  }
+  _controller = [(UIViewController<RNSSplitScreenControlling> *)[controllerClass alloc]
+      initWithSplitScreenComponentView:self];
   _controller.view = self;
 }
 

--- a/ios/gamma/split/RNSSplitScreenController.swift
+++ b/ios/gamma/split/RNSSplitScreenController.swift
@@ -6,8 +6,8 @@ import UIKit
 ///
 /// Associated with a RNSSplitScreenComponentView, it handles layout synchronization with the
 /// Shadow Tree, emits React lifecycle events, and interacts with the SplitHost hierarchy.
-@objc
-public class RNSSplitScreenController: UIViewController {
+@objc(RNSSplitScreenController)
+public class RNSSplitScreenController: UIViewController, RNSSplitScreenControlling {
   let splitScreenComponentView: RNSSplitScreenComponentView
 
   private var shadowStateProxy: RNSSplitScreenShadowStateProxy {
@@ -42,7 +42,7 @@ public class RNSSplitScreenController: UIViewController {
     }
 
     if let splitHost = self.splitScreenComponentView.splitHost {
-      return splitHost.splitHostController
+      return splitHost.splitHostController as? RNSSplitHostController
     }
 
     return nil

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -13,7 +13,6 @@
 #import "RNSStackNavigationController.h"
 #import "RNSStackOperationCoordinator.h"
 #import "RNSStackScreenComponentView.h"
-#import "Swift-Bridging.h"
 
 namespace react = facebook::react;
 

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -14,8 +14,6 @@
 #import "RNSStackScreenController.h"
 #import "RNSStackScreenHeaderCoordinator.h"
 
-#import "Swift-Bridging.h"
-
 namespace react = facebook::react;
 
 @interface RNSStackScreenComponentView () <RCTMountingTransactionObserving>

--- a/ios/utils/extensions/RCTImageSource+AccessHiddenMembers.h
+++ b/ios/utils/extensions/RCTImageSource+AccessHiddenMembers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#import <React/RCTImageSource.h>
+
 // This field should exist in extension in `RCTImageSource.m`
 
 @interface RCTImageSource (AccessHiddenMembers)


### PR DESCRIPTION
## Description

When working on building RNScreens using SwiftPM, we found that there were some cyclic references between Swift- and ObjC-code - which won't work in SwiftPM since it doesn't support mixed languages in a target - and targets can reference each other in both directions.

### Details:

Gamma's split-view layer mixes ObjC++ component views with Swift controllers that are mutually coupled: the .mm files import the generated RNScreens-Swift.h, and the Swift controllers reference the ObjC view classes. CocoaPods handles this as a single mixed-language module (DEFINES_MODULE), but SwiftPM does not allow mixed-language targets (nor the circular dependency a mixed module would otherwise require), so gamma cannot currently be compiled with SwiftPM.

### Explanation:

This PR breaks the ObjC → Swift compile-time edge so the ObjC and Swift sources can be built as two separate SwiftPM targets, while remaining fully compatible with the existing CocoaPods (mixed-module) build. The change is gated entirely by which sources a build compiles — there is no behavior change when gamma is off, and the CocoaPods path is unaffected.

## Changes

- Introduce pure-ObjC protocols `RNSSplitHostControlling` / `RNSSplitScreenControlling` describing what the component views call on their controllers.
- Instantiate the Swift controllers via `NSClassFromString(...) `instead of `[[ConcreteSwiftClass alloc] init...]`, so no .mm imports `RNScreens-Swift.h`. If the class can't be resolved at runtime, raise `NSInternalInconsistencyException` (visible in Debug and Release).
- Annotate the Swift controllers with `@objc(RNSSplitHostController)` / `@objc(RNSSplitScreenController)` for stable runtime names and conform them to the new protocols.
- Type the controllers' public properties as protocol compositions (`UISplitViewController<RNSSplitHostControlling> *`, `UIViewController<RNSSplitScreenControlling> *`) so Swift's importer keeps them when the module is imported.
- Make `Swift-Bridging.h` a no-op when `RNScreens-Swift.h is` absent (separate-module / non-gamma builds).
- Make `RCTImageSource+AccessHiddenMembers.h` self-contained by importing `<React/RCTImageSource.h>` (Required to build as Clang module)
- Remove now-unused `Swift-Bridging.h` imports from the stack component views.

##  Test code and steps to reproduce

Verified by building RNScreens as a prebuilt XCFramework through Expo's SwiftPM precompile pipeline:
- Gamma enabled (separate ObjC + Swift targets): builds and composes for both Debug and Release.
- Gamma disabled (existing default): still builds and composes — confirming the source changes are mode-agnostic.

| Note: I have not run RNScreens' own example app / CocoaPods build for this change; the edits are designed to be inert in the mixed-module (CocoaPods) path, but a maintainer build there is the authoritative check.
