### PR TITLE
chore: Replace useEffect with useLayoutEffect in header items test

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,
@@ -144,7 +144,7 @@ function ConfigScreen() {
     [trailingItemsCount, showToast],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setRouteOptions(routeKey, {
       headerConfig,
     });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react';
@@ -257,7 +258,7 @@ function ConfigScreen() {
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(() => buildHeaderConfig(config), [config]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setRouteOptions(routeKey, {
       headerConfig,
     });


### PR DESCRIPTION
Fixes https://github.com/software-mansion/react-native-screens-labs/issues/1514

## Description

This is a small fix for header items SFTs in iOS where transitions would glitch because headerConfig was being detected too late. Replacing useEffect with useLayoutEffect fixes the issue for now, but more refactoring will come soon.

## Changes

- replaced useEffect with useLayoutEffect in `test-stack-subviews-ios` and `test-stack-header-menu-ios`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/92b53be3-e59a-4fa8-af99-5b9883cfed0d" /> | <video src="https://github.com/user-attachments/assets/66c80d7a-840b-4841-b111-5e887821e103" /> |

## Test plan

Verify the above in `test-stack-subviews-ios`

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
