### PR TITLE
fix(CI): add `brew trust` for installing `Applesimutils` in iOS e2e workflow

### DIFF
--- a/.github/workflows/ios-e2e-test-fabric.yml
+++ b/.github/workflows/ios-e2e-test-fabric.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get Xcode version
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils
-        run: brew tap wix/brew && brew install applesimutils
+        run: brew tap wix/brew && brew trust wix/brew && brew install applesimutils
       - name: Install root node dependencies
         run: yarn install && yarn submodules
       - name: Install node dependencies


### PR DESCRIPTION
## Description

It seems like `homebrew` was updated in GitHub Actions runners which broke iOS e2e CI. In this PR, we're adding `brew trust` command to installation step in order to fix the problem.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1570.

### Details.
We get:
```
Run brew tap wix/brew && brew install applesimutils
==> Tapping wix/brew
Cloning into '/opt/homebrew/Library/Taps/wix/homebrew-brew'...
Tapped 1 cask and 2 formulae (18 files, 1.7MB).
// ...
Error: Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew.
Run `brew trust --formula wix/brew/applesimutils` or `brew trust wix/brew` to trust it.
Error: Process completed with exit code 1.
```

In prior CI runs there was a warning about this:

```
==> Tapping wix/brew
Cloning into '/opt/homebrew/Library/Taps/wix/homebrew-brew'...
Tapped 1 cask and 2 formulae (18 files, 1.7MB).
Warning: The following taps are not trusted:
  aws/tap
  azure/bicep
  wix/brew

Homebrew will ignore formulae, casks and commands from these taps when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.
Enable trust checks now with:
  export HOMEBREW_REQUIRE_TAP_TRUST=1
Trust specific formulae, casks or commands with:
  brew trust --formula <user>/<tap>/<formula>
  brew trust --cask <user>/<tap>/<cask>
  brew trust --command <user>/<tap>/<command>
or trust installed formulae from these taps with:
  brew trust --formula azure/bicep/bicep
You can trust all formulae, casks and commands from these taps with:
  brew trust aws/tap azure/bicep wix/brew
Prefer trusting only the specific formulae, casks or commands you need.
Untap them with:
  brew untap aws/tap azure/bicep wix/brew
To keep allowing them by default during the transition:
  export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
This is not recommended and will be removed in a later release.

Inspect the formula dependency plan before installing with `brew install --ask`.
Enable ask mode by setting `HOMEBREW_ASK=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Fetching downloads for: applesimutils
✔︎ Bottle applesimutils (0.9.12)
==> Installing applesimutils from wix/brew
==> Pouring applesimutils-0.9.12.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/applesimutils/0.9.12: 3 files, 665KB
```

## Changes

- add `brew trust wix/brew` in AppleSimulatorUtils installation step

## Before & after - visual documentation

N/A

## Test plan

CI should pass.

## Checklist

- [ ] Ensured that CI passes
