### PR TITLE
feat(Android, Stack, Tabs, SVM): improve nested container integration -> introduce `Container` & `ContainerItem`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ext/WeakReferenceExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ext/WeakReferenceExt.kt
@@ -1,0 +1,16 @@
+package com.swmansion.rnscreens.ext
+
+import android.os.Build
+import java.lang.ref.WeakReference
+
+internal fun <T> WeakReference<T>.refersToCompat(referent: T): Boolean {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        return this.refersTo(referent)
+    } else {
+        this.get()?.let { strongRef ->
+            return strongRef === referent
+        }
+        // Compatibility with `refersTo`
+        return referent == null
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.common.container
 
 import android.view.ViewGroup
 
-interface Container {
+internal interface Container {
     /**
      * A container can have multiple items, and each item can have its own
      * content scroll view. It's down to implementer to decide, which scroll view to return here

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
@@ -1,0 +1,14 @@
+package com.swmansion.rnscreens.gamma.common.container
+
+import android.view.ViewGroup
+
+typealias ContainerItemVisitor = (ContainerItem) -> Boolean
+
+interface Container {
+    /**
+     * A container can have multiple items, and each item can have its own
+     * content scroll view. It's down to implementer to decide, which scroll view to return here
+     * (if any).
+     */
+    fun resolveCurrentContentScrollView(): ViewGroup?
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
@@ -2,8 +2,6 @@ package com.swmansion.rnscreens.gamma.common.container
 
 import android.view.ViewGroup
 
-typealias ContainerItemVisitor = (ContainerItem) -> Boolean
-
 interface Container {
     /**
      * A container can have multiple items, and each item can have its own

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/Container.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.common.container
 
 import android.view.ViewGroup
 
-internal interface Container {
+interface Container {
     /**
      * A container can have multiple items, and each item can have its own
      * content scroll view. It's down to implementer to decide, which scroll view to return here

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.common.container
 
 import android.view.ViewGroup
 
-interface ContainerItem {
+internal interface ContainerItem {
     // region Nested Container handling
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
@@ -5,6 +5,12 @@ import android.view.ViewGroup
 interface ContainerItem {
     // region Nested Container handling
 
+    /**
+     * A `ContainerItem` supports at most a single nested `Container`. Registering
+     * a second container while one is already registered overwrites the previous
+     * one. This is an intentional design invariant: a single item is expected to
+     * host at most one nested container.
+     */
     fun registerNestedContainer(container: Container)
     fun unregisterNestedContainer(container: Container)
     fun resolveNestedContainer(): Container?

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
@@ -1,0 +1,22 @@
+package com.swmansion.rnscreens.gamma.common.container
+
+import android.view.ViewGroup
+
+interface ContainerItem {
+    // region Nested Container handling
+
+    fun registerNestedContainer(container: Container)
+    fun unregisterNestedContainer(container: Container)
+    fun resolveNestedContainer(): Container?
+
+    // endregion
+
+    // region Content Scroll View support
+
+    /**
+     * @return Content scroll view associated with this container item.
+     */
+    fun findContentScrollView(): ViewGroup?
+
+    // endregion
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItem.kt
@@ -12,7 +12,9 @@ interface ContainerItem {
      * host at most one nested container.
      */
     fun registerNestedContainer(container: Container)
+
     fun unregisterNestedContainer(container: Container)
+
     fun resolveNestedContainer(): Container?
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItemSupport.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerItemSupport.kt
@@ -1,0 +1,54 @@
+package com.swmansion.rnscreens.gamma.common.container
+
+import android.view.ViewGroup
+import com.swmansion.rnscreens.ext.refersToCompat
+import com.swmansion.rnscreens.gamma.helpers.ViewFinder
+import java.lang.ref.WeakReference
+
+/**
+ * Shared state & logic backing a [ContainerItem]. Holds the (optional) nested
+ * [Container] and the cached content scroll view, and resolves the content scroll
+ * view on behalf of the owning item.
+ *
+ * A [ContainerItem] supports at most a single nested [Container]; see
+ * [ContainerItem.registerNestedContainer].
+ */
+internal class ContainerItemSupport {
+    private var nestedContainer: WeakReference<Container> = WeakReference(null)
+    private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
+
+    fun registerScrollView(scrollView: ViewGroup) {
+        contentScrollView = WeakReference(scrollView)
+    }
+
+    fun registerNestedContainer(container: Container) {
+        nestedContainer = WeakReference(container)
+    }
+
+    fun unregisterNestedContainer(container: Container) {
+        if (nestedContainer.refersToCompat(container)) {
+            nestedContainer.clear()
+        }
+    }
+
+    fun resolveNestedContainer(): Container? = nestedContainer.get()
+
+    /**
+     * Resolves the content scroll view for the owning item: the cached one if
+     * present, otherwise the one provided by the nested container, otherwise a
+     * heuristic search through [owner]'s first descendant chain.
+     */
+    fun findContentScrollView(owner: ViewGroup): ViewGroup? {
+        // Cached one
+        contentScrollView.get()?.let { return it }
+
+        // Provided by nested container
+        resolveNestedContainer()?.resolveCurrentContentScrollView()?.let { scrollView ->
+            return scrollView
+        }
+
+        // Heuristic
+        ViewFinder.findScrollViewInFirstDescendantChain(owner)?.let { return it }
+        return null
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerUtils.kt
@@ -14,14 +14,18 @@ internal fun findParentContainerItem(searchStartPoint: ViewGroup): ContainerItem
     return null
 }
 
-internal fun registerWithParentContainerItem(container: Container, searchStartPoint: ViewGroup): ContainerItem? {
-    return findParentContainerItem(searchStartPoint)?.let {
+internal fun registerWithParentContainerItem(
+    container: Container,
+    searchStartPoint: ViewGroup,
+): ContainerItem? =
+    findParentContainerItem(searchStartPoint)?.let {
         it.registerNestedContainer(container)
         it
     }
-}
 
-internal fun unregisterFromParentContainerItem(parentContainerItem: ContainerItem?, childContainer: Container) {
+internal fun unregisterFromParentContainerItem(
+    parentContainerItem: ContainerItem?,
+    childContainer: Container,
+) {
     parentContainerItem?.unregisterNestedContainer(childContainer)
 }
-

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerUtils.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ContainerUtils.kt
@@ -1,0 +1,27 @@
+package com.swmansion.rnscreens.gamma.common.container
+
+import android.view.ViewGroup
+
+internal fun findParentContainerItem(searchStartPoint: ViewGroup): ContainerItem? {
+    var currView = searchStartPoint.parent
+
+    while (currView != null) {
+        if (currView is ContainerItem) {
+            return currView
+        }
+        currView = currView.parent
+    }
+    return null
+}
+
+internal fun registerWithParentContainerItem(container: Container, searchStartPoint: ViewGroup): ContainerItem? {
+    return findParentContainerItem(searchStartPoint)?.let {
+        it.registerNestedContainer(container)
+        it
+    }
+}
+
+internal fun unregisterFromParentContainerItem(parentContainerItem: ContainerItem?, childContainer: Container) {
+    parentContainerItem?.unregisterNestedContainer(childContainer)
+}
+

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ParentContainerItemRegistry.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/common/container/ParentContainerItemRegistry.kt
@@ -1,0 +1,21 @@
+package com.swmansion.rnscreens.gamma.common.container
+
+import android.view.ViewGroup
+
+/**
+ * Shared state & logic backing a [Container]'s registration with the nearest
+ * parent [ContainerItem] in the view hierarchy. Call [attach] when the container
+ * attaches to the window and [detach] when it detaches.
+ */
+internal class ParentContainerItemRegistry {
+    private var parentContainerItem: ContainerItem? = null
+
+    fun <T> attach(self: T) where T : ViewGroup, T : Container {
+        parentContainerItem = registerWithParentContainerItem(self, self)
+    }
+
+    fun detach(self: Container) {
+        unregisterFromParentContainerItem(parentContainerItem, self)
+        parentContainerItem = null
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
@@ -3,10 +3,15 @@ package com.swmansion.rnscreens.gamma.stack.host
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.swmansion.rnscreens.ext.isMeasured
+import com.swmansion.rnscreens.gamma.common.container.Container
+import com.swmansion.rnscreens.gamma.common.container.ContainerItem
+import com.swmansion.rnscreens.gamma.common.container.registerWithParentContainerItem
+import com.swmansion.rnscreens.gamma.common.container.unregisterFromParentContainerItem
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.gamma.helpers.ViewIdGenerator
 import com.swmansion.rnscreens.gamma.stack.screen.StackScreen
@@ -19,6 +24,7 @@ internal class StackContainer(
     context: Context,
     private val delegate: WeakReference<StackContainerDelegate>,
 ) : FrameLayout(context),
+    Container,
     FragmentManager.OnBackStackChangedListener {
     private var fragmentManager: FragmentManager? = null
 
@@ -29,6 +35,8 @@ internal class StackContainer(
      * Will crash in case parent does not implement StackContainerParent interface.
      */
     private fun containerParentOrNull(): StackContainerParent? = this.parent as StackContainerParent?
+
+    private var parentContainerItem: ContainerItem? = null
 
     /**
      * Describes most up-to-date view of the stack. It might be different from
@@ -53,6 +61,7 @@ internal class StackContainer(
         RNSLog.d(TAG, "StackContainer [$id] attached to window")
         super.onAttachedToWindow()
 
+        setUpContainerHierarchy()
         setupFragmentManger()
 
         // Following line works with a couple of assumptions.
@@ -73,6 +82,7 @@ internal class StackContainer(
         super.onDetachedFromWindow()
         requireFragmentManager().removeOnBackStackChangedListener(this)
         fragmentManager = null
+        tearDownContainerHierarchy()
     }
 
     internal fun setupFragmentManger() {
@@ -217,6 +227,17 @@ internal class StackContainer(
     }
 
     /**
+     * Computes top fragment from FragmentManager's state.
+     * This one does not query the `stackModel`!
+     *
+     * Might return `null` if the stack is empty.
+     */
+    private fun determineTopFragment(): StackScreenFragment? =
+        requireFragmentManager().fragments
+            .filterIsInstance<StackScreenFragment>()
+            .lastOrNull()
+
+    /**
      * If this.isLaidOut == false, then SpecialEffectsController won't perform animations / transitions.
      * This function tries to ensure that the container is laid out if it already has layout information.
      */
@@ -261,6 +282,24 @@ internal class StackContainer(
         )
 
         layout(left, top, right, bottom)
+    }
+
+    // region Container
+
+    override fun resolveCurrentContentScrollView(): ViewGroup? =
+        determineTopFragment()
+            ?.stackScreen
+            ?.findContentScrollView()
+
+    // endregion
+
+    private fun setUpContainerHierarchy() {
+        parentContainerItem = registerWithParentContainerItem(this, this)
+    }
+
+    private fun tearDownContainerHierarchy() {
+        unregisterFromParentContainerItem(parentContainerItem, this)
+        parentContainerItem = null
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
@@ -9,9 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.swmansion.rnscreens.ext.isMeasured
 import com.swmansion.rnscreens.gamma.common.container.Container
-import com.swmansion.rnscreens.gamma.common.container.ContainerItem
-import com.swmansion.rnscreens.gamma.common.container.registerWithParentContainerItem
-import com.swmansion.rnscreens.gamma.common.container.unregisterFromParentContainerItem
+import com.swmansion.rnscreens.gamma.common.container.ParentContainerItemRegistry
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.gamma.helpers.ViewIdGenerator
 import com.swmansion.rnscreens.gamma.stack.screen.StackScreen
@@ -36,7 +34,7 @@ internal class StackContainer(
      */
     private fun containerParentOrNull(): StackContainerParent? = this.parent as StackContainerParent?
 
-    private var parentContainerItem: ContainerItem? = null
+    private val parentContainerRegistry = ParentContainerItemRegistry()
 
     /**
      * Describes most up-to-date view of the stack. It might be different from
@@ -61,7 +59,7 @@ internal class StackContainer(
         RNSLog.d(TAG, "StackContainer [$id] attached to window")
         super.onAttachedToWindow()
 
-        setUpContainerHierarchy()
+        parentContainerRegistry.attach(this)
         setupFragmentManger()
 
         // Following line works with a couple of assumptions.
@@ -82,7 +80,7 @@ internal class StackContainer(
         super.onDetachedFromWindow()
         requireFragmentManager().removeOnBackStackChangedListener(this)
         fragmentManager = null
-        tearDownContainerHierarchy()
+        parentContainerRegistry.detach(this)
     }
 
     internal fun setupFragmentManger() {
@@ -293,15 +291,6 @@ internal class StackContainer(
             ?.findContentScrollView()
 
     // endregion
-
-    private fun setUpContainerHierarchy() {
-        parentContainerItem = registerWithParentContainerItem(this, this)
-    }
-
-    private fun tearDownContainerHierarchy() {
-        unregisterFromParentContainerItem(parentContainerItem, this)
-        parentContainerItem = null
-    }
 
     companion object {
         const val TAG = "StackContainer"

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/host/StackContainer.kt
@@ -233,7 +233,8 @@ internal class StackContainer(
      * Might return `null` if the stack is empty.
      */
     private fun determineTopFragment(): StackScreenFragment? =
-        requireFragmentManager().fragments
+        requireFragmentManager()
+            .fragments
             .filterIsInstance<StackScreenFragment>()
             .lastOrNull()
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
@@ -6,8 +6,14 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.ext.findFragmentOrNull
+import com.swmansion.rnscreens.ext.refersToCompat
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
+import com.swmansion.rnscreens.gamma.common.container.Container
+import com.swmansion.rnscreens.gamma.common.container.ContainerItem
+import com.swmansion.rnscreens.gamma.helpers.ViewFinder
+import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewMarker
+import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewSeeking
 import com.swmansion.rnscreens.gamma.stack.header.config.OnHeaderConfigurationAttachListener
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfig
 import com.swmansion.rnscreens.gamma.stack.host.StackHost
@@ -18,11 +24,16 @@ import kotlin.properties.Delegates
 class StackScreen(
     private val reactContext: ThemedReactContext,
 ) : ViewGroup(reactContext),
-    FragmentProviding {
+    FragmentProviding,
+    ScrollViewSeeking,
+    ContainerItem {
     enum class ActivityMode {
         DETACHED,
         ATTACHED,
     }
+
+    private var nestedContainer: WeakReference<Container> = WeakReference(null)
+    private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
 
     internal var isPreventNativeDismissEnabled: Boolean by Delegates.observable(false) { _, oldValue, newValue ->
         if (oldValue != newValue) {
@@ -115,6 +126,14 @@ class StackScreen(
 
     // endregion
 
+    // region ScrollViewSeeking
+
+    override fun registerScrollView(marker: ScrollViewMarker, scrollView: ViewGroup) {
+        contentScrollView = WeakReference(scrollView)
+    }
+
+    // endregion
+
     internal lateinit var eventEmitter: StackScreenEventEmitter
 
     /**
@@ -146,4 +165,30 @@ class StackScreen(
         this.findFragmentOrNull()?.also {
             check(it is StackScreenFragment) { "[RNScreens] Unexpected fragment type: ${it.javaClass.simpleName}" }
         }
+
+    override fun registerNestedContainer(container: Container) {
+        nestedContainer = WeakReference(container)
+    }
+
+    override fun unregisterNestedContainer(container: Container) {
+        if (nestedContainer.refersToCompat(container)) {
+            nestedContainer.clear()
+        }
+    }
+
+    override fun resolveNestedContainer(): Container? = nestedContainer.get()
+
+    override fun findContentScrollView(): ViewGroup? {
+        // Cached one
+        contentScrollView.get()?.let { return it }
+
+        // Provided by nested container
+        resolveNestedContainer()?.resolveCurrentContentScrollView()?.let { scrollView ->
+            return scrollView
+        }
+
+        // Heuristic
+        ViewFinder.findScrollViewInFirstDescendantChain(this)?.let { return it }
+        return null
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/screen/StackScreen.kt
@@ -6,12 +6,11 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.ext.findFragmentOrNull
-import com.swmansion.rnscreens.ext.refersToCompat
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
 import com.swmansion.rnscreens.gamma.common.container.Container
 import com.swmansion.rnscreens.gamma.common.container.ContainerItem
-import com.swmansion.rnscreens.gamma.helpers.ViewFinder
+import com.swmansion.rnscreens.gamma.common.container.ContainerItemSupport
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewMarker
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewSeeking
 import com.swmansion.rnscreens.gamma.stack.header.config.OnHeaderConfigurationAttachListener
@@ -32,8 +31,7 @@ class StackScreen(
         ATTACHED,
     }
 
-    private var nestedContainer: WeakReference<Container> = WeakReference(null)
-    private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
+    private val containerItemSupport = ContainerItemSupport()
 
     internal var isPreventNativeDismissEnabled: Boolean by Delegates.observable(false) { _, oldValue, newValue ->
         if (oldValue != newValue) {
@@ -128,8 +126,11 @@ class StackScreen(
 
     // region ScrollViewSeeking
 
-    override fun registerScrollView(marker: ScrollViewMarker, scrollView: ViewGroup) {
-        contentScrollView = WeakReference(scrollView)
+    override fun registerScrollView(
+        marker: ScrollViewMarker,
+        scrollView: ViewGroup,
+    ) {
+        containerItemSupport.registerScrollView(scrollView)
     }
 
     // endregion
@@ -166,29 +167,11 @@ class StackScreen(
             check(it is StackScreenFragment) { "[RNScreens] Unexpected fragment type: ${it.javaClass.simpleName}" }
         }
 
-    override fun registerNestedContainer(container: Container) {
-        nestedContainer = WeakReference(container)
-    }
+    override fun registerNestedContainer(container: Container) = containerItemSupport.registerNestedContainer(container)
 
-    override fun unregisterNestedContainer(container: Container) {
-        if (nestedContainer.refersToCompat(container)) {
-            nestedContainer.clear()
-        }
-    }
+    override fun unregisterNestedContainer(container: Container) = containerItemSupport.unregisterNestedContainer(container)
 
-    override fun resolveNestedContainer(): Container? = nestedContainer.get()
+    override fun resolveNestedContainer(): Container? = containerItemSupport.resolveNestedContainer()
 
-    override fun findContentScrollView(): ViewGroup? {
-        // Cached one
-        contentScrollView.get()?.let { return it }
-
-        // Provided by nested container
-        resolveNestedContainer()?.resolveCurrentContentScrollView()?.let { scrollView ->
-            return scrollView
-        }
-
-        // Heuristic
-        ViewFinder.findScrollViewInFirstDescendantChain(this)?.let { return it }
-        return null
-    }
+    override fun findContentScrollView(): ViewGroup? = containerItemSupport.findContentScrollView(this)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -24,9 +24,7 @@ import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeCoordinator
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeListener
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeProviding
 import com.swmansion.rnscreens.gamma.common.container.Container
-import com.swmansion.rnscreens.gamma.common.container.ContainerItem
-import com.swmansion.rnscreens.gamma.common.container.registerWithParentContainerItem
-import com.swmansion.rnscreens.gamma.common.container.unregisterFromParentContainerItem
+import com.swmansion.rnscreens.gamma.common.container.ParentContainerItemRegistry
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.gamma.helpers.ViewFinder
 import com.swmansion.rnscreens.gamma.helpers.ViewIdGenerator
@@ -99,7 +97,7 @@ class TabsContainer internal constructor(
     private var lastUINavState: TabsNavigationState = TabsNavigationState.EMPTY
     private val tabsModel: MutableList<TabsScreenFragment> = arrayListOf()
 
-    private var parentContainerItem: ContainerItem? = null
+    private val parentContainerRegistry = ParentContainerItemRegistry()
 
     internal var rejectStaleNavigationStateUpdates: Boolean = false
 
@@ -295,7 +293,7 @@ class TabsContainer internal constructor(
 
         super.onAttachedToWindow()
 
-        setUpContainerHierarchy()
+        parentContainerRegistry.attach(this)
         setupFragmentManager()
 
         // When TabsContainer is reattached to window, it might find new fragment manager (other
@@ -320,7 +318,7 @@ class TabsContainer internal constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         teardownFragmentManager()
-        tearDownContainerHierarchy()
+        parentContainerRegistry.detach(this)
         colorSchemeCoordinator.teardown()
     }
 
@@ -773,15 +771,6 @@ class TabsContainer internal constructor(
     private fun isNavigationStateStale(request: TabsNavigationStateUpdateRequest): Boolean {
         if (navState.isEmpty() || lastUINavState.isEmpty()) return false
         return request.baseProvenance < lastUINavState.provenance
-    }
-
-    private fun setUpContainerHierarchy() {
-        parentContainerItem = registerWithParentContainerItem(this, this)
-    }
-
-    private fun tearDownContainerHierarchy() {
-        unregisterFromParentContainerItem(parentContainerItem, this)
-        parentContainerItem = null
     }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -23,6 +23,10 @@ import com.swmansion.rnscreens.gamma.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeCoordinator
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeListener
 import com.swmansion.rnscreens.gamma.common.colorscheme.ColorSchemeProviding
+import com.swmansion.rnscreens.gamma.common.container.Container
+import com.swmansion.rnscreens.gamma.common.container.ContainerItem
+import com.swmansion.rnscreens.gamma.common.container.registerWithParentContainerItem
+import com.swmansion.rnscreens.gamma.common.container.unregisterFromParentContainerItem
 import com.swmansion.rnscreens.gamma.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.gamma.helpers.ViewFinder
 import com.swmansion.rnscreens.gamma.helpers.ViewIdGenerator
@@ -51,6 +55,7 @@ import kotlin.properties.Delegates
 class TabsContainer internal constructor(
     private val context: Context,
 ) : FrameLayout(context),
+    Container,
     ColorSchemeProviding,
     TabsScreenDelegate,
     SafeAreaProvider,
@@ -70,16 +75,10 @@ class TabsContainer internal constructor(
                 }
             }
             if (selectedTabScreen.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
-                val scrollView = resolveContentScrollViewForScreen(selectedTabScreen)
+                val scrollView = selectedTabScreen.findContentScrollView()
                 scrollView?.let { return trySmoothScrollToTop(it) }
             }
             return false
-        }
-
-        private fun resolveContentScrollViewForScreen(tabsScreen: TabsScreen): ViewGroup? {
-            tabsScreen.contentScrollView()?.let { return it }
-            ViewFinder.findScrollViewInFirstDescendantChain(tabsScreen)?.let { return it }
-            return null
         }
 
         /**
@@ -99,6 +98,8 @@ class TabsContainer internal constructor(
     private var navState: TabsNavigationState = TabsNavigationState.EMPTY
     private var lastUINavState: TabsNavigationState = TabsNavigationState.EMPTY
     private val tabsModel: MutableList<TabsScreenFragment> = arrayListOf()
+
+    private var parentContainerItem: ContainerItem? = null
 
     internal var rejectStaleNavigationStateUpdates: Boolean = false
 
@@ -293,6 +294,8 @@ class TabsContainer internal constructor(
         RNSLog.d(TAG, "TabsContainer [$id] attached to window")
 
         super.onAttachedToWindow()
+
+        setUpContainerHierarchy()
         setupFragmentManager()
 
         // When TabsContainer is reattached to window, it might find new fragment manager (other
@@ -317,6 +320,7 @@ class TabsContainer internal constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         teardownFragmentManager()
+        tearDownContainerHierarchy()
         colorSchemeCoordinator.teardown()
     }
 
@@ -769,6 +773,24 @@ class TabsContainer internal constructor(
     private fun isNavigationStateStale(request: TabsNavigationStateUpdateRequest): Boolean {
         if (navState.isEmpty() || lastUINavState.isEmpty()) return false
         return request.baseProvenance < lastUINavState.provenance
+    }
+
+    private fun setUpContainerHierarchy() {
+        parentContainerItem = registerWithParentContainerItem(this, this)
+    }
+
+    private fun tearDownContainerHierarchy() {
+        unregisterFromParentContainerItem(parentContainerItem, this)
+        parentContainerItem = null
+    }
+
+    // endregion
+
+    // region Container
+
+    override fun resolveCurrentContentScrollView(): ViewGroup? {
+        // We assume here that the selectedTab actually corresponds to whats in FragmentManager
+        return selectedTab.tabsScreen.findContentScrollView()
     }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -5,11 +5,10 @@ import android.graphics.drawable.Drawable
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.facebook.react.uimanager.ThemedReactContext
-import com.swmansion.rnscreens.ext.refersToCompat
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
 import com.swmansion.rnscreens.gamma.common.container.Container
 import com.swmansion.rnscreens.gamma.common.container.ContainerItem
-import com.swmansion.rnscreens.gamma.helpers.ViewFinder
+import com.swmansion.rnscreens.gamma.common.container.ContainerItemSupport
 import com.swmansion.rnscreens.gamma.helpers.getSystemDrawableResource
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewMarker
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewSeeking
@@ -28,8 +27,7 @@ class TabsScreen(
     ScrollViewSeeking,
     ContainerItem {
     private var tabsScreenDelegate: WeakReference<TabsScreenDelegate> = WeakReference(null)
-    private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
-    private var nestedContainer: WeakReference<Container> = WeakReference(null)
+    private val containerItemSupport = ContainerItemSupport()
 
     internal lateinit var eventEmitter: TabsScreenEventEmitter
 
@@ -163,38 +161,20 @@ class TabsScreen(
         marker: ScrollViewMarker,
         scrollView: ViewGroup,
     ) {
-        contentScrollView = WeakReference(scrollView)
+        containerItemSupport.registerScrollView(scrollView)
     }
 
     // endregion
 
     // region ContainerItem
 
-    override fun registerNestedContainer(container: Container) {
-        nestedContainer = WeakReference(container)
-    }
+    override fun registerNestedContainer(container: Container) = containerItemSupport.registerNestedContainer(container)
 
-    override fun unregisterNestedContainer(container: Container) {
-        if (nestedContainer.refersToCompat(container)) {
-            nestedContainer.clear()
-        }
-    }
+    override fun unregisterNestedContainer(container: Container) = containerItemSupport.unregisterNestedContainer(container)
 
-    override fun resolveNestedContainer(): Container? = nestedContainer.get()
+    override fun resolveNestedContainer(): Container? = containerItemSupport.resolveNestedContainer()
 
-    override fun findContentScrollView(): ViewGroup? {
-        // Cached one
-        contentScrollView.get()?.let { return it }
-
-        // Provided by nested container
-        resolveNestedContainer()?.resolveCurrentContentScrollView()?.let { scrollView ->
-            return scrollView
-        }
-
-        // Heuristic
-        ViewFinder.findScrollViewInFirstDescendantChain(this)?.let { return it }
-        return null
-    }
+    override fun findContentScrollView(): ViewGroup? = containerItemSupport.findContentScrollView(this)
 
     // endregion
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreen.kt
@@ -5,7 +5,11 @@ import android.graphics.drawable.Drawable
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.facebook.react.uimanager.ThemedReactContext
+import com.swmansion.rnscreens.ext.refersToCompat
 import com.swmansion.rnscreens.gamma.common.FragmentProviding
+import com.swmansion.rnscreens.gamma.common.container.Container
+import com.swmansion.rnscreens.gamma.common.container.ContainerItem
+import com.swmansion.rnscreens.gamma.helpers.ViewFinder
 import com.swmansion.rnscreens.gamma.helpers.getSystemDrawableResource
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewMarker
 import com.swmansion.rnscreens.gamma.scrollviewmarker.ScrollViewSeeking
@@ -21,9 +25,11 @@ class TabsScreen(
     val reactContext: ThemedReactContext,
 ) : ViewGroup(reactContext),
     FragmentProviding,
-    ScrollViewSeeking {
+    ScrollViewSeeking,
+    ContainerItem {
     private var tabsScreenDelegate: WeakReference<TabsScreenDelegate> = WeakReference(null)
     private var contentScrollView: WeakReference<ViewGroup> = WeakReference(null)
+    private var nestedContainer: WeakReference<Container> = WeakReference(null)
 
     internal lateinit var eventEmitter: TabsScreenEventEmitter
 
@@ -160,7 +166,35 @@ class TabsScreen(
         contentScrollView = WeakReference(scrollView)
     }
 
-    internal fun contentScrollView(): ViewGroup? = contentScrollView.get()
+    // endregion
+
+    // region ContainerItem
+
+    override fun registerNestedContainer(container: Container) {
+        nestedContainer = WeakReference(container)
+    }
+
+    override fun unregisterNestedContainer(container: Container) {
+        if (nestedContainer.refersToCompat(container)) {
+            nestedContainer.clear()
+        }
+    }
+
+    override fun resolveNestedContainer(): Container? = nestedContainer.get()
+
+    override fun findContentScrollView(): ViewGroup? {
+        // Cached one
+        contentScrollView.get()?.let { return it }
+
+        // Provided by nested container
+        resolveNestedContainer()?.resolveCurrentContentScrollView()?.let { scrollView ->
+            return scrollView
+        }
+
+        // Heuristic
+        ViewFinder.findScrollViewInFirstDescendantChain(this)?.let { return it }
+        return null
+    }
 
     // endregion
 

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
@@ -21,7 +21,7 @@ TBD
 
 ## Note
 
-Android does to support pop-to-root - it is yet unimplemented. Scroll-to-top should work.
+Android does not yet support pop-to-root - it is unimplemented. Scroll-to-top should work.
 
 iOS implementation doesn't currently support nested container interaction yet. 
 This test needs to be updated after such interaction is supported.
@@ -41,8 +41,8 @@ This test needs to be updated after such interaction is supported.
 
 3. Press `Home` tab item (repeated tab selection) to trigger the special effect.
 
-    - [ ] *scroll-top-top* should be triggered and you should observe the scroll-view scrolling 
-    to it's top.
+    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling 
+    to its top.
 
 ### Nested stack
 
@@ -57,5 +57,5 @@ This test needs to be updated after such interaction is supported.
 
 6. Press `Stack` tab item (repeated tab selection) to trigger the special effect.
 
-    - [ ] *scroll-top-top* should be triggered and you should observe the scroll-view scrolling 
-    to it's top.
+    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling 
+    to its top.

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
@@ -21,17 +21,19 @@ TBD
 
 ## Note
 
-Android part of the code is unimplemented yet, therefore it is expected not to work.
+Android does to support pop-to-root - it is yet unimplemented. Scroll-to-top should work.
 
 iOS implementation doesn't currently support nested container interaction yet. 
 This test needs to be updated after such interaction is supported.
 
 ## Steps
 
+### Basic case - no nesting
+
 1. Launch the app and navigate to the **SVM in Stack & Tabs - tabs special effects** screen.
 
-- [ ] There should be two tabs: `Home` and `Stack`.
-- [ ] `Home` tab should be selected.
+    - [ ] There should be two tabs: `Home` and `Stack`.
+    - [ ] `Home` tab should be selected.
 
 2. Scroll down a bit.
 
@@ -39,5 +41,21 @@ This test needs to be updated after such interaction is supported.
 
 3. Press `Home` tab item (repeated tab selection) to trigger the special effect.
 
-- [ ] *scroll-top-top* should be triggered and you should observe the scroll-view scrolling 
-to it's top.
+    - [ ] *scroll-top-top* should be triggered and you should observe the scroll-view scrolling 
+    to it's top.
+
+### Nested stack
+
+4. Change tab to `Stack`.
+
+    - [ ] The `Stack` screen should be displayed. 
+    - [ ] Scroll-view should be visible and scrolled to top.
+    
+5. Scroll down a bit.
+
+    Doesn't really matter how much you scroll - the distance should be "noticeable". 
+
+6. Press `Stack` tab item (repeated tab selection) to trigger the special effect.
+
+    - [ ] *scroll-top-top* should be triggered and you should observe the scroll-view scrolling 
+    to it's top.


### PR DESCRIPTION
## Description

Closes: <https://github.com/software-mansion/react-native-screens-labs/issues/1572>

On Android, nested navigation containers (e.g. a `Stack` rendered inside a
`Tabs` screen) had no way to propagate nesting information between each other.
As a result, special effects that need to reach into the *currently presented*
content — concretely the repeated-tab-selection scroll-to-top — could not
resolve the correct content scroll view across a nesting boundary.

> [!note]
> To be precise here - it simple case, with stack nested in tabs worked even
> before this PR - but only because the StackScreen did not implement the
> `ScrollViewSeeking` interface. Once it does (and we want that), the behavior
> breaks. This PR makes both of that possible -> `StackScreen` is now aware
> of its content scroll-view and yet it does not break the *tabs special effects*.

This PR introduces a small container-nesting protocol so that information can be
propagated between containers, and uses it right away to resolve the content
scroll view through nested containers.

The mechanism is intentionally simple. Both `StackContainer` and `TabsContainer`
implement a new `Container` interface; their respective screen classes
(`StackScreen`, `TabsScreen`) implement a new `ContainerItem` interface.

- When attached to the window, a `Container` walks up its view hierarchy, finds
  the nearest parent `ContainerItem`, and registers itself with it.
- When detached, the `Container` unregisters itself from that parent.

A `ContainerItem` supports at most a single nested `Container` — this is an
intentional design invariant (documented on `registerNestedContainer`).

This protocol can later be expanded to other use-cases beyond resolving the
content scroll view (e.g. orientation support & coordination between nested
containers).

## Changes

- Added the `Container` / `ContainerItem` interfaces and the `ContainerUtils`
  helpers that perform the parent lookup and (un)registration in the view
  hierarchy.
- `StackContainer` / `TabsContainer` now implement `Container` and register with
  their parent `ContainerItem` on attach / detach to the window.
- `StackScreen` / `TabsScreen` now implement `ContainerItem`; `StackScreen`
  additionally integrates with `ScrollViewSeeking` so its content scroll view is
  discoverable.
- Content-scroll-view resolution now follows: cached value → value provided by
  the nested container → descendant-chain heuristic.
- Added `refersToCompat` (`WeakReference.refersTo` with a pre-Tiramisu fallback)
  used by the unregister path.
- Extracted the duplicated nesting state/logic across the Stack/Tabs pairs into
  two shared composition holders: `ContainerItemSupport` (screen side) and
  `ParentContainerItemRegistry` (container side). Logic was moved verbatim, so
  behaviour is unchanged; composition was chosen over a common base class to
  keep the existing `ViewGroup` / `FrameLayout` hierarchies intact and to match
  the existing codebase idiom.

##  visual documentation

https://github.com/user-attachments/assets/d6eaf026-b550-4dbd-a3ac-dd666f6e25ff


## Test plan

Manual, see `test-stack-svm-tabs-special-effects` and appropriate scenario description there.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
