### PR TITLE
feat(Android, FormSheet v5): Replace native animations with custom slide+fade

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
@@ -17,7 +17,7 @@ class DimmingViewManager(
     screen: Screen,
 ) {
     internal val dimmingView: DimmingView = createDimmingView(screen)
-    internal val maxAlpha: Float = 0.3f
+    internal val maxAlpha: Float = MAX_ALPHA
     private var dimmingViewCallback: BottomSheetCallback? = null
 
     /**
@@ -176,5 +176,9 @@ class DimmingViewManager(
             dimmingViewCallback = AnimateDimmingViewCallback(screen, dimmingView, maxAlpha)
         }
         return dimmingViewCallback!!
+    }
+
+    companion object {
+        private const val MAX_ALPHA = 0.3f
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/bottomsheet/DimmingViewManager.kt
@@ -17,7 +17,7 @@ class DimmingViewManager(
     screen: Screen,
 ) {
     internal val dimmingView: DimmingView = createDimmingView(screen)
-    internal val maxAlpha: Float = MAX_ALPHA
+    internal val maxAlpha: Float = 0.3f
     private var dimmingViewCallback: BottomSheetCallback? = null
 
     /**
@@ -176,9 +176,5 @@ class DimmingViewManager(
             dimmingViewCallback = AnimateDimmingViewCallback(screen, dimmingView, maxAlpha)
         }
         return dimmingViewCallback!!
-    }
-
-    companion object {
-        private const val MAX_ALPHA = 0.3f
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingView.kt
@@ -1,0 +1,83 @@
+package com.swmansion.rnscreens.gamma.modals.dimmingview
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.view.MotionEvent
+import android.view.ViewGroup
+import com.facebook.react.uimanager.ReactCompoundViewGroup
+import com.facebook.react.uimanager.ReactPointerEventsView
+import com.swmansion.rnscreens.ext.equalWithRespectToEps
+
+/**
+ * Serves as dimming view that can be used as background for some view that does not fully fill
+ * the viewport.
+ *
+ * This dimming view has one more additional feature: it blocks gestures if its alpha > 0.
+ */
+@SuppressLint("ViewConstructor") // Only we instantiate this view
+internal class DimmingView(
+    context: Context,
+    initialAlpha: Float = 0.6F,
+    private val pointerEventsProxy: DimmingViewPointerEventsProxy,
+) : ViewGroup(context),
+    ReactCompoundViewGroup,
+    ReactPointerEventsView by pointerEventsProxy {
+    constructor(context: Context, initialAlpha: Float = 0.6F) : this(
+        context,
+        initialAlpha,
+        DimmingViewPointerEventsProxy(null),
+    )
+
+    init {
+        pointerEventsProxy.pointerEventsImpl = DimmingViewPointerEventsImpl(this)
+        setFocusable(false)
+    }
+
+    internal val blockGestures
+        get() = !alpha.equalWithRespectToEps(0F)
+
+    init {
+        setBackgroundColor(Color.BLACK)
+        alpha = initialAlpha
+    }
+
+    // This view group is not supposed to have any children, however we need it to be a view group
+    override fun onLayout(
+        changed: Boolean,
+        l: Int,
+        t: Int,
+        r: Int,
+        b: Int,
+    ) = Unit
+
+    // We do not want to have any action defined here. We just want listeners notified that the click happened.
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        if (blockGestures && event?.actionMasked == MotionEvent.ACTION_UP) {
+            callOnClick()
+        }
+        return blockGestures
+    }
+
+    override fun reactTagForTouch(
+        x: Float,
+        y: Float,
+    ): Int = throw IllegalStateException("[RNScreens] $TAG should never be asked for the view tag!")
+
+    override fun interceptsTouchEvent(
+        x: Float,
+        y: Float,
+    ) = blockGestures
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+
+        // Break reference cycle, since the pointerEventsImpl strongly retains this.
+        pointerEventsProxy.pointerEventsImpl = null
+    }
+
+    companion object {
+        const val TAG = "DimmingView"
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingView.kt
@@ -18,12 +18,12 @@ import com.swmansion.rnscreens.ext.equalWithRespectToEps
 @SuppressLint("ViewConstructor") // Only we instantiate this view
 internal class DimmingView(
     context: Context,
-    initialAlpha: Float = 0.6F,
+    initialAlpha: Float,
     private val pointerEventsProxy: DimmingViewPointerEventsProxy,
 ) : ViewGroup(context),
     ReactCompoundViewGroup,
     ReactPointerEventsView by pointerEventsProxy {
-    constructor(context: Context, initialAlpha: Float = 0.6F) : this(
+    constructor(context: Context, initialAlpha: Float) : this(
         context,
         initialAlpha,
         DimmingViewPointerEventsProxy(null),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -12,8 +12,6 @@ class DimmingViewManager(
     private val dialog: BottomSheetDialog,
     private val onCloseRequested: () -> Unit,
 ) {
-    private val dimmingView: DimmingView = createDimmingView(context)
-
     // TODO: @t0maboro - consider exposing as a prop
     internal val maxAlpha: Float = 0.3f
 
@@ -23,7 +21,7 @@ class DimmingViewManager(
             dimmingView.alpha = value
         }
 
-    private fun createDimmingView(context: Context): DimmingView =
+    private val dimmingView =
         DimmingView(context, maxAlpha).apply {
             layoutParams =
                 CoordinatorLayout.LayoutParams(
@@ -31,14 +29,13 @@ class DimmingViewManager(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                 )
             alpha = 0f
-            fitsSystemWindows = false
 
             setOnClickListener {
                 onCloseRequested()
             }
         }
 
-    internal fun onShow() {
+    internal fun onDialogShown() {
         attachDimmingViewOverNativeTouchOutside()
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.gamma.modals.dimmingview
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -65,7 +66,16 @@ class DimmingViewManager(
 
         if (coordinator != null && dimmingView.parent == null && bottomSheetView != null) {
             val sheetIndex = coordinator.indexOfChild(bottomSheetView)
-            coordinator.addView(dimmingView, sheetIndex)
+            if (sheetIndex >= 0) {
+                coordinator.addView(dimmingView, sheetIndex)
+            } else {
+                Log.e(TAG, "[RNScreens] BottomSheetView not found! Falling back to bottom index.")
+                coordinator.addView(dimmingView, 0)
+            }
         }
+    }
+
+    companion object {
+        const val TAG = "DimmingViewManager"
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -38,11 +38,7 @@ class DimmingViewManager(
         }
 
     internal fun onShow() {
-        val coordinator = dialog.findViewById<CoordinatorLayout>(com.google.android.material.R.id.coordinator)
-
-        if (coordinator != null && dimmingView.parent == null) {
-            coordinator.addView(dimmingView, 0)
-        }
+        attachDimmingViewOverNativeTouchOutside()
     }
 
     internal fun attachToBehavior(behavior: BottomSheetBehavior<*>) {
@@ -62,5 +58,15 @@ class DimmingViewManager(
                 }
             },
         )
+    }
+
+    private fun attachDimmingViewOverNativeTouchOutside() {
+        val coordinator = dialog.findViewById<CoordinatorLayout>(com.google.android.material.R.id.coordinator)
+        val bottomSheetView = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+
+        if (coordinator != null && dimmingView.parent == null && bottomSheetView != null) {
+            val sheetIndex = coordinator.indexOfChild(bottomSheetView)
+            coordinator.addView(dimmingView, sheetIndex)
+        }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -4,21 +4,18 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.facebook.react.bridge.ReactContext
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 class DimmingViewManager(
-    private val reactContext: ReactContext?,
+    context: Context,
     private val dialog: BottomSheetDialog,
 ) {
-    private val dimmingView: DimmingView = createDimmingView(reactContext?.baseContext)
+    private val dimmingView: DimmingView = createDimmingView(context)
     private val maxAlpha: Float = 0.3f
 
-    private fun createDimmingView(context: Context?): DimmingView {
-        // TODO: @t0maboro - needs to be changed, we shouldn't attach dimming view to main app window
-        val safeContext = context ?: return DimmingView(reactContext as Context, maxAlpha)
-        return DimmingView(safeContext, maxAlpha).apply {
+    private fun createDimmingView(context: Context): DimmingView =
+        DimmingView(context, maxAlpha).apply {
             layoutParams =
                 CoordinatorLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
@@ -31,14 +28,12 @@ class DimmingViewManager(
                 dialog.cancel()
             }
         }
-    }
 
     internal fun onShow() {
-        // TODO: @t0maboro - needs to be changed, we shouldn't attach dimming view to main app window
-        val activityDecorView = reactContext?.currentActivity?.window?.decorView as? ViewGroup
+        val coordinator = dialog.findViewById<CoordinatorLayout>(com.google.android.material.R.id.coordinator)
 
-        if (activityDecorView != null && dimmingView.parent == null) {
-            activityDecorView.addView(dimmingView)
+        if (coordinator != null && dimmingView.parent == null) {
+            coordinator.addView(dimmingView, 0)
         }
 
         // TODO: @t0maboro - it should be placed in some FormSheetAnimator class

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -13,7 +13,7 @@ class DimmingViewManager(
     private val dialog: BottomSheetDialog,
 ) {
     // TODO: @t0maboro - consider exposing as a prop
-    internal val maxAlpha: Float = 0.3f
+    internal val maxAlpha: Float = MAX_ALPHA
 
     internal var dimmingViewAlpha: Float
         get() = dimmingView.alpha
@@ -22,13 +22,12 @@ class DimmingViewManager(
         }
 
     private val dimmingView =
-        DimmingView(context, maxAlpha).apply {
+        DimmingView(context, initialAlpha = 0f).apply {
             layoutParams =
                 CoordinatorLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.MATCH_PARENT,
                 )
-            alpha = 0f
         }
 
     internal fun setOnBackdropClickListener(listener: () -> Unit) {
@@ -77,5 +76,7 @@ class DimmingViewManager(
 
     companion object {
         const val TAG = "DimmingViewManager"
+
+        private const val MAX_ALPHA = 0.3f
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -51,23 +51,12 @@ class DimmingViewManager(
                 override fun onStateChanged(
                     bottomSheet: View,
                     newState: Int,
-                ) {
-                    // TODO: @t0maboro - it should be placed in some FormSheetAnimator/Behavior class
-                    if (newState == BottomSheetBehavior.STATE_HIDDEN) {
-                        dimmingView.animate().cancel()
-                        dimmingView
-                            .animate()
-                            .alpha(0f)
-                            .setDuration(250)
-                            .start()
-                    }
-                }
+                ) = Unit
 
                 override fun onSlide(
                     bottomSheet: View,
                     slideOffset: Float,
                 ) {
-                    dimmingView.animate().cancel()
                     val fraction = if (slideOffset >= 0) 1f else 1f + slideOffset
                     dimmingView.alpha = fraction * maxAlpha
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -10,7 +10,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 class DimmingViewManager(
     context: Context,
     private val dialog: BottomSheetDialog,
-    private val onCloseRequested: () -> Unit,
 ) {
     // TODO: @t0maboro - consider exposing as a prop
     internal val maxAlpha: Float = 0.3f
@@ -29,11 +28,13 @@ class DimmingViewManager(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                 )
             alpha = 0f
-
-            setOnClickListener {
-                onCloseRequested()
-            }
         }
+
+    internal fun setOnBackdropClickListener(listener: () -> Unit) {
+        dimmingView.setOnClickListener {
+            listener()
+        }
+    }
 
     internal fun onDialogShown() {
         attachDimmingViewOverNativeTouchOutside()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -13,14 +13,15 @@ class DimmingViewManager(
     private val onCloseRequested: () -> Unit,
 ) {
     private val dimmingView: DimmingView = createDimmingView(context)
+
+    // TODO: @t0maboro - consider exposing as a prop
     internal val maxAlpha: Float = 0.3f
 
-    internal val currentAlpha: Float
+    internal var dimmingViewAlpha: Float
         get() = dimmingView.alpha
-
-    internal fun updateAlpha(currentAlpha: Float) {
-        dimmingView.alpha = currentAlpha
-    }
+        set(value) {
+            dimmingView.alpha = value
+        }
 
     private fun createDimmingView(context: Context): DimmingView =
         DimmingView(context, maxAlpha).apply {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -1,0 +1,92 @@
+package com.swmansion.rnscreens.gamma.modals.dimmingview
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.facebook.react.bridge.ReactContext
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+class DimmingViewManager(
+    private val reactContext: ReactContext?,
+    private val dialog: BottomSheetDialog,
+) {
+    private val dimmingView: DimmingView = createDimmingView(reactContext?.baseContext)
+    private val maxAlpha: Float = 0.3f
+
+    private fun createDimmingView(context: Context?): DimmingView {
+        // TODO: @t0maboro - needs to be changed, we shouldn't attach dimming view to main app window
+        val safeContext = context ?: return DimmingView(reactContext as Context, maxAlpha)
+        return DimmingView(safeContext, maxAlpha).apply {
+            layoutParams =
+                CoordinatorLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            alpha = 0f
+            fitsSystemWindows = false
+
+            setOnClickListener {
+                dialog.cancel()
+            }
+        }
+    }
+
+    internal fun onShow() {
+        // TODO: @t0maboro - needs to be changed, we shouldn't attach dimming view to main app window
+        val activityDecorView = reactContext?.currentActivity?.window?.decorView as? ViewGroup
+
+        if (activityDecorView != null && dimmingView.parent == null) {
+            activityDecorView.addView(dimmingView)
+        }
+
+        // TODO: @t0maboro - it should be placed in some FormSheetAnimator class
+        dimmingView.animate().cancel()
+        dimmingView
+            .animate()
+            .alpha(maxAlpha)
+            .setDuration(250)
+            .start()
+    }
+
+    internal fun onDismiss() {
+        // TODO: @t0maboro - it should be placed in some FormSheetAnimator class
+        dimmingView.animate().cancel()
+        dimmingView
+            .animate()
+            .alpha(0f)
+            .setDuration(250)
+            .start()
+    }
+
+    internal fun attachToBehavior(behavior: BottomSheetBehavior<*>) {
+        behavior.addBottomSheetCallback(
+            object : BottomSheetBehavior.BottomSheetCallback() {
+                override fun onStateChanged(
+                    bottomSheet: View,
+                    newState: Int,
+                ) {
+                    // TODO: @t0maboro - it should be placed in some FormSheetAnimator/Behavior class
+                    if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+                        dimmingView.animate().cancel()
+                        dimmingView
+                            .animate()
+                            .alpha(0f)
+                            .setDuration(250)
+                            .start()
+                    }
+                }
+
+                override fun onSlide(
+                    bottomSheet: View,
+                    slideOffset: Float,
+                ) {
+                    dimmingView.animate().cancel()
+                    val fraction = if (slideOffset >= 0) 1f else 1f + slideOffset
+                    dimmingView.alpha = fraction * maxAlpha
+                }
+            },
+        )
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -10,9 +10,17 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 class DimmingViewManager(
     context: Context,
     private val dialog: BottomSheetDialog,
+    private val onCloseRequested: () -> Unit,
 ) {
     private val dimmingView: DimmingView = createDimmingView(context)
-    private val maxAlpha: Float = 0.3f
+    internal val maxAlpha: Float = 0.3f
+
+    internal val currentAlpha: Float
+        get() = dimmingView.alpha
+
+    internal fun updateAlpha(currentAlpha: Float) {
+        dimmingView.alpha = currentAlpha
+    }
 
     private fun createDimmingView(context: Context): DimmingView =
         DimmingView(context, maxAlpha).apply {
@@ -25,7 +33,7 @@ class DimmingViewManager(
             fitsSystemWindows = false
 
             setOnClickListener {
-                dialog.cancel()
+                onCloseRequested()
             }
         }
 
@@ -35,24 +43,6 @@ class DimmingViewManager(
         if (coordinator != null && dimmingView.parent == null) {
             coordinator.addView(dimmingView, 0)
         }
-
-        // TODO: @t0maboro - it should be placed in some FormSheetAnimator class
-        dimmingView.animate().cancel()
-        dimmingView
-            .animate()
-            .alpha(maxAlpha)
-            .setDuration(250)
-            .start()
-    }
-
-    internal fun onDismiss() {
-        // TODO: @t0maboro - it should be placed in some FormSheetAnimator class
-        dimmingView.animate().cancel()
-        dimmingView
-            .animate()
-            .alpha(0f)
-            .setDuration(250)
-            .start()
     }
 
     internal fun attachToBehavior(behavior: BottomSheetBehavior<*>) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewPointerEvents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewPointerEvents.kt
@@ -1,0 +1,18 @@
+package com.swmansion.rnscreens.gamma.modals.dimmingview
+
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactPointerEventsView
+
+internal class DimmingViewPointerEventsImpl(
+    val dimmingView: DimmingView,
+) : ReactPointerEventsView {
+    override val pointerEvents: PointerEvents
+        get() = if (dimmingView.blockGestures) PointerEvents.AUTO else PointerEvents.NONE
+}
+
+internal class DimmingViewPointerEventsProxy(
+    var pointerEventsImpl: DimmingViewPointerEventsImpl?,
+) : ReactPointerEventsView {
+    override val pointerEvents: PointerEvents
+        get() = pointerEventsImpl?.pointerEvents ?: PointerEvents.NONE
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -1,0 +1,70 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ValueAnimator
+import android.view.View
+import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
+
+internal class FormSheetAnimationCoordinator(
+    private val dimmingManager: DimmingViewManager,
+    private val onDismissEnd: () -> Unit,
+) {
+    // TODO: @t0maboro - consider exposing as a prop
+    val animationDuration = 250L
+
+    internal fun runEnterAnimation(view: View) {
+        view.translationY = view.height.toFloat()
+
+        val slideAnimator = ValueAnimator.ofFloat(view.translationY, 0f).apply {
+            addUpdateListener { animation ->
+                view.translationY = animation.animatedValue as Float
+            }
+        }
+
+        val alphaAnimator = ValueAnimator.ofFloat(0f, dimmingManager.maxAlpha).apply {
+            addUpdateListener { animation ->
+                dimmingManager.updateAlpha(animation.animatedValue as Float)
+            }
+        }
+
+        AnimatorSet().apply {
+            playTogether(slideAnimator, alphaAnimator)
+            duration = animationDuration
+            start()
+        }
+    }
+
+    internal fun runExitAnimation(view: View?) {
+        if (view == null) {
+            onDismissEnd()
+            return
+        }
+
+        view.animate().cancel()
+
+        val slideAnimator = ValueAnimator.ofFloat(view.translationY, view.height.toFloat()).apply {
+            addUpdateListener { animation ->
+                view.translationY = animation.animatedValue as Float
+            }
+        }
+
+        val alphaAnimator = ValueAnimator.ofFloat(dimmingManager.currentAlpha, 0f).apply {
+            addUpdateListener { animation ->
+                dimmingManager.updateAlpha(animation.animatedValue as Float)
+            }
+        }
+
+        AnimatorSet().apply {
+            playTogether(slideAnimator, alphaAnimator)
+            duration = animationDuration
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    onDismissEnd()
+                }
+            })
+            start()
+        }
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -28,7 +28,7 @@ internal class FormSheetAnimationCoordinator(
         val alphaAnimator =
             ValueAnimator.ofFloat(0f, dimmingManager.maxAlpha).apply {
                 addUpdateListener { animation ->
-                    dimmingManager.updateAlpha(animation.animatedValue as Float)
+                    dimmingManager.dimmingViewAlpha = animation.animatedValue as Float
                 }
             }
 
@@ -61,9 +61,9 @@ internal class FormSheetAnimationCoordinator(
             }
 
         val alphaAnimator =
-            ValueAnimator.ofFloat(dimmingManager.currentAlpha, 0f).apply {
+            ValueAnimator.ofFloat(dimmingManager.dimmingViewAlpha, 0f).apply {
                 addUpdateListener { animation ->
-                    dimmingManager.updateAlpha(animation.animatedValue as Float)
+                    dimmingManager.dimmingViewAlpha = animation.animatedValue as Float
                 }
             }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -14,8 +14,10 @@ internal class FormSheetAnimationCoordinator(
     // TODO: @t0maboro - consider exposing as a prop
     val animationDuration = 250L
 
+    private var currentAnimatorSet: AnimatorSet? = null
+
     internal fun runEnterAnimation(view: View) {
-        view.translationY = view.height.toFloat()
+        currentAnimatorSet?.cancel()
 
         val slideAnimator =
             ValueAnimator.ofFloat(view.translationY, 0f).apply {
@@ -25,17 +27,25 @@ internal class FormSheetAnimationCoordinator(
             }
 
         val alphaAnimator =
-            ValueAnimator.ofFloat(0f, dimmingManager.maxAlpha).apply {
+            ValueAnimator.ofFloat(dimmingManager.dimmingViewAlpha, dimmingManager.maxAlpha).apply {
                 addUpdateListener { animation ->
                     dimmingManager.dimmingViewAlpha = animation.animatedValue as Float
                 }
             }
 
-        AnimatorSet().apply {
-            playTogether(slideAnimator, alphaAnimator)
-            duration = animationDuration
-            start()
-        }
+        currentAnimatorSet =
+            AnimatorSet().apply {
+                playTogether(slideAnimator, alphaAnimator)
+                duration = animationDuration
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            if (currentAnimatorSet == this@apply) currentAnimatorSet = null
+                        }
+                    },
+                )
+                start()
+            }
     }
 
     internal fun runExitAnimation(
@@ -53,7 +63,7 @@ internal class FormSheetAnimationCoordinator(
             return
         }
 
-        view.animate().cancel()
+        currentAnimatorSet?.cancel()
 
         val slideAnimator =
             ValueAnimator.ofFloat(view.translationY, view.height.toFloat()).apply {
@@ -69,17 +79,19 @@ internal class FormSheetAnimationCoordinator(
                 }
             }
 
-        AnimatorSet().apply {
-            playTogether(slideAnimator, alphaAnimator)
-            duration = animationDuration
-            addListener(
-                object : AnimatorListenerAdapter() {
-                    override fun onAnimationEnd(animation: Animator) {
-                        onAnimationEnd()
-                    }
-                },
-            )
-            start()
-        }
+        currentAnimatorSet =
+            AnimatorSet().apply {
+                playTogether(slideAnimator, alphaAnimator)
+                duration = animationDuration
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            if (currentAnimatorSet == this@apply) currentAnimatorSet = null
+                            onAnimationEnd()
+                        }
+                    },
+                )
+                start()
+            }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -10,7 +10,6 @@ import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
 internal class FormSheetAnimationCoordinator(
     private val dimmingManager: DimmingViewManager,
-    private val onDismissEnd: () -> Unit,
 ) {
     // TODO: @t0maboro - consider exposing as a prop
     val animationDuration = 250L
@@ -39,15 +38,15 @@ internal class FormSheetAnimationCoordinator(
         }
     }
 
-    internal fun runExitAnimation(view: View?) {
+    internal fun runExitAnimation(view: View?, onAnimationEnd: () -> Unit) {
         if (view == null) {
-            onDismissEnd()
+            onAnimationEnd()
             return
         }
 
         val behavior = BottomSheetBehavior.from(view)
         if (behavior.state == BottomSheetBehavior.STATE_HIDDEN) {
-            onDismissEnd()
+            onAnimationEnd()
             return
         }
 
@@ -73,7 +72,7 @@ internal class FormSheetAnimationCoordinator(
             addListener(
                 object : AnimatorListenerAdapter() {
                     override fun onAnimationEnd(animation: Animator) {
-                        onDismissEnd()
+                        onAnimationEnd()
                     }
                 },
             )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
 internal class FormSheetAnimationCoordinator(
@@ -17,17 +18,19 @@ internal class FormSheetAnimationCoordinator(
     internal fun runEnterAnimation(view: View) {
         view.translationY = view.height.toFloat()
 
-        val slideAnimator = ValueAnimator.ofFloat(view.translationY, 0f).apply {
-            addUpdateListener { animation ->
-                view.translationY = animation.animatedValue as Float
+        val slideAnimator =
+            ValueAnimator.ofFloat(view.translationY, 0f).apply {
+                addUpdateListener { animation ->
+                    view.translationY = animation.animatedValue as Float
+                }
             }
-        }
 
-        val alphaAnimator = ValueAnimator.ofFloat(0f, dimmingManager.maxAlpha).apply {
-            addUpdateListener { animation ->
-                dimmingManager.updateAlpha(animation.animatedValue as Float)
+        val alphaAnimator =
+            ValueAnimator.ofFloat(0f, dimmingManager.maxAlpha).apply {
+                addUpdateListener { animation ->
+                    dimmingManager.updateAlpha(animation.animatedValue as Float)
+                }
             }
-        }
 
         AnimatorSet().apply {
             playTogether(slideAnimator, alphaAnimator)
@@ -42,28 +45,38 @@ internal class FormSheetAnimationCoordinator(
             return
         }
 
+        val behavior = BottomSheetBehavior.from(view)
+        if (behavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+            onDismissEnd()
+            return
+        }
+
         view.animate().cancel()
 
-        val slideAnimator = ValueAnimator.ofFloat(view.translationY, view.height.toFloat()).apply {
-            addUpdateListener { animation ->
-                view.translationY = animation.animatedValue as Float
+        val slideAnimator =
+            ValueAnimator.ofFloat(view.translationY, view.height.toFloat()).apply {
+                addUpdateListener { animation ->
+                    view.translationY = animation.animatedValue as Float
+                }
             }
-        }
 
-        val alphaAnimator = ValueAnimator.ofFloat(dimmingManager.currentAlpha, 0f).apply {
-            addUpdateListener { animation ->
-                dimmingManager.updateAlpha(animation.animatedValue as Float)
+        val alphaAnimator =
+            ValueAnimator.ofFloat(dimmingManager.currentAlpha, 0f).apply {
+                addUpdateListener { animation ->
+                    dimmingManager.updateAlpha(animation.animatedValue as Float)
+                }
             }
-        }
 
         AnimatorSet().apply {
             playTogether(slideAnimator, alphaAnimator)
             duration = animationDuration
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator) {
-                    onDismissEnd()
-                }
-            })
+            addListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        onDismissEnd()
+                    }
+                },
+            )
             start()
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -38,7 +38,10 @@ internal class FormSheetAnimationCoordinator(
         }
     }
 
-    internal fun runExitAnimation(view: View?, onAnimationEnd: () -> Unit) {
+    internal fun runExitAnimation(
+        view: View?,
+        onAnimationEnd: () -> Unit,
+    ) {
         if (view == null) {
             onAnimationEnd()
             return

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
@@ -1,0 +1,22 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+import android.content.Context
+import android.os.Bundle
+import android.view.Window
+import android.view.WindowManager
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+internal class FormSheetDialog(
+    context: Context,
+) : BottomSheetDialog(context) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        hideNativeDimmingView(window)
+        disableNativeWindowAnimation(window)
+    }
+
+    private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+
+    private fun disableNativeWindowAnimation(window: Window?) = window?.setWindowAnimations(0)
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -48,7 +48,7 @@ class FormSheetDialogManager(
         }
         setupDialogShowListener()
 
-        dimmingManager.setOnBackdropClickListener(host::onNativeDismiss)
+        dimmingManager.setOnBackdropClickListener(onDismissRequest)
     }
 
     internal fun show() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -65,7 +65,7 @@ class FormSheetDialogManager(
         }
 
         dialog.setOnShowListener {
-            dimmingManager.onShow()
+            dimmingManager.onDialogShown()
 
             bottomSheetView?.let {
                 animationCoordinator.runEnterAnimation(it)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -29,6 +29,7 @@ class FormSheetDialogManager(
     private val dialog =
         FormSheetDialog(themedContext).apply {
             setContentView(container)
+            setCanceledOnTouchOutside(false)
 
             setOnCancelListener {
                 onDismissRequest()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -5,7 +5,6 @@ import android.view.ContextThemeWrapper
 import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
-import com.facebook.react.bridge.ReactContext
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
@@ -43,7 +42,7 @@ class FormSheetDialogManager(
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
 
-    private val dimmingManager = DimmingViewManager(context as ReactContext?, dialog)
+    private val dimmingManager = DimmingViewManager(context, dialog)
 
     init {
         bottomSheetView?.let {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -43,21 +43,35 @@ class FormSheetDialogManager(
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
 
-    private val dimmingManager = DimmingViewManager(context, dialog)
+    private val dimmingManager = DimmingViewManager(context, dialog) {
+        dismiss()
+    }
+
+    private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager) {
+        dialog.dismiss()
+    }
 
     init {
-        bottomSheetView?.let {
+        bottomSheetView?.let { view ->
             // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
-            val behavior = BottomSheetBehavior.from(it)
+            val behavior = BottomSheetBehavior.from(view)
             dimmingManager.attachToBehavior(behavior)
+
+            view.viewTreeObserver.addOnPreDrawListener(object : android.view.ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    view.viewTreeObserver.removeOnPreDrawListener(this)
+                    view.translationY = view.height.toFloat()
+                    return true
+                }
+            })
         }
 
         dialog.setOnShowListener {
             dimmingManager.onShow()
-        }
 
-        dialog.setOnDismissListener {
-            dimmingManager.onDismiss()
+            bottomSheetView?.let {
+                animationCoordinator.runEnterAnimation(it)
+            }
         }
     }
 
@@ -66,7 +80,7 @@ class FormSheetDialogManager(
     }
 
     internal fun dismiss() {
-        dialog.dismiss()
+        animationCoordinator.runExitAnimation(bottomSheetView)
     }
 
     private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -37,40 +37,16 @@ class FormSheetDialogManager(
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
 
-    private val dimmingManager =
-        DimmingViewManager(context, dialog) {
-            host.onNativeDismiss()
-        }
+    private val dimmingManager = DimmingViewManager(context, dialog, host::onNativeDismiss)
 
-    private val animationCoordinator =
-        FormSheetAnimationCoordinator(dimmingManager) {
-            dialog.dismiss()
-        }
+    private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager, dialog::dismiss)
 
     init {
         bottomSheetView?.let { view ->
-            // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
-            val behavior = BottomSheetBehavior.from(view)
-            dimmingManager.attachToBehavior(behavior)
-
-            view.viewTreeObserver.addOnPreDrawListener(
-                object : android.view.ViewTreeObserver.OnPreDrawListener {
-                    override fun onPreDraw(): Boolean {
-                        view.viewTreeObserver.removeOnPreDrawListener(this)
-                        view.translationY = view.height.toFloat()
-                        return true
-                    }
-                },
-            )
+            setupDimmingViewBehavior(view)
+            setupOffscreenPositionBeforeFirstDraw(view)
         }
-
-        dialog.setOnShowListener {
-            dimmingManager.onDialogShown()
-
-            bottomSheetView?.let {
-                animationCoordinator.runEnterAnimation(it)
-            }
-        }
+        setupDialogShowListener()
     }
 
     internal fun show() {
@@ -79,5 +55,33 @@ class FormSheetDialogManager(
 
     internal fun dismiss() {
         animationCoordinator.runExitAnimation(bottomSheetView)
+    }
+
+    private fun setupDimmingViewBehavior(view: FrameLayout) {
+        // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
+        val behavior = BottomSheetBehavior.from(view)
+        dimmingManager.attachToBehavior(behavior)
+    }
+
+    private fun setupOffscreenPositionBeforeFirstDraw(view: FrameLayout) {
+        view.viewTreeObserver.addOnPreDrawListener(
+            object : android.view.ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    view.viewTreeObserver.removeOnPreDrawListener(this)
+                    view.translationY = view.height.toFloat()
+                    return true
+                }
+            },
+        )
+    }
+
+    private fun setupDialogShowListener() {
+        dialog.setOnShowListener {
+            dimmingManager.onDialogShown()
+
+            bottomSheetView?.let { view ->
+                animationCoordinator.runEnterAnimation(view)
+            }
+        }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -43,7 +43,7 @@ class FormSheetDialogManager(
 
     init {
         bottomSheetView?.let { view ->
-            setupDimmingViewBehavior(view)
+            setupBehaviorCallbacksForDimmingView(view)
             setupOffscreenPositionBeforeFirstDraw(view)
         }
         setupDialogShowListener()
@@ -61,7 +61,7 @@ class FormSheetDialogManager(
         }
     }
 
-    private fun setupDimmingViewBehavior(view: FrameLayout) {
+    private fun setupBehaviorCallbacksForDimmingView(view: FrameLayout) {
         // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
         val behavior = BottomSheetBehavior.from(view)
         dimmingManager.attachToBehavior(behavior)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -1,13 +1,26 @@
 package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.Window
+import android.view.WindowManager
+import android.widget.FrameLayout
+import com.facebook.react.bridge.ReactContext
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
 class FormSheetDialogManager(
     context: Context,
     private val onUpdateState: (width: Int, height: Int) -> Unit,
     private val onDismissRequest: () -> Unit,
 ) {
+    private val themedContext =
+        ContextThemeWrapper(
+            context,
+            com.google.android.material.R.style.Theme_Material3_DayNight_NoActionBar,
+        )
+
     // Eagerly create the container so it's always ready for React's children
     private val container =
         FormSheetContainer(context) { width, height ->
@@ -18,12 +31,35 @@ class FormSheetDialogManager(
 
     // Eagerly create the dialog and attach the container
     private val dialog =
-        BottomSheetDialog(context).apply {
+        BottomSheetDialog(themedContext).apply {
             setContentView(container)
+
+            hideNativeDimmingView(window)
+
             setOnCancelListener {
                 onDismissRequest()
             }
         }
+
+    private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+
+    private val dimmingManager = DimmingViewManager(context as ReactContext?, dialog)
+
+    init {
+        bottomSheetView?.let {
+            // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
+            val behavior = BottomSheetBehavior.from(it)
+            dimmingManager.attachToBehavior(behavior)
+        }
+
+        dialog.setOnShowListener {
+            dimmingManager.onShow()
+        }
+
+        dialog.setOnDismissListener {
+            dimmingManager.onDismiss()
+        }
+    }
 
     internal fun show() {
         dialog.show()
@@ -32,4 +68,6 @@ class FormSheetDialogManager(
     internal fun dismiss() {
         dialog.dismiss()
     }
+
+    private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -34,6 +34,7 @@ class FormSheetDialogManager(
             setContentView(container)
 
             hideNativeDimmingView(window)
+            disableNativeWindowAnimation(window)
 
             setOnCancelListener {
                 onDismissRequest()
@@ -69,4 +70,6 @@ class FormSheetDialogManager(
     }
 
     private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+
+    private fun disableNativeWindowAnimation(window: Window?) = window?.setWindowAnimations(0)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -2,11 +2,8 @@ package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
 import android.view.ContextThemeWrapper
-import android.view.Window
-import android.view.WindowManager
 import android.widget.FrameLayout
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
 class FormSheetDialogManager(
@@ -30,11 +27,8 @@ class FormSheetDialogManager(
 
     // Eagerly create the dialog and attach the container
     private val dialog =
-        BottomSheetDialog(themedContext).apply {
+        FormSheetDialog(themedContext).apply {
             setContentView(container)
-
-            hideNativeDimmingView(window)
-            disableNativeWindowAnimation(window)
 
             setOnCancelListener {
                 onDismissRequest()
@@ -86,8 +80,4 @@ class FormSheetDialogManager(
     internal fun dismiss() {
         animationCoordinator.runExitAnimation(bottomSheetView)
     }
-
-    private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-
-    private fun disableNativeWindowAnimation(window: Window?) = window?.setWindowAnimations(0)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -43,13 +43,15 @@ class FormSheetDialogManager(
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
 
-    private val dimmingManager = DimmingViewManager(context, dialog) {
-        dismiss()
-    }
+    private val dimmingManager =
+        DimmingViewManager(context, dialog) {
+            host.onNativeDismiss()
+        }
 
-    private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager) {
-        dialog.dismiss()
-    }
+    private val animationCoordinator =
+        FormSheetAnimationCoordinator(dimmingManager) {
+            dialog.dismiss()
+        }
 
     init {
         bottomSheetView?.let { view ->
@@ -57,13 +59,15 @@ class FormSheetDialogManager(
             val behavior = BottomSheetBehavior.from(view)
             dimmingManager.attachToBehavior(behavior)
 
-            view.viewTreeObserver.addOnPreDrawListener(object : android.view.ViewTreeObserver.OnPreDrawListener {
-                override fun onPreDraw(): Boolean {
-                    view.viewTreeObserver.removeOnPreDrawListener(this)
-                    view.translationY = view.height.toFloat()
-                    return true
-                }
-            })
+            view.viewTreeObserver.addOnPreDrawListener(
+                object : android.view.ViewTreeObserver.OnPreDrawListener {
+                    override fun onPreDraw(): Boolean {
+                        view.viewTreeObserver.removeOnPreDrawListener(this)
+                        view.translationY = view.height.toFloat()
+                        return true
+                    }
+                },
+            )
         }
 
         dialog.setOnShowListener {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -37,9 +37,9 @@ class FormSheetDialogManager(
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
 
-    private val dimmingManager = DimmingViewManager(context, dialog, host::onNativeDismiss)
+    private val dimmingManager = DimmingViewManager(context, dialog)
 
-    private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager, dialog::dismiss)
+    private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager)
 
     init {
         bottomSheetView?.let { view ->
@@ -47,6 +47,8 @@ class FormSheetDialogManager(
             setupOffscreenPositionBeforeFirstDraw(view)
         }
         setupDialogShowListener()
+
+        dimmingManager.setOnBackdropClickListener(host::onNativeDismiss)
     }
 
     internal fun show() {
@@ -54,7 +56,9 @@ class FormSheetDialogManager(
     }
 
     internal fun dismiss() {
-        animationCoordinator.runExitAnimation(bottomSheetView)
+        animationCoordinator.runExitAnimation(bottomSheetView) {
+            dialog.dismiss()
+        }
     }
 
     private fun setupDimmingViewBehavior(view: FrameLayout) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -39,8 +39,6 @@ class FormSheetHost(
 
     // TODO: @t0maboro - dedicated FormSheetHostEventEmitter needs to be implemented later
     internal fun onNativeDismiss() {
-        this.isOpen = false
-
         val reactContext = context as? ThemedReactContext ?: return
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
         val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1566

This PR introduces a custom DimmingView and slide-in animation to replace native window animation for BottomSheetDialog. The native animation curve was providing a really bad user experience, giving the impression of content flicker. I am replacing native transitions to achieve full control over the entrance/exit animations.

I am introducing a custom DimmingView implementation that will handle backdrop taps, attaching it over `touch_outside` native view to intercept gestures, preventing native dismissal from the Material component level, and handling it manually to synchronize it with a custom animation. Additionally, the dimming view should update the background opacity dynamically in response to native drag gestures, whereas the native DimmingView had a static configuration and a single opacity level. Having our own implementation for a DimmingView is unblocking for us many potential customizations in the future.

FormSheetAnimationCoordinator is added to orchestrate synchronized entrance and exit transitions. The container slide-up/down and the background fade-in/out are bundled together using a single AnimatorSet for the frame synchronization.

I needed to subclass `BottomSheetDialog` into my custom `FormSheetDialog` to disable the native window animations and background dimming.

On the dialog manager level, I added `setupOffscreenPositionBeforeFirstDraw` using an `OnPreDrawListener` to push the sheet below the bottom edge before the first frame is rendered.

Note: I set a theme for the bottom sheet to Theme_Material3_DayNight_NoActionBar following material guidelines. It introduces an issue with recalculating the shadow state in flight during the drag animation, and the content might jump/lag during the transition to the expanded state - the issue will be fixed in a follow-up PR. Issue link: https://github.com/software-mansion/react-native-screens-labs/issues/1568.

https://github.com/user-attachments/assets/bcd5bc09-28b3-41a3-ba51-dc37c63c01d5

## Changes

- Added DimmingView implementation
- Added animation coordinator
- Binded dialog manager state logic with animation coordinator
- Disabled native window animations

## Before & after - visual documentation

https://github.com/user-attachments/assets/3e5af222-7bea-4610-a2e8-e43e94c7a844

## Test plan

Testing on the Basic/FormSheet stacking examples for FormSheets from SFTs.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
