### PR TITLE
fix(Android, FormSheet v5): Precalculate react's content space for sheet

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
@@ -2,8 +2,10 @@ package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
 import android.os.Bundle
+import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
+import android.widget.FrameLayout
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 internal class FormSheetDialog(
@@ -14,9 +16,16 @@ internal class FormSheetDialog(
 
         hideNativeDimmingView(window)
         disableNativeWindowAnimation(window)
+
+        setupBottomSheetHeight()
     }
 
     private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
 
     private fun disableNativeWindowAnimation(window: Window?) = window?.setWindowAnimations(0)
+
+    private fun setupBottomSheetHeight() {
+        val bottomSheetView = findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+        bottomSheetView?.layoutParams?.height = ViewGroup.LayoutParams.MATCH_PARENT
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -109,7 +109,10 @@ class FormSheetDialogManager(
      * during the drag gesture. By calculating and enforcing a static height that explicitly subtracts
      * the system insets, we completely bypass these redundant layout passes.
      */
-    private fun updateNativeContainerHeight(view: View, insets: WindowInsetsCompat) {
+    private fun updateNativeContainerHeight(
+        view: View,
+        insets: WindowInsetsCompat,
+    ) {
         val topInset = getTopInset(insets)
         val bottomInset = getBottomInset(insets)
         val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
@@ -118,10 +121,11 @@ class FormSheetDialogManager(
             val availableHeight = dialogDecorHeight - topInset - bottomInset
 
             if (view.layoutParams.height != availableHeight) {
-                view.layoutParams = FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    availableHeight,
-                )
+                view.layoutParams =
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        availableHeight,
+                    )
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -118,14 +118,15 @@ class FormSheetDialogManager(
         val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
 
         if (dialogDecorHeight > 0) {
-            val availableHeight = dialogDecorHeight - topInset - bottomInset
+            val availableHeight = (dialogDecorHeight - topInset - bottomInset).coerceAtLeast(0)
 
-            if (view.layoutParams.height != availableHeight) {
-                view.layoutParams =
-                    FrameLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        availableHeight,
-                    )
+            val layoutParams =
+                view.layoutParams
+                    ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, availableHeight)
+            if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != availableHeight) {
+                layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+                layoutParams.height = availableHeight
+                view.layoutParams = layoutParams
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -2,7 +2,11 @@ package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
 import android.view.ContextThemeWrapper
+import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
@@ -48,6 +52,7 @@ class FormSheetDialogManager(
             setupOffscreenPositionBeforeFirstDraw(view)
         }
         setupDialogShowListener()
+        setupWindowInsetsListener()
 
         dimmingManager.setOnBackdropClickListener(onDismissRequest)
     }
@@ -89,4 +94,47 @@ class FormSheetDialogManager(
             }
         }
     }
+
+    private fun setupWindowInsetsListener() {
+        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
+            updateNativeContainerHeight(view, insets)
+            insets
+        }
+    }
+
+    /**
+     * For Yoga we require the container height to be "stable" to avoid updating content size in flight.
+     * If left as MATCH_PARENT, BottomSheetDialog dynamically applies insets as padding when sheet overflows
+     * status bar or display cutout. This causes Yoga to recalculate the layout, resulting in UI flickering
+     * during the drag gesture. By calculating and enforcing a static height that explicitly subtracts
+     * the system insets, we completely bypass these redundant layout passes.
+     */
+    private fun updateNativeContainerHeight(view: View, insets: WindowInsetsCompat) {
+        val topInset = getTopInset(insets)
+        val bottomInset = getBottomInset(insets)
+        val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
+
+        if (dialogDecorHeight > 0) {
+            val availableHeight = dialogDecorHeight - topInset - bottomInset
+
+            if (view.layoutParams.height != availableHeight) {
+                view.layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    availableHeight,
+                )
+            }
+        }
+    }
+
+    private fun getTopInset(insetsCompat: WindowInsetsCompat): Int =
+        insetsCompat
+            .getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).top
+
+    private fun getBottomInset(insetsCompat: WindowInsetsCompat): Int =
+        insetsCompat
+            .getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).bottom
 }


### PR DESCRIPTION
## Description

For Yoga we require the container height to be as consistent as possible to avoid updating content size in flight (well known jumping content issues with async state updates). If left as MATCH_PARENT, BottomSheetDialog dynamically applies insets as padding when sheet overflows status bar or display cutout. This causes Yoga to recalculate the layout, resulting in UI flickering during the drag gesture. By calculating and enforcing a static height that explicitly subtracts the system insets, we completely bypass these redundant layout passes.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1568

## Changes

- attached insets listener to prepare the proper container for react's content

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bcd5bc09-28b3-41a3-ba51-dc37c63c01d5" /> | <video src="https://github.com/user-attachments/assets/0353b213-7720-4680-9fe9-26c222f25ed1" /> |

## Test plan

Any test with FormSheets, detents aren't configured yet, so you just need to drag the sheet to expanded state.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
