### PR TITLE
fix(Android, FormSheet v5): Fix fast refresh inside Dialog window

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -74,6 +74,10 @@ class FormSheetHost(
         super.onDetachedFromWindow()
     }
 
+    internal fun getReactSubviewCount(): Int = dialogManager.contentView.childCount
+
+    internal fun getReactSubviewAt(index: Int): View = dialogManager.contentView.getChildAt(index)
+
     // The React children are teleported into the dialog window. This host occupies space in the
     // main window, but holds no content there. NONE makes the host subtree invisible to
     // hit-testing so touches reach the views behind it.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -76,7 +76,7 @@ class FormSheetHost(
 
     internal fun getReactSubviewCount(): Int = dialogManager.contentView.childCount
 
-    internal fun getReactSubviewAt(index: Int): View = dialogManager.contentView.getChildAt(index)
+    internal fun getReactSubviewAt(index: Int): View? = dialogManager.contentView.getChildAt(index)
 
     // The React children are teleported into the dialog window. This host occupies space in the
     // main window, but holds no content there. NONE makes the host subtree invisible to

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -51,6 +51,14 @@ class FormSheetHostViewManager :
         parent.unmountAllReactSubviews()
     }
 
+    override fun getChildCount(parent: FormSheetHost): Int {
+        return parent.getReactSubviewCount()
+    }
+
+    override fun getChildAt(parent: FormSheetHost, index: Int): View? {
+        return parent.getReactSubviewAt(index)
+    }
+
     override fun setIsOpen(
         view: FormSheetHost,
         value: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -51,13 +51,12 @@ class FormSheetHostViewManager :
         parent.unmountAllReactSubviews()
     }
 
-    override fun getChildCount(parent: FormSheetHost): Int {
-        return parent.getReactSubviewCount()
-    }
+    override fun getChildCount(parent: FormSheetHost): Int = parent.getReactSubviewCount()
 
-    override fun getChildAt(parent: FormSheetHost, index: Int): View? {
-        return parent.getReactSubviewAt(index)
-    }
+    override fun getChildAt(
+        parent: FormSheetHost,
+        index: Int,
+    ): View? = parent.getReactSubviewAt(index)
 
     override fun setIsOpen(
         view: FormSheetHost,


### PR DESCRIPTION
## Description

This PR addresses an issue with the ViewManager synchronization bug that left empty views on Fast Refresh. When teleporting views to a Dialog window, the FormSheetHost itself remains an empty ViewGroup with 0 children. Because the default ViewGroupManager relies on parent.getChildCount() during diffing, React Native would assume there were no children to unmount, leaving orphaned UI elements on the screen during Fast Refresh. 

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1580

## Changes

Added `getReactSubviewCount` and `getReactSubviewAt` to Host and overrode `getChildCount` / `getChildAt` in `FormSheetHostViewManager`. These methods now correctly redirect React Native's queries to the `dialogManager.contentView`, keeping the Shadow Tree in sync with Host Tree.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/6b7c22d6-3c70-4f9d-94ae-84691b6b818d" /> | <video src="https://github.com/user-attachments/assets/4f7de5b4-9648-474e-bc52-b010fbfa5f4a" /> |

## Test plan

Test fast refresh on any FormSheet example.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
