### PR TITLE
refactor(Android, FormSheet v5): Add EventEmitter for FormSheetHost

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetContentView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetContentView.kt
@@ -33,7 +33,6 @@ class FormSheetContentView(
     private val jsTouchDispatcher = JSTouchDispatcher(this)
     private var jsPointerDispatcher: JSPointerDispatcher? = null
 
-    // TODO: @t0maboro - refactor in EventEmitter PR
     private val eventDispatcher: EventDispatcher?
         get() = UIManagerHelper.getEventDispatcher(themedReactContext, UIManagerType.FABRIC)
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -26,6 +26,8 @@ class FormSheetHost(
 
     internal var stateWrapper by shadowStateProxy::stateWrapper
 
+    internal lateinit var eventEmitter: FormSheetHostEventEmitter
+
     internal fun setIsOpen(open: Boolean) {
         if (this.isOpen == open) return
         this.isOpen = open
@@ -37,15 +39,8 @@ class FormSheetHost(
         }
     }
 
-    // TODO: @t0maboro - dedicated FormSheetHostEventEmitter needs to be implemented later
     internal fun onNativeDismiss() {
-        val reactContext = context as? ThemedReactContext ?: return
-        val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-        val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
-
-        dispatcher?.dispatchEvent(
-            FormSheetNativeDismissEvent(surfaceId, id),
-        )
+        eventEmitter.emitOnNativeDismissEvent()
     }
 
     internal fun mountReactSubviewAt(
@@ -89,6 +84,11 @@ class FormSheetHost(
         b: Int,
     ) = Unit
 
+    internal fun onViewManagerAddEventEmitters() {
+        check(id != NO_ID) { "[RNScreens] FormSheetHost must have its tag set when registering event emitters" }
+        eventEmitter = FormSheetHostEventEmitter(context as ReactContext, id)
+    }
+
     internal fun updateStateIfNeeded(
         width: Int,
         height: Int,
@@ -108,12 +108,6 @@ class FormSheetHost(
     // traversal phase, the actual mounting callback will be executed on the next frame.
     // To prevent drawing a stale layout, we block drawing the frame in `FormSheetContentView`.
     private fun flushPendingStateUpdates() {
-        val reactContext = context as? ReactContext ?: return
-        val surfaceId = UIManagerHelper.getSurfaceId(this)
-
-        // TODO: @t0maboro - implement EventEmitter in followup PR
-        UIManagerHelper
-            .getEventDispatcherForReactTag(reactContext, id)
-            ?.dispatchEvent(FormSheetSyncFlushEvent(surfaceId, id))
+        eventEmitter.emitOnSyncFlushEvent()
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -1,16 +1,15 @@
 package com.swmansion.rnscreens.gamma.modals.formsheet
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
+import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
 
 class FormSheetHost(
-    context: Context,
-) : ViewGroup(context),
+    val reactContext: ThemedReactContext,
+) : ViewGroup(reactContext),
     ReactPointerEventsView {
     private val dialogManager =
         FormSheetDialogManager(
@@ -84,7 +83,7 @@ class FormSheetHost(
 
     internal fun onViewManagerAddEventEmitters() {
         check(id != NO_ID) { "[RNScreens] FormSheetHost must have its tag set when registering event emitters" }
-        eventEmitter = FormSheetHostEventEmitter(context as ReactContext, id)
+        eventEmitter = FormSheetHostEventEmitter(reactContext, id)
     }
 
     internal fun updateStateIfNeeded(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -6,8 +6,6 @@ import android.view.ViewGroup
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
-import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerHelper
 import com.swmansion.rnscreens.gamma.common.ShadowStateProxy
 
 class FormSheetHost(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostEventEmitter.kt
@@ -1,0 +1,22 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+import com.facebook.react.bridge.ReactContext
+import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
+
+internal class FormSheetHostEventEmitter(
+    reactContext: ReactContext,
+    viewTag: Int,
+) : BaseEventEmitter(reactContext, viewTag) {
+
+    fun emitOnNativeDismissEvent() {
+        reactEventDispatcher.dispatchEvent(
+            FormSheetNativeDismissEvent(surfaceId, viewTag),
+        )
+    }
+
+    fun emitOnSyncFlushEvent() {
+        reactEventDispatcher.dispatchEvent(
+            FormSheetSyncFlushEvent(surfaceId, viewTag),
+        )
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostEventEmitter.kt
@@ -7,7 +7,6 @@ internal class FormSheetHostEventEmitter(
     reactContext: ReactContext,
     viewTag: Int,
 ) : BaseEventEmitter(reactContext, viewTag) {
-
     fun emitOnNativeDismissEvent() {
         reactEventDispatcher.dispatchEvent(
             FormSheetNativeDismissEvent(surfaceId, viewTag),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -136,6 +136,11 @@ class FormSheetHostViewManager :
         return super.updateState(view, props, stateWrapper)
     }
 
+    override fun addEventEmitters(reactContext: ThemedReactContext, view: FormSheetHost) {
+        super.addEventEmitters(reactContext, view)
+        view.onViewManagerAddEventEmitters()
+    }
+
     override fun onDropViewInstance(view: FormSheetHost) {
         view.setIsOpen(false)
         super.onDropViewInstance(view)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -136,7 +136,10 @@ class FormSheetHostViewManager :
         return super.updateState(view, props, stateWrapper)
     }
 
-    override fun addEventEmitters(reactContext: ThemedReactContext, view: FormSheetHost) {
+    override fun addEventEmitters(
+        reactContext: ThemedReactContext,
+        view: FormSheetHost,
+    ) {
         super.addEventEmitters(reactContext, view)
         view.onViewManagerAddEventEmitters()
     }


### PR DESCRIPTION
## Description

Aligning the event-emitting logic with the architecture of other components.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1549

## Changes

- Added dedicated FormSheetHostEventEmitter impl
- Refactored event-emitting logic in Host

## Before & after - visual documentation

N/A - refactor

## Test plan

Base SFT from FormSheet group

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
