### PR TITLE
refactor(Android, FormSheet v5): Decouple `FormSheetDialogManager` from React's `FormSheetContentView`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -12,7 +12,7 @@ import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
 class FormSheetDialogManager(
     context: Context,
-    private val onUpdateState: (width: Int, height: Int) -> Unit,
+    private val contentView: View,
     private val onDismissRequest: () -> Unit,
 ) {
     private var formSheetConfig = FormSheetConfig()
@@ -22,11 +22,6 @@ class FormSheetDialogManager(
             context,
             com.google.android.material.R.style.Theme_Material3_DayNight_NoActionBar,
         )
-
-    internal val contentView =
-        FormSheetContentView(context) { width, height ->
-            onUpdateState(width, height)
-        }
 
     // Eagerly create the container so it's always ready for React's children
     private val container = FormSheetContainer(themedContext, contentView)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -23,7 +23,7 @@ class FormSheetDialogManager(
             com.google.android.material.R.style.Theme_Material3_DayNight_NoActionBar,
         )
 
-    // Eagerly create the container so it's always ready for React's children
+    // Eagerly create the container so it's always ready for the provided content view
     private val container = FormSheetContainer(themedContext, contentView)
 
     // Eagerly create the dialog and attach the container

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -11,7 +11,6 @@ class FormSheetHost(
     val reactContext: ThemedReactContext,
 ) : ViewGroup(reactContext),
     ReactPointerEventsView {
-
     private val shadowStateProxy = ShadowStateProxy()
 
     internal var stateWrapper by shadowStateProxy::stateWrapper
@@ -57,9 +56,9 @@ class FormSheetHost(
         sheetContentView.removeAllViews()
     }
 
-    internal fun getReactSubviewCount(): Int = dialogManager.contentView.childCount
+    internal fun getReactSubviewCount(): Int = sheetContentView.childCount
 
-    internal fun getReactSubviewAt(index: Int): View? = dialogManager.contentView.getChildAt(index)
+    internal fun getReactSubviewAt(index: Int): View? = sheetContentView.getChildAt(index)
 
     // The React children are teleported into the dialog window. This host occupies space in the
     // main window, but holds no content there. NONE makes the host subtree invisible to

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -11,12 +11,6 @@ class FormSheetHost(
     val reactContext: ThemedReactContext,
 ) : ViewGroup(reactContext),
     ReactPointerEventsView {
-    private val dialogManager =
-        FormSheetDialogManager(
-            context = context,
-            onUpdateState = ::updateStateIfNeeded,
-            onDismissRequest = ::onNativeDismiss,
-        )
 
     private val shadowStateProxy = ShadowStateProxy()
 
@@ -28,6 +22,18 @@ class FormSheetHost(
 
     internal var prefersGrabberVisible = false
 
+    private val sheetContentView =
+        FormSheetContentView(context) { width, height ->
+            updateStateIfNeeded(width, height)
+        }
+
+    private val dialogManager =
+        FormSheetDialogManager(
+            context = context,
+            contentView = sheetContentView,
+            onDismissRequest = ::onNativeDismiss,
+        )
+
     internal fun onNativeDismiss() {
         eventEmitter.emitOnNativeDismissEvent()
     }
@@ -36,19 +42,19 @@ class FormSheetHost(
         child: View,
         index: Int,
     ) {
-        dialogManager.contentView.addView(child, index)
+        sheetContentView.addView(child, index)
     }
 
     internal fun unmountReactSubview(child: View) {
-        dialogManager.contentView.removeView(child)
+        sheetContentView.removeView(child)
     }
 
     internal fun unmountReactSubviewAt(index: Int) {
-        dialogManager.contentView.removeViewAt(index)
+        sheetContentView.removeViewAt(index)
     }
 
     internal fun unmountAllReactSubviews() {
-        dialogManager.contentView.removeAllViews()
+        sheetContentView.removeAllViews()
     }
 
     internal fun getReactSubviewCount(): Int = dialogManager.contentView.childCount


### PR DESCRIPTION
## Description

Previously, the native `FormSheetDialogManager` was tightly coupled with RN, as it was responsible for instantiating the `FormSheetContentView` - a `ReactViewGroup` which is a destination for teleported react children. This PR extracts this React Native dependency out of the native manager.

## Changes

- Removed the FormSheetContentView instantiation from the dialog manager. The manager now accepts an Android View via its constructor. It no longer knows what the content is (ContentView from RN or some other Android View).
- Moved the creation of `FormSheetContentView` to `FormSheetHost` to integrate it directly with RN lifecycle. `FormSheetHost` now adds and removes React subviews directly to/from its instantiated `sheetContentView`, bypassing the native manager completely.

## Before & after - visual documentation

N/A - refactor 

## Test plan

N/A - refactor 

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
