### PR TITLE
feat(iOS, Stack, Tabs): improve nested container integration -> introduce `Container` & `ContainerItem`

### DIFF
--- a/apps/src/tests/component-integration-tests/index.tsx
+++ b/apps/src/tests/component-integration-tests/index.tsx
@@ -18,6 +18,7 @@ export * from './orientation';
 export * from './scroll-view';
 export * from './form-sheet';
 export * from './tabs-stack-v5';
+export * from './scroll-view-marker';
 
 export const COMPONENT_SCENARIOS = {
   Orientation: OrientationScenarioGroup,

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/index.ts
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/index.ts
@@ -2,6 +2,9 @@ import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestSvmTabsScrollEdgeEffects from './test-svm-tabs-scroll-edge-effects';
 import TestStackSvmTabsSpecialEffects from './test-stack-svm-tabs-special-effects';
 
+export { default as TestSvmTabsScrollEdgeEffects } from './test-svm-tabs-scroll-edge-effects';
+export { default as TestStackSvmTabsSpecialEffects } from './test-stack-svm-tabs-special-effects';
+
 const scenarios = {
   TestSvmTabsScrollEdgeEffects,
   TestStackSvmTabsSpecialEffects,

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -47,13 +47,19 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   RNSLog(@"[RNScreens] StackHost [%ld] attached to window", self.tag);
-  if (self.window != nil && _stackNavigationController.parentViewController == nil) {
-    BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
-                                          toViewControllerManaging:self.reactSuperview
-                                                 withContainerView:self];
-    if (mountResult) {
-      [self setupViewConstraintsForController:_stackNavigationController];
+  if (self.window != nil) {
+    if (_stackNavigationController.parentViewController == nil) {
+      BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
+                                            toViewControllerManaging:self.reactSuperview
+                                                   withContainerView:self];
+      if (mountResult) {
+        [self setupViewConstraintsForController:_stackNavigationController];
+      }
     }
+    
+    [_stackNavigationController attachToParentContainerItem];
+  } else {
+    [_stackNavigationController detachFromParentContainerItem];
   }
 }
 

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -56,7 +56,7 @@ namespace react = facebook::react;
         [self setupViewConstraintsForController:_stackNavigationController];
       }
     }
-    
+
     [_stackNavigationController attachToParentContainerItem];
   } else {
     [_stackNavigationController detachFromParentContainerItem];

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -47,19 +47,13 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   RNSLog(@"[RNScreens] StackHost [%ld] attached to window", self.tag);
-  if (self.window != nil) {
-    if (_stackNavigationController.parentViewController == nil) {
-      BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
-                                            toViewControllerManaging:self.reactSuperview
-                                                   withContainerView:self];
-      if (mountResult) {
-        [self setupViewConstraintsForController:_stackNavigationController];
-      }
+  if (self.window != nil && _stackNavigationController.parentViewController == nil) {
+    BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
+                                          toViewControllerManaging:self.reactSuperview
+                                                 withContainerView:self];
+    if (mountResult) {
+      [self setupViewConstraintsForController:_stackNavigationController];
     }
-
-    [_stackNavigationController attachToParentContainerItem];
-  } else {
-    [_stackNavigationController detachFromParentContainerItem];
   }
 }
 

--- a/ios/gamma/stack/host/RNSStackNavigationController.h
+++ b/ios/gamma/stack/host/RNSStackNavigationController.h
@@ -18,16 +18,4 @@
 
 - (void)performContainerUpdateIfNeeded;
 
-/**
- * Register this container with the nearest parent `RNSContainerItem` in the view-controller
- * hierarchy (if any). Call when the owning host view is attached to a window.
- */
-- (void)attachToParentContainerItem;
-
-/**
- * Unregister this container from its parent `RNSContainerItem`. Call when the owning host view is
- * detached from its window.
- */
-- (void)detachFromParentContainerItem;
-
 @end

--- a/ios/gamma/stack/host/RNSStackNavigationController.h
+++ b/ios/gamma/stack/host/RNSStackNavigationController.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#import "RNSContainer.h"
 #include "RNSStackNavigationBarCoordinator.h"
 #include "RNSStackScreenComponentView.h"
 
 @protocol RNSViewFrameChangeDelegate;
 
-@interface RNSStackNavigationController : UINavigationController
+@interface RNSStackNavigationController : UINavigationController <RNSContainer>
 
 @property (nonatomic, weak, nullable) id<RNSViewFrameChangeDelegate> navigationBarFrameChangeDelegate;
 
@@ -16,5 +17,17 @@
 - (void)enqueuePopOperation:(nonnull RNSStackScreenComponentView *)stackScreen;
 
 - (void)performContainerUpdateIfNeeded;
+
+/**
+ * Register this container with the nearest parent `RNSContainerItem` in the view-controller
+ * hierarchy (if any). Call when the owning host view is attached to a window.
+ */
+- (void)attachToParentContainerItem;
+
+/**
+ * Unregister this container from its parent `RNSContainerItem`. Call when the owning host view is
+ * detached from its window.
+ */
+- (void)detachFromParentContainerItem;
 
 @end

--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -1,5 +1,7 @@
 #import "RNSStackNavigationController.h"
+#import "RNSContainer.h"
 #import "RNSLog.h"
+#import "RNSParentContainerItemRegistry.h"
 #import "RNSStackOperation.h"
 #import "RNSStackScreenController.h"
 #import "RNSViewFrameChangeDelegate.h"
@@ -8,6 +10,7 @@
 @implementation RNSStackNavigationController {
   NSMutableArray<RNSPushOperation *> *_Nonnull _pendingPushOperations;
   NSMutableArray<RNSPopOperation *> *_Nonnull _pendingPopOperations;
+  RNSParentContainerItemRegistry *_Nonnull _parentContainerRegistry;
 }
 
 - (instancetype)init
@@ -24,6 +27,50 @@
 {
   _pendingPushOperations = [NSMutableArray array];
   _pendingPopOperations = [NSMutableArray array];
+  _parentContainerRegistry = [RNSParentContainerItemRegistry new];
+  [self removeFromParentViewController];
+}
+
+#pragma mark - Overrides
+
+- (void)willMoveToParentViewController:(UIViewController *)parent
+{
+  [super willMoveToParentViewController:parent];
+}
+
+- (void)didMoveToParentViewController:(UIViewController *)parent
+{
+  [super didMoveToParentViewController:parent];
+}
+
+#pragma mark-- Layout
+
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+  [_navigationBarFrameChangeDelegate viewFrameDidChange:self.navigationBar];
+}
+
+#pragma mark - RNSContainer
+
+- (nullable UIScrollView *)resolveCurrentContentScrollView
+{
+  // We assume `topViewController` corresponds to the currently presented screen.
+  UIViewController *topController = self.topViewController;
+  if (![topController isKindOfClass:RNSStackScreenController.class]) {
+    return nil;
+  }
+  return [static_cast<RNSStackScreenController *>(topController) findContentScrollView];
+}
+
+- (void)attachToParentContainerItem
+{
+  [_parentContainerRegistry attachContainer:self];
+}
+
+- (void)detachFromParentContainerItem
+{
+  [_parentContainerRegistry detachContainer:self];
 }
 
 - (BOOL)hasPendingOperations
@@ -73,14 +120,6 @@
 
   [_pendingPopOperations removeAllObjects];
   [_pendingPushOperations removeAllObjects];
-}
-
-#pragma mark - Layout
-
-- (void)viewDidLayoutSubviews
-{
-  [super viewDidLayoutSubviews];
-  [_navigationBarFrameChangeDelegate viewFrameDidChange:self.navigationBar];
 }
 
 #pragma mark - Debug

--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -28,7 +28,6 @@
   _pendingPushOperations = [NSMutableArray array];
   _pendingPopOperations = [NSMutableArray array];
   _parentContainerRegistry = [RNSParentContainerItemRegistry new];
-  [self removeFromParentViewController];
 }
 
 #pragma mark - Overrides

--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -30,18 +30,6 @@
   _parentContainerRegistry = [RNSParentContainerItemRegistry new];
 }
 
-#pragma mark - Overrides
-
-- (void)willMoveToParentViewController:(UIViewController *)parent
-{
-  [super willMoveToParentViewController:parent];
-}
-
-- (void)didMoveToParentViewController:(UIViewController *)parent
-{
-  [super didMoveToParentViewController:parent];
-}
-
 #pragma mark-- Layout
 
 - (void)viewDidLayoutSubviews

--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -60,6 +60,19 @@
   [_parentContainerRegistry detachContainer:self];
 }
 
+#pragma mark - View controller containment
+
+- (void)didMoveToParentViewController:(UIViewController *)parent
+{
+  [super didMoveToParentViewController:parent];
+
+  if (parent != nil) {
+    [self attachToParentContainerItem];
+  } else {
+    [self detachFromParentContainerItem];
+  }
+}
+
 - (BOOL)hasPendingOperations
 {
   return _pendingPushOperations.count > 0 || _pendingPopOperations.count > 0;

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.h
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.h
@@ -43,4 +43,16 @@ typedef NS_ENUM(int, RNSStackScreenActivityMode) {
 
 @end
 
+#pragma mark - Content scroll view
+
+@interface RNSStackScreenComponentView ()
+
+/**
+ * Content scroll view registered by a descendant `RNSScrollViewMarkerComponentView`, or nil if
+ * none has been registered. Queried by the owning controller (`RNSContainerItem`).
+ */
+- (nullable UIScrollView *)cachedContentScrollView;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -90,6 +90,9 @@ namespace react = facebook::react;
 
 - (void)registerDescendantScrollView:(UIScrollView *)scrollView fromMarker:(RNSScrollViewMarkerComponentView *)marker
 {
+  // Native scroll-edge behavior (UINavigationBar scroll edge appearance, top-screen-tap scroll-to-top on iPad).
+  [_controller setContentScrollView:scrollView forEdge:NSDirectionalRectEdgeAll];
+  // Cache used by the container-nesting content-scroll-view resolution.
   _contentScrollView = scrollView;
 }
 

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -8,6 +8,8 @@
 #import <rnscreens/RNSStackScreenComponentDescriptor.h>
 
 #import "RNSConversions-Stack.h"
+#import "RNSScrollViewMarkerComponentView.h"
+#import "RNSScrollViewSeeking.h"
 #import "RNSStackHeaderConfigComponentView.h"
 #import "RNSStackHostComponentView.h"
 #import "RNSStackNavigationController.h"
@@ -18,7 +20,7 @@
 
 namespace react = facebook::react;
 
-@interface RNSStackScreenComponentView () <RCTMountingTransactionObserving>
+@interface RNSStackScreenComponentView () <RCTMountingTransactionObserving, RNSScrollViewSeeking>
 @end
 
 #pragma mark - View implementation
@@ -26,6 +28,11 @@ namespace react = facebook::react;
 @implementation RNSStackScreenComponentView {
   RNSStackScreenController *_Nonnull _controller;
   RNSStackScreenComponentEventEmitter *_Nonnull _reactEventEmitter;
+
+  // Content scroll view registered by a descendant `RNSScrollViewMarkerComponentView`. Queried by
+  // the owning `RNSStackScreenController` (as `RNSContainerItem`) when resolving the content
+  // scroll view for special effects.
+  __weak UIScrollView *_Nullable _contentScrollView;
 
   // Flags
   BOOL _hasUpdatedActivityMode;
@@ -77,6 +84,18 @@ namespace react = facebook::react;
       strongSelf->_controller = nil;
     }
   });
+}
+
+#pragma mark - RNSScrollViewSeeking
+
+- (void)registerDescendantScrollView:(UIScrollView *)scrollView fromMarker:(RNSScrollViewMarkerComponentView *)marker
+{
+  _contentScrollView = scrollView;
+}
+
+- (nullable UIScrollView *)cachedContentScrollView
+{
+  return _contentScrollView;
 }
 
 #pragma mark - Events

--- a/ios/gamma/stack/screen/RNSStackScreenController.h
+++ b/ios/gamma/stack/screen/RNSStackScreenController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+#import "RNSContainerItem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RNSStackController;
 @class RNSStackScreenHeaderCoordinator;
 
-@interface RNSStackScreenController : UIViewController
+@interface RNSStackScreenController : UIViewController <RNSContainerItem>
 
 @property (nonatomic, strong, readonly, nonnull) RNSStackScreenHeaderCoordinator *headerCoordinator;
 

--- a/ios/gamma/stack/screen/RNSStackScreenController.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenController.mm
@@ -1,4 +1,6 @@
 #import "RNSStackScreenController.h"
+#import "RNSContainer.h"
+#import "RNSContainerItemSupport.h"
 #import "RNSLog.h"
 #import "RNSStackHostComponentView.h"
 #import "RNSStackNavigationController.h"
@@ -8,6 +10,7 @@
 
 @implementation RNSStackScreenController {
   RNSStackScreenComponentView *_Nonnull _screenView;
+  RNSContainerItemSupport *_Nonnull _containerItemSupport;
 }
 
 - (instancetype)initWithComponentView:(RNSStackScreenComponentView *)componentView
@@ -15,8 +18,32 @@
   if (self = [super initWithNibName:nil bundle:nil]) {
     _screenView = componentView;
     _headerCoordinator = [[RNSStackScreenHeaderCoordinator alloc] initWithScreenController:self];
+    _containerItemSupport = [RNSContainerItemSupport new];
   }
   return self;
+}
+
+#pragma mark - RNSContainerItem
+
+- (void)registerNestedContainer:(id<RNSContainer>)container
+{
+  [_containerItemSupport registerNestedContainer:container];
+}
+
+- (void)unregisterNestedContainer:(id<RNSContainer>)container
+{
+  [_containerItemSupport unregisterNestedContainer:container];
+}
+
+- (nullable id<RNSContainer>)resolveNestedContainer
+{
+  return [_containerItemSupport resolveNestedContainer];
+}
+
+- (nullable UIScrollView *)findContentScrollView
+{
+  return [_containerItemSupport findContentScrollViewWithCachedScrollView:[_screenView cachedContentScrollView]
+                                                            heuristicRoot:_screenView];
 }
 
 - (RNSStackScreenComponentEventEmitter *)reactEventEmitter

--- a/ios/helpers/container/RNSContainer.h
+++ b/ios/helpers/container/RNSContainer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A navigation container (e.g. stack, tabs) that hosts items and can resolve the content scroll
+ * view of whichever item is currently presented.
+ *
+ * On iOS the concept is implemented at the view-controller level: `RNSStackNavigationController`
+ * and `RNSTabBarController` conform to this protocol.
+ */
+@protocol RNSContainer <NSObject>
+
+/**
+ * A container can host multiple items, each with its own content scroll view. It is up to the
+ * implementer to decide which scroll view to return here (if any) for the item that is currently
+ * presented.
+ */
+- (nullable UIScrollView *)resolveCurrentContentScrollView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSContainerItem.h
+++ b/ios/helpers/container/RNSContainerItem.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+#import "RNSContentScrollViewProviding.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSContainer;
+
+/**
+ * A single item hosted by an `RNSContainer` (e.g. a stack screen, a tab). An item may itself host
+ * a single nested `RNSContainer` and exposes the content scroll view of its subtree via
+ * `findContentScrollView` (inherited from `RNSContentScrollViewProviding`).
+ *
+ * On iOS the concept is implemented at the view-controller level: `RNSStackScreenController` and
+ * `RNSTabsScreenViewController` conform to this protocol.
+ */
+@protocol RNSContainerItem <RNSContentScrollViewProviding>
+
+#pragma mark - Nested Container handling
+
+/**
+ * A `RNSContainerItem` supports at most a single nested `RNSContainer`. Registering a second
+ * container while one is already registered overwrites the previous one. This is an intentional
+ * design invariant: a single item is expected to host at most one nested container.
+ */
+- (void)registerNestedContainer:(id<RNSContainer>)container;
+
+- (void)unregisterNestedContainer:(id<RNSContainer>)container;
+
+- (nullable id<RNSContainer>)resolveNestedContainer;
+
+#pragma mark - Content Scroll View support
+
+// `findContentScrollView` is inherited from `RNSContentScrollViewProviding`.
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSContainerItemSupport.h
+++ b/ios/helpers/container/RNSContainerItemSupport.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSContainer;
+
+/**
+ * Composition holder for the `RNSContainerItem` side of the container-nesting mechanism.
+ *
+ * It owns the (weak) reference to the nested container and implements the content-scroll-view
+ * resolution order shared by all container items. The cached content scroll view itself is NOT
+ * owned here - it lives on the item's component view and is passed in by the owner.
+ */
+@interface RNSContainerItemSupport : NSObject
+
+- (void)registerNestedContainer:(id<RNSContainer>)container;
+
+- (void)unregisterNestedContainer:(id<RNSContainer>)container;
+
+- (nullable id<RNSContainer>)resolveNestedContainer;
+
+/**
+ * Resolves the content scroll view using the shared order:
+ *   1. the provided `cachedScrollView` (registered on the owner's view by the scroll view marker),
+ *   2. the nested container's current content scroll view,
+ *   3. a first-descendant-chain heuristic rooted at `rootView`.
+ */
+- (nullable UIScrollView *)findContentScrollViewWithCachedScrollView:(nullable UIScrollView *)cachedScrollView
+                                                       heuristicRoot:(nullable UIView *)rootView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSContainerItemSupport.mm
+++ b/ios/helpers/container/RNSContainerItemSupport.mm
@@ -1,0 +1,47 @@
+#import "RNSContainerItemSupport.h"
+
+#import "RNSContainer.h"
+#import "RNSScrollViewFinder.h"
+
+@implementation RNSContainerItemSupport {
+  __weak id<RNSContainer> _nestedContainer;
+}
+
+- (void)registerNestedContainer:(id<RNSContainer>)container
+{
+  _nestedContainer = container;
+}
+
+- (void)unregisterNestedContainer:(id<RNSContainer>)container
+{
+  // Only clear if the currently held container is the one being unregistered. A stale container
+  // detaching after a newer one already registered must not clear the newer reference.
+  if (_nestedContainer == container) {
+    _nestedContainer = nil;
+  }
+}
+
+- (nullable id<RNSContainer>)resolveNestedContainer
+{
+  return _nestedContainer;
+}
+
+- (nullable UIScrollView *)findContentScrollViewWithCachedScrollView:(nullable UIScrollView *)cachedScrollView
+                                                       heuristicRoot:(nullable UIView *)rootView
+{
+  // Cached one (registered on the owner's view by the scroll view marker).
+  if (cachedScrollView != nil) {
+    return cachedScrollView;
+  }
+
+  // Provided by nested container.
+  if (UIScrollView *fromNestedContainer = [_nestedContainer resolveCurrentContentScrollView];
+      fromNestedContainer != nil) {
+    return fromNestedContainer;
+  }
+
+  // Heuristic.
+  return [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:rootView];
+}
+
+@end

--- a/ios/helpers/container/RNSParentContainerItemRegistry.h
+++ b/ios/helpers/container/RNSParentContainerItemRegistry.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSContainer;
+
+/**
+ * Composition holder for the `RNSContainer` side of the container-nesting mechanism.
+ *
+ * On attach it walks the view-controller hierarchy upwards to find the nearest parent
+ * `RNSContainerItem` and registers the container with it; on detach it unregisters the container
+ * from the remembered parent item. The parent item is held weakly.
+ */
+@interface RNSParentContainerItemRegistry : NSObject
+
+- (void)attachContainer:(UIViewController<RNSContainer> *)container;
+
+- (void)detachContainer:(UIViewController<RNSContainer> *)container;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSParentContainerItemRegistry.mm
+++ b/ios/helpers/container/RNSParentContainerItemRegistry.mm
@@ -1,0 +1,47 @@
+#import "RNSParentContainerItemRegistry.h"
+
+#import "RNSContainer.h"
+#import "RNSContainerItem.h"
+
+@interface RNSParentContainerItemRegistry ()
+- (nullable id<RNSContainerItem>)findParentContainerItemFrom:(UIViewController *)viewController;
+@end
+
+@implementation RNSParentContainerItemRegistry {
+  __weak id<RNSContainerItem> _parentItem;
+}
+
+- (void)attachContainer:(UIViewController<RNSContainer> *)container
+{
+  id<RNSContainerItem> parentItem = [self findParentContainerItemFrom:container];
+  if (parentItem == nil) {
+    return;
+  }
+  [parentItem registerNestedContainer:container];
+  _parentItem = parentItem;
+}
+
+- (void)detachContainer:(UIViewController<RNSContainer> *)container
+{
+  [_parentItem unregisterNestedContainer:container];
+  _parentItem = nil;
+}
+
+/**
+ * Walks the view-controller containment chain (`parentViewController`) upwards looking for the
+ * nearest `RNSContainerItem`. We test via `respondsToSelector:` rather than `conformsToProtocol:`
+ * to match the lock-free idiom used elsewhere (e.g. `RNSScrollViewMarkerComponentView`).
+ */
+- (nullable id<RNSContainerItem>)findParentContainerItemFrom:(UIViewController *)viewController
+{
+  UIViewController *parent = viewController.parentViewController;
+  while (parent != nil) {
+    if ([parent respondsToSelector:@selector(registerNestedContainer:)]) {
+      return static_cast<id<RNSContainerItem>>(parent);
+    }
+    parent = parent.parentViewController;
+  }
+  return nil;
+}
+
+@end

--- a/ios/helpers/container/RNSParentContainerItemRegistry.mm
+++ b/ios/helpers/container/RNSParentContainerItemRegistry.mm
@@ -14,10 +14,9 @@
 - (void)attachContainer:(UIViewController<RNSContainer> *)container
 {
   id<RNSContainerItem> parentItem = [self findParentContainerItemFrom:container];
-  if (parentItem == nil) {
-    return;
+  if (parentItem != nil) {
+    [parentItem registerNestedContainer:container];
   }
-  [parentItem registerNestedContainer:container];
   _parentItem = parentItem;
 }
 

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -170,18 +170,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)tearDown;
 
-/**
- * Register this container with the nearest parent `RNSContainerItem` in the view-controller
- * hierarchy (if any). Call when the owning host view is attached to a window.
- */
-- (void)attachToParentContainerItem;
-
-/**
- * Unregister this container from its parent `RNSContainerItem`. Call when the owning host view is
- * detached from its window.
- */
-- (void)detachFromParentContainerItem;
-
 #pragma mark Individual flush methods (internal)
 
 /**

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+#import "RNSContainer.h"
 #import "RNSTabBarAppearanceCoordinator.h"
 #import "RNSTabsNavigationState.h"
 #import "RNSTabsScreenViewController.h"
@@ -50,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Members under `#pragma mark - Internal API` are host-only (`RNSTabsHostComponentView`)
  * implementation detail and may change without notice. Do not call from third-party code.
  */
-@interface RNSTabBarController : UITabBarController <RNSReactTransactionObserving
+@interface RNSTabBarController : UITabBarController <RNSReactTransactionObserving,
+                                                     RNSContainer
 #if !TARGET_OS_TV
                                                      ,
                                                      RNSOrientationProviding
@@ -167,6 +169,18 @@ NS_ASSUME_NONNULL_BEGIN
  * Called by the host on view lifecycle end.
  */
 - (void)tearDown;
+
+/**
+ * Register this container with the nearest parent `RNSContainerItem` in the view-controller
+ * hierarchy (if any). Call when the owning host view is attached to a window.
+ */
+- (void)attachToParentContainerItem;
+
+/**
+ * Unregister this container from its parent `RNSContainerItem`. Call when the owning host view is
+ * detached from its window.
+ */
+- (void)detachFromParentContainerItem;
 
 #pragma mark Individual flush methods (internal)
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -183,6 +183,9 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
   if (parent != nil) {
     [self updateLayoutDirectionBelowIOS17IfNeeded];
+    [self attachToParentContainerItem];
+  } else {
+    [self detachFromParentContainerItem];
   }
 }
 

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -6,6 +6,7 @@
 #import <limits>
 #import "NSString+RNSUtility.h"
 #import "RNSLog.h"
+#import "RNSParentContainerItemRegistry.h"
 #import "RNSScreenWindowTraits.h"
 #import "RNSTabsHostComponentView.h"
 #import "RNSTabsNavigationStateObserverRegistry.h"
@@ -86,6 +87,8 @@ static void rns_pushViewController(__unsafe_unretained id self,
   BOOL _isHandlingExplicitSelectionUpdate;
 
   RNSTabsNavigationStateObserverRegistry *_observerRegistry;
+
+  RNSParentContainerItemRegistry *_Nonnull _parentContainerRegistry;
 }
 
 - (instancetype)init
@@ -98,6 +101,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
     _pendingStateUpdate = nil;
     _shouldProgressStateOnMoreNavigationControllerPush = NO;
     _observerRegistry = [RNSTabsNavigationStateObserverRegistry new];
+    _parentContainerRegistry = [RNSParentContainerItemRegistry new];
 
     // Delegate field retains weakly, no risk of cycle.
     self.delegate = self;
@@ -148,7 +152,35 @@ static void rns_pushViewController(__unsafe_unretained id self,
   return self;
 }
 
+#pragma mark - RNSContainer
+
+- (nullable UIScrollView *)resolveCurrentContentScrollView
+{
+  // `selectedViewController` may be the `moreNavigationController` (a `UINavigationController`) -
+  // we only resolve for our own tab screens.
+  UIViewController *selectedController = self.selectedViewController;
+  if (![selectedController isKindOfClass:RNSTabsScreenViewController.class]) {
+    return nil;
+  }
+  return [static_cast<RNSTabsScreenViewController *>(selectedController) findContentScrollView];
+}
+
+- (void)attachToParentContainerItem
+{
+  [_parentContainerRegistry attachContainer:self];
+}
+
+- (void)detachFromParentContainerItem
+{
+  [_parentContainerRegistry detachContainer:self];
+}
+
 #pragma mark - UIKit callbacks
+
+- (void)willMoveToParentViewController:(UIViewController *)parent
+{
+  [super willMoveToParentViewController:parent];
+}
 
 - (void)didMoveToParentViewController:(UIViewController *)parent
 {

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -177,11 +177,6 @@ static void rns_pushViewController(__unsafe_unretained id self,
 
 #pragma mark - UIKit callbacks
 
-- (void)willMoveToParentViewController:(UIViewController *)parent
-{
-  [super willMoveToParentViewController:parent];
-}
-
 - (void)didMoveToParentViewController:(UIViewController *)parent
 {
   [super didMoveToParentViewController:parent];

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -116,19 +116,13 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
-  if (self.window != nil) {
-    if (_controller.parentViewController == nil) {
-      BOOL mountResult = [RNSContainerHelpers addChildViewController:_controller
-                                            toViewControllerManaging:self.reactSuperview
-                                                   withContainerView:self];
-      if (mountResult) {
-        [self setupViewConstraintsForController:_controller];
-      }
+  if (self.window != nil && _controller.parentViewController == nil) {
+    BOOL mountResult = [RNSContainerHelpers addChildViewController:_controller
+                                          toViewControllerManaging:self.reactSuperview
+                                                 withContainerView:self];
+    if (mountResult) {
+      [self setupViewConstraintsForController:_controller];
     }
-
-    [_controller attachToParentContainerItem];
-  } else {
-    [_controller detachFromParentContainerItem];
   }
 }
 

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -116,13 +116,19 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
-  if (self.window != nil && _controller.parentViewController == nil) {
-    BOOL mountResult = [RNSContainerHelpers addChildViewController:_controller
-                                          toViewControllerManaging:self.reactSuperview
-                                                 withContainerView:self];
-    if (mountResult) {
-      [self setupViewConstraintsForController:_controller];
+  if (self.window != nil) {
+    if (_controller.parentViewController == nil) {
+      BOOL mountResult = [RNSContainerHelpers addChildViewController:_controller
+                                            toViewControllerManaging:self.reactSuperview
+                                                   withContainerView:self];
+      if (mountResult) {
+        [self setupViewConstraintsForController:_controller];
+      }
     }
+
+    [_controller attachToParentContainerItem];
+  } else {
+    [_controller detachFromParentContainerItem];
   }
 }
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -92,4 +92,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark - Content scroll view
+
+@interface RNSTabsScreenComponentView ()
+
+/**
+ * Content scroll view registered by a descendant `RNSScrollViewMarkerComponentView`, or nil if
+ * none has been registered. Queried by the owning controller (`RNSContainerItem`).
+ */
+- (nullable UIScrollView *)cachedContentScrollView;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -36,6 +36,11 @@ namespace react = facebook::react;
 
   RNSTabsScreenEventEmitter *_Nonnull _reactEventEmitter;
 
+  // Content scroll view registered by a descendant `RNSScrollViewMarkerComponentView`. Queried by
+  // the owning `RNSTabsScreenViewController` (as `RNSContainerItem`) when resolving the content
+  // scroll view for special effects.
+  __weak UIScrollView *_Nullable _contentScrollView;
+
   // We need this information to warn users about dynamic changes to behavior being currently unsupported.
   BOOL _isOverrideScrollViewContentInsetAdjustmentBehaviorSet;
   // Tracks that the first child was mounted before props were set.
@@ -119,9 +124,17 @@ RNS_IGNORE_SUPER_CALL_END
 #if RNS_GAMMA_ENABLED
 - (void)registerDescendantScrollView:(UIScrollView *)scrollView fromMarker:(RNSScrollViewMarkerComponentView *)marker
 {
+  // Native iOS-26 scroll-edge behavior (status-bar tap scroll-to-top, scroll edge appearance).
   [_controller setContentScrollView:scrollView forEdge:NSDirectionalRectEdgeAll];
+  // Cache used by the container-nesting content-scroll-view resolution.
+  _contentScrollView = scrollView;
 }
 #endif // RNS_GAMMA_ENABLED
+
+- (nullable UIScrollView *)cachedContentScrollView
+{
+  return _contentScrollView;
+}
 
 #pragma mark - Events
 

--- a/ios/tabs/screen/RNSTabsScreenViewController.h
+++ b/ios/tabs/screen/RNSTabsScreenViewController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+#import "RNSContainerItem.h"
 #import "RNSTabsScreenComponentView.h"
 #import "RNSTabsSpecialEffectsSupporting.h"
 
@@ -10,10 +11,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNSTabsScreenViewController : UIViewController
+@interface RNSTabsScreenViewController : UIViewController <RNSContainerItem
 #if !TARGET_OS_TV
-                                         <RNSOrientationProviding>
+                                                           ,
+                                                           RNSOrientationProviding
 #endif // !TARGET_OS_TV
+                                                           >
 
 @property (nonatomic, strong, readonly, nullable) RNSTabsScreenComponentView *tabScreenComponentView;
 @property (nonatomic, weak, readonly, nullable) id<RNSTabsSpecialEffectsSupporting> tabsSpecialEffectsDelegate;

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -1,10 +1,21 @@
 #import "RNSTabsScreenViewController.h"
+#import "RNSContainer.h"
+#import "RNSContainerItemSupport.h"
 #import "RNSLog.h"
-#import "RNSScrollViewFinder.h"
 #import "RNSTabBarController.h"
 #import "UIScrollView+RNScreens.h"
 
-@implementation RNSTabsScreenViewController
+@implementation RNSTabsScreenViewController {
+  RNSContainerItemSupport *_Nonnull _containerItemSupport;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _containerItemSupport = [RNSContainerItemSupport new];
+  }
+  return self;
+}
 
 - (nullable RNSTabBarController *)findTabBarController
 {
@@ -105,13 +116,31 @@
 
 - (nullable UIScrollView *)resolveContentScrollView
 {
-  if (auto sv = [self contentScrollViewForEdge:NSDirectionalRectEdgeBottom]; sv != nil) {
-    return sv;
-  }
-  if (auto sv = [self contentScrollViewForEdge:NSDirectionalRectEdgeTop]; sv != nil) {
-    return sv;
-  }
-  return [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:[self tabScreenComponentView]];
+  return [self findContentScrollView];
+}
+
+#pragma mark - RNSContainerItem
+
+- (void)registerNestedContainer:(id<RNSContainer>)container
+{
+  [_containerItemSupport registerNestedContainer:container];
+}
+
+- (void)unregisterNestedContainer:(id<RNSContainer>)container
+{
+  [_containerItemSupport unregisterNestedContainer:container];
+}
+
+- (nullable id<RNSContainer>)resolveNestedContainer
+{
+  return [_containerItemSupport resolveNestedContainer];
+}
+
+- (nullable UIScrollView *)findContentScrollView
+{
+  return [_containerItemSupport
+      findContentScrollViewWithCachedScrollView:[self.tabScreenComponentView cachedContentScrollView]
+                                  heuristicRoot:self.tabScreenComponentView];
 }
 
 #if !TARGET_OS_TV

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -108,15 +108,10 @@
   if ([self tabsSpecialEffectsDelegate] != nil) {
     return [[self tabsSpecialEffectsDelegate] onRepeatedTabSelectionOfTabScreenController:self];
   } else if (self.tabScreenComponentView.shouldUseRepeatedTabSelectionScrollToTopSpecialEffect) {
-    return [[self resolveContentScrollView] rnscreens_scrollToTop];
+    return [[self findContentScrollView] rnscreens_scrollToTop];
   }
 
   return false;
-}
-
-- (nullable UIScrollView *)resolveContentScrollView
-{
-  return [self findContentScrollView];
 }
 
 #pragma mark - RNSContainerItem


### PR DESCRIPTION
## Description

Port the container-nesting protocol from Android to iOS so nesting information
propagates between containers, and use it to resolve the content scroll view for
special effects (e.g. scroll-to-top) across a nesting boundary.

On iOS the protocol is expressed at the view-controller level, mirroring the
Android side. Shared state/logic lives in two composition holders:
`RNSContainerItemSupport` (item side) and `RNSParentContainerItemRegistry`
(container side).

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1573
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1424

## Changes

- Introduce the `RNSContainer` and `RNSContainerItem` protocols and the two
  composition holders (`RNSContainerItemSupport`, `RNSParentContainerItemRegistry`)
  mirroring the Android implementation.
- `RNSStackNavigationController` and `RNSTabBarController` adopt `RNSContainer`
  and self-register / unregister with the nearest parent `RNSContainerItem` from
  their own `didMoveToParentViewController:` lifecycle (i.e. as the container is
  added to / removed from the view-controller hierarchy). The host views only
  mount the controller.
- `RNSStackScreenController` and `RNSTabsScreenViewController` adopt
  `RNSContainerItem`. Content-scroll-view resolution now follows
  cached -> nested container -> descendant-chain heuristic.
- The parent walk follows the view-controller containment chain
  (`parentViewController`) upwards to the nearest `RNSContainerItem`.
- `RNSTabsScreenViewController.resolveContentScrollView` delegates to
  `findContentScrollView`, removing the duplicated edge / heuristic lookup.
- Wire the stack screen's content scroll view via `setContentScrollView:forEdge:`
  (native `UINavigationBar` scroll edge appearance, top-screen-tap scroll-to-top
  on iPad), matching the tabs screen.

## Before & after - visual documentation

There is no change in behaviour. It should work correctly right now, just not "by accident". 

## Test plan

Use the `test-stack-svm-tabs-special-effects` to confirm that indeed, special effects now do work in nested container scenario, even when the "standard UIKit heuristic" is broken. 

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
