### PR TITLE
feat(Android, Stack v5): add support for groups in toolbar menu

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -300,6 +300,17 @@ internal class StackHeaderApplicator(
         }
     }
 
+    /**
+     * Recursively traverses menu elements and maps user-friendly string item IDs to integers
+     * expected by Android.
+     *
+     * @param elements List of menu elements.
+     * @param forwardIdMap Reference to String->Int ID map to which ID entries will be added.
+     * @param reverseIdMap Reference to Int->String ID map to which ID entries will be added.
+     * @param nextId Function that returns next ID integer. New unique integer should be returned
+     *               each time the function is called. The function is used to handle recursive
+     *               element traversal.
+     */
     private fun assignElementIds(
         elements: List<StackHeaderToolbarMenuElementConfig>,
         forwardIdMap: MutableMap<String, Int>,
@@ -319,6 +330,17 @@ internal class StackHeaderApplicator(
         }
     }
 
+    /**
+     * Recursively traverses menu elements and maps user-friendly string group IDs to integers
+     * expected by Android.
+     *
+     * @param elements List of menu elements.
+     * @param forwardIdMap Reference to String->Int ID map to which ID entries will be added.
+     * @param reverseIdMap Reference to Int->String ID map to which ID entries will be added.
+     * @param nextId Function that returns next ID integer. New unique integer should be returned
+     *               each time the function is called. The function is used to handle recursive
+     *               element traversal.
+     */
     private fun assignGroupIds(
         menuConfig: StackHeaderToolbarMenuConfig,
         forwardMap: MutableMap<String, Int>,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header
 
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.text.TextUtils
 import android.util.Log
 import android.view.Gravity
@@ -279,6 +280,27 @@ internal class StackHeaderApplicator(
         )
     }
 
+    fun validateRadioInitialSelection(menuConfig: StackHeaderToolbarMenuConfig) {
+        for (group in menuConfig.groups) {
+            if (!group.singleSelection) continue
+            var count = 0
+            for (element in menuConfig.children) {
+                if (element.item.groupId == group.groupId && element.item.initialToggleState) {
+                    count++
+                }
+            }
+            require(count <= 1) {
+                "[RNScreens] Radio group '${group.groupId}' has $count items with " +
+                    "initialToggleState=true. At most 1 is allowed for single-selection groups."
+            }
+        }
+        for (element in menuConfig.children) {
+            if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
+                validateRadioInitialSelection(element.menu)
+            }
+        }
+    }
+
     private fun assignElementIds(
         elements: List<StackHeaderToolbarMenuElementConfig>,
         forwardIdMap: MutableMap<String, Int>,
@@ -286,6 +308,9 @@ internal class StackHeaderApplicator(
         nextId: () -> Int,
     ) {
         for (element in elements) {
+            require(element.item.id !in forwardIdMap) {
+                "[RNScreens] Duplicate toolbar menu item id: '${element.item.id}'. Item IDs must be unique across the entire menu."
+            }
             val nativeId = nextId()
             forwardIdMap[element.item.id] = nativeId
             reverseIdMap[nativeId] = element.item.id
@@ -302,11 +327,12 @@ internal class StackHeaderApplicator(
         nextId: () -> Int,
     ) {
         for (group in menuConfig.groups) {
-            if (group.groupId !in forwardMap) {
-                val nativeId = nextId()
-                forwardMap[group.groupId] = nativeId
-                reverseMap[nativeId] = group.groupId
+            require(group.groupId !in forwardMap) {
+                "[RNScreens] Duplicate toolbar menu group id: '${group.groupId}'. Group IDs must be unique across the entire menu."
             }
+            val nativeId = nextId()
+            forwardMap[group.groupId] = nativeId
+            reverseMap[nativeId] = group.groupId
         }
         for (element in menuConfig.children) {
             if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
@@ -321,12 +347,18 @@ internal class StackHeaderApplicator(
         groupSingleSelection: MutableMap<String, Boolean>,
         groupMemberItems: MutableMap<String, MutableList<String>>,
     ) {
+        val localGroupIds = config.groups.map { it.groupId }.toSet()
         for (group in config.groups) {
             groupSingleSelection[group.groupId] = group.singleSelection
             groupMemberItems.getOrPut(group.groupId) { mutableListOf() }
         }
         for (element in config.children) {
             element.item.groupId?.let { gid ->
+                require(gid in localGroupIds) {
+                    "[RNScreens] Menu item '${element.item.id}' references group '$gid' " +
+                        "which is not defined at the same menu level. " +
+                        "Groups cannot span submenus."
+                }
                 itemGroupMap[element.item.id] = gid
                 groupMemberItems.getOrPut(gid) { mutableListOf() }.add(element.item.id)
             }
@@ -342,18 +374,18 @@ internal class StackHeaderApplicator(
         forwardIdMap: Map<String, Int>,
         reverseIdMap: Map<Int, String>,
         forwardGroupIdMap: Map<String, Int>,
-        onItemClicked: (id: String) -> Unit,
-        onGroupSelectionChanged: (itemId: String) -> Unit,
+        groupDividerEnabled: Boolean,
+        onItemClicked: (id: String, menuItem: MenuItem) -> Unit,
     ) {
         toolbar.menu.clear()
         addElements(toolbar, toolbar.menu, menuConfig, forwardIdMap, forwardGroupIdMap)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            toolbar.menu.setGroupDividerEnabled(groupDividerEnabled)
+        }
         toolbar.setOnMenuItemClickListener { menuItem ->
             val stringId = reverseIdMap[menuItem.itemId]
             if (stringId != null) {
-                onItemClicked(stringId)
-                if (menuItem.isCheckable && menuItem.groupId != Menu.NONE) {
-                    onGroupSelectionChanged(stringId)
-                }
+                onItemClicked(stringId, menuItem)
             }
             true
         }
@@ -408,7 +440,13 @@ internal class StackHeaderApplicator(
     ) {
         val shouldBeCheckable =
             when (itemConfig.itemType) {
-                StackHeaderToolbarMenuItemType.TOGGLE -> true
+                StackHeaderToolbarMenuItemType.TOGGLE -> {
+                    require(itemConfig.groupId != null) {
+                        "[RNScreens] Menu item '${itemConfig.id}' has itemType=TOGGLE but no groupId. " +
+                            "Toggle items must belong to a group."
+                    }
+                    true
+                }
                 StackHeaderToolbarMenuItemType.AUTOMATIC -> itemConfig.groupId != null
                 StackHeaderToolbarMenuItemType.ACTION -> false
             }
@@ -440,7 +478,10 @@ internal class StackHeaderApplicator(
         options.title?.let { menuItem.title = it }
         options.hidden?.let { menuItem.isVisible = !it }
         options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
-        options.checked?.let { menuItem.isChecked = it }
+
+        // checked is intentionally not handled here. The coordinator layout manages it in
+        // handleGroupItemStateChange because toggling checked state requires group metadata
+        // (radio vs checkbox) and may emit onGroupSelectionChanged events.
 
         options.icon?.let {
             when (it) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -260,12 +260,11 @@ internal class StackHeaderApplicator(
         return Pair(forwardIdMap.toMap(), reverseIdMap.toMap())
     }
 
-    fun generateToolbarMenuGroupMappings(menuConfig: StackHeaderToolbarMenuConfig): Pair<Map<String, Int>, Map<Int, String>> {
+    fun generateToolbarMenuGroupMappings(menuConfig: StackHeaderToolbarMenuConfig): Map<String, Int> {
         val forwardGroupIdMap = mutableMapOf<String, Int>()
-        val reverseGroupIdMap = mutableMapOf<Int, String>()
         var counter = 1
-        assignGroupIds(menuConfig, forwardGroupIdMap, reverseGroupIdMap) { counter++ }
-        return Pair(forwardGroupIdMap.toMap(), reverseGroupIdMap.toMap())
+        assignGroupIds(menuConfig, forwardGroupIdMap) { counter++ }
+        return forwardGroupIdMap.toMap()
     }
 
     fun computeGroupMetadata(menuConfig: StackHeaderToolbarMenuConfig): StackHeaderToolbarMenuGroupMetadata {
@@ -323,20 +322,17 @@ internal class StackHeaderApplicator(
     private fun assignGroupIds(
         menuConfig: StackHeaderToolbarMenuConfig,
         forwardMap: MutableMap<String, Int>,
-        reverseMap: MutableMap<Int, String>,
         nextId: () -> Int,
     ) {
         for (group in menuConfig.groups) {
             require(group.groupId !in forwardMap) {
                 "[RNScreens] Duplicate toolbar menu group id: '${group.groupId}'. Group IDs must be unique across the entire menu."
             }
-            val nativeId = nextId()
-            forwardMap[group.groupId] = nativeId
-            reverseMap[nativeId] = group.groupId
+            forwardMap[group.groupId] = nextId()
         }
         for (element in menuConfig.children) {
             if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
-                assignGroupIds(element.menu, forwardMap, reverseMap, nextId)
+                assignGroupIds(element.menu, forwardMap, nextId)
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -378,7 +378,7 @@ internal class StackHeaderApplicator(
                         "Groups cannot span submenus."
                 }
                 itemGroupMap[element.item.id] = gid
-                groupMemberItems.getOrPut(gid) { mutableListOf() }.add(element.item.id)
+                groupMemberItems[gid]!!.add(element.item.id)
             }
             if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
                 collectGroupMetadata(element.menu, itemGroupMap, groupSingleSelection, groupMemberItems)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -31,8 +31,11 @@ import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfiguratio
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupMetadata
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
 import com.swmansion.rnscreens.utils.resolveDrawableAttr
 
@@ -256,6 +259,26 @@ internal class StackHeaderApplicator(
         return Pair(forwardIdMap.toMap(), reverseIdMap.toMap())
     }
 
+    fun generateToolbarMenuGroupMappings(menuConfig: StackHeaderToolbarMenuConfig): Pair<Map<String, Int>, Map<Int, String>> {
+        val forwardGroupIdMap = mutableMapOf<String, Int>()
+        val reverseGroupIdMap = mutableMapOf<Int, String>()
+        var counter = 1
+        assignGroupIds(menuConfig, forwardGroupIdMap, reverseGroupIdMap) { counter++ }
+        return Pair(forwardGroupIdMap.toMap(), reverseGroupIdMap.toMap())
+    }
+
+    fun computeGroupMetadata(menuConfig: StackHeaderToolbarMenuConfig): StackHeaderToolbarMenuGroupMetadata {
+        val itemGroupMap = mutableMapOf<String, String>()
+        val groupSingleSelection = mutableMapOf<String, Boolean>()
+        val groupMemberItems = mutableMapOf<String, MutableList<String>>()
+        collectGroupMetadata(menuConfig, itemGroupMap, groupSingleSelection, groupMemberItems)
+        return StackHeaderToolbarMenuGroupMetadata(
+            itemGroupMap,
+            groupSingleSelection,
+            groupMemberItems.mapValues { it.value.toList() },
+        )
+    }
+
     private fun assignElementIds(
         elements: List<StackHeaderToolbarMenuElementConfig>,
         forwardIdMap: MutableMap<String, Int>,
@@ -272,17 +295,66 @@ internal class StackHeaderApplicator(
         }
     }
 
+    private fun assignGroupIds(
+        menuConfig: StackHeaderToolbarMenuConfig,
+        forwardMap: MutableMap<String, Int>,
+        reverseMap: MutableMap<Int, String>,
+        nextId: () -> Int,
+    ) {
+        for (group in menuConfig.groups) {
+            if (group.groupId !in forwardMap) {
+                val nativeId = nextId()
+                forwardMap[group.groupId] = nativeId
+                reverseMap[nativeId] = group.groupId
+            }
+        }
+        for (element in menuConfig.children) {
+            if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
+                assignGroupIds(element.menu, forwardMap, reverseMap, nextId)
+            }
+        }
+    }
+
+    private fun collectGroupMetadata(
+        config: StackHeaderToolbarMenuConfig,
+        itemGroupMap: MutableMap<String, String>,
+        groupSingleSelection: MutableMap<String, Boolean>,
+        groupMemberItems: MutableMap<String, MutableList<String>>,
+    ) {
+        for (group in config.groups) {
+            groupSingleSelection[group.groupId] = group.singleSelection
+            groupMemberItems.getOrPut(group.groupId) { mutableListOf() }
+        }
+        for (element in config.children) {
+            element.item.groupId?.let { gid ->
+                itemGroupMap[element.item.id] = gid
+                groupMemberItems.getOrPut(gid) { mutableListOf() }.add(element.item.id)
+            }
+            if (element is StackHeaderToolbarMenuElementConfig.Submenu) {
+                collectGroupMetadata(element.menu, itemGroupMap, groupSingleSelection, groupMemberItems)
+            }
+        }
+    }
+
     fun rebuildToolbarMenu(
         toolbar: MaterialToolbar,
         menuConfig: StackHeaderToolbarMenuConfig,
         forwardIdMap: Map<String, Int>,
         reverseIdMap: Map<Int, String>,
+        forwardGroupIdMap: Map<String, Int>,
         onItemClicked: (id: String) -> Unit,
+        onGroupSelectionChanged: (itemId: String) -> Unit,
     ) {
         toolbar.menu.clear()
-        addElements(toolbar, toolbar.menu, menuConfig.children, forwardIdMap)
+        addElements(toolbar, toolbar.menu, menuConfig, forwardIdMap, forwardGroupIdMap)
         toolbar.setOnMenuItemClickListener { menuItem ->
-            reverseIdMap[menuItem.itemId]?.let(onItemClicked)
+            val stringId = reverseIdMap[menuItem.itemId]
+            if (stringId != null) {
+                onItemClicked(stringId)
+                if (menuItem.isCheckable && menuItem.groupId != Menu.NONE) {
+                    onGroupSelectionChanged(stringId)
+                }
+            }
             true
         }
     }
@@ -290,25 +362,59 @@ internal class StackHeaderApplicator(
     private fun addElements(
         toolbar: MaterialToolbar,
         menu: Menu,
-        elements: List<StackHeaderToolbarMenuElementConfig>,
+        menuConfig: StackHeaderToolbarMenuConfig,
         forwardIdMap: Map<String, Int>,
+        forwardGroupIdMap: Map<String, Int>,
     ) {
-        elements.forEachIndexed { index, element ->
+        menuConfig.children.forEachIndexed { index, element ->
             val itemId =
                 requireNotNull(forwardIdMap[element.item.id]) {
                     "[RNScreens] Invalid forwardIdMap received. Missing item: ${element.item}."
                 }
+            val groupIntId =
+                element.item.groupId
+                    ?.let { forwardGroupIdMap[it] ?: Menu.NONE }
+                    ?: Menu.NONE
             when (element) {
                 is StackHeaderToolbarMenuElementConfig.MenuItem -> {
-                    val menuItem = menu.add(Menu.NONE, itemId, index, null)
+                    val menuItem = menu.add(groupIntId, itemId, index, null)
                     applyMenuItemOptions(toolbar, menuItem, element.item.toOptions())
+                    applyCheckability(menuItem, element.item)
                 }
                 is StackHeaderToolbarMenuElementConfig.Submenu -> {
-                    val subMenu = menu.addSubMenu(Menu.NONE, itemId, index, null)
+                    val subMenu = menu.addSubMenu(groupIntId, itemId, index, null)
                     applyMenuItemOptions(toolbar, subMenu.item, element.item.toOptions())
-                    addElements(toolbar, subMenu, element.menu.children, forwardIdMap)
+                    addElements(toolbar, subMenu, element.menu, forwardIdMap, forwardGroupIdMap)
                 }
             }
+        }
+        configureGroupCheckability(menu, menuConfig.groups, forwardGroupIdMap)
+    }
+
+    private fun configureGroupCheckability(
+        menu: Menu,
+        groups: List<StackHeaderToolbarMenuGroupConfig>,
+        forwardGroupIdMap: Map<String, Int>,
+    ) {
+        for (group in groups) {
+            val groupIntId = forwardGroupIdMap[group.groupId] ?: continue
+            menu.setGroupCheckable(groupIntId, true, group.singleSelection)
+        }
+    }
+
+    private fun applyCheckability(
+        menuItem: MenuItem,
+        itemConfig: StackHeaderToolbarMenuItemConfig,
+    ) {
+        val shouldBeCheckable =
+            when (itemConfig.itemType) {
+                StackHeaderToolbarMenuItemType.TOGGLE -> true
+                StackHeaderToolbarMenuItemType.AUTOMATIC -> itemConfig.groupId != null
+                StackHeaderToolbarMenuItemType.ACTION -> false
+            }
+        if (shouldBeCheckable) {
+            menuItem.isCheckable = true
+            menuItem.isChecked = itemConfig.initialToggleState
         }
     }
 
@@ -334,6 +440,7 @@ internal class StackHeaderApplicator(
         options.title?.let { menuItem.title = it }
         options.hidden?.let { menuItem.isVisible = !it }
         options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
+        options.checked?.let { menuItem.isChecked = it }
 
         options.icon?.let {
             when (it) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -448,7 +448,13 @@ internal class StackHeaderApplicator(
                     true
                 }
                 StackHeaderToolbarMenuItemType.AUTOMATIC -> itemConfig.groupId != null
-                StackHeaderToolbarMenuItemType.ACTION -> false
+                StackHeaderToolbarMenuItemType.ACTION -> {
+                    require(itemConfig.groupId == null) {
+                        "[RNScreens] Menu item '${itemConfig.id}' has itemType=ACTION " +
+                            "and belongs to a group. Action items cannot belong to groups."
+                    }
+                    false
+                }
             }
         if (shouldBeCheckable) {
             menuItem.isCheckable = true

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -218,7 +218,7 @@ internal class StackHeaderCoordinatorLayout(
                     applicator.generateToolbarMenuItemMappings(
                         provider.toolbarMenu,
                     )
-                val (forwardGroupIdMap, _) =
+                val forwardGroupIdMap =
                     applicator.generateToolbarMenuGroupMappings(
                         provider.toolbarMenu,
                     )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Build
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.activity.OnBackPressedDispatcherOwner
@@ -10,12 +11,14 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.facebook.react.bridge.ReactContext
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.MaterialToolbar
 import com.swmansion.rnscreens.gamma.stack.header.config.OnHeaderConfigurationAttachListener
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfigurationObserver
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfigurationProviding
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderDelegate
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderInvalidationFlags
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewProviding
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupMetadata
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.screen.StackScreen
 
@@ -69,6 +72,21 @@ internal class StackHeaderCoordinatorLayout(
             ) {
                 val toolbar = appBarLayout?.toolbar ?: return
                 applicator.updateToolbarMenuItem(toolbar, toolbarMenuForwardIdMap, id, options)
+
+                val checked = options.checked ?: return
+                val groupId = toolbarMenuGroupMetadata.itemGroupMap[id] ?: return
+                val singleSelection = toolbarMenuGroupMetadata.groupSingleSelection[groupId] ?: return
+
+                if (singleSelection && checked) {
+                    for (memberId in toolbarMenuGroupMetadata.groupMemberItems[groupId].orEmpty()) {
+                        if (memberId != id) {
+                            val intId = toolbarMenuForwardIdMap[memberId] ?: continue
+                            toolbar.menu.findItem(intId)?.isChecked = false
+                        }
+                    }
+                }
+
+                emitGroupSelectionChange(toolbar, id)
             }
         }
 
@@ -160,6 +178,7 @@ internal class StackHeaderCoordinatorLayout(
     private var appBarLayout: StackHeaderAppBarLayout? = null
 
     private var toolbarMenuForwardIdMap = emptyMap<String, Int>()
+    private var toolbarMenuGroupMetadata = StackHeaderToolbarMenuGroupMetadata.EMPTY
 
     private val onNavigationIconClick: () -> Unit = {
         val activity =
@@ -211,16 +230,31 @@ internal class StackHeaderCoordinatorLayout(
                     applicator.generateToolbarMenuItemMappings(
                         provider.toolbarMenu,
                     )
+                val (forwardGroupIdMap, _) =
+                    applicator.generateToolbarMenuGroupMappings(
+                        provider.toolbarMenu,
+                    )
+                val groupMetadata =
+                    applicator.computeGroupMetadata(
+                        provider.toolbarMenu,
+                    )
 
                 applicator.rebuildToolbarMenu(
                     appBar.toolbar,
                     provider.toolbarMenu,
                     forwardIdMap,
                     reverseIdMap,
-                ) { id -> currentDelegate?.onMenuItemClicked(id) }
+                    forwardGroupIdMap,
+                    onItemClicked = { id -> currentDelegate?.onMenuItemClicked(id) },
+                    onGroupSelectionChanged = { itemId -> emitGroupSelectionChange(appBar.toolbar, itemId) },
+                )
 
-                // We only need to keep forward map for view commands.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    appBar.toolbar.menu.setGroupDividerEnabled(provider.toolbarMenuGroupDividerEnabled)
+                }
+
                 toolbarMenuForwardIdMap = forwardIdMap
+                toolbarMenuGroupMetadata = groupMetadata
 
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TOOLBAR_MENU)
             }
@@ -228,6 +262,31 @@ internal class StackHeaderCoordinatorLayout(
 
         onMaybeHeaderLayoutChanged()
     }
+
+    // endregion
+
+    // region Group selection
+
+    private fun emitGroupSelectionChange(
+        toolbar: MaterialToolbar,
+        itemId: String,
+    ) {
+        val groupId = toolbarMenuGroupMetadata.itemGroupMap[itemId] ?: return
+        val selectedIds = collectSelectedIds(toolbar, groupId)
+        currentDelegate?.onGroupSelectionChanged(groupId, selectedIds)
+    }
+
+    private fun collectSelectedIds(
+        toolbar: MaterialToolbar,
+        groupId: String,
+    ): List<String> =
+        toolbarMenuGroupMetadata
+            .groupMemberItems[groupId]
+            .orEmpty()
+            .filter { memberId ->
+                val intId = toolbarMenuForwardIdMap[memberId] ?: return@filter false
+                toolbar.menu.findItem(intId)?.isChecked == true
+            }
 
     // endregion
 
@@ -240,6 +299,7 @@ internal class StackHeaderCoordinatorLayout(
         }
         appBarLayout = null
         toolbarMenuForwardIdMap = emptyMap()
+        toolbarMenuGroupMetadata = StackHeaderToolbarMenuGroupMetadata.EMPTY
     }
 
     private fun removeHeader() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
+import android.util.Log
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.activity.OnBackPressedDispatcherOwner
@@ -72,21 +72,9 @@ internal class StackHeaderCoordinatorLayout(
             ) {
                 val toolbar = appBarLayout?.toolbar ?: return
                 applicator.updateToolbarMenuItem(toolbar, toolbarMenuForwardIdMap, id, options)
-
-                val checked = options.checked ?: return
-                val groupId = toolbarMenuGroupMetadata.itemGroupMap[id] ?: return
-                val singleSelection = toolbarMenuGroupMetadata.groupSingleSelection[groupId] ?: return
-
-                if (singleSelection && checked) {
-                    for (memberId in toolbarMenuGroupMetadata.groupMemberItems[groupId].orEmpty()) {
-                        if (memberId != id) {
-                            val intId = toolbarMenuForwardIdMap[memberId] ?: continue
-                            toolbar.menu.findItem(intId)?.isChecked = false
-                        }
-                    }
+                if (options.checked != null) {
+                    handleGroupItemStateChange(toolbar, id, options.checked)
                 }
-
-                emitGroupSelectionChange(toolbar, id)
             }
         }
 
@@ -239,22 +227,26 @@ internal class StackHeaderCoordinatorLayout(
                         provider.toolbarMenu,
                     )
 
+                applicator.validateRadioInitialSelection(provider.toolbarMenu)
+
+                toolbarMenuForwardIdMap = forwardIdMap
+                toolbarMenuGroupMetadata = groupMetadata
+
                 applicator.rebuildToolbarMenu(
                     appBar.toolbar,
                     provider.toolbarMenu,
                     forwardIdMap,
                     reverseIdMap,
                     forwardGroupIdMap,
-                    onItemClicked = { id -> currentDelegate?.onMenuItemClicked(id) },
-                    onGroupSelectionChanged = { itemId -> emitGroupSelectionChange(appBar.toolbar, itemId) },
+                    groupDividerEnabled = provider.toolbarMenuGroupDividerEnabled,
+                    onItemClicked = { id, menuItem ->
+                        if (menuItem.isCheckable) {
+                            handleGroupItemStateChange(appBar.toolbar, id)
+                        } else {
+                            currentDelegate?.onMenuItemClicked(id)
+                        }
+                    },
                 )
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    appBar.toolbar.menu.setGroupDividerEnabled(provider.toolbarMenuGroupDividerEnabled)
-                }
-
-                toolbarMenuForwardIdMap = forwardIdMap
-                toolbarMenuGroupMetadata = groupMetadata
 
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TOOLBAR_MENU)
             }
@@ -267,11 +259,34 @@ internal class StackHeaderCoordinatorLayout(
 
     // region Group selection
 
-    private fun emitGroupSelectionChange(
+    private fun handleGroupItemStateChange(
         toolbar: MaterialToolbar,
         itemId: String,
+        explicitCheckedValue: Boolean? = null,
     ) {
         val groupId = toolbarMenuGroupMetadata.itemGroupMap[itemId] ?: return
+        val singleSelection = toolbarMenuGroupMetadata.groupSingleSelection[groupId] ?: return
+        val intId = toolbarMenuForwardIdMap[itemId] ?: return
+        val menuItem = toolbar.menu.findItem(intId) ?: return
+
+        if (singleSelection && explicitCheckedValue == false) {
+            Log.w(
+                TAG,
+                "[RNScreens] Cannot uncheck item '$itemId' in single-selection group '$groupId'. " +
+                    "Check a different item instead.",
+            )
+            return
+        }
+
+        val newChecked =
+            if (singleSelection) {
+                true
+            } else {
+                explicitCheckedValue ?: !menuItem.isChecked
+            }
+        if (menuItem.isChecked == newChecked) return
+        menuItem.isChecked = newChecked
+
         val selectedIds = collectSelectedIds(toolbar, groupId)
         currentDelegate?.onGroupSelectionChanged(groupId, selectedIds)
     }
@@ -376,4 +391,8 @@ internal class StackHeaderCoordinatorLayout(
     }
 
     // endregion
+
+    companion object {
+        private const val TAG = "StackHeaderCoordinatorLayout"
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -140,9 +140,14 @@ internal class StackHeaderConfig(
         internal set
 
     override var toolbarMenu: StackHeaderToolbarMenuConfig
-        by Delegates.observable(StackHeaderToolbarMenuConfig(emptyList())) { _, old, new ->
+        by Delegates.observable(StackHeaderToolbarMenuConfig(emptyList(), emptyList())) { _, old, new ->
             if (old != new) invalidate(StackHeaderInvalidationFlags.TOOLBAR_MENU)
         }
+        internal set
+
+    override var toolbarMenuGroupDividerEnabled: Boolean by Delegates.observable(false) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TOOLBAR_MENU)
+    }
         internal set
 
     override val isRTL: Boolean
@@ -324,6 +329,13 @@ internal class StackHeaderConfig(
 
     override fun onMenuItemClicked(id: String) {
         eventEmitter.emitOnToolbarMenuItemPress(id)
+    }
+
+    override fun onGroupSelectionChanged(
+        groupId: String,
+        selectedIds: List<String>,
+    ) {
+        eventEmitter.emitOnToolbarMenuGroupSelectionChange(groupId, selectedIds)
     }
 
     override fun onSubviewOriginChanged(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigEventEmitter.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.gamma.stack.header.config
 
 import com.facebook.react.bridge.ReactContext
 import com.swmansion.rnscreens.gamma.common.event.BaseEventEmitter
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.event.StackHeaderToolbarMenuGroupSelectionChangeEvent
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.event.StackHeaderToolbarMenuItemPressEvent
 
 internal class StackHeaderConfigEventEmitter(
@@ -11,6 +12,15 @@ internal class StackHeaderConfigEventEmitter(
     internal fun emitOnToolbarMenuItemPress(id: String) {
         reactEventDispatcher.dispatchEvent(
             StackHeaderToolbarMenuItemPressEvent(surfaceId, viewTag, id),
+        )
+    }
+
+    internal fun emitOnToolbarMenuGroupSelectionChange(
+        groupId: String,
+        selectedIds: List<String>,
+    ) {
+        reactEventDispatcher.dispatchEvent(
+            StackHeaderToolbarMenuGroupSelectionChangeEvent(surfaceId, viewTag, groupId, selectedIds),
         )
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -216,6 +216,13 @@ internal open class StackHeaderConfigViewManager :
         view.scrollFlagSnap = value
     }
 
+    override fun setToolbarMenuGroupDividerEnabled(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.toolbarMenuGroupDividerEnabled = value
+    }
+
     override fun setToolbarMenu(
         view: StackHeaderConfig,
         value: Dynamic,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -227,8 +227,9 @@ internal open class StackHeaderConfigViewManager :
         view: StackHeaderConfig,
         value: Dynamic,
     ) {
-        view.toolbarMenu = StackHeaderToolbarMenuMapper.parseMenu(value)
-        view.toolbarMenuItemIconSourceMap = StackHeaderToolbarMenuMapper.collectIconSources(value)
+        val (menu, iconSources) = StackHeaderToolbarMenuMapper.parseMenu(value)
+        view.toolbarMenu = menu
+        view.toolbarMenuItemIconSourceMap = iconSources
     }
 
     override fun setToolbarMenuItemOptions(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -24,6 +24,7 @@ internal interface StackHeaderConfigurationProviding {
     val trailingSubview: StackHeaderSubviewProviding?
     val backgroundSubview: StackHeaderSubviewProviding?
     val toolbarMenu: StackHeaderToolbarMenuConfig
+    val toolbarMenuGroupDividerEnabled: Boolean
     val isRTL: Boolean
 
     val invalidationFlags: StackHeaderInvalidationFlags

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderDelegate.kt
@@ -11,6 +11,11 @@ internal interface StackHeaderDelegate {
 
     fun onMenuItemClicked(id: String)
 
+    fun onGroupSelectionChanged(
+        groupId: String,
+        selectedIds: List<String>,
+    )
+
     fun onSubviewOriginChanged(
         type: StackHeaderSubviewType,
         x: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuConfig.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Drawable
 // the changed leaf to the root is copied; unchanged subtrees keep their
 // original instances.
 internal data class StackHeaderToolbarMenuConfig(
+    val groups: List<StackHeaderToolbarMenuGroupConfig>,
     val children: List<StackHeaderToolbarMenuElementConfig>,
 ) {
     internal fun updateItemIcon(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuGroupConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuGroupConfig.kt
@@ -1,0 +1,6 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+internal data class StackHeaderToolbarMenuGroupConfig(
+    val groupId: String,
+    val singleSelection: Boolean,
+)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuGroupMetadata.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuGroupMetadata.kt
@@ -1,0 +1,16 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+internal data class StackHeaderToolbarMenuGroupMetadata(
+    val itemGroupMap: Map<String, String>,
+    val groupSingleSelection: Map<String, Boolean>,
+    val groupMemberItems: Map<String, List<String>>,
+) {
+    companion object {
+        val EMPTY =
+            StackHeaderToolbarMenuGroupMetadata(
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+            )
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -12,4 +12,7 @@ internal data class StackHeaderToolbarMenuItemConfig(
     val iconTintColorPressed: Int?,
     val iconTintColorFocused: Int?,
     val iconTintColorDisabled: Int?,
+    val groupId: String?,
+    val itemType: StackHeaderToolbarMenuItemType,
+    val initialToggleState: Boolean,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -17,4 +17,7 @@ internal object StackHeaderToolbarMenuItemDefaults {
     val ICON_TINT_COLOR_DISABLED: Int? = null
     val DRAWABLE_ICON_RESOURCE_NAME: String? = null
     val IMAGE_ICON_URI: String? = null
+    val ITEM_TYPE: StackHeaderToolbarMenuItemType = StackHeaderToolbarMenuItemType.AUTOMATIC
+    const val INITIAL_TOGGLE_STATE: Boolean = false
+    const val SINGLE_SELECTION: Boolean = false
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -16,6 +16,7 @@ internal data class StackHeaderToolbarMenuItemOptions(
     val iconTintColorPressed: StackHeaderToolbarUpdate<Int>?,
     val iconTintColorFocused: StackHeaderToolbarUpdate<Int>?,
     val iconTintColorDisabled: StackHeaderToolbarUpdate<Int>?,
+    val checked: Boolean? = null,
 ) {
     val requiresIconTintColorUpdate: Boolean
         get() =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemType.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemType.kt
@@ -1,0 +1,7 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar
+
+internal enum class StackHeaderToolbarMenuItemType {
+    ACTION,
+    TOGGLE,
+    AUTOMATIC,
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -111,6 +111,7 @@ internal object StackHeaderToolbarMenuMapper {
                     item = item,
                     menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources)),
                 )
+
             else ->
                 throw JSApplicationIllegalArgumentException(
                     "[RNScreens] Unknown toolbar menu element type: $type.",
@@ -134,13 +135,28 @@ internal object StackHeaderToolbarMenuMapper {
             hidden = map.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
             showAsAction = map.readShowAsActionEnum("showAsAction", StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION),
             icon = null,
-            iconTintColorNormal = map.readColor("iconTintColorNormal", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL),
-            iconTintColorPressed = map.readColor("iconTintColorPressed", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED),
-            iconTintColorFocused = map.readColor("iconTintColorFocused", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED),
-            iconTintColorDisabled = map.readColor("iconTintColorDisabled", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED),
+            iconTintColorNormal = map.readColor(
+                "iconTintColorNormal",
+                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL
+            ),
+            iconTintColorPressed = map.readColor(
+                "iconTintColorPressed",
+                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED
+            ),
+            iconTintColorFocused = map.readColor(
+                "iconTintColorFocused",
+                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED
+            ),
+            iconTintColorDisabled = map.readColor(
+                "iconTintColorDisabled",
+                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED
+            ),
             groupId = map.readOptionalString("groupId"),
             itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
-            initialToggleState = map.readBoolean("initialToggleState", StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE),
+            initialToggleState = map.readBoolean(
+                "initialToggleState",
+                StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE
+            ),
         )
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -15,21 +15,16 @@ import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
-    fun parseMenu(value: Dynamic): StackHeaderToolbarMenuConfig {
-        if (value.isNull) return StackHeaderToolbarMenuConfig(emptyList(), emptyList())
+    fun parseMenu(value: Dynamic): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
+        if (value.isNull) return Pair(StackHeaderToolbarMenuConfig(emptyList(), emptyList()), emptyMap())
         val map =
             value.asMapOrNull()
                 ?: throw JSApplicationIllegalArgumentException(
                     "[RNScreens] toolbarMenu must be an object.",
                 )
-        return StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map))
-    }
-
-    fun collectIconSources(value: Dynamic): Map<String, StackHeaderToolbarMenuItemIconSource> {
-        val map = value.asMapOrNull() ?: return emptyMap()
-        val result = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
-        collectIconSourcesFromChildren(map, result)
-        return result
+        val iconSources = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
+        val config = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources))
+        return Pair(config, iconSources)
     }
 
     // endregion
@@ -89,30 +84,48 @@ internal object StackHeaderToolbarMenuMapper {
         }
     }
 
-    private fun parseChildren(map: ReadableMap): List<StackHeaderToolbarMenuElementConfig> {
+    private fun parseChildren(
+        map: ReadableMap,
+        iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
+    ): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
         return (0 until array.size()).map { i ->
             val child =
                 requireNotNull(array.getMap(i)) {
                     "[RNScreens] Menu children array must contain objects."
                 }
-            parseElement(child)
+            parseElement(child, iconSources)
         }
     }
 
-    private fun parseElement(map: ReadableMap): StackHeaderToolbarMenuElementConfig =
-        when (val type = map.readOptionalString("type")) {
-            "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = parseItemConfig(map))
+    private fun parseElement(
+        map: ReadableMap,
+        iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
+    ): StackHeaderToolbarMenuElementConfig {
+        val item = parseItemConfig(map)
+        iconSources[item.id] = parseItemIconSource(map)
+        return when (val type = map.readOptionalString("type")) {
+            "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = item)
             "menu" ->
                 StackHeaderToolbarMenuElementConfig.Submenu(
-                    item = parseItemConfig(map),
-                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map)),
+                    item = item,
+                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources)),
                 )
             else ->
                 throw JSApplicationIllegalArgumentException(
                     "[RNScreens] Unknown toolbar menu element type: $type.",
                 )
         }
+    }
+
+    private fun parseItemIconSource(map: ReadableMap): StackHeaderToolbarMenuItemIconSource =
+        StackHeaderToolbarMenuItemIconSource(
+            drawableIconResourceName =
+                map.getString("drawableIconResourceName")
+                    ?: StackHeaderToolbarMenuItemDefaults.DRAWABLE_ICON_RESOURCE_NAME,
+            imageIconUri =
+                map.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
+        )
 
     private fun parseItemConfig(map: ReadableMap): StackHeaderToolbarMenuItemConfig =
         StackHeaderToolbarMenuItemConfig(
@@ -132,42 +145,13 @@ internal object StackHeaderToolbarMenuMapper {
 
     // endregion
 
-    // region Icon source collection
-
-    private fun collectIconSourcesFromChildren(
-        map: ReadableMap,
-        result: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
-    ) {
-        val array = map.getArray("children") ?: return
-        for (i in 0 until array.size()) {
-            val child = array.getMap(i) ?: continue
-            val type = child.readOptionalString("type") ?: continue
-            val id = child.getString("id") ?: continue
-
-            result[id] =
-                StackHeaderToolbarMenuItemIconSource(
-                    drawableIconResourceName =
-                        child.getString("drawableIconResourceName")
-                            ?: StackHeaderToolbarMenuItemDefaults.DRAWABLE_ICON_RESOURCE_NAME,
-                    imageIconUri =
-                        child.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
-                )
-
-            if (type == "menu") {
-                collectIconSourcesFromChildren(child, result)
-            }
-        }
-    }
-
-    // endregion
-
     // region Enum helpers
 
     private fun ReadableMap.readShowAsActionEnum(
         key: String,
         default: StackHeaderToolbarMenuItemShowAsAction,
     ): StackHeaderToolbarMenuItemShowAsAction {
-        val stringValue = this.getString(key) ?: return default
+        val stringValue = readOptionalString(key) ?: return default
         return toShowAsActionEnum(stringValue)
     }
 
@@ -188,7 +172,7 @@ internal object StackHeaderToolbarMenuMapper {
         key: String,
         default: StackHeaderToolbarMenuItemType,
     ): StackHeaderToolbarMenuItemType {
-        val stringValue = this.getString(key) ?: return default
+        val stringValue = readOptionalString(key) ?: return default
         return toItemTypeEnum(stringValue)
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -16,13 +16,13 @@ internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
     fun parseMenu(value: Dynamic): StackHeaderToolbarMenuConfig {
-        if (value.isNull) return StackHeaderToolbarMenuConfig(emptyList())
+        if (value.isNull) return StackHeaderToolbarMenuConfig(emptyList(), emptyList())
         val map =
             value.asMapOrNull()
                 ?: throw JSApplicationIllegalArgumentException(
                     "[RNScreens] toolbarMenu must be an object.",
                 )
-        return StackHeaderToolbarMenuConfig(parseChildren(map))
+        return StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map))
     }
 
     fun collectIconSources(value: Dynamic): Map<String, StackHeaderToolbarMenuItemIconSource> {
@@ -50,6 +50,11 @@ internal object StackHeaderToolbarMenuMapper {
             iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed"),
             iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused"),
             iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled"),
+            checked =
+                map.readNullableBooleanUpdate(
+                    "checked",
+                    StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE,
+                ),
         )
 
     fun parseMenuItemIconSource(map: ReadableMap): StackHeaderToolbarMenuItemIconSource? {
@@ -65,6 +70,24 @@ internal object StackHeaderToolbarMenuMapper {
     // endregion
 
     // region Menu tree parsing
+
+    private fun parseGroups(map: ReadableMap): List<StackHeaderToolbarMenuGroupConfig> {
+        val array = map.getArray("groups") ?: return emptyList()
+        return (0 until array.size()).map { i ->
+            val group =
+                requireNotNull(array.getMap(i)) {
+                    "[RNScreens] Menu groups array must contain objects."
+                }
+            StackHeaderToolbarMenuGroupConfig(
+                groupId = group.requireNotNullString("groupId"),
+                singleSelection =
+                    group.readBoolean(
+                        "singleSelection",
+                        StackHeaderToolbarMenuItemDefaults.SINGLE_SELECTION,
+                    ),
+            )
+        }
+    }
 
     private fun parseChildren(map: ReadableMap): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
@@ -83,7 +106,7 @@ internal object StackHeaderToolbarMenuMapper {
             "menu" ->
                 StackHeaderToolbarMenuElementConfig.Submenu(
                     item = parseItemConfig(map),
-                    menu = StackHeaderToolbarMenuConfig(parseChildren(map)),
+                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map)),
                 )
             else ->
                 throw JSApplicationIllegalArgumentException(
@@ -102,6 +125,9 @@ internal object StackHeaderToolbarMenuMapper {
             iconTintColorPressed = map.readColor("iconTintColorPressed", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED),
             iconTintColorFocused = map.readColor("iconTintColorFocused", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED),
             iconTintColorDisabled = map.readColor("iconTintColorDisabled", StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED),
+            groupId = map.readOptionalString("groupId"),
+            itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
+            initialToggleState = map.readBoolean("initialToggleState", StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE),
         )
 
     // endregion
@@ -155,6 +181,25 @@ internal object StackHeaderToolbarMenuMapper {
             else ->
                 throw JSApplicationIllegalArgumentException(
                     "[RNScreens] Invalid value for StackHeaderToolbarMenuItemShowAsAction: $value.",
+                )
+        }
+
+    private fun ReadableMap.readItemTypeEnum(
+        key: String,
+        default: StackHeaderToolbarMenuItemType,
+    ): StackHeaderToolbarMenuItemType {
+        val stringValue = this.getString(key) ?: return default
+        return toItemTypeEnum(stringValue)
+    }
+
+    private fun toItemTypeEnum(value: String): StackHeaderToolbarMenuItemType =
+        when (value) {
+            "action" -> StackHeaderToolbarMenuItemType.ACTION
+            "toggle" -> StackHeaderToolbarMenuItemType.TOGGLE
+            "automatic" -> StackHeaderToolbarMenuItemType.AUTOMATIC
+            else ->
+                throw JSApplicationIllegalArgumentException(
+                    "[RNScreens] Invalid value for StackHeaderToolbarMenuItemType: $value.",
                 )
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -135,28 +135,33 @@ internal object StackHeaderToolbarMenuMapper {
             hidden = map.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
             showAsAction = map.readShowAsActionEnum("showAsAction", StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION),
             icon = null,
-            iconTintColorNormal = map.readColor(
-                "iconTintColorNormal",
-                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL
-            ),
-            iconTintColorPressed = map.readColor(
-                "iconTintColorPressed",
-                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED
-            ),
-            iconTintColorFocused = map.readColor(
-                "iconTintColorFocused",
-                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED
-            ),
-            iconTintColorDisabled = map.readColor(
-                "iconTintColorDisabled",
-                StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED
-            ),
+            iconTintColorNormal =
+                map.readColor(
+                    "iconTintColorNormal",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
+                ),
+            iconTintColorPressed =
+                map.readColor(
+                    "iconTintColorPressed",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
+                ),
+            iconTintColorFocused =
+                map.readColor(
+                    "iconTintColorFocused",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
+                ),
+            iconTintColorDisabled =
+                map.readColor(
+                    "iconTintColorDisabled",
+                    StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
+                ),
             groupId = map.readOptionalString("groupId"),
             itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
-            initialToggleState = map.readBoolean(
-                "initialToggleState",
-                StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE
-            ),
+            initialToggleState =
+                map.readBoolean(
+                    "initialToggleState",
+                    StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE,
+                ),
         )
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -71,7 +71,7 @@ internal object StackHeaderToolbarMenuMapper {
         return (0 until array.size()).map { i ->
             val group =
                 requireNotNull(array.getMap(i)) {
-                    "[RNScreens] Menu groups array must contain objects."
+                    "[RNScreens] Menu groups array must contain valid group specification objects."
                 }
             StackHeaderToolbarMenuGroupConfig(
                 groupId = group.requireNotNullString("groupId"),
@@ -92,7 +92,7 @@ internal object StackHeaderToolbarMenuMapper {
         return (0 until array.size()).map { i ->
             val child =
                 requireNotNull(array.getMap(i)) {
-                    "[RNScreens] Menu children array must contain objects."
+                    "[RNScreens] Menu children array must contain valid menu element specification objects."
                 }
             parseElement(child, iconSources)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuGroupSelectionChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/event/StackHeaderToolbarMenuGroupSelectionChangeEvent.kt
@@ -1,0 +1,42 @@
+package com.swmansion.rnscreens.gamma.stack.header.toolbar.event
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.rnscreens.gamma.common.event.NamingAwareEventType
+
+internal class StackHeaderToolbarMenuGroupSelectionChangeEvent(
+    surfaceId: Int,
+    viewTag: Int,
+    private val groupId: String,
+    private val selectedIds: List<String>,
+) : Event<StackHeaderToolbarMenuGroupSelectionChangeEvent>(surfaceId, viewTag),
+    NamingAwareEventType {
+    override fun getEventName() = EVENT_NAME
+
+    override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+
+    override fun canCoalesce(): Boolean = false
+
+    override fun getEventData() =
+        Arguments.createMap().apply {
+            putString(EK_GROUP_ID, groupId)
+            putArray(
+                EK_SELECTED_IDS,
+                Arguments.createArray().apply {
+                    selectedIds.forEach { pushString(it) }
+                },
+            )
+        }
+
+    companion object : NamingAwareEventType {
+        const val EVENT_NAME = "topToolbarMenuGroupSelectionChange"
+        const val EVENT_REGISTRATION_NAME = "onToolbarMenuGroupSelectionChange"
+
+        private const val EK_GROUP_ID = "groupId"
+        private const val EK_SELECTED_IDS = "selectedIds"
+
+        override fun getEventName() = EVENT_NAME
+
+        override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+    }
+}

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -28,8 +28,10 @@ export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
 export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
 export { default as TestStackBackButton } from './test-stack-back-button-android';
 export { default as TestStackToolbarMenuCommands } from './test-stack-toolbar-menu-commands-android';
+export { default as TestStackToolbarMenuGroups } from './test-stack-toolbar-menu-groups-android';
 export { default as TestStackToolbarMenuShowAsAction } from './test-stack-toolbar-menu-show-as-action-android';
 export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-icon-android';
+export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nested-menu-android';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -13,6 +13,7 @@ import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
 import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
 import TestStackToolbarMenuIcon from './test-stack-toolbar-menu-icon-android';
+import TestStackToolbarMenuGroups from './test-stack-toolbar-menu-groups-android';
 import TestStackToolbarNestedMenu from './test-stack-toolbar-nested-menu-android';
 import TestStackHeaderSubviewOnPress from './test-stack-header-subview-onpress-ios';
 
@@ -41,6 +42,7 @@ const scenarios = {
   TestStackHeaderSubviewOnPress,
   TestStackBackButton,
   TestStackToolbarMenuCommands,
+  TestStackToolbarMenuGroups,
   TestStackToolbarMenuShowAsAction,
   TestStackToolbarMenuIcon,
   TestStackToolbarNestedMenu,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -3,10 +3,10 @@
 ## Details
 
 **Description:** This test focuses on the Android toolbar menu items API
-on the gamma stack header — both the `toolbarMenuItems` prop and the
+on the gamma stack header — both the `toolbarMenu` prop and the
 imperative `setToolbarMenuItemOptions(id, options)` command. It verifies
 that the menu renders correctly from props on first mount, that the
-`onToolbarMenuItemClicked` event fires with the correct id, and that
+per-item `onPress` callback fires with the correct id, and that
 imperative commands behave as specified: fields absent from `options`
 preserve their current value, fields set to `undefined` (encoded as
 `null` over the bridge) reset to the prop's regular default (not to the
@@ -36,7 +36,7 @@ Other — automation is not implemented yet.
   currently in the menu (slot excluded via `include: false`, or unknown
   id) must not crash and must not leak state into other items.
 - A props update on any single slot rebuilds the entire
-  `toolbarMenuItems` array, so all command-applied overrides on every
+  `toolbarMenu` children array, so all command-applied overrides on every
   item are dropped at the same time.
 
 ## Steps

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -172,7 +172,7 @@ function buildMenu(
 
 const HEADER_TITLE = 'Toolbar Menu Groups Test';
 
-export function App() {
+function TestStackToolbarMenuGroups() {
   return (
     <ToastProvider>
       <StackContainer
@@ -357,4 +357,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createScenario(App, scenarioDescription);
+export default createScenario(TestStackToolbarMenuGroups, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -5,7 +5,12 @@ import {
   StackContainer,
   useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
-import { SettingsPicker, SettingsSwitch, ToastProvider, useToast } from '@apps/shared';
+import {
+  SettingsPicker,
+  SettingsSwitch,
+  ToastProvider,
+  useToast,
+} from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderConfigRef,
@@ -33,7 +38,11 @@ type CmdTitleOption = 'no change' | 'Changed' | 'undefined';
 type CmdHiddenOption = 'no change' | 'true' | 'false' | 'undefined';
 
 const CMD_CHECKED_OPTIONS: CmdCheckedOption[] = ['no change', 'true', 'false'];
-const CMD_TITLE_OPTIONS: CmdTitleOption[] = ['no change', 'Changed', 'undefined'];
+const CMD_TITLE_OPTIONS: CmdTitleOption[] = [
+  'no change',
+  'Changed',
+  'undefined',
+];
 const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = [
   'no change',
   'true',
@@ -175,7 +184,11 @@ export function App() {
               headerConfig: {
                 title: HEADER_TITLE,
                 android: {
-                  toolbarMenu: buildMenu(DEFAULT_CONFIG, () => {}, () => {}),
+                  toolbarMenu: buildMenu(
+                    DEFAULT_CONFIG,
+                    () => {},
+                    () => {},
+                  ),
                 },
               },
             },
@@ -260,10 +273,7 @@ function MainScreen() {
         title: cmdTitle === 'undefined' ? undefined : cmdTitle,
       }),
       ...(cmdHidden !== 'no change' && {
-        hidden:
-          cmdHidden === 'undefined'
-            ? undefined
-            : cmdHidden === 'true',
+        hidden: cmdHidden === 'undefined' ? undefined : cmdHidden === 'true',
       }),
     };
     headerConfigRef.current?.android?.setToolbarMenuItemOptions(

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -1,0 +1,354 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch, ToastProvider, useToast } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import type {
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuBaseAndroid,
+  StackHeaderToolbarMenuItemOptionsAndroid,
+} from 'react-native-screens/experimental';
+import { scenarioDescription } from './scenario-description';
+
+const ALL_IDS = [
+  'red',
+  'green',
+  'blue',
+  'small',
+  'medium',
+  'large',
+  'share',
+  'light',
+  'dark',
+  'info',
+] as const;
+type AllIds = (typeof ALL_IDS)[number];
+
+type CmdCheckedOption = 'no change' | 'true' | 'false';
+type CmdTitleOption = 'no change' | 'Changed' | 'undefined';
+type CmdHiddenOption = 'no change' | 'true' | 'false' | 'undefined';
+
+const CMD_CHECKED_OPTIONS: CmdCheckedOption[] = ['no change', 'true', 'false'];
+const CMD_TITLE_OPTIONS: CmdTitleOption[] = ['no change', 'Changed', 'undefined'];
+const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = [
+  'no change',
+  'true',
+  'false',
+  'undefined',
+];
+
+interface MenuConfig {
+  singleSelectionOnColors: boolean;
+  includeBlue: boolean;
+  dividerEnabled: boolean;
+}
+
+const DEFAULT_CONFIG: MenuConfig = {
+  singleSelectionOnColors: false,
+  includeBlue: true,
+  dividerEnabled: false,
+};
+
+function buildMenu(
+  config: MenuConfig,
+  onItemPress: (id: string) => void,
+  onGroupChange: (groupId: string, selectedIds: string[]) => void,
+): StackHeaderToolbarMenuBaseAndroid {
+  const colorItems = [
+    {
+      type: 'menuItem' as const,
+      id: 'red',
+      title: 'Red',
+      groupId: 'colors',
+      initialToggleState: true,
+    },
+    {
+      type: 'menuItem' as const,
+      id: 'green',
+      title: 'Green',
+      groupId: 'colors',
+    },
+    ...(config.includeBlue
+      ? [
+          {
+            type: 'menuItem' as const,
+            id: 'blue',
+            title: 'Blue',
+            groupId: 'colors',
+          },
+        ]
+      : []),
+  ];
+
+  return {
+    groups: [
+      {
+        groupId: 'colors',
+        singleSelection: config.singleSelectionOnColors,
+        onSelectionChange: ids => onGroupChange('colors', ids),
+      },
+      {
+        groupId: 'size',
+        singleSelection: true,
+        onSelectionChange: ids => onGroupChange('size', ids),
+      },
+    ],
+    children: [
+      ...colorItems,
+      {
+        type: 'menuItem',
+        id: 'small',
+        title: 'Small',
+        groupId: 'size',
+      },
+      {
+        type: 'menuItem',
+        id: 'medium',
+        title: 'Medium',
+        groupId: 'size',
+        initialToggleState: true,
+      },
+      {
+        type: 'menuItem',
+        id: 'large',
+        title: 'Large',
+        groupId: 'size',
+      },
+      {
+        type: 'menuItem',
+        id: 'share',
+        title: 'Share',
+        onPress: () => onItemPress('share'),
+      },
+      {
+        type: 'menu',
+        id: 'sub',
+        title: 'More',
+        groups: [
+          {
+            groupId: 'theme',
+            singleSelection: true,
+            onSelectionChange: ids => onGroupChange('theme', ids),
+          },
+        ],
+        children: [
+          {
+            type: 'menuItem',
+            id: 'light',
+            title: 'Light',
+            groupId: 'theme',
+            initialToggleState: true,
+          },
+          {
+            type: 'menuItem',
+            id: 'dark',
+            title: 'Dark',
+            groupId: 'theme',
+          },
+          {
+            type: 'menuItem',
+            id: 'info',
+            title: 'Info',
+            onPress: () => onItemPress('info'),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const HEADER_TITLE = 'Toolbar Menu Groups Test';
+
+export function App() {
+  return (
+    <ToastProvider>
+      <StackContainer
+        routeConfigs={[
+          {
+            name: 'Main',
+            Component: MainScreen,
+            options: {
+              headerConfig: {
+                title: HEADER_TITLE,
+                android: {
+                  toolbarMenu: buildMenu(DEFAULT_CONFIG, () => {}, () => {}),
+                },
+              },
+            },
+          },
+        ]}
+      />
+    </ToastProvider>
+  );
+}
+
+function MainScreen() {
+  const [config, setConfig] = useState<MenuConfig>(DEFAULT_CONFIG);
+  const [lastEvent, setLastEvent] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<AllIds>('red');
+  const [cmdChecked, setCmdChecked] = useState<CmdCheckedOption>('no change');
+  const [cmdTitle, setCmdTitle] = useState<CmdTitleOption>('no change');
+  const [cmdHidden, setCmdHidden] = useState<CmdHiddenOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+  const toast = useToast();
+
+  const showToast = useCallback(
+    (text: string) => {
+      toast.push({ backgroundColor: Colors.GreenDark120, message: text });
+    },
+    [toast],
+  );
+
+  const handleItemPress = useCallback(
+    (id: string) => {
+      const msg = `Pressed: ${id}`;
+      setLastEvent(msg);
+      showToast(msg);
+    },
+    [showToast],
+  );
+
+  const handleGroupChange = useCallback(
+    (groupId: string, selectedIds: string[]) => {
+      const msg = `${groupId}: ${JSON.stringify(selectedIds)}`;
+      setLastEvent(msg);
+      showToast(msg);
+    },
+    [showToast],
+  );
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenu: buildMenu(
+            DEFAULT_CONFIG,
+            handleItemPress,
+            handleGroupChange,
+          ),
+          toolbarMenuGroupDividerEnabled: config.dividerEnabled,
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey, handleItemPress, handleGroupChange, config.dividerEnabled]);
+
+  const applyConfig = useCallback(
+    (next: MenuConfig) => {
+      setConfig(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenu: buildMenu(next, handleItemPress, handleGroupChange),
+            toolbarMenuGroupDividerEnabled: next.dividerEnabled,
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey, handleItemPress, handleGroupChange],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdChecked !== 'no change' && { checked: cmdChecked === 'true' }),
+      ...(cmdTitle !== 'no change' && {
+        title: cmdTitle === 'undefined' ? undefined : cmdTitle,
+      }),
+      ...(cmdHidden !== 'no change' && {
+        hidden:
+          cmdHidden === 'undefined'
+            ? undefined
+            : cmdHidden === 'true',
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [cmdTargetId, cmdChecked, cmdTitle, cmdHidden]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Last Event</Text>
+      <Text style={styles.result}>{lastEvent ?? '—'}</Text>
+
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<AllIds>
+        label="target id"
+        value={cmdTargetId}
+        items={[...ALL_IDS]}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdCheckedOption>
+        label="checked"
+        value={cmdChecked}
+        items={CMD_CHECKED_OPTIONS}
+        onValueChange={setCmdChecked}
+      />
+      <SettingsPicker<CmdTitleOption>
+        label="title"
+        value={cmdTitle}
+        items={CMD_TITLE_OPTIONS}
+        onValueChange={setCmdTitle}
+      />
+      <SettingsPicker<CmdHiddenOption>
+        label="hidden"
+        value={cmdHidden}
+        items={CMD_HIDDEN_OPTIONS}
+        onValueChange={setCmdHidden}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Menu Config — Props</Text>
+      <SettingsSwitch
+        label="singleSelection on colors"
+        value={config.singleSelectionOnColors}
+        onValueChange={v =>
+          applyConfig({ ...config, singleSelectionOnColors: v })
+        }
+      />
+      <SettingsSwitch
+        label="include Blue"
+        value={config.includeBlue}
+        onValueChange={v => applyConfig({ ...config, includeBlue: v })}
+      />
+      <SettingsSwitch
+        label="divider enabled"
+        value={config.dividerEnabled}
+        onValueChange={v => applyConfig({ ...config, dividerEnabled: v })}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(App, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -15,6 +15,7 @@ import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderConfigRef,
   StackHeaderToolbarMenuBaseAndroid,
+  StackHeaderToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
@@ -67,31 +68,30 @@ function buildMenu(
   onItemPress: (id: string) => void,
   onGroupChange: (groupId: string, selectedIds: string[]) => void,
 ): StackHeaderToolbarMenuBaseAndroid {
-  const colorItems = [
+  const colorItems: StackHeaderToolbarMenuElementAndroid[] = [
     {
-      type: 'menuItem' as const,
+      type: 'menuItem',
       id: 'red',
       title: 'Red',
       groupId: 'colors',
       initialToggleState: true,
     },
     {
-      type: 'menuItem' as const,
+      type: 'menuItem',
       id: 'green',
       title: 'Green',
       groupId: 'colors',
     },
-    ...(config.includeBlue
-      ? [
-          {
-            type: 'menuItem' as const,
-            id: 'blue',
-            title: 'Blue',
-            groupId: 'colors',
-          },
-        ]
-      : []),
   ];
+
+  if (config.includeBlue) {
+    colorItems.push({
+      type: 'menuItem',
+      id: 'blue',
+      title: 'Blue',
+      groupId: 'colors',
+    });
+  }
 
   return {
     groups: [

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -229,17 +229,13 @@ function MainScreen() {
       headerConfig: {
         title: HEADER_TITLE,
         android: {
-          toolbarMenu: buildMenu(
-            DEFAULT_CONFIG,
-            handleItemPress,
-            handleGroupChange,
-          ),
+          toolbarMenu: buildMenu(config, handleItemPress, handleGroupChange),
           toolbarMenuGroupDividerEnabled: config.dividerEnabled,
         },
       },
       headerConfigRef,
     });
-  }, [setRouteOptions, routeKey, handleItemPress, handleGroupChange, config.dividerEnabled]);
+  }, [setRouteOptions, routeKey, handleItemPress, handleGroupChange, config]);
 
   const applyConfig = useCallback(
     (next: MenuConfig) => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Groups (Android)',
+  key: 'test-stack-toolbar-menu-groups-android',
+  details:
+    'Tests toolbar menu groups: multi-toggle, single-selection, nested submenu groups, callbacks, imperative commands (checked, title, hidden), dividers, and props rebuild.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
@@ -2,16 +2,13 @@
 
 ## Details
 
-**Description:** This test focuses on toolbar menu groups on the
-gamma stack header for Android. It verifies multi-toggle (checkbox)
-and single-selection (radio) group behavior, `onSelectionChange`
-callbacks with correct IDs, `onPress` on ungrouped action items,
-groups scoped to nested submenus, `initialToggleState`,
-`toolbarMenuGroupDividerEnabled`, runtime props updates (group
-type change, adding/removing items, full rebuild resetting command
-state), and imperative `setToolbarMenuItemOptions` commands
-(`checked`, `title`, `hidden`) — including auto-uncheck in
-single-selection groups, no-op on `checked=false` for radio,
+**Description:** This test focuses on toolbar menu groups on the Stack v5 header
+for Android. It verifies multi-toggle (checkbox) and single-selection (radio)
+group behavior, `onSelectionChange` callbacks with correct IDs on groups of
+items, `onPress` on action items, `initialToggleState`,
+`toolbarMenuGroupDividerEnabled`, runtime props updates (group type change,
+adding/removing items, full rebuild resetting command state), and imperative
+`setToolbarMenuItemOptions` commands for setting `checked`, `title`, `hidden`,
 and hidden items preserving their selection in callbacks.
 
 **OS test creation version:** Android: API Level 36

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
@@ -23,21 +23,6 @@ TBD — automation is possible and planned but not yet implemented.
 
 ## Note
 
-- The initial menu structure is:
-  - Colors group (multi-toggle, `groupId: 'colors'`):
-    - `red`: "Red" (checked via `initialToggleState`)
-    - `green`: "Green"
-    - `blue`: "Blue"
-  - Size group (single-selection, `groupId: 'size'`):
-    - `small`: "Small"
-    - `medium`: "Medium" (checked via `initialToggleState`)
-    - `large`: "Large"
-  - `share`: "Share" (ungrouped action item)
-  - `sub`: "More" (submenu containing):
-    - Theme group (single-selection, `groupId: 'theme'`):
-      - `light`: "Light" (checked via `initialToggleState`)
-      - `dark`: "Dark"
-    - `info`: "Info" (ungrouped action item)
 - Groups are scoped to the menu level they are defined in —
   groups cannot span submenus.
 - `setToolbarMenuItemOptions` targets elements by `id`. It works
@@ -107,7 +92,7 @@ TBD — automation is possible and planned but not yet implemented.
 
 ---
 
-### Ungrouped action item
+### Action item
 
 10. Open the overflow menu and tap "Share".
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
@@ -1,0 +1,302 @@
+# Test Scenario: Stack Toolbar Menu Groups (Android)
+
+## Details
+
+**Description:** This test focuses on toolbar menu groups on the
+gamma stack header for Android. It verifies multi-toggle (checkbox)
+and single-selection (radio) group behavior, `onSelectionChange`
+callbacks with correct IDs, `onPress` on ungrouped action items,
+groups scoped to nested submenus, `initialToggleState`,
+`toolbarMenuGroupDividerEnabled`, runtime props updates (group
+type change, adding/removing items, full rebuild resetting command
+state), and imperative `setToolbarMenuItemOptions` commands
+(`checked`, `title`, `hidden`) — including auto-uncheck in
+single-selection groups, no-op on `checked=false` for radio,
+and hidden items preserving their selection in callbacks.
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+TBD — automation is possible and planned but not yet implemented.
+
+## Prerequisites
+
+- Android emulator or device
+
+## Note
+
+- The initial menu structure is:
+  - Colors group (multi-toggle, `groupId: 'colors'`):
+    - `red`: "Red" (checked via `initialToggleState`)
+    - `green`: "Green"
+    - `blue`: "Blue"
+  - Size group (single-selection, `groupId: 'size'`):
+    - `small`: "Small"
+    - `medium`: "Medium" (checked via `initialToggleState`)
+    - `large`: "Large"
+  - `share`: "Share" (ungrouped action item)
+  - `sub`: "More" (submenu containing):
+    - Theme group (single-selection, `groupId: 'theme'`):
+      - `light`: "Light" (checked via `initialToggleState`)
+      - `dark`: "Dark"
+    - `info`: "Info" (ungrouped action item)
+- Groups are scoped to the menu level they are defined in —
+  groups cannot span submenus.
+- `setToolbarMenuItemOptions` targets elements by `id`. It works
+  on items at any nesting depth.
+
+## Steps
+
+### Baseline — initial render and toggle states
+
+1. Launch the app and navigate to **Stack Toolbar Menu Groups**.
+   Open the overflow menu.
+
+- [ ] Header title reads "Toolbar Menu Groups Test". The overflow
+      menu shows: Red (checked), Green, Blue, Small, Medium
+      (checked), Large, Share, More (with submenu indicator).
+
+2. Tap "More" in the overflow menu.
+
+- [ ] A submenu opens showing: Light (checked), Dark, Info.
+
+---
+
+### Multi-toggle group (colors)
+
+3. Open the overflow menu and tap "Green".
+
+- [ ] A toast `colors: ["red", "green"]` is displayed.
+- [ ] When the menu is reopened, both Red and Green are checked.
+
+4. Open the overflow menu and tap "Red".
+
+- [ ] A toast `colors: ["green"]` is displayed.
+- [ ] When the menu is reopened, Red is unchecked. Green is
+      still checked.
+
+5. Open the overflow menu and tap "Green".
+
+- [ ] A toast `colors: []` is displayed.
+- [ ] When the menu is reopened, no items in the colors group
+      are checked.
+
+6. Open the overflow menu and tap "Blue".
+
+- [ ] A toast `colors: ["blue"]` is displayed.
+- [ ] When the menu is reopened, Blue is checked.
+
+---
+
+### Single-selection group (size)
+
+7. Open the overflow menu and tap "Small".
+
+- [ ] A toast `size: ["small"]` is displayed.
+- [ ] When the menu is reopened, Small is checked. Medium is
+      unchecked.
+
+8. Open the overflow menu and tap "Large".
+
+- [ ] A toast `size: ["large"]` is displayed.
+- [ ] When the menu is reopened, Large is checked. Small is
+      unchecked.
+
+9. Open the overflow menu and tap "Large" again.
+
+- [ ] No toast is displayed (already selected, single-selection
+      keeps it). Large remains checked.
+
+---
+
+### Ungrouped action item
+
+10. Open the overflow menu and tap "Share".
+
+- [ ] A toast `Pressed: share` is displayed.
+- [ ] Share has no checkmark. The menu closes.
+
+---
+
+### Submenu group (theme — single-selection)
+
+11. Open the overflow menu, tap "More", then tap "Dark".
+
+- [ ] A toast `theme: ["dark"]` is displayed.
+- [ ] When More is reopened, Dark is checked. Light is unchecked.
+
+12. Open the overflow menu, tap "More", then tap "Light".
+
+- [ ] A toast `theme: ["light"]` is displayed.
+- [ ] When More is reopened, Light is checked. Dark is unchecked.
+
+13. Open the overflow menu, tap "More", then tap "Info".
+
+- [ ] A toast `Pressed: info` is displayed.
+- [ ] Info has no checkmark. No toggle behavior.
+
+---
+
+### Divider enabled
+
+14. Toggle "divider enabled" ON in the controls.
+
+- [ ] Reopen the overflow menu: visual dividers appear between
+      groups (between colors and size group, between size group
+      and Share, etc.).
+
+15. Toggle "divider enabled" OFF.
+
+- [ ] Dividers disappear from the overflow menu.
+
+---
+
+### Props update — change group type
+
+16. Toggle "singleSelection on colors" ON.
+
+- [ ] Props rebuild occurs. Open the overflow menu: the colors
+      group now behaves as single-selection. Only Red is checked
+      (from `initialToggleState`).
+
+17. Open the overflow menu and tap "Green".
+
+- [ ] A toast `colors: ["green"]` is displayed.
+- [ ] When the menu is reopened, Green is checked. Red is
+      unchecked (radio behavior).
+
+18. Toggle "singleSelection on colors" OFF.
+
+- [ ] Props rebuild occurs. The colors group reverts to
+      multi-toggle. Open the menu: only Red is checked
+      (initial state restored).
+
+---
+
+### Props update — add/remove items
+
+19. Toggle "include Blue" OFF.
+
+- [ ] Open the overflow menu: Blue is gone. Red (checked) and
+      Green are visible in the colors group.
+
+20. Toggle "include Blue" ON.
+
+- [ ] Blue reappears in the overflow menu (unchecked, since
+      `initialToggleState` is false/absent).
+
+---
+
+### Command: checked on multi-toggle group
+
+21. In **Send Command**, set target id = `green`,
+    checked = `true`. Tap **Send Command**.
+
+- [ ] Open the overflow menu: Green is now checked alongside
+      Red.
+
+22. Set target id = `green`, checked = `false`.
+    Tap **Send Command**.
+
+- [ ] Open the overflow menu: Green is unchecked. Red is still
+      checked.
+
+---
+
+### Command: checked in single-selection group (auto-uncheck)
+
+23. Set target id = `large`, checked = `true`.
+    Tap **Send Command**.
+
+- [ ] A toast `size: ["large"]` is displayed.
+- [ ] Open the overflow menu: Large is checked. Medium is
+      unchecked.
+
+24. Set target id = `small`, checked = `true`.
+    Tap **Send Command**.
+
+- [ ] A toast `size: ["small"]` is displayed.
+- [ ] Open the overflow menu: Small is checked. Large is
+      unchecked.
+
+---
+
+### Command: checked=false on radio is a no-op
+
+25. Ensure Medium is selected in the size group (if not, set
+    target id = `medium`, checked = `true`, send). Then set
+    target id = `medium`, checked = `false`.
+    Tap **Send Command**.
+
+- [ ] Open the overflow menu: Medium is still checked. Setting
+      `checked=false` on a single-selection item that is
+      currently selected is a no-op — the group always keeps
+      one selection.
+
+---
+
+### Command: title and hidden on grouped items
+
+26. Set target id = `red`, title = `Changed`, other fields
+    = `no change`. Tap **Send Command**.
+
+- [ ] Open the overflow menu: the item reads "Changed" instead
+      of "Red". It is still checked.
+
+27. Set target id = `green`, hidden = `true`, other fields
+    = `no change`. Tap **Send Command**.
+
+- [ ] Open the overflow menu: Green is not visible.
+
+28. Set target id = `green`, hidden = `false`.
+    Tap **Send Command**.
+
+- [ ] Open the overflow menu: Green reappears.
+
+---
+
+### Command: hidden preserves selection in callbacks
+
+29. Set target id = `green`, checked = `true`. Send. Then set
+    target id = `green`, hidden = `true`. Send.
+
+- [ ] Open the overflow menu: Green is not visible.
+
+30. Open the overflow menu and tap "Blue".
+
+- [ ] A toast `colors: ["red", "green", "blue"]` is displayed.
+      Green is still reported as selected despite being hidden.
+
+31. Set target id = `green`, hidden = `false`.
+    Tap **Send Command**.
+
+- [ ] Open the overflow menu: Green reappears and is still
+      checked.
+
+---
+
+### Props rebuild resets command state
+
+32. Toggle "include Blue" OFF then back ON (props rebuild).
+
+- [ ] All command state is lost. Open the overflow menu: Red
+      reads "Red" again (not "Changed"). Green is visible and
+      unchecked. Medium is checked in the size group (initial
+      state restored).
+
+---
+
+### Command: checked in submenu group
+
+33. Set target id = `dark`, checked = `true`.
+    Tap **Send Command**.
+
+- [ ] A toast `theme: ["dark"]` is displayed.
+- [ ] Open More: Dark is checked. Light is unchecked.
+
+34. Set target id = `light`, checked = `true`.
+    Tap **Send Command**.
+
+- [ ] A toast `theme: ["light"]` is displayed.
+- [ ] Open More: Light is checked. Dark is unchecked.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -3,7 +3,7 @@
 ## Details
 
 **Description:** Tests the `icon` and state-aware `iconTintColor*` props on
-Android toolbar menu items. Covers both the props flow (via `toolbarMenuItems`
+Android toolbar menu items. Covers both the props flow (via `toolbarMenu`
 prop) and the imperative command flow (via `setToolbarMenuItemOptions`). The
 props flow rebuilds all items from scratch on every update and discards all
 prior command state on all items simultaneously. The command flow merges changes

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -149,7 +149,7 @@ function buildMenu(
 
 const HEADER_TITLE = 'Toolbar Nested Menu Test';
 
-export function App() {
+function TestStackToolbarNestedMenu() {
   return (
     <StackContainer
       routeConfigs={[
@@ -300,4 +300,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createScenario(App, scenarioDescription);
+export default createScenario(TestStackToolbarNestedMenu, scenarioDescription);

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -35,7 +35,7 @@ import type {
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
-  StackHeaderToolbarMenuGroup,
+  StackHeaderToolbarMenuGroupAndroid,
 } from './StackHeaderConfig.android.types';
 import { parseAndroidIconToNativeProps } from '../../../shared';
 
@@ -255,7 +255,7 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
 function findToolbarMenuGroupById(
   menu: StackHeaderToolbarMenuBaseAndroid | undefined,
   groupId: string,
-): StackHeaderToolbarMenuGroup | null {
+): StackHeaderToolbarMenuGroupAndroid | null {
   if (!menu) {
     return null;
   }
@@ -309,7 +309,7 @@ function parseToolbarMenuToNativeProps(
 }
 
 function parseGroupsToNativeProps(
-  groups: StackHeaderToolbarMenuGroup[] | undefined,
+  groups: StackHeaderToolbarMenuGroupAndroid[] | undefined,
 ) {
   if (!groups?.length) {
     return undefined;
@@ -333,6 +333,7 @@ function parseElementToNativeProps(
     };
   }
 
+  assertItemTypeGroupIdConsistency(element);
   assertNoOnPressOnToggleItem(element);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -345,6 +346,25 @@ function parseElementToNativeProps(
     initialToggleState,
     ...parseBaseItemToNativeProps(baseProps),
   };
+}
+
+function assertItemTypeGroupIdConsistency(
+  element: StackHeaderToolbarMenuItemAndroid,
+): void {
+  if (element.itemType === 'toggle' && element.groupId == null) {
+    throw new Error(
+      `[RNScreens] Menu item '${element.id}' has itemType='toggle' ` +
+        `but no groupId. Toggle items must belong to a group.`,
+    );
+  }
+
+  if (element.itemType === 'action' && element.groupId != null) {
+    throw new Error(
+      `[RNScreens] Menu item '${element.id}' has itemType='action' ` +
+        `and belongs to group '${element.groupId}'. ` +
+        `Action items cannot belong to groups.`,
+    );
+  }
 }
 
 function assertNoOnPressOnToggleItem(

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -302,6 +302,10 @@ function parseToolbarMenuToNativeProps(
   if (!menu?.children?.length) {
     return undefined;
   }
+  assertUniqueItemIds(menu.children);
+  assertUniqueGroupIds(menu);
+  assertGroupIdReferencesExist(menu);
+  assertRadioInitialSelection(menu);
   return {
     groups: parseGroupsToNativeProps(menu.groups),
     children: menu.children.map(parseElementToNativeProps),
@@ -346,6 +350,106 @@ function parseElementToNativeProps(
     initialToggleState,
     ...parseBaseItemToNativeProps(baseProps),
   };
+}
+
+function assertUniqueItemIds(
+  elements: StackHeaderToolbarMenuElementAndroid[],
+  seen: Set<string> = new Set(),
+): void {
+  for (const element of elements) {
+    if (seen.has(element.id)) {
+      throw new Error(
+        `[RNScreens] Duplicate toolbar menu item id: '${element.id}'. ` +
+          `Item IDs must be unique across the entire menu.`,
+      );
+    }
+    seen.add(element.id);
+    if (element.type === 'menu' && element.children) {
+      assertUniqueItemIds(element.children, seen);
+    }
+  }
+}
+
+function assertUniqueGroupIds(
+  menu: StackHeaderToolbarMenuBaseAndroid,
+  seen: Set<string> = new Set(),
+): void {
+  if (menu.groups) {
+    for (const group of menu.groups) {
+      if (seen.has(group.groupId)) {
+        throw new Error(
+          `[RNScreens] Duplicate toolbar menu group id: '${group.groupId}'. ` +
+            `Group IDs must be unique across the entire menu.`,
+        );
+      }
+      seen.add(group.groupId);
+    }
+  }
+  if (menu.children) {
+    for (const element of menu.children) {
+      if (element.type === 'menu') {
+        assertUniqueGroupIds(element, seen);
+      }
+    }
+  }
+}
+
+function assertGroupIdReferencesExist(
+  menu: StackHeaderToolbarMenuBaseAndroid,
+): void {
+  const localGroupIds = new Set(menu.groups?.map(g => g.groupId));
+  if (menu.children) {
+    for (const element of menu.children) {
+      if (element.type === 'menuItem' && element.groupId != null) {
+        if (!localGroupIds.has(element.groupId)) {
+          throw new Error(
+            `[RNScreens] Menu item '${element.id}' references group ` +
+              `'${element.groupId}' which is not defined at the same ` +
+              `menu level. Groups cannot span submenus.`,
+          );
+        }
+      }
+      if (element.type === 'menu') {
+        assertGroupIdReferencesExist(element);
+      }
+    }
+  }
+}
+
+function assertRadioInitialSelection(
+  menu: StackHeaderToolbarMenuBaseAndroid,
+): void {
+  if (menu.groups && menu.children) {
+    for (const group of menu.groups) {
+      if (!group.singleSelection) {
+        continue;
+      }
+      let count = 0;
+      for (const element of menu.children) {
+        if (
+          element.type === 'menuItem' &&
+          element.groupId === group.groupId &&
+          element.initialToggleState
+        ) {
+          count++;
+        }
+      }
+      if (count > 1) {
+        throw new Error(
+          `[RNScreens] Radio group '${group.groupId}' has ${count} items ` +
+            `with initialToggleState=true. At most 1 is allowed for ` +
+            `single-selection groups.`,
+        );
+      }
+    }
+  }
+  if (menu.children) {
+    for (const element of menu.children) {
+      if (element.type === 'menu') {
+        assertRadioInitialSelection(element);
+      }
+    }
+  }
 }
 
 function assertItemTypeGroupIdConsistency(

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -31,6 +31,7 @@ import type {
   StackHeaderConfigPropsAndroid,
   StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
+  StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
@@ -332,6 +333,8 @@ function parseElementToNativeProps(
     };
   }
 
+  assertNoOnPressOnToggleItem(element);
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { type, onPress, groupId, itemType, initialToggleState, ...baseProps } =
     element;
@@ -342,6 +345,31 @@ function parseElementToNativeProps(
     initialToggleState,
     ...parseBaseItemToNativeProps(baseProps),
   };
+}
+
+function assertNoOnPressOnToggleItem(
+  element: StackHeaderToolbarMenuItemAndroid,
+): void {
+  if (!element.onPress) {
+    return;
+  }
+
+  const effectiveItemType = element.itemType ?? 'automatic';
+
+  if (effectiveItemType === 'toggle') {
+    throw new Error(
+      `[RNScreens] Menu item '${element.id}' has itemType='toggle' and defines onPress. ` +
+        `Toggle items do not emit press events. Use onSelectionChange on the group instead.`,
+    );
+  }
+
+  if (effectiveItemType === 'automatic' && element.groupId != null) {
+    throw new Error(
+      `[RNScreens] Menu item '${element.id}' belongs to group '${element.groupId}' ` +
+        `and defines onPress. Items in a group behave as toggles and do not emit press events. ` +
+        `Use onSelectionChange on the group instead.`,
+    );
+  }
 }
 
 function parseBaseItemToNativeProps({

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -23,6 +23,7 @@ import type {
   StackHeaderToolbarMenuBaseAndroid as NativeToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid as NativeToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemPressEventAndroid,
+  StackHeaderToolbarMenuGroupSelectionChangeEventAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid as NativeToolbarMenuItemOptionsAndroid,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
@@ -33,6 +34,7 @@ import type {
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderTypeAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuGroup,
 } from './StackHeaderConfig.android.types';
 import { parseAndroidIconToNativeProps } from '../../../shared';
 
@@ -61,6 +63,7 @@ function StackHeaderConfig(
     scrollFlagExitUntilCollapsed,
     scrollFlagSnap,
     toolbarMenu,
+    toolbarMenuGroupDividerEnabled,
     ...filteredAndroidProps
   } = android ?? {};
 
@@ -76,6 +79,15 @@ function StackHeaderConfig(
       element.onPress?.();
     }
   };
+
+  const handleToolbarMenuGroupSelectionChange = (
+    event: NativeSyntheticEvent<StackHeaderToolbarMenuGroupSelectionChangeEventAndroid>,
+  ) => {
+    const { groupId, selectedIds } = event.nativeEvent;
+    const group = findToolbarMenuGroupById(toolbarMenu, groupId);
+    group?.onSelectionChange?.(selectedIds);
+  };
+
   const backButtonIconProps = parseBackButtonIconToNativeProps(backButtonIcon);
   const scrollFlagProps = resolveScrollFlags(filteredAndroidProps.type, {
     scrollFlagScroll,
@@ -91,7 +103,9 @@ function StackHeaderConfig(
       collapsable={false}
       style={StyleSheet.absoluteFill}
       toolbarMenu={parsedToolbarMenu}
+      toolbarMenuGroupDividerEnabled={toolbarMenuGroupDividerEnabled}
       onToolbarMenuItemPress={handleToolbarMenuItemPress}
+      onToolbarMenuGroupSelectionChange={handleToolbarMenuGroupSelectionChange}
       {...baseProps}
       {...filteredAndroidProps}
       {...backButtonIconProps}
@@ -237,6 +251,29 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
   return ref;
 }
 
+function findToolbarMenuGroupById(
+  menu: StackHeaderToolbarMenuBaseAndroid | undefined,
+  groupId: string,
+): StackHeaderToolbarMenuGroup | null {
+  if (!menu) {
+    return null;
+  }
+  for (const group of menu.groups ?? []) {
+    if (group.groupId === groupId) {
+      return group;
+    }
+  }
+  for (const element of menu.children ?? []) {
+    if (element.type === 'menu') {
+      const found = findToolbarMenuGroupById(element, groupId);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
 function findToolbarMenuElementById(
   elements: StackHeaderToolbarMenuElementAndroid[] | undefined,
   id: string,
@@ -265,26 +302,44 @@ function parseToolbarMenuToNativeProps(
     return undefined;
   }
   return {
+    groups: parseGroupsToNativeProps(menu.groups),
     children: menu.children.map(parseElementToNativeProps),
   };
+}
+
+function parseGroupsToNativeProps(
+  groups: StackHeaderToolbarMenuGroup[] | undefined,
+) {
+  if (!groups?.length) {
+    return undefined;
+  }
+  return groups.map(({ groupId, singleSelection }) => ({
+    groupId,
+    singleSelection,
+  }));
 }
 
 function parseElementToNativeProps(
   element: StackHeaderToolbarMenuElementAndroid,
 ): NativeToolbarMenuElementAndroid {
   if (element.type === 'menu') {
-    const { type, children, ...baseProps } = element;
+    const { type, children, groups, ...baseProps } = element;
     return {
       type,
       ...parseBaseItemToNativeProps(baseProps),
+      groups: parseGroupsToNativeProps(groups),
       children: children?.map(parseElementToNativeProps),
     };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { type, onPress, ...baseProps } = element;
+  const { type, onPress, groupId, itemType, initialToggleState, ...baseProps } =
+    element;
   return {
     type,
+    groupId,
+    itemType,
+    initialToggleState,
     ...parseBaseItemToNativeProps(baseProps),
   };
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -110,9 +110,13 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    *   will be placed in the overflow menu instead.
    *
    * @remarks
-   * Due to native limitations, the width limit for the `ifRoom` options is
-   * determined during the initial render and will not adapt to subsequent
-   * layout or orientation changes.
+   * This prop only affects top-level menu elements. Items inside
+   * submenus are always displayed in the popup and ignore this
+   * setting.
+   *
+   * Due to native limitations, the width limit for the `ifRoom`
+   * options is determined during the initial render and will not
+   * adapt to subsequent layout or orientation changes.
    *
    * @default never
    * @platform android
@@ -208,6 +212,9 @@ export interface StackHeaderToolbarMenuItemAndroid
    * multi-toggle). A group is scoped to the menu level it is defined
    * in — groups cannot span submenus.
    *
+   * Required when `itemType` is `toggle`. Cannot be set when
+   * `itemType` is `action`.
+   *
    * @platform android
    */
   groupId?: string | undefined;
@@ -231,19 +238,28 @@ export interface StackHeaderToolbarMenuItemAndroid
    * @description
    * Only meaningful when effective `itemType` is `toggle`.
    *
+   * @remarks
+   * The initial state does not trigger `onSelectionChange` on
+   * the group at mount time.
+   *
    * @default false
    * @platform android
    */
   initialToggleState?: boolean | undefined;
   /**
-   * @summary Callback invoked when the menu item is clicked.
+   * @summary Callback invoked when the menu item is pressed.
+   *
+   * @remarks
+   * Not called for items that behave as toggles (items with a
+   * `groupId` or `itemType: 'toggle'`). For those items, use
+   * `onSelectionChange` on the group instead.
    *
    * @platform android
    */
   onPress?: (() => void) | undefined;
 }
 
-export interface StackHeaderToolbarMenuGroup {
+export interface StackHeaderToolbarMenuGroupAndroid {
   /**
    * @summary Unique identifier of the group.
    *
@@ -282,7 +298,7 @@ export interface StackHeaderToolbarMenuBaseAndroid {
    *
    * @platform android
    */
-  groups?: StackHeaderToolbarMenuGroup[] | undefined;
+  groups?: StackHeaderToolbarMenuGroupAndroid[] | undefined;
   /**
    * @summary Menu elements displayed in the toolbar menu.
    *
@@ -296,6 +312,10 @@ export interface StackHeaderToolbarMenuAndroid
     StackHeaderToolbarMenuBaseAndroid {
   /**
    * @summary Marks this object as a submenu.
+   *
+   * @remarks
+   * Android's `MenuItem` interface claims that nesting submenus isn't supported
+   * but Material's implementation handles it correctly.
    *
    * @platform android
    */

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -187,6 +187,11 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
   iconTintColorDisabled?: ColorValue | undefined;
 }
 
+export type StackHeaderToolbarMenuItemTypeAndroid =
+  | 'action'
+  | 'toggle'
+  | 'automatic';
+
 export interface StackHeaderToolbarMenuItemAndroid
   extends StackHeaderToolbarMenuItemBaseAndroid {
   /**
@@ -196,6 +201,41 @@ export interface StackHeaderToolbarMenuItemAndroid
    */
   type: 'menuItem';
   /**
+   * @summary Assigns this item to a group.
+   *
+   * @description
+   * Groups enable selection behavior (single-selection / radio, or
+   * multi-toggle). A group is scoped to the menu level it is defined
+   * in — groups cannot span submenus.
+   *
+   * @platform android
+   */
+  groupId?: string | undefined;
+  /**
+   * @summary Controls how the item behaves when clicked.
+   *
+   * @description
+   * The following values are available:
+   * - `action` - the item fires `onPress` without any toggle state,
+   * - `toggle` - the item is checkable; requires `groupId`,
+   * - `automatic` - the item becomes checkable if it has a `groupId`,
+   *   otherwise it behaves as an action.
+   *
+   * @default automatic
+   * @platform android
+   */
+  itemType?: StackHeaderToolbarMenuItemTypeAndroid | undefined;
+  /**
+   * @summary Initial checked state for toggle items.
+   *
+   * @description
+   * Only meaningful when effective `itemType` is `toggle`.
+   *
+   * @default false
+   * @platform android
+   */
+  initialToggleState?: boolean | undefined;
+  /**
    * @summary Callback invoked when the menu item is clicked.
    *
    * @platform android
@@ -203,7 +243,46 @@ export interface StackHeaderToolbarMenuItemAndroid
   onPress?: (() => void) | undefined;
 }
 
+export interface StackHeaderToolbarMenuGroup {
+  /**
+   * @summary Unique identifier of the group.
+   *
+   * @platform android
+   */
+  groupId: string;
+  /**
+   * @summary Determines the type of selection in the group.
+   *
+   * @description
+   * When `true`, only one item in the group can be selected
+   * at a time (radio behavior). When `false`, items toggle
+   * independently (checkbox behavior).
+   *
+   * @default false
+   * @platform android
+   */
+  singleSelection?: boolean | undefined;
+  /**
+   * @summary Callback invoked when the selection within the group
+   * changes. Receives the list of currently selected item IDs.
+   *
+   * @platform android
+   */
+  onSelectionChange?: (selectedMenuElementIds: string[]) => void;
+}
+
 export interface StackHeaderToolbarMenuBaseAndroid {
+  /**
+   * @summary Group definitions for items in this menu level.
+   *
+   * @description
+   * Groups enable selection behavior (single or multi-toggle) for
+   * items that share the same `groupId`. A group is scoped to the
+   * menu level it is defined in — groups cannot span submenus.
+   *
+   * @platform android
+   */
+  groups?: StackHeaderToolbarMenuGroup[] | undefined;
   /**
    * @summary Menu elements displayed in the toolbar menu.
    *
@@ -229,7 +308,18 @@ export type StackHeaderToolbarMenuElementAndroid =
 
 export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
   Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
->;
+> & {
+  /**
+   * @summary Sets the checked state of the menu item.
+   *
+   * @description
+   * In single-selection groups, setting `checked: true`
+   * automatically unchecks other group members.
+   *
+   * @platform android
+   */
+  checked?: boolean | undefined;
+};
 
 export interface StackHeaderConfigCommandsAndroid {
   /**
@@ -441,4 +531,16 @@ export interface StackHeaderConfigPropsAndroid {
    * @platform android
    */
   toolbarMenu?: StackHeaderToolbarMenuBaseAndroid | undefined;
+  /**
+   * @summary Enables visual dividers between menu groups.
+   *
+   * @remarks
+   * Requires API 28 (Android 9). On earlier versions, the value of this prop is
+   * ignored.
+   *
+   * @default false
+   * @platform android
+   * @supported API 28 or higher
+   */
+  toolbarMenuGroupDividerEnabled?: boolean | undefined;
 }

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -263,6 +263,13 @@ export interface StackHeaderToolbarMenuGroupAndroid {
   /**
    * @summary Unique identifier of the group.
    *
+   * @description
+   * Groups enable selection behavior (single-selection / radio, or
+   * multi-toggle). A group is scoped to the menu level it is defined
+   * in — groups cannot span submenus.
+   *
+   * Group identifier must be unique across the entire menu tree.
+   *
    * @platform android
    */
   groupId: string;

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -228,6 +228,11 @@ export interface StackHeaderToolbarMenuItemAndroid
    * - `automatic` - the item becomes checkable if it has a `groupId`,
    *   otherwise it behaves as an action.
    *
+   * @remarks
+   * If `toggle` menu item is shown in the toolbar by setting `showAsAction`
+   * prop to value other than `never`, there is no visual indication of the item
+   * toggle state.
+   *
    * @default automatic
    * @platform android
    */

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -27,7 +27,7 @@ export type {
   StackHeaderToolbarMenuAndroid,
   StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
-  StackHeaderToolbarMenuGroup,
+  StackHeaderToolbarMenuGroupAndroid,
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -27,10 +27,12 @@ export type {
   StackHeaderToolbarMenuAndroid,
   StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
+  StackHeaderToolbarMenuGroup,
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderToolbarMenuItemOptionsAndroid,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
+  StackHeaderToolbarMenuItemTypeAndroid,
   // iOS
   StackHeaderConfigPropsIOS,
   StackHeaderInlineItemIOS,

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -17,12 +17,19 @@ export type StackHeaderToolbarMenuItemPressEventAndroid = Readonly<{
   id: string;
 }>;
 
+export type StackHeaderToolbarMenuGroupSelectionChangeEventAndroid = Readonly<{
+  groupId: string;
+  selectedIds: string[];
+}>;
+
 type StackHeaderToolbarMenuItemShowAsActionAndroid =
   | 'always'
   | 'alwaysWithText'
   | 'ifRoom'
   | 'ifRoomWithText'
   | 'never';
+
+type StackHeaderToolbarMenuItemTypeAndroid = 'action' | 'toggle' | 'automatic';
 
 export interface StackHeaderToolbarMenuItemBaseAndroid {
   id: string;
@@ -43,9 +50,21 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
 type StackHeaderToolbarMenuItemAndroid =
   StackHeaderToolbarMenuItemBaseAndroid & {
     type: 'menuItem';
+    groupId?: string | undefined;
+    itemType?: CT.WithDefault<
+      StackHeaderToolbarMenuItemTypeAndroid,
+      'automatic'
+    >;
+    initialToggleState?: CT.WithDefault<boolean, false>;
   };
 
+type StackHeaderToolbarMenuGroupAndroid = {
+  groupId: string;
+  singleSelection?: CT.WithDefault<boolean, false>;
+};
+
 export type StackHeaderToolbarMenuBaseAndroid = {
+  groups?: StackHeaderToolbarMenuGroupAndroid[] | undefined;
   children?: StackHeaderToolbarMenuElementAndroid[] | undefined;
 };
 
@@ -80,8 +99,12 @@ export interface NativeProps extends ViewProps {
   scrollFlagSnap?: CT.WithDefault<boolean, false>;
 
   toolbarMenu?: UnsafeMixed<StackHeaderToolbarMenuBaseAndroid> | undefined;
+  toolbarMenuGroupDividerEnabled?: CT.WithDefault<boolean, false>;
   onToolbarMenuItemPress?:
     | CT.DirectEventHandler<StackHeaderToolbarMenuItemPressEventAndroid>
+    | undefined;
+  onToolbarMenuGroupSelectionChange?:
+    | CT.DirectEventHandler<StackHeaderToolbarMenuGroupSelectionChangeEventAndroid>
     | undefined;
 }
 

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -112,7 +112,9 @@ type ComponentType = HostComponent<NativeProps>;
 
 export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
   Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
->;
+> & {
+  checked?: boolean | undefined;
+};
 
 export interface NativeCommands {
   setToolbarMenuItemOptions: (


### PR DESCRIPTION
## Description

Adds support for defining groups in (sub)menus which allows creating radio and multiselect menus.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1203.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1476.

### Details

#### API difference between Android and iOS

On iOS, there is no concept of groups. `UIMenu` defines a "group" and its display can be set to `displayInline` to show multiple submenus in one menu. On Android, to achieve similar effect we need to use multiple groups for one (sub)menu. 

For now, I decided to expose groups mechanism directly. Later we'll add an abstraction in JS that will map common JS API (similar to iOS) to Android-compatible groups (e.g. submenu with `displayInline` will be parsed to items in parent menu with additional group).

https://github.com/software-mansion/react-native-screens-labs/issues/1583

#### `singleSelection` difference between Android and iOS

On iOS, if you set `singleSelection` on a menu, all submenus are also single selection. On Android, we map `singleSelection` to `exclusive` group prop. Groups are limited to single submenu only therefore radio across multiple submenus isn't currently supported. 

We would need a custom implementation to handle it - not sure if we want to do so.

#### `groupDivider`

Enabling group divider is possible on every (sub)menu level but I decided not to expose it on all menus as setting it on a submenu just forwards the setting to parent menu - that's how it's implemented in `appcompat`'s `SubMenuBuilder`:

```java
@Override
public void setGroupDividerEnabled(boolean groupDividerEnabled) {
    mParentMenu.setGroupDividerEnabled(groupDividerEnabled);
}
```

#### `checked` option in view command

`checked` option is exposed via view command to allow toggling selection in runtime from JS. It respects `singleSelection`'s behavior but if `checked: false` is provided, the action is no-op (radios can't have all items deselected after first selection).

I was wondering if we should expose separate `toggle` mechanism so that the caller doesn't need to know the current state of the item but I'm not sure if there is any valid use case for this.

## Changes

- JS:
  - expose group configuration (`MenuBase.groups` with `groupId`, `singleSelection`, `onSelectionChange`)
  - add `itemType`, `groupId` and `initialToggleState` to `MenuItem`
  - map `onToolbarMenuGroupSelectionChange` native event to `onSelectionChange` callbacks
  - add assertions for item uniqueness, group uniqueness, item type, valid groupIds on items, valid callbacks (`onPress` for action, `onSelectionChange` for groups/toggles) and valid radio initial selection
  - add `toolbarMenuGroupDividerEnabled` prop for header config
  - add `checked` field in view command's options to allow changing selection in runtime
- tests:
  - add `test-stack-toolbar-menu-groups` SFT
  - adapt `menu-groups` and `nested-menu` SFTs to new test export convention
- native:
  - handle new props and callback in `StackHeaderConfig`
  - add new event for group selection
  - update menu mapper to handle groups
  - add logic for configuring groups and assertions in `StackHeaderApplicator`

## Visual documentation

https://github.com/user-attachments/assets/c60be37d-083f-4587-a8e5-aba05510cf0d

## Test plan

Run `test-stack-toolbar-menu-groups` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
