### PR TITLE
chore(test): Add e2e test for SVM in stack & tabs with special effects

### DIFF
--- a/FabricExample/e2e/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects.e2e.ts
+++ b/FabricExample/e2e/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects.e2e.ts
@@ -17,7 +17,6 @@ describe('SVM in Stack & Tabs - tabs special effects — scrollToTop: no nesting
 
   it('should display tab bar and Home tab with scrollable view on load', async () => {
     await expect(element(by.id('home-scrollview'))).toBeVisible();
-    await expect(element(by.id('home-tab-item'))).toBeVisible();
     if (device.getPlatform() === 'ios') {
       await expect(element(by.type('UITabBar'))).toBeVisible();
     } else {

--- a/FabricExample/e2e/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects.e2e.ts
+++ b/FabricExample/e2e/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects.e2e.ts
@@ -1,0 +1,71 @@
+import { device, expect, element, by } from 'detox';
+import {
+  scrollUntilVisible,
+  selectComponentIntegrationTestsScreen,
+  forceSelectTabByLabel,
+  describeIfAndroid,
+} from '../../e2e-utils';
+
+describe('SVM in Stack & Tabs - tabs special effects — scrollToTop: no nesting', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectComponentIntegrationTestsScreen(
+      'ScrollViewMarkerIntegrationTests',
+      'test-stack-svm-tabs-special-effects',
+    );
+  });
+
+  it('should display tab bar and Home tab with scrollable view on load', async () => {
+    await expect(element(by.id('home-scrollview'))).toBeVisible();
+    await expect(element(by.id('home-tab-item'))).toBeVisible();
+    if (device.getPlatform() === 'ios') {
+      await expect(element(by.type('UITabBar'))).toBeVisible();
+    } else {
+      await expect(element(by.id('home-tab-item'))).toBeVisible();
+      await expect(element(by.id('stack-tab-item'))).toBeVisible();
+    }
+  });
+
+  it('Re-tapping active Home tab scrolls scroll-view back to top', async () => {
+    await scrollUntilVisible('Home-item-10', 'home-scrollview');
+    await expect(element(by.id('Home-item-1'))).not.toBeVisible();
+
+    await forceSelectTabByLabel('home-tab-item-label');
+
+    await waitFor(element(by.id('Home-item-1')))
+      .toBeVisible()
+      .withTimeout(3000);
+  });
+});
+
+describeIfAndroid(
+  'SVM in Stack & Tabs - tabs special effects — scrollToTop: nested stack',
+  () => {
+    beforeAll(async () => {
+      await device.reloadReactNative();
+      await selectComponentIntegrationTestsScreen(
+        'ScrollViewMarkerIntegrationTests',
+        'test-stack-svm-tabs-special-effects',
+      );
+    });
+
+    it('should display tab bar and Stack tab with scrollable view on load', async () => {
+      await expect(element(by.id('home-scrollview'))).toBeVisible();
+      await expect(element(by.id('home-tab-item'))).toBeVisible();
+      await expect(element(by.id('stack-tab-item'))).toBeVisible();
+      await element(by.id('stack-tab-item')).tap();
+      await expect(element(by.id('stack-scrollview'))).toBeVisible();
+    });
+
+    it('Re-tapping active Stack tab scrolls scroll-view back to top', async () => {
+      await scrollUntilVisible('Stack-item-10', 'stack-scrollview');
+      await expect(element(by.id('Stack-item-1'))).not.toBeVisible();
+
+      await forceSelectTabByLabel('stack-tab-item-label');
+
+      await waitFor(element(by.id('Stack-item-1')))
+        .toBeVisible()
+        .withTimeout(3000);
+    });
+  },
+);

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -38,6 +38,37 @@ export async function selectIssueTestScreen(screenName: string) {
   await element(by.id(`issue-tests-${screenName}`)).tap();
 }
 
+export async function selectComponentIntegrationTestsScreen(
+  scenarioGroup: string,
+  screenKey: string,
+) {
+  await scrollUntilVisible(
+    'root-screen-component-integration-tests',
+    'root-screen-examples-scrollview',
+  );
+  await element(by.id('root-screen-component-integration-tests')).tap();
+
+  await waitFor(element(by.id('component-integration-tests-scrollview')))
+    .toBeVisible()
+    .withTimeout(3000);
+
+  await scrollUntilVisible(
+    `component-integration-tests-${scenarioGroup}`,
+    'component-integration-tests-scrollview',
+  );
+
+  await element(by.id(`component-integration-tests-${scenarioGroup}`)).tap();
+  await waitFor(element(by.id(`${scenarioGroup}-scenarios-scrollview`)))
+    .toBeVisible()
+    .withTimeout(3000);
+
+  await scrollUntilVisible(
+    `${screenKey}`,
+    `${scenarioGroup}-scenarios-scrollview`,
+  );
+  await element(by.id(`${screenKey}`)).tap();
+}
+
 export async function selectSingleFeatureTestsScreen(
   scenarioGroup: string,
   screenKey: string,
@@ -93,4 +124,12 @@ export async function forceTapByLabeliOS(testLabel: string) {
     x: x + width / 2,
     y: y + height / 2,
   });
+}
+
+export async function forceSelectTabByLabel(label: string) {
+  if (device.getPlatform() === 'ios') {
+    await forceTapByLabeliOS(label);
+  } else {
+    await element(by.label(label)).tap();
+  }
 }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -42,6 +42,7 @@ export async function selectComponentIntegrationTestsScreen(
   scenarioGroup: string,
   screenKey: string,
 ) {
+  const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
   await scrollUntilVisible(
     'root-screen-component-integration-tests',
     'root-screen-examples-scrollview',
@@ -53,18 +54,18 @@ export async function selectComponentIntegrationTestsScreen(
     .withTimeout(3000);
 
   await scrollUntilVisible(
-    `component-integration-tests-${scenarioGroup}`,
+    `component-integration-tests-${scenarioGroupId}`,
     'component-integration-tests-scrollview',
   );
 
-  await element(by.id(`component-integration-tests-${scenarioGroup}`)).tap();
-  await waitFor(element(by.id(`${scenarioGroup}-scenarios-scrollview`)))
+  await element(by.id(`component-integration-tests-${scenarioGroupId}`)).tap();
+  await waitFor(element(by.id(`${scenarioGroupId}-scenarios-scrollview`)))
     .toBeVisible()
     .withTimeout(3000);
 
   await scrollUntilVisible(
     `${screenKey}`,
-    `${scenarioGroup}-scenarios-scrollview`,
+    `${scenarioGroupId}-scenarios-scrollview`,
   );
   await element(by.id(`${screenKey}`)).tap();
 }

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top.e2e.ts
@@ -2,19 +2,8 @@ import { device, expect, element, by } from 'detox';
 import {
   scrollUntilVisible,
   selectSingleFeatureTestsScreen,
-  forceTapByLabeliOS,
+  forceSelectTabByLabel,
 } from '../../e2e-utils';
-/**
- * Selects a tab bar item. On iOS, this uses a forced coordinate tap to
- * ensure the tab is selected even if it is obstructed by the iOS 26 Liquid Glass lens.
- */
-async function forceSelectTabByLabel(label: string) {
-  if (device.getPlatform() === 'ios') {
-    await forceTapByLabeliOS(label);
-  } else {
-    await element(by.label(label)).tap();
-  }
-}
 
 describe('Tabs specialEffects — scrollToTop', () => {
   beforeAll(async () => {

--- a/apps/src/tests/component-integration-tests/index.tsx
+++ b/apps/src/tests/component-integration-tests/index.tsx
@@ -18,7 +18,7 @@ export * from './orientation';
 export * from './scroll-view';
 export * from './form-sheet';
 export * from './tabs-stack-v5';
-export * from './scroll-view-marker'
+export * from './scroll-view-marker';
 
 export const COMPONENT_SCENARIOS = {
   Orientation: OrientationScenarioGroup,
@@ -43,7 +43,11 @@ export function HomeScreen() {
           title={scenarioGroup.name}
           route={key}
           details={scenarioGroup.details}
-          testID={`component-integration-tests-${scenarioGroup.name.replace(/\s/g, '')}`} />
+          testID={`component-integration-tests-${scenarioGroup.name.replace(
+            /\s/g,
+            '',
+          )}`}
+        />
       ))}
     </ScrollView>
   );

--- a/apps/src/tests/component-integration-tests/index.tsx
+++ b/apps/src/tests/component-integration-tests/index.tsx
@@ -18,6 +18,7 @@ export * from './orientation';
 export * from './scroll-view';
 export * from './form-sheet';
 export * from './tabs-stack-v5';
+export * from './scroll-view-marker'
 
 export const COMPONENT_SCENARIOS = {
   Orientation: OrientationScenarioGroup,
@@ -33,14 +34,16 @@ type ParamsList = { [k: keyof typeof COMPONENT_SCENARIOS]: undefined } & {
 
 export function HomeScreen() {
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      testID="component-integration-tests-scrollview">
       {Object.entries(COMPONENT_SCENARIOS).map(([key, scenarioGroup]) => (
         <ScenarioButton
           key={key}
           title={scenarioGroup.name}
           route={key}
           details={scenarioGroup.details}
-        />
+          testID={`component-integration-tests-${scenarioGroup.name.replace(/\s/g, '')}`} />
       ))}
     </ScrollView>
   );

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -105,6 +105,7 @@ function StackTabScreen() {
 }
 
 function ScrollViewContents(props: { elementCount?: number }) {
+  const tabName = useTabsNavigationContext().routeKey;
   const elementCount = props.elementCount ?? 48;
   return (
     <>
@@ -112,7 +113,7 @@ function ScrollViewContents(props: { elementCount?: number }) {
         return (
           <View key={index.toString()} style={[{ width: '100%' }]}>
             <Rectangle
-              testID={`${useTabsNavigationContext().routeKey}-item-${
+              testID={`${tabName}-item-${
                 index + 1
               }`}
               key={index.toString()}

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -114,7 +114,6 @@ function ScrollViewContents(props: { elementCount?: number }) {
           <View key={index.toString()} style={[{ width: '100%' }]}>
             <Rectangle
               testID={`${tabName}-item-${index + 1}`}
-              key={index.toString()}
               color={Colors.RedDark100}
               width={'100%'}
               height={128}

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -113,9 +113,7 @@ function ScrollViewContents(props: { elementCount?: number }) {
         return (
           <View key={index.toString()} style={[{ width: '100%' }]}>
             <Rectangle
-              testID={`${tabName}-item-${
-                index + 1
-              }`}
+              testID={`${tabName}-item-${index + 1}`}
               key={index.toString()}
               color={Colors.RedDark100}
               width={'100%'}

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -28,6 +28,8 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
+      tabBarItemTestID: 'home-tab-item',
+      tabBarItemAccessibilityLabel: 'home-tab-item-label',
     },
   },
   {
@@ -36,6 +38,8 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Stack',
+      tabBarItemTestID: 'stack-tab-item',
+      tabBarItemAccessibilityLabel: 'stack-tab-item-label',
     },
   },
 ];
@@ -64,6 +68,7 @@ function TabContents() {
         style={styles.fillParent}
         scrollEdgeEffects={{ top: 'hidden', bottom: edgeEffectStyle }}>
         <ScrollView
+          testID={`home-scrollview`}
           contentInsetAdjustmentBehavior="automatic"
           style={styles.fillParent}>
           <ScrollViewContents />
@@ -81,6 +86,7 @@ function StackContents() {
         style={styles.fillParent}
         scrollEdgeEffects={{ top: 'hidden', bottom: 'hard' }}>
         <ScrollView
+          testID={`stack-scrollview`}
           contentInsetAdjustmentBehavior="automatic"
           style={styles.fillParent}>
           <ScrollViewContents />
@@ -106,6 +112,7 @@ function ScrollViewContents(props: { elementCount?: number }) {
         return (
           <View key={index.toString()} style={[{ width: '100%' }]}>
             <Rectangle
+              testID={`${useTabsNavigationContext().routeKey}-item-${index + 1}`}
               key={index.toString()}
               color={Colors.RedDark100}
               width={'100%'}

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -68,7 +68,7 @@ function TabContents() {
         style={styles.fillParent}
         scrollEdgeEffects={{ top: 'hidden', bottom: edgeEffectStyle }}>
         <ScrollView
-          testID={`home-scrollview`}
+          testID="home-scrollview"
           contentInsetAdjustmentBehavior="automatic"
           style={styles.fillParent}>
           <ScrollViewContents />
@@ -86,7 +86,7 @@ function StackContents() {
         style={styles.fillParent}
         scrollEdgeEffects={{ top: 'hidden', bottom: 'hard' }}>
         <ScrollView
-          testID={`stack-scrollview`}
+          testID="stack-scrollview"
           contentInsetAdjustmentBehavior="automatic"
           style={styles.fillParent}>
           <ScrollViewContents />

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -112,7 +112,9 @@ function ScrollViewContents(props: { elementCount?: number }) {
         return (
           <View key={index.toString()} style={[{ width: '100%' }]}>
             <Rectangle
-              testID={`${useTabsNavigationContext().routeKey}-item-${index + 1}`}
+              testID={`${useTabsNavigationContext().routeKey}-item-${
+                index + 1
+              }`}
               key={index.toString()}
               color={Colors.RedDark100}
               width={'100%'}

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario-description.ts
@@ -7,6 +7,6 @@ export const scenarioDescription: ScenarioDescription = {
     'Test whether special effects (on tab repetition) are performed correctly in nested container scenario ' +
     '(stack in tabs)',
   platforms: ['ios', 'android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'full',
   smokeTest: false,
 };

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
@@ -12,7 +12,7 @@ iOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
-TBD
+Full: All manual test steps covered.
 
 ## Prerequisites
 

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -13,11 +13,12 @@ function ScenarioSelect(props: {
   scenarios: Record<string, Scenario>;
   groupName: string;
 }) {
+  const scenarioGroupName = props.groupName.replace(/\s/g, '');
   return (
     <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        testID={`${props.groupName.replace(/\s/g, '')}-scenarios-scrollview`}>
+        testID={`${scenarioGroupName}-scenarios-scrollview`}>
         {Object.values(props.scenarios).map(
           ({ scenarioDescription }: Scenario) => {
             const { name, key, details, platforms, smokeTest, e2eCoverage } =

--- a/apps/src/tests/shared/ScenarioScreen.tsx
+++ b/apps/src/tests/shared/ScenarioScreen.tsx
@@ -17,7 +17,7 @@ function ScenarioSelect(props: {
     <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        testID={`${props.groupName}-scenarios-scrollview`}>
+        testID={`${props.groupName.replace(/\s/g, '')}-scenarios-scrollview`}>
         {Object.values(props.scenarios).map(
           ({ scenarioDescription }: Scenario) => {
             const { name, key, details, platforms, smokeTest, e2eCoverage } =


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1579

This PR adds comprehensive e2e test coverage for the ScrollViewMarker (SVM) component when used in a Stack nested within Tabs with special effects (scrollToTop behavior). The scenario tests whether re-tapping an active tab correctly scrolls the associated scroll view back to the top, a key use case for the scrollToTop special effect.

**Scope:** iOS and Android
**Key changes:**
- New e2e test suite with iOS general case and Android nested-stack-specific tests
- Extracted shared tab-selection helper (`forceSelectTabByLabel`) to e2e-utils to reduce code duplication
- Added testID and accessibility labels to the test screen for e2e element targeting
- Updated scenario documentation to reflect full e2e coverage

## Changes

- **FabricExample e2e**: Added new test file `test-stack-svm-tabs-special-effects.e2e.ts` with platform-specific test suites for SVM scrollToTop behavior in tabs
- **e2e-utils**: Extracted `selectComponentIntegrationTestsScreen()` and `forceSelectTabByLabel()` helpers; removed duplicate `forceSelectTabByLabel()` from single-feature-tests
- **test-tabs-special-effects-scroll-to-top**: Refactored to use new shared `forceSelectTabByLabel()` utility from e2e-utils
- **Test screen setup**: Added testIDs and accessibility labels to tab items and scrollviews in the SVM+tabs test screen to support e2e element targeting
- **Scenario documentation**: Updated scenario-description.ts e2eCoverage from "tbd" to "full" and updated scenario.md with e2e test information
- **Component-integration-tests registry**: Added export for scroll-view-marker test group and testID to the CIT root scrollview for navigation