### PR TITLE
refactor(iOS, Tabs): extract controller mounting infrastructure to shared utils

### DIFF
--- a/ios/helpers/container/RNSContainerHelpers.h
+++ b/ios/helpers/container/RNSContainerHelpers.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSContainerHelpers : NSObject
+
++ (BOOL)addChildViewController:(nullable UIViewController *)childViewController
+      toViewControllerManaging:(nullable UIView *)startingView
+             withContainerView:(nullable UIView *)containerView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSContainerHelpers.mm
+++ b/ios/helpers/container/RNSContainerHelpers.mm
@@ -1,0 +1,64 @@
+#import "RNSContainerHelpers.h"
+#import <React/UIView+React.h>
+
+@implementation RNSContainerHelpers
+
++ (BOOL)addChildViewController:(nullable UIViewController *)childViewController
+      toViewControllerManaging:(nullable UIView *)startingView
+             withContainerView:(nullable UIView *)containerView
+{
+  if (startingView == nil || childViewController == nil || containerView == nil) {
+    return NO;
+  }
+
+  if (childViewController.parentViewController != nil) {
+    return NO;
+  }
+
+  UIViewController *_Nullable parentViewController = [self findParentViewControllerCandidateFromView:startingView];
+
+  if (parentViewController == nil) {
+    return NO;
+  }
+
+  return [self addChildController:childViewController toParent:parentViewController containerView:containerView];
+}
+
++ (nullable UIViewController *)findParentViewControllerCandidateFromView:(nonnull UIView *)view
+{
+  if (view == nil) {
+    return nil;
+  }
+
+  UIView *currView = view;
+  UIViewController *_Nullable maybeViewController;
+
+  while (currView != nil) {
+    maybeViewController = currView.reactViewController;
+
+    if (maybeViewController != nil) {
+      return maybeViewController;
+    }
+
+    currView = currView.reactSuperview;
+  }
+
+  return nil;
+}
+
++ (BOOL)addChildController:(nullable UIViewController *)childViewController
+                  toParent:(nullable UIViewController *)parentViewController
+             containerView:(nullable UIView *)containerView
+{
+  if (!childViewController || !parentViewController || !containerView) {
+    return NO;
+  }
+
+  [parentViewController addChildViewController:childViewController];
+  [containerView addSubview:childViewController.view];
+  [childViewController didMoveToParentViewController:parentViewController];
+
+  return YES;
+}
+
+@end

--- a/ios/helpers/container/RNSContainerHelpers.mm
+++ b/ios/helpers/container/RNSContainerHelpers.mm
@@ -24,7 +24,7 @@
   return [self addChildController:childViewController toParent:parentViewController containerView:containerView];
 }
 
-+ (nullable UIViewController *)findParentViewControllerCandidateFromView:(nonnull UIView *)view
++ (nullable UIViewController *)findParentViewControllerCandidateFromView:(nullable UIView *)view
 {
   if (view == nil) {
     return nil;

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -10,6 +10,7 @@
 #import <rnscreens/RNSTabsHostComponentDescriptor.h>
 #import "RNSTabsHostComponentView+RNSImageLoader.h"
 
+#import "RNSContainerHelpers.h"
 #import "RNSConversions.h"
 #import "RNSConvert.h"
 #import "RNSDefines.h"
@@ -115,36 +116,13 @@ namespace react = facebook::react;
 
 - (void)didMoveToWindow
 {
-  if ([self window] != nil) {
-    [self reactAddControllerToClosestParent:_controller];
-  }
-}
-
-- (void)reactAddControllerToClosestParent:(UIViewController *)controller
-{
-  if (!controller.parentViewController) {
-    UIView *parentView = (UIView *)self.reactSuperview;
-    while (parentView) {
-      if (parentView.reactViewController) {
-        [parentView.reactViewController addChildViewController:controller];
-        [self addSubview:controller.view];
-
-        // Enable auto-layout to ensure valid size of tabBarController.view.
-        // In host tree, tabBarController.view is the only child of HostComponentView.
-        controller.view.translatesAutoresizingMaskIntoConstraints = NO;
-        [NSLayoutConstraint activateConstraints:@[
-          [controller.view.topAnchor constraintEqualToAnchor:self.topAnchor],
-          [controller.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-          [controller.view.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
-          [controller.view.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
-        ]];
-
-        [controller didMoveToParentViewController:parentView.reactViewController];
-        break;
-      }
-      parentView = (UIView *)parentView.reactSuperview;
+  if (self.window != nil && _controller.parentViewController == nil) {
+    BOOL mountResult = [RNSContainerHelpers addChildViewController:_controller
+                                          toViewControllerManaging:self.reactSuperview
+                                                 withContainerView:self];
+    if (mountResult) {
+      [self setupViewConstraintsForController:_controller];
     }
-    return;
   }
 }
 
@@ -425,6 +403,19 @@ namespace react = facebook::react;
       [_controller updateLayoutDirectionBelowIOS17IfNeeded];
     }
   }
+}
+
+- (void)setupViewConstraintsForController:(nonnull UIViewController *)controller
+{
+  // Enable auto-layout to ensure valid size of tabBarController.view.
+  // In host tree, tabBarController.view is the only child of HostComponentView.
+  controller.view.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [controller.view.topAnchor constraintEqualToAnchor:self.topAnchor],
+    [controller.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+    [controller.view.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+    [controller.view.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
+  ]];
 }
 
 #pragma mark - React Image Loader


### PR DESCRIPTION

I extract shared logic between all three containers (Stack, Split, Tabs) into
a shared helper and migrate the Tabs to use it.

I'll do other two container in a follow-up PR to keep the diff smaller and easier to review.

There should be no behavioral changes.
I do work now on ScrollViewMarker integration and this comes as a side quest.
