### PR TITLE
refactor(iOS, Stack): use RNSContainerHelpers for controller mounting

### DIFF
--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -10,6 +10,7 @@
 #import "RNSDefines.h"
 #import "RNSLog.h"
 
+#import "RNSContainerHelpers.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackOperationCoordinator.h"
 #import "RNSStackScreenComponentView.h"
@@ -46,8 +47,14 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   RNSLog(@"[RNScreens] StackHost [%ld] attached to window", self.tag);
-  [self reactAddControllerToClosestParent:_stackNavigationController];
-  [self setupViewConstraintsForController:_stackNavigationController];
+  if (self.window != nil && _stackNavigationController.parentViewController == nil) {
+    BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
+                                          toViewControllerManaging:self.reactSuperview
+                                                 withContainerView:self];
+    if (mountResult) {
+      [self setupViewConstraintsForController:_stackNavigationController];
+    }
+  }
 }
 
 #pragma mark - Communication with StackScreen
@@ -125,24 +132,6 @@ namespace react = facebook::react;
 {
   if (stackScreen.activityMode == RNSStackScreenActivityModeAttached) {
     [_stackOperationCoordinator addPushOperation:stackScreen];
-  }
-}
-
-- (void)reactAddControllerToClosestParent:(nonnull UIViewController *)controller
-{
-  RCTAssert(controller != nil, @"[RNScreens] Attempt to move to a nullish controller");
-  if (!controller.parentViewController) {
-    UIView *parentView = (UIView *)self.reactSuperview;
-    while (parentView) {
-      if (parentView.reactViewController) {
-        [parentView.reactViewController addChildViewController:controller];
-        [self addSubview:controller.view];
-        [controller didMoveToParentViewController:parentView.reactViewController];
-        break;
-      }
-      parentView = (UIView *)parentView.reactSuperview;
-    }
-    return;
   }
 }
 


### PR DESCRIPTION
> **Stacked on #4230.** This PR is based on the `@kkafar/ios-fix-container-controller-mounting-1-tabs` branch, not `main`. Review/merge #4230 first; the diff here is only the Stack-specific change.

## Description

#4230 extracted the duplicated "walk up the react superview chain, find the closest parent view controller and attach the child" logic into a shared `RNSContainerHelpers`. This PR is the second step of that consolidation: it migrates the gamma (v5) Stack host (`RNSStackHostComponentView`) onto the shared helper and removes its private `reactAddControllerToClosestParent:` copy.

Beyond deduplication, this also tightens the Stack host's `didMoveToWindow` to match the pattern already applied to the Tabs host, which fixes pre-existing latent issues in the gamma Stack:

- The old code ran the mounting + constraint setup **unconditionally on every `didMoveToWindow`**, with no `self.window != nil` guard, so it also executed while the view was being *removed* from a window.
- `setupViewConstraintsForController:` ran **unconditionally**, even when no parent view controller was found and the controller's view had not been added to the hierarchy. Activating full-bleed constraints against a view with no common ancestor raises an `NSLayoutConstraint` "no common ancestor" exception, and on repeated calls it accumulated duplicate constraints.

The new code is window-gated, idempotent across repeated `didMoveToWindow` calls, and only activates constraints when the controller was actually mounted (via the helper's `BOOL` return).

## Changes

- Import and use `RNSContainerHelpers addChildViewController:toViewControllerManaging:withContainerView:` in `RNSStackHostComponentView.didMoveToWindow`.
- Gate mounting on `self.window != nil && _stackNavigationController.parentViewController == nil`, and gate `setupViewConstraintsForController:` on the helper's mount result.
- Remove the now-unused private `reactAddControllerToClosestParent:` from `RNSStackHostComponentView`.

Note: the legacy (paper) `RNSScreenStack` is intentionally left untouched — its mounting logic also sets up `interactivePopGestureRecognizer` delegates and triggers `navigationController:willShowViewController:`, which the shared helper does not cover.

## Test plan

There should be no behavioural changes. I've validated the PR on `test-stack-simple-nav`.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes