### PR TITLE
refactor(iOS, Split): use RNSContainerHelpers for controller mounting

### DIFF
--- a/ios/gamma/split/RNSSplitHostComponentView.mm
+++ b/ios/gamma/split/RNSSplitHostComponentView.mm
@@ -5,6 +5,7 @@
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 
+#import "RNSContainerHelpers.h"
 #import "RNSConversions.h"
 #import "RNSDefines.h"
 #import "RNSSplitScreenComponentView.h"
@@ -124,23 +125,10 @@ static const CGFloat epsilon = 1e-6;
   [self setupController];
   RCTAssert(_controller != nil, @"[RNScreens] Controller must not be nil while attaching to window");
   [self requestSplitHostControllerForAppearanceUpdate];
-  [self reactAddControllerToClosestParent:_controller];
-}
-
-- (void)reactAddControllerToClosestParent:(UIViewController *)controller
-{
-  if (!controller.parentViewController) {
-    UIView *parentView = (UIView *)self.reactSuperview;
-    while (parentView) {
-      if (parentView.reactViewController) {
-        [parentView.reactViewController addChildViewController:controller];
-        [self addSubview:controller.view];
-        [controller didMoveToParentViewController:parentView.reactViewController];
-        break;
-      }
-      parentView = (UIView *)parentView.reactSuperview;
-    }
-    return;
+  if (self.window != nil && _controller.parentViewController == nil) {
+    [RNSContainerHelpers addChildViewController:_controller
+                       toViewControllerManaging:self.reactSuperview
+                              withContainerView:self];
   }
 }
 


### PR DESCRIPTION
> **Stacked on #4231.** This PR is based on the `@kkafar/ios-fix-container-controller-mounting-2-stack` branch, not `main`. Merge order is #4230 → #4231 → this PR; the diff here is only the Split-specific change.

## Description

Third step of the controller-mounting consolidation. #4230 extracted the duplicated "walk up the react superview chain, find the closest parent view controller and attach the child" logic into a shared `RNSContainerHelpers`; #4231 migrated the Stack host. This PR migrates the gamma (v5) Split host (`RNSSplitHostComponentView`) onto the same helper and removes its private `reactAddControllerToClosestParent:` copy.

Unlike the Tabs and Stack hosts, the Split host does **not** set up Auto Layout constraints for the controller's view — it relies on autoresizing masks. Its old mounting method only did add-child / add-subview / did-move, which is exactly what `RNSContainerHelpers` provides, so the helper call alone fully replaces the method with no constraint step (and no need for the helper's `BOOL` return here).

This also tightens `didMoveToWindow` to match the pattern applied to the other hosts: mounting is now guarded by `self.window != nil` in addition to the existing `parentViewController == nil` check, so the controller is no longer mounted while the host view is leaving its window.

## Changes

- Import and use `RNSContainerHelpers addChildViewController:toViewControllerManaging:withContainerView:` in `RNSSplitHostComponentView.didMoveToWindow`.
- Gate mounting on `self.window != nil && _controller.parentViewController == nil`.
- Remove the now-unused private `reactAddControllerToClosestParent:` from `RNSSplitHostComponentView`.
- Leave `setupController`, the non-nil assert, and `requestSplitHostControllerForAppearanceUpdate` outside the guard — they must run on every `didMoveToWindow`, as before.

## Test plan

There should be no behavioural changes. I've tested using `test-split-top-collumn-for-collapsing` - worked fine. 

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes