### PR TITLE
feat(Android, Stack v5): add toolbar menu item text related props

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -38,6 +38,7 @@ import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenu
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.valueOrNull
 import com.swmansion.rnscreens.utils.resolveDrawableAttr
 
 internal class StackHeaderApplicator(
@@ -500,6 +501,8 @@ internal class StackHeaderApplicator(
         options: StackHeaderToolbarMenuItemOptions,
     ) {
         options.title?.let { menuItem.title = it }
+        options.titleCondensed?.let { menuItem.titleCondensed = it.valueOrNull() }
+        options.tooltipText?.let { MenuItemCompat.setTooltipText(menuItem, it.valueOrNull()) }
         options.hidden?.let { menuItem.isVisible = !it }
         options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
 
@@ -593,6 +596,8 @@ internal class StackHeaderApplicator(
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =
         StackHeaderToolbarMenuItemOptions(
             title = title,
+            titleCondensed = StackHeaderToolbarUpdate.from(titleCondensed),
+            tooltipText = StackHeaderToolbarUpdate.from(tooltipText),
             hidden = hidden,
             showAsAction = showAsAction,
             icon = StackHeaderToolbarUpdate.from(icon),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -500,7 +500,7 @@ internal class StackHeaderApplicator(
         menuItem: MenuItem,
         options: StackHeaderToolbarMenuItemOptions,
     ) {
-        options.title?.let { menuItem.title = it }
+        options.title?.let { menuItem.title = it.valueOrNull() }
         options.titleCondensed?.let { menuItem.titleCondensed = it.valueOrNull() }
         options.tooltipText?.let { MenuItemCompat.setTooltipText(menuItem, it.valueOrNull()) }
         options.hidden?.let { menuItem.isVisible = !it }
@@ -595,7 +595,7 @@ internal class StackHeaderApplicator(
 
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =
         StackHeaderToolbarMenuItemOptions(
-            title = title,
+            title = StackHeaderToolbarUpdate.from(title),
             titleCondensed = StackHeaderToolbarUpdate.from(titleCondensed),
             tooltipText = StackHeaderToolbarUpdate.from(tooltipText),
             hidden = hidden,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -5,6 +5,8 @@ import android.graphics.drawable.Drawable
 internal data class StackHeaderToolbarMenuItemConfig(
     val id: String,
     val title: String,
+    val titleCondensed: String?,
+    val tooltipText: String?,
     val hidden: Boolean,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction,
     val icon: Drawable?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -4,7 +4,7 @@ import android.graphics.drawable.Drawable
 
 internal data class StackHeaderToolbarMenuItemConfig(
     val id: String,
-    val title: String,
+    val title: String?,
     val titleCondensed: String?,
     val tooltipText: String?,
     val hidden: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -9,6 +9,8 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
  */
 internal object StackHeaderToolbarMenuItemDefaults {
     const val TITLE: String = ""
+    val TITLE_CONDENSED: String? = null
+    val TOOLTIP_TEXT: String? = null
     const val HIDDEN: Boolean = false
     val SHOW_AS_ACTION: StackHeaderToolbarMenuItemShowAsAction = StackHeaderToolbarMenuItemShowAsAction.NEVER
     val ICON_TINT_COLOR_NORMAL: Int? = null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -8,7 +8,7 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
  * so the native side is the source of truth for them.
  */
 internal object StackHeaderToolbarMenuItemDefaults {
-    const val TITLE: String = ""
+    val TITLE: String? = null
     val TITLE_CONDENSED: String? = null
     val TOOLTIP_TEXT: String? = null
     const val HIDDEN: Boolean = false

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -8,7 +8,7 @@ import android.graphics.drawable.Drawable
  * A `null` field means "leave the current value unchanged".
  */
 internal data class StackHeaderToolbarMenuItemOptions(
-    val title: String? = null,
+    val title: StackHeaderToolbarUpdate<String>? = null,
     val titleCondensed: StackHeaderToolbarUpdate<String>? = null,
     val tooltipText: StackHeaderToolbarUpdate<String>? = null,
     val hidden: Boolean? = null,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -9,6 +9,8 @@ import android.graphics.drawable.Drawable
  */
 internal data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
+    val titleCondensed: StackHeaderToolbarUpdate<String>? = null,
+    val tooltipText: StackHeaderToolbarUpdate<String>? = null,
     val hidden: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
     val icon: StackHeaderToolbarUpdate<Drawable>?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -9,7 +9,6 @@ import com.swmansion.rnscreens.gamma.helpers.readBoolean
 import com.swmansion.rnscreens.gamma.helpers.readColor
 import com.swmansion.rnscreens.gamma.helpers.readImageUri
 import com.swmansion.rnscreens.gamma.helpers.readOptionalString
-import com.swmansion.rnscreens.gamma.helpers.readString
 import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 
 internal object StackHeaderToolbarMenuMapper {
@@ -33,7 +32,7 @@ internal object StackHeaderToolbarMenuMapper {
 
     fun parseMenuItemOptions(map: ReadableMap): StackHeaderToolbarMenuItemOptions =
         StackHeaderToolbarMenuItemOptions(
-            title = map.readNullableStringUpdateWithDefault("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            title = map.readNullableStringUpdate("title"),
             titleCondensed = map.readNullableStringUpdate("titleCondensed"),
             tooltipText = map.readNullableStringUpdate("tooltipText"),
             hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
@@ -133,7 +132,7 @@ internal object StackHeaderToolbarMenuMapper {
     private fun parseItemConfig(map: ReadableMap): StackHeaderToolbarMenuItemConfig =
         StackHeaderToolbarMenuItemConfig(
             id = map.requireNotNullString("id"),
-            title = map.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            title = map.readOptionalString("title") ?: StackHeaderToolbarMenuItemDefaults.TITLE,
             titleCondensed =
                 map.readOptionalString("titleCondensed") ?: StackHeaderToolbarMenuItemDefaults.TITLE_CONDENSED,
             tooltipText =
@@ -225,18 +224,8 @@ internal object StackHeaderToolbarMenuMapper {
     //
     // A plain `T?` return can encode this only when the field's default is non-null,
     // so `null` unambiguously means "no change". Fields whose default is null (the
-    // tint colors) must return `StackHeaderToolbarUpdate<T>?` instead, to tell "no
-    // change" (null) apart from "reset" (Reset).
-    private fun ReadableMap.readNullableStringUpdateWithDefault(
-        key: String,
-        default: String,
-    ): String? =
-        when {
-            !this.hasKey(key) -> null
-            this.isNull(key) -> default
-            else -> this.getString(key) ?: default
-        }
-
+    // string fields and tint colors) must return `StackHeaderToolbarUpdate<T>?`
+    // instead, to tell "no change" (null) apart from "reset" (Reset).
     private fun ReadableMap.readNullableStringUpdate(key: String): StackHeaderToolbarUpdate<String>? =
         when {
             !this.hasKey(key) -> null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -33,7 +33,9 @@ internal object StackHeaderToolbarMenuMapper {
 
     fun parseMenuItemOptions(map: ReadableMap): StackHeaderToolbarMenuItemOptions =
         StackHeaderToolbarMenuItemOptions(
-            title = map.readNullableStringUpdate("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            title = map.readNullableStringUpdateWithDefault("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            titleCondensed = map.readNullableStringUpdate("titleCondensed"),
+            tooltipText = map.readNullableStringUpdate("tooltipText"),
             hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
             showAsAction =
                 map.readNullableShowAsActionEnumUpdate(
@@ -132,6 +134,10 @@ internal object StackHeaderToolbarMenuMapper {
         StackHeaderToolbarMenuItemConfig(
             id = map.requireNotNullString("id"),
             title = map.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
+            titleCondensed =
+                map.readOptionalString("titleCondensed") ?: StackHeaderToolbarMenuItemDefaults.TITLE_CONDENSED,
+            tooltipText =
+                map.readOptionalString("tooltipText") ?: StackHeaderToolbarMenuItemDefaults.TOOLTIP_TEXT,
             hidden = map.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
             showAsAction = map.readShowAsActionEnum("showAsAction", StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION),
             icon = null,
@@ -221,7 +227,7 @@ internal object StackHeaderToolbarMenuMapper {
     // so `null` unambiguously means "no change". Fields whose default is null (the
     // tint colors) must return `StackHeaderToolbarUpdate<T>?` instead, to tell "no
     // change" (null) apart from "reset" (Reset).
-    private fun ReadableMap.readNullableStringUpdate(
+    private fun ReadableMap.readNullableStringUpdateWithDefault(
         key: String,
         default: String,
     ): String? =
@@ -229,6 +235,13 @@ internal object StackHeaderToolbarMenuMapper {
             !this.hasKey(key) -> null
             this.isNull(key) -> default
             else -> this.getString(key) ?: default
+        }
+
+    private fun ReadableMap.readNullableStringUpdate(key: String): StackHeaderToolbarUpdate<String>? =
+        when {
+            !this.hasKey(key) -> null
+            this.isNull(key) -> StackHeaderToolbarUpdate.Reset
+            else -> StackHeaderToolbarUpdate.from(this.getString(key))
         }
 
     private fun ReadableMap.readNullableBooleanUpdate(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarUpdate.kt
@@ -16,3 +16,9 @@ internal sealed interface StackHeaderToolbarUpdate<out T> {
             }
     }
 }
+
+internal fun <T> StackHeaderToolbarUpdate<T>.valueOrNull(): T? =
+    when (this) {
+        StackHeaderToolbarUpdate.Reset -> null
+        is StackHeaderToolbarUpdate.Set -> value
+    }

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -12,6 +12,7 @@ import TestStackHeaderMenuIOS from './test-stack-header-menu-ios';
 import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
 import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
+import TestStackToolbarMenuTitle from './test-stack-toolbar-menu-title-android';
 import TestStackToolbarMenuIcon from './test-stack-toolbar-menu-icon-android';
 import TestStackToolbarMenuGroups from './test-stack-toolbar-menu-groups-android';
 import TestStackToolbarNestedMenu from './test-stack-toolbar-nested-menu-android';
@@ -30,6 +31,7 @@ export { default as TestStackBackButton } from './test-stack-back-button-android
 export { default as TestStackToolbarMenuCommands } from './test-stack-toolbar-menu-commands-android';
 export { default as TestStackToolbarMenuGroups } from './test-stack-toolbar-menu-groups-android';
 export { default as TestStackToolbarMenuShowAsAction } from './test-stack-toolbar-menu-show-as-action-android';
+export { default as TestStackToolbarMenuTitle } from './test-stack-toolbar-menu-title-android';
 export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-icon-android';
 export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nested-menu-android';
 
@@ -46,6 +48,7 @@ const scenarios = {
   TestStackToolbarMenuCommands,
   TestStackToolbarMenuGroups,
   TestStackToolbarMenuShowAsAction,
+  TestStackToolbarMenuTitle,
   TestStackToolbarMenuIcon,
   TestStackToolbarNestedMenu,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -1,0 +1,347 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import type {
+  StackHeaderToolbarMenuElementAndroid,
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuItemShowAsActionAndroid,
+} from 'react-native-screens/experimental';
+import type { PlatformIconAndroid } from 'react-native-screens';
+import { scenarioDescription } from './scenario-descriptions';
+
+const ID_OPTIONS = ['item-1', 'item-2', 'item-3'] as const;
+type IdOption = (typeof ID_OPTIONS)[number];
+
+const ICON_OPTIONS = ['undefined', 'searchIcon'] as const;
+type IconOption = (typeof ICON_OPTIONS)[number];
+
+const SHOW_AS_ACTION_OPTIONS = [
+  'undefined',
+  'never',
+  'always',
+  'alwaysWithText',
+  'ifRoom',
+  'ifRoomWithText',
+] as const;
+type ShowAsActionOption = (typeof SHOW_AS_ACTION_OPTIONS)[number];
+
+const TITLE_CONDENSED_OPTIONS = ['undefined', 'Cond', 'Short'] as const;
+type TitleCondensedOption = (typeof TITLE_CONDENSED_OPTIONS)[number];
+
+const TOOLTIP_OPTIONS = ['undefined', 'Tooltip text', 'Hi!'] as const;
+type TooltipOption = (typeof TOOLTIP_OPTIONS)[number];
+
+// Title is fixed per id so the condensed/tooltip fallbacks are easy to spot.
+const ITEM_TITLES: Record<IdOption, string> = {
+  'item-1': 'First Item',
+  'item-2': 'Second Item Title',
+  'item-3': 'Third Item Long Title',
+};
+
+type CmdTitleOption = 'no change' | 'Cmd Title' | 'undefined';
+type CmdCondensedOption = 'no change' | TitleCondensedOption;
+type CmdTooltipOption = 'no change' | TooltipOption;
+
+const CMD_TITLE_OPTIONS: CmdTitleOption[] = [
+  'no change',
+  'Cmd Title',
+  'undefined',
+];
+const CMD_CONDENSED_OPTIONS: CmdCondensedOption[] = [
+  'no change',
+  ...TITLE_CONDENSED_OPTIONS,
+];
+const CMD_TOOLTIP_OPTIONS: CmdTooltipOption[] = [
+  'no change',
+  ...TOOLTIP_OPTIONS,
+];
+
+interface SlotConfig {
+  id: IdOption;
+  icon: IconOption;
+  showAsAction: ShowAsActionOption;
+  titleCondensed: TitleCondensedOption;
+  tooltipText: TooltipOption;
+}
+
+type Slots = [SlotConfig, SlotConfig, SlotConfig];
+
+const DEFAULT_SLOTS: Slots = [
+  {
+    id: 'item-1',
+    icon: 'searchIcon',
+    showAsAction: 'alwaysWithText',
+    titleCondensed: 'Cond',
+    tooltipText: 'Tooltip text',
+  },
+  {
+    id: 'item-2',
+    icon: 'searchIcon',
+    showAsAction: 'always',
+    titleCondensed: 'undefined',
+    tooltipText: 'undefined',
+  },
+  {
+    id: 'item-3',
+    icon: 'undefined',
+    showAsAction: 'never',
+    titleCondensed: 'Short',
+    tooltipText: 'undefined',
+  },
+];
+
+function resolveIcon(option: IconOption): PlatformIconAndroid | undefined {
+  switch (option) {
+    case 'searchIcon':
+      return {
+        type: 'imageSource',
+        imageSource: require('@assets/search_black.png'),
+      };
+    default:
+      return undefined;
+  }
+}
+
+function resolveShowAsAction(
+  v: ShowAsActionOption,
+): StackHeaderToolbarMenuItemShowAsActionAndroid | undefined {
+  return v === 'undefined' ? undefined : v;
+}
+
+function resolveOptionalString(v: string): string | undefined {
+  return v === 'undefined' ? undefined : v;
+}
+
+function buildItems(slots: Slots): StackHeaderToolbarMenuElementAndroid[] {
+  return slots.map(
+    ({ id, icon, showAsAction, titleCondensed, tooltipText }) => ({
+      type: 'menuItem',
+      id,
+      title: ITEM_TITLES[id],
+      titleCondensed: resolveOptionalString(titleCondensed),
+      tooltipText: resolveOptionalString(tooltipText),
+      icon: resolveIcon(icon),
+      showAsAction: resolveShowAsAction(showAsAction),
+    }),
+  );
+}
+
+function withOnPress(
+  items: ReturnType<typeof buildItems>,
+  onPress: (id: string) => void,
+) {
+  return items.map(item => ({
+    ...item,
+    onPress: () => onPress(item.id),
+  }));
+}
+
+function updateSlotAt(
+  slots: Slots,
+  index: number,
+  patch: Partial<SlotConfig>,
+): Slots {
+  return slots.map((s, i) => (i === index ? { ...s, ...patch } : s)) as Slots;
+}
+
+const HEADER_TITLE = 'Title / Condensed / Tooltip';
+
+function TestStackToolbarMenuTitle() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Main',
+          Component: MainScreen,
+          options: {
+            headerConfig: {
+              title: HEADER_TITLE,
+              android: { toolbarMenu: { children: buildItems(DEFAULT_SLOTS) } },
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function MainScreen() {
+  const [slots, setSlots] = useState<Slots>(DEFAULT_SLOTS);
+  const [lastClicked, setLastClicked] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<IdOption>('item-1');
+  const [cmdTitle, setCmdTitle] = useState<CmdTitleOption>('no change');
+  const [cmdCondensed, setCmdCondensed] =
+    useState<CmdCondensedOption>('no change');
+  const [cmdTooltip, setCmdTooltip] = useState<CmdTooltipOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenu: {
+            children: withOnPress(buildItems(DEFAULT_SLOTS), setLastClicked),
+          },
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey]);
+
+  const applySlots = useCallback(
+    (next: Slots) => {
+      setSlots(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenu: {
+              children: withOnPress(buildItems(next), setLastClicked),
+            },
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdTitle !== 'no change' && {
+        title: cmdTitle === 'undefined' ? undefined : cmdTitle,
+      }),
+      ...(cmdCondensed !== 'no change' && {
+        titleCondensed: resolveOptionalString(cmdCondensed),
+      }),
+      ...(cmdTooltip !== 'no change' && {
+        tooltipText: resolveOptionalString(cmdTooltip),
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [cmdTargetId, cmdTitle, cmdCondensed, cmdTooltip]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<IdOption>
+        label="target id"
+        value={cmdTargetId}
+        items={[...ID_OPTIONS]}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdTitleOption>
+        label="title"
+        value={cmdTitle}
+        items={CMD_TITLE_OPTIONS}
+        onValueChange={setCmdTitle}
+      />
+      <SettingsPicker<CmdCondensedOption>
+        label="titleCondensed"
+        value={cmdCondensed}
+        items={CMD_CONDENSED_OPTIONS}
+        onValueChange={setCmdCondensed}
+      />
+      <SettingsPicker<CmdTooltipOption>
+        label="tooltipText"
+        value={cmdTooltip}
+        items={CMD_TOOLTIP_OPTIONS}
+        onValueChange={setCmdTooltip}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Result</Text>
+      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+
+      <Text style={styles.heading}>Menu Items — Props</Text>
+      <SlotControls
+        slots={slots}
+        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+      />
+    </ScrollView>
+  );
+}
+
+interface SlotControlsProps {
+  slots: Slots;
+  updateSlot: (index: number, patch: Partial<SlotConfig>) => void;
+}
+
+function SlotControls({ slots, updateSlot }: SlotControlsProps) {
+  return (
+    <>
+      {slots.map((slot, i) => (
+        <React.Fragment key={i}>
+          <Text style={styles.slotLabel}>
+            Slot {i + 1} ({slot.id}) — title "{ITEM_TITLES[slot.id]}"
+          </Text>
+          <SettingsPicker<IconOption>
+            label="icon"
+            value={slot.icon}
+            items={[...ICON_OPTIONS]}
+            onValueChange={v => updateSlot(i, { icon: v })}
+          />
+          <SettingsPicker<ShowAsActionOption>
+            label="showAsAction"
+            value={slot.showAsAction}
+            items={[...SHOW_AS_ACTION_OPTIONS]}
+            onValueChange={v => updateSlot(i, { showAsAction: v })}
+          />
+          <SettingsPicker<TitleCondensedOption>
+            label="titleCondensed"
+            value={slot.titleCondensed}
+            items={[...TITLE_CONDENSED_OPTIONS]}
+            onValueChange={v => updateSlot(i, { titleCondensed: v })}
+          />
+          <SettingsPicker<TooltipOption>
+            label="tooltipText"
+            value={slot.tooltipText}
+            items={[...TOOLTIP_OPTIONS]}
+            onValueChange={v => updateSlot(i, { tooltipText: v })}
+          />
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  slotLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(TestStackToolbarMenuTitle, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -5,7 +5,7 @@ import {
   StackContainer,
   useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
-import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { SettingsPicker } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderToolbarMenuElementAndroid,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario-descriptions.ts
@@ -1,0 +1,12 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Title',
+  key: 'test-stack-toolbar-menu-title-android',
+  details:
+    'Tests the title-related toolbar menu item props: title, titleCondensed ' +
+    '(toolbar button label) and tooltipText (long-press tooltip).',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario.md
@@ -1,0 +1,152 @@
+# Test Scenario: Stack Toolbar Menu Title
+
+## Details
+
+**Description:** This test focuses on the title-related Android toolbar
+menu item props on the gamma stack header: `title`, `titleCondensed` and
+`tooltipText`. It verifies where each one renders and how they relate:
+`titleCondensed` is the label shown on the **Toolbar action button**
+(falling back to `title`), `tooltipText` is the **long-press / hover
+tooltip** of a Toolbar button (falling back to `title`), and the full
+`title` is always used in the **overflow menu**. It also verifies the
+text with icon appears only if there is room (visible in landscape, hidden
+in portrait on a phone).
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+TBD — automation is possible and planned but not yet implemented.
+
+## Prerequisites
+
+- Android emulator (phone)
+
+## Note
+
+- `titleCondensed` only affects the **Toolbar action button** text. The
+  overflow menu always shows the full `title`. When `titleCondensed` is
+  unset, the button uses `title`.
+- `tooltipText` only affects the long-press tooltip of a **Toolbar
+  button**. It has no effect on overflow rows. When unset, the tooltip
+  falls back to `title`.
+- Text-with-icon "if room": when an item has both an icon and a
+  `*WithText` action, the text label is shown next to the icon only when
+  there is room — on a phone this means it appears in **landscape** and is
+  hidden in **portrait**. An item with text but **no icon** always shows
+  its text.
+- Changing any **Props** control rebuilds the whole menu and discards any
+  prior `setToolbarMenuItemOptions` state.
+
+## Steps
+
+### Baseline — initial render
+
+1. Launch the app and navigate to **Stack Toolbar Menu Title** (in
+   portrait).
+
+- [ ] Header reads "Title / Condensed / Tooltip". The Toolbar shows two
+      icon buttons (`item-1` and `item-2`) plus an overflow button (⋮).
+      `item-1`'s "Cond" text is **not** shown next to its icon in portrait.
+
+2. Open the overflow menu (⋮).
+
+- [ ] One row is present reading the full title "Third Item Long Title"
+      (`item-3`) — the condensed "Short" is **not** used in the overflow.
+
+---
+
+### titleCondensed on the Toolbar button (no icon)
+
+3. Set **Slot 1** `icon` = `undefined` (keep `showAsAction` =
+   `alwaysWithText`, `titleCondensed` = `Cond`).
+
+- [ ] `item-1` now appears as a **text** button reading "Cond" (the
+      condensed title), not "First Item".
+
+4. Set **Slot 1** `titleCondensed` = `undefined`.
+
+- [ ] The button text falls back to the full title "First Item".
+
+5. Set **Slot 1** `titleCondensed` = `Cond`, then `showAsAction` =
+   `never`.
+
+- [ ] `item-1` moves into the overflow menu. Its overflow row reads the
+      full title "First Item" — the condensed "Cond" is **not** used.
+
+---
+
+### titleCondensed with an icon depends on room (orientation)
+
+6. Set **Slot 1** `icon` = `searchIcon`, `showAsAction` =
+   `alwaysWithText`, `titleCondensed` = `Cond`. Keep portrait.
+
+- [ ] `item-1` shows the **icon only**.
+
+7. Rotate the device to **landscape**.
+
+- [ ] `item-1` now shows the icon **and** the "Cond" label beside it.
+
+8. Rotate back to **portrait**.
+
+- [ ] The label is hidden again (icon only).
+
+---
+
+### tooltipText on a Toolbar icon button
+
+9. Long-press `item-2`'s icon button (default: no `tooltipText`).
+
+- [ ] A tooltip appears reading the full title "Second Item Title"
+      (tooltip falls back to `title`).
+
+10. Set **Slot 2** `tooltipText` = `Tooltip text`, then long-press
+    `item-2`.
+
+- [ ] The tooltip now reads "Tooltip text".
+
+11. Set **Slot 2** `tooltipText` = `undefined`, then long-press `item-2`.
+
+- [ ] The tooltip falls back to "Second Item Title" again.
+
+12. Set **Slot 2** `showAsAction` = `never`, `tooltipText` =
+    `Tooltip text`. Open the overflow menu.
+
+- [ ] `item-2` is a normal overflow row reading "Second Item Title"; the
+      `tooltipText` has no effect on overflow rows.
+
+---
+
+### Imperative command — set and reset
+
+13. Set **Slot 1** `icon` = `undefined`, `showAsAction` =
+    `alwaysWithText`, `titleCondensed` = `Cond`.
+
+- [ ] `item-1` Toolbar button reads "Cond".
+
+14. In **Send Command**, set target id = `item-1`, titleCondensed =
+    `Short`, title = `no change`, tooltipText = `no change`. Tap **Send
+    Command**.
+
+- [ ] The button text updates live to "Short".
+
+15. Send Command: target id = `item-1`, titleCondensed = `undefined`
+    (reset).
+
+- [ ] The button text falls back to the full title "First Item".
+
+16. Send Command: target id = `item-1`, title = `Cmd Title`,
+    titleCondensed = `no change`.
+
+- [ ] The button text becomes "Cmd Title" (no condensed set, so `title`
+      is used).
+
+17. Set **Slot 2** `showAsAction` = `always`. Then Send Command:
+    target id = `item-2`, tooltipText = `Hi!`. Long-press `item-2`'s icon button.
+
+- [ ] The tooltip reads "Hi!".
+
+18. Send Command: target id = `item-2`, tooltipText = `undefined`
+    (reset). Long-press `item-2`.
+
+- [ ] The tooltip falls back to "Second Item Title".

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -85,6 +85,29 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    */
   title?: string | undefined;
   /**
+   * @summary Shorter title used for the menu element when it is displayed as
+   * a button in the Toolbar.
+   *
+   * @description
+   * When the element is shown in the Toolbar with a text label, this
+   * condensed title is used instead of `title`. The full `title` is still
+   * used everywhere else (the overflow menu and submenus).
+   *
+   * @platform android
+   */
+  titleCondensed?: string | undefined;
+  /**
+   * @summary Tooltip shown on long-press (or pointer hover) of the menu
+   * element when it is displayed as a button in the Toolbar.
+   *
+   * @remarks
+   * Applies only to elements shown as a button in the Toolbar; it has no
+   * effect on elements placed in the overflow menu.
+   *
+   * @platform android
+   */
+  tooltipText?: string | undefined;
+  /**
    * @summary Specifies if the menu element should be hidden.
    *
    * @default false

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -33,7 +33,7 @@ type StackHeaderToolbarMenuItemTypeAndroid = 'action' | 'toggle' | 'automatic';
 
 export interface StackHeaderToolbarMenuItemBaseAndroid {
   id: string;
-  title?: CT.WithDefault<string, ''>;
+  title?: string | undefined;
   titleCondensed?: string | undefined;
   tooltipText?: string | undefined;
   hidden?: CT.WithDefault<boolean, false>;

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -34,6 +34,8 @@ type StackHeaderToolbarMenuItemTypeAndroid = 'action' | 'toggle' | 'automatic';
 export interface StackHeaderToolbarMenuItemBaseAndroid {
   id: string;
   title?: CT.WithDefault<string, ''>;
+  titleCondensed?: string | undefined;
+  tooltipText?: string | undefined;
   hidden?: CT.WithDefault<boolean, false>;
   showAsAction?: CT.WithDefault<
     StackHeaderToolbarMenuItemShowAsActionAndroid,


### PR DESCRIPTION
## Description

Adds `titleCondensed`, `tooltipText` props for menu items in toolbar menu.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1496.

## Changes

- add `titleCondensed`, `tooltipText` props to JS layer
- handle new props in native Applicator
- unify handling strings (`title`) - even though empty string and null doesn't really make a difference for text props (only in `textCondensed` but this is also controllable by `withText` `showAsAction` flag; but e.g. for `groupId` no id and id set to empty string is different), I decided to use one unified approach for all props - differentiate between empty string and null and led Android decide what to do
- add SFT

## Visual documentation

https://github.com/user-attachments/assets/3d5ec4bc-ed3e-409a-9a55-33c8da684d90

## Test plan

Run `test-stack-toolbar-menu-title` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
