### PR TITLE
chore(deps): aggregate dependabot updates

### DIFF
--- a/FabricExample/Gemfile.lock
+++ b/FabricExample/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     escape (0.0.4)

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -10538,15 +10538,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -7813,12 +7813,12 @@ __metadata:
   linkType: hard
 
 "launch-editor@npm:^2.9.1":
-  version: 2.10.0
-  resolution: "launch-editor@npm:2.10.0"
+  version: 2.14.1
+  resolution: "launch-editor@npm:2.14.1"
   dependencies:
-    picocolors: "npm:^1.0.0"
-    shell-quote: "npm:^1.8.1"
-  checksum: 10c0/8b5a26be6b0da1da039ed2254b837dea0651a6406ea4dc4c9a5b28ea72862f1b12880135c495baf9d8a08997473b44034172506781744cf82e155451a40b7d51
+    picocolors: "npm:^1.1.1"
+    shell-quote: "npm:^1.8.4"
+  checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
   languageName: node
   linkType: hard
 
@@ -10074,10 +10074,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.2, shell-quote@npm:^1.8.1":
+"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.2":
   version: 1.8.2
   resolution: "shell-quote@npm:1.8.2"
   checksum: 10c0/85fdd44f2ad76e723d34eb72c753f04d847ab64e9f1f10677e3f518d0e5b0752a176fd805297b30bb8c3a1556ebe6e77d2288dbd7b7b0110c7e941e9e9c20ce1
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 

--- a/TVOSExample/Gemfile
+++ b/TVOSExample/Gemfile
@@ -8,7 +8,7 @@ ruby ">= 2.6.10", "<= 3.3.6"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '< 1.3.8'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/TVOSExample/Gemfile.lock
+++ b/TVOSExample/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     escape (0.0.4)
@@ -108,7 +108,7 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
+  concurrent-ruby (< 1.3.8)
   logger
   mutex_m
   nkf

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7844,8 +7844,8 @@ __metadata:
   linkType: hard
 
 "http-proxy-middleware@npm:^2.0.3":
-  version: 2.0.9
-  resolution: "http-proxy-middleware@npm:2.0.9"
+  version: 2.0.10
+  resolution: "http-proxy-middleware@npm:2.0.10"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -7857,7 +7857,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10c0/8e9032af625f7c9f2f0d318f6cdb14eb725cc16ffe7b4ccccea25cf591fa819bb7c3bb579e0b543e0ae9c73059b505a6d728290c757bff27bae526a6ed11c05e
+  checksum: 10c0/363cd25fbac18f851af93cea34ac7068656413c9af5af12d3b2a127adc70623d2c0d6e9e12037bbac5a4744b762fd9f89fb16e16c29ad06af2b17766890c1b26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Aggregate dependabot updates

This PR aggregates all currently open Dependabot dependency updates into a single
branch so they can be reviewed and landed as one unit instead of five separate
merges. All changes are lock-file / manifest version bumps.

### Merged PRs

- #4215 — chore(deps): bump http-proxy-middleware from 2.0.9 to 2.0.10 in /docs
- #4207 — chore(deps): bump concurrent-ruby from 1.3.6 to 1.3.7 in /FabricExample
- #4206 — chore(deps): bump concurrent-ruby from 1.3.3 to 1.3.7 in /TVOSExample
- #4187 — chore(deps): bump tar from 7.5.11 to 7.5.16 in /FabricExample
- #4186 — chore(deps): bump launch-editor from 2.10.0 to 2.14.1 in /FabricExample