### PR TITLE
feat(Android, Stack v5): add support for disabling menu items

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -501,6 +501,7 @@ internal class StackHeaderApplicator(
     ) {
         options.title?.let { menuItem.title = it }
         options.hidden?.let { menuItem.isVisible = !it }
+        options.disabled?.let { menuItem.isEnabled = !it }
         options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
 
         // checked is intentionally not handled here. The coordinator layout manages it in
@@ -594,6 +595,7 @@ internal class StackHeaderApplicator(
         StackHeaderToolbarMenuItemOptions(
             title = title,
             hidden = hidden,
+            disabled = disabled,
             showAsAction = showAsAction,
             icon = StackHeaderToolbarUpdate.from(icon),
             iconTintColorNormal = StackHeaderToolbarUpdate.from(iconTintColorNormal),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemConfig.kt
@@ -6,6 +6,7 @@ internal data class StackHeaderToolbarMenuItemConfig(
     val id: String,
     val title: String,
     val hidden: Boolean,
+    val disabled: Boolean,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction,
     val icon: Drawable?,
     val iconTintColorNormal: Int?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemDefaults.kt
@@ -10,6 +10,7 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 internal object StackHeaderToolbarMenuItemDefaults {
     const val TITLE: String = ""
     const val HIDDEN: Boolean = false
+    const val DISABLED: Boolean = false
     val SHOW_AS_ACTION: StackHeaderToolbarMenuItemShowAsAction = StackHeaderToolbarMenuItemShowAsAction.NEVER
     val ICON_TINT_COLOR_NORMAL: Int? = null
     val ICON_TINT_COLOR_PRESSED: Int? = null

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuItemOptions.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable
 internal data class StackHeaderToolbarMenuItemOptions(
     val title: String? = null,
     val hidden: Boolean? = null,
+    val disabled: Boolean? = null,
     val showAsAction: StackHeaderToolbarMenuItemShowAsAction? = null,
     val icon: StackHeaderToolbarUpdate<Drawable>?,
     val iconTintColorNormal: StackHeaderToolbarUpdate<Int>?,

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -35,6 +35,7 @@ internal object StackHeaderToolbarMenuMapper {
         StackHeaderToolbarMenuItemOptions(
             title = map.readNullableStringUpdate("title", StackHeaderToolbarMenuItemDefaults.TITLE),
             hidden = map.readNullableBooleanUpdate("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+            disabled = map.readNullableBooleanUpdate("disabled", StackHeaderToolbarMenuItemDefaults.DISABLED),
             showAsAction =
                 map.readNullableShowAsActionEnumUpdate(
                     "showAsAction",
@@ -133,6 +134,7 @@ internal object StackHeaderToolbarMenuMapper {
             id = map.requireNotNullString("id"),
             title = map.readString("title", StackHeaderToolbarMenuItemDefaults.TITLE),
             hidden = map.readBoolean("hidden", StackHeaderToolbarMenuItemDefaults.HIDDEN),
+            disabled = map.readBoolean("disabled", StackHeaderToolbarMenuItemDefaults.DISABLED),
             showAsAction = map.readShowAsActionEnum("showAsAction", StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION),
             icon = null,
             iconTintColorNormal =

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -11,6 +11,7 @@ import TestStackSubviewsIOS from './test-stack-subviews-ios';
 import TestStackHeaderMenuIOS from './test-stack-header-menu-ios';
 import TestStackBackButton from './test-stack-back-button-android';
 import TestStackToolbarMenuCommands from './test-stack-toolbar-menu-commands-android';
+import TestStackToolbarMenuDisabled from './test-stack-toolbar-menu-disabled-android';
 import TestStackToolbarMenuShowAsAction from './test-stack-toolbar-menu-show-as-action-android';
 import TestStackToolbarMenuIcon from './test-stack-toolbar-menu-icon-android';
 import TestStackToolbarMenuGroups from './test-stack-toolbar-menu-groups-android';
@@ -28,6 +29,7 @@ export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
 export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
 export { default as TestStackBackButton } from './test-stack-back-button-android';
 export { default as TestStackToolbarMenuCommands } from './test-stack-toolbar-menu-commands-android';
+export { default as TestStackToolbarMenuDisabled } from './test-stack-toolbar-menu-disabled-android';
 export { default as TestStackToolbarMenuGroups } from './test-stack-toolbar-menu-groups-android';
 export { default as TestStackToolbarMenuShowAsAction } from './test-stack-toolbar-menu-show-as-action-android';
 export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-icon-android';
@@ -44,6 +46,7 @@ const scenarios = {
   TestStackHeaderSubviewOnPress,
   TestStackBackButton,
   TestStackToolbarMenuCommands,
+  TestStackToolbarMenuDisabled,
   TestStackToolbarMenuGroups,
   TestStackToolbarMenuShowAsAction,
   TestStackToolbarMenuIcon,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -82,6 +82,8 @@ function buildMenu(
         title: 'Action Bar',
         showAsAction: 'always',
         icon: SEARCH_ICON,
+        iconTintColorNormal: Colors.PurpleLight100,
+        iconTintColorDisabled: Colors.PurpleLight60,
         disabled: disabled['action-bar'],
         onPress: () => onItemPress('action-bar'),
       },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import type {
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuBaseAndroid,
+  StackHeaderToolbarMenuItemOptionsAndroid,
+} from 'react-native-screens/experimental';
+import type { PlatformIconAndroid } from 'react-native-screens';
+import { scenarioDescription } from './scenario-descriptions';
+
+// Every disable-relevant element: a toolbar action button, an overflow
+// action item, a checkable group (one item starts checked), and a submenu
+// with a leaf item.
+const ALL_IDS = [
+  'action-bar',
+  'action-overflow',
+  'opt-a',
+  'opt-b',
+  'submenu',
+  'sub-item',
+] as const;
+type AllIds = (typeof ALL_IDS)[number];
+
+type CmdDisabledOption = 'no change' | 'true' | 'false' | 'undefined';
+
+const CMD_DISABLED_OPTIONS: CmdDisabledOption[] = [
+  'no change',
+  'true',
+  'false',
+  'undefined',
+];
+
+type DisabledById = Record<AllIds, boolean>;
+
+const DEFAULT_DISABLED: DisabledById = {
+  'action-bar': false,
+  'action-overflow': false,
+  'opt-a': false,
+  'opt-b': false,
+  submenu: false,
+  'sub-item': false,
+};
+
+const ITEM_LABELS: Record<AllIds, string> = {
+  'action-bar': 'action-bar (toolbar button)',
+  'action-overflow': 'action-overflow',
+  'opt-a': 'opt-a (checkable, checked)',
+  'opt-b': 'opt-b (checkable)',
+  submenu: 'submenu',
+  'sub-item': 'sub-item',
+};
+
+const SEARCH_ICON: PlatformIconAndroid = {
+  type: 'imageSource',
+  imageSource: require('@assets/search_black.png'),
+};
+
+function buildMenu(
+  disabled: DisabledById,
+  onItemPress: (id: string) => void,
+  onGroupChange: (groupId: string, selectedIds: string[]) => void,
+): StackHeaderToolbarMenuBaseAndroid {
+  return {
+    groups: [
+      {
+        groupId: 'options',
+        singleSelection: false,
+        onSelectionChange: ids => onGroupChange('options', ids),
+      },
+    ],
+    children: [
+      {
+        type: 'menuItem',
+        id: 'action-bar',
+        title: 'Action Bar',
+        showAsAction: 'always',
+        icon: SEARCH_ICON,
+        disabled: disabled['action-bar'],
+        onPress: () => onItemPress('action-bar'),
+      },
+      {
+        type: 'menuItem',
+        id: 'action-overflow',
+        title: 'Action Overflow',
+        showAsAction: 'never',
+        disabled: disabled['action-overflow'],
+        onPress: () => onItemPress('action-overflow'),
+      },
+      {
+        type: 'menuItem',
+        id: 'opt-a',
+        title: 'Option A',
+        groupId: 'options',
+        initialToggleState: true,
+        disabled: disabled['opt-a'],
+      },
+      {
+        type: 'menuItem',
+        id: 'opt-b',
+        title: 'Option B',
+        groupId: 'options',
+        disabled: disabled['opt-b'],
+      },
+      {
+        type: 'menu',
+        id: 'submenu',
+        title: 'More',
+        disabled: disabled.submenu,
+        children: [
+          {
+            type: 'menuItem',
+            id: 'sub-item',
+            title: 'Sub Item',
+            disabled: disabled['sub-item'],
+            onPress: () => onItemPress('sub-item'),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const HEADER_TITLE = 'Toolbar Menu Disabled Test';
+
+function TestStackToolbarMenuDisabled() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Main',
+          Component: MainScreen,
+          options: {
+            headerConfig: {
+              title: HEADER_TITLE,
+              android: {
+                toolbarMenu: buildMenu(
+                  DEFAULT_DISABLED,
+                  () => {},
+                  () => {},
+                ),
+              },
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function MainScreen() {
+  const [disabledById, setDisabledById] =
+    useState<DisabledById>(DEFAULT_DISABLED);
+  const [lastEvent, setLastEvent] = useState<string | null>(null);
+
+  const [cmdTargetId, setCmdTargetId] = useState<AllIds>('action-bar');
+  const [cmdDisabled, setCmdDisabled] =
+    useState<CmdDisabledOption>('no change');
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+
+  const handleItemPress = useCallback((id: string) => {
+    setLastEvent(`Pressed: ${id}`);
+  }, []);
+
+  const handleGroupChange = useCallback(
+    (groupId: string, selectedIds: string[]) => {
+      setLastEvent(`${groupId}: ${JSON.stringify(selectedIds)}`);
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: HEADER_TITLE,
+        android: {
+          toolbarMenu: buildMenu(
+            DEFAULT_DISABLED,
+            handleItemPress,
+            handleGroupChange,
+          ),
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey, handleItemPress, handleGroupChange]);
+
+  const applyDisabled = useCallback(
+    (next: DisabledById) => {
+      setDisabledById(next);
+      setRouteOptions(routeKey, {
+        headerConfig: {
+          title: HEADER_TITLE,
+          android: {
+            toolbarMenu: buildMenu(next, handleItemPress, handleGroupChange),
+          },
+        },
+      });
+    },
+    [setRouteOptions, routeKey, handleItemPress, handleGroupChange],
+  );
+
+  const sendCommand = useCallback(() => {
+    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+      ...(cmdDisabled !== 'no change' && {
+        disabled:
+          cmdDisabled === 'undefined' ? undefined : cmdDisabled === 'true',
+      }),
+    };
+    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+      cmdTargetId,
+      options,
+    );
+  }, [cmdTargetId, cmdDisabled]);
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Last Event</Text>
+      <Text style={styles.result}>{lastEvent ?? '—'}</Text>
+
+      <Text style={styles.heading}>Send Command</Text>
+      <SettingsPicker<AllIds>
+        label="target id"
+        value={cmdTargetId}
+        items={[...ALL_IDS]}
+        onValueChange={setCmdTargetId}
+      />
+      <SettingsPicker<CmdDisabledOption>
+        label="disabled"
+        value={cmdDisabled}
+        items={CMD_DISABLED_OPTIONS}
+        onValueChange={setCmdDisabled}
+      />
+      <Button title="Send Command" onPress={sendCommand} />
+
+      <Text style={styles.heading}>Menu Items — Props</Text>
+      {ALL_IDS.map(id => (
+        <SettingsSwitch
+          key={id}
+          label={`disable ${ITEM_LABELS[id]}`}
+          value={disabledById[id]}
+          onValueChange={v => applyDisabled({ ...disabledById, [id]: v })}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 10,
+    paddingBottom: 50,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  result: {
+    fontSize: 15,
+    paddingHorizontal: 10,
+  },
+});
+
+export default createScenario(
+  TestStackToolbarMenuDisabled,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario-descriptions.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Toolbar Menu Disabled',
+  key: 'test-stack-toolbar-menu-disabled-android',
+  details:
+    'Tests the disabled prop on toolbar menu items (action items, checkable group items, and submenus), both via props and via the setToolbarMenuItemOptions view command.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario.md
@@ -2,18 +2,15 @@
 
 ## Details
 
-**Description:** Tests the `disabled` prop on Android toolbar menu items.
-Covers all disable-relevant element kinds — an action button shown in the
-toolbar (`showAsAction: always`), an action item in the overflow menu
-(`showAsAction: never`), checkable items in a selection group, and a
-submenu — across both flows: the props flow (via the `toolbarMenu` prop)
-and the imperative command flow (via `setToolbarMenuItemOptions`). A
-disabled element is greyed out and ignores interaction: it emits neither
-`onPress` nor `onSelectionChange`, a disabled submenu cannot be opened,
-and a disabled checked item keeps its checked state. The props flow
-rebuilds all items from scratch on every update; the command flow merges
-a change onto a single item (absent field = no change, `undefined` =
-reset to the default enabled state).
+**Description:** Tests the `disabled` prop on Android toolbar menu items. Covers
+all disable-relevant element kinds — an action button shown in the toolbar
+(`showAsAction: always`), an action item in the overflow menu (`showAsAction:
+never`), checkable items in a selection group, and a submenu — across both
+flows: the props flow (via the `toolbarMenu` prop) and the imperative command
+flow (via `setToolbarMenuItemOptions`). A disabled element is greyed out/correct
+tint is applied and ignores interaction: it emits neither `onPress` nor
+`onSelectionChange`, a disabled submenu cannot be opened, and a disabled checked
+item keeps its checked state.
 
 **OS test creation version:** Android: API Level 36
 
@@ -27,18 +24,12 @@ TBD: E2E coverage has not been determined yet.
 
 ## Note
 
-- The menu contains: `action-bar` (toolbar action button with the
-  `search_black.png` icon), `action-overflow` (overflow action item),
-  `opt-a` and `opt-b` (checkable items in the `options` group, `opt-a`
-  starts checked), `submenu` (the "More" submenu) and `sub-item` (a leaf
-  inside it).
-- `options` is a multi-select (checkbox) group, so `opt-a` and `opt-b`
-  toggle independently.
 - The **Last Event** line shows the most recent `onPress` /
   `onSelectionChange`. "Does not update" below means the previous text
   stays unchanged — disabled elements fire no events.
-- Overflow items, `opt-*`, and `sub-item` are reached by tapping the
-  three-dot overflow icon (and then "More" for `sub-item`).
+- The props flow rebuilds the menu from scratch on every update,
+  resetting toggle states to their initial values (`opt-a` checked,
+  `opt-b` unchecked).
 
 ## Steps
 
@@ -47,8 +38,8 @@ TBD: E2E coverage has not been determined yet.
 1. Launch the app and navigate to **Stack Toolbar Menu Disabled**.
 
 - [ ] The toolbar shows the `action-bar` icon button and a three-dot
-      overflow icon. All elements are enabled (full-opacity). The overflow
-      menu lists Action Overflow, Option A (checked), Option B, and More.
+      overflow icon. All elements are enabled. The overflow menu lists
+      Action Overflow, Option A (checked), Option B, and More.
 
 ---
 
@@ -57,16 +48,16 @@ TBD: E2E coverage has not been determined yet.
 2. In **Menu Items — Props**, toggle `disable action-bar (toolbar
    button)` on.
 
-- [ ] The `action-bar` icon button greys out (reduced opacity).
+- [ ] The `action-bar` icon button changes tint to a lighter color.
 
-3. Tap the greyed `action-bar` button.
+3. Tap the disabled `action-bar` button.
 
 - [ ] Nothing happens. **Last Event** does not update (no `onPress`).
 
 4. Toggle `disable action-bar` back off.
 
-- [ ] The button returns to full opacity and tapping it again sets
-      **Last Event** to `Pressed: action-bar`.
+- [ ] The icon returns to its normal tint color and tapping it again
+      sets **Last Event** to `Pressed: action-bar`.
 
 ---
 
@@ -78,40 +69,39 @@ TBD: E2E coverage has not been determined yet.
 
 6. Tap the greyed **Action Overflow** row.
 
-- [ ] Nothing happens (the menu may stay open). **Last Event** does not
-      update.
+- [ ] Nothing happens (the menu may stay open). **Last Event** does
+      not update.
 
 7. Toggle `disable action-overflow` back off.
 
-- [ ] Opening the overflow menu and tapping **Action Overflow** now sets
-      **Last Event** to `Pressed: action-overflow`.
+- [ ] Opening the overflow menu and tapping **Action Overflow** now
+      sets **Last Event** to `Pressed: action-overflow`.
 
 ---
 
 ### Props — disabled checkable items
 
-8. Open the overflow menu and tap **Option B** once to check it.
+8. Toggle `disable opt-a (checkable, checked)` on, then open the
+   overflow menu.
 
-- [ ] **Option B** becomes checked. **Last Event** shows
-      `options: ["opt-a","opt-b"]`.
+- [ ] **Option A** is greyed but remains **checked** (its initial
+      toggle state is preserved while disabled).
 
-9. Toggle `disable opt-b (checkable)` on, then open the overflow menu and
-   tap **Option B**.
+9. Tap the greyed **Option A**.
 
-- [ ] **Option B** is greyed but stays **checked**. Tapping it does not
-      change the check and **Last Event** does not update.
+- [ ] Nothing happens. **Last Event** does not update.
 
-10. Toggle `disable opt-a (checkable, checked)` on, open the overflow
-    menu and tap **Option A**.
+10. Toggle `disable opt-b (checkable)` on, then open the overflow
+    menu.
 
-- [ ] **Option A** is greyed but stays **checked** (its checked state is
-      preserved while disabled). Tapping it does nothing and **Last
-      Event** does not update.
+- [ ] **Option B** is greyed and **unchecked**. Tapping it does
+      nothing and **Last Event** does not update.
 
 11. Toggle `disable opt-a` and `disable opt-b` back off.
 
-- [ ] Both rows return to full opacity, retain their checked states, and
-      tapping either one toggles it and updates **Last Event** again.
+- [ ] Both rows return to normal. **Option A** is checked,
+      **Option B** is unchecked (their initial states). Tapping
+      either one toggles it and updates **Last Event**.
 
 ---
 
@@ -144,8 +134,8 @@ TBD: E2E coverage has not been determined yet.
 
 17. Toggle `disable sub-item` back off.
 
-- [ ] Opening **More** and tapping **Sub Item** now sets **Last Event**
-      to `Pressed: sub-item`.
+- [ ] Opening **More** and tapping **Sub Item** now sets **Last
+      Event** to `Pressed: sub-item`.
 
 ---
 
@@ -154,11 +144,11 @@ TBD: E2E coverage has not been determined yet.
 18. In **Send Command**, set target id = `action-bar`, disabled =
     `true`. Tap **Send Command**.
 
-- [ ] The `action-bar` button greys out. Tapping it does nothing and
-      **Last Event** does not update.
+- [ ] The `action-bar` icon changes tint to a lighter color. Tapping
+      it does nothing and **Last Event** does not update.
 
-19. Set target id = `submenu`, disabled = `true`. Tap **Send Command**,
-    then open the overflow menu.
+19. Set target id = `submenu`, disabled = `true`. Tap **Send
+    Command**, then open the overflow menu.
 
 - [ ] **More** is greyed out and cannot be opened.
 
@@ -175,8 +165,8 @@ TBD: E2E coverage has not been determined yet.
 21. Set target id = `action-bar`, disabled = `false`. Tap **Send
     Command**.
 
-- [ ] The `action-bar` button returns to full opacity and tapping it sets
-      **Last Event** to `Pressed: action-bar`.
+- [ ] The `action-bar` icon returns to its normal tint color and
+      tapping it sets **Last Event** to `Pressed: action-bar`.
 
 ---
 
@@ -188,15 +178,3 @@ TBD: E2E coverage has not been determined yet.
 - [ ] **More** returns to enabled (reset to the default `disabled =
       false`) and opens normally. Sending `undefined` restored the
       default rather than leaving it disabled.
-
----
-
-### Commands — props update rebuilds and discards command state
-
-23. With several command-applied disables still in effect (e.g. `opt-a`
-    from step 20), toggle any switch in **Menu Items — Props** off and on
-    (for an item that is currently `false`).
-
-- [ ] The whole menu rebuilds from props. All command-applied `disabled`
-      overrides are discarded; every element returns to the state defined
-      by the **Menu Items — Props** switches.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/scenario.md
@@ -1,0 +1,202 @@
+# Test Scenario: Stack Toolbar Menu Disabled
+
+## Details
+
+**Description:** Tests the `disabled` prop on Android toolbar menu items.
+Covers all disable-relevant element kinds — an action button shown in the
+toolbar (`showAsAction: always`), an action item in the overflow menu
+(`showAsAction: never`), checkable items in a selection group, and a
+submenu — across both flows: the props flow (via the `toolbarMenu` prop)
+and the imperative command flow (via `setToolbarMenuItemOptions`). A
+disabled element is greyed out and ignores interaction: it emits neither
+`onPress` nor `onSelectionChange`, a disabled submenu cannot be opened,
+and a disabled checked item keeps its checked state. The props flow
+rebuilds all items from scratch on every update; the command flow merges
+a change onto a single item (absent field = no change, `undefined` =
+reset to the default enabled state).
+
+**OS test creation version:** Android: API Level 36
+
+## E2E test
+
+TBD: E2E coverage has not been determined yet.
+
+## Prerequisites
+
+- Android emulator or device
+
+## Note
+
+- The menu contains: `action-bar` (toolbar action button with the
+  `search_black.png` icon), `action-overflow` (overflow action item),
+  `opt-a` and `opt-b` (checkable items in the `options` group, `opt-a`
+  starts checked), `submenu` (the "More" submenu) and `sub-item` (a leaf
+  inside it).
+- `options` is a multi-select (checkbox) group, so `opt-a` and `opt-b`
+  toggle independently.
+- The **Last Event** line shows the most recent `onPress` /
+  `onSelectionChange`. "Does not update" below means the previous text
+  stays unchanged — disabled elements fire no events.
+- Overflow items, `opt-*`, and `sub-item` are reached by tapping the
+  three-dot overflow icon (and then "More" for `sub-item`).
+
+## Steps
+
+### Baseline — initial render from props
+
+1. Launch the app and navigate to **Stack Toolbar Menu Disabled**.
+
+- [ ] The toolbar shows the `action-bar` icon button and a three-dot
+      overflow icon. All elements are enabled (full-opacity). The overflow
+      menu lists Action Overflow, Option A (checked), Option B, and More.
+
+---
+
+### Props — disabled action item (toolbar button)
+
+2. In **Menu Items — Props**, toggle `disable action-bar (toolbar
+   button)` on.
+
+- [ ] The `action-bar` icon button greys out (reduced opacity).
+
+3. Tap the greyed `action-bar` button.
+
+- [ ] Nothing happens. **Last Event** does not update (no `onPress`).
+
+4. Toggle `disable action-bar` back off.
+
+- [ ] The button returns to full opacity and tapping it again sets
+      **Last Event** to `Pressed: action-bar`.
+
+---
+
+### Props — disabled action item (overflow)
+
+5. Toggle `disable action-overflow` on, then open the overflow menu.
+
+- [ ] The **Action Overflow** row is greyed out.
+
+6. Tap the greyed **Action Overflow** row.
+
+- [ ] Nothing happens (the menu may stay open). **Last Event** does not
+      update.
+
+7. Toggle `disable action-overflow` back off.
+
+- [ ] Opening the overflow menu and tapping **Action Overflow** now sets
+      **Last Event** to `Pressed: action-overflow`.
+
+---
+
+### Props — disabled checkable items
+
+8. Open the overflow menu and tap **Option B** once to check it.
+
+- [ ] **Option B** becomes checked. **Last Event** shows
+      `options: ["opt-a","opt-b"]`.
+
+9. Toggle `disable opt-b (checkable)` on, then open the overflow menu and
+   tap **Option B**.
+
+- [ ] **Option B** is greyed but stays **checked**. Tapping it does not
+      change the check and **Last Event** does not update.
+
+10. Toggle `disable opt-a (checkable, checked)` on, open the overflow
+    menu and tap **Option A**.
+
+- [ ] **Option A** is greyed but stays **checked** (its checked state is
+      preserved while disabled). Tapping it does nothing and **Last
+      Event** does not update.
+
+11. Toggle `disable opt-a` and `disable opt-b` back off.
+
+- [ ] Both rows return to full opacity, retain their checked states, and
+      tapping either one toggles it and updates **Last Event** again.
+
+---
+
+### Props — disabled submenu
+
+12. Toggle `disable submenu` on, then open the overflow menu.
+
+- [ ] The **More** row is greyed out.
+
+13. Tap the greyed **More** row.
+
+- [ ] The submenu does **not** open.
+
+14. Toggle `disable submenu` back off and open **More**.
+
+- [ ] The submenu opens and shows **Sub Item**.
+
+---
+
+### Props — disabled item inside a submenu
+
+15. Toggle `disable sub-item` on, open the overflow menu, then open
+    **More**.
+
+- [ ] **Sub Item** is greyed out.
+
+16. Tap the greyed **Sub Item**.
+
+- [ ] Nothing happens. **Last Event** does not update.
+
+17. Toggle `disable sub-item` back off.
+
+- [ ] Opening **More** and tapping **Sub Item** now sets **Last Event**
+      to `Pressed: sub-item`.
+
+---
+
+### Commands — disable via command
+
+18. In **Send Command**, set target id = `action-bar`, disabled =
+    `true`. Tap **Send Command**.
+
+- [ ] The `action-bar` button greys out. Tapping it does nothing and
+      **Last Event** does not update.
+
+19. Set target id = `submenu`, disabled = `true`. Tap **Send Command**,
+    then open the overflow menu.
+
+- [ ] **More** is greyed out and cannot be opened.
+
+20. Set target id = `opt-a`, disabled = `true`. Tap **Send Command**,
+    then open the overflow menu and tap **Option A**.
+
+- [ ] **Option A** is greyed, stays checked, and tapping it does not
+      update **Last Event**.
+
+---
+
+### Commands — re-enable via command
+
+21. Set target id = `action-bar`, disabled = `false`. Tap **Send
+    Command**.
+
+- [ ] The `action-bar` button returns to full opacity and tapping it sets
+      **Last Event** to `Pressed: action-bar`.
+
+---
+
+### Commands — three-state reset (`undefined`)
+
+22. Set target id = `submenu`, disabled = `undefined`. Tap **Send
+    Command**, then open the overflow menu.
+
+- [ ] **More** returns to enabled (reset to the default `disabled =
+      false`) and opens normally. Sending `undefined` restored the
+      default rather than leaving it disabled.
+
+---
+
+### Commands — props update rebuilds and discards command state
+
+23. With several command-applied disables still in effect (e.g. `opt-a`
+    from step 20), toggle any switch in **Menu Items — Props** off and on
+    (for an item that is currently `false`).
+
+- [ ] The whole menu rebuilds from props. All command-applied `disabled`
+      overrides are discarded; every element returns to the state defined
+      by the **Menu Items — Props** switches.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -30,11 +30,17 @@ type ShowAsActionOption = (typeof SHOW_AS_ACTION_OPTIONS)[number];
 
 type CmdIconOption = 'no change' | IconOption;
 type CmdTintColorOption = 'no change' | TintColorOption;
+type CmdDisabledOption = 'no change' | 'true' | 'false';
 
 const CMD_ICON_OPTIONS: CmdIconOption[] = ['no change', ...ICON_OPTIONS];
 const CMD_TINT_COLOR_OPTIONS: CmdTintColorOption[] = [
   'no change',
   ...TINT_COLOR_OPTIONS,
+];
+const CMD_DISABLED_OPTIONS: CmdDisabledOption[] = [
+  'no change',
+  'true',
+  'false',
 ];
 
 interface SlotConfig {
@@ -46,6 +52,7 @@ interface SlotConfig {
   tintColorPressed: TintColorOption;
   tintColorFocused: TintColorOption;
   tintColorDisabled: TintColorOption;
+  disabled: boolean;
 }
 
 type Slots = [SlotConfig, SlotConfig, SlotConfig];
@@ -58,6 +65,7 @@ const SLOT_DEFAULTS: Omit<SlotConfig, 'id'> = {
   tintColorPressed: 'default',
   tintColorFocused: 'default',
   tintColorDisabled: 'default',
+  disabled: false,
 };
 
 const DEFAULT_SLOTS: Slots = [
@@ -115,6 +123,7 @@ function buildItems(slots: Slots): StackHeaderToolbarMenuItemAndroid[] {
       iconTintColorPressed: resolveTintColor(s.tintColorPressed),
       iconTintColorFocused: resolveTintColor(s.tintColorFocused),
       iconTintColorDisabled: resolveTintColor(s.tintColorDisabled),
+      disabled: s.disabled,
     }));
 }
 
@@ -171,6 +180,8 @@ function MainScreen() {
     useState<CmdTintColorOption>('no change');
   const [cmdTintColorDisabled, setCmdTintColorDisabled] =
     useState<CmdTintColorOption>('no change');
+  const [cmdDisabled, setCmdDisabled] =
+    useState<CmdDisabledOption>('no change');
 
   const headerConfigRef = useRef<StackHeaderConfigRef>(null);
   const { setRouteOptions, routeKey } = useStackNavigationContext();
@@ -223,6 +234,9 @@ function MainScreen() {
       ...(cmdTintColorDisabled !== 'no change' && {
         iconTintColorDisabled: resolveTintColor(cmdTintColorDisabled),
       }),
+      ...(cmdDisabled !== 'no change' && {
+        disabled: cmdDisabled === 'true',
+      }),
     };
     headerConfigRef.current?.android?.setToolbarMenuItemOptions(
       cmdTargetId,
@@ -235,6 +249,7 @@ function MainScreen() {
     cmdTintColorPressed,
     cmdTintColorFocused,
     cmdTintColorDisabled,
+    cmdDisabled,
   ]);
 
   return (
@@ -275,6 +290,12 @@ function MainScreen() {
         value={cmdTintColorDisabled}
         items={CMD_TINT_COLOR_OPTIONS}
         onValueChange={setCmdTintColorDisabled}
+      />
+      <SettingsPicker<CmdDisabledOption>
+        label="disabled"
+        value={cmdDisabled}
+        items={CMD_DISABLED_OPTIONS}
+        onValueChange={setCmdDisabled}
       />
       <Button title="Send Command" onPress={sendCommand} />
 
@@ -343,6 +364,11 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
             value={slot.tintColorDisabled}
             items={[...TINT_COLOR_OPTIONS]}
             onValueChange={v => updateSlot(i, { tintColorDisabled: v })}
+          />
+          <SettingsSwitch
+            label="disabled"
+            value={slot.disabled}
+            onValueChange={v => updateSlot(i, { disabled: v })}
           />
         </React.Fragment>
       ))}

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -22,7 +22,13 @@ type IdOption = (typeof ID_OPTIONS)[number];
 const ICON_OPTIONS = ['none', 'imageSource', 'drawableResource'] as const;
 type IconOption = (typeof ICON_OPTIONS)[number];
 
-const TINT_COLOR_OPTIONS = ['default', 'purple', 'red', 'green'] as const;
+const TINT_COLOR_OPTIONS = [
+  'default',
+  'purple',
+  'red',
+  'green',
+  'blue',
+] as const;
 type TintColorOption = (typeof TINT_COLOR_OPTIONS)[number];
 
 const SHOW_AS_ACTION_OPTIONS = ['always', 'never', 'ifRoom'] as const;
@@ -105,6 +111,8 @@ function resolveTintColor(option: TintColorOption): ColorValue | undefined {
       return Colors.RedLight100;
     case 'green':
       return Colors.GreenLight100;
+    case 'blue':
+      return Colors.BlueLight100;
     default:
       return undefined;
   }

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -38,10 +38,6 @@ TBD: E2E coverage has not been determined yet.
   This is Android platform behavior, not a library bug. Always set
   `iconTintColorNormal` alongside other state tints if you want the icon visible
   in the normal state.
-- `iconTintColorDisabled` is only visible when the item is `disabled`. Each slot
-  has a `disabled` switch, and the command panel has a `disabled` option, to
-  toggle it. A disabled item is greyed out and ignores taps; its icon shows
-  `iconTintColorDisabled` instead of the platform's default greyed icon.
 
 ## Steps
 
@@ -88,18 +84,28 @@ TBD: E2E coverage has not been determined yet.
 
 ---
 
-### Props — multiple state tints (Normal + Pressed + Focused)
+### Props — multiple state tints (Normal + Pressed + Focused + Disabled)
 
 8. Change Slot 2 `tintColorNormal` to `purple`, then `tintColorPressed` to
-   `green`, then `tintColorFocused` to `red`.
+   `green`, then `tintColorFocused` to `red`, then `tintColorDisabled` to
+   `blue`.
 
 - [ ] Normal: Item 2 shows purple.
 - [ ] Pressed: Press and hold Item 2 — it turns green while pressed.
 - [ ] Focused: Use Ctrl+Tab to move keyboard focus to the toolbar, navigate to
       Item 2 — it turns red while focused.
 
-9. Change Slot 2 `tintColorNormal`, `tintColorPressed`, and `tintColorFocused`
-   all back to `default`.
+9. Toggle Slot 2 `disabled` on.
+
+- [ ] Disabled: Item 2 shows the **blue** disabled tint. Tapping Item 2 does
+      nothing. Items 1 and 3 stay enabled and unaffected.
+
+10. Toggle Slot 2 `disabled` back off.
+
+- [ ] Item 2 returns to its enabled appearance, showing purple at rest again.
+
+11. Change Slot 2 `tintColorNormal`, `tintColorPressed`, `tintColorFocused`, and
+    `tintColorDisabled` all back to `default`.
 
 - [ ] Item 2 returns to its original default appearance in all interaction
       states.
@@ -108,19 +114,19 @@ TBD: E2E coverage has not been determined yet.
 
 ### Props — native limitation: non-Normal tint without Normal tint
 
-10. Change Slot 3 `tintColorPressed` to `red` (leave `tintColorNormal` at
+12. Change Slot 3 `tintColorPressed` to `red` (leave `tintColorNormal` at
     `default`).
 
 - [ ] Item 3 icon becomes **invisible** in the normal state (Android platform
       behavior: setting any state-specific tint without a Normal tint causes the
       icon to disappear at rest). The tint is visible when Item 3 is pressed.
 
-11. Change Slot 3 `tintColorNormal` to `purple`.
+13. Change Slot 3 `tintColorNormal` to `purple`.
 
 - [ ] Item 3 icon becomes visible again, showing purple at rest and red when
       pressed.
 
-12. Change Slot 3 `tintColorNormal` and `tintColorPressed` back to `default`.
+14. Change Slot 3 `tintColorNormal` and `tintColorPressed` back to `default`.
 
 - [ ] Item 3 returns to its untinted `search_black.png` appearance.
 
@@ -128,17 +134,17 @@ TBD: E2E coverage has not been determined yet.
 
 ### Props — icon removed while tint is set
 
-13. Change Slot 3 `tintColorNormal` to `green`, then change Slot 3 `icon` to
+15. Change Slot 3 `tintColorNormal` to `green`, then change Slot 3 `icon` to
     `none`.
 
 - [ ] Item 3 shows no icon.
 
-14. Change Slot 3 `icon` back to `imageSource`.
+16. Change Slot 3 `icon` back to `imageSource`.
 
 - [ ] Item 3 shows `search_black.png` with green tint already applied. The tint
       was preserved while the icon was absent.
 
-15. Change Slot 3 `tintColorNormal` to `default`.
+17. Change Slot 3 `tintColorNormal` to `default`.
 
 - [ ] Item 3 returns to untinted `search_black.png`.
 
@@ -146,7 +152,7 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — no-op
 
-16. In **Send Command**, set target id = `item-1`, all fields = `no change`. Tap
+18. In **Send Command**, set target id = `item-1`, all fields = `no change`. Tap
     **Send Command**.
 
 - [ ] No visible change. All items appear exactly as before.
@@ -155,12 +161,12 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — single tint color change
 
-17. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
+19. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 turns red. Items 2 and 3 are unchanged.
 
-18. Set target id = `item-2`, `tintColorNormal` = `purple`, all others = `no
+20. Set target id = `item-2`, `tintColorNormal` = `purple`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 2 turns purple. Items 1 and 3 are unchanged.
@@ -169,13 +175,13 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — native limitation: non-Normal tint without Normal tint
 
-19. Set target id = `item-3`, `tintColorPressed` = `green`, all others = `no
+21. Set target id = `item-3`, `tintColorPressed` = `green`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 3 becomes **invisible** in the normal state (same platform behavior
-      as in steps 10–11). It is visible (green) when pressed.
+      as in steps 12–13). It is visible (green) when pressed.
 
-20. Set target id = `item-3`, `tintColorNormal` = `purple`, all others = `no
+22. Set target id = `item-3`, `tintColorNormal` = `purple`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 3 becomes visible again, showing purple at rest and green when
@@ -185,36 +191,46 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — restore single tint color to default
 
-21. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
+23. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 returns to no tint (original colors).
 
 ---
 
-### Commands — multiple tint colors at once (Normal + Pressed + Focused)
+### Commands — multiple tint colors (Normal + Pressed + Focused + Disabled)
 
-22. Set target id = `item-3`, `tintColorNormal` = `green`, `tintColorPressed` =
-    `red`, `tintColorFocused` = `purple`, all others = `no change`. Tap **Send
-    Command**.
+24. Set target id = `item-3`, `tintColorNormal` = `green`, `tintColorPressed` =
+    `red`, `tintColorFocused` = `purple`, `tintColorDisabled` = `blue`, all
+    others = `no change`. Tap **Send Command**.
 
-- [ ] Normal: Item 3 shows green. Item 2 still shows purple from step 18. Item 1
+- [ ] Normal: Item 3 shows green. Item 2 still shows purple from step 20. Item 1
       is at default.
 - [ ] Pressed: Press and hold Item 3 — it turns red.
 - [ ] Focused: Use Ctrl+Tab and keyboard to focus Item 3 — it turns purple.
+
+25. Set target id = `item-3`, `disabled` = `true`, all others = `no change`. Tap
+    **Send Command**.
+
+- [ ] Item 3 shows the **blue** disabled tint. Tapping Item 3 does nothing.
+
+26. Set target id = `item-3`, `disabled` = `false`, all others = `no change`.
+    Tap **Send Command**.
+
+- [ ] Item 3 returns to its enabled appearance, showing green at rest again.
 
 ---
 
 ### Commands — partial restore (change one, restore another, preserve third)
 
-23. Set target id = `item-3`, `tintColorNormal` = `purple`, `tintColorPressed` =
+27. Set target id = `item-3`, `tintColorNormal` = `purple`, `tintColorPressed` =
     `no change`, `tintColorFocused` = `no change`. Tap **Send Command**.
 
 - [ ] Item 3 normal tint changes to purple. `tintColorPressed` (red) and
       `tintColorFocused` (purple) are preserved — they were absent from the
       options object. Pressing Item 3 still shows red.
 
-24. Set target id = `item-3`, `tintColorNormal` = `no change`,
+28. Set target id = `item-3`, `tintColorNormal` = `no change`,
     `tintColorPressed` = `default`, `tintColorFocused` = `no change`. Tap
     **Send Command**.
 
@@ -227,17 +243,17 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — change icon only (tint colors preserved)
 
-25. Set target id = `item-2`, `icon` = `drawableResource`, all tint fields = `no
+29. Set target id = `item-2`, `icon` = `drawableResource`, all tint fields = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 2 changes to the `sym_call_missed` icon. Its `tintColorNormal`
-      remains purple from step 18 — the drawable is shown in purple.
+      remains purple from step 20 — the drawable is shown in purple.
 
 ---
 
 ### Commands — change icon and tint color simultaneously
 
-26. Set target id = `item-1`, `icon` = `drawableResource`, `tintColorNormal` =
+30. Set target id = `item-1`, `icon` = `drawableResource`, `tintColorNormal` =
     `green`, all others = `no change`. Tap **Send Command**.
 
 - [ ] Item 1 changes to `sym_call_missed` and simultaneously turns green.
@@ -246,7 +262,7 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — restore tint color only (icon preserved)
 
-27. Set target id = `item-1`, `tintColorNormal` = `default`, `icon` = `no
+31. Set target id = `item-1`, `tintColorNormal` = `default`, `icon` = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 `tintColorNormal` resets to the regular default (no tint). The icon
@@ -256,29 +272,29 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — restore icon to none, then restore with stored tint
 
-28. Set target id = `item-1`, `icon` = `none`, `tintColorNormal` = `no change`.
+32. Set target id = `item-1`, `icon` = `none`, `tintColorNormal` = `no change`.
     Tap **Send Command**.
 
 - [ ] Item 1 shows no icon.
 
-29. Set target id = `item-1`, `tintColorNormal` = `red`, `icon` = `no change`.
+33. Set target id = `item-1`, `tintColorNormal` = `red`, `icon` = `no change`.
     Tap **Send Command**.
 
 - [ ] Item 1 still shows no icon. The tint is stored but invisible.
 
-30. Set target id = `item-1`, `icon` = `imageSource`, `tintColorNormal` = `no
+34. Set target id = `item-1`, `icon` = `imageSource`, `tintColorNormal` = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 shows `search_black.png` with red tint (the `tintColorNormal` set
-      in step 29 was preserved while the icon was absent and becomes visible
+      in step 33 was preserved while the icon was absent and becomes visible
       once the icon is restored).
 
 ---
 
 ### Commands — props update resets all command state
 
-31. At this point all three items have command overrides applied (icon and/or
-    tint changes from steps 17–30). In **Menu Items — Props**, change Slot 1
+35. At this point all three items have command overrides applied (icon and/or
+    tint changes from steps 19–34). In **Menu Items — Props**, change Slot 1
     `tintColorNormal` from `default` to `purple` and then immediately back to
     `default`.
 
@@ -291,16 +307,16 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — restore resets to global default, not prop value
 
-32. In **Menu Items — Props**, change Slot 1 `tintColorNormal` to `purple`.
+36. In **Menu Items — Props**, change Slot 1 `tintColorNormal` to `purple`.
 
 - [ ] Item 1 shows purple.
 
-33. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
+37. Set target id = `item-1`, `tintColorNormal` = `red`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 changes to red (command override on top of the purple prop value).
 
-34. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
+38. Set target id = `item-1`, `tintColorNormal` = `default`, all others = `no
     change`. Tap **Send Command**.
 
 - [ ] Item 1 shows **no tint** — the icon returns to its original colors. This
@@ -308,7 +324,7 @@ TBD: E2E coverage has not been determined yet.
       `tintColorNormal = purple` for Slot 1, but the command's `default` resets
       to the regular default (no tint) rather than restoring purple.
 
-35. In **Menu Items — Props**, change Slot 1 `tintColorNormal` back to
+39. In **Menu Items — Props**, change Slot 1 `tintColorNormal` back to
     `default`.
 
 - [ ] Item 1 remains untinted (no visible change — command already set the
@@ -318,51 +334,16 @@ TBD: E2E coverage has not been determined yet.
 
 ### Commands — excluded item safe targeting
 
-36. In **Menu Items — Props**, toggle Slot 2 `include` to `false`.
+40. In **Menu Items — Props**, toggle Slot 2 `include` to `false`.
 
 - [ ] Item 2 disappears from the toolbar.
 
-37. Set target id = `item-2`, `icon` = `drawableResource`, `tintColorNormal` =
+41. Set target id = `item-2`, `icon` = `drawableResource`, `tintColorNormal` =
     `red`. Tap **Send Command**.
 
 - [ ] No crash. Items 1 and 3 are unaffected.
 
-38. Toggle Slot 2 `include` back to `true`.
+42. Toggle Slot 2 `include` back to `true`.
 
 - [ ] Item 2 reappears with its props-configured appearance (`search_black.png`,
-      no tint). The command from step 37 did not leak into the re-included slot.
-
----
-
-### Props — disabled reveals the disabled tint
-
-39. Change Slot 1 `tintColorDisabled` to `red`, then toggle Slot 1 `disabled`
-    on.
-
-- [ ] Item 1 greys out and its icon shows the **red** disabled tint (instead of
-      the platform's default greyed icon). Items 2 and 3 stay enabled and
-      unaffected. Tapping Item 1 does nothing.
-
-40. Toggle Slot 1 `disabled` back off.
-
-- [ ] Item 1 returns to its enabled appearance with no tint. The red disabled
-      tint is no longer shown.
-
-41. Change Slot 1 `tintColorDisabled` back to `default`.
-
-- [ ] No visible change (Item 1 is enabled).
-
----
-
-### Commands — disabled reveals the disabled tint
-
-42. Set target id = `item-2`, `tintColorDisabled` = `green`, `disabled` =
-    `true`. Tap **Send Command**.
-
-- [ ] Item 2 greys out and its icon shows the **green** disabled tint.
-
-43. Set target id = `item-2`, `disabled` = `false`, all others = `no change`.
-    Tap **Send Command**.
-
-- [ ] Item 2 returns to its enabled appearance. The disabled tint is retained
-      but not visible while the item is enabled.
+      no tint). The command from step 41 did not leak into the re-included slot.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -38,8 +38,10 @@ TBD: E2E coverage has not been determined yet.
   This is Android platform behavior, not a library bug. Always set
   `iconTintColorNormal` alongside other state tints if you want the icon visible
   in the normal state.
-- `iconTintColorDisabled` requires a disabled item. This isn't supported yet, so
-  that prop is not exercised here.
+- `iconTintColorDisabled` is only visible when the item is `disabled`. Each slot
+  has a `disabled` switch, and the command panel has a `disabled` option, to
+  toggle it. A disabled item is greyed out and ignores taps; its icon shows
+  `iconTintColorDisabled` instead of the platform's default greyed icon.
 
 ## Steps
 
@@ -329,3 +331,38 @@ TBD: E2E coverage has not been determined yet.
 
 - [ ] Item 2 reappears with its props-configured appearance (`search_black.png`,
       no tint). The command from step 37 did not leak into the re-included slot.
+
+---
+
+### Props — disabled reveals the disabled tint
+
+39. Change Slot 1 `tintColorDisabled` to `red`, then toggle Slot 1 `disabled`
+    on.
+
+- [ ] Item 1 greys out and its icon shows the **red** disabled tint (instead of
+      the platform's default greyed icon). Items 2 and 3 stay enabled and
+      unaffected. Tapping Item 1 does nothing.
+
+40. Toggle Slot 1 `disabled` back off.
+
+- [ ] Item 1 returns to its enabled appearance with no tint. The red disabled
+      tint is no longer shown.
+
+41. Change Slot 1 `tintColorDisabled` back to `default`.
+
+- [ ] No visible change (Item 1 is enabled).
+
+---
+
+### Commands — disabled reveals the disabled tint
+
+42. Set target id = `item-2`, `tintColorDisabled` = `green`, `disabled` =
+    `true`. Tap **Send Command**.
+
+- [ ] Item 2 greys out and its icon shows the **green** disabled tint.
+
+43. Set target id = `item-2`, `disabled` = `false`, all others = `no change`.
+    Tap **Send Command**.
+
+- [ ] Item 2 returns to its enabled appearance. The disabled tint is retained
+      but not visible while the item is enabled.

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -92,6 +92,13 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    */
   hidden?: boolean | undefined;
   /**
+   * @summary Specifies if the menu element should be disabled.
+   *
+   * @default false
+   * @platform android
+   */
+  disabled?: boolean | undefined;
+  /**
    * @summary Specifies whether the element should be displayed as a button in
    * the Toolbar.
    *
@@ -180,7 +187,7 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    * it is disabled.
    *
    * @remarks
-   * Disabling menu elements isn't currently supported.
+   * Only visible when the element is `disabled`.
    *
    * Due to native platform limitations, if you set this prop, you must also
    * provide `iconTintColorNormal`. Otherwise, the icon will become

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -187,11 +187,9 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
    * it is disabled.
    *
    * @remarks
-   * Only visible when the element is `disabled`.
-   *
-   * Due to native platform limitations, if you set this prop, you must also
+   * Due to native platform limitations, if you set this prop, you should also
    * provide `iconTintColorNormal`. Otherwise, the icon will become
-   * transparent.
+   * transparent when the item is not disabled.
    *
    * @platform android
    */

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -35,6 +35,7 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
   id: string;
   title?: CT.WithDefault<string, ''>;
   hidden?: CT.WithDefault<boolean, false>;
+  disabled?: CT.WithDefault<boolean, false>;
   showAsAction?: CT.WithDefault<
     StackHeaderToolbarMenuItemShowAsActionAndroid,
     'never'


### PR DESCRIPTION
## Description

Adds support for disabling menu items in toolbar menu.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1497

## Changes

- add support on JS/native side for `disabled` prop
- update `test-stack-toolbar-menu-icon-android` SFT to include testing disabled item's icon tint
- add `test-stack-toolbar-menu-disabled-android` SFT to test disabling menu item in toolbar, in overflow menu, a submenu and submenu item

## Visual documentation

https://github.com/user-attachments/assets/1d0aa842-3725-4c8c-94f2-95f86ceb78d2

## Test plan

Run `test-stack-toolbar-menu-icon-android`, `test-stack-toolbar-menu-disabled-android` SFTs.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
