### PR TITLE
fix(android): inset formSheet content above the navigation bar

### DIFF
--- a/apps/src/tests/issue-tests/Test3580.tsx
+++ b/apps/src/tests/issue-tests/Test3580.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { Button, Text, View } from 'react-native';
+
+type RouteParamList = {
+  Home: undefined;
+  FormSheet: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<RouteParamList>;
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function Home({ navigation }: StackNavigationProp) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Button
+        title="Open FormSheet"
+        onPress={() => navigation.navigate('FormSheet')}
+      />
+    </View>
+  );
+}
+
+function FormSheet() {
+  return (
+    <View style={{ padding: 20, gap: 16 }}>
+      <Text style={{ fontSize: 16, fontWeight: '600' }}>
+        Android formSheet bottom inset
+      </Text>
+      <Text>
+        On Android the content of a content-sized formSheet used to render under the
+        system navigation bar. The row below should sit fully above the nav bar, the
+        same way it already does on iOS.
+      </Text>
+      <View style={{ backgroundColor: '#208AEF', padding: 16, borderRadius: 12 }}>
+        <Text style={{ color: 'white', fontWeight: '600' }}>
+          Bottom row - must clear the navigation bar
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export default function Test3580() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen
+          name="FormSheet"
+          component={FormSheet}
+          options={{
+            presentation: 'formSheet',
+            headerShown: false,
+            sheetAllowedDetents: 'fitToContents',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -178,6 +178,7 @@ export { default as Test3564 } from './Test3564';
 export { default as Test3566 } from './Test3566';
 export { default as Test3568 } from './Test3568';
 export { default as Test3576 } from './Test3576';
+export { default as Test3580 } from './Test3580';
 export { default as Test3596 } from './Test3596';
 export { default as Test3606 } from './Test3606';
 export { default as Test3611 } from './Test3611';

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -124,7 +124,18 @@ function ScreenStackItem(
     contentStyle = contentWrapperStyles;
   }
 
-  const shouldUseSafeAreaView = isIOS26OrHigher;
+  // Android does not inset formSheet content for the bottom safe area the way
+  // iOS does natively, so content runs under the navigation bar. RNS already
+  // dispatches the keyboard-aware bottom inset (SheetDelegate); we just need the
+  // content to consume it via SafeAreaView. Skipped when a sheet footer is used,
+  // since the footer owns the bottom edge in that case.
+  // eslint-disable-next-line camelcase
+  const hasSheetFooter = unstable_sheetFooter != null;
+  const isAndroidFormSheet =
+    Platform.OS === 'android' &&
+    stackPresentationWithDefault === 'formSheet' &&
+    !hasSheetFooter;
+  const shouldUseSafeAreaView = isIOS26OrHigher || isAndroidFormSheet;
 
   const content = (
     <>
@@ -134,7 +145,12 @@ function ScreenStackItem(
           style={debugContainerStyle}
           stackPresentation={stackPresentationWithDefault}>
           {shouldUseSafeAreaView ? (
-            <SafeAreaView edges={getSafeAreaEdges(headerConfig)}>
+            <SafeAreaView
+              edges={
+                isAndroidFormSheet
+                  ? { bottom: true }
+                  : getSafeAreaEdges(headerConfig)
+              }>
               {children}
             </SafeAreaView>
           ) : (


### PR DESCRIPTION
## What

On Android a content-sized formSheet (`sheetAllowedDetents: 'fitToContents'`) draws its content under the system navigation bar when the keyboard is down. iOS already insets the content for the bottom safe area, so Android ends up clipping the bottom of the content (a `TextInput`, the last row and so on) behind the nav bar.

Keyboard-up is already fine (the sheet sits on top of the keyboard) and this PR leaves it alone.

| | keyboard up | keyboard down |
| --- | --- | --- |
| Android before | ✅ | ❌ |
| Android after | ✅ | ✅ |
| iOS | ✅ | ✅ |

Before and after on Android (content-sized formSheet). In the before the bottom row is clipped under the navigation bar. After it sits above it.

| before | after |
| --- | --- |
| <img width="1080" height="2424" alt="android-before" src="https://github.com/user-attachments/assets/1579efe1-1887-433a-9c61-a805b515d1dd" /> | <img width="1080" height="2424" alt="android-after" src="https://github.com/user-attachments/assets/c1627eda-a7b5-4154-b4d7-3c605db95cd8" /> |

Related to #3580 (iOS insets formSheet content for the bottom safe area, Android does not).

## Why it happens

RNS already computes the right keyboard-aware bottom inset for the sheet in `SheetDelegate.onApplyWindowInsets`:

```kotlin
val newBottomInset = if (!isImeVisible) systemBarsInsets.bottom else 0
// dispatched down via WindowInsetsCompat: nav bar when the keyboard is down, 0 when it is up
```

So the inset value is correct. The problem is that nothing consumes it on Android. `ScreenStackItem` wraps the content in our `SafeAreaView` only when `isIOS26OrHigher`, otherwise on Android it renders the content raw so it runs edge to edge under the nav bar. iOS applies this inset natively, which is why the bug is Android only.

## The change

Extend the existing `SafeAreaView` wrap to Android formSheets with a bottom edge:

```diff
-  const shouldUseSafeAreaView = isIOS26OrHigher;
+  const isAndroidFormSheet =
+    Platform.OS === 'android' &&
+    stackPresentationWithDefault === 'formSheet' &&
+    !unstable_sheetFooter;
+  const shouldUseSafeAreaView = isIOS26OrHigher || isAndroidFormSheet;
   ...
-            <SafeAreaView edges={getSafeAreaEdges(headerConfig)}>
+            <SafeAreaView
+              edges={
+                isAndroidFormSheet
+                  ? { bottom: true }
+                  : getSafeAreaEdges(headerConfig)
+              }>
               {children}
             </SafeAreaView>
```

A native `setPadding` on the content does not work here. `Screen`'s children are laid out by Yoga, so they ignore native parent padding (I tried that first). Reusing our `SafeAreaView` keeps it Fabric-safe.

Because `@react-navigation/native-stack` renders content through `ScreenStackItem` (`NativeStackView.native.tsx`), this also covers react-navigation and expo-router, not just the raw `ScreenStackItem` API.

## Notes on the approach

I put this in `ScreenStackItem`, though I'm not sure it's the best layer. `Screen.tsx` does not wrap children and native-stack goes through `ScreenStackItem`, so it looks like the one spot that reaches every consumer. It also sits next to the existing iOS26 wrap. Raw `<Screen stackPresentation="formSheet">` usage bypasses it, but that already bypasses the iOS26 wrap too. If you'd prefer a shared content path or a native fix, I can move it.

I only apply the bottom edge. `getSafeAreaEdges` only ever returns `top`, since iOS handles the bottom natively. Adding `top` on Android would double up with the native header and the sheet height calc (`lastTopInset`). Left and right (landscape nav bar or display cutout) are 0 in portrait, so I left them for a follow-up.

I skip the wrap when a footer is set. `unstable_sheetFooter` renders outside the wrap and owns the bottom edge, so wrapping the content as well would push it up above the footer.

I don't think detents, scroll content or edge-to-edge are affected. The inset does not depend on sheet height, so fixed detents behave like `fitToContents`. The wrap pads a scroll container the same way the iOS26 wrap already does. The `BottomSheetDialog` is edge-to-edge regardless of the app setting. If the window already consumed the inset the dispatched value is 0 and the wrap is a no-op.

## Tests

This is an inset overlap and the e2e setup here cannot assert insets. The existing formSheet e2e only check which detent is visible. There are already cases skipped for this reason (for example `Test750`). I added a manual repro screen at `apps/src/tests/issue-tests/Test3580.tsx`: a content-sized formSheet with a bottom row that has to clear the nav bar.

Verified by hand on an Android emulator with plain content, on the raw API and on `@react-navigation/native-stack`: keyboard up sits flush, keyboard down clears the nav bar. Before and after screenshots are in the What section above.

If you want an automated check, one option is asserting that a bottom-anchored `testID` is `toBeVisible()` (hidden behind the nav bar when broken, visible once fixed), but that is a new pattern for this repo and would need validating.

## expo-router NativeTabs (coordination)

This fixes the standalone case. It does not fix a separate expo-router symptom where a formSheet under `NativeTabs` shows a gap above the keyboard the size of the tab bar, because expo-router wraps each tab's content in its own `SafeAreaView edges={{ bottom: true }}` (in `NativeTabsView.android`) that is not keyboard-aware. That one is an expo-router change.

Once this lands, a sheet under `NativeTabs` gets wrapped by both this `SafeAreaView` and expo-router's, so the bottom inset can double up. The expo-router side should drop its wrapper for presented sheets (or make it keyboard-aware) so the inset lives in one place.

expo-router follow-up: TODO add the link once the expo-router PR or issue is opened.

