### PR TITLE
feat(Android, Stack v5): add support for `menuTitle` (`headerTitle`) in submenus

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderApplicator.kt
@@ -32,10 +32,10 @@ import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfiguratio
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupConfig
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupMetadata
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemConfig
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.valueOrNull
@@ -429,12 +429,13 @@ internal class StackHeaderApplicator(
             when (element) {
                 is StackHeaderToolbarMenuElementConfig.MenuItem -> {
                     val menuItem = menu.add(groupIntId, itemId, index, null)
-                    applyMenuItemOptions(toolbar, menuItem, element.item.toOptions())
+                    applyMenuElementOptions(toolbar, menuItem, element.item.toOptions())
                     applyCheckability(menuItem, element.item)
                 }
                 is StackHeaderToolbarMenuElementConfig.Submenu -> {
                     val subMenu = menu.addSubMenu(groupIntId, itemId, index, null)
-                    applyMenuItemOptions(toolbar, subMenu.item, element.item.toOptions())
+                    applyMenuElementOptions(toolbar, subMenu.item, element.item.toOptions())
+                    element.menuTitle?.let { subMenu.setHeaderTitle(it) }
                     addElements(toolbar, subMenu, element.menu, forwardIdMap, forwardGroupIdMap)
                 }
             }
@@ -481,24 +482,24 @@ internal class StackHeaderApplicator(
         }
     }
 
-    fun updateToolbarMenuItem(
+    fun updateToolbarMenuElement(
         toolbar: MaterialToolbar,
         forwardIdMap: Map<String, Int>,
         id: String,
-        options: StackHeaderToolbarMenuItemOptions,
+        options: StackHeaderToolbarMenuElementOptions,
     ) {
         val item =
             forwardIdMap[id]?.let { toolbar.menu.findItem(it) } ?: run {
-                Log.e(TAG, "[RNScreens] Unable to find menu item.")
+                Log.e(TAG, "[RNScreens] Unable to find menu element.")
                 return
             }
-        applyMenuItemOptions(toolbar, item, options)
+        applyMenuElementOptions(toolbar, item, options)
     }
 
-    private fun applyMenuItemOptions(
+    private fun applyMenuElementOptions(
         toolbar: MaterialToolbar,
         menuItem: MenuItem,
-        options: StackHeaderToolbarMenuItemOptions,
+        options: StackHeaderToolbarMenuElementOptions,
     ) {
         options.title?.let { menuItem.title = it.valueOrNull() }
         options.titleCondensed?.let { menuItem.titleCondensed = it.valueOrNull() }
@@ -521,6 +522,19 @@ internal class StackHeaderApplicator(
 
         if (options.requiresIconTintColorUpdate || options.icon != null) {
             MenuItemCompat.setIconTintList(menuItem, getResolvedIconTintList(menuItem, options))
+        }
+
+        options.menuTitle?.let { update ->
+            val subMenu = menuItem.subMenu
+            if (subMenu != null) {
+                // In order to match native behavior, we need to clear the header first and then use
+                // regular title if menuTitle is not provided. If title is also null, there will be
+                // no submenu header at all.
+                subMenu.clearHeader()
+                subMenu.setHeaderTitle(update.valueOrNull() ?: menuItem.title)
+            } else {
+                Log.w(TAG, "[RNScreens] menuTitle ignored: target is not a submenu.")
+            }
         }
     }
 
@@ -595,7 +609,7 @@ internal class StackHeaderApplicator(
     }
 
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =
-        StackHeaderToolbarMenuItemOptions(
+        StackHeaderToolbarMenuElementOptions(
             title = StackHeaderToolbarUpdate.from(title),
             titleCondensed = StackHeaderToolbarUpdate.from(titleCondensed),
             tooltipText = StackHeaderToolbarUpdate.from(tooltipText),
@@ -637,7 +651,7 @@ internal class StackHeaderApplicator(
 
     private fun getResolvedIconTintList(
         menuItem: MenuItem,
-        options: StackHeaderToolbarMenuItemOptions,
+        options: StackHeaderToolbarMenuElementOptions,
     ): ColorStateList? {
         val currentTintList = MenuItemCompat.getIconTintList(menuItem)
         // The currently-applied normal (catch-all) color, if any. Used both as the "leave

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/StackHeaderCoordinatorLayout.kt
@@ -18,8 +18,8 @@ import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderConfiguratio
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderDelegate
 import com.swmansion.rnscreens.gamma.stack.header.config.StackHeaderInvalidationFlags
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewProviding
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuGroupMetadata
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.screen.StackScreen
 
 @SuppressLint("ViewConstructor")
@@ -66,12 +66,12 @@ internal class StackHeaderCoordinatorLayout(
         object : StackHeaderConfigurationObserver {
             override fun onConfigChanged(config: StackHeaderConfigurationProviding) = processUpdate(config)
 
-            override fun onMenuItemUpdated(
+            override fun onMenuElementUpdated(
                 id: String,
-                options: StackHeaderToolbarMenuItemOptions,
+                options: StackHeaderToolbarMenuElementOptions,
             ) {
                 val toolbar = appBarLayout?.toolbar ?: return
-                applicator.updateToolbarMenuItem(toolbar, toolbarMenuForwardIdMap, id, options)
+                applicator.updateToolbarMenuElement(toolbar, toolbarMenuForwardIdMap, id, options)
                 if (options.checked != null) {
                     handleGroupItemStateChange(toolbar, id, options.checked)
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfig.kt
@@ -18,8 +18,8 @@ import com.swmansion.rnscreens.gamma.stack.header.subview.OnStackHeaderSubviewCh
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.gamma.stack.header.subview.StackHeaderSubviewType
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuConfig
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemIconSource
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
 import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarUpdate
 import java.lang.ref.WeakReference
 import kotlin.properties.Delegates
@@ -193,8 +193,8 @@ internal class StackHeaderConfig(
     // Last resolved icon per menu item id. Unlike every other field on this config — which
     // mirrors a single prop — this cache deliberately merges resolved icons from BOTH sources
     // that can set a menu item icon: the `toolbarMenu` prop
-    // (resolveToolbarMenuItemIconsIfNeeded) and the imperative `setToolbarMenuItemOptions`
-    // view command (dispatchMenuItemUpdate). It is necessary to ensure consistency.
+    // (resolveToolbarMenuItemIconsIfNeeded) and the imperative `setToolbarMenuElementOptions`
+    // view command (dispatchMenuElementUpdate). It is necessary to ensure consistency.
     private var toolbarMenuItemIcons = mapOf<String, Drawable?>()
 
     internal fun resolveToolbarMenuItemIconsIfNeeded() {
@@ -374,20 +374,20 @@ internal class StackHeaderConfig(
      * resolved first and all options — including the icon — are delivered together in a single
      * update, so the change is applied atomically once the (possibly async) image has loaded.
      */
-    internal fun dispatchMenuItemUpdate(
+    internal fun dispatchMenuElementUpdate(
         id: String,
-        options: StackHeaderToolbarMenuItemOptions,
+        options: StackHeaderToolbarMenuElementOptions,
         iconSource: StackHeaderToolbarMenuItemIconSource?,
     ) {
         if (iconSource == null) {
-            configObserver?.onMenuItemUpdated(id, options)
+            configObserver?.onMenuElementUpdated(id, options)
             return
         }
 
         val resolver = toolbarMenuItemIconResolvers[id]
         if (resolver == null) {
-            Log.w(TAG, "[RNScreens] Unable to find icon resolver for menu item $id.")
-            configObserver?.onMenuItemUpdated(id, options)
+            Log.w(TAG, "[RNScreens] Unable to find icon resolver for menu element $id.")
+            configObserver?.onMenuElementUpdated(id, options)
             return
         }
 
@@ -402,7 +402,7 @@ internal class StackHeaderConfig(
                         StackHeaderToolbarUpdate.from(result.drawable)
                     }
                 }
-            configObserver?.onMenuItemUpdated(id, options.copy(icon = icon))
+            configObserver?.onMenuElementUpdated(id, options.copy(icon = icon))
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -232,16 +232,16 @@ internal open class StackHeaderConfigViewManager :
         view.toolbarMenuItemIconSourceMap = iconSources
     }
 
-    override fun setToolbarMenuItemOptions(
+    override fun setToolbarMenuElementOptions(
         view: StackHeaderConfig,
         id: String,
         options: ReadableArray,
     ) {
         val map = options.getMap(0) ?: return
-        view.dispatchMenuItemUpdate(
+        view.dispatchMenuElementUpdate(
             id,
-            StackHeaderToolbarMenuMapper.parseMenuItemOptions(map),
-            StackHeaderToolbarMenuMapper.parseMenuItemIconSource(map),
+            StackHeaderToolbarMenuMapper.parseMenuElementOptions(map),
+            StackHeaderToolbarMenuMapper.parseMenuElementIconSource(map),
         )
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationObserver.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigurationObserver.kt
@@ -1,12 +1,12 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
-import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuItemOptions
+import com.swmansion.rnscreens.gamma.stack.header.toolbar.StackHeaderToolbarMenuElementOptions
 
 internal interface StackHeaderConfigurationObserver {
     fun onConfigChanged(config: StackHeaderConfigurationProviding)
 
-    fun onMenuItemUpdated(
+    fun onMenuElementUpdated(
         id: String,
-        options: StackHeaderToolbarMenuItemOptions,
+        options: StackHeaderToolbarMenuElementOptions,
     )
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementConfig.kt
@@ -10,5 +10,6 @@ internal sealed interface StackHeaderToolbarMenuElementConfig {
     data class Submenu(
         override val item: StackHeaderToolbarMenuItemConfig,
         val menu: StackHeaderToolbarMenuConfig,
+        val menuTitle: String?,
     ) : StackHeaderToolbarMenuElementConfig
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementOptions.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuElementOptions.kt
@@ -3,11 +3,11 @@ package com.swmansion.rnscreens.gamma.stack.header.toolbar
 import android.graphics.drawable.Drawable
 
 /**
- * Partial update for a toolbar menu item.
+ * Partial update for a toolbar menu element.
  *
  * A `null` field means "leave the current value unchanged".
  */
-internal data class StackHeaderToolbarMenuItemOptions(
+internal data class StackHeaderToolbarMenuElementOptions(
     val title: StackHeaderToolbarUpdate<String>? = null,
     val titleCondensed: StackHeaderToolbarUpdate<String>? = null,
     val tooltipText: StackHeaderToolbarUpdate<String>? = null,
@@ -20,6 +20,7 @@ internal data class StackHeaderToolbarMenuItemOptions(
     val iconTintColorFocused: StackHeaderToolbarUpdate<Int>?,
     val iconTintColorDisabled: StackHeaderToolbarUpdate<Int>?,
     val checked: Boolean? = null,
+    val menuTitle: StackHeaderToolbarUpdate<String>? = null,
 ) {
     val requiresIconTintColorUpdate: Boolean
         get() =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -28,7 +28,7 @@ internal object StackHeaderToolbarMenuMapper {
 
     // endregion
 
-    // region Menu item command parsing
+    // region Menu element command parsing
 
     fun parseMenuElementOptions(map: ReadableMap): StackHeaderToolbarMenuElementOptions =
         StackHeaderToolbarMenuElementOptions(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -30,8 +30,8 @@ internal object StackHeaderToolbarMenuMapper {
 
     // region Menu item command parsing
 
-    fun parseMenuItemOptions(map: ReadableMap): StackHeaderToolbarMenuItemOptions =
-        StackHeaderToolbarMenuItemOptions(
+    fun parseMenuElementOptions(map: ReadableMap): StackHeaderToolbarMenuElementOptions =
+        StackHeaderToolbarMenuElementOptions(
             title = map.readNullableStringUpdate("title"),
             titleCondensed = map.readNullableStringUpdate("titleCondensed"),
             tooltipText = map.readNullableStringUpdate("tooltipText"),
@@ -52,9 +52,10 @@ internal object StackHeaderToolbarMenuMapper {
                     "checked",
                     StackHeaderToolbarMenuItemDefaults.INITIAL_TOGGLE_STATE,
                 ),
+            menuTitle = map.readNullableStringUpdate("menuTitle"),
         )
 
-    fun parseMenuItemIconSource(map: ReadableMap): StackHeaderToolbarMenuItemIconSource? {
+    fun parseMenuElementIconSource(map: ReadableMap): StackHeaderToolbarMenuItemIconSource? {
         if (!map.hasKey("drawableIconResourceName") && !map.hasKey("imageIconResource")) {
             return null
         }
@@ -112,6 +113,7 @@ internal object StackHeaderToolbarMenuMapper {
                 StackHeaderToolbarMenuElementConfig.Submenu(
                     item = item,
                     menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources)),
+                    menuTitle = map.readOptionalString("menuTitle"),
                 )
 
             else ->

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -10,7 +10,7 @@ import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderToolbarMenuElementAndroid,
   StackHeaderConfigRef,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-descriptions';
 
@@ -152,11 +152,11 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdTitle !== 'no change' && { title: resolveTitle(cmdTitle) }),
       ...(cmdHidden !== 'no change' && { hidden: resolveHidden(cmdHidden) }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** This test focuses on the Android toolbar menu items API
 on the gamma stack header — both the `toolbarMenu` prop and the
-imperative `setToolbarMenuItemOptions(id, options)` command. It verifies
+imperative `setToolbarMenuElementOptions(id, options)` command. It verifies
 that the menu renders correctly from props on first mount, that the
 per-item `onPress` callback fires with the correct id, and that
 imperative commands behave as specified: fields absent from `options`
@@ -26,7 +26,7 @@ Other — automation is not implemented yet.
 
 ## Note (Optional)
 
-- `StackHeaderToolbarMenuItemOptionsAndroid` semantics:
+- `StackHeaderToolbarMenuElementOptionsAndroid` semantics:
   - A field missing from the options object means "preserve current
     value".
   - A field set to `undefined` (sent over the bridge as `null`) means

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -16,7 +16,7 @@ import type {
   StackHeaderConfigRef,
   StackHeaderToolbarMenuBaseAndroid,
   StackHeaderToolbarMenuElementAndroid,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
 
@@ -267,7 +267,7 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdChecked !== 'no change' && { checked: cmdChecked === 'true' }),
       ...(cmdTitle !== 'no change' && {
         title: cmdTitle === 'undefined' ? undefined : cmdTitle,
@@ -276,7 +276,7 @@ function MainScreen() {
         hidden: cmdHidden === 'undefined' ? undefined : cmdHidden === 'true',
       }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/scenario.md
@@ -8,7 +8,7 @@ group behavior, `onSelectionChange` callbacks with correct IDs on groups of
 items, `onPress` on action items, `initialToggleState`,
 `toolbarMenuGroupDividerEnabled`, runtime props updates (group type change,
 adding/removing items, full rebuild resetting command state), and imperative
-`setToolbarMenuItemOptions` commands for setting `checked`, `title`, `hidden`,
+`setToolbarMenuElementOptions` commands for setting `checked`, `title`, `hidden`,
 and hidden items preserving their selection in callbacks.
 
 **OS test creation version:** Android: API Level 36
@@ -25,7 +25,7 @@ TBD — automation is possible and planned but not yet implemented.
 
 - Groups are scoped to the menu level they are defined in —
   groups cannot span submenus.
-- `setToolbarMenuItemOptions` targets elements by `id`. It works
+- `setToolbarMenuElementOptions` targets elements by `id`. It works
   on items at any nesting depth.
 
 ## Steps

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -11,7 +11,7 @@ import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderConfigRef,
   StackHeaderToolbarMenuItemAndroid,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
 } from 'react-native-screens/experimental';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-descriptions';
@@ -226,7 +226,7 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdIcon !== 'no change' && {
         icon: cmdIcon === 'none' ? undefined : resolveIcon(cmdIcon),
       }),
@@ -246,7 +246,7 @@ function MainScreen() {
         disabled: cmdDisabled === 'true',
       }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-descriptions.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-descriptions.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Toolbar Menu Icon',
   key: 'test-stack-toolbar-menu-icon-android',
   details:
-    'Tests the icon and state-aware tint props on toolbar menu items, both via props and via the setToolbarMenuItemOptions view command.',
+    'Tests the icon and state-aware tint props on toolbar menu items, both via props and via the setToolbarMenuElementOptions view command.',
   platforms: ['android'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Tests the `icon` and state-aware `iconTintColor*` props on
 Android toolbar menu items. Covers both the props flow (via `toolbarMenu`
-prop) and the imperative command flow (via `setToolbarMenuItemOptions`). The
+prop) and the imperative command flow (via `setToolbarMenuElementOptions`). The
 props flow rebuilds all items from scratch on every update and discards all
 prior command state on all items simultaneously. The command flow merges changes
 onto individual items: absent fields preserve the current value; fields set to

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -10,7 +10,7 @@ import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderToolbarMenuElementAndroid,
   StackHeaderConfigRef,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
 } from 'react-native-screens/experimental';
 import type { PlatformIconAndroid } from 'react-native-screens';
@@ -175,7 +175,7 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdIcon !== 'no change' && {
         icon: resolveIcon(cmdIcon),
       }),
@@ -183,7 +183,7 @@ function MainScreen() {
         showAsAction: resolveShowAsAction(cmdShowAsAction),
       }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/scenario.md
@@ -7,7 +7,7 @@ toolbar menu items. It verifies that items placed in the action bar
 vs overflow menu behave correctly for all five values: `never`,
 `always`, `alwaysWithText`, `ifRoom`, `ifRoomWithText`. It also
 verifies that the default (omitted prop) is equivalent to `never`,
-and that runtime updates via `setToolbarMenuItemOptions` — including
+and that runtime updates via `setToolbarMenuElementOptions` — including
 resetting to the default with `undefined` — take effect immediately.
 The test exercises the interaction between `showAsAction` and the
 `icon` prop, since the `WITH_TEXT` modifier only has a visible

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -10,7 +10,7 @@ import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderToolbarMenuElementAndroid,
   StackHeaderConfigRef,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
 } from 'react-native-screens/experimental';
 import type { PlatformIconAndroid } from 'react-native-screens';
@@ -217,7 +217,7 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdTitle !== 'no change' && {
         title: cmdTitle === 'undefined' ? undefined : cmdTitle,
       }),
@@ -228,7 +228,7 @@ function MainScreen() {
         tooltipText: resolveOptionalString(cmdTooltip),
       }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/scenario.md
@@ -36,7 +36,7 @@ TBD — automation is possible and planned but not yet implemented.
   hidden in **portrait**. An item with text but **no icon** always shows
   its text.
 - Changing any **Props** control rebuilds the whole menu and discards any
-  prior `setToolbarMenuItemOptions` state.
+  prior `setToolbarMenuElementOptions` state.
 
 ## Steps
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -10,7 +10,7 @@ import { Colors } from '@apps/shared/styling';
 import {
   type StackHeaderConfigRef,
   type StackHeaderToolbarMenuElementAndroid,
-  type StackHeaderToolbarMenuItemOptionsAndroid,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
 } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
 
@@ -32,8 +32,18 @@ type HiddenOption = 'true' | 'false' | 'undefined';
 type CmdTitleOption = TitleOption | 'no change';
 type CmdHiddenOption = HiddenOption | 'no change';
 
+type MenuTitleOption = 'Header X' | 'undefined';
+type CmdMenuTitleOption = MenuTitleOption | 'no change';
+
 const SUBMENU1_TITLE_OPTIONS = ['Submenu A', 'Changed', 'undefined'] as const;
 type Submenu1TitleOption = (typeof SUBMENU1_TITLE_OPTIONS)[number];
+
+const SUBMENU1_MENU_TITLE_OPTIONS = [
+  'Header A',
+  'Changed Header',
+  'undefined',
+] as const;
+type Submenu1MenuTitleOption = (typeof SUBMENU1_MENU_TITLE_OPTIONS)[number];
 
 const CMD_TITLE_OPTIONS: CmdTitleOption[] = [
   'no change',
@@ -44,6 +54,11 @@ const CMD_HIDDEN_OPTIONS: CmdHiddenOption[] = [
   'no change',
   'true',
   'false',
+  'undefined',
+];
+const CMD_MENU_TITLE_OPTIONS: CmdMenuTitleOption[] = [
+  'no change',
+  'Header X',
   'undefined',
 ];
 
@@ -57,9 +72,16 @@ function resolveHidden(h: HiddenOption): boolean | undefined {
   return h === 'undefined' ? undefined : h === 'true';
 }
 
+function resolveMenuTitle(
+  t: MenuTitleOption | Submenu1MenuTitleOption,
+): string | undefined {
+  return t === 'undefined' ? undefined : t;
+}
+
 interface MenuConfig {
   includeSubmenu1: boolean;
   submenu1Title: Submenu1TitleOption;
+  submenu1MenuTitle: Submenu1MenuTitleOption;
   addExtraItem: boolean;
   includeSubmenu2: boolean;
 }
@@ -67,6 +89,7 @@ interface MenuConfig {
 const DEFAULT_CONFIG: MenuConfig = {
   includeSubmenu1: true,
   submenu1Title: 'Submenu A',
+  submenu1MenuTitle: 'Header A',
   addExtraItem: false,
   includeSubmenu2: true,
 };
@@ -111,6 +134,7 @@ function buildMenu(
       type: 'menu',
       id: 'submenu-1',
       title: resolveTitle(config.submenu1Title),
+      menuTitle: resolveMenuTitle(config.submenu1MenuTitle),
       children: sub1Children,
     });
   }
@@ -179,6 +203,8 @@ function MainScreen() {
   const [cmdTargetId, setCmdTargetId] = useState<AllIds>('item-top');
   const [cmdTitle, setCmdTitle] = useState<CmdTitleOption>('no change');
   const [cmdHidden, setCmdHidden] = useState<CmdHiddenOption>('no change');
+  const [cmdMenuTitle, setCmdMenuTitle] =
+    useState<CmdMenuTitleOption>('no change');
 
   const headerConfigRef = useRef<StackHeaderConfigRef>(null);
   const { setRouteOptions, routeKey } = useStackNavigationContext();
@@ -215,17 +241,20 @@ function MainScreen() {
   );
 
   const sendCommand = useCallback(() => {
-    const options: StackHeaderToolbarMenuItemOptionsAndroid = {
+    const options: StackHeaderToolbarMenuElementOptionsAndroid = {
       ...(cmdTitle !== 'no change' && { title: resolveTitle(cmdTitle) }),
       ...(cmdHidden !== 'no change' && {
         hidden: resolveHidden(cmdHidden),
       }),
+      ...(cmdMenuTitle !== 'no change' && {
+        menuTitle: resolveMenuTitle(cmdMenuTitle),
+      }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );
-  }, [cmdTargetId, cmdTitle, cmdHidden]);
+  }, [cmdTargetId, cmdTitle, cmdHidden, cmdMenuTitle]);
 
   return (
     <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
@@ -251,6 +280,12 @@ function MainScreen() {
         items={CMD_HIDDEN_OPTIONS}
         onValueChange={setCmdHidden}
       />
+      <SettingsPicker<CmdMenuTitleOption>
+        label="menuTitle"
+        value={cmdMenuTitle}
+        items={CMD_MENU_TITLE_OPTIONS}
+        onValueChange={setCmdMenuTitle}
+      />
       <Button title="Send Command" onPress={sendCommand} />
 
       <Text style={styles.heading}>Menu Structure — Props</Text>
@@ -264,6 +299,12 @@ function MainScreen() {
         value={config.submenu1Title}
         items={[...SUBMENU1_TITLE_OPTIONS]}
         onValueChange={v => applyConfig({ ...config, submenu1Title: v })}
+      />
+      <SettingsPicker<Submenu1MenuTitleOption>
+        label="submenu-1 menuTitle"
+        value={config.submenu1MenuTitle}
+        items={[...SUBMENU1_MENU_TITLE_OPTIONS]}
+        onValueChange={v => applyConfig({ ...config, submenu1MenuTitle: v })}
       />
       <SettingsSwitch
         label="add extra item to submenu-1"

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
@@ -6,7 +6,7 @@
 support on the gamma stack header. It verifies that submenus render
 correctly as expandable groups in the overflow menu, that `onPress`
 fires with the correct id for items at every nesting level (including
-deeply nested submenus), that imperative `setToolbarMenuItemOptions`
+deeply nested submenus), that imperative `setToolbarMenuElementOptions`
 commands work on both leaf items inside submenus and on submenu
 containers themselves (including `menuTitle` changes), and that any
 props update rebuilds the entire menu tree — discarding all prior
@@ -27,7 +27,7 @@ TBD — automation is possible and planned but not yet implemented.
 - Submenus appear as items with a submenu indicator (caret/arrow
   icon). Tapping a submenu opens a nested menu instead of firing
   `onPress`.
-- `setToolbarMenuItemOptions` targets elements by `id`. It works
+- `setToolbarMenuElementOptions` targets elements by `id`. It works
   on both leaf items and submenu containers at any nesting depth.
 - `menuTitle` controls the header text shown above submenu items
   when the submenu is opened. Only `submenu-1` has `menuTitle`

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
@@ -8,8 +8,9 @@ correctly as expandable groups in the overflow menu, that `onPress`
 fires with the correct id for items at every nesting level (including
 deeply nested submenus), that imperative `setToolbarMenuItemOptions`
 commands work on both leaf items inside submenus and on submenu
-containers themselves, and that any props update rebuilds the entire
-menu tree — discarding all prior command-applied state at every level.
+containers themselves (including `menuTitle` changes), and that any
+props update rebuilds the entire menu tree — discarding all prior
+command-applied state at every level. 
 
 **OS test creation version:** Android: API Level 36
 
@@ -23,19 +24,17 @@ TBD — automation is possible and planned but not yet implemented.
 
 ## Note
 
-- The initial menu structure is:
-  - `item-top`: "Top Item" (regular menu item)
-  - `submenu-1`: "Submenu A" (submenu containing):
-    - `sub-1-1`: "Sub A.1"
-    - `sub-1-2`: "Sub A.2"
-  - `submenu-2`: "Submenu B" (submenu containing):
-    - `sub-2-1`: "Sub B.1"
-    - `deep-menu`: "Deep" (submenu containing):
-      - `deep-1`: "Deep.1"
-- Submenus appear as items with a submenu indicator (caret/arrow icon).
-  Tapping a submenu opens a nested menu instead of firing `onPress`.
-- `setToolbarMenuItemOptions` targets elements by `id`. It works on
-  both leaf items and submenu containers at any nesting depth.
+- Submenus appear as items with a submenu indicator (caret/arrow
+  icon). Tapping a submenu opens a nested menu instead of firing
+  `onPress`.
+- `setToolbarMenuItemOptions` targets elements by `id`. It works
+  on both leaf items and submenu containers at any nesting depth.
+- `menuTitle` controls the header text shown above submenu items
+  when the submenu is opened. Only `submenu-1` has `menuTitle`
+  set by default ("Header A"). `submenu-2` and `deep-menu` have
+  no `menuTitle`, so their submenu headers fall back to `title`.
+  When both `menuTitle` and `title` are undefined, no submenu
+  header is shown.
 
 ## Steps
 
@@ -50,17 +49,21 @@ TBD — automation is possible and planned but not yet implemented.
 
 2. Tap "Submenu A" in the overflow menu.
 
-- [ ] A nested menu opens showing two items: "Sub A.1" and
-      "Sub A.2".
+- [ ] A nested menu opens with a submenu header reading
+      "Header A". It shows two items: "Sub A.1" and "Sub A.2".
 
 3. Go back to the top-level menu. Tap "Submenu B".
 
-- [ ] A nested menu opens showing two entries: "Sub B.1" and
-      "Deep" (with a submenu indicator).
+- [ ] A nested menu opens with a submenu header reading
+      "Submenu B" (fallback from title — no menuTitle set). It
+      shows two entries: "Sub B.1" and "Deep" (with a submenu
+      indicator).
 
 4. Tap "Deep" in the Submenu B menu.
 
-- [ ] A nested menu opens showing one item: "Deep.1".
+- [ ] A nested menu opens with a submenu header reading "Deep"
+      (fallback from title — no menuTitle set). It shows one
+      item: "Deep.1".
 
 ---
 
@@ -142,75 +145,140 @@ TBD — automation is possible and planned but not yet implemented.
 
 ---
 
+### Imperative command — change menuTitle
+
+17. Set target id = `submenu-1`, menuTitle = `Header X`,
+    title = `no change`, hidden = `no change`.
+    Tap **Send Command**.
+
+- [ ] Open the submenu (still labeled "Title X" from step 14):
+      the submenu header now reads "Header X".
+
+18. Set target id = `submenu-1`, menuTitle = `undefined`,
+    title = `no change`, hidden = `no change`.
+    Tap **Send Command**.
+
+- [ ] Open the submenu: the submenu header falls back to the
+      title value and reads "Title X".
+
+19. Set target id = `submenu-1`, title = `undefined`,
+    menuTitle = `undefined`, hidden = `no change`.
+    Tap **Send Command**.
+
+- [ ] Open the submenu: no submenu header is shown at all (both
+      menuTitle and title are undefined). The submenu entry in
+      the overflow menu also has no title.
+
+---
+
 ### Props update drops all command state
 
-17. In **Menu Structure — Props**, toggle the "add extra item to
+20. In **Menu Structure — Props**, toggle the "add extra item to
     submenu-1" switch ON.
 
-- [ ] Open "Submenu A" (which reverts to its prop-configured title
-      "Submenu A" because the props update rebuilt the menu). It now
-      shows three items: "Sub A.1" (reverted from "Title X"),
-      "Sub A.2", and "Sub A.3". All command state is gone.
+- [ ] Open "Submenu A" (which reverts to its prop-configured
+      title "Submenu A" because the props update rebuilt the
+      menu). The submenu header reads "Header A" (restored from
+      props). It now shows three items: "Sub A.1" (reverted from
+      "Title X"), "Sub A.2", and "Sub A.3". All command state is
+      gone.
 
 ---
 
 ### Props update — structural changes
 
-18. Toggle the "add extra item to submenu-1" switch OFF.
+21. Toggle the "add extra item to submenu-1" switch OFF.
 
 - [ ] Open "Submenu A": "Sub A.3" disappears. Two items remain:
       "Sub A.1" and "Sub A.2".
 
-19. Change the "submenu-1 title" picker to `Changed`.
+22. Change the "submenu-1 title" picker to `Changed`.
 
 - [ ] The submenu now reads "Changed" in the overflow menu. Its
       children are unchanged.
 
-20. Change the "submenu-1 title" picker back to `Submenu A`.
+23. Change the "submenu-1 title" picker back to `Submenu A`.
 
 - [ ] The submenu reads "Submenu A" again.
 
-21. Toggle the "include submenu-1" switch OFF.
+24. Change the "submenu-1 menuTitle" picker to `Changed Header`.
+
+- [ ] Open "Submenu A": the submenu header reads
+      "Changed Header". Children unchanged.
+
+25. Change the "submenu-1 menuTitle" picker back to `Header A`.
+
+- [ ] Open "Submenu A": the submenu header reads "Header A"
+      again.
+
+26. Change the "submenu-1 menuTitle" picker to `undefined`.
+
+- [ ] Open "Submenu A": the submenu header falls back to the
+      title and reads "Submenu A".
+
+27. Change the "submenu-1 title" picker to `undefined`
+    (menuTitle is still undefined from the previous step).
+
+- [ ] Open the submenu: no submenu header is shown. The submenu
+      entry in the overflow menu also has no title.
+
+28. Change the "submenu-1 title" picker back to `Submenu A`,
+    then change "submenu-1 menuTitle" back to `Header A`.
+
+- [ ] The submenu reads "Submenu A" in the overflow menu and the
+      submenu header reads "Header A" when opened.
+
+29. Toggle the "include submenu-1" switch OFF.
 
 - [ ] "Submenu A" disappears from the overflow menu. Only
       "Top Item" and "Submenu B" remain.
 
-22. Toggle the "include submenu-1" switch ON.
+30. Toggle the "include submenu-1" switch ON.
 
 - [ ] "Submenu A" reappears with its default children ("Sub A.1"
       and "Sub A.2").
 
-23. Toggle the "include submenu-2" switch OFF.
+31. Toggle the "include submenu-2" switch OFF.
 
 - [ ] "Submenu B" disappears. Only "Top Item" and "Submenu A"
       remain.
 
-24. Toggle the "include submenu-2" switch ON.
+32. Toggle the "include submenu-2" switch ON.
 
-- [ ] "Submenu B" reappears with "Sub B.1" and "Deep" (containing
-      "Deep.1").
+- [ ] "Submenu B" reappears with "Sub B.1" and "Deep"
+      (containing "Deep.1").
 
 ---
 
 ### Deeply nested submenu — commands at depth
 
-25. Set target id = `deep-1`, title = `Title X`,
-    hidden = `no change`. Tap **Send Command**.
+33. Set target id = `deep-1`, title = `Title X`,
+    hidden/menuTitle = `no change`. Tap **Send Command**.
 
 - [ ] Open Submenu B > Deep: the item now reads "Title X".
 
-26. Tap "Title X".
+34. Tap "Title X".
 
 - [ ] "Last clicked" updates to `deep-1`.
 
-27. Set target id = `deep-menu`, title = `Title X`,
-    hidden = `no change`. Tap **Send Command**.
+35. Set target id = `deep-menu`, title = `Title X`,
+    hidden/menuTitle = `no change`. Tap **Send Command**.
 
 - [ ] Open Submenu B: the nested submenu now reads "Title X"
       instead of "Deep".
 
-28. In **Menu Structure — Props**, toggle "include submenu-2" OFF
+36. Set target id = `deep-menu`, menuTitle = `Header X`,
+    title = `no change`, hidden = `no change`.
+    Tap **Send Command**.
+
+- [ ] Open Submenu B > "Title X" (from step 35): the submenu
+      header reads "Header X" instead of "Title X" (the title
+      fallback).
+
+37. In **Menu Structure — Props**, toggle "include submenu-2" OFF
     and back ON.
 
-- [ ] Open Submenu B: "Deep" is restored (props rebuild). Open
-      Deep: "Deep.1" is restored.
+- [ ] Open Submenu B: its submenu header reads "Submenu B"
+      (title fallback — props rebuild). Open Deep: its submenu
+      header reads "Deep" (title fallback — props rebuild).
+      "Deep.1" is restored.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/scenario.md
@@ -10,7 +10,7 @@ deeply nested submenus), that imperative `setToolbarMenuElementOptions`
 commands work on both leaf items inside submenus and on submenu
 containers themselves (including `menuTitle` changes), and that any
 props update rebuilds the entire menu tree — discarding all prior
-command-applied state at every level. 
+command-applied state at every level.
 
 **OS test creation version:** Android: API Level 36
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.tsx
@@ -24,7 +24,7 @@ import type {
   StackHeaderToolbarMenuElementAndroid as NativeToolbarMenuElementAndroid,
   StackHeaderToolbarMenuItemPressEventAndroid,
   StackHeaderToolbarMenuGroupSelectionChangeEventAndroid,
-  StackHeaderToolbarMenuItemOptionsAndroid as NativeToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid as NativeToolbarMenuElementOptionsAndroid,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent';
 import StackHeaderSubview from './android/StackHeaderSubview.android';
 import type {
@@ -34,7 +34,7 @@ import type {
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemBaseAndroid,
   StackHeaderTypeAndroid,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
   StackHeaderToolbarMenuGroupAndroid,
 } from './StackHeaderConfig.android.types';
 import { parseAndroidIconToNativeProps } from '../../../shared';
@@ -232,7 +232,7 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
 
   useImperativeHandle(forwardedRef, () => ({
     android: {
-      setToolbarMenuItemOptions: (id, options) => {
+      setToolbarMenuElementOptions: (id, options) => {
         if (!ref.current) {
           console.warn(
             '[RNScreens] Reference to native header config component has not been updated yet.',
@@ -240,10 +240,10 @@ function useHeaderConfigRef(forwardedRef: Ref<StackHeaderConfigRef>) {
           return;
         }
 
-        StackHeaderConfigAndroidNativeCommands.setToolbarMenuItemOptions(
+        StackHeaderConfigAndroidNativeCommands.setToolbarMenuElementOptions(
           ref.current,
           id,
-          parseToolbarMenuItemOptionsToNativeProps(options),
+          parseToolbarMenuElementOptionsToNativeProps(options),
         );
       },
     },
@@ -514,67 +514,69 @@ function parseBaseItemToNativeProps({
   };
 }
 
-function parseToolbarMenuItemOptionsToNativeProps(
-  options: StackHeaderToolbarMenuItemOptionsAndroid,
-): NativeToolbarMenuItemOptionsAndroid[] {
-  const nativeOptions: NativeToolbarMenuItemOptionsAndroid = Object.fromEntries(
-    Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
-      const typedKey = key as keyof StackHeaderToolbarMenuItemOptionsAndroid;
+function parseToolbarMenuElementOptionsToNativeProps(
+  options: StackHeaderToolbarMenuElementOptionsAndroid,
+): NativeToolbarMenuElementOptionsAndroid[] {
+  const nativeOptions: NativeToolbarMenuElementOptionsAndroid =
+    Object.fromEntries(
+      Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
+        const typedKey =
+          key as keyof StackHeaderToolbarMenuElementOptionsAndroid;
 
-      switch (typedKey) {
-        case 'iconTintColorNormal':
-        case 'iconTintColorPressed':
-        case 'iconTintColorFocused':
-        case 'iconTintColorDisabled':
-          return [
-            [
-              key,
-              processColor(
-                value as StackHeaderToolbarMenuItemOptionsAndroid[typeof typedKey],
-              ) ?? null,
-            ],
-          ];
+        switch (typedKey) {
+          case 'iconTintColorNormal':
+          case 'iconTintColorPressed':
+          case 'iconTintColorFocused':
+          case 'iconTintColorDisabled':
+            return [
+              [
+                key,
+                processColor(
+                  value as StackHeaderToolbarMenuElementOptionsAndroid[typeof typedKey],
+                ) ?? null,
+              ],
+            ];
 
-        case 'icon': {
-          const iconValue =
-            value as StackHeaderToolbarMenuItemOptionsAndroid['icon'];
+          case 'icon': {
+            const iconValue =
+              value as StackHeaderToolbarMenuElementOptionsAndroid['icon'];
 
-          // Explicit `undefined` means "reset the icon". The native side treats
-          // an absent key as "no change", so to clear the icon we must send every
-          // native icon key explicitly as `null`.
-          if (iconValue === undefined) {
-            const noIcon: Pick<
-              NativeToolbarMenuItemOptionsAndroid,
-              'imageIconResource' | 'drawableIconResourceName'
-            > = {
-              imageIconResource: null,
-              drawableIconResourceName: null,
-            };
-            return Object.entries(noIcon);
+            // Explicit `undefined` means "reset the icon". The native side treats
+            // an absent key as "no change", so to clear the icon we must send every
+            // native icon key explicitly as `null`.
+            if (iconValue === undefined) {
+              const noIcon: Pick<
+                NativeToolbarMenuElementOptionsAndroid,
+                'imageIconResource' | 'drawableIconResourceName'
+              > = {
+                imageIconResource: null,
+                drawableIconResourceName: null,
+              };
+              return Object.entries(noIcon);
+            }
+
+            return Object.entries(parseAndroidIconToNativeProps(iconValue));
           }
-
-          return Object.entries(parseAndroidIconToNativeProps(iconValue));
         }
-      }
 
-      if (
-        typeof value === 'object' &&
-        value !== null &&
-        !Array.isArray(value)
-      ) {
-        throw new Error(`[RNScreens] Unexpected nested object.`);
-      }
+        if (
+          typeof value === 'object' &&
+          value !== null &&
+          !Array.isArray(value)
+        ) {
+          throw new Error(`[RNScreens] Unexpected nested object.`);
+        }
 
-      return [
-        [
-          key,
-          // We need to replace explicit `undefined` with `null`
-          // so that we're able to read that information on the native side.
-          value === undefined ? null : value,
-        ],
-      ];
-    }),
-  );
+        return [
+          [
+            key,
+            // We need to replace explicit `undefined` with `null`
+            // so that we're able to read that information on the native side.
+            value === undefined ? null : value,
+          ],
+        ];
+      }),
+    );
 
   // For some reason Codegen requires passing an array (we can't use plain object).
   return [nativeOptions];

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -360,13 +360,23 @@ export interface StackHeaderToolbarMenuAndroid
    * @platform android
    */
   type: 'menu';
+  /**
+   * @summary Header title displayed at the top of the submenu popup.
+   *
+   * @description
+   * Maps to Android's `SubMenu.setHeaderTitle()`. This is distinct from
+   * `title`, which controls the label shown in the parent menu's item row.
+   *
+   * @platform android
+   */
+  menuTitle?: string | undefined;
 }
 
 export type StackHeaderToolbarMenuElementAndroid =
   | StackHeaderToolbarMenuItemAndroid
   | StackHeaderToolbarMenuAndroid;
 
-export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
+export type StackHeaderToolbarMenuElementOptionsAndroid = Partial<
   Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
 > & {
   /**
@@ -379,21 +389,31 @@ export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
    * @platform android
    */
   checked?: boolean | undefined;
+  /**
+   * @summary Sets the header title of a submenu popup.
+   *
+   * @description
+   * Only applies to `type: 'menu'` elements. Ignored if the target is a regular
+   * menu item.
+   *
+   * @platform android
+   */
+  menuTitle?: string | undefined;
 };
 
 export interface StackHeaderConfigCommandsAndroid {
   /**
-   * @summary Allows to change menu item configuration in runtime.
+   * @summary Allows to change menu element configuration in runtime.
    *
-   * @param id The ID of the menu item which will be updated.
+   * @param id The ID of the menu element which will be updated.
    * @param options Object with properties that should be changed. If property
    *        is omitted, the current value will be preserved. If property is
    *        explicitly set to `undefined`, the default value of the prop will be
    *        restored.
    */
-  setToolbarMenuItemOptions: (
+  setToolbarMenuElementOptions: (
     id: string,
-    options: StackHeaderToolbarMenuItemOptionsAndroid,
+    options: StackHeaderToolbarMenuElementOptionsAndroid,
   ) => void;
 }
 
@@ -582,11 +602,11 @@ export interface StackHeaderConfigPropsAndroid {
    *
    * @description
    * This prop serves as initial configuration of the toolbar menu. If you
-   * want to change some property in runtime, use `setToolbarMenuItemOptions`
+   * want to change some property in runtime, use `setToolbarMenuElementOptions`
    * view command.
    *
    * Changing this prop in runtime will result in full toolbar menu rebuild.
-   * Any prior changes applied via `setToolbarMenuItemOptions` will be lost.
+   * Any prior changes applied via `setToolbarMenuElementOptions` will be lost.
    *
    * @platform android
    */

--- a/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.android.types.ts
@@ -81,6 +81,13 @@ export interface StackHeaderToolbarMenuItemBaseAndroid {
   /**
    * @summary Title of the menu element.
    *
+   * @remarks
+   * If `title` is changed for the element of type `menu` by using the
+   * `setToolbarMenuElementOptions` view command, the menu title (`menuTitle`)
+   * will also be changed to the new title (unless the new title is set to
+   * `undefined`). In order to keep the custom menu title, you should also
+   * include `menuTitle` in the view command.
+   *
    * @platform android
    */
   title?: string | undefined;
@@ -366,6 +373,12 @@ export interface StackHeaderToolbarMenuAndroid
    * @description
    * Maps to Android's `SubMenu.setHeaderTitle()`. This is distinct from
    * `title`, which controls the label shown in the parent menu's item row.
+   *
+   * @remarks
+   * If `title` is changed by using the `setToolbarMenuElementOptions` view
+   * command, the menu title will also be changed to the new title (unless the
+   * new title is set to `undefined`). In order to keep the custom menu title,
+   * you should also include `menuTitle` in the view command.
    *
    * @platform android
    */

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -30,7 +30,7 @@ export type {
   StackHeaderToolbarMenuGroupAndroid,
   StackHeaderToolbarMenuItemAndroid,
   StackHeaderToolbarMenuItemBaseAndroid,
-  StackHeaderToolbarMenuItemOptionsAndroid,
+  StackHeaderToolbarMenuElementOptionsAndroid,
   StackHeaderToolbarMenuItemShowAsActionAndroid,
   StackHeaderToolbarMenuItemTypeAndroid,
   // iOS

--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -74,6 +74,7 @@ export type StackHeaderToolbarMenuBaseAndroid = {
 type StackHeaderToolbarMenuAndroid = StackHeaderToolbarMenuItemBaseAndroid &
   StackHeaderToolbarMenuBaseAndroid & {
     type: 'menu';
+    menuTitle?: string | undefined;
   };
 
 export type StackHeaderToolbarMenuElementAndroid =
@@ -113,24 +114,25 @@ export interface NativeProps extends ViewProps {
 
 type ComponentType = HostComponent<NativeProps>;
 
-export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
+export type StackHeaderToolbarMenuElementOptionsAndroid = Partial<
   Omit<StackHeaderToolbarMenuItemBaseAndroid, 'id'>
 > & {
   checked?: boolean | undefined;
+  menuTitle?: string | undefined;
 };
 
 export interface NativeCommands {
-  setToolbarMenuItemOptions: (
+  setToolbarMenuElementOptions: (
     viewRef: React.ComponentRef<ComponentType>,
     id: string,
     // We use the array here only due to codegen limitation. We're using only
     // the first index of the array.
-    options: StackHeaderToolbarMenuItemOptionsAndroid[],
+    options: StackHeaderToolbarMenuElementOptionsAndroid[],
   ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['setToolbarMenuItemOptions'],
+  supportedCommands: ['setToolbarMenuElementOptions'],
 });
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Description

Adds support for `menuTitle` prop (maps to native `SubMenu.setHeaderTitle()`).

> [!NOTE]
>
> Changing `title` via view command will also change the `menuTitle` (native Android behavior). Unfortunately, `SubMenu` interface doesn't provide a way to read current `headerTitle` to be able to restore it after updating the title. For now, I decided to describe the limitation in JSDocs of the two props. We can also use unsafe cast/reflection to read the title or add some state in `StackHeaderCoordinatorLayout` and pass it to `StackHeaderApplicator` but I decided that it is an overkill just for one prop. We can consider handling this in the future though.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1498.

## Changes

- add `menuTitle` prop to `StackHeaderToolbarMenuAndroid`
- rename `StackHeaderToolbarMenuItemOptionsAndroid` to `StackHeaderToolbarMenuElementOptionsAndroid` because `menuTitle` isn't part of menu item but menu and related view command/functions both in JS and on native side
- handle the prop on the native side
- describe limitations in JSDocs
- update SFTs after rename
- update `test-stack-toolbar-nested-menu-android` SFT to include `menuTitle` prop

## Visual documentation

https://github.com/user-attachments/assets/a4eccfdc-03a7-4f40-9813-5b65548f4a5d

## Test plan

Run `test-stack-toolbar-nested-menu-android` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
