### PR TITLE
fix(Android): handle nullable Fresco bitmap

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -56,8 +56,10 @@ private fun loadImageInternal(
 
                 if (closeableImage is CloseableStaticBitmap) {
                     val bitmap = closeableImage.underlyingBitmap
-                    val drawable = bitmap.toDrawable(context.resources)
-                    onLoaded(drawable)
+                    if (bitmap != null) {
+                        val drawable = bitmap.toDrawable(context.resources)
+                        onLoaded(drawable)
+                    }
                 }
 
                 imageReference.close()


### PR DESCRIPTION
> [!IMPORTANT]  
> This is needed to unblock the react-native@nightly job against react-native-screens.

## Description

RN 0.87 will ship with a Fresco 3.7.0 bump.
Fresco 3.7.0 marks `CloseableBitmap.getUnderlyingBitmap()` as nullable. 

With this bump, `react-native-screens` started failing Android Kotlin compilation because `ImageLoader.kt` was calling `toDrawable()` on the returned bitmap without a null check.

This guards the bitmap before creating the drawable, while preserving compatibility with older Fresco versions where Kotlin sees the Java return type as a platform type.

## Test plan

¯\_(ツ)_/¯