### PR TITLE
chore(Android): make `ImageLoader` `onLoaded`'s result nullable

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -23,7 +23,7 @@ private const val TAG = "ImageLoader"
 internal fun loadImage(
     context: Context,
     uri: String,
-    onLoaded: (Drawable) -> Unit,
+    onLoaded: (Drawable?) -> Unit,
 ) {
     // Since image loading might happen on a background thread
     // ref. https://frescolib.org/docs/intro-image-pipeline.html
@@ -39,7 +39,7 @@ internal fun loadImage(
 private fun loadImageInternal(
     context: Context,
     uri: Uri,
-    onLoaded: (Drawable) -> Unit,
+    onLoaded: (Drawable?) -> Unit,
 ) {
     val imageRequest =
         ImageRequestBuilder
@@ -59,6 +59,8 @@ private fun loadImageInternal(
                     if (bitmap != null) {
                         val drawable = bitmap.toDrawable(context.resources)
                         onLoaded(drawable)
+                    } else {
+                        onLoaded(null)
                     }
                 }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/software-mansion/react-native-screens/pull/4242. Ensures that `onLoaded` callback is called even if bitmap was null.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1589.

### Reasoning

E.g. in Stack v5 toolbar menu item implementation when update via view command contains icon, we delay updating the menu item until we load the image. We don't want to miss the onLoaded callback, otherwise we won't update the menu item at all.

## Changes

- make `onLoaded`'s result in `ImageLoader.loadImage` and `ImageLoader.loadImageInternal` nullable `Drawable` (`Drawable?`)
   - no changes were required in existing code that uses the image loader

## Before & after - visual documentation

N/A

## Test plan

Ensure that images still load in tabs, stack v5.

## Checklist

- [x] Ensured that CI passes
