### PR TITLE
feat(Android, FormSheet v5): Add support for fractional detents

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -30,14 +30,8 @@ class DimmingViewManager(
                 )
         }
 
-    internal fun setOnBackdropClickListener(listener: (() -> Unit)?) {
-        if (listener != null) {
-            dimmingView.setOnClickListener {
-                listener()
-            }
-        } else {
-            dimmingView.setOnClickListener(null)
-        }
+    internal fun setOnBackdropClickListener(listener: View.OnClickListener?) {
+        dimmingView.setOnClickListener(listener)
     }
 
     internal fun onDialogShown() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/dimmingview/DimmingViewManager.kt
@@ -30,9 +30,13 @@ class DimmingViewManager(
                 )
         }
 
-    internal fun setOnBackdropClickListener(listener: () -> Unit) {
-        dimmingView.setOnClickListener {
-            listener()
+    internal fun setOnBackdropClickListener(listener: (() -> Unit)?) {
+        if (listener != null) {
+            dimmingView.setOnClickListener {
+                listener()
+            }
+        } else {
+            dimmingView.setOnClickListener(null)
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetBehaviorController.kt
@@ -1,0 +1,100 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+import android.widget.FrameLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+internal class FormSheetBehaviorController(
+    private val sheetView: FrameLayout,
+) {
+    private val behavior = BottomSheetBehavior.from(sheetView)
+
+    private var detents: FormSheetDetents? = null
+    private var sheetAvailableSpace: Int = 0
+    private var shouldApplyInitialState = false
+
+    internal fun updateSheetDetents(detents: FormSheetDetents) {
+        this.detents = detents
+        shouldApplyInitialState = true
+        reconfigureSheetBehavior()
+    }
+
+    /**
+     * @param maxHeight - the full window height that detent fractions are measured against.
+     * Using the full height lets a BottomSheet with large detent configured to slide
+     * behind the status bar, where Material pads insets for us.
+     */
+    internal fun updateSheetAvailableSpace(maxHeight: Int) {
+        if (maxHeight <= 0 || maxHeight == sheetAvailableSpace) {
+            return
+        }
+        sheetAvailableSpace = maxHeight
+        reconfigureSheetBehavior()
+    }
+
+    private fun reconfigureSheetBehavior() {
+        val detents = detents ?: return
+        if (sheetAvailableSpace <= 0) {
+            return
+        }
+
+        val applyInitialState = shouldApplyInitialState
+
+        when (detents.count) {
+            1 -> configureSingleDetent(detents, applyInitialState)
+            2 -> configureTwoDetents(detents, applyInitialState)
+            3 -> configureThreeDetents(detents, applyInitialState)
+            else -> throw IllegalStateException(
+                "[RNScreens] Unsupported detent count ${detents.count}.",
+            )
+        }
+
+        shouldApplyInitialState = false
+
+        // Metrics were mutated on an already-measured sheet; force a fresh layout
+        // pass so the behavior re-settles to the new detent instead of keeping its
+        // stale height.
+        sheetView.requestLayout()
+    }
+
+    private fun configureSingleDetent(
+        detents: FormSheetDetents,
+        applyInitialState: Boolean,
+    ) = behavior.apply {
+        skipCollapsed = true
+        isFitToContents = true
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        if (applyInitialState) {
+            state = BottomSheetBehavior.STATE_EXPANDED
+        }
+    }
+
+    private fun configureTwoDetents(
+        detents: FormSheetDetents,
+        applyInitialState: Boolean,
+    ) = behavior.apply {
+        skipCollapsed = false
+        isFitToContents = true
+        peekHeight = detents.firstHeight(sheetAvailableSpace)
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        // TODO: @t0maboro - in v4 impl the state was passed as a param, consider the same approach
+        if (applyInitialState) {
+            state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+    }
+
+    private fun configureThreeDetents(
+        detents: FormSheetDetents,
+        applyInitialState: Boolean,
+    ) = behavior.apply {
+        skipCollapsed = false
+        isFitToContents = false
+        peekHeight = detents.firstHeight(sheetAvailableSpace)
+        halfExpandedRatio = detents.halfExpandedRatio()
+        expandedOffset = detents.expandedOffsetFromTop(sheetAvailableSpace)
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        // TODO: @t0maboro - in v4 impl the state was passed as a param, consider the same approach
+        if (applyInitialState) {
+            state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetBehaviorController.kt
@@ -8,47 +8,31 @@ internal class FormSheetBehaviorController(
 ) {
     private val behavior = BottomSheetBehavior.from(sheetView)
 
-    private var detents: FormSheetDetents? = null
-    private var sheetAvailableSpace: Int = 0
-    private var shouldApplyInitialState = false
-
-    internal fun updateSheetDetents(detents: FormSheetDetents) {
-        this.detents = detents
-        shouldApplyInitialState = true
-        reconfigureSheetBehavior()
-    }
-
     /**
-     * @param maxHeight - the full window height that detent fractions are measured against.
+     * @param detents - parsed detents configuration.
+     * @param sheetAvailableSpace - the full window height that detent fractions are measured against.
      * Using the full height lets a BottomSheet with large detent configured to slide
      * behind the status bar, where Material pads insets for us.
+     * @param applyInitialState - whether to force the sheet to snap to its default starting position
+     * Should be set to `true` when the detents configuration changes.
      */
-    internal fun updateSheetAvailableSpace(maxHeight: Int) {
-        if (maxHeight <= 0 || maxHeight == sheetAvailableSpace) {
-            return
-        }
-        sheetAvailableSpace = maxHeight
-        reconfigureSheetBehavior()
-    }
-
-    private fun reconfigureSheetBehavior() {
-        val detents = detents ?: return
+    internal fun updateSheetBehavior(
+        detents: FormSheetDetents,
+        sheetAvailableSpace: Int,
+        applyInitialState: Boolean = false,
+    ) {
         if (sheetAvailableSpace <= 0) {
             return
         }
 
-        val applyInitialState = shouldApplyInitialState
-
         when (detents.count) {
-            1 -> configureSingleDetent(detents, applyInitialState)
-            2 -> configureTwoDetents(detents, applyInitialState)
-            3 -> configureThreeDetents(detents, applyInitialState)
+            1 -> configureSingleDetent(detents, sheetAvailableSpace, applyInitialState)
+            2 -> configureTwoDetents(detents, sheetAvailableSpace, applyInitialState)
+            3 -> configureThreeDetents(detents, sheetAvailableSpace, applyInitialState)
             else -> throw IllegalStateException(
                 "[RNScreens] Unsupported detent count ${detents.count}.",
             )
         }
-
-        shouldApplyInitialState = false
 
         // Metrics were mutated on an already-measured sheet; force a fresh layout
         // pass so the behavior re-settles to the new detent instead of keeping its
@@ -58,6 +42,7 @@ internal class FormSheetBehaviorController(
 
     private fun configureSingleDetent(
         detents: FormSheetDetents,
+        sheetAvailableSpace: Int,
         applyInitialState: Boolean,
     ) = behavior.apply {
         skipCollapsed = true
@@ -70,6 +55,7 @@ internal class FormSheetBehaviorController(
 
     private fun configureTwoDetents(
         detents: FormSheetDetents,
+        sheetAvailableSpace: Int,
         applyInitialState: Boolean,
     ) = behavior.apply {
         skipCollapsed = false
@@ -84,6 +70,7 @@ internal class FormSheetBehaviorController(
 
     private fun configureThreeDetents(
         detents: FormSheetDetents,
+        sheetAvailableSpace: Int,
         applyInitialState: Boolean,
     ) = behavior.apply {
         skipCollapsed = false

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetConfig.kt
@@ -2,5 +2,6 @@ package com.swmansion.rnscreens.gamma.modals.formsheet
 
 internal data class FormSheetConfig(
     val isOpen: Boolean = false,
+    val detents: List<Double> = emptyList(),
     val prefersGrabberVisible: Boolean = false,
 )

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
@@ -22,12 +22,12 @@ internal class FormSheetDetents(
 
     internal val count: Int get() = detents.size
 
-    internal fun at(index: Int): Double = detents[index]
+    private fun heightFractionAt(index: Int): Double = detents[index]
 
-    internal fun heightAt(
+    private fun heightAt(
         index: Int,
         containerHeight: Int,
-    ): Int = (at(index) * containerHeight).toInt()
+    ): Int = (heightFractionAt(index) * containerHeight).toInt()
 
     internal fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
 
@@ -35,7 +35,7 @@ internal class FormSheetDetents(
 
     internal fun halfExpandedRatio(): Float {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for halfExpandedRatio." }
-        return (at(1) / at(2)).toFloat()
+        return (heightFractionAt(1) / heightFractionAt(2)).toFloat()
     }
 
     internal fun expandedOffsetFromTop(
@@ -43,7 +43,7 @@ internal class FormSheetDetents(
         topInset: Int = 0,
     ): Int {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for expandedOffsetFromTop." }
-        return ((1 - at(2)) * containerHeight).toInt() + topInset
+        return ((1 - heightFractionAt(2)) * containerHeight).toInt() + topInset
     }
 
     // Distance from the top of the window to the top of the largest detent's surface.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
@@ -46,6 +46,26 @@ internal class FormSheetDetents(
         return ((1 - at(2)) * containerHeight).toInt() + topInset
     }
 
+    // Distance from the top of the window to the top of the largest detent's surface.
+    private fun largestDetentTopOffset(containerHeight: Int): Int = containerHeight - maxAllowedHeight(containerHeight)
+
+    /**
+     * Material's BottomSheetDialog dynamically applies padding when its content overlaps 
+     * system insets. To prevent recalculating the size, we pre-calculate a static height 
+     * inside safe area bounds.
+     */
+    internal fun sheetContainerHeight(
+        containerHeight: Int,
+        topInset: Int,
+        bottomInset: Int,
+    ): Int {
+        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and its 
+        // anchored to the bottom.
+        // Top inset is subtracted only by the amount the sheet actually overlaps it.
+        val topOverlap = (topInset - largestDetentTopOffset(containerHeight)).coerceAtLeast(0)
+        return (maxAllowedHeight(containerHeight) - topOverlap - bottomInset).coerceAtLeast(0)
+    }
+
     companion object {
         const val MAX_DETENTS = 3
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
@@ -15,8 +15,8 @@ internal class FormSheetDetents(
             }
         }
 
-        require(detents == detents.sorted()) {
-            "[RNScreens] Detents must be sorted in ascending order."
+        require(detents == detents.distinct().sorted()) {
+            "[RNScreens] Detents must be sorted in strictly ascending order."
         }
     }
 
@@ -50,8 +50,8 @@ internal class FormSheetDetents(
     private fun largestDetentTopOffset(containerHeight: Int): Int = containerHeight - maxAllowedHeight(containerHeight)
 
     /**
-     * Material's BottomSheetDialog dynamically applies padding when its content overlaps 
-     * system insets. To prevent recalculating the size, we pre-calculate a static height 
+     * Material's BottomSheetDialog dynamically applies padding when its content overlaps
+     * system insets. To prevent recalculating the size, we pre-calculate a static height
      * inside safe area bounds.
      */
     internal fun sheetContainerHeight(
@@ -59,7 +59,7 @@ internal class FormSheetDetents(
         topInset: Int,
         bottomInset: Int,
     ): Int {
-        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and its 
+        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and its
         // anchored to the bottom.
         // Top inset is subtracted only by the amount the sheet actually overlaps it.
         val topOverlap = (topInset - largestDetentTopOffset(containerHeight)).coerceAtLeast(0)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
@@ -1,0 +1,52 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+internal class FormSheetDetents(
+    rawDetents: List<Double>,
+) {
+    private val detents: List<Double> = rawDetents.toList()
+
+    init {
+        require(detents.isNotEmpty()) { "[RNScreens] At least one detent must be provided." }
+        require(detents.size <= MAX_DETENTS) { "[RNScreens] Maximum of $MAX_DETENTS detents supported, got ${detents.size}." }
+
+        detents.forEach {
+            require(it in 0.0..1.0) {
+                "[RNScreens] Detent values must be within 0.0 and 1.0, got $it."
+            }
+        }
+
+        require(detents == detents.sorted()) {
+            "[RNScreens] Detents must be sorted in ascending order."
+        }
+    }
+
+    internal val count: Int get() = detents.size
+
+    internal fun at(index: Int): Double = detents[index]
+
+    internal fun heightAt(
+        index: Int,
+        containerHeight: Int,
+    ): Int = (at(index) * containerHeight).toInt()
+
+    internal fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
+
+    internal fun maxAllowedHeight(containerHeight: Int): Int = heightAt(count - 1, containerHeight)
+
+    internal fun halfExpandedRatio(): Float {
+        check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for halfExpandedRatio." }
+        return (at(1) / at(2)).toFloat()
+    }
+
+    internal fun expandedOffsetFromTop(
+        containerHeight: Int,
+        topInset: Int = 0,
+    ): Int {
+        check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for expandedOffsetFromTop." }
+        return ((1 - at(2)) * containerHeight).toInt() + topInset
+    }
+
+    companion object {
+        const val MAX_DETENTS = 3
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDetents.kt
@@ -59,7 +59,7 @@ internal class FormSheetDetents(
         topInset: Int,
         bottomInset: Int,
     ): Int {
-        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and its
+        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and it's
         // anchored to the bottom.
         // Top inset is subtracted only by the amount the sheet actually overlaps it.
         val topOverlap = (topInset - largestDetentTopOffset(containerHeight)).coerceAtLeast(0)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
@@ -10,6 +10,13 @@ import android.widget.FrameLayout
 import androidx.core.view.WindowCompat
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
+/**
+ * A custom BottomSheetDialog override used to render the FormSheet native component.
+ *
+ * We enforce edge-to-edge rendering, bypassing standard Material checks.
+ * This enforcement is required because our custom dimming view must span the entire screen.
+ * The FormSheetContainer is sized manually against the system insets.
+ */
 internal class FormSheetDialog(
     context: Context,
 ) : BottomSheetDialog(context) {
@@ -34,7 +41,6 @@ internal class FormSheetDialog(
      * `BottomSheetDialog#onAttachedToWindow`).
      *
      * We force edge-to-edge on every API level so the custom dimming view covers the whole screen.
-     * The sheet content is sized manually against the system insets, so drawing behind the bars is safe here.
      */
     private fun forceEdgeToEdge() {
         val window = window ?: return

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialog.kt
@@ -2,10 +2,12 @@ package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
+import androidx.core.view.WindowCompat
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 internal class FormSheetDialog(
@@ -18,6 +20,27 @@ internal class FormSheetDialog(
         disableNativeWindowAnimation(window)
 
         setupBottomSheetHeight()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        forceEdgeToEdge()
+    }
+
+    /**
+     * Material's [BottomSheetDialog] only draws edge-to-edge when its theme opts in via the
+     * `enableEdgeToEdge` attribute AND the navigation bar is translucent (see
+     * `BottomSheetDialog#onAttachedToWindow`).
+     *
+     * We force edge-to-edge on every API level so the custom dimming view covers the whole screen.
+     * The sheet content is sized manually against the system insets, so drawing behind the bars is safe here.
+     */
+    private fun forceEdgeToEdge() {
+        val window = window ?: return
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        findViewById<View>(com.google.android.material.R.id.container)?.fitsSystemWindows = false
+        findViewById<View>(com.google.android.material.R.id.coordinator)?.fitsSystemWindows = false
     }
 
     private fun hideNativeDimmingView(window: Window?) = window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -19,7 +19,7 @@ class FormSheetDialogManager(
 
     private var resolvedDetents: FormSheetDetents? = null
 
-    private var hasPendingDetentsChange = false
+    private var shouldReconfigureDetents = false
 
     private var lastTopInset = 0
     private var lastBottomInset = 0
@@ -78,7 +78,18 @@ class FormSheetDialogManager(
 
         if (resolvedDetents == null || formSheetConfig.detents != newConfig.detents) {
             resolvedDetents = resolveDetents(newConfig.detents)
-            hasPendingDetentsChange = true
+            shouldReconfigureDetents = true
+        }
+
+        // TODO: @t0maboro
+        // - a dedicated presentation manager should be introduced as on iOS,
+        // - invalidation flags logic should be implemented following other components convention
+        val isOpening = newConfig.isOpen && !formSheetConfig.isOpen
+        if (isOpening) {
+            shouldReconfigureDetents = true
+        }
+
+        if (shouldReconfigureDetents) {
             updateNativeContainerHeight()
         }
 
@@ -165,9 +176,9 @@ class FormSheetDialogManager(
                 behaviorController?.updateSheetBehavior(
                     detents = detents,
                     sheetAvailableSpace = dialogDecorHeight,
-                    applyInitialState = hasPendingDetentsChange,
+                    applyInitialState = shouldReconfigureDetents,
                 )
-                hasPendingDetentsChange = false
+                shouldReconfigureDetents = false
             }
 
             val sheetContainerHeight =

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.gamma.modals.formsheet
 
 import android.content.Context
+import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.View
 import android.view.ViewGroup
@@ -96,22 +97,22 @@ class FormSheetDialogManager(
         formSheetConfig = newConfig
     }
 
-private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
-    if (rawDetents.isEmpty()) {
-        return FormSheetDetents(listOf(LARGE_DETENT))
-    }
+    private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
+        if (rawDetents.isEmpty()) {
+            return FormSheetDetents(listOf(LARGE_DETENT))
+        }
 
-    return try {
-        FormSheetDetents(rawDetents)
-    } catch (e: IllegalArgumentException) {
-        android.util.Log.e(
-            "[RNScreens]",
-            "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
-            e,
-        )
-        FormSheetDetents(listOf(LARGE_DETENT))
+        return try {
+            FormSheetDetents(rawDetents)
+        } catch (e: IllegalArgumentException) {
+            Log.e(
+                "[RNScreens]",
+                "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
+                e,
+            )
+            FormSheetDetents(listOf(LARGE_DETENT))
+        }
     }
-}
 
     private fun setupBehaviorCallbacksForDimmingView(view: FrameLayout) {
         // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -104,10 +104,25 @@ class FormSheetDialogManager(
                 override fun onPreDraw(): Boolean {
                     view.viewTreeObserver.removeOnPreDrawListener(this)
                     view.translationY = view.height.toFloat()
+                    disableMaterialInsetsAnimationCallback(view)
                     return true
                 }
             },
         )
+    }
+
+    /**
+     * BottomSheetBehavior registers an internal `WindowInsetsAnimationCallback` on the
+     * sheet view during its first `onLayoutChild`. That callback drives `translationY` to follow
+     * animated inset changes, what interferes with our slide-in custom animation.
+     *
+     * We manage insets ourselves by seeing a fixed height for FormSheetContainer, so we can
+     * clear the Material's callback to remove the conflict entirely.
+     *
+     * This method must run after the first layout pass.
+     */
+    private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
+        ViewCompat.setWindowInsetsAnimationCallback(view, null)
     }
 
     private fun setupDialogShowListener() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -181,28 +181,30 @@ class FormSheetDialogManager(
     private fun updateNativeContainerHeight() {
         val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
 
-        if (dialogDecorHeight > 0) {
-            resolvedDetents?.let { detents ->
-                behaviorController?.updateSheetBehavior(
-                    detents = detents,
-                    sheetAvailableSpace = dialogDecorHeight,
-                    applyInitialState = shouldReconfigureDetents,
-                )
-                shouldReconfigureDetents = false
-            }
+        if (dialogDecorHeight <= 0) {
+            return
+        }
 
-            val sheetContainerHeight =
-                resolvedDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)
-                    ?: (dialogDecorHeight - lastTopInset - lastBottomInset).coerceAtLeast(0)
+        resolvedDetents?.let { detents ->
+            behaviorController?.updateSheetBehavior(
+                detents = detents,
+                sheetAvailableSpace = dialogDecorHeight,
+                applyInitialState = shouldReconfigureDetents,
+            )
+            shouldReconfigureDetents = false
+        }
 
-            val layoutParams =
-                container.layoutParams
-                    ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, sheetContainerHeight)
-            if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != sheetContainerHeight) {
-                layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
-                layoutParams.height = sheetContainerHeight
-                container.layoutParams = layoutParams
-            }
+        val sheetContainerHeight =
+            resolvedDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)
+                ?: (dialogDecorHeight - lastTopInset - lastBottomInset).coerceAtLeast(0)
+
+        val layoutParams =
+            container.layoutParams
+                ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, sheetContainerHeight)
+        if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != sheetContainerHeight) {
+            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+            layoutParams.height = sheetContainerHeight
+            container.layoutParams = layoutParams
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -63,13 +63,13 @@ class FormSheetDialogManager(
     }
 
     internal fun applyConfig(newConfig: FormSheetConfig) {
-        if (formSheetConfig.isOpen != newConfig.isOpen) {
-            if (newConfig.isOpen) {
-                dialog.show()
-            } else {
-                animationCoordinator.runExitAnimation(bottomSheetView) {
-                    dialog.dismiss()
-                }
+        val isOpening = newConfig.isOpen && !formSheetConfig.isOpen
+        val isClosing = !newConfig.isOpen && formSheetConfig.isOpen
+        if (isOpening) {
+            dialog.show()
+        } else if (isClosing) {
+            animationCoordinator.runExitAnimation(bottomSheetView) {
+                dialog.dismiss()
             }
         }
 
@@ -85,7 +85,6 @@ class FormSheetDialogManager(
         // TODO: @t0maboro
         // - a dedicated presentation manager should be introduced as on iOS,
         // - invalidation flags logic should be implemented following other components convention
-        val isOpening = newConfig.isOpen && !formSheetConfig.isOpen
         if (isOpening) {
             shouldReconfigureDetents = true
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -19,6 +19,8 @@ class FormSheetDialogManager(
 
     private var resolvedDetents: FormSheetDetents? = null
 
+    private var hasPendingDetentsChange = false
+
     private var lastTopInset = 0
     private var lastBottomInset = 0
 
@@ -75,9 +77,8 @@ class FormSheetDialogManager(
         }
 
         if (resolvedDetents == null || formSheetConfig.detents != newConfig.detents) {
-            val detents = resolveDetents(newConfig.detents)
-            resolvedDetents = detents
-            behaviorController?.updateSheetDetents(detents)
+            resolvedDetents = resolveDetents(newConfig.detents)
+            hasPendingDetentsChange = true
             updateNativeContainerHeight()
         }
 
@@ -145,7 +146,14 @@ class FormSheetDialogManager(
         val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
 
         if (dialogDecorHeight > 0) {
-            behaviorController?.updateSheetAvailableSpace(dialogDecorHeight)
+            resolvedDetents?.let { detents ->
+                behaviorController?.updateSheetBehavior(
+                    detents = detents,
+                    sheetAvailableSpace = dialogDecorHeight,
+                    applyInitialState = hasPendingDetentsChange,
+                )
+                hasPendingDetentsChange = false
+            }
 
             val sheetContainerHeight =
                 resolvedDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -96,12 +96,22 @@ class FormSheetDialogManager(
         formSheetConfig = newConfig
     }
 
-    private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
-        if (rawDetents.isEmpty()) {
-            return FormSheetDetents(listOf(LARGE_DETENT))
-        }
-        return FormSheetDetents(rawDetents)
+private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
+    if (rawDetents.isEmpty()) {
+        return FormSheetDetents(listOf(LARGE_DETENT))
     }
+
+    return try {
+        FormSheetDetents(rawDetents)
+    } catch (e: IllegalArgumentException) {
+        android.util.Log.e(
+            "[RNScreens]",
+            "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
+            e,
+        )
+        FormSheetDetents(listOf(LARGE_DETENT))
+    }
+}
 
     private fun setupBehaviorCallbacksForDimmingView(view: FrameLayout) {
         // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
@@ -127,7 +137,7 @@ class FormSheetDialogManager(
      * sheet view during its first `onLayoutChild`. That callback drives `translationY` to follow
      * animated inset changes, what interferes with our slide-in custom animation.
      *
-     * We manage insets ourselves by seeing a fixed height for FormSheetContainer, so we can
+     * We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
      * clear the Material's callback to remove the conflict entirely.
      *
      * This method must run after the first layout pass.

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -17,6 +17,8 @@ class FormSheetDialogManager(
 ) {
     private var formSheetConfig = FormSheetConfig()
 
+    private var rawDetents: List<Double> = emptyList()
+
     private val themedContext =
         ContextThemeWrapper(
             context,
@@ -64,6 +66,11 @@ class FormSheetDialogManager(
 
         if (formSheetConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
             container.setGrabberVisible(newConfig.prefersGrabberVisible)
+        }
+
+        if (formSheetConfig.detents != newConfig.detents) {
+            // TODO(@t0maboro): resolve into FormSheetDetents and hand off to the behavior controller.
+            rawDetents = newConfig.detents
         }
 
         formSheetConfig = newConfig

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -17,7 +17,10 @@ class FormSheetDialogManager(
 ) {
     private var formSheetConfig = FormSheetConfig()
 
-    private var rawDetents: List<Double> = emptyList()
+    private var resolvedDetents: FormSheetDetents? = null
+
+    private var lastTopInset = 0
+    private var lastBottomInset = 0
 
     private val themedContext =
         ContextThemeWrapper(
@@ -36,6 +39,9 @@ class FormSheetDialogManager(
         }
 
     private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+
+    private val behaviorController =
+        bottomSheetView?.let { FormSheetBehaviorController(it) }
 
     private val dimmingManager = DimmingViewManager(context, dialog)
 
@@ -68,12 +74,21 @@ class FormSheetDialogManager(
             container.setGrabberVisible(newConfig.prefersGrabberVisible)
         }
 
-        if (formSheetConfig.detents != newConfig.detents) {
-            // TODO(@t0maboro): resolve into FormSheetDetents and hand off to the behavior controller.
-            rawDetents = newConfig.detents
+        if (resolvedDetents == null || formSheetConfig.detents != newConfig.detents) {
+            val detents = resolveDetents(newConfig.detents)
+            resolvedDetents = detents
+            behaviorController?.updateSheetDetents(detents)
+            updateNativeContainerHeight()
         }
 
         formSheetConfig = newConfig
+    }
+
+    private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
+        if (rawDetents.isEmpty()) {
+            return FormSheetDetents(listOf(LARGE_DETENT))
+        }
+        return FormSheetDetents(rawDetents)
     }
 
     private fun setupBehaviorCallbacksForDimmingView(view: FrameLayout) {
@@ -111,8 +126,10 @@ class FormSheetDialogManager(
     }
 
     private fun setupWindowInsetsListener() {
-        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
-            updateNativeContainerHeight(view, insets)
+        ViewCompat.setOnApplyWindowInsetsListener(container) { _, insets ->
+            lastTopInset = getTopInset(insets)
+            lastBottomInset = getBottomInset(insets)
+            updateNativeContainerHeight()
             insets
         }
     }
@@ -124,24 +141,23 @@ class FormSheetDialogManager(
      * during the drag gesture. By calculating and enforcing a static height that explicitly subtracts
      * the system insets, we completely bypass these redundant layout passes.
      */
-    private fun updateNativeContainerHeight(
-        view: View,
-        insets: WindowInsetsCompat,
-    ) {
-        val topInset = getTopInset(insets)
-        val bottomInset = getBottomInset(insets)
+    private fun updateNativeContainerHeight() {
         val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
 
         if (dialogDecorHeight > 0) {
-            val availableHeight = (dialogDecorHeight - topInset - bottomInset).coerceAtLeast(0)
+            behaviorController?.updateSheetAvailableSpace(dialogDecorHeight)
+
+            val sheetContainerHeight =
+                resolvedDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)
+                    ?: (dialogDecorHeight - lastTopInset - lastBottomInset).coerceAtLeast(0)
 
             val layoutParams =
-                view.layoutParams
-                    ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, availableHeight)
-            if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != availableHeight) {
+                container.layoutParams
+                    ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, sheetContainerHeight)
+            if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != sheetContainerHeight) {
                 layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
-                layoutParams.height = availableHeight
-                view.layoutParams = layoutParams
+                layoutParams.height = sheetContainerHeight
+                container.layoutParams = layoutParams
             }
         }
     }
@@ -157,6 +173,10 @@ class FormSheetDialogManager(
             .getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
             ).bottom
+
+    companion object {
+        private const val LARGE_DETENT = 1.0
+    }
 
     internal fun destroy() {
         dimmingManager.setOnBackdropClickListener {}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -221,7 +221,7 @@ class FormSheetDialogManager(
             ).bottom
 
     internal fun destroy() {
-        dimmingManager.setOnBackdropClickListener {}
+        dimmingManager.setOnBackdropClickListener(null)
 
         ViewCompat.setOnApplyWindowInsetsListener(container, null)
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -99,7 +99,7 @@ class FormSheetDialogManager(
 
     private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
         if (rawDetents.isEmpty()) {
-            return FormSheetDetents(listOf(LARGE_DETENT))
+            return FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
         }
 
         return try {
@@ -110,7 +110,7 @@ class FormSheetDialogManager(
                 "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
                 e,
             )
-            FormSheetDetents(listOf(LARGE_DETENT))
+            FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
         }
     }
 
@@ -231,6 +231,6 @@ class FormSheetDialogManager(
     }
 
     companion object {
-        private const val LARGE_DETENT = 1.0
+        private const val LARGE_DETENT_FRACTION = 1.0
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -125,7 +125,6 @@ class FormSheetDialogManager(
             object : android.view.ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
                     view.viewTreeObserver.removeOnPreDrawListener(this)
-                    view.translationY = view.height.toFloat()
                     disableMaterialInsetsAnimationCallback(view)
                     return true
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -59,7 +59,7 @@ class FormSheetDialogManager(
         setupDialogCancelListener()
         setupWindowInsetsListener()
 
-        dimmingManager.setOnBackdropClickListener(onDismissRequest)
+        dimmingManager.setOnBackdropClickListener { onDismissRequest() }
     }
 
     internal fun applyConfig(newConfig: FormSheetConfig) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -182,10 +182,6 @@ class FormSheetDialogManager(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
             ).bottom
 
-    companion object {
-        private const val LARGE_DETENT = 1.0
-    }
-
     internal fun destroy() {
         dimmingManager.setOnBackdropClickListener {}
 
@@ -194,5 +190,9 @@ class FormSheetDialogManager(
         dialog.setOnShowListener(null)
         dialog.setOnCancelListener(null)
         dialog.dismiss()
+    }
+
+    companion object {
+        private const val LARGE_DETENT = 1.0
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -21,6 +21,8 @@ class FormSheetHost(
 
     internal var prefersGrabberVisible = false
 
+    internal var detents: List<Double> = emptyList()
+
     private val sheetContentView =
         FormSheetContentView(context) { width, height ->
             updateStateIfNeeded(width, height)
@@ -82,6 +84,7 @@ class FormSheetHost(
         val config =
             FormSheetConfig(
                 isOpen = this.isOpen,
+                detents = this.detents,
                 prefersGrabberVisible = this.prefersGrabberVisible,
             )
         dialogManager.applyConfig(config)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -69,7 +69,10 @@ class FormSheetHostViewManager :
         view: FormSheetHost,
         value: ReadableArray?,
     ) {
-        // TODO: @t0maboro - implement later
+        view.detents =
+            value?.let { array ->
+                List(array.size()) { index -> array.getDouble(index) }
+            } ?: emptyList()
     }
 
     override fun setPrefersGrabberVisible(


### PR DESCRIPTION
## Description

Adds configurable detents to the new FormSheets on Android. Due to the native limitations, it allows passing 0-3 detents from JS, which are parsed to BottomSheetBehavior params (peek/half-expanded/expanded/max-height).
I am introducing a `FormSheetBehaviorController` which is a stateless mapper from a resolved detent config to `BottomSheetBehavior`, forcing a fresh layout pass so the behavior re-settles to the new detent configuration.

Additionally, I am making some bugfixes related to or exposed by introducing the sheet detents mechanism.

- Enter-animation flicker on API < 30 - Material's `BottomSheetBehavior` registers a `WindowInsetsAnimationCallback` which updates `translationY` and is causing the sheet to jump during the enter animation (I am modifying translation on a custom slide-in animation). We clear that callback **after** the first layout, because we manage insets ourselves via a fixed container height, preventing the conflict.
- Material only draws the `BottomSheetDialog` edge-to-edge when the theme opts in, and the nav bar is translucent; otherwise, the CoordinatorLayout (and our full-bleed dimming view) is inset below the status bar. We now force edge-to-edge on the dialog window on every API level.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1551

## Changes

- Introduced `FormSheetBehaviorController`  responsible for mapping the raw JS detents array into specific `BottomSheetBehavior` properties.
- Disabled native insets animation to explicitly clear Material's `WindowInsetsAnimationCallback`, unblocking our custom `translationY` enter-animation.
- Forced Edge-to-Edge in `onAttachedToWindow()` in `FormSheetDialog` on both the window decor and the internal Material containers (`R.id.container`, `R.id.coordinator`), ensuring the dimming view covers the status bar area and the FormSheetContainer space is predictable across different API levels.

## Before & after - visual documentation

https://github.com/user-attachments/assets/80c8ed00-643d-4d83-8b35-ebab36bf5fb8

## Test plan

Tested on the base example & 

```tsx
import React, { useState } from 'react';
import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
import { FormSheet, SafeAreaView } from 'react-native-screens/experimental';
import { scenarioDescription } from './scenario-description';
import { createScenario } from '@apps/tests/shared/helpers';
import { Colors } from '@apps/shared/styling';

const DETENT_CONFIGS = [
  { label: 'Single detent (0.5)', detents: [0.5] },
  { label: 'Full screen (1.0)', detents: [1.0] },
  { label: 'Two detents (0.3, 0.8)', detents: [0.3, 0.8] },
  { label: 'Half and full (0.5, 1.0)', detents: [0.5, 1.0] },
  { label: 'Three detents (0.2, 0.5, 0.9)', detents: [0.2, 0.5, 0.9] },
  { label: 'Three tall (0.35, 0.65, 1.0)', detents: [0.35, 0.65, 1.0] },
  { label: 'Default fallback (empty array)', detents: [] },
];

function SheetScenario({ label, detents }) {
  const [isOpen, setIsOpen] = useState(false);

  return (
    <View style={styles.scenarioContainer}>
      <Button
        title={`Open: ${label}`}
        color={Colors.primary}
        onPress={() => setIsOpen(true)}
      />

      <FormSheet
        isOpen={isOpen}
        onNativeDismiss={() => setIsOpen(false)}
        detents={detents}>
        <View style={styles.sheetContent}>
          <Text style={styles.sheetTitle}>FormSheet Content</Text>
          <Text style={styles.sheetSubtitle}>
            Static configuration: {JSON.stringify(detents)}
          </Text>
          <View style={styles.spacing} />
          <Button
            title="Close sheet from JS"
            color={Colors.primary}
            onPress={() => setIsOpen(false)}
          />
        </View>
      </FormSheet>
    </View>
  );
}

function TestFormSheetBase() {
  return (
    <SafeAreaView edges={{top: true, bottom: true}} style={styles.container}>
      <Text style={styles.title}>FormSheet Configuration Tests</Text>

      <ScrollView
        style={styles.scrollContainer}
        contentContainerStyle={styles.scrollContent}>
        {DETENT_CONFIGS.map((config, index) => (
          <SheetScenario
            key={index}
            label={config.label}
            detents={config.detents}
          />
        ))}
      </ScrollView>
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: Colors.offBackground,
  },
  scrollContainer: {
    flex: 1,
  },
  scrollContent: {
    padding: 16,
    paddingBottom: 40,
  },
  title: {
    fontSize: 20,
    fontWeight: 'bold',
    marginVertical: 20,
    color: Colors.text,
    textAlign: 'center',
  },
  scenarioContainer: {
    marginBottom: 16,
    backgroundColor: 'rgba(0,0,0,0.03)',
    padding: 12,
    borderRadius: 8,
    borderWidth: 1,
    borderColor: 'rgba(0,0,0,0.1)',
  },
  sheetContent: {
    flex: 1,
    backgroundColor: Colors.background,
    padding: 24,
    justifyContent: 'center',
    alignItems: 'center',
  },
  sheetTitle: {
    fontSize: 22,
    fontWeight: '600',
    marginBottom: 8,
    color: Colors.text,
  },
  sheetSubtitle: {
    fontSize: 14,
    color: Colors.text,
    opacity: 0.7,
    fontFamily: 'monospace',
  },
  spacing: {
    height: 32,
  },
});

export default createScenario(TestFormSheetBase, scenarioDescription);
```

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
