### PR TITLE
feat(iOS): implement unstable_sheetFooter for formSheet

### DIFF
--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -447,17 +447,21 @@ function Home() {
 }
 ```
 
-### `unstable_sheetFooter` (Android only)
+### `unstable_sheetFooter`
 
 Footer component that can be used alongside form sheet stack presentation style.
 
 This option is provided, because due to implementation details it might be problematic
 to implement such layout with JS-only code.
 
+The footer overlays the sheet content and is pinned to the bottom edge of the sheet,
+moving above the keyboard when one appears. Reserve space for it (if needed) by padding
+the sheet's scroll content.
+
 Please note that this prop is marked as unstable and might be subject of breaking changes,
 even removal.
 
-Currently supported on Android only.
+Supported on Android and iOS.
 
 ### `contentStyle`
 

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @class RNSScreenStackHeaderConfig;
+@class RNSScreenFooter;
 
 @interface RNSScreenView : RNSReactBaseView <RNSScreenContentWrapperDelegate,
                                              RNSScrollViewBehaviorOverriding,
@@ -159,6 +160,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Looks for header configuration in instance's `reactSubviews` and returns it. If not present returns `nil`.
  */
 - (RNSScreenStackHeaderConfig *_Nullable)findHeaderConfig;
+
+/**
+ * Looks for a sheet footer (`unstable_sheetFooter`) in instance's `reactSubviews` and returns it.
+ * If not present returns `nil`.
+ */
+- (RNSScreenFooter *_Nullable)findSheetFooter;
 
 /**
  * Returns `YES` if the wrapper has been registered and it should not attempt to register on screen views higher in the

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -701,6 +701,26 @@ RNS_IGNORE_SUPER_CALL_END
   return nil;
 }
 
+- (nullable RNSScreenFooter *)findSheetFooter
+{
+  for (UIView *view in self.reactSubviews) {
+    if ([view isKindOfClass:RNSScreenFooter.class]) {
+      return (RNSScreenFooter *)view;
+    }
+  }
+
+  return nil;
+}
+
+// Keeps the sheet footer pinned to the bottom edge while UIKit resizes the
+// screen view (detent changes, interactive detent drags, keyboard-driven
+// sheet moves).
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [[self findSheetFooter] updateFooterPosition];
+}
+
 /// Looks for RCTScrollView in direct line - goes through the subviews at index 0 down the view hierarchy.
 - (nullable RCTScrollViewComponentView *)tryFindDescendantScrollView
 {

--- a/ios/RNSScreenFooter.h
+++ b/ios/RNSScreenFooter.h
@@ -16,6 +16,14 @@ typedef void (^OnLayoutCallback)(CGRect frame);
 
 @property (nonatomic, copy, nullable) OnLayoutCallback onLayout;
 
+/**
+ * Pins the footer to the bottom edge of its parent RNSScreenView, lifting it
+ * above the keyboard when one overlaps the sheet. Idempotent - safe to call
+ * from any layout pass (layout metrics updates, parent layoutSubviews,
+ * keyboard frame changes).
+ */
+- (void)updateFooterPosition;
+
 @end
 
 @interface RNSScreenFooterManager : RCTViewManager

--- a/ios/RNSScreenFooter.mm
+++ b/ios/RNSScreenFooter.mm
@@ -5,90 +5,166 @@
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #import "RNSScreen.h"
 
+// iOS implementation of the formSheet sheet footer (`unstable_sheetFooter`),
+// mirroring the contract of Android's ScreenFooter:
+//
+//  - The footer overlays the sheet content and is pinned to the bottom edge of
+//    the parent RNSScreenView. Consumers reserve space for it (if desired) by
+//    padding their scroll content; the footer can also be used as a surface
+//    for blur / scroll edge effects layered over the content.
+//  - Yoga lays the footer out as a regular child of the Screen (full width,
+//    height derived from its children, positioned in flow). We accept Yoga's
+//    size but re-pin `origin.y` to the bottom of the parent after every layout
+//    pass. Frames are used on purpose instead of Auto Layout constraints -
+//    Fabric assigns frames directly and fights constraint-based positioning.
+//    The pin is (re)applied from `updateLayoutMetrics:` (React-driven writes)
+//    and from the parent screen's `layoutSubviews` (UIKit-driven writes,
+//    including continuous resizes during interactive detent changes).
+//  - When the keyboard overlaps the sheet, the footer is lifted above it,
+//    animated with the keyboard's own duration & curve - the counterpart of
+//    the WindowInsetsAnimationCompat callback in Android's ScreenFooter.
+
 @implementation RNSScreenFooter {
-  RNSScreenView *_parent;
+  // Keyboard end frame in screen coordinates. CGRectNull when hidden.
+  CGRect _keyboardFrameEnd;
 }
 
 - (instancetype)init
 {
   if (self = [super init]) {
     self.translatesAutoresizingMaskIntoConstraints = false;
-    _parent = nil;
+    _keyboardFrameEnd = CGRectNull;
+#if !TARGET_OS_TV && !TARGET_OS_VISION
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self
+               selector:@selector(keyboardWillChangeFrame:)
+                   name:UIKeyboardWillChangeFrameNotification
+                 object:nil];
+    [center addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+#endif // !TARGET_OS_TV && !TARGET_OS_VISION
   }
   return self;
 }
 
-- (void)willMoveToSuperview:(UIView *)newSuperview
+- (void)dealloc
 {
-  [super willMoveToSuperview:newSuperview];
-  //  if ([newSuperview isKindOfClass:RNSScreenView.class]) {
-  //    RNSScreenView *screen = (RNSScreenView *)newSuperview;
-  //    _parent = (RNSScreenView *)newSuperview;
-
-  //    [NSLayoutConstraint activateConstraints:@[
-  //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom
-  //      relatedBy:NSLayoutRelationEqual toItem:screen attribute:NSLayoutAttributeBottom multiplier:1.0
-  //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeLeft
-  //      relatedBy:NSLayoutRelationEqual toItem:screen attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0],
-  //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual
-  //      toItem:screen attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0], [NSLayoutConstraint
-  //      constraintWithItem:self attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:screen
-  //      attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0], [NSLayoutConstraint
-  //      constraintWithItem:screen attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self
-  //      attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0], [NSLayoutConstraint constraintWithItem:screen
-  //      attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop
-  //      multiplier:1.0 constant:0.0],
-  //    ]];
-  //    [self setNeedsLayout];
-  //  }
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
+- (nullable RNSScreenView *)screenView
+{
+  if ([self.superview isKindOfClass:RNSScreenView.class]) {
+    return (RNSScreenView *)self.superview;
+  }
+  return nil;
+}
+
+#pragma mark - Positioning
+
+- (CGFloat)keyboardOverlapWithParent:(UIView *)parent
+{
+  if (CGRectIsNull(_keyboardFrameEnd) || CGRectIsEmpty(_keyboardFrameEnd) || parent.window == nil) {
+    return 0;
+  }
+  // Keyboard frames are delivered in screen coordinates; convert via the window.
+  CGRect frameInWindow = [parent.window convertRect:_keyboardFrameEnd fromWindow:nil];
+  CGRect frameInParent = [parent convertRect:frameInWindow fromView:parent.window];
+  return MAX(0, CGRectGetMaxY(parent.bounds) - CGRectGetMinY(frameInParent));
+}
+
+- (void)updateFooterPosition
+{
+  UIView *parent = [self screenView] ?: self.superview;
+  if (parent == nil) {
+    return;
+  }
+
+  CGRect frame = self.frame;
+  CGFloat targetY = parent.bounds.size.height - frame.size.height - [self keyboardOverlapWithParent:parent];
+  // Never push the footer above the top of the sheet.
+  targetY = MAX(0, targetY);
+
+  if (fabs(frame.origin.y - targetY) < 0.5) {
+    return;
+  }
+  frame.origin.y = targetY;
+  self.frame = frame;
+
+  if (self.onLayout != nil) {
+    self.onLayout(self.frame);
+  }
+}
+
+#pragma mark - UIView / Fabric lifecycle
 
 - (void)didMoveToSuperview
 {
-  if (_parent != nil) {
-    //    [NSLayoutConstraint activateConstraints:@[
-    //      [NSLayoutConstraint constraintWithItem:self
-    //                                   attribute:NSLayoutAttributeBottom
-    //                                   relatedBy:NSLayoutRelationEqual
-    //                                      toItem:_parent
-    //                                   attribute:NSLayoutAttributeBottom
-    //                                  multiplier:1.0
-    //                                    constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeLeft
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeLeft multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeRight multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeTop
-    //      relatedBy:NSLayoutRelationEqual toItem:_parent attribute:NSLayoutAttributeTop multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeBottom
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0
-    //      constant:0.0], [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeLeft
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeRight
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0],
-    //      [NSLayoutConstraint constraintWithItem:_parent attribute:NSLayoutAttributeTop
-    //      relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0],
-    //    ]];
-    //    [self setNeedsLayout];
+  [super didMoveToSuperview];
+  if (self.superview != nil) {
+    [self updateFooterPosition];
   }
 }
 
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  if (self.onLayout != nil) {
-    self.onLayout(self.frame);
-  }
-  //
-  //  if (self.subviews.count > 0) {
-  //    CGSize childsSize = self.subviews[0].frame.size;
-  //
-  //  }
+  [self updateFooterPosition];
 }
+
+- (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
+{
+  // Super applies Yoga's frame. Accept the size, then immediately re-pin to
+  // the bottom edge of the parent screen.
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+  [self updateFooterPosition];
+}
+
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+  _keyboardFrameEnd = CGRectNull;
+}
+
+#pragma mark - Keyboard
+
+#if !TARGET_OS_TV && !TARGET_OS_VISION
+
+- (void)keyboardWillChangeFrame:(NSNotification *)notification
+{
+  _keyboardFrameEnd = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  [self animateFooterWithKeyboardNotification:notification];
+}
+
+- (void)keyboardWillHide:(NSNotification *)notification
+{
+  _keyboardFrameEnd = CGRectNull;
+  [self animateFooterWithKeyboardNotification:notification];
+}
+
+- (void)animateFooterWithKeyboardNotification:(NSNotification *)notification
+{
+  if (self.window == nil) {
+    return;
+  }
+  NSTimeInterval duration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+  UIViewAnimationCurve curve =
+      (UIViewAnimationCurve)[notification.userInfo[UIKeyboardAnimationCurveUserInfoKey] integerValue];
+  // UIKit may move / resize the whole sheet in response to the keyboard as
+  // well; the parent's layoutSubviews re-pins the footer during that
+  // animation, this block covers the keyboard-only part of the movement.
+  [UIView animateWithDuration:duration
+                        delay:0
+                      options:(UIViewAnimationOptions)(curve << 16)
+                   animations:^{
+                     [self updateFooterPosition];
+                   }
+                   completion:nil];
+}
+
+#endif // !TARGET_OS_TV && !TARGET_OS_VISION
+
+#pragma mark - Fabric registration
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider
 {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -626,7 +626,7 @@ export interface ScreenProps extends ViewProps {
    * including removal, in particular when we find solution that will make implementing it with JS
    * straightforward.
    *
-   * @platform android
+   * @platform android, ios
    */
   unstable_sheetFooter?: (() => React.ReactNode) | undefined;
 }


### PR DESCRIPTION
## Description

`unstable_sheetFooter` is currently Android-only — `RNSScreenFooter.mm` ships as a stub with the positioning logic commented out. This PR implements the iOS side, mirroring the contract of Android's `ScreenFooter`: the footer overlays the sheet content, pinned to the bottom edge of the sheet, and lifts above the keyboard when one appears. Consumers reserve space for it (when desired) by padding their scroll content; since it overlays, it can also serve as a surface for blur / scroll-edge effects layered over the content.

The abandoned constraint-based approach (the commented-out code) was replaced with frame pinning: Fabric assigns frames directly and fights Auto Layout, so the footer instead accepts Yoga's size and re-pins `origin.y` after every layout pass, from both directions:

- `updateLayoutMetrics:` — React-driven writes (footer content resize, state updates), and
- the parent `RNSScreenView`'s `layoutSubviews` — UIKit-driven writes, which makes the footer track **interactive detent drags** natively since `UISheetPresentationController` resizes the presented view continuously during the gesture.

Keyboard handling is the counterpart of Android's `WindowInsetsAnimationCompat` callback: the footer computes the keyboard's overlap with the sheet (converted through the window, so floating / centered iPad sheets get correct geometry) and animates with the keyboard's own duration and curve.

## Changes

- `ios/RNSScreenFooter.mm` — implemented pinning, keyboard tracking, `prepareForRecycle` cleanup (replaces the stub).
- `ios/RNSScreenFooter.h` — exposed `updateFooterPosition`.
- `ios/RNSScreen.h` / `ios/RNSScreen.mm` — added `findSheetFooter` (analogous to `findHeaderConfig`) and a `layoutSubviews` override on `RNSScreenView` that re-pins the footer during UIKit-driven resizes.
- `src/types.tsx` — `@platform android` → `@platform android, ios` on `unstable_sheetFooter`.
- `guides/GUIDE_FOR_LIBRARY_AUTHORS.md` — removed the Android-only note, documented the overlay contract.

No new props, no codegen changes — the existing Fabric component registration is reused.

## Test plan

- Existing `apps/src/tests/issue-tests/TestScreenFooterKeyboardInsets.tsx` — now exercisable on iOS.
- Existing `apps/src/tests/issue-tests/TestFormSheet.tsx` — the commented-out `unstable_sheetFooter` options can be enabled on iOS.
- Field-tested in a production app (patched into 4.25.2) on iPhone 17 Pro and iPad Pro 11" (iOS 26): `formSheet` with `fitToContents` and detent arrays, footer pinned correctly at rest, during interactive detent drags, during sheet resize when footer content height changes, and above the keyboard; buttons at the sheet bottom remain tappable (frame-based pinning keeps UIKit hit-testing correct).

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
