### PR TITLE
refactor(Android, FormSheet v5): Separate layout management for FormSheet

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.view.View
+import androidx.core.view.doOnPreDraw
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
@@ -15,6 +16,12 @@ internal class FormSheetAnimationCoordinator(
     val animationDuration = 250L
 
     private var currentAnimatorSet: AnimatorSet? = null
+
+    internal fun prepareViewForAnimation(view: View) {
+        view.doOnPreDraw {
+            it.translationY = it.height.toFloat()
+        }
+    }
 
     internal fun runEnterAnimation(view: View) {
         val isAnimating = currentAnimatorSet?.isRunning == true

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAnimationCoordinator.kt
@@ -5,7 +5,6 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.view.View
-import androidx.core.view.doOnPreDraw
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
@@ -16,12 +15,6 @@ internal class FormSheetAnimationCoordinator(
     val animationDuration = 250L
 
     private var currentAnimatorSet: AnimatorSet? = null
-
-    internal fun prepareViewForAnimation(view: View) {
-        view.doOnPreDraw {
-            it.translationY = it.height.toFloat()
-        }
-    }
 
     internal fun runEnterAnimation(view: View) {
         val isAnimating = currentAnimatorSet?.isRunning == true

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -4,10 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.View
-import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.gamma.modals.dimmingview.DimmingViewManager
 
@@ -21,9 +18,6 @@ class FormSheetDialogManager(
     private var resolvedDetents: FormSheetDetents? = null
 
     private var shouldReconfigureDetents = false
-
-    private var lastTopInset = 0
-    private var lastBottomInset = 0
 
     private val themedContext =
         ContextThemeWrapper(
@@ -50,6 +44,14 @@ class FormSheetDialogManager(
 
     private val animationCoordinator = FormSheetAnimationCoordinator(dimmingManager)
 
+    private val dimensionsCoordinator =
+        FormSheetDimensionsCoordinator(
+            dialog = dialog,
+            container = container,
+            bottomSheetView = bottomSheetView,
+            behaviorController = behaviorController,
+        )
+
     private val lifecycleCoordinator =
         FormSheetLifecycleCoordinator(
             dialog = dialog,
@@ -66,10 +68,10 @@ class FormSheetDialogManager(
     init {
         bottomSheetView?.let { view ->
             setupBehaviorCallbacksForDimmingView(view)
-            setupOffscreenPositionBeforeFirstDraw(view)
+            animationCoordinator.prepareViewForAnimation(view)
         }
         lifecycleCoordinator.setup()
-        setupWindowInsetsListener()
+        dimensionsCoordinator.setup()
     }
 
     internal fun applyConfig(newConfig: FormSheetConfig) {
@@ -100,7 +102,8 @@ class FormSheetDialogManager(
         }
 
         if (shouldReconfigureDetents) {
-            updateNativeContainerHeight()
+            dimensionsCoordinator.updateFormSheetDetents(resolvedDetents, shouldReconfigureDetents)
+            shouldReconfigureDetents = false
         }
 
         formSheetConfig = newConfig
@@ -129,93 +132,9 @@ class FormSheetDialogManager(
         dimmingManager.attachToBehavior(behavior)
     }
 
-    private fun setupOffscreenPositionBeforeFirstDraw(view: FrameLayout) {
-        view.viewTreeObserver.addOnPreDrawListener(
-            object : android.view.ViewTreeObserver.OnPreDrawListener {
-                override fun onPreDraw(): Boolean {
-                    view.viewTreeObserver.removeOnPreDrawListener(this)
-                    disableMaterialInsetsAnimationCallback(view)
-                    return true
-                }
-            },
-        )
-    }
-
-    /**
-     * BottomSheetBehavior registers an internal `WindowInsetsAnimationCallback` on the
-     * sheet view during its first `onLayoutChild`. That callback drives `translationY` to follow
-     * animated inset changes, what interferes with our slide-in custom animation.
-     *
-     * We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
-     * clear the Material's callback to remove the conflict entirely.
-     *
-     * This method must run after the first layout pass.
-     */
-    private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
-        ViewCompat.setWindowInsetsAnimationCallback(view, null)
-    }
-
-    private fun setupWindowInsetsListener() {
-        ViewCompat.setOnApplyWindowInsetsListener(container) { _, insets ->
-            lastTopInset = getTopInset(insets)
-            lastBottomInset = getBottomInset(insets)
-            updateNativeContainerHeight()
-            insets
-        }
-    }
-
-    /**
-     * For Yoga we require the container height to be "stable" to avoid updating content size in flight.
-     * If left as MATCH_PARENT, BottomSheetDialog dynamically applies insets as padding when sheet overflows
-     * status bar or display cutout. This causes Yoga to recalculate the layout, resulting in UI flickering
-     * during the drag gesture. By calculating and enforcing a static height that explicitly subtracts
-     * the system insets, we completely bypass these redundant layout passes.
-     */
-    private fun updateNativeContainerHeight() {
-        val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
-
-        if (dialogDecorHeight <= 0) {
-            return
-        }
-
-        resolvedDetents?.let { detents ->
-            behaviorController?.updateSheetBehavior(
-                detents = detents,
-                sheetAvailableSpace = dialogDecorHeight,
-                applyInitialState = shouldReconfigureDetents,
-            )
-            shouldReconfigureDetents = false
-        }
-
-        val sheetContainerHeight =
-            resolvedDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)
-                ?: (dialogDecorHeight - lastTopInset - lastBottomInset).coerceAtLeast(0)
-
-        val layoutParams =
-            container.layoutParams
-                ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, sheetContainerHeight)
-        if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != sheetContainerHeight) {
-            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
-            layoutParams.height = sheetContainerHeight
-            container.layoutParams = layoutParams
-        }
-    }
-
-    private fun getTopInset(insetsCompat: WindowInsetsCompat): Int =
-        insetsCompat
-            .getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
-            ).top
-
-    private fun getBottomInset(insetsCompat: WindowInsetsCompat): Int =
-        insetsCompat
-            .getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
-            ).bottom
-
     internal fun destroy() {
         lifecycleCoordinator.destroy()
-        ViewCompat.setOnApplyWindowInsetsListener(container, null)
+        dimensionsCoordinator.destroy()
         dialog.dismiss()
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -68,7 +68,6 @@ class FormSheetDialogManager(
     init {
         bottomSheetView?.let { view ->
             dimmingManager.attachToBehavior(BottomSheetBehavior.from(view))
-            animationCoordinator.prepareViewForAnimation(view)
         }
         lifecycleCoordinator.setup()
         dimensionsCoordinator.setup()

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -67,7 +67,7 @@ class FormSheetDialogManager(
 
     init {
         bottomSheetView?.let { view ->
-            setupBehaviorCallbacksForDimmingView(view)
+            dimmingManager.attachToBehavior(BottomSheetBehavior.from(view))
             animationCoordinator.prepareViewForAnimation(view)
         }
         lifecycleCoordinator.setup()
@@ -124,12 +124,6 @@ class FormSheetDialogManager(
             )
             FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
         }
-    }
-
-    private fun setupBehaviorCallbacksForDimmingView(view: FrameLayout) {
-        // TODO: @t0maboro - BottomSheetBehavior override might be needed at some point
-        val behavior = BottomSheetBehavior.from(view)
-        dimmingManager.attachToBehavior(behavior)
     }
 
     internal fun destroy() {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
@@ -46,18 +46,30 @@ internal class FormSheetDimensionsCoordinator(
      * This method must run after the first layout pass.
      */
     private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
-        view.addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
-            override fun onLayoutChange(
-                v: View, left: Int, top: Int, right: Int, bottom: Int,
-                oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int
-            ) {
-                ViewCompat.setWindowInsetsAnimationCallback(v, null)
-                v.removeOnLayoutChangeListener(this)
-            }
-        })
+        view.addOnLayoutChangeListener(
+            object : View.OnLayoutChangeListener {
+                override fun onLayoutChange(
+                    v: View,
+                    left: Int,
+                    top: Int,
+                    right: Int,
+                    bottom: Int,
+                    oldLeft: Int,
+                    oldTop: Int,
+                    oldRight: Int,
+                    oldBottom: Int,
+                ) {
+                    ViewCompat.setWindowInsetsAnimationCallback(v, null)
+                    v.removeOnLayoutChangeListener(this)
+                }
+            },
+        )
     }
 
-    internal fun updateFormSheetDetents(detents: FormSheetDetents?, applyInitialState: Boolean) {
+    internal fun updateFormSheetDetents(
+        detents: FormSheetDetents?,
+        applyInitialState: Boolean,
+    ) {
         currentDetents = detents
         if (applyInitialState) {
             pendingInitialState = true

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
@@ -42,7 +42,7 @@ internal class FormSheetDimensionsCoordinator(
      *
      * We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
      * clear the Material's callback to remove the conflict entirely.
-     * 
+     *
      * This method must run after the first layout pass.
      */
     private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
@@ -1,0 +1,121 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+internal class FormSheetDimensionsCoordinator(
+    private val dialog: BottomSheetDialog,
+    private val container: FormSheetContainer,
+    private val bottomSheetView: FrameLayout?,
+    private val behaviorController: FormSheetBehaviorController?,
+) {
+    private var lastTopInset = 0
+    private var lastBottomInset = 0
+    private var currentDetents: FormSheetDetents? = null
+    private var pendingInitialState = false
+
+    internal fun setup() {
+        setupWindowInsetsListener()
+
+        bottomSheetView?.let { view ->
+            disableMaterialInsetsAnimationCallback(view)
+        }
+    }
+
+    private fun setupWindowInsetsListener() {
+        ViewCompat.setOnApplyWindowInsetsListener(container) { _, insets ->
+            lastTopInset = getTopInset(insets)
+            lastBottomInset = getBottomInset(insets)
+            updateNativeContainerHeight()
+            insets
+        }
+    }
+
+    /**
+     * BottomSheetBehavior registers an internal `WindowInsetsAnimationCallback` on the
+     * sheet view during its first `onLayoutChild`. That callback drives `translationY` to follow
+     * animated inset changes, what interferes with our slide-in custom animation.
+     *
+     * We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
+     * clear the Material's callback to remove the conflict entirely.
+     * 
+     * This method must run after the first layout pass.
+     */
+    private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
+        view.addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+            override fun onLayoutChange(
+                v: View, left: Int, top: Int, right: Int, bottom: Int,
+                oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int
+            ) {
+                ViewCompat.setWindowInsetsAnimationCallback(v, null)
+                v.removeOnLayoutChangeListener(this)
+            }
+        })
+    }
+
+    internal fun updateFormSheetDetents(detents: FormSheetDetents?, applyInitialState: Boolean) {
+        currentDetents = detents
+        if (applyInitialState) {
+            pendingInitialState = true
+        }
+        updateNativeContainerHeight()
+    }
+
+    /**
+     * For Yoga we require the container height to be "stable" to avoid updating content size in flight.
+     * If left as MATCH_PARENT, BottomSheetDialog dynamically applies insets as padding when sheet overflows
+     * status bar or display cutout. This causes Yoga to recalculate the layout, resulting in UI flickering
+     * during the drag gesture. By calculating and enforcing a static height that explicitly subtracts
+     * the system insets, we completely bypass these redundant layout passes.
+     */
+    private fun updateNativeContainerHeight() {
+        val dialogDecorHeight = dialog.window?.decorView?.height ?: 0
+
+        if (dialogDecorHeight <= 0) {
+            return
+        }
+
+        currentDetents?.let { detents ->
+            behaviorController?.updateSheetBehavior(
+                detents = detents,
+                sheetAvailableSpace = dialogDecorHeight,
+                applyInitialState = pendingInitialState,
+            )
+            pendingInitialState = false
+        }
+
+        val sheetContainerHeight =
+            currentDetents?.sheetContainerHeight(dialogDecorHeight, lastTopInset, lastBottomInset)
+                ?: (dialogDecorHeight - lastTopInset - lastBottomInset).coerceAtLeast(0)
+
+        val layoutParams =
+            container.layoutParams
+                ?: FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, sheetContainerHeight)
+
+        if (layoutParams.width != ViewGroup.LayoutParams.MATCH_PARENT || layoutParams.height != sheetContainerHeight) {
+            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+            layoutParams.height = sheetContainerHeight
+            container.layoutParams = layoutParams
+        }
+    }
+
+    private fun getTopInset(insetsCompat: WindowInsetsCompat): Int =
+        insetsCompat
+            .getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).top
+
+    private fun getBottomInset(insetsCompat: WindowInsetsCompat): Int =
+        insetsCompat
+            .getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).bottom
+
+    internal fun destroy() {
+        ViewCompat.setOnApplyWindowInsetsListener(container, null)
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 internal class FormSheetDimensionsCoordinator(
@@ -46,24 +47,9 @@ internal class FormSheetDimensionsCoordinator(
      * This method must run after the first layout pass.
      */
     private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
-        view.addOnLayoutChangeListener(
-            object : View.OnLayoutChangeListener {
-                override fun onLayoutChange(
-                    v: View,
-                    left: Int,
-                    top: Int,
-                    right: Int,
-                    bottom: Int,
-                    oldLeft: Int,
-                    oldTop: Int,
-                    oldRight: Int,
-                    oldBottom: Int,
-                ) {
-                    ViewCompat.setWindowInsetsAnimationCallback(v, null)
-                    v.removeOnLayoutChangeListener(this)
-                }
-            },
-        )
+        view.doOnLayout {
+            ViewCompat.setWindowInsetsAnimationCallback(it, null)
+        }
     }
 
     internal fun updateFormSheetDetents(

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDimensionsCoordinator.kt
@@ -1,6 +1,5 @@
 package com.swmansion.rnscreens.gamma.modals.formsheet
 
-import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat


### PR DESCRIPTION
## Description

Following the extraction of the lifecycle coordinator, this PR further refactors the `FormSheetDialogManager`. All logic related to view dimensions and insets has been decoupled into dedicated coordinator.

## Changes

- Moved all insets handling, dynamic container height calculations, and dimension states into a dedicated coordinator. The main manager now only delegates the resolved detents to this class when the configuration changes.
- Moved the `translationY = height` pre-draw setup to `FormSheetAnimationCoordinator.prepareViewForAnimation` - preparing the initial state of an animation is now explicitly handled on the animation layer.
- `disableMaterialInsetsAnimationCallback` now is rewired to `OnLayoutChangeListener`, rather than relying on the `OnPreDrawListener`, which would run after calculating the layout, but the newly registered callback is more explicit regarding the intention.

## Before & after - visual documentation

N/A - refactor

## Test plan

Already existing SFTs.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
