### PR TITLE
feat(Stack v5, iOS): Add `keepsMenuPresented` prop to menuItems

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -33,6 +33,7 @@ function TestStackHeaderMenuIOS() {
 function buildHeaderConfig(
   trailingItemsCount: number,
   showToast: (text: string) => void,
+  keepsMenuPresented: boolean,
 ): StackHeaderConfigProps {
   const trailingItems: NonNullable<
     StackHeaderConfigProps['ios']
@@ -58,6 +59,7 @@ function buildHeaderConfig(
             type: 'menuItem',
             itemType: 'action',
             title: `Action ${i}-1`,
+            keepsMenuPresented,
             onPress: () => showToast(`Clicked Action ${i}-1`),
           },
           {
@@ -65,18 +67,21 @@ function buildHeaderConfig(
             type: 'menuItem',
             itemType: 'toggle',
             title: `Toggle ${i}-1`,
+            keepsMenuPresented,
           },
           {
             id: `toggle-${i}-2`,
             type: 'menuItem',
             itemType: 'toggle',
             title: `Toggle ${i}-2`,
+            keepsMenuPresented,
           },
           {
             id: `toggle-${i}-3`,
             type: 'menuItem',
             itemType: 'toggle',
             title: `Toggle ${i}-3`,
+            keepsMenuPresented,
           },
           {
             id: `submenu-${i}`,
@@ -130,6 +135,7 @@ function ConfigScreen() {
   const [trailingItemsCount, setTrailingItemsCount] = useState<number>(
     DEFAULT_TRAILING_ITEMS_COUNT,
   );
+  const [keepsMenuPresented, setKeepsMenuPresented] = useState(false);
 
   const showToast = useCallback(
     (text: string) => {
@@ -140,8 +146,8 @@ function ConfigScreen() {
 
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(
-    () => buildHeaderConfig(trailingItemsCount, showToast),
-    [trailingItemsCount, showToast],
+    () => buildHeaderConfig(trailingItemsCount, showToast, keepsMenuPresented),
+    [trailingItemsCount, showToast, keepsMenuPresented],
   );
 
   useLayoutEffect(() => {
@@ -155,6 +161,10 @@ function ConfigScreen() {
       <Button
         title={`Toggle trailing items count (${trailingItemsCount}/4)`}
         onPress={() => setTrailingItemsCount(count => (count + 1) % 5)}
+      />
+      <Button
+        title={`keepsMenuPresented: ${keepsMenuPresented}`}
+        onPress={() => setKeepsMenuPresented(prev => !prev)}
       />
       <LongText />
     </ScrollView>

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -239,13 +239,8 @@
 + (void)decorateActionKeepsMenuPresented:(UIAction *)action withData:(RNSStackHeaderMenuItemData *)data
 {
   if (data.keepsMenuPresented) {
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
-    if (@available(iOS 16.0, *)) {
-      action.attributes |= UIMenuElementAttributesKeepsMenuPresented;
-    }
-#endif
-#if TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 160000
-    if (@available(tvOS 16.0, *)) {
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) || (TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 160000)
+    if (@available(iOS 16.0, tvOS 16.0, *)) {
       action.attributes |= UIMenuElementAttributesKeepsMenuPresented;
     }
 #endif

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -1,4 +1,5 @@
 #import "RNSStackHeaderMenuCoordinator.h"
+#import "RNSDefines.h"
 
 #import <React/RCTAssert.h>
 
@@ -169,6 +170,8 @@
               }];
   toggleAction.state = isItemToggledOn ? UIMenuElementStateOn : UIMenuElementStateOff;
 
+  [self decorateActionKeepsMenuPresented:toggleAction withData:data];
+
   return toggleAction;
 }
 
@@ -177,12 +180,16 @@
 {
   __weak id<RNSStackHeaderEventsDelegate> weakDelegate = delegate;
 
-  return [UIAction actionWithTitle:data.title
-                             image:nil
-                        identifier:nil
-                           handler:^(__kindof UIAction *_Nonnull action) {
-                             [weakDelegate didPressMenuItem:data.menuElementId];
-                           }];
+  UIAction *action = [UIAction actionWithTitle:data.title
+                                         image:nil
+                                    identifier:nil
+                                       handler:^(__kindof UIAction *_Nonnull action) {
+                                         [weakDelegate didPressMenuItem:data.menuElementId];
+                                       }];
+
+  [self decorateActionKeepsMenuPresented:action withData:data];
+
+  return action;
 }
 
 #pragma mark - Helpers
@@ -226,6 +233,22 @@
                                 intoArray:ids
                     insideSingleSelection:insideSingleSelection];
     }
+  }
+}
+
++ (void)decorateActionKeepsMenuPresented:(UIAction *)action withData:(RNSStackHeaderMenuItemData *)data
+{
+  if (data.keepsMenuPresented) {
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
+    if (@available(iOS 16.0, *)) {
+      action.attributes |= UIMenuElementAttributesKeepsMenuPresented;
+    }
+#endif
+#if TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 160000
+    if (@available(tvOS 16.0, *)) {
+      action.attributes |= UIMenuElementAttributesKeepsMenuPresented;
+    }
+#endif
   }
 }
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -21,11 +21,13 @@ typedef NS_ENUM(NSInteger, RNSMenuItemType) {
 @property (nonatomic, copy, readonly, nullable) NSString *title;
 @property (nonatomic, readonly) RNSMenuItemType itemType;
 @property (nonatomic, readonly) BOOL initialToggleState;
+@property (nonatomic, readonly) BOOL keepsMenuPresented;
 
 - (instancetype)initWithId:(NSString *)menuElementId
                      title:(nullable NSString *)title
                   itemType:(RNSMenuItemType)itemType
-        initialToggleState:(BOOL)initialToggleState;
+        initialToggleState:(BOOL)initialToggleState
+        keepsMenuPresented:(BOOL)keepsMenuPresented;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
@@ -8,12 +8,14 @@
                      title:(nullable NSString *)title
                   itemType:(RNSMenuItemType)itemType
         initialToggleState:(BOOL)initialToggleState
+        keepsMenuPresented:(BOOL)keepsMenuPresented
 {
   if (self = [super init]) {
     _menuElementId = [menuElementId copy];
     _title = [title copy];
     _itemType = itemType;
     _initialToggleState = initialToggleState;
+    _keepsMenuPresented = keepsMenuPresented;
   }
   return self;
 }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -3,6 +3,11 @@
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 
+static NSSet<NSString *> *const kAllowedMenuKeys =
+    [NSSet setWithObjects:@"id", @"type", @"title", @"children", @"singleSelection", nil];
+static NSSet<NSString *> *const kAllowedMenuItemKeys =
+    [NSSet setWithObjects:@"id", @"type", @"title", @"itemType", @"initialToggleState", @"keepsMenuPresented", nil];
+
 @implementation RNSStackHeaderMenuMapper
 
 + (nullable RNSStackHeaderMenuData *)menuFromDictionary:(nullable id)dictionary
@@ -66,10 +71,7 @@
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
-                  [key isEqualToString:@"children"] || [key isEqualToString:@"singleSelection"],
-              @"[RNScreens] Invalid key \"%@\" found in menu",
-              key);
+    RCTAssert([kAllowedMenuKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu", key);
   }
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
@@ -78,11 +80,7 @@
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
-                  [key isEqualToString:@"itemType"] || [key isEqualToString:@"initialToggleState"] ||
-                  [key isEqualToString:@"keepsMenuPresented"],
-              @"[RNScreens] Invalid key \"%@\" found in menu item",
-              key);
+    RCTAssert([kAllowedMenuItemKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu item", key);
   }
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -3,9 +3,9 @@
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 
-static NSSet<NSString *> *const kAllowedMenuKeys =
+static NSSet<NSString *> *const kRNSAllowedMenuKeys =
     [NSSet setWithObjects:@"id", @"type", @"title", @"children", @"singleSelection", nil];
-static NSSet<NSString *> *const kAllowedMenuItemKeys =
+static NSSet<NSString *> *const kRNSAllowedMenuItemKeys =
     [NSSet setWithObjects:@"id", @"type", @"title", @"itemType", @"initialToggleState", @"keepsMenuPresented", nil];
 
 @implementation RNSStackHeaderMenuMapper
@@ -71,7 +71,7 @@ static NSSet<NSString *> *const kAllowedMenuItemKeys =
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([kAllowedMenuKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu", key);
+    RCTAssert([kRNSAllowedMenuKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu", key);
   }
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
@@ -80,7 +80,7 @@ static NSSet<NSString *> *const kAllowedMenuItemKeys =
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
   for (NSString *key in dict) {
-    RCTAssert([kAllowedMenuItemKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu item", key);
+    RCTAssert([kRNSAllowedMenuItemKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu item", key);
   }
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -54,7 +54,8 @@
                                                     title:[self stringForKey:@"title" in:dict]
                                                  itemType:[self itemTypeFromString:[self stringForKey:@"itemType"
                                                                                                    in:dict]]
-                                       initialToggleState:[self boolForKey:@"initialToggleState" in:dict]];
+                                       initialToggleState:[self boolForKey:@"initialToggleState" in:dict]
+                                       keepsMenuPresented:[self boolForKey:@"keepsMenuPresented" in:dict]];
   }
 
   return nil;
@@ -78,7 +79,8 @@
 {
   for (NSString *key in dict) {
     RCTAssert([key isEqualToString:@"id"] || [key isEqualToString:@"type"] || [key isEqualToString:@"title"] ||
-                  [key isEqualToString:@"itemType"] || [key isEqualToString:@"initialToggleState"],
+                  [key isEqualToString:@"itemType"] || [key isEqualToString:@"initialToggleState"] ||
+                  [key isEqualToString:@"keepsMenuPresented"],
               @"[RNScreens] Invalid key \"%@\" found in menu item",
               key);
   }

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -76,7 +76,7 @@ export interface StackHeaderMenuItemIOS {
    */
   onPress?: () => void | undefined;
   /**
-   * @summary Keeps the menu presented after this item is selected.
+   * @summary Keeps the menu presented after this item is tapped.
    *
    * @description
    * When enabled, selecting this item will not dismiss the menu,

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -86,7 +86,7 @@ export interface StackHeaderMenuItemIOS {
    * This prop should only be used for items in top-level menus. Requires iOS 16.0 or later.
    *
    * @default false
-
+   *
    * @platform ios
    */
   keepsMenuPresented?: boolean | undefined;

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -75,6 +75,21 @@ export interface StackHeaderMenuItemIOS {
    * @platform ios
    */
   onPress?: () => void | undefined;
+  /**
+   * @summary Keeps the menu presented after this item is selected.
+   *
+   * @description
+   * When enabled, selecting this item will not dismiss the menu,
+   * allowing the user to continue interacting with other items.
+   *
+   * @remarks
+   * This prop should only be used for items in top-level menus. Requires iOS 16.0 or later.
+   *
+   * @default false
+
+   * @platform ios
+   */
+  keepsMenuPresented?: boolean | undefined;
 }
 
 /**

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -15,6 +15,7 @@ export type StackHeaderMenuItemIOS = {
   id: string;
   type: 'menuItem';
   title?: string | undefined;
+  keepsMenuPresented?: boolean | undefined;
 };
 
 export type StackHeaderMenuIOS = {


### PR DESCRIPTION
## Description

This PR adds `keepsMenuPresented` to configurable options on menu items. When action with `keepsMenuPresented == true` is clicked, the menu is still displayed. This only really works correctly on top-level menus (also on native), nested menus are hidden anyways (all but the top-level menu).

## Changes

- added `keepsMenuPresented` prop and handled on menu building
- updated typing
- updated menu SFT

## Visual documentation

https://github.com/user-attachments/assets/62190fc4-f1c2-43db-af2b-86a563dd088c

> [!note]
> This flashing when first checkmark is added or last checkmark is removed also appears natively. There's nothing we can do about it

## Test plan

Use Stack Header Menu SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
