### PR TITLE
refactor(Android, FormSheet v5): Introduce invalidation flags for updates

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -14,8 +14,6 @@ class FormSheetDialogManager(
 ) {
     private var formSheetConfig = FormSheetConfig()
 
-    internal val invalidationFlags = FormSheetInvalidationFlags()
-
     private val themedContext =
         ContextThemeWrapper(
             context,
@@ -61,58 +59,24 @@ class FormSheetDialogManager(
     }
 
     internal fun applyConfig(newConfig: FormSheetConfig) {
-        if (formSheetConfig.isOpen != newConfig.isOpen) {
-            invalidationFlags.isPresentationInvalidated = true
-            if (newConfig.isOpen) {
-                // ALWAYS refresh the sheet configuration when reopening to ensure that BottomSheet
-                // state and layout are synchronized with native behavior.
-                invalidationFlags.isAppearanceInvalidated = true
-                invalidationFlags.isBehaviorInvalidated = true
-            }
-        }
-
-        if (formSheetConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
-            invalidationFlags.isAppearanceInvalidated = true
-        }
-
-        if (formSheetConfig.detents != newConfig.detents) {
-            invalidationFlags.isBehaviorInvalidated = true
-        }
-
+        val oldConfig = formSheetConfig
         formSheetConfig = newConfig
 
-        flushPendingUpdates()
-    }
+        // ALWAYS refresh behavior & appearance when reopening to ensure that BottomSheet
+        // state and layout are synchronized with native behavior.
+        val reopened = !oldConfig.isOpen && newConfig.isOpen
 
-    private fun flushPendingUpdates() {
-        if (!invalidationFlags.any()) return
-
-        if (invalidationFlags.isBehaviorInvalidated) {
-            invalidationFlags.isBehaviorInvalidated = false
-            updateSheetBehavior()
+        if (reopened || oldConfig.detents != newConfig.detents) {
+            dimensionsCoordinator.updateFormSheetDetents(resolveDetents(newConfig.detents))
         }
 
-        if (invalidationFlags.isAppearanceInvalidated) {
-            invalidationFlags.isAppearanceInvalidated = false
-            updateSheetAppearance()
+        if (reopened || oldConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
+            container.setGrabberVisible(newConfig.prefersGrabberVisible)
         }
 
-        if (invalidationFlags.isPresentationInvalidated) {
-            invalidationFlags.isPresentationInvalidated = false
-            updateSheetPresentation()
+        if (oldConfig.isOpen != newConfig.isOpen) {
+            presentationManager.updatePresentationState(newConfig.isOpen)
         }
-    }
-
-    private fun updateSheetBehavior() {
-        dimensionsCoordinator.updateFormSheetDetents(resolveDetents(formSheetConfig.detents))
-    }
-
-    private fun updateSheetAppearance() {
-        container.setGrabberVisible(formSheetConfig.prefersGrabberVisible)
-    }
-
-    private fun updateSheetPresentation() {
-        presentationManager.updatePresentationState(formSheetConfig.isOpen)
     }
 
     private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -14,8 +14,6 @@ class FormSheetDialogManager(
 ) {
     private var formSheetConfig = FormSheetConfig()
 
-    private var resolvedDetents: FormSheetDetents? = null
-
     internal val invalidationFlags = FormSheetInvalidationFlags()
 
     private val themedContext =
@@ -77,7 +75,7 @@ class FormSheetDialogManager(
             invalidationFlags.isAppearanceInvalidated = true
         }
 
-        if (resolvedDetents == null || formSheetConfig.detents != newConfig.detents) {
+        if (formSheetConfig.detents != newConfig.detents) {
             invalidationFlags.isBehaviorInvalidated = true
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -16,6 +16,8 @@ class FormSheetDialogManager(
 
     private var resolvedDetents: FormSheetDetents? = null
 
+    internal val invalidationFlags = FormSheetInvalidationFlags()
+
     private val themedContext =
         ContextThemeWrapper(
             context,
@@ -62,29 +64,57 @@ class FormSheetDialogManager(
 
     internal fun applyConfig(newConfig: FormSheetConfig) {
         if (formSheetConfig.isOpen != newConfig.isOpen) {
-            presentationManager.updatePresentationState(newConfig.isOpen)
+            invalidationFlags.isPresentationInvalidated = true
+            if (newConfig.isOpen) {
+                // ALWAYS refresh the sheet configuration when reopening to ensure that BottomSheet
+                // state and layout is synchronized with native behavior.
+                invalidationFlags.isAppearanceInvalidated = true
+                invalidationFlags.isBehaviorInvalidated = true
+            }
         }
 
         if (formSheetConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
-            container.setGrabberVisible(newConfig.prefersGrabberVisible)
+            invalidationFlags.isAppearanceInvalidated = true
         }
 
-        // TODO: @t0maboro
-        // - invalidation flags logic should be implemented following other components convention
-        val isOpening = newConfig.isOpen && !formSheetConfig.isOpen
-        val detentsChanged = resolvedDetents == null || formSheetConfig.detents != newConfig.detents
-
-        if (detentsChanged) {
-            resolvedDetents = resolveDetents(newConfig.detents)
-        }
-
-        if (detentsChanged || isOpening) {
-            dimensionsCoordinator.updateFormSheetDetents(
-                detents = resolvedDetents,
-            )
+        if (resolvedDetents == null || formSheetConfig.detents != newConfig.detents) {
+            invalidationFlags.isBehaviorInvalidated = true
         }
 
         formSheetConfig = newConfig
+
+        flushPendingUpdates()
+    }
+
+    private fun flushPendingUpdates() {
+        if (!invalidationFlags.any()) return
+
+        if (invalidationFlags.isBehaviorInvalidated) {
+            invalidationFlags.isBehaviorInvalidated = false
+            updateSheetBehavior()
+        }
+
+        if (invalidationFlags.isAppearanceInvalidated) {
+            invalidationFlags.isAppearanceInvalidated = false
+            updateSheetAppearance()
+        }
+
+        if (invalidationFlags.isPresentationInvalidated) {
+            invalidationFlags.isPresentationInvalidated = false
+            updateSheetPresentation()
+        }
+    }
+
+    private fun updateSheetBehavior() {
+        dimensionsCoordinator.updateFormSheetDetents(resolveDetents(formSheetConfig.detents))
+    }
+
+    private fun updateSheetAppearance() {
+        container.setGrabberVisible(formSheetConfig.prefersGrabberVisible)
+    }
+
+    private fun updateSheetPresentation() {
+        presentationManager.updatePresentationState(formSheetConfig.isOpen)
     }
 
     private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -65,7 +65,7 @@ class FormSheetDialogManager(
             invalidationFlags.isPresentationInvalidated = true
             if (newConfig.isOpen) {
                 // ALWAYS refresh the sheet configuration when reopening to ensure that BottomSheet
-                // state and layout is synchronized with native behavior.
+                // state and layout are synchronized with native behavior.
                 invalidationFlags.isAppearanceInvalidated = true
                 invalidationFlags.isBehaviorInvalidated = true
             }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
@@ -1,0 +1,10 @@
+package com.swmansion.rnscreens.gamma.modals.formsheet
+
+class FormSheetInvalidationFlags(
+    var isPresentationInvalidated: Boolean = false,
+    var isAppearanceInvalidated: Boolean = false,
+    var isBehaviorInvalidated: Boolean = false,
+) {
+    internal fun any(): Boolean =
+        isPresentationInvalidated || isAppearanceInvalidated || isBehaviorInvalidated
+}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
@@ -5,6 +5,5 @@ internal class FormSheetInvalidationFlags(
     var isAppearanceInvalidated: Boolean = false,
     var isBehaviorInvalidated: Boolean = false,
 ) {
-    internal fun any(): Boolean =
-        isPresentationInvalidated || isAppearanceInvalidated || isBehaviorInvalidated
+    internal fun any(): Boolean = isPresentationInvalidated || isAppearanceInvalidated || isBehaviorInvalidated
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
@@ -1,9 +1,0 @@
-package com.swmansion.rnscreens.gamma.modals.formsheet
-
-internal class FormSheetInvalidationFlags(
-    var isPresentationInvalidated: Boolean = false,
-    var isAppearanceInvalidated: Boolean = false,
-    var isBehaviorInvalidated: Boolean = false,
-) {
-    internal fun any(): Boolean = isPresentationInvalidated || isAppearanceInvalidated || isBehaviorInvalidated
-}

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetInvalidationFlags.kt
@@ -1,6 +1,6 @@
 package com.swmansion.rnscreens.gamma.modals.formsheet
 
-class FormSheetInvalidationFlags(
+internal class FormSheetInvalidationFlags(
     var isPresentationInvalidated: Boolean = false,
     var isAppearanceInvalidated: Boolean = false,
     var isBehaviorInvalidated: Boolean = false,


### PR DESCRIPTION
## Description

Cleanup the `applyConfig` method, which now reevaluates what changed while reopening the sheet. All appearance-related and behavior-related props should now be considered for reapplying their configuration while sheet is reopening to ensure the initial state is consistent between presentation cycles.

## Changes

- refactored `applyConfig`

## Before & after - visual documentation

N/A - refactor

## Test plan

N/A - refactor

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
