### PR TITLE
feat(tabs): support iOS scroll edge effects

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/scrollviewmarker/ScrollViewMarkerViewManager.kt
@@ -49,6 +49,12 @@ class ScrollViewMarkerViewManager :
         value: String?,
     ) = Unit
 
+    // iOS only
+    override fun setHasScrollEdgeEffects(
+        view: ScrollViewMarker?,
+        value: Boolean,
+    ) = Unit
+
     companion object {
         const val REACT_CLASS = "RNSScrollViewMarker"
     }

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -357,6 +357,48 @@ UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSyst
   return UITabBarSystemItemSearch;
 }
 
+#define SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT(X)           \
+  switch (edgeEffect) {                                    \
+    using enum react::X;                                   \
+    case Automatic:                                        \
+      return RNSScrollEdgeEffectAutomatic;                 \
+    case Hard:                                             \
+      return RNSScrollEdgeEffectHard;                      \
+    case Soft:                                             \
+      return RNSScrollEdgeEffectSoft;                      \
+    case Hidden:                                           \
+      return RNSScrollEdgeEffectHidden;                    \
+    default:                                               \
+      RCTLogError(@"[RNScreens] unsupported edge effect"); \
+      return RNSScrollEdgeEffectAutomatic;                 \
+  }
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffect(
+    react::RNSTabsScreenIOSBottomScrollEdgeEffect edgeEffect)
+{
+  SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT(RNSTabsScreenIOSBottomScrollEdgeEffect);
+}
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffect(
+    react::RNSTabsScreenIOSLeftScrollEdgeEffect edgeEffect)
+{
+  SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT(RNSTabsScreenIOSLeftScrollEdgeEffect);
+}
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenRightScrollEdgeEffect(
+    react::RNSTabsScreenIOSRightScrollEdgeEffect edgeEffect)
+{
+  SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT(RNSTabsScreenIOSRightScrollEdgeEffect);
+}
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenTopScrollEdgeEffect(
+    react::RNSTabsScreenIOSTopScrollEdgeEffect edgeEffect)
+{
+  SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT(RNSTabsScreenIOSTopScrollEdgeEffect);
+}
+
+#undef SWITCH_TABS_SCREEN_SCROLL_EDGE_EFFECT
+
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 API_AVAILABLE(ios(26.0))

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -56,6 +56,18 @@ RNSTabsScreenSystemItem RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(
 
 UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem);
 
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffect(
+    react::RNSTabsScreenIOSBottomScrollEdgeEffect edgeEffect);
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffect(
+    react::RNSTabsScreenIOSLeftScrollEdgeEffect edgeEffect);
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenRightScrollEdgeEffect(
+    react::RNSTabsScreenIOSRightScrollEdgeEffect edgeEffect);
+
+RNSScrollEdgeEffect RNSScrollEdgeEffectFromTabsScreenTopScrollEdgeEffect(
+    react::RNSTabsScreenIOSTopScrollEdgeEffect edgeEffect);
+
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 API_AVAILABLE(ios(26.0))

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.h
@@ -4,7 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class UIScrollView;
+
 @interface RNSScrollViewMarkerComponentView : RNSReactBaseView
+
+- (BOOL)hasScrollEdgeEffects;
+- (void)applyScrollEdgeEffectsToScrollView:(nullable UIScrollView *)scrollView;
 
 @end
 

--- a/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
+++ b/ios/gamma/scroll-view-marker/RNSScrollViewMarkerComponentView.mm
@@ -21,11 +21,13 @@ namespace react = facebook::react;
 @implementation RNSScrollViewMarkerComponentView {
   BOOL _hasAttemptedRegistration;
   BOOL _needsEdgeEffectUpdate;
+  BOOL _needsSeekingAncestorUpdate;
 
   RNSScrollEdgeEffect _leftScrollEdgeEffect;
   RNSScrollEdgeEffect _topScrollEdgeEffect;
   RNSScrollEdgeEffect _rightScrollEdgeEffect;
   RNSScrollEdgeEffect _bottomScrollEdgeEffect;
+  BOOL _hasScrollEdgeEffects;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -43,6 +45,7 @@ namespace react = facebook::react;
   [self resetProps];
   _hasAttemptedRegistration = NO;
   _needsEdgeEffectUpdate = NO;
+  _needsSeekingAncestorUpdate = NO;
 }
 
 - (void)resetProps
@@ -53,6 +56,7 @@ namespace react = facebook::react;
   _topScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
   _rightScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
   _bottomScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
+  _hasScrollEdgeEffects = NO;
 }
 
 /**
@@ -121,6 +125,16 @@ namespace react = facebook::react;
     return;
   }
   [RNSScrollEdgeEffectApplicator applyToScrollView:scrollView withProvider:self];
+}
+
+- (BOOL)hasScrollEdgeEffects
+{
+  return _hasScrollEdgeEffects;
+}
+
+- (void)applyScrollEdgeEffectsToScrollView:(nullable UIScrollView *)scrollView
+{
+  [self configureScrollView:scrollView];
 }
 
 /**
@@ -215,6 +229,12 @@ namespace react = facebook::react;
     _needsEdgeEffectUpdate = YES;
   }
 
+  if (oldComponentProps.hasScrollEdgeEffects != newComponentProps.hasScrollEdgeEffects) {
+    _hasScrollEdgeEffects = newComponentProps.hasScrollEdgeEffects;
+    _needsEdgeEffectUpdate = YES;
+    _needsSeekingAncestorUpdate = YES;
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -227,6 +247,11 @@ namespace react = facebook::react;
   if (_needsEdgeEffectUpdate) {
     _needsEdgeEffectUpdate = NO;
     [self configureScrollView:[self findScrollView]];
+  }
+
+  if (_needsSeekingAncestorUpdate) {
+    _needsSeekingAncestorUpdate = NO;
+    [self registerWithSeekingAncestor];
   }
 
   // It allows 0 for cases where the child is unmounted

--- a/ios/gamma/stack/host/RNSStackNavigationController.h
+++ b/ios/gamma/stack/host/RNSStackNavigationController.h
@@ -18,4 +18,6 @@
 
 - (void)performContainerUpdateIfNeeded;
 
+- (void)notifyContentScrollViewChange;
+
 @end

--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -50,6 +50,16 @@
   return [static_cast<RNSStackScreenController *>(topController) findContentScrollView];
 }
 
+- (BOOL)isCurrentContentScrollViewConfiguredForScrollEdgeEffects
+{
+  UIViewController *topController = self.topViewController;
+  if (![topController respondsToSelector:@selector(isContentScrollViewConfiguredForScrollEdgeEffects)]) {
+    return NO;
+  }
+
+  return [static_cast<id<RNSContainerItem>>(topController) isContentScrollViewConfiguredForScrollEdgeEffects];
+}
+
 - (void)attachToParentContainerItem
 {
   [_parentContainerRegistry attachContainer:self];
@@ -120,6 +130,12 @@
 
   [_pendingPopOperations removeAllObjects];
   [_pendingPushOperations removeAllObjects];
+  [self notifyContentScrollViewChange];
+}
+
+- (void)notifyContentScrollViewChange
+{
+  [_parentContainerRegistry notifyContentScrollViewChangeInContainer:self];
 }
 
 #pragma mark - Debug

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.h
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.h
@@ -53,6 +53,8 @@ typedef NS_ENUM(int, RNSStackScreenActivityMode) {
  */
 - (nullable UIScrollView *)cachedContentScrollView;
 
+- (BOOL)hasDirectContentScrollViewScrollEdgeEffects;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -33,6 +33,7 @@ namespace react = facebook::react;
   // the owning `RNSStackScreenController` (as `RNSContainerItem`) when resolving the content
   // scroll view for special effects.
   __weak UIScrollView *_Nullable _contentScrollView;
+  __weak RNSScrollViewMarkerComponentView *_Nullable _contentScrollViewMarker;
 
   // Flags
   BOOL _hasUpdatedActivityMode;
@@ -94,11 +95,18 @@ namespace react = facebook::react;
   [_controller setContentScrollView:scrollView forEdge:NSDirectionalRectEdgeAll];
   // Cache used by the container-nesting content-scroll-view resolution.
   _contentScrollView = scrollView;
+  _contentScrollViewMarker = marker;
+  [_controller contentScrollViewSourceDidChange];
 }
 
 - (nullable UIScrollView *)cachedContentScrollView
 {
   return _contentScrollView;
+}
+
+- (BOOL)hasDirectContentScrollViewScrollEdgeEffects
+{
+  return [_contentScrollViewMarker hasScrollEdgeEffects];
 }
 
 #pragma mark - Events

--- a/ios/gamma/stack/screen/RNSStackScreenController.h
+++ b/ios/gamma/stack/screen/RNSStackScreenController.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithComponentView:(RNSStackScreenComponentView *)componentView;
 
+- (void)contentScrollViewSourceDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/screen/RNSStackScreenController.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenController.mm
@@ -28,16 +28,44 @@
 - (void)registerNestedContainer:(id<RNSContainer>)container
 {
   [_containerItemSupport registerNestedContainer:container];
+  [self contentScrollViewSourceDidChange];
 }
 
 - (void)unregisterNestedContainer:(id<RNSContainer>)container
 {
   [_containerItemSupport unregisterNestedContainer:container];
+  [self contentScrollViewSourceDidChange];
 }
 
 - (nullable id<RNSContainer>)resolveNestedContainer
 {
   return [_containerItemSupport resolveNestedContainer];
+}
+
+- (void)nestedContainerContentScrollViewDidChange:(UIViewController<RNSContainer> *)container
+{
+  [self contentScrollViewSourceDidChange];
+}
+
+- (void)contentScrollViewSourceDidChange
+{
+  if ([self.navigationController isKindOfClass:RNSStackNavigationController.class]) {
+    [static_cast<RNSStackNavigationController *>(self.navigationController) notifyContentScrollViewChange];
+  }
+}
+
+- (BOOL)isContentScrollViewConfiguredForScrollEdgeEffects
+{
+  if ([_screenView hasDirectContentScrollViewScrollEdgeEffects]) {
+    return YES;
+  }
+
+  id<RNSContainer> nestedContainer = [_containerItemSupport resolveNestedContainer];
+  if ([nestedContainer respondsToSelector:@selector(isCurrentContentScrollViewConfiguredForScrollEdgeEffects)]) {
+    return [nestedContainer isCurrentContentScrollViewConfiguredForScrollEdgeEffects];
+  }
+
+  return NO;
 }
 
 - (nullable UIScrollView *)findContentScrollView

--- a/ios/helpers/container/RNSContainer.h
+++ b/ios/helpers/container/RNSContainer.h
@@ -20,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable UIScrollView *)resolveCurrentContentScrollView;
 
+@optional
+
+- (BOOL)isCurrentContentScrollViewConfiguredForScrollEdgeEffects;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSContainerItem.h
+++ b/ios/helpers/container/RNSContainerItem.h
@@ -30,6 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id<RNSContainer>)resolveNestedContainer;
 
+@optional
+
+- (void)nestedContainerContentScrollViewDidChange:(UIViewController<RNSContainer> *)container;
+
+- (BOOL)isContentScrollViewConfiguredForScrollEdgeEffects;
+
 #pragma mark - Content Scroll View support
 
 // `findContentScrollView` is inherited from `RNSContentScrollViewProviding`.

--- a/ios/helpers/container/RNSParentContainerItemRegistry.h
+++ b/ios/helpers/container/RNSParentContainerItemRegistry.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)detachContainer:(UIViewController<RNSContainer> *)container;
 
+- (void)notifyContentScrollViewChangeInContainer:(UIViewController<RNSContainer> *)container;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/helpers/container/RNSParentContainerItemRegistry.mm
+++ b/ios/helpers/container/RNSParentContainerItemRegistry.mm
@@ -26,6 +26,13 @@
   _parentItem = nil;
 }
 
+- (void)notifyContentScrollViewChangeInContainer:(UIViewController<RNSContainer> *)container
+{
+  if ([_parentItem respondsToSelector:@selector(nestedContainerContentScrollViewDidChange:)]) {
+    [_parentItem nestedContainerContentScrollViewDidChange:container];
+  }
+}
+
 /**
  * Walks the view-controller containment chain (`parentViewController`) upwards looking for the
  * nearest `RNSContainerItem`. We test via `respondsToSelector:` rather than `conformsToProtocol:`

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -105,6 +105,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)removeNavigationStateObserver:(id<RNSTabsNavigationStateObserver>)observer;
 
+- (void)notifyContentScrollViewChange;
+
 #pragma mark - Internal API (host-only; subject to change without notice)
 
 - (instancetype)initWithTabsHostComponentView:(nullable RNSTabsHostComponentView *)tabsHostComponentView;

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -165,6 +165,16 @@ static void rns_pushViewController(__unsafe_unretained id self,
   return [static_cast<RNSTabsScreenViewController *>(selectedController) findContentScrollView];
 }
 
+- (BOOL)isCurrentContentScrollViewConfiguredForScrollEdgeEffects
+{
+  UIViewController *selectedController = self.selectedViewController;
+  if (![selectedController respondsToSelector:@selector(isContentScrollViewConfiguredForScrollEdgeEffects)]) {
+    return NO;
+  }
+
+  return [static_cast<id<RNSContainerItem>>(selectedController) isContentScrollViewConfiguredForScrollEdgeEffects];
+}
+
 - (void)attachToParentContainerItem
 {
   [_parentContainerRegistry attachContainer:self];
@@ -173,6 +183,11 @@ static void rns_pushViewController(__unsafe_unretained id self,
 - (void)detachFromParentContainerItem
 {
   [_parentContainerRegistry detachContainer:self];
+}
+
+- (void)notifyContentScrollViewChange
+{
+  [_parentContainerRegistry notifyContentScrollViewChangeInContainer:self];
 }
 
 #pragma mark - UIKit callbacks
@@ -200,6 +215,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   if (!_isHandlingExplicitSelectionUpdate) {
     [self reconcileNavigationStateWithUIKitState];
   }
+  [self notifyContentScrollViewChange];
 }
 
 - (void)setSelectedViewController:(__kindof UIViewController *)selectedViewController
@@ -208,6 +224,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   if (!_isHandlingExplicitSelectionUpdate) {
     [self reconcileNavigationStateWithUIKitState];
   }
+  [self notifyContentScrollViewChange];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/ios/tabs/screen/RNSTabsScreenComponentView.h
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.h
@@ -64,6 +64,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL preventNativeSelection;
 
 @property (nonatomic, readonly) BOOL overrideScrollViewContentInsetAdjustmentBehavior;
+@property (nonatomic, readonly) RNSScrollEdgeEffect bottomScrollEdgeEffect;
+@property (nonatomic, readonly) RNSScrollEdgeEffect leftScrollEdgeEffect;
+@property (nonatomic, readonly) RNSScrollEdgeEffect rightScrollEdgeEffect;
+@property (nonatomic, readonly) RNSScrollEdgeEffect topScrollEdgeEffect;
+@property (nonatomic, readonly) BOOL hasScrollEdgeEffects;
 
 @property (nonatomic, readonly, nullable) NSString *tabItemTestID;
 @property (nonatomic, readonly, nullable) NSString *tabItemAccessibilityLabel;
@@ -101,6 +106,10 @@ NS_ASSUME_NONNULL_BEGIN
  * none has been registered. Queried by the owning controller (`RNSContainerItem`).
  */
 - (nullable UIScrollView *)cachedContentScrollView;
+
+- (BOOL)hasDirectContentScrollViewScrollEdgeEffects;
+
+- (void)updateContentScrollViewEdgeEffectsIfExists;
 
 @end
 

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -1,10 +1,11 @@
 #import "RNSTabsScreenComponentView.h"
 #import "NSString+RNSUtility.h"
+#import "RNSContainer.h"
 #import "RNSConversions.h"
 #import "RNSDefines.h"
 #import "RNSLog.h"
 #import "RNSSafeAreaViewNotifications.h"
-#import "RNSScrollViewFinder.h"
+#import "RNSScrollEdgeEffectApplicator.h"
 #import "RNSScrollViewHelper.h"
 #import "RNSTabBarAppearanceCoordinator.h"
 #import "RNSTabBarController.h"
@@ -26,7 +27,10 @@ namespace react = facebook::react;
 #pragma mark - View implementation
 
 #if RNS_GAMMA_ENABLED
-@interface RNSTabsScreenComponentView () <RNSScrollViewSeeking>
+@interface RNSTabsScreenComponentView () <RNSScrollViewSeeking, RNSScrollEdgeEffectProviding>
+@end
+#else
+@interface RNSTabsScreenComponentView () <RNSScrollEdgeEffectProviding>
 @end
 #endif
 
@@ -40,12 +44,19 @@ namespace react = facebook::react;
   // the owning `RNSTabsScreenViewController` (as `RNSContainerItem`) when resolving the content
   // scroll view for special effects.
   __weak UIScrollView *_Nullable _contentScrollView;
+#if RNS_GAMMA_ENABLED
+  __weak RNSScrollViewMarkerComponentView *_Nullable _contentScrollViewMarker;
+#endif
+  NSHashTable<UIScrollView *> *_Nonnull _tabScrollEdgeEffectsScrollViews;
 
   // We need this information to warn users about dynamic changes to behavior being currently unsupported.
   BOOL _isOverrideScrollViewContentInsetAdjustmentBehaviorSet;
   // Tracks that the first child was mounted before props were set.
   // The pending override will be applied once updateProps runs.
   BOOL _needsScrollViewBehaviorOverride;
+  BOOL _shouldUpdateScrollEdgeEffects;
+  BOOL _shouldResetScrollEdgeEffects;
+  BOOL _shouldNotifyScrollEdgeEffectsOwnershipChange;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -85,6 +96,15 @@ namespace react = facebook::react;
 
   _overrideScrollViewContentInsetAdjustmentBehavior = YES;
   _isOverrideScrollViewContentInsetAdjustmentBehaviorSet = NO;
+  _bottomScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
+  _leftScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
+  _rightScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
+  _topScrollEdgeEffect = RNSScrollEdgeEffectAutomatic;
+  _hasScrollEdgeEffects = NO;
+  _tabScrollEdgeEffectsScrollViews = [NSHashTable weakObjectsHashTable];
+  _shouldUpdateScrollEdgeEffects = NO;
+  _shouldResetScrollEdgeEffects = NO;
+  _shouldNotifyScrollEdgeEffectsOwnershipChange = NO;
 
   _iconType = RNSTabsIconTypeSfSymbol;
 
@@ -128,12 +148,73 @@ RNS_IGNORE_SUPER_CALL_END
   [_controller setContentScrollView:scrollView forEdge:NSDirectionalRectEdgeAll];
   // Cache used by the container-nesting content-scroll-view resolution.
   _contentScrollView = scrollView;
+#if RNS_GAMMA_ENABLED
+  _contentScrollViewMarker = marker;
+#endif
+  [self updateContentScrollViewEdgeEffectsIfExists];
+  [self notifyParentContainerAboutContentScrollViewChangeIfNeeded];
 }
 #endif // RNS_GAMMA_ENABLED
 
 - (nullable UIScrollView *)cachedContentScrollView
 {
   return _contentScrollView;
+}
+
+- (BOOL)hasDirectContentScrollViewScrollEdgeEffects
+{
+  if (_hasScrollEdgeEffects) {
+    return YES;
+  }
+
+#if RNS_GAMMA_ENABLED
+  return [_contentScrollViewMarker hasScrollEdgeEffects];
+#else
+  return NO;
+#endif
+}
+
+- (void)updateContentScrollViewEdgeEffectsIfExists
+{
+  UIScrollView *scrollView = [_controller findContentScrollView];
+
+  BOOL hasDirectMarkerOwner = NO;
+#if RNS_GAMMA_ENABLED
+  hasDirectMarkerOwner = scrollView == _contentScrollView && [_contentScrollViewMarker hasScrollEdgeEffects];
+#endif
+
+  id<RNSContainer> nestedContainer = [_controller resolveNestedContainer];
+  BOOL hasNestedOwner = scrollView != nil && scrollView != _contentScrollView &&
+      [nestedContainer respondsToSelector:@selector(isCurrentContentScrollViewConfiguredForScrollEdgeEffects)] &&
+      [nestedContainer isCurrentContentScrollViewConfiguredForScrollEdgeEffects];
+
+  if (_shouldResetScrollEdgeEffects) {
+    for (UIScrollView *tabScrollView in _tabScrollEdgeEffectsScrollViews) {
+      if (tabScrollView == scrollView && (hasDirectMarkerOwner || hasNestedOwner)) {
+        continue;
+      }
+      [RNSScrollEdgeEffectApplicator applyToScrollView:tabScrollView withProvider:self];
+    }
+    [_tabScrollEdgeEffectsScrollViews removeAllObjects];
+  }
+
+#if RNS_GAMMA_ENABLED
+  if (hasDirectMarkerOwner) {
+    [_tabScrollEdgeEffectsScrollViews removeObject:scrollView];
+    [_contentScrollViewMarker applyScrollEdgeEffectsToScrollView:scrollView];
+    return;
+  }
+#endif
+
+  if (hasNestedOwner) {
+    [_tabScrollEdgeEffectsScrollViews removeObject:scrollView];
+    return;
+  }
+
+  if (scrollView != nil && _hasScrollEdgeEffects) {
+    [RNSScrollEdgeEffectApplicator applyToScrollView:scrollView withProvider:self];
+    [_tabScrollEdgeEffectsScrollViews addObject:scrollView];
+  }
 }
 
 #pragma mark - Events
@@ -147,6 +228,14 @@ RNS_IGNORE_SUPER_CALL_END
 - (nullable RNSTabBarController *)findTabBarController
 {
   return static_cast<RNSTabBarController *>(_controller.tabBarController);
+}
+
+- (void)notifyParentContainerAboutContentScrollViewChangeIfNeeded
+{
+  RNSTabBarController *tabBarController = [self findTabBarController];
+  if (tabBarController.selectedViewController == _controller) {
+    [tabBarController notifyContentScrollViewChange];
+  }
 }
 
 #pragma mark - RNSScrollViewBehaviorOverriding
@@ -355,6 +444,37 @@ RNS_IGNORE_SUPER_CALL_END
     }
   }
 
+  if (newComponentProps.bottomScrollEdgeEffect != oldComponentProps.bottomScrollEdgeEffect) {
+    _bottomScrollEdgeEffect = rnscreens::conversion::RNSScrollEdgeEffectFromTabsScreenBottomScrollEdgeEffect(
+        newComponentProps.bottomScrollEdgeEffect);
+    _shouldUpdateScrollEdgeEffects = YES;
+  }
+
+  if (newComponentProps.leftScrollEdgeEffect != oldComponentProps.leftScrollEdgeEffect) {
+    _leftScrollEdgeEffect = rnscreens::conversion::RNSScrollEdgeEffectFromTabsScreenLeftScrollEdgeEffect(
+        newComponentProps.leftScrollEdgeEffect);
+    _shouldUpdateScrollEdgeEffects = YES;
+  }
+
+  if (newComponentProps.rightScrollEdgeEffect != oldComponentProps.rightScrollEdgeEffect) {
+    _rightScrollEdgeEffect = rnscreens::conversion::RNSScrollEdgeEffectFromTabsScreenRightScrollEdgeEffect(
+        newComponentProps.rightScrollEdgeEffect);
+    _shouldUpdateScrollEdgeEffects = YES;
+  }
+
+  if (newComponentProps.topScrollEdgeEffect != oldComponentProps.topScrollEdgeEffect) {
+    _topScrollEdgeEffect = rnscreens::conversion::RNSScrollEdgeEffectFromTabsScreenTopScrollEdgeEffect(
+        newComponentProps.topScrollEdgeEffect);
+    _shouldUpdateScrollEdgeEffects = YES;
+  }
+
+  if (newComponentProps.hasScrollEdgeEffects != oldComponentProps.hasScrollEdgeEffects) {
+    _hasScrollEdgeEffects = newComponentProps.hasScrollEdgeEffects;
+    _shouldResetScrollEdgeEffects = oldComponentProps.hasScrollEdgeEffects && !newComponentProps.hasScrollEdgeEffects;
+    _shouldUpdateScrollEdgeEffects = YES;
+    _shouldNotifyScrollEdgeEffectsOwnershipChange = YES;
+  }
+
   // This flag is set to YES when overrideScrollViewContentInsetAdjustmentBehavior prop
   // is assigned for the first time. This allows us to identify any subsequent changes to this prop,
   // enabling us to warn users that dynamic changes are not supported.
@@ -401,6 +521,22 @@ RNS_IGNORE_SUPER_CALL_END
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
+{
+  [super finalizeUpdates:updateMask];
+
+  if (_shouldUpdateScrollEdgeEffects) {
+    [self updateContentScrollViewEdgeEffectsIfExists];
+    _shouldUpdateScrollEdgeEffects = NO;
+    _shouldResetScrollEdgeEffects = NO;
+  }
+
+  if (_shouldNotifyScrollEdgeEffectsOwnershipChange) {
+    [self notifyParentContainerAboutContentScrollViewChangeIfNeeded];
+    _shouldNotifyScrollEdgeEffectsOwnershipChange = NO;
+  }
+}
+
 - (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics
 {
@@ -431,6 +567,8 @@ RNS_IGNORE_SUPER_CALL_END
     } else {
       _needsScrollViewBehaviorOverride = YES;
     }
+
+    [self updateContentScrollViewEdgeEffectsIfExists];
   }
 }
 

--- a/ios/tabs/screen/RNSTabsScreenViewController.mm
+++ b/ios/tabs/screen/RNSTabsScreenViewController.mm
@@ -119,16 +119,46 @@
 - (void)registerNestedContainer:(id<RNSContainer>)container
 {
   [_containerItemSupport registerNestedContainer:container];
+  [self.tabScreenComponentView updateContentScrollViewEdgeEffectsIfExists];
+  if (self.tabBarController.selectedViewController == self) {
+    [[self findTabBarController] notifyContentScrollViewChange];
+  }
 }
 
 - (void)unregisterNestedContainer:(id<RNSContainer>)container
 {
   [_containerItemSupport unregisterNestedContainer:container];
+  [self.tabScreenComponentView updateContentScrollViewEdgeEffectsIfExists];
+  if (self.tabBarController.selectedViewController == self) {
+    [[self findTabBarController] notifyContentScrollViewChange];
+  }
 }
 
 - (nullable id<RNSContainer>)resolveNestedContainer
 {
   return [_containerItemSupport resolveNestedContainer];
+}
+
+- (void)nestedContainerContentScrollViewDidChange:(UIViewController<RNSContainer> *)container
+{
+  [self.tabScreenComponentView updateContentScrollViewEdgeEffectsIfExists];
+  if (self.tabBarController.selectedViewController == self) {
+    [[self findTabBarController] notifyContentScrollViewChange];
+  }
+}
+
+- (BOOL)isContentScrollViewConfiguredForScrollEdgeEffects
+{
+  if ([self.tabScreenComponentView hasDirectContentScrollViewScrollEdgeEffects]) {
+    return YES;
+  }
+
+  id<RNSContainer> nestedContainer = [_containerItemSupport resolveNestedContainer];
+  if ([nestedContainer respondsToSelector:@selector(isCurrentContentScrollViewConfiguredForScrollEdgeEffects)]) {
+    return [nestedContainer isCurrentContentScrollViewConfiguredForScrollEdgeEffects];
+  }
+
+  return NO;
 }
 
 - (nullable UIScrollView *)findContentScrollView

--- a/src/components/gamma/scroll-view-marker/ScrollViewMarker.tsx
+++ b/src/components/gamma/scroll-view-marker/ScrollViewMarker.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ScrollViewMarkerNativeComponent from '../../../fabric/gamma/ScrollViewMarkerNativeComponent';
+import { hasExplicitScrollEdgeEffects } from '../../helpers/scrollEdgeEffects';
 import type { ScrollViewMarkerProps } from './ScrollViewMarker.types';
 
 export function ScrollViewMarker(props: ScrollViewMarkerProps) {
   const { scrollEdgeEffects, ...rest } = props;
+  const hasScrollEdgeEffects =
+    hasExplicitScrollEdgeEffects(scrollEdgeEffects);
 
   return (
     <ScrollViewMarkerNativeComponent
@@ -11,6 +14,7 @@ export function ScrollViewMarker(props: ScrollViewMarkerProps) {
       topScrollEdgeEffect={scrollEdgeEffects?.top}
       rightScrollEdgeEffect={scrollEdgeEffects?.right}
       bottomScrollEdgeEffect={scrollEdgeEffects?.bottom}
+      hasScrollEdgeEffects={hasScrollEdgeEffects}
       {...rest}
     />
   );

--- a/src/components/helpers/scrollEdgeEffects.ts
+++ b/src/components/helpers/scrollEdgeEffects.ts
@@ -1,0 +1,20 @@
+import type { ScrollEdgeEffect } from '../shared/types';
+
+export type ScrollEdgeEffects = {
+  bottom?: ScrollEdgeEffect | undefined;
+  left?: ScrollEdgeEffect | undefined;
+  right?: ScrollEdgeEffect | undefined;
+  top?: ScrollEdgeEffect | undefined;
+};
+
+export function hasExplicitScrollEdgeEffects(
+  scrollEdgeEffects: ScrollEdgeEffects | undefined,
+): boolean {
+  return (
+    scrollEdgeEffects !== undefined &&
+    (scrollEdgeEffects.bottom !== undefined ||
+      scrollEdgeEffects.left !== undefined ||
+      scrollEdgeEffects.right !== undefined ||
+      scrollEdgeEffects.top !== undefined)
+  );
+}

--- a/src/components/tabs/screen/TabsScreen.ios.tsx
+++ b/src/components/tabs/screen/TabsScreen.ios.tsx
@@ -22,6 +22,7 @@ import type {
 import type { TabsScreenProps } from './TabsScreen.types';
 import type { PlatformIconIOS } from '../../../types';
 import { useTabsScreen } from './useTabsScreen';
+import { hasExplicitScrollEdgeEffects } from '../../helpers/scrollEdgeEffects';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -55,6 +56,8 @@ function TabsScreen(props: TabsScreenProps) {
     });
 
   const iconProps = parseIconsToNativeProps(ios?.icon, ios?.selectedIcon);
+  const scrollEdgeEffects = ios?.scrollEdgeEffects;
+  const hasScrollEdgeEffects = hasExplicitScrollEdgeEffects(scrollEdgeEffects);
 
   return (
     <TabsScreenIOSNativeComponent
@@ -73,6 +76,11 @@ function TabsScreen(props: TabsScreenProps) {
       scrollEdgeAppearance={mapAppearanceToNativeProp(
         ios?.scrollEdgeAppearance,
       )}
+      bottomScrollEdgeEffect={scrollEdgeEffects?.bottom}
+      leftScrollEdgeEffect={scrollEdgeEffects?.left}
+      rightScrollEdgeEffect={scrollEdgeEffects?.right}
+      topScrollEdgeEffect={scrollEdgeEffects?.top}
+      hasScrollEdgeEffects={hasScrollEdgeEffects}
       userInterfaceStyle={ios?.experimental_userInterfaceStyle}
       systemItem={ios?.systemItem}
       overrideScrollViewContentInsetAdjustmentBehavior={

--- a/src/components/tabs/screen/TabsScreen.ios.types.ts
+++ b/src/components/tabs/screen/TabsScreen.ios.types.ts
@@ -1,5 +1,9 @@
 import type { ColorValue, TextStyle } from 'react-native';
-import type { UserInterfaceStyle, BlurEffect } from '../../shared/types';
+import type {
+  UserInterfaceStyle,
+  BlurEffect,
+  ScrollEdgeEffect,
+} from '../../shared/types';
 import type { PlatformIconIOS } from '../../../types';
 
 export type TabsScreenBlurEffect = BlurEffect | 'systemDefault';
@@ -226,6 +230,26 @@ export interface TabsScreenPropsIOS {
    * @platform ios
    */
   scrollEdgeAppearance?: TabsScreenAppearanceIOS | undefined;
+  /**
+   * @summary Specifies scroll edge effects applied to the tab screen's content scroll view.
+   *
+   * The supported values correspond to the `UIScrollEdgeEffect`'s `style` and `isHidden` props.
+   *
+   * To disable iOS 26 bottom tab bar fade for a screen, use `{ bottom: 'hidden' }`.
+   *
+   * @see {@link https://developer.apple.com/documentation/uikit/uiscrolledgeeffect|UIScrollEdgeEffect}
+   *
+   * @platform ios
+   * @supported iOS 26 or higher
+   */
+  scrollEdgeEffects?:
+    | {
+        bottom?: ScrollEdgeEffect | undefined;
+        left?: ScrollEdgeEffect | undefined;
+        right?: ScrollEdgeEffect | undefined;
+        top?: ScrollEdgeEffect | undefined;
+      }
+    | undefined;
   /**
    * @summary Specifies the icon for the tab bar item.
    *

--- a/src/fabric/gamma/ScrollViewMarkerNativeComponent.ts
+++ b/src/fabric/gamma/ScrollViewMarkerNativeComponent.ts
@@ -10,6 +10,7 @@ interface NativeProps extends ViewProps {
   topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   bottomScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
+  hasScrollEdgeEffects?: CT.WithDefault<boolean, false>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSScrollViewMarker');

--- a/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsScreenIOSNativeComponent.ts
@@ -107,6 +107,8 @@ type SystemItem =
 
 type UserInterfaceStyle = 'unspecified' | 'light' | 'dark';
 
+type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
+
 // #endregion iOS-specific helpers
 
 export interface NativeProps extends ViewProps {
@@ -162,6 +164,11 @@ export interface NativeProps extends ViewProps {
     boolean,
     true
   >;
+  bottomScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
+  leftScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
+  rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
+  topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
+  hasScrollEdgeEffects?: CT.WithDefault<boolean, false>;
   // Experimental
   userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;
 }


### PR DESCRIPTION
## Description

Completes `TabsScreenPropsIOS.scrollEdgeEffects` support for native iOS tabs.

The public type already documents `ios.scrollEdgeEffects`, but the value was not passed to the Fabric native component or applied on iOS. This PR wires the prop through to native tabs and applies the configured `UIScrollEdgeEffect` values to the active content scroll view.

This enables use cases like hiding the iOS 26 bottom tab bar fade:

```tsx
<Tabs.Screen
  name="Home"
  ios={{
    scrollEdgeEffects: {
      bottom: 'hidden',
    },
  }}
/>
```

## Changes

- Pass `ios.scrollEdgeEffects` from `Tabs.Screen` to the iOS Fabric native component.
- Add per-edge Fabric props for native tabs.
- Convert tab scroll edge effect enum values on iOS.
- Apply effects through the existing `RNSScrollEdgeEffectApplicator`.
- Preserve innermost ownership semantics for nested `Tabs`, `Stack`, and `ScrollViewMarker` content.
- Add explicit ownership flags so `{ bottom: 'automatic' }` is treated as an explicit config, not as an omitted prop.
- Add container propagation so active scroll view changes reapply the correct owner's effects.
- Add Android no-op handling for iOS-only generated marker props.

## Before & after - visual documentation

### Before

On iOS 26, native tabs always use the default bottom scroll edge effect, so scrollable content can show the system fade behind the bottom tab bar.

### After

Using `ios.scrollEdgeEffects={{ bottom: 'hidden' }}` hides the bottom scroll edge effect for that tab screen.

<!-- Add iOS 26 before/after screenshots or recordings here. -->

## Test plan

Manual test example:

```tsx
<Tabs.Screen
  name="Feed"
  ios={{
    scrollEdgeEffects: {
      bottom: 'hidden',
    },
  }}>
  <ScrollView>
    {/* enough content to scroll behind the tab bar */}
  </ScrollView>
</Tabs.Screen>
```

Expected behavior on iOS 26: the bottom tab fade is hidden for this tab.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
