### PR TITLE
refactor(test): add scenario for test-stack-simple-nav

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
-import { StyleSheet, Text, View } from 'react-native';
 import {
   StackContainer,
-  useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
 import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 import { Colors } from '@apps/shared/styling';
 import { StackNavigationButtons } from '@apps/tests/shared/components/stack-v5/StackNavigationButtons';
+import { StackRouteInformation } from '@apps/tests/shared/components/stack-v5/StackRouteInformation';
 
 function TestStackSimpleNav() {
   return <StackSetup />;
@@ -56,7 +55,7 @@ function StackSetup() {
 function HomeScreen() {
   return (
     <CenteredLayoutView style={{ backgroundColor: Colors.BlueLight40 }}>
-      <RouteInformation routeName="Home" />
+      <StackRouteInformation routeName="Home" />
       <StackNavigationButtons isPopEnabled={false} routeNames={['A', 'B']} />
     </CenteredLayoutView>
   );
@@ -65,7 +64,7 @@ function HomeScreen() {
 function AScreen() {
   return (
     <CenteredLayoutView style={{ backgroundColor: Colors.YellowLight40 }}>
-      <RouteInformation routeName="A" />
+      <StackRouteInformation routeName="A" />
       <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />
     </CenteredLayoutView>
   );
@@ -74,29 +73,10 @@ function AScreen() {
 function BScreen() {
   return (
     <CenteredLayoutView style={{ backgroundColor: Colors.GreenLight100 }}>
-      <RouteInformation routeName="B" />
+      <StackRouteInformation routeName="B" />
       <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />
     </CenteredLayoutView>
   );
 }
-
-function RouteInformation(props: { routeName: string }) {
-  const routeKey = useStackNavigationContext().routeKey;
-
-  return (
-    <View>
-      <Text style={styles.routeInformation}>Name: {props.routeName}</Text>
-      <Text style={styles.routeInformation}>Key: {routeKey}</Text>
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  routeInformation: {
-    color: 'black',
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-});
 
 export default createScenario(TestStackSimpleNav, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
@@ -21,17 +21,32 @@ function StackSetup() {
         {
           name: 'Home',
           Component: HomeScreen,
-          options: {},
+          // Rendering a header (via headerConfig) makes the native back
+          // button appear on non-root screens, including on Android. The
+          // root screen (Home) always hides the back button.
+          options: {
+            headerConfig: {
+              title: 'Home',
+            },
+          },
         },
         {
           name: 'A',
           Component: AScreen,
-          options: {},
+          options: {
+            headerConfig: {
+              title: 'A',
+            },
+          },
         },
         {
           name: 'B',
           Component: BScreen,
-          options: {},
+          options: {
+            headerConfig: {
+              title: 'B',
+            },
+          },
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario-description.ts
@@ -1,7 +1,7 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Simple navigation scenario',
+  name: 'Simple stack navigation',
   key: 'test-stack-simple-nav',
   details: 'Test simple push and pop operations',
   platforms: ['android', 'ios'],

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -50,7 +50,7 @@ not yet implemented.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Simple navigation** screen (Stack
+1. Launch the app and navigate to the **Simple stack navigation** screen (Stack
    v5).
 
 - [ ] The **Home** screen is shown with a light blue background, `Name:

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -76,7 +76,7 @@ and are not yet implemented.
    the selection menu, Android directly via `App.tsx`) so the **Home**
    screen of the Simple stack navigation is shown.
 
-- [ ] The **Home** screen is shown with a light blue background, `Name:
+- [ ] The **Home** screen is shown with `Name:
   Home`, and a `Key`. No back button is visible in
   the header. No **Pop** button is shown, only **Push A** and **Push B**.
   Note the displayed `Key` value to compare against later steps.
@@ -101,7 +101,7 @@ and are not yet implemented.
 4. While on **B**, tap **Push A** again.
 
 - [ ] A new instance of screen **A** is pushed on top of the stack (stack
-  is now Home, A, B, A). `Name: A`, background light yellow, and a new
+  is now Home, A, B, A). `Name: A` and a new
   `Key` that is **different** from the `Key` shown in step 2.
 
 ### Pop via the on-screen button

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -134,7 +134,7 @@ header.
   returns to screen **A** with its `Key` unchanged. No crash and no
   inconsistent state.
 
-### Edge-swipe / system gesture-back 
+### Edge-swipe / system gesture-back
 
 9. While on screen **A** or **B**, swipe from the left screen edge
    to the right to trigger the interactive pop gesture.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -2,20 +2,16 @@
 
 ## Details
 
-**Description:** Verifies basic push and pop navigation on the gamma/v5
-`StackContainer`. The route stack starts with **Home** and can push **A**
-or **B** any number of times (including re-pushing a route that is already
-on the stack), each push creating a new screen instance with its own unique
-`routeKey` exposed via `useStackNavigationContext`. Non-root screens expose
-a **Pop** button that calls `navigation.pop(routeKey)` on themselves. The
-test validates that JS-driven push/pop via on-screen buttons produces
-consistent stack state on both platforms, that the iOS native header back
-button and interactive edge-swipe-back gesture behave the same as **Pop**,
-that `routeKey` values are unique per pushed instance (even for repeated
-pushes of the same route name), and that the root screen (**Home**) cannot
-be popped and shows no back button. On Android there is no header back
-button and the system/hardware back button does not currently pop the
-stack (see issue #1459), so back-button steps are iOS-only.
+**Description:** Verify basic push and pop navigation on the gamma/v5
+`StackContainer`. The stack starts with **Home** and can push **A** or **B**
+any number of times (including re-pushing a route already on the stack),
+each push creating a new screen instance with its own unique `routeKey`;
+non-root screens expose a **Pop** button. The test validates that push/pop
+via the on-screen buttons, the iOS native header back button, and the iOS
+edge-swipe-back gesture all produce consistent stack state, that `routeKey`
+values are unique per pushed instance, and that the root screen (**Home**)
+cannot be popped. See the Notes for `routeKey` behavior and the Android
+back-button caveat (issue #1459).
 
 **OS test creation version:** iOS 18.6 and 26.5, Android API Level 36.
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -1,0 +1,151 @@
+# Test Scenario: Simple navigation
+
+## Details
+
+**Description:** Verifies basic push and pop navigation on the gamma/v5
+`StackContainer`. The route stack starts with **Home** and can push **A**
+or **B** any number of times (including re-pushing a route that is already
+on the stack), each push creating a new screen instance with its own unique
+`routeKey` exposed via `useStackNavigationContext`. Non-root screens expose
+a **Pop** button that calls `navigation.pop(routeKey)` on themselves. The
+test validates that JS-driven push/pop via on-screen buttons produces
+consistent stack state on both platforms, that the iOS native header back
+button and interactive edge-swipe-back gesture behave the same as **Pop**,
+that `routeKey` values are unique per pushed instance (even for repeated
+pushes of the same route name), and that the root screen (**Home**) cannot
+be popped and shows no back button. On Android there is no header back
+button and the system/hardware back button does not currently pop the
+stack (see issue #1459), so back-button steps are iOS-only.
+
+**OS test creation version:** iOS 18.6 and 26.5, Android API Level 36.
+
+## E2E test
+
+TBD: Automation is planned and should be straightforward for the
+button-driven push/pop steps (similar in scope to the tabs
+`test-tabs-simple-nav` suite). Native back button, iOS edge-swipe gesture,
+and Android hardware back steps may need platform-specific handling and are
+not yet implemented.
+
+## Prerequisites
+
+- iOS device or simulator
+- Android emulator or device
+
+## Note
+
+- Each screen shows two labels: `Name` (the route name: `Home`, `A`, or
+  `B`) and `Key` (the route's unique `routeKey`). Use the `Key` value to
+  tell apart multiple stacked instances of the same route name.
+- The `Key` has the form `r-<routeName>-<n>`, where `<n>` comes from a
+  global counter that increments on every push and is **never reset** for
+  the lifetime of the app session (it is shared across all Stack
+  containers). Do **not** expect specific numbers such as `r-A-1`: the
+  exact suffix depends on how many screens were pushed earlier in the
+  session and will differ between runs and after a JS reload. Only the
+  **relationships** matter — every push produces a strictly new `Key`, and
+  a preserved (not recreated) screen keeps the same `Key`.
+- **Android:** the gamma Stack does not render a header back button, and
+  the Android system/hardware back button does not currently pop the stack
+  (see issue #1459). All back-button steps below are therefore **iOS
+  only**; on Android use the on-screen **Pop** button to go back.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Simple navigation** screen (Stack
+   v5).
+
+- [ ] The **Home** screen is shown with a light blue background, `Name:
+  Home`, and a `Key` of the form `r-Home-<n>`. No back button is visible in
+  the header. No **Pop** button is shown, only **Push A** and **Push B**.
+  Note the displayed `Key` value to compare against later steps.
+
+### Push navigation
+
+2. Tap **Push A**.
+
+- [ ] Screen **A** is pushed. Background is light yellow, `Name: A`, and a
+  `Key` of the form `r-A-<n>` is shown (a new value, distinct from Home's).
+  On iOS a native back button is visible in the header (Android shows no
+  header back button). **Push A**, **Push B**, and **Pop** buttons are all
+  shown. Note this `Key` value.
+
+3. While on **A**, tap **Push B**.
+
+- [ ] Screen **B** is pushed on top of **A**. Background is green, `Name:
+  B`, and a new `Key` of the form `r-B-<n>` is shown (distinct from all
+  previous keys). On iOS a native back button is visible in the header.
+  Note this `Key` value.
+
+### Re-pushing an already-present route
+
+4. While on **B**, tap **Push A** again.
+
+- [ ] A new instance of screen **A** is pushed on top of the stack (stack
+  is now Home, A, B, A). `Name: A`, background light yellow, and a new
+  `r-A-<n>` `Key` that is **different** from the `Key` shown in step 2.
+
+### Pop via the on-screen button
+
+5. Tap **Pop**.
+
+- [ ] Returns to screen **B**. `Name: B` and the **same** `Key` value
+  observed in step 3 (the instance was preserved, not recreated).
+
+6. Tap **Pop** again.
+
+- [ ] Returns to the original screen **A**. `Name: A` and the **same** `Key`
+  value observed in step 2.
+
+7. Tap **Pop** again.
+
+- [ ] Returns to **Home**. No **Pop** button is shown and, on iOS, no
+  header back button appears (root screen reached).
+
+### Native header back button (iOS only)
+
+8. On iOS, tap **Push A**, then tap **Push B**. Then tap the native back
+   button in the header (not the **Pop** button).
+
+- [ ] Tapping the native back button behaves the same as tapping **Pop**:
+  returns to screen **A** with its `Key` unchanged. No crash and no
+  inconsistent state.
+
+### iOS edge-swipe-back gesture (iOS only)
+
+9. On iOS, while on screen **A** or **B**, swipe from the left screen edge
+   to the right to trigger the interactive pop gesture.
+
+- [ ] Completing the swipe pops the current screen, identical in effect to
+  tapping **Pop**. The screen below is shown with its original,
+  unchanged `Key`.
+- [ ] Starting the swipe and releasing before the halfway point cancels
+  the gesture: the current screen returns to place and no navigation
+  change occurs.
+
+### Route key uniqueness (edge case)
+
+10. From **Home**, tap **Push A**. While on the newly pushed **A**, tap
+    **Push A** again. While on that new **A**, tap **Push A** once more,
+    without popping in between.
+
+- [ ] Three separate **A** instances are stacked. Each shows `Name: A`,
+  but the `Key` value is different every time you land on a new push.
+
+### Rapid tapping (edge case)
+
+11. From any screen, rapidly tap **Push A** several times in quick
+    succession, before each push transition finishes animating.
+
+- [ ] Each tap results in exactly one additional **A** screen being
+  pushed. No crash, no dropped pushes, and no duplicate `Key` values.
+
+12. From the deepest screen reached in step 11, rapidly tap **Pop**
+    several times in quick succession, before each pop transition
+    finishes animating.
+
+- [ ] The stack pops one screen per completed transition, eventually
+  stabilizing on **Home**. No crash occurs, and no attempt is made to pop
+  past the root screen.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -56,14 +56,10 @@ and are not yet implemented.
 - Each screen shows two labels: `Name` (the route name: `Home`, `A`, or
   `B`) and `Key` (the route's unique `routeKey`). Use the `Key` value to
   tell apart multiple stacked instances of the same route name.
-- The `Key` has the form `r-<routeName>-<n>`, where `<n>` comes from a
-  global counter that increments on every push and is **never reset** for
+- `Key` values use a session-global counterthat increments on every push and is **never reset** for
   the lifetime of the app session (it is shared across all Stack
-  containers). Do **not** expect specific numbers such as `r-A-1`: the
-  exact suffix depends on how many screens were pushed earlier in the
-  session and will differ between runs and after a JS reload. Only the
-  **relationships** matter — every push produces a strictly new `Key`, and
-  a preserved (not recreated) screen keeps the same `Key`.
+  containers). Only the **relationships** matter — every push produces a strictly
+  new `Key`, and a preserved (not recreated) screen keeps the same `Key`.
 - **Android:** when the screen is launched **directly** via `App.tsx` (see
   the Android launch prerequisite),both the **native header back button** and
   the **system gesture-back** work — the same as on iOS. These only fail when the screen
@@ -81,7 +77,7 @@ and are not yet implemented.
    screen of the Simple stack navigation is shown.
 
 - [ ] The **Home** screen is shown with a light blue background, `Name:
-  Home`, and a `Key` of the form `r-Home-<n>`. No back button is visible in
+  Home`, and a `Key`. No back button is visible in
   the header. No **Pop** button is shown, only **Push A** and **Push B**.
   Note the displayed `Key` value to compare against later steps.
 
@@ -90,14 +86,14 @@ and are not yet implemented.
 2. Tap **Push A**.
 
 - [ ] Screen **A** is pushed. Background is light yellow, `Name: A`, and a
-  `Key` of the form `r-A-<n>` is shown (a new value, distinct from Home's).
+  `Key` with a new value, distinct from Home's.
   A native back button is visible in the header. **Push A**, **Push B**, and **Pop**
   buttons are all shown. Note this `Key` value.
 
 3. While on **A**, tap **Push B**.
 
 - [ ] Screen **B** is pushed on top of **A**. Background is green, `Name:
-  B`, and a new `Key` of the form `r-B-<n>` is shown.
+  B`, and a new `Key`is shown.
   A native back button is visible in the header. Note this `Key` value.
 
 ### Re-pushing an already-present route
@@ -106,7 +102,7 @@ and are not yet implemented.
 
 - [ ] A new instance of screen **A** is pushed on top of the stack (stack
   is now Home, A, B, A). `Name: A`, background light yellow, and a new
-  `r-A-<n>` `Key` that is **different** from the `Key` shown in step 2.
+  `Key` that is **different** from the `Key` shown in step 2.
 
 ### Pop via the on-screen button
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -43,7 +43,7 @@ not yet implemented.
   a preserved (not recreated) screen keeps the same `Key`.
 - **Android:** the gamma Stack does not render a header back button, and
   the Android system/hardware back button does not currently pop the stack
-  (see issue #1459). All back-button steps below are therefore **iOS
+  (see issue [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)). All back-button steps below are therefore **iOS
   only**; on Android use the on-screen **Pop** button to go back.
 
 ## Steps

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/scenario.md
@@ -7,11 +7,12 @@
 any number of times (including re-pushing a route already on the stack),
 each push creating a new screen instance with its own unique `routeKey`;
 non-root screens expose a **Pop** button. The test validates that push/pop
-via the on-screen buttons, the iOS native header back button, and the iOS
-edge-swipe-back gesture all produce consistent stack state, that `routeKey`
-values are unique per pushed instance, and that the root screen (**Home**)
-cannot be popped. See the Notes for `routeKey` behavior and the Android
-back-button caveat (issue #1459).
+via the on-screen buttons, the native header back button, and the
+edge-swipe-back / system gesture-back produce
+consistent stack state, that `routeKey` values are unique per pushed
+instance, and that the root screen (**Home**) cannot be popped. See the
+Notes for `routeKey` behavior and how the two platforms are launched
+(issue #1459).
 
 **OS test creation version:** iOS 18.6 and 26.5, Android API Level 36.
 
@@ -20,13 +21,35 @@ back-button caveat (issue #1459).
 TBD: Automation is planned and should be straightforward for the
 button-driven push/pop steps (similar in scope to the tabs
 `test-tabs-simple-nav` suite). Native back button, iOS edge-swipe gesture,
-and Android hardware back steps may need platform-specific handling and are
-not yet implemented.
+and Android system gesture-back steps may need platform-specific handling
+and are not yet implemented.
 
 ## Prerequisites
 
 - iOS device or simulator
 - Android emulator or device
+
+### iOS launch
+
+- Run the app normally and navigate to the **Simple stack navigation**
+  screen (Stack v5) from the in-app scenario selection menu.
+
+### Android launch
+
+- To test on Android, run the screen **directly** by editing
+  [apps/App.tsx](../../../../../App.tsx): import and render
+  `TestStackSimpleNav` as the root component instead of `Example`, e.g.:
+
+  ```tsx
+  import { TestStackSimpleNav as Example } from './src/tests/single-feature-tests';
+  ```
+
+  With the gamma `StackContainer` at the root, the Android system
+  gesture-back pops the stack directly.
+
+- The Android system gesture-back requires **Gesture navigation** to be
+  enabled on the emulator/device. If it is not already set, enable it
+  manually in **Settings → Navigation mode → select Gesture navigation**.
 
 ## Note
 
@@ -41,17 +64,21 @@ not yet implemented.
   session and will differ between runs and after a JS reload. Only the
   **relationships** matter — every push produces a strictly new `Key`, and
   a preserved (not recreated) screen keeps the same `Key`.
-- **Android:** the gamma Stack does not render a header back button, and
-  the Android system/hardware back button does not currently pop the stack
-  (see issue [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)). All back-button steps below are therefore **iOS
-  only**; on Android use the on-screen **Pop** button to go back.
+- **Android:** when the screen is launched **directly** via `App.tsx` (see
+  the Android launch prerequisite),both the **native header back button** and
+  the **system gesture-back** work — the same as on iOS. These only fail when the screen
+  is nested inside the example app's own navigation (issue
+  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)),
+  which is exactly why Android is tested via the direct launch. On both
+  platforms the on-screen **Pop** button always works.
 
 ## Steps
 
 ### Baseline
 
-1. Launch the app and navigate to the **Simple stack navigation** screen (Stack
-   v5).
+1. Launch the app for the platform under test (see Prerequisites: iOS from
+   the selection menu, Android directly via `App.tsx`) so the **Home**
+   screen of the Simple stack navigation is shown.
 
 - [ ] The **Home** screen is shown with a light blue background, `Name:
   Home`, and a `Key` of the form `r-Home-<n>`. No back button is visible in
@@ -64,16 +91,14 @@ not yet implemented.
 
 - [ ] Screen **A** is pushed. Background is light yellow, `Name: A`, and a
   `Key` of the form `r-A-<n>` is shown (a new value, distinct from Home's).
-  On iOS a native back button is visible in the header (Android shows no
-  header back button). **Push A**, **Push B**, and **Pop** buttons are all
-  shown. Note this `Key` value.
+  A native back button is visible in the header. **Push A**, **Push B**, and **Pop**
+  buttons are all shown. Note this `Key` value.
 
 3. While on **A**, tap **Push B**.
 
 - [ ] Screen **B** is pushed on top of **A**. Background is green, `Name:
-  B`, and a new `Key` of the form `r-B-<n>` is shown (distinct from all
-  previous keys). On iOS a native back button is visible in the header.
-  Note this `Key` value.
+  B`, and a new `Key` of the form `r-B-<n>` is shown.
+  A native back button is visible in the header. Note this `Key` value.
 
 ### Re-pushing an already-present route
 
@@ -97,29 +122,29 @@ not yet implemented.
 
 7. Tap **Pop** again.
 
-- [ ] Returns to **Home**. No **Pop** button is shown and, on iOS, no
-  header back button appears (root screen reached).
+- [ ] Returns to **Home**. No **Pop** button is shown and no header back
+  button appears (root screen reached).
 
-### Native header back button (iOS only)
+### Native header back button
 
-8. On iOS, tap **Push A**, then tap **Push B**. Then tap the native back
-   button in the header (not the **Pop** button).
+8. Tap **Push A**, then tap **Push B**. Then tap the native back button in the
+header.
 
 - [ ] Tapping the native back button behaves the same as tapping **Pop**:
   returns to screen **A** with its `Key` unchanged. No crash and no
   inconsistent state.
 
-### iOS edge-swipe-back gesture (iOS only)
+### Edge-swipe / system gesture-back 
 
-9. On iOS, while on screen **A** or **B**, swipe from the left screen edge
+9. While on screen **A** or **B**, swipe from the left screen edge
    to the right to trigger the interactive pop gesture.
 
-- [ ] Completing the swipe pops the current screen, identical in effect to
-  tapping **Pop**. The screen below is shown with its original,
+- [ ] Completing the swipe/gesture pops the current screen, identical in
+  effect to tapping **Pop**. The screen below is shown with its original,
   unchanged `Key`.
-- [ ] Starting the swipe and releasing before the halfway point cancels
-  the gesture: the current screen returns to place and no navigation
-  change occurs.
+- [ ] Starting the swipe/gesture and releasing before the halfway point
+  cancels it: the current screen returns to place and no navigation change
+  occurs.
 
 ### Route key uniqueness (edge case)
 


### PR DESCRIPTION
## Description
Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1601

This PR adds a comprehensive manual test scenario for the gamma/v5 `StackContainer`'s simple push/pop navigation, and adjusts the `test-stack-simple-nav` screen so the scenario can be exercised on both platforms.

The scenario documents the full lifecycle from root (**Home**) through stacking/unstacking screens **A** and **B**, covering:
- push/pop via the on-screen buttons,
- the native header back button,
- the iOS edge-swipe-back / Android system gesture-back.

It validates that each push creates a new instance with a unique `routeKey`, that a preserved (not recreated) screen keeps its `routeKey` on pop, and that the root screen (**Home**) cannot be popped. Edge cases (re-pushing an already-present route, rapid tapping push/pop, route-key uniqueness) are included.

The scenario also documents the platform launch difference: iOS runs from the in-app scenario menu, while Android must be launched **directly** via `apps/App.tsx` (rendering `TestStackSimpleNav` as the root). This is the current workaround for the Android back-button limitation ([issue #1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)), where the native back button and system gesture-back only pop the stack when the `StackContainer` is at the root rather than nested inside the example app's navigation.

## Changes

- **Test screen (`index.tsx`)**: Added `headerConfig` with a `title` to the **Home**, **A**, and **B** routes. Rendering a header makes the native back button appear on non-root screens (including on Android), which is required to test the header-back-button and gesture-back flows.
- **Scenario metadata (`scenario-description.ts`)**: Renamed the scenario from `"Simple navigation scenario"` to `"Simple stack navigation"`.
- **Scenario (`scenario.md`)**: Added the manual scenario documenting all push/pop flows, native header-back-button and edge-swipe / system gesture-back interactions, `routeKey` behavior, per-platform launch instructions, and edge cases (re-pushing the same route, rapid tapping, root-screen protection). E2E automation is noted as TBD.
