### PR TITLE
fix(Android, Tabs): prevent crash on appearance change after remount when detached from window

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -399,7 +399,7 @@ class TabsContainer internal constructor(
     // region TabsScreenDelegate impl
 
     override fun onAppearanceChanged(tabsScreen: TabsScreen) {
-        if (selectedTab.tabsScreen === tabsScreen) {
+        if (isAttachedToWindow && selectedTab.tabsScreen === tabsScreen) {
             invalidationFlags.isNavigationMenuAppearanceInvalidated = true
             post {
                 this.flushPendingUpdates()

--- a/apps/src/tests/issue-tests/Test4258.tsx
+++ b/apps/src/tests/issue-tests/Test4258.tsx
@@ -116,18 +116,14 @@ function SecondTab() {
   );
 }
 
-function TabsScreen({
-  navigation,
-}: {
-  navigation: NativeStackNavigationProp<RouteParamList>;
-}) {
+function TabsScreen({ homeTab }: { homeTab: TabRouteConfig['Component'] }) {
   const { dark, generation } = React.useContext(AppStateContext);
   const bg = dark ? DarkColors.background : Colors.background;
 
   const routeConfigs: TabRouteConfig[] = [
     {
       name: 'Home',
-      Component: () => HomeTab({ navigation }),
+      Component: homeTab,
       options: {
         ...DEFAULT_TAB_ROUTE_OPTIONS,
         title: 'Home',
@@ -201,7 +197,8 @@ function CoverScreen() {
 }
 
 function MainScreen({ navigation }: StackNavigationProp) {
-  return <TabsScreen navigation={navigation} />;
+  const homeTab = () => <HomeTab navigation={navigation} />;
+  return <TabsScreen homeTab={homeTab} />;
 }
 
 export default function App() {

--- a/apps/src/tests/issue-tests/Test4258.tsx
+++ b/apps/src/tests/issue-tests/Test4258.tsx
@@ -18,6 +18,7 @@ import {
   type TabRouteConfig,
   useTabsNavigationContext,
 } from '@apps/shared/gamma/containers/tabs';
+import { Colors, DarkColors, Palette } from '@apps/shared/styling';
 
 type RouteParamList = {
   Tabs: undefined;
@@ -33,9 +34,6 @@ const Stack = createNativeStackNavigator<RouteParamList>();
 const AppStateContext = React.createContext({
   generation: 0,
   dark: false,
-  stackNavigation: undefined as
-    | NativeStackNavigationProp<RouteParamList>
-    | undefined,
   setGeneration: (_: number) => {},
   setDark: (_: boolean) => {},
 });
@@ -45,7 +43,7 @@ function useAppearanceSync() {
   const { routeKey, setRouteOptions } = useTabsNavigationContext();
 
   useEffect(() => {
-    const bg = dark ? '#111318' : '#ffffff';
+    const bg = dark ? DarkColors.background : Colors.background;
     setRouteOptions(routeKey, {
       android: {
         ...DEFAULT_TAB_ROUTE_OPTIONS.android,
@@ -63,10 +61,14 @@ function useAppearanceSync() {
   }, [dark, routeKey, setRouteOptions]);
 }
 
-function HomeTab() {
+function HomeTab({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<RouteParamList>;
+}) {
   useAppearanceSync();
 
-  const { generation, dark, setGeneration, setDark, stackNavigation } =
+  const { generation, dark, setGeneration, setDark } =
     React.useContext(AppStateContext);
 
   return (
@@ -99,7 +101,7 @@ function HomeTab() {
         />
         <Button
           title="Push cover screen"
-          onPress={() => stackNavigation?.navigate('Cover')}
+          onPress={() => navigation.navigate('Cover')}
         />
       </View>
     </ScrollView>
@@ -116,14 +118,18 @@ function SecondTab() {
   );
 }
 
-function TabsScreen() {
+function TabsScreen({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<RouteParamList>;
+}) {
   const { dark, generation } = React.useContext(AppStateContext);
-  const bg = dark ? '#111318' : '#ffffff';
+  const bg = dark ? DarkColors.background : Colors.background;
 
   const routeConfigs: TabRouteConfig[] = [
     {
       name: 'Home',
-      Component: HomeTab,
+      Component: () => HomeTab({ navigation }),
       options: {
         ...DEFAULT_TAB_ROUTE_OPTIONS,
         title: 'Home',
@@ -175,7 +181,7 @@ function TabsScreen() {
   );
 }
 
-function CoverScreen({ navigation }: StackNavigationProp) {
+function CoverScreen() {
   const { generation, dark, setGeneration, setDark } =
     React.useContext(AppStateContext);
 
@@ -193,22 +199,13 @@ function CoverScreen({ navigation }: StackNavigationProp) {
           title={`Toggle theme (current: ${dark ? 'dark' : 'light'})`}
           onPress={() => setDark(!dark)}
         />
-        <Button title="Go back" onPress={() => navigation.goBack()} />
       </View>
     </View>
   );
 }
 
 function MainScreen({ navigation }: StackNavigationProp) {
-  return (
-    <AppStateContext.Provider
-      value={{
-        ...React.useContext(AppStateContext),
-        stackNavigation: navigation,
-      }}>
-      <TabsScreen />
-    </AppStateContext.Provider>
-  );
+  return <TabsScreen navigation={navigation} />;
 }
 
 export default function App() {
@@ -220,7 +217,6 @@ export default function App() {
       value={{
         generation,
         dark,
-        stackNavigation: undefined,
         setGeneration,
         setDark,
       }}>
@@ -231,11 +227,7 @@ export default function App() {
             component={MainScreen}
             options={{ headerShown: false }}
           />
-          <Stack.Screen
-            name="Cover"
-            component={CoverScreen}
-            options={{ headerShown: false }}
-          />
+          <Stack.Screen name="Cover" component={CoverScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </AppStateContext.Provider>
@@ -267,7 +259,7 @@ const styles = StyleSheet.create({
   },
   step: {
     fontSize: 14,
-    color: '#555',
+    color: Palette.NavyLight60,
   },
   buttons: {
     marginTop: 24,

--- a/apps/src/tests/issue-tests/Test4258.tsx
+++ b/apps/src/tests/issue-tests/Test4258.tsx
@@ -78,9 +78,7 @@ function HomeTab({
         1. Press "Push cover screen" (tabs get detached underneath).
       </Text>
       <Text style={styles.step}>
-        2. On the cover screen press "Remount tabs while detached" (simulates
-        what expo-router does when the visible tab set changes — the new
-        TabsContainer never attaches, so its navState stays EMPTY).
+        2. On the cover screen press "Remount tabs while detached".
       </Text>
       <Text style={styles.step}>
         3. Press "Toggle theme" (changes standardAppearance
@@ -170,9 +168,7 @@ function TabsScreen({
   ];
 
   // `key` remounts TabsContainer, exactly like expo-router does when the set
-  // of visible tabs changes (its internal `key: visibleTabsKeys`). The old
-  // TabsContainer leaks (stays detached with EMPTY navState) but keeps
-  // receiving Fabric prop updates.
+  // of visible tabs changes (its internal `key: visibleTabsKeys`).
   return (
     <TabsContainer
       key={`generation-${generation}`}

--- a/apps/src/tests/issue-tests/Test4258.tsx
+++ b/apps/src/tests/issue-tests/Test4258.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import {
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  TabsContainer,
+  type TabRouteConfig,
+  useTabsNavigationContext,
+} from '@apps/shared/gamma/containers/tabs';
+
+type RouteParamList = {
+  Tabs: undefined;
+  Cover: undefined;
+};
+
+type StackNavigationProp = {
+  navigation: NativeStackNavigationProp<RouteParamList>;
+};
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+const AppStateContext = React.createContext({
+  generation: 0,
+  dark: false,
+  stackNavigation: undefined as
+    | NativeStackNavigationProp<RouteParamList>
+    | undefined,
+  setGeneration: (_: number) => {},
+  setDark: (_: boolean) => {},
+});
+
+function useAppearanceSync() {
+  const { dark } = React.useContext(AppStateContext);
+  const { routeKey, setRouteOptions } = useTabsNavigationContext();
+
+  useEffect(() => {
+    const bg = dark ? '#111318' : '#ffffff';
+    setRouteOptions(routeKey, {
+      android: {
+        ...DEFAULT_TAB_ROUTE_OPTIONS.android,
+        standardAppearance: {
+          tabBarBackgroundColor: bg,
+        },
+      },
+      ios: {
+        ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
+        standardAppearance: {
+          tabBarBackgroundColor: bg,
+        },
+      },
+    });
+  }, [dark, routeKey, setRouteOptions]);
+}
+
+function HomeTab() {
+  useAppearanceSync();
+
+  const { generation, dark, setGeneration, setDark, stackNavigation } =
+    React.useContext(AppStateContext);
+
+  return (
+    <ScrollView contentContainerStyle={styles.homeContent}>
+      <Text style={styles.title}>Tabs crash repro</Text>
+      <Text style={styles.step}>
+        1. Press "Push cover screen" (tabs get detached underneath).
+      </Text>
+      <Text style={styles.step}>
+        2. On the cover screen press "Remount tabs while detached" (simulates
+        what expo-router does when the visible tab set changes — the new
+        TabsContainer never attaches, so its navState stays EMPTY).
+      </Text>
+      <Text style={styles.step}>
+        3. Press "Toggle theme" (changes standardAppearance
+        tabBarBackgroundColor via setRouteOptions).
+      </Text>
+      <Text style={styles.step}>
+        4. Android throws: IllegalStateException "[RNScreens] No selected tab
+        present" (fatal crash in release builds).
+      </Text>
+      <View style={styles.buttons}>
+        <Button
+          title={`Remount tabs (generation: ${generation})`}
+          onPress={() => setGeneration(generation + 1)}
+        />
+        <Button
+          title={`Toggle theme (current: ${dark ? 'dark' : 'light'})`}
+          onPress={() => setDark(!dark)}
+        />
+        <Button
+          title="Push cover screen"
+          onPress={() => stackNavigation?.navigate('Cover')}
+        />
+      </View>
+    </ScrollView>
+  );
+}
+
+function SecondTab() {
+  useAppearanceSync();
+
+  return (
+    <View style={styles.tabContent}>
+      <Text>Second tab</Text>
+    </View>
+  );
+}
+
+function TabsScreen() {
+  const { dark, generation } = React.useContext(AppStateContext);
+  const bg = dark ? '#111318' : '#ffffff';
+
+  const routeConfigs: TabRouteConfig[] = [
+    {
+      name: 'Home',
+      Component: HomeTab,
+      options: {
+        ...DEFAULT_TAB_ROUTE_OPTIONS,
+        title: 'Home',
+        android: {
+          ...DEFAULT_TAB_ROUTE_OPTIONS.android,
+          standardAppearance: {
+            tabBarBackgroundColor: bg,
+          },
+        },
+        ios: {
+          ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
+          standardAppearance: {
+            tabBarBackgroundColor: bg,
+          },
+        },
+      },
+    },
+    {
+      name: 'Second',
+      Component: SecondTab,
+      options: {
+        ...DEFAULT_TAB_ROUTE_OPTIONS,
+        title: 'Second',
+        android: {
+          ...DEFAULT_TAB_ROUTE_OPTIONS.android,
+          standardAppearance: {
+            tabBarBackgroundColor: bg,
+          },
+        },
+        ios: {
+          ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
+          standardAppearance: {
+            tabBarBackgroundColor: bg,
+          },
+        },
+      },
+    },
+  ];
+
+  // `key` remounts TabsContainer, exactly like expo-router does when the set
+  // of visible tabs changes (its internal `key: visibleTabsKeys`). The old
+  // TabsContainer leaks (stays detached with EMPTY navState) but keeps
+  // receiving Fabric prop updates.
+  return (
+    <TabsContainer
+      key={`generation-${generation}`}
+      routeConfigs={routeConfigs}
+    />
+  );
+}
+
+function CoverScreen({ navigation }: StackNavigationProp) {
+  const { generation, dark, setGeneration, setDark } =
+    React.useContext(AppStateContext);
+
+  return (
+    <View style={styles.cover}>
+      <Text style={{ fontSize: 16, fontWeight: '600' }}>
+        Cover screen (tabs are detached underneath)
+      </Text>
+      <View style={styles.buttons}>
+        <Button
+          title={`Remount tabs while detached (generation: ${generation})`}
+          onPress={() => setGeneration(generation + 1)}
+        />
+        <Button
+          title={`Toggle theme (current: ${dark ? 'dark' : 'light'})`}
+          onPress={() => setDark(!dark)}
+        />
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+}
+
+function MainScreen({ navigation }: StackNavigationProp) {
+  return (
+    <AppStateContext.Provider
+      value={{
+        ...React.useContext(AppStateContext),
+        stackNavigation: navigation,
+      }}>
+      <TabsScreen />
+    </AppStateContext.Provider>
+  );
+}
+
+export default function App() {
+  const [generation, setGeneration] = useState(0);
+  const [dark, setDark] = useState(false);
+
+  return (
+    <AppStateContext.Provider
+      value={{
+        generation,
+        dark,
+        stackNavigation: undefined,
+        setGeneration,
+        setDark,
+      }}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Tabs"
+            component={MainScreen}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="Cover"
+            component={CoverScreen}
+            options={{ headerShown: false }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </AppStateContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  homeContent: {
+    padding: 24,
+    paddingTop: Platform.OS === 'android' ? 60 : 80,
+    gap: 8,
+  },
+  cover: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 24,
+  },
+  tabContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  step: {
+    fontSize: 14,
+    color: '#555',
+  },
+  buttons: {
+    marginTop: 24,
+    gap: 12,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -199,6 +199,7 @@ export { default as Test4155 } from './Test4155';
 export { default as Test4161 } from './Test4161';
 export { default as Test4220 } from './Test4220';
 export { default as Test4240 } from './Test4240';
+export { default as Test4258 } from './Test4258';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
## Description

Prevents a crash on appearance change when `TabsContainer` is remounted while detached from window.

Closes https://github.com/software-mansion/react-native-screens/issues/4258.

### Details

In Stack v4, when we push a new screen, previous screen is detached from window. If at that moment the `TabsContainer` on that previous screen is remounted (e.g. `expo-router` does so when available tabs change), new `TabsContainer` instance is created. As it isn't attached to window after initialization (because it's on the screen below top), the navigation state is not initialized. When appearance update arrives via prop, the app crashes because `selectedTab` asserts that we have non-empty navigation state. 

I considered following approaches:

1. Ensure non-empty navigation state even if tabs are detached - I decided against it as the initialization happens deep in update flow and the original assumption was that the updates are performed only when attached to window.
2. Add additional guard to `onAppearanceChange`
  - `tabsModel.isNotEmpty()` - this seemed to be a bit random for a method that handles appearance (different domain),
  - create `selectedTabOrNull` & rename `selectedTab` to `requireSelectedTab` - I thought about this but it seems to me that in most places we want to have a check and having 2 getters might introduce some problems later with incorrect usage,
  - add `isAttachedToWindow` check - I decided to go with this approach as it fits with the current condition in `TabsContainer.onAppearanceChange` - we want to handle appearance update via prop only if it applies to the currently visible tab -> adding a check for attachment to window seems to complete the condition.

I looked through other prop update flows and they seem to be okay but it's not as clear as I think it should be. We're planning to introduce invalidation flags per-tabs-screen. I think this will be a great opporunity to also look into the flow of updates and the attachment condition.

## Changes

- add `isAttachedToWindow` to condition in `TabsContainer.onAppearanceChanged`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/dc8f3bd9-1c11-4955-a045-72ed3f2cda54"> | <video src="https://github.com/user-attachments/assets/7471c4df-627f-4531-96d8-75a703c128ac"> |

## Test plan

Run `Test4258`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] Included screenshots / GIFs / recordings documenting the change.
- [ ] Ensured that CI passes
