### PR TITLE
fix(Android): prevent Fresco recycled bitmap crash in ImageLoader by copying the bitmap

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -59,7 +59,7 @@ private fun loadImageInternal(
                     val bitmap = closeableImage.underlyingBitmap
                     val drawable =
                         bitmap
-                            ?.copy(closeableImage.underlyingBitmap.config ?: Bitmap.Config.ARGB_8888, false)
+                            ?.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false)
                             ?.toDrawable(context.resources)
                     onLoaded(drawable)
                 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.gamma.helpers
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Handler
@@ -57,7 +58,8 @@ private fun loadImageInternal(
                 if (closeableImage is CloseableStaticBitmap) {
                     val bitmap = closeableImage.underlyingBitmap
                     if (bitmap != null) {
-                        val drawable = bitmap.toDrawable(context.resources)
+                        val safeBitmap = bitmap.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false) ?: bitmap
+                        val drawable = safeBitmap.toDrawable(context.resources)
                         onLoaded(drawable)
                     } else {
                         onLoaded(null)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -56,8 +56,9 @@ private fun loadImageInternal(
                 val closeableImage = imageReference.get()
 
                 if (closeableImage is CloseableStaticBitmap) {
+                    val bitmap = closeableImage.underlyingBitmap
                     val drawable =
-                        closeableImage.underlyingBitmap
+                        bitmap
                             ?.copy(closeableImage.underlyingBitmap.config ?: Bitmap.Config.ARGB_8888, false)
                             ?.toDrawable(context.resources)
                     onLoaded(drawable)

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ImageLoader.kt
@@ -56,14 +56,11 @@ private fun loadImageInternal(
                 val closeableImage = imageReference.get()
 
                 if (closeableImage is CloseableStaticBitmap) {
-                    val bitmap = closeableImage.underlyingBitmap
-                    if (bitmap != null) {
-                        val safeBitmap = bitmap.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false) ?: bitmap
-                        val drawable = safeBitmap.toDrawable(context.resources)
-                        onLoaded(drawable)
-                    } else {
-                        onLoaded(null)
-                    }
+                    val drawable =
+                        closeableImage.underlyingBitmap
+                            ?.copy(closeableImage.underlyingBitmap.config ?: Bitmap.Config.ARGB_8888, false)
+                            ?.toDrawable(context.resources)
+                    onLoaded(drawable)
                 }
 
                 imageReference.close()

--- a/apps/src/tests/issue-tests/Test4265.tsx
+++ b/apps/src/tests/issue-tests/Test4265.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {
+  Dimensions,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  TabsContainerWithHostConfigContext,
+  type TabRouteConfig,
+  DEFAULT_TAB_ROUTE_OPTIONS,
+} from '@apps/shared/gamma/containers/tabs';
+import { SafeAreaView } from 'react-native-screens/experimental';
+
+const TILE_SIZE = Math.floor((Dimensions.get('window').width - 24) / 2);
+
+function ImageGrid({ seed }: { seed: number }) {
+  const images = Array.from({ length: 30 }, (_, i) => ({
+    key: `${seed}-${i}`,
+    uri: `https://picsum.photos/seed/${seed * 100 + i}/400/400`,
+  }));
+
+  return (
+    <ScrollView contentContainerStyle={styles.grid}>
+      {images.map(img => (
+        <Image key={img.key} source={{ uri: img.uri }} style={styles.image} />
+      ))}
+    </ScrollView>
+  );
+}
+
+function HomeTab() {
+  return (
+    <View style={styles.screen}>
+      <SafeAreaView edges={{ top: true, bottom: true }}>
+        <Text style={styles.description}>
+          Recycled bitmap crash reproduction.{'\n\n'}
+          Tab icons are loaded via imageSource URLs (picsum.photos) which route
+          through ImageLoader.kt / Fresco on Android.{'\n\n'}
+          Scroll through the images below to fill Fresco's memory cache. Once
+          the cache evicts the small tab-icon bitmaps, the next tab bar redraw
+          crashes with "Canvas: trying to use a recycled bitmap".{'\n\n'}
+          Switch between tabs and scroll to accelerate eviction.
+        </Text>
+        <ImageGrid seed={1} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+function SearchTab() {
+  return (
+    <View style={styles.screen}>
+      <SafeAreaView edges={{ top: true, bottom: true }}>
+        <ImageGrid seed={2} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+function ProfileTab() {
+  return (
+    <View style={styles.screen}>
+      <SafeAreaView edges={{ top: true, bottom: true }}>
+        <ImageGrid seed={3} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'Home',
+    Component: HomeTab,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Home',
+      ios: {
+        icon: { type: 'sfSymbol', name: 'house' },
+        selectedIcon: { type: 'sfSymbol', name: 'house.fill' },
+      },
+      android: {
+        icon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon1/48/48' },
+        },
+        selectedIcon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon1s/48/48' },
+        },
+      },
+    },
+  },
+  {
+    name: 'Search',
+    Component: SearchTab,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Search',
+      ios: {
+        icon: { type: 'sfSymbol', name: 'magnifyingglass' },
+      },
+      android: {
+        icon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon2/48/48' },
+        },
+        selectedIcon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon2s/48/48' },
+        },
+      },
+    },
+  },
+  {
+    name: 'Profile',
+    Component: ProfileTab,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Profile',
+      ios: {
+        icon: { type: 'sfSymbol', name: 'person' },
+        selectedIcon: { type: 'sfSymbol', name: 'person.fill' },
+      },
+      android: {
+        icon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon3/48/48' },
+        },
+        selectedIcon: {
+          type: 'imageSource',
+          imageSource: { uri: 'https://picsum.photos/seed/icon3s/48/48' },
+        },
+      },
+    },
+  },
+];
+
+export default function Test0000() {
+  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  description: {
+    padding: 16,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 4,
+  },
+  image: {
+    width: TILE_SIZE,
+    height: TILE_SIZE,
+    margin: 4,
+    borderRadius: 8,
+    backgroundColor: '#e0e0e0',
+  },
+});

--- a/apps/src/tests/issue-tests/Test4265.tsx
+++ b/apps/src/tests/issue-tests/Test4265.tsx
@@ -138,7 +138,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
 ];
 
-export default function Test0000() {
+export default function App() {
   return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
 }
 

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -199,6 +199,7 @@ export { default as Test4155 } from './Test4155';
 export { default as Test4161 } from './Test4161';
 export { default as Test4220 } from './Test4220';
 export { default as Test4240 } from './Test4240';
+export { default as Test4265 } from './Test4265';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
## Description

Prevents Fresco recycled bitmap usage crash by copying the bitmap in `ImageLoader` before returning the drawable via `onLoaded`.

Thanks to @krsjoseph for reporting the issue and suggesting the fix!

Closes https://github.com/software-mansion/react-native-screens/issues/4265.

## Changes

- copy the bitmap before returning it via `onLoaded` in `ImageLoader.loadImageInternal`

## Visual documentation

### Before 

https://github.com/user-attachments/assets/777c836d-5c2b-45c7-aec7-5cff96895ae4

### After

https://github.com/user-attachments/assets/68a1451d-d618-4d55-949d-aaaa7b7083ad

## Test plan

Run `Test4265`. Run `test-stack-toolbar-menu-icon-android`, `test-tabs-item-icon`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] Included screenshots / GIFs / recordings documenting the change.
- [ ] Ensured that CI passes
