### PR TITLE
feat(Android, FormSheet v5): Add support for native container background color

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAppearanceCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAppearanceCoordinator.kt
@@ -17,7 +17,7 @@ internal class FormSheetAppearanceCoordinator(
     private var isCornerRadiusApplyPending = false
     private var isBackgroundColorApplyPending = false
 
-    // Needs to be caught to restore when the app switches back to `systemDefault`.
+    // Needs to be cached to restore when the app switches back to `systemDefault`.
     private var defaultShapeAppearanceModel: ShapeAppearanceModel? = null
     private var defaultBackgroundColor: android.content.res.ColorStateList? = null
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAppearanceCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetAppearanceCoordinator.kt
@@ -12,11 +12,14 @@ internal class FormSheetAppearanceCoordinator(
     private val bottomSheetView: FrameLayout?,
 ) {
     private var currentCornerRadius = FormSheetConfig.SYSTEM_DEFAULT_CORNER_RADIUS
+    private var currentBackgroundColor: Int? = null
 
     private var isCornerRadiusApplyPending = false
+    private var isBackgroundColorApplyPending = false
 
     // Needs to be caught to restore when the app switches back to `systemDefault`.
     private var defaultShapeAppearanceModel: ShapeAppearanceModel? = null
+    private var defaultBackgroundColor: android.content.res.ColorStateList? = null
 
     // Rounded-corner clipping of the sheet's content is only reliable on Android API 33+. Prior to API 33,
     // `Outline.canClip()` returns `false` for asymmetrical outlines, causing clipToOutline to be ignored
@@ -77,5 +80,39 @@ internal class FormSheetAppearanceCoordinator(
                 .setTopLeftCorner(CornerFamily.ROUNDED, radiusInPx)
                 .setTopRightCorner(CornerFamily.ROUNDED, radiusInPx)
                 .build()
+    }
+
+    internal fun updateBackgroundColor(color: Int?) {
+        currentBackgroundColor = color
+
+        val view = bottomSheetView ?: return
+
+        val background = view.background as? MaterialShapeDrawable
+        if (background != null) {
+            applyBackgroundColor(background)
+            return
+        }
+
+        if (isBackgroundColorApplyPending) return
+        isBackgroundColorApplyPending = true
+        view.doOnNextLayout {
+            isBackgroundColorApplyPending = false
+            (it.background as? MaterialShapeDrawable)?.let(::applyBackgroundColor)
+        }
+    }
+
+    private fun applyBackgroundColor(background: MaterialShapeDrawable) {
+        if (defaultBackgroundColor == null) {
+            defaultBackgroundColor = background.fillColor
+        }
+
+        val color = currentBackgroundColor
+        if (color == null) {
+            background.fillColor = defaultBackgroundColor
+        } else {
+            background.fillColor =
+                android.content.res.ColorStateList
+                    .valueOf(color)
+        }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetConfig.kt
@@ -6,6 +6,7 @@ internal data class FormSheetConfig(
     val prefersGrabberVisible: Boolean = false,
     val initialDetentIndex: Int = 0,
     val preferredCornerRadius: Float = SYSTEM_DEFAULT_CORNER_RADIUS,
+    val nativeContainerBackgroundColor: Int? = null,
 ) {
     companion object {
         const val SYSTEM_DEFAULT_CORNER_RADIUS = -1f

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetDialogManager.kt
@@ -99,6 +99,10 @@ class FormSheetDialogManager(
             appearanceCoordinator.updateCornerRadius(newConfig.preferredCornerRadius)
         }
 
+        if (oldConfig.nativeContainerBackgroundColor != newConfig.nativeContainerBackgroundColor) {
+            appearanceCoordinator.updateBackgroundColor(newConfig.nativeContainerBackgroundColor)
+        }
+
         if (oldConfig.isOpen != newConfig.isOpen) {
             presentationManager.updatePresentationState(newConfig.isOpen)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHost.kt
@@ -23,6 +23,8 @@ class FormSheetHost(
 
     internal var preferredCornerRadius = FormSheetConfig.SYSTEM_DEFAULT_CORNER_RADIUS
 
+    internal var nativeContainerBackgroundColor: Int? = null
+
     internal var detents: List<Double> = emptyList()
 
     internal var initialDetentIndex: Int = 0
@@ -92,6 +94,7 @@ class FormSheetHost(
                 prefersGrabberVisible = this.prefersGrabberVisible,
                 initialDetentIndex = this.initialDetentIndex,
                 preferredCornerRadius = this.preferredCornerRadius,
+                nativeContainerBackgroundColor = this.nativeContainerBackgroundColor,
             )
         dialogManager.applyConfig(config)
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/modals/formsheet/FormSheetHostViewManager.kt
@@ -121,7 +121,7 @@ class FormSheetHostViewManager :
         view: FormSheetHost,
         value: Int?,
     ) {
-        // TODO: @t0maboro - implement later
+        view.nativeContainerBackgroundColor = value
     }
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -10,7 +10,7 @@ import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
-import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style-ios';
+import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state';
@@ -27,7 +27,7 @@ export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabbe
 export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
 export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
 export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
-export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style-ios';
+export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
 export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';
 export { default as TestFormSheetPreferredCornerRadius } from './test-form-sheet-preferred-corner-radius';
 export { default as TestFormSheetPresentationState } from './test-form-sheet-presentation-state';

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/index.tsx
@@ -82,7 +82,6 @@ function TestFormSheetNativeContainerStyle() {
 
           <Button
             title={isExpanded ? 'Collapse Content' : 'Expand Content'}
-            color={Colors.White}
             onPress={() => setIsExpanded(!isExpanded)}
           />
 
@@ -100,7 +99,6 @@ function TestFormSheetNativeContainerStyle() {
 
           <Button
             title="Dismiss from JS"
-            color={Colors.White}
             onPress={handleDismiss}
           />
         </View>

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/index.tsx
@@ -6,6 +6,7 @@ import {
   View,
   TouchableOpacity,
   ColorValue,
+  Platform,
 } from 'react-native';
 import { FormSheet } from 'react-native-screens/experimental';
 import { scenarioDescription } from './scenario-description';
@@ -82,6 +83,7 @@ function TestFormSheetNativeContainerStyle() {
 
           <Button
             title={isExpanded ? 'Collapse Content' : 'Expand Content'}
+            color={Platform.OS === 'ios' ? Colors.White : undefined}
             onPress={() => setIsExpanded(!isExpanded)}
           />
 
@@ -99,6 +101,7 @@ function TestFormSheetNativeContainerStyle() {
 
           <Button
             title="Dismiss from JS"
+            color={Platform.OS === 'ios' ? Colors.White : undefined}
             onPress={handleDismiss}
           />
         </View>

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
@@ -5,7 +5,7 @@ export const scenarioDescription: ScenarioDescription = {
   key: 'test-form-sheet-native-container-style-ios',
   details:
     'Allows to test the native container style properties (backgroundColor) of the FormSheet.',
-  platforms: ['ios'],
+  platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
@@ -2,7 +2,7 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
   name: 'Native container style',
-  key: 'test-form-sheet-native-container-style-ios',
+  key: 'test-form-sheet-native-container-style',
   details:
     'Allows to test the native container style properties (backgroundColor) of the FormSheet.',
   platforms: ['android', 'ios'],

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the `nativeContainerStyle` functionality of the `FormSheet` component. This test ensures that styling properties applied to the native container (e.g. `backgroundColor`) correctly map to the underlying `UIView`, seamlessly filling the entire modal bounds including the bottom safe area.
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4
+**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
 
 ## E2E test
 
@@ -13,6 +13,7 @@ TBD: Planned, but will be implemented separately.
 ## Prerequisites
 
 - iOS device or simulator: iPhone with a Home Indicator (e.g., iPhone 13/14/15) to properly verify the bottom safe area coverage.
+- Android emulator
 
 ## Steps
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -139,8 +139,6 @@ export interface FormSheetProps {
    * @summary Style applied to the native container hosting the sheet content.
    *
    * These properties are forwarded directly to the underlying native view.
-   *
-   * @platform ios
    */
   nativeContainerStyle?: FormSheetNativeContainerStyleProps | undefined;
 

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -11,8 +11,6 @@ export interface FormSheetDetentChangedEvent {
 export type FormSheetNativeContainerStyleProps = {
   /**
    * @summary Specifies the background color of the native container hosting the sheet content.
-   *
-   * @platform ios
    */
   backgroundColor?: ColorValue | undefined;
 };

--- a/src/components/gamma/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/gamma/modals/form-sheet/FormSheet.types.ts
@@ -11,6 +11,8 @@ export interface FormSheetDetentChangedEvent {
 export type FormSheetNativeContainerStyleProps = {
   /**
    * @summary Specifies the background color of the native container hosting the sheet content.
+   *
+   * @platform android, ios
    */
   backgroundColor?: ColorValue | undefined;
 };
@@ -137,6 +139,8 @@ export interface FormSheetProps {
    * @summary Style applied to the native container hosting the sheet content.
    *
    * These properties are forwarded directly to the underlying native view.
+   *
+   * @platform android, ios
    */
   nativeContainerStyle?: FormSheetNativeContainerStyleProps | undefined;
 


### PR DESCRIPTION
## Description

This PR adds support for the `nativeContainerBackgroundColor` property passed via `nativeContainerStyle` on Android. This is useful for making a consistent background on the Material's container level, which is drawn behind navigation bars.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1557

## Changes

- Added a new `ConfigStep` in `FormSheetDialogManager`
- The custom color is applied to the bottom sheet's underlying MaterialShapeDrawable by modifying its fillColor via ColorStateList.

## Before & after - visual documentation

https://github.com/user-attachments/assets/6cb6aff3-8689-4dd1-9ca5-2695331fc631

https://github.com/user-attachments/assets/3b82a336-4ed1-4495-96e4-bf5271de2af5

## Test plan

Marked proper SFT as applicable on Android

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
