### PR TITLE
fix(Android, Tabs): handle platform color in tabs appearance props

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
@@ -26,11 +26,11 @@ internal fun ReadableMap.readOptionalFloat(key: String): Float? {
 }
 
 internal fun ReadableMap.readOptionalColor(
-    key: String,
     context: Context,
+    key: String,
 ): Int? {
     if (!hasKey(key) || isNull(key)) return null
-    return parseColor(key, context)
+    return parseColor(context, key)
 }
 
 // endregion
@@ -48,10 +48,10 @@ internal fun ReadableMap.readBoolean(
 ): Boolean = readOptionalBoolean(key) ?: default
 
 internal fun ReadableMap.readColor(
+    context: Context,
     key: String,
     default: Int?,
-    context: Context,
-): Int? = if (!hasKey(key) || isNull(key)) default else parseColor(key, context)
+): Int? = if (!hasKey(key) || isNull(key)) default else parseColor(context, key)
 
 internal fun ReadableMap.readImageUri(
     key: String,
@@ -79,8 +79,8 @@ internal fun ReadableMap.requireNotNullString(key: String): String =
 // region Parsing color
 
 internal fun ReadableMap.parseColor(
-    key: String,
     context: Context,
+    key: String,
 ): Int? =
     try {
         when (getType(key)) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/helpers/ReadableMapExt.kt
@@ -1,7 +1,8 @@
 package com.swmansion.rnscreens.gamma.helpers
 
+import android.content.Context
 import android.util.Log
-import androidx.core.graphics.toColorInt
+import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 
@@ -24,9 +25,12 @@ internal fun ReadableMap.readOptionalFloat(key: String): Float? {
     return if (getType(key) == ReadableType.Number) getDouble(key).toFloat() else null
 }
 
-internal fun ReadableMap.readOptionalColor(key: String): Int? {
+internal fun ReadableMap.readOptionalColor(
+    key: String,
+    context: Context,
+): Int? {
     if (!hasKey(key) || isNull(key)) return null
-    return parseColor(key)
+    return parseColor(key, context)
 }
 
 // endregion
@@ -46,7 +50,8 @@ internal fun ReadableMap.readBoolean(
 internal fun ReadableMap.readColor(
     key: String,
     default: Int?,
-): Int? = if (!hasKey(key) || isNull(key)) default else parseColor(key)
+    context: Context,
+): Int? = if (!hasKey(key) || isNull(key)) default else parseColor(key, context)
 
 internal fun ReadableMap.readImageUri(
     key: String,
@@ -71,13 +76,16 @@ internal fun ReadableMap.requireNotNullString(key: String): String =
 
 // endregion
 
-// region Building blocks
+// region Parsing color
 
-internal fun ReadableMap.parseColor(key: String): Int? =
+internal fun ReadableMap.parseColor(
+    key: String,
+    context: Context,
+): Int? =
     try {
         when (getType(key)) {
+            ReadableType.Map -> ColorPropConverter.getColor(getMap(key), context)
             ReadableType.Number -> getInt(key)
-            ReadableType.String -> getString(key)?.toColorInt()
             else -> null
         }
     } catch (e: Exception) {

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -227,7 +227,7 @@ internal open class StackHeaderConfigViewManager :
         view: StackHeaderConfig,
         value: Dynamic,
     ) {
-        val (menu, iconSources) = StackHeaderToolbarMenuMapper.parseMenu(value, view.context)
+        val (menu, iconSources) = StackHeaderToolbarMenuMapper.parseMenu(view.context, value)
         view.toolbarMenu = menu
         view.toolbarMenuItemIconSourceMap = iconSources
     }
@@ -240,7 +240,7 @@ internal open class StackHeaderConfigViewManager :
         val map = options.getMap(0) ?: return
         view.dispatchMenuElementUpdate(
             id,
-            StackHeaderToolbarMenuMapper.parseMenuElementOptions(map, view.context),
+            StackHeaderToolbarMenuMapper.parseMenuElementOptions(view.context, map),
             StackHeaderToolbarMenuMapper.parseMenuElementIconSource(map),
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,6 +1,5 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
-import android.content.Context
 import android.view.View
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens.gamma.stack.header.config
 
+import android.content.Context
 import android.view.View
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
@@ -227,7 +228,7 @@ internal open class StackHeaderConfigViewManager :
         view: StackHeaderConfig,
         value: Dynamic,
     ) {
-        val (menu, iconSources) = StackHeaderToolbarMenuMapper.parseMenu(value)
+        val (menu, iconSources) = StackHeaderToolbarMenuMapper.parseMenu(value, view.context)
         view.toolbarMenu = menu
         view.toolbarMenuItemIconSourceMap = iconSources
     }
@@ -240,7 +241,7 @@ internal open class StackHeaderConfigViewManager :
         val map = options.getMap(0) ?: return
         view.dispatchMenuElementUpdate(
             id,
-            StackHeaderToolbarMenuMapper.parseMenuElementOptions(map),
+            StackHeaderToolbarMenuMapper.parseMenuElementOptions(map, view.context),
             StackHeaderToolbarMenuMapper.parseMenuElementIconSource(map),
         )
     }

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -16,8 +16,8 @@ internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
     fun parseMenu(
-        value: Dynamic,
         context: Context,
+        value: Dynamic,
     ): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
         if (value.isNull) return Pair(StackHeaderToolbarMenuConfig(emptyList(), emptyList()), emptyMap())
         val map =
@@ -26,7 +26,7 @@ internal object StackHeaderToolbarMenuMapper {
                     "[RNScreens] toolbarMenu must be an object.",
                 )
         val iconSources = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
-        val config = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources, context))
+        val config = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(context, map, iconSources))
         return Pair(config, iconSources)
     }
 
@@ -35,8 +35,8 @@ internal object StackHeaderToolbarMenuMapper {
     // region Menu element command parsing
 
     fun parseMenuElementOptions(
-        map: ReadableMap,
         context: Context,
+        map: ReadableMap,
     ): StackHeaderToolbarMenuElementOptions =
         StackHeaderToolbarMenuElementOptions(
             title = map.readNullableStringUpdate("title"),
@@ -50,10 +50,10 @@ internal object StackHeaderToolbarMenuMapper {
                     StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                 ),
             icon = null,
-            iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal", context),
-            iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed", context),
-            iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused", context),
-            iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled", context),
+            iconTintColorNormal = map.readNullableColorUpdate(context, "iconTintColorNormal"),
+            iconTintColorPressed = map.readNullableColorUpdate(context, "iconTintColorPressed"),
+            iconTintColorFocused = map.readNullableColorUpdate(context, "iconTintColorFocused"),
+            iconTintColorDisabled = map.readNullableColorUpdate(context, "iconTintColorDisabled"),
             checked =
                 map.readNullableBooleanUpdate(
                     "checked",
@@ -95,9 +95,9 @@ internal object StackHeaderToolbarMenuMapper {
     }
 
     private fun parseChildren(
+        context: Context,
         map: ReadableMap,
         iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
-        context: Context,
     ): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
         return (0 until array.size()).map { i ->
@@ -105,23 +105,23 @@ internal object StackHeaderToolbarMenuMapper {
                 requireNotNull(array.getMap(i)) {
                     "[RNScreens] Menu children array must contain valid menu element specification objects."
                 }
-            parseElement(child, iconSources, context)
+            parseElement(context, child, iconSources)
         }
     }
 
     private fun parseElement(
+        context: Context,
         map: ReadableMap,
         iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
-        context: Context,
     ): StackHeaderToolbarMenuElementConfig {
-        val item = parseItemConfig(map, context)
+        val item = parseItemConfig(context, map)
         iconSources[item.id] = parseItemIconSource(map)
         return when (val type = map.readOptionalString("type")) {
             "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = item)
             "menu" ->
                 StackHeaderToolbarMenuElementConfig.Submenu(
                     item = item,
-                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources, context)),
+                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(context, map, iconSources)),
                     menuTitle = map.readOptionalString("menuTitle"),
                 )
 
@@ -142,8 +142,8 @@ internal object StackHeaderToolbarMenuMapper {
         )
 
     private fun parseItemConfig(
-        map: ReadableMap,
         context: Context,
+        map: ReadableMap,
     ): StackHeaderToolbarMenuItemConfig =
         StackHeaderToolbarMenuItemConfig(
             id = map.requireNotNullString("id"),
@@ -158,27 +158,27 @@ internal object StackHeaderToolbarMenuMapper {
             icon = null,
             iconTintColorNormal =
                 map.readColor(
+                    context,
                     "iconTintColorNormal",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
-                    context,
                 ),
             iconTintColorPressed =
                 map.readColor(
+                    context,
                     "iconTintColorPressed",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
-                    context,
                 ),
             iconTintColorFocused =
                 map.readColor(
+                    context,
                     "iconTintColorFocused",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
-                    context,
                 ),
             iconTintColorDisabled =
                 map.readColor(
+                    context,
                     "iconTintColorDisabled",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
-                    context,
                 ),
             groupId = map.readOptionalString("groupId"),
             itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
@@ -277,13 +277,13 @@ internal object StackHeaderToolbarMenuMapper {
         }
 
     private fun ReadableMap.readNullableColorUpdate(
-        key: String,
         context: Context,
+        key: String,
     ): StackHeaderToolbarUpdate<Int>? =
         when {
             !this.hasKey(key) -> null
             this.isNull(key) -> StackHeaderToolbarUpdate.Reset
-            else -> StackHeaderToolbarUpdate.from(parseColor(key, context))
+            else -> StackHeaderToolbarUpdate.from(parseColor(context, key))
         }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -15,7 +15,10 @@ import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
-    fun parseMenu(value: Dynamic, context: Context): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
+    fun parseMenu(
+        value: Dynamic,
+        context: Context,
+    ): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
         if (value.isNull) return Pair(StackHeaderToolbarMenuConfig(emptyList(), emptyList()), emptyMap())
         val map =
             value.asMapOrNull()
@@ -31,7 +34,10 @@ internal object StackHeaderToolbarMenuMapper {
 
     // region Menu element command parsing
 
-    fun parseMenuElementOptions(map: ReadableMap, context: Context): StackHeaderToolbarMenuElementOptions =
+    fun parseMenuElementOptions(
+        map: ReadableMap,
+        context: Context,
+    ): StackHeaderToolbarMenuElementOptions =
         StackHeaderToolbarMenuElementOptions(
             title = map.readNullableStringUpdate("title"),
             titleCondensed = map.readNullableStringUpdate("titleCondensed"),
@@ -91,7 +97,7 @@ internal object StackHeaderToolbarMenuMapper {
     private fun parseChildren(
         map: ReadableMap,
         iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
-        context: Context
+        context: Context,
     ): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
         return (0 until array.size()).map { i ->
@@ -135,7 +141,10 @@ internal object StackHeaderToolbarMenuMapper {
                 map.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
         )
 
-    private fun parseItemConfig(map: ReadableMap, context: Context): StackHeaderToolbarMenuItemConfig =
+    private fun parseItemConfig(
+        map: ReadableMap,
+        context: Context,
+    ): StackHeaderToolbarMenuItemConfig =
         StackHeaderToolbarMenuItemConfig(
             id = map.requireNotNullString("id"),
             title = map.readOptionalString("title") ?: StackHeaderToolbarMenuItemDefaults.TITLE,
@@ -151,25 +160,25 @@ internal object StackHeaderToolbarMenuMapper {
                 map.readColor(
                     "iconTintColorNormal",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
-                    context
+                    context,
                 ),
             iconTintColorPressed =
                 map.readColor(
                     "iconTintColorPressed",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
-                    context
+                    context,
                 ),
             iconTintColorFocused =
                 map.readColor(
                     "iconTintColorFocused",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
-                    context
+                    context,
                 ),
             iconTintColorDisabled =
                 map.readColor(
                     "iconTintColorDisabled",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
-                    context
+                    context,
                 ),
             groupId = map.readOptionalString("groupId"),
             itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
@@ -267,7 +276,10 @@ internal object StackHeaderToolbarMenuMapper {
                 } ?: default
         }
 
-    private fun ReadableMap.readNullableColorUpdate(key: String, context: Context): StackHeaderToolbarUpdate<Int>? =
+    private fun ReadableMap.readNullableColorUpdate(
+        key: String,
+        context: Context,
+    ): StackHeaderToolbarUpdate<Int>? =
         when {
             !this.hasKey(key) -> null
             this.isNull(key) -> StackHeaderToolbarUpdate.Reset

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/stack/header/toolbar/StackHeaderToolbarMenuMapper.kt
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens.gamma.stack.header.toolbar
 
+import android.content.Context
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableMap
@@ -14,7 +15,7 @@ import com.swmansion.rnscreens.gamma.helpers.requireNotNullString
 internal object StackHeaderToolbarMenuMapper {
     // region Menu prop parsing
 
-    fun parseMenu(value: Dynamic): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
+    fun parseMenu(value: Dynamic, context: Context): Pair<StackHeaderToolbarMenuConfig, Map<String, StackHeaderToolbarMenuItemIconSource>> {
         if (value.isNull) return Pair(StackHeaderToolbarMenuConfig(emptyList(), emptyList()), emptyMap())
         val map =
             value.asMapOrNull()
@@ -22,7 +23,7 @@ internal object StackHeaderToolbarMenuMapper {
                     "[RNScreens] toolbarMenu must be an object.",
                 )
         val iconSources = mutableMapOf<String, StackHeaderToolbarMenuItemIconSource>()
-        val config = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources))
+        val config = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources, context))
         return Pair(config, iconSources)
     }
 
@@ -30,7 +31,7 @@ internal object StackHeaderToolbarMenuMapper {
 
     // region Menu element command parsing
 
-    fun parseMenuElementOptions(map: ReadableMap): StackHeaderToolbarMenuElementOptions =
+    fun parseMenuElementOptions(map: ReadableMap, context: Context): StackHeaderToolbarMenuElementOptions =
         StackHeaderToolbarMenuElementOptions(
             title = map.readNullableStringUpdate("title"),
             titleCondensed = map.readNullableStringUpdate("titleCondensed"),
@@ -43,10 +44,10 @@ internal object StackHeaderToolbarMenuMapper {
                     StackHeaderToolbarMenuItemDefaults.SHOW_AS_ACTION,
                 ),
             icon = null,
-            iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal"),
-            iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed"),
-            iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused"),
-            iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled"),
+            iconTintColorNormal = map.readNullableColorUpdate("iconTintColorNormal", context),
+            iconTintColorPressed = map.readNullableColorUpdate("iconTintColorPressed", context),
+            iconTintColorFocused = map.readNullableColorUpdate("iconTintColorFocused", context),
+            iconTintColorDisabled = map.readNullableColorUpdate("iconTintColorDisabled", context),
             checked =
                 map.readNullableBooleanUpdate(
                     "checked",
@@ -90,6 +91,7 @@ internal object StackHeaderToolbarMenuMapper {
     private fun parseChildren(
         map: ReadableMap,
         iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
+        context: Context
     ): List<StackHeaderToolbarMenuElementConfig> {
         val array = map.getArray("children") ?: return emptyList()
         return (0 until array.size()).map { i ->
@@ -97,22 +99,23 @@ internal object StackHeaderToolbarMenuMapper {
                 requireNotNull(array.getMap(i)) {
                     "[RNScreens] Menu children array must contain valid menu element specification objects."
                 }
-            parseElement(child, iconSources)
+            parseElement(child, iconSources, context)
         }
     }
 
     private fun parseElement(
         map: ReadableMap,
         iconSources: MutableMap<String, StackHeaderToolbarMenuItemIconSource>,
+        context: Context,
     ): StackHeaderToolbarMenuElementConfig {
-        val item = parseItemConfig(map)
+        val item = parseItemConfig(map, context)
         iconSources[item.id] = parseItemIconSource(map)
         return when (val type = map.readOptionalString("type")) {
             "menuItem" -> StackHeaderToolbarMenuElementConfig.MenuItem(item = item)
             "menu" ->
                 StackHeaderToolbarMenuElementConfig.Submenu(
                     item = item,
-                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources)),
+                    menu = StackHeaderToolbarMenuConfig(parseGroups(map), parseChildren(map, iconSources, context)),
                     menuTitle = map.readOptionalString("menuTitle"),
                 )
 
@@ -132,7 +135,7 @@ internal object StackHeaderToolbarMenuMapper {
                 map.readImageUri("imageIconResource", StackHeaderToolbarMenuItemDefaults.IMAGE_ICON_URI),
         )
 
-    private fun parseItemConfig(map: ReadableMap): StackHeaderToolbarMenuItemConfig =
+    private fun parseItemConfig(map: ReadableMap, context: Context): StackHeaderToolbarMenuItemConfig =
         StackHeaderToolbarMenuItemConfig(
             id = map.requireNotNullString("id"),
             title = map.readOptionalString("title") ?: StackHeaderToolbarMenuItemDefaults.TITLE,
@@ -148,21 +151,25 @@ internal object StackHeaderToolbarMenuMapper {
                 map.readColor(
                     "iconTintColorNormal",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_NORMAL,
+                    context
                 ),
             iconTintColorPressed =
                 map.readColor(
                     "iconTintColorPressed",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_PRESSED,
+                    context
                 ),
             iconTintColorFocused =
                 map.readColor(
                     "iconTintColorFocused",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_FOCUSED,
+                    context
                 ),
             iconTintColorDisabled =
                 map.readColor(
                     "iconTintColorDisabled",
                     StackHeaderToolbarMenuItemDefaults.ICON_TINT_COLOR_DISABLED,
+                    context
                 ),
             groupId = map.readOptionalString("groupId"),
             itemType = map.readItemTypeEnum("itemType", StackHeaderToolbarMenuItemDefaults.ITEM_TYPE),
@@ -260,11 +267,11 @@ internal object StackHeaderToolbarMenuMapper {
                 } ?: default
         }
 
-    private fun ReadableMap.readNullableColorUpdate(key: String): StackHeaderToolbarUpdate<Int>? =
+    private fun ReadableMap.readNullableColorUpdate(key: String, context: Context): StackHeaderToolbarUpdate<Int>? =
         when {
             !this.hasKey(key) -> null
             this.isNull(key) -> StackHeaderToolbarUpdate.Reset
-            else -> StackHeaderToolbarUpdate.from(parseColor(key))
+            else -> StackHeaderToolbarUpdate.from(parseColor(key, context))
         }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -171,7 +171,10 @@ class TabsScreenViewManager :
         view.appearance = parseAndroidTabsAppearance(value, view.context)
     }
 
-    private fun parseAndroidTabsAppearance(appearance: ReadableMap, context: Context): TabsAppearance =
+    private fun parseAndroidTabsAppearance(
+        appearance: ReadableMap,
+        context: Context,
+    ): TabsAppearance =
         TabsAppearance(
             tabBarBackgroundColor = appearance.readOptionalColor("tabBarBackgroundColor", context),
             tabBarItemRippleColor = appearance.readOptionalColor("tabBarItemRippleColor", context),
@@ -191,7 +194,10 @@ class TabsScreenViewManager :
             tabBarItemBadgeTextColor = appearance.readOptionalColor("tabBarItemBadgeTextColor", context),
         )
 
-    private fun parseItemStateAppearance(itemStateAppearance: ReadableMap?, context: Context): ItemStateAppearance? {
+    private fun parseItemStateAppearance(
+        itemStateAppearance: ReadableMap?,
+        context: Context,
+    ): ItemStateAppearance? {
         if (itemStateAppearance == null) return null
         return ItemStateAppearance(
             tabBarItemIconColor = itemStateAppearance.readOptionalColor("tabBarItemIconColor", context),

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens.gamma.tabs.screen
 
+import android.content.Context
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
@@ -167,34 +168,34 @@ class TabsScreenViewManager :
             return
         }
 
-        view.appearance = parseAndroidTabsAppearance(value)
+        view.appearance = parseAndroidTabsAppearance(value, view.context)
     }
 
-    private fun parseAndroidTabsAppearance(appearance: ReadableMap): TabsAppearance =
+    private fun parseAndroidTabsAppearance(appearance: ReadableMap, context: Context): TabsAppearance =
         TabsAppearance(
-            tabBarBackgroundColor = appearance.readOptionalColor("tabBarBackgroundColor"),
-            tabBarItemRippleColor = appearance.readOptionalColor("tabBarItemRippleColor"),
+            tabBarBackgroundColor = appearance.readOptionalColor("tabBarBackgroundColor", context),
+            tabBarItemRippleColor = appearance.readOptionalColor("tabBarItemRippleColor", context),
             tabBarItemLabelVisibilityMode = appearance.readOptionalString("tabBarItemLabelVisibilityMode"),
-            normal = if (appearance.hasKey("normal")) parseItemStateAppearance(appearance.getMap("normal")) else null,
-            selected = if (appearance.hasKey("selected")) parseItemStateAppearance(appearance.getMap("selected")) else null,
-            focused = if (appearance.hasKey("focused")) parseItemStateAppearance(appearance.getMap("focused")) else null,
-            disabled = if (appearance.hasKey("disabled")) parseItemStateAppearance(appearance.getMap("disabled")) else null,
-            tabBarItemActiveIndicatorColor = appearance.readOptionalColor("tabBarItemActiveIndicatorColor"),
+            normal = if (appearance.hasKey("normal")) parseItemStateAppearance(appearance.getMap("normal"), context) else null,
+            selected = if (appearance.hasKey("selected")) parseItemStateAppearance(appearance.getMap("selected"), context) else null,
+            focused = if (appearance.hasKey("focused")) parseItemStateAppearance(appearance.getMap("focused"), context) else null,
+            disabled = if (appearance.hasKey("disabled")) parseItemStateAppearance(appearance.getMap("disabled"), context) else null,
+            tabBarItemActiveIndicatorColor = appearance.readOptionalColor("tabBarItemActiveIndicatorColor", context),
             tabBarItemActiveIndicatorEnabled = appearance.readOptionalBoolean("tabBarItemActiveIndicatorEnabled"),
             tabBarItemTitleFontFamily = appearance.readOptionalString("tabBarItemTitleFontFamily"),
             tabBarItemTitleSmallLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleSmallLabelFontSize"),
             tabBarItemTitleLargeLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleLargeLabelFontSize"),
             tabBarItemTitleFontWeight = appearance.readOptionalString("tabBarItemTitleFontWeight"),
             tabBarItemTitleFontStyle = appearance.readOptionalString("tabBarItemTitleFontStyle"),
-            tabBarItemBadgeBackgroundColor = appearance.readOptionalColor("tabBarItemBadgeBackgroundColor"),
-            tabBarItemBadgeTextColor = appearance.readOptionalColor("tabBarItemBadgeTextColor"),
+            tabBarItemBadgeBackgroundColor = appearance.readOptionalColor("tabBarItemBadgeBackgroundColor", context),
+            tabBarItemBadgeTextColor = appearance.readOptionalColor("tabBarItemBadgeTextColor", context),
         )
 
-    private fun parseItemStateAppearance(itemStateAppearance: ReadableMap?): ItemStateAppearance? {
+    private fun parseItemStateAppearance(itemStateAppearance: ReadableMap?, context: Context): ItemStateAppearance? {
         if (itemStateAppearance == null) return null
         return ItemStateAppearance(
-            tabBarItemIconColor = itemStateAppearance.readOptionalColor("tabBarItemIconColor"),
-            tabBarItemTitleFontColor = itemStateAppearance.readOptionalColor("tabBarItemTitleFontColor"),
+            tabBarItemIconColor = itemStateAppearance.readOptionalColor("tabBarItemIconColor", context),
+            tabBarItemTitleFontColor = itemStateAppearance.readOptionalColor("tabBarItemTitleFontColor", context),
         )
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/screen/TabsScreenViewManager.kt
@@ -168,40 +168,40 @@ class TabsScreenViewManager :
             return
         }
 
-        view.appearance = parseAndroidTabsAppearance(value, view.context)
+        view.appearance = parseAndroidTabsAppearance(view.context, value)
     }
 
     private fun parseAndroidTabsAppearance(
-        appearance: ReadableMap,
         context: Context,
+        appearance: ReadableMap,
     ): TabsAppearance =
         TabsAppearance(
-            tabBarBackgroundColor = appearance.readOptionalColor("tabBarBackgroundColor", context),
-            tabBarItemRippleColor = appearance.readOptionalColor("tabBarItemRippleColor", context),
+            tabBarBackgroundColor = appearance.readOptionalColor(context, "tabBarBackgroundColor"),
+            tabBarItemRippleColor = appearance.readOptionalColor(context, "tabBarItemRippleColor"),
             tabBarItemLabelVisibilityMode = appearance.readOptionalString("tabBarItemLabelVisibilityMode"),
-            normal = if (appearance.hasKey("normal")) parseItemStateAppearance(appearance.getMap("normal"), context) else null,
-            selected = if (appearance.hasKey("selected")) parseItemStateAppearance(appearance.getMap("selected"), context) else null,
-            focused = if (appearance.hasKey("focused")) parseItemStateAppearance(appearance.getMap("focused"), context) else null,
-            disabled = if (appearance.hasKey("disabled")) parseItemStateAppearance(appearance.getMap("disabled"), context) else null,
-            tabBarItemActiveIndicatorColor = appearance.readOptionalColor("tabBarItemActiveIndicatorColor", context),
+            normal = if (appearance.hasKey("normal")) parseItemStateAppearance(context, appearance.getMap("normal")) else null,
+            selected = if (appearance.hasKey("selected")) parseItemStateAppearance(context, appearance.getMap("selected")) else null,
+            focused = if (appearance.hasKey("focused")) parseItemStateAppearance(context, appearance.getMap("focused")) else null,
+            disabled = if (appearance.hasKey("disabled")) parseItemStateAppearance(context, appearance.getMap("disabled")) else null,
+            tabBarItemActiveIndicatorColor = appearance.readOptionalColor(context, "tabBarItemActiveIndicatorColor"),
             tabBarItemActiveIndicatorEnabled = appearance.readOptionalBoolean("tabBarItemActiveIndicatorEnabled"),
             tabBarItemTitleFontFamily = appearance.readOptionalString("tabBarItemTitleFontFamily"),
             tabBarItemTitleSmallLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleSmallLabelFontSize"),
             tabBarItemTitleLargeLabelFontSize = appearance.readOptionalFloat("tabBarItemTitleLargeLabelFontSize"),
             tabBarItemTitleFontWeight = appearance.readOptionalString("tabBarItemTitleFontWeight"),
             tabBarItemTitleFontStyle = appearance.readOptionalString("tabBarItemTitleFontStyle"),
-            tabBarItemBadgeBackgroundColor = appearance.readOptionalColor("tabBarItemBadgeBackgroundColor", context),
-            tabBarItemBadgeTextColor = appearance.readOptionalColor("tabBarItemBadgeTextColor", context),
+            tabBarItemBadgeBackgroundColor = appearance.readOptionalColor(context, "tabBarItemBadgeBackgroundColor"),
+            tabBarItemBadgeTextColor = appearance.readOptionalColor(context, "tabBarItemBadgeTextColor"),
         )
 
     private fun parseItemStateAppearance(
-        itemStateAppearance: ReadableMap?,
         context: Context,
+        itemStateAppearance: ReadableMap?,
     ): ItemStateAppearance? {
         if (itemStateAppearance == null) return null
         return ItemStateAppearance(
-            tabBarItemIconColor = itemStateAppearance.readOptionalColor("tabBarItemIconColor", context),
-            tabBarItemTitleFontColor = itemStateAppearance.readOptionalColor("tabBarItemTitleFontColor", context),
+            tabBarItemIconColor = itemStateAppearance.readOptionalColor(context, "tabBarItemIconColor"),
+            tabBarItemTitleFontColor = itemStateAppearance.readOptionalColor(context, "tabBarItemTitleFontColor"),
         )
     }
 


### PR DESCRIPTION
## Description

Fixes handling color props in Tabs appearance on Android.

Thanks to @satya164 for reporting the issue!

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1590.

## Changes

- change `ReadableMapExt.parseColor`:
  - handle `ReadableType.Map` - use React's `ColorPropConverter`
  - add `context` as parameter as it is required by `ColorPropConverter.getColor`
  - add `context` to all usages (extract it from view in view manager methods)

## Before & after - visual documentation

| before | after |
| --- | --- |
| <img width="1280" height="2856" alt="before4284" src="https://github.com/user-attachments/assets/ff1c8849-9874-4303-8384-00f7edab3c89" /> | <img width="1280" height="2856" alt="after4284" src="https://github.com/user-attachments/assets/fec90be7-ac4f-4ebe-980a-e218e3b46519" /> |

## Test plan

Use this test screen:

<details>
    <summary>Test screen</summary>

```tsx
import React from 'react';
import { PlatformColor, Text } from 'react-native';
import {
  TabsContainer,
  type TabRouteConfig,
  DEFAULT_TAB_ROUTE_OPTIONS,
} from '@apps/shared/gamma/containers/tabs';
import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';

function ContentView() {
  return (
    <CenteredLayoutView
      style={{
        backgroundColor: PlatformColor('@android:color/holo_green_light'),
      }}>
      <Text>Hello, World!</Text>
    </CenteredLayoutView>
  );
}

const ROUTE_CONFIGS: TabRouteConfig[] = [
  {
    name: 'First',
    Component: ContentView,
    options: {
      ...DEFAULT_TAB_ROUTE_OPTIONS,
      title: 'First',
      android: {
        ...DEFAULT_TAB_ROUTE_OPTIONS.android,
        standardAppearance: {
          tabBarBackgroundColor: PlatformColor(
            '@android:color/holo_blue_light',
          ),
          // tabBarBackgroundColor: 'red',
        },
      },
    },
  },
  {
    name: 'Second',
    Component: ContentView,
    options: {
      ...DEFAULT_TAB_ROUTE_OPTIONS,
      title: 'Second',
    },
  },
  {
    name: 'Third',
    Component: ContentView,
    options: {
      ...DEFAULT_TAB_ROUTE_OPTIONS,
      title: 'Third',
    },
  },
];

export default function App() {
  return <TabsContainer routeConfigs={ROUTE_CONFIGS} />;
}
```

</details>

I decided not to add the issue test screen. I think we should instead add `PlatformColor` to existing tabs appearance SFT. Here is the ticket to do so: https://github.com/software-mansion/react-native-screens-labs/issues/1621.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
