### PR TITLE
fix(iOS, Stack v4): fix header positioning in shadow tree

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
@@ -26,7 +26,8 @@ void RNSScreenStackHeaderConfigShadowNode::applyFrameCorrections() {
   ensureUnsealed();
 
   const auto &stateData = getStateData();
-  layoutMetrics_.frame.origin.y = -stateData.frameSize.height;
+  layoutMetrics_.frame.origin.x = stateData.frameOrigin.x;
+  layoutMetrics_.frame.origin.y = stateData.frameOrigin.y;
 }
 
 #if !defined(ANDROID)

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigShadowNode.cpp
@@ -26,8 +26,12 @@ void RNSScreenStackHeaderConfigShadowNode::applyFrameCorrections() {
   ensureUnsealed();
 
   const auto &stateData = getStateData();
+#if defined(ANDROID)
+  layoutMetrics_.frame.origin.y = -stateData.frameSize.height;
+#else // defined(ANDROID)
   layoutMetrics_.frame.origin.x = stateData.frameOrigin.x;
   layoutMetrics_.frame.origin.y = stateData.frameOrigin.y;
+#endif // defined(ANDROID)
 }
 
 #if !defined(ANDROID)

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenStackHeaderConfigState.h
@@ -18,28 +18,38 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
   RNSScreenStackHeaderConfigState() = default;
 
 #if !defined(ANDROID)
-  RNSScreenStackHeaderConfigState(Size frameSize_, EdgeInsets edgeInsets_)
-      : frameSize{frameSize_}, edgeInsets{edgeInsets_} {}
+  RNSScreenStackHeaderConfigState(
+      Size frameSize_,
+      EdgeInsets edgeInsets_,
+      Point frameOrigin_)
+      : frameSize{frameSize_},
+        edgeInsets{edgeInsets_},
+        frameOrigin{frameOrigin_} {}
 
   // Make it copyable
   RNSScreenStackHeaderConfigState(const RNSScreenStackHeaderConfigState &source)
-      : frameSize{source.frameSize}, edgeInsets{source.edgeInsets} {}
+      : frameSize{source.frameSize},
+        edgeInsets{source.edgeInsets},
+        frameOrigin{source.frameOrigin} {}
   RNSScreenStackHeaderConfigState &operator=(
       const RNSScreenStackHeaderConfigState &source) {
     this->frameSize.width = source.frameSize.width;
     this->frameSize.height = source.frameSize.height;
     this->edgeInsets = source.edgeInsets;
+    this->frameOrigin = source.frameOrigin;
     return *this;
   }
 
   bool operator==(const RNSScreenStackHeaderConfigState &other) {
     return this->frameSize == other.frameSize &&
-        this->edgeInsets == other.edgeInsets;
+        this->edgeInsets == other.edgeInsets &&
+        this->frameOrigin == other.frameOrigin;
   }
 
   bool operator!=(const RNSScreenStackHeaderConfigState &other) {
     return this->frameSize != other.frameSize ||
-        this->edgeInsets != other.edgeInsets;
+        this->edgeInsets != other.edgeInsets ||
+        this->frameOrigin != other.frameOrigin;
   }
 #endif
 
@@ -68,6 +78,7 @@ class JSI_EXPORT RNSScreenStackHeaderConfigState final {
 
 #if !defined(ANDROID)
   EdgeInsets edgeInsets{}; // zero initialized
+  Point frameOrigin{};
 #endif
 
 #ifdef ANDROID

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -87,7 +87,9 @@ NS_ASSUME_NONNULL_END
  * Allows to send information with size to the corresponding node in shadow tree.
  * This method updates state of header config shadow node only.
  */
-- (void)updateShadowStateWithSize:(CGSize)size edgeInsets:(NSDirectionalEdgeInsets)edgeInsets;
+- (void)updateShadowStateWithSize:(CGSize)size
+                       edgeInsets:(NSDirectionalEdgeInsets)edgeInsets
+                      frameOrigin:(CGPoint)frameOrigin;
 
 /**
  * Updates state of header config shadow node and all subview shadow nodes in context of given UINavigationBar.

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -69,7 +69,7 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
     _show = YES;
     _translucent = NO;
     _addedReactSubviewsInCurrentTransaction = false;
-    _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});
+    _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{}, react::Point{});
     [self initProps];
   }
   return self;
@@ -167,13 +167,16 @@ RNS_IGNORE_SUPER_CALL_END
   [navctr.view setNeedsLayout];
 }
 
-- (void)updateShadowStateWithSize:(CGSize)size edgeInsets:(NSDirectionalEdgeInsets)edgeInsets
+- (void)updateShadowStateWithSize:(CGSize)size
+                       edgeInsets:(NSDirectionalEdgeInsets)edgeInsets
+                      frameOrigin:(CGPoint)frameOrigin
 {
   // I believe Yoga handles RTL internally & .left will be treated as .right in RTL etc.
   react::EdgeInsets convertedEdgeInsets{
       .left = edgeInsets.leading, .top = edgeInsets.top, .right = edgeInsets.trailing, .bottom = edgeInsets.bottom};
   react::Size convertedSize = RCTSizeFromCGSize(size);
-  auto newState = react::RNSScreenStackHeaderConfigState(convertedSize, convertedEdgeInsets);
+  auto newState =
+      react::RNSScreenStackHeaderConfigState(convertedSize, convertedEdgeInsets, RCTPointFromCGPoint(frameOrigin));
 
   if (newState != _lastSendState) {
     _lastSendState = newState;
@@ -190,8 +193,20 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
+  CGRect navBarFrameInScreenView = [navigationBar convertRect:navigationBar.bounds toView:_screenView];
+
+  // On iOS 26+ in landscape mode there is a bug with `edgesForExtendedLayout` for non-transparent
+  // header. We're applying SAV to fix it but we need to take it into account for HeaderConfig's
+  // origin as well.
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (!_translucent && self.shouldHeaderBeVisible) {
+    navBarFrameInScreenView.origin.y -= _screenView.safeAreaInsets.top;
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
   [self updateShadowStateWithSize:navigationBar.frame.size
-                       edgeInsets:[self computeEdgeInsetsOfNavigationBar:navigationBar]];
+                       edgeInsets:[self computeEdgeInsetsOfNavigationBar:navigationBar]
+                      frameOrigin:navBarFrameInScreenView.origin];
   for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {
     [subview updateShadowStateInContextOfAncestorView:navigationBar];
   }
@@ -970,7 +985,7 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
   [super prepareForRecycle];
   _initialPropsSet = NO;
 
-  _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{});
+  _lastSendState = react::RNSScreenStackHeaderConfigState(react::Size{}, react::EdgeInsets{}, react::Point{});
 }
 
 - (NSNumber *)getFontSizePropValue:(int)value

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -175,8 +175,9 @@ RNS_IGNORE_SUPER_CALL_END
   react::EdgeInsets convertedEdgeInsets{
       .left = edgeInsets.leading, .top = edgeInsets.top, .right = edgeInsets.trailing, .bottom = edgeInsets.bottom};
   react::Size convertedSize = RCTSizeFromCGSize(size);
-  auto newState =
-      react::RNSScreenStackHeaderConfigState(convertedSize, convertedEdgeInsets, RCTPointFromCGPoint(frameOrigin));
+  react::Point convertedOrigin = RCTPointFromCGPoint(frameOrigin);
+
+  auto newState = react::RNSScreenStackHeaderConfigState(convertedSize, convertedEdgeInsets, convertedOrigin);
 
   if (newState != _lastSendState) {
     _lastSendState = newState;


### PR DESCRIPTION
## Description

Fixes positioning of header confing in Shadow Tree in Stack v4 on iOS.

Fixes Pressables in transparent header.

> [!WARNING]
> 
> Pressables in the screen's content in landscape orientation when opaque header is used still don't work. 
> Here is the ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1622.
> 
> https://github.com/user-attachments/assets/f80cbba0-ff49-4e0f-9667-70a66d8a6d74

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1594.

### Details

On Android, Pressables in the header work correctly after https://github.com/software-mansion/react-native-screens/pull/3239. In transparent header, we're skipping applying any offset and it solves the problem.

<img width="3391" height="4002" alt="android_v4_hc" src="https://github.com/user-attachments/assets/ab639348-c4fe-4525-9386-e5fdf9328274" />

On iOS, transparent header wasn't handled in any other way - we would still move the header config above the screen which is incorrect (the HC is moved off the screen completely). The correct value of the offset is always the relative position of header config in relation to the screen. It will adapt automatically to every situation (instead of relying on assumption that the toolbar/navigation bar is always just above the screen/just at the top of the screen). Same approach is/will be used in Stack v5.

<img width="3397" height="6007" alt="ios_v4_hc" src="https://github.com/user-attachments/assets/2d2ea552-7502-46b4-b783-0aef207a6c88" />

The difference in platforms comes down to handling the top inset. On Android, the toolbar applies padding therefore the inset is included in its height. On iOS, navigation bar is offset by the inset value therefore its height doesn't contain the offset.

## Changes

- send frame origin via header config state
- calculate frame origin based on position of navigation bar in relation to screen
- apply iOS 26 landscape `edgesForExtendedLayout` correction when header is opaque
- apply frame origin in shadow node

## Before & after - visual documentation

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7bb654ee-fba3-418d-9965-3cd78ade53a0" /> | <video src="https://github.com/user-attachments/assets/6564cc67-f661-48f1-9235-15b7edec4977" /> |

## Test plan

- `Test3446` + `headerTransparent: true` - test {portrait,landscape}x{ios18,ios26}x{opaque,transparent}
- `Test3111`

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
