### PR TITLE
feat(Stack v5, iOS): Implement hitSlop for custom header items

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -56,6 +56,10 @@ function ResizingItem() {
   return (
     <PressableWithFeedback
       onPress={() => setLarge(lg => !lg)}
+      // pressable props don't seem to update at runtime
+      // changing the key forces the view to rebuild completely
+      // - similar thing has been done in Test3446
+      key={`${pressableProps.hitSlop}_${pressableProps.pressRetentionOffset}`}
       {...pressableProps}
       style={{
         width: large ? 60 : 20,

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -61,7 +61,24 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   return [_children copy];
 }
 
-#pragma mark - UIView lifecycle
+#pragma mark - UIView
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  for (UIView *child in _children) {
+    if ([child isKindOfClass:RNSStackHeaderItemComponentView.class] && child.window != nil) {
+      for (UIView *hitableView in [child.subviews reverseObjectEnumerator]) {
+        CGPoint convertedPoint = [self convertPoint:point toView:hitableView];
+        UIView *hitTestResult = [hitableView hitTest:convertedPoint withEvent:event];
+
+        if (hitTestResult != nil) {
+          return hitTestResult;
+        }
+      }
+    }
+  }
+  return nil;
+}
 
 - (void)didMoveToWindow
 {

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -65,7 +65,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-  for (UIView *child in _children) {
+  for (UIView *child in [_children reverseObjectEnumerator]) {
     if ([child isKindOfClass:RNSStackHeaderItemComponentView.class] && child.window != nil) {
       for (UIView *hitableView in [child.subviews reverseObjectEnumerator]) {
         CGPoint convertedPoint = [self convertPoint:point toView:hitableView];

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -166,7 +166,7 @@ namespace react = facebook::react;
 - (RNSStackHeaderConfigComponentView *)requireTopScreenHeaderConfig
 {
   RCTAssert([_stackNavigationController.topViewController.view isKindOfClass:[RNSStackScreenComponentView class]],
-            @"[RNScreens] Expected top screen to be a react compontent view of type RNSStackScreenComponentView");
+            @"[RNScreens] Expected top screen to be a react component view of type RNSStackScreenComponentView");
   auto screenView = (RNSStackScreenComponentView *)_stackNavigationController.topViewController.view;
 
   return screenView.headerConfig;

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -11,6 +11,7 @@
 #import "RNSLog.h"
 
 #import "RNSContainerHelpers.h"
+#import "RNSStackHeaderConfigComponentView.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackOperationCoordinator.h"
 #import "RNSStackScreenComponentView.h"
@@ -55,6 +56,21 @@ namespace react = facebook::react;
       [self setupViewConstraintsForController:_stackNavigationController];
     }
   }
+}
+
+// By default, the header buttons that are not inside the native hit area
+// cannot be clicked, so we check it by ourselves
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if (CGRectContainsPoint(_stackNavigationController.navigationBar.frame, point)) {
+    RNSStackHeaderConfigComponentView *headerConfig = [self requireTopScreenHeaderConfig];
+    CGPoint convertedPoint = [self convertPoint:point toView:headerConfig];
+    UIView *headerHitTestResult = [headerConfig hitTest:convertedPoint withEvent:event];
+    if (headerHitTestResult != nil) {
+      return headerHitTestResult;
+    }
+  }
+  return [super hitTest:point withEvent:event];
 }
 
 #pragma mark - Communication with StackScreen
@@ -145,6 +161,15 @@ namespace react = facebook::react;
     [controller.view.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
     [controller.view.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
   ]];
+}
+
+- (RNSStackHeaderConfigComponentView *)requireTopScreenHeaderConfig
+{
+  RCTAssert([_stackNavigationController.topViewController.view isKindOfClass:[RNSStackScreenComponentView class]],
+            @"[RNScreens] Expected top screen to be a react compontent view of type RNSStackScreenComponentView");
+  auto screenView = (RNSStackScreenComponentView *)_stackNavigationController.topViewController.view;
+
+  return screenView.headerConfig;
 }
 
 #pragma mark - RCTMountingTransactionObserving

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.h
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.h
@@ -17,6 +17,7 @@ typedef NS_ENUM(int, RNSStackScreenActivityMode) {
 @interface RNSStackScreenComponentView : RNSReactBaseView
 
 @property (nonatomic, weak, readwrite, nullable) RNSStackHostComponentView *stackHost;
+@property (nonatomic, weak, readonly, nullable) RNSStackHeaderConfigComponentView *headerConfig;
 @property (nonatomic, strong, readonly, nonnull) RNSStackScreenController *controller;
 @property (nonatomic) BOOL isNativelyDismissed;
 

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -130,10 +130,19 @@ namespace react = facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  if ([childComponentView isKindOfClass:RNSStackHeaderConfigComponentView.class]) {
+    _headerConfig = (RNSStackHeaderConfigComponentView *)childComponentView;
+  }
+  [super mountChildComponentView:childComponentView index:index];
+}
+
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   if ([childComponentView isKindOfClass:RNSStackHeaderConfigComponentView.class]) {
     [_controller.headerCoordinator clearHeaderConfiguration];
+    _headerConfig = nil;
   }
   [super unmountChildComponentView:childComponentView index:index];
 }


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1417

## Description

This PR adds support for `hitSlop` and `pressRetentionOffset` for Stack v5 header.

## Changes

- stack screen now has a weak ref to header config
- header config implements custom `hitTest` that iterates over its childrens' react views that may have `hitSlop` and `pressRetentionOffset` specified
- stack host fetches the header config through `navigationController -> top screen -> headerConfig` and calls the custom `hitTest`

## Visual documentation

https://github.com/user-attachments/assets/56de1fc8-99c6-46d6-8a06-32e7e2003b41

## Test plan

Use `test-stack-subviews-ios`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
