### PR TITLE
feat(iOS, Tabs): add `bottomAccessoryHidden` prop

### DIFF
--- a/apps/src/tests/single-feature-tests/tabs/index.ts
+++ b/apps/src/tests/single-feature-tests/tabs/index.ts
@@ -25,6 +25,7 @@ import TestTabsMoreNavigationController from './test-tabs-more-navigation-contro
 import TestTabsTabBarMinimizeBehavior from './test-tabs-tab-bar-minimize-behavior-ios';
 import TestTabsTabBarControllerMode from './test-tabs-tab-bar-controller-mode-ios';
 import TestTabsBottomAccessory from './test-tabs-bottom-accessory-layout-ios';
+import TestTabsBottomAccessoryVisibility from './test-tabs-bottom-accessory-visibility-ios';
 import TestTabsScreenOrientation from './test-tabs-screen-orientation';
 import TestTabsTabBarExperimentalUserInterfaceStyle from './test-tabs-tab-bar-experimental-user-interface-style-ios';
 
@@ -53,6 +54,7 @@ export { default as TestTabsMoreNavigationController } from './test-tabs-more-na
 export { default as TestTabsTabBarMinimizeBehavior } from './test-tabs-tab-bar-minimize-behavior-ios';
 export { default as TestTabsTabBarControllerMode } from './test-tabs-tab-bar-controller-mode-ios';
 export { default as TestTabsBottomAccessory } from './test-tabs-bottom-accessory-layout-ios';
+export { default as TestTabsBottomAccessoryVisibility } from './test-tabs-bottom-accessory-visibility-ios';
 export { default as TestTabsScreenOrientation } from './test-tabs-screen-orientation';
 export { default as TestTabsTabBarExperimentalUserInterfaceStyle } from './test-tabs-tab-bar-experimental-user-interface-style-ios';
 
@@ -80,6 +82,7 @@ const scenarios = {
   TestTabsTabBarMinimizeBehavior,
   TestTabsTabBarControllerMode,
   TestTabsBottomAccessory,
+  TestTabsBottomAccessoryVisibility,
   TestTabsScreenOrientation,
   TestTabsTabBarExperimentalUserInterfaceStyle,
 };

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { SettingsSwitch } from '@apps/shared';
+import {
+  TabsContainerWithHostConfigContext,
+  type TabRouteConfig,
+  useTabsHostConfig,
+  DEFAULT_TAB_ROUTE_OPTIONS,
+} from '@apps/shared/gamma/containers/tabs';
+import { Colors } from '@apps/shared/styling';
+
+function BottomAccessoryContent() {
+  return (
+    <View style={styles.accessory}>
+      <Text style={styles.accessoryText}>Bottom Accessory</Text>
+    </View>
+  );
+}
+
+function ConfigScreen() {
+  const [rendered, setRendered] = useState(true);
+  const [hidden, setHidden] = useState(false);
+  const { updateHostConfig } = useTabsHostConfig();
+
+  useEffect(() => {
+    updateHostConfig({
+      ios: {
+        bottomAccessory: rendered
+          ? () => <BottomAccessoryContent />
+          : undefined,
+        bottomAccessoryHidden: hidden,
+      },
+    });
+  }, [rendered, hidden, updateHostConfig]);
+
+  return (
+    <ScrollView style={styles.container}>
+      <SettingsSwitch
+        label="rendered"
+        value={rendered}
+        onValueChange={setRendered}
+      />
+      <SettingsSwitch label="hidden" value={hidden} onValueChange={setHidden} />
+    </ScrollView>
+  );
+}
+
+const ROUTE_CONFIGS: TabRouteConfig[] = [
+  {
+    name: 'Config',
+    Component: ConfigScreen,
+    options: {
+      ...DEFAULT_TAB_ROUTE_OPTIONS,
+      title: 'Config',
+    },
+  },
+];
+
+function TestTabsBottomAccessoryVisibility() {
+  return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
+}
+
+export default createScenario(
+  TestTabsBottomAccessoryVisibility,
+  scenarioDescription,
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  accessory: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.NavyLightTransparent,
+  },
+  accessoryText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
@@ -4,7 +4,8 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Bottom Accessory Visibility',
   key: 'test-tabs-bottom-accessory-visibility-ios',
   details:
-    'Test bottom accessory visibility toggling via bottomAccessory and hidden props.',
+    'Test bottom accessory visibility toggling via bottomAccessory ' +
+    'and bottomAccessoryHidden props.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Bottom Accessory Visibility',
+  key: 'test-tabs-bottom-accessory-visibility-ios',
+  details:
+    'Test bottom accessory visibility toggling via bottomAccessory and hidden props.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario.md
@@ -1,0 +1,67 @@
+# Test Scenario: Bottom Accessory Visibility
+
+## Details
+
+**Description:** Validates the `bottomAccessoryHidden` prop on
+TabsHost. The test verifies that the bottom accessory can be hidden
+and shown with animation via the `hidden` toggle (which sets
+`bottomAccessoryHidden`), independently from unmounting the React
+tree via the `rendered` toggle (which sets `bottomAccessory` to
+`undefined`). The key success criterion is that toggling `hidden`
+produces a smooth animation with visible content, while toggling
+`rendered` off may show blank content during the exit animation.
+
+**OS test creation version:** iOS 26.0
+
+## E2E test
+
+TBD: Automation is possible and planned but not yet implemented.
+
+## Prerequisites
+
+- iOS 26 physical device or simulator
+
+## Steps
+
+### Baseline
+
+1. Open the test scenario.
+
+- [ ] The bottom accessory is visible above the tab bar with
+  "Bottom Accessory" text centered.
+
+### Hidden prop
+
+2. Toggle `hidden` on.
+
+- [ ] The bottom accessory animates out smoothly. The content
+  remains visible during the animation.
+
+3. Toggle `hidden` off.
+
+- [ ] The bottom accessory animates back in. The content is
+  immediately visible — no blank frame.
+
+### Rendered prop
+
+4. Toggle `rendered` off.
+
+- [ ] The bottom accessory disappears.
+
+5. Toggle `rendered` on.
+
+- [ ] The bottom accessory reappears with content.
+
+### Combined
+
+6. Toggle `hidden` on, then toggle `rendered` off.
+
+- [ ] No crash. The bottom accessory remains absent.
+
+7. Toggle `rendered` on.
+
+- [ ] The bottom accessory does not appear (still hidden).
+
+8. Toggle `hidden` off.
+
+- [ ] The bottom accessory animates in with content visible.

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL tabBarHidden;
 
+@property (nonatomic, readonly) BOOL bottomAccessoryHidden;
+
 @property (nonatomic, strong, readonly, nullable) UIColor *nativeContainerBackgroundColor;
 
 @property (nonatomic, readonly) UIUserInterfaceStyle colorScheme;

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -86,7 +86,9 @@ namespace react = facebook::react;
   _hasModifiedBottomAccessoryInCurrentTransation = NO;
   _needsTabBarAppearanceUpdate = NO;
 
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
   _bottomAccessoryWrapperView = nil;
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 }
 
 - (void)resetProps

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -50,6 +50,10 @@ namespace react = facebook::react;
   BOOL _needsTabBarAppearanceUpdate;
 
   RNSTabsNavigationStateUpdateRequest *_Nullable _navStateRequest;
+
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
+  UIView *_Nullable _bottomAccessoryWrapperView;
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -81,6 +85,8 @@ namespace react = facebook::react;
   _hasModifiedTabsScreensInCurrentTransaction = NO;
   _hasModifiedBottomAccessoryInCurrentTransation = NO;
   _needsTabBarAppearanceUpdate = NO;
+
+  _bottomAccessoryWrapperView = nil;
 }
 
 - (void)resetProps
@@ -91,6 +97,7 @@ namespace react = facebook::react;
   _layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified;
   _colorScheme = UIUserInterfaceStyleUnspecified;
   _rejectStaleNavStateUpdates = NO;
+  _bottomAccessoryHidden = NO;
 #if !TARGET_OS_TV
   _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
 #else // !TARGET_OS_TV
@@ -158,7 +165,7 @@ namespace react = facebook::react;
 
   if (_hasModifiedBottomAccessoryInCurrentTransation) {
     RNSLog(@"updateContainer: bottomAccessory: %@", bottomAccessory);
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV && !TARGET_OS_VISION
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
     if (@available(iOS 26.0, *)) {
       if (bottomAccessory != nil) {
         // We wrap RNSTabsBottomAccessoryComponentView in plain UIView to maintain native
@@ -167,13 +174,14 @@ namespace react = facebook::react;
         // to default corner radius.
         UIView *wrapperView = [UIView new];
         [wrapperView addSubview:bottomAccessory];
-
-        [_controller setBottomAccessory:[[UITabAccessory alloc] initWithContentView:wrapperView] animated:YES];
+        _bottomAccessoryWrapperView = wrapperView;
       } else {
-        [_controller setBottomAccessory:nil animated:YES];
+        _bottomAccessoryWrapperView = nil;
       }
+
+      [self applyBottomAccessoryVisibility];
     }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV && !TARGET_OS_VISION
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
   }
 }
 
@@ -240,6 +248,15 @@ namespace react = facebook::react;
     {
       _controller.tabBar.hidden = _tabBarHidden;
     }
+  }
+
+  if (newComponentProps.bottomAccessoryHidden != oldComponentProps.bottomAccessoryHidden) {
+    _bottomAccessoryHidden = newComponentProps.bottomAccessoryHidden;
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
+    if (@available(iOS 26.0, *)) {
+      [self applyBottomAccessoryVisibility];
+    }
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
   }
 
   if (newComponentProps.nativeContainerBackgroundColor != oldComponentProps.nativeContainerBackgroundColor) {
@@ -385,6 +402,18 @@ namespace react = facebook::react;
     [_reactSubviews removeObject:subview];
   }
 }
+
+#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+{
+  if (_bottomAccessoryWrapperView != nil && !_bottomAccessoryHidden) {
+    [_controller setBottomAccessory:[[UITabAccessory alloc] initWithContentView:_bottomAccessoryWrapperView]
+                           animated:YES];
+  } else {
+    [_controller setBottomAccessory:nil animated:YES];
+  }
+}
+#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 
 - (void)setLayoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
 {

--- a/src/components/tabs/host/TabsHost.ios.tsx
+++ b/src/components/tabs/host/TabsHost.ios.tsx
@@ -54,6 +54,7 @@ function TabsHost(props: TabsHostProps) {
       tabBarControllerMode={ios?.tabBarControllerMode}
       tabBarMinimizeBehavior={ios?.tabBarMinimizeBehavior}
       tabBarTintColor={ios?.tabBarTintColor}
+      bottomAccessoryHidden={ios?.bottomAccessoryHidden}
       onMoreTabSelected={ios?.onMoreTabSelected}>
       {children}
       {ios?.bottomAccessory && isIOS26OrHigher && (

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -96,6 +96,16 @@ export interface TabsHostPropsIOS {
    */
   bottomAccessory?: TabsBottomAccessoryComponentFactory | undefined;
   /**
+   * @summary Hides the bottom accessory with animation while keeping the React
+   * tree mounted.
+   *
+   * @default false
+   *
+   * @platform iOS
+   * @supported iOS 26 or higher
+   */
+  bottomAccessoryHidden?: boolean | undefined;
+  /**
    * @summary Specifies the display mode for the tab bar.
    *
    * Available starting from iOS 18.

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -96,8 +96,7 @@ export interface TabsHostPropsIOS {
    */
   bottomAccessory?: TabsBottomAccessoryComponentFactory | undefined;
   /**
-   * @summary Hides the bottom accessory with animation while keeping the React
-   * tree mounted.
+   * @summary Hides the bottom accessory with animation.
    *
    * @default false
    *

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -83,6 +83,7 @@ export interface NativeProps extends ViewProps {
   tabBarTintColor?: ColorValue | undefined;
   tabBarMinimizeBehavior?: CT.WithDefault<TabBarMinimizeBehavior, 'automatic'>;
   tabBarControllerMode?: CT.WithDefault<TabBarControllerMode, 'automatic'>;
+  bottomAccessoryHidden?: CT.WithDefault<boolean, false>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSTabsHostIOS', {


### PR DESCRIPTION
## Description

Adds `bottomAccessoryHidden` property that allows to hide the accessory smoothly (keeping accessory rendered before exit animation ends).

Closes https://github.com/software-mansion/react-native-screens-labs/issues/749.

## Changes

- add `bottomAccessoryHidden` prop
- keep reference to created `bottomAccessoryWrapperView` 
- extract bottom accessory visibility to helper method and use it both in `updateProps` and `updateContainer`
- add bottom accessory visibility SFT

## Visual documentation

https://github.com/user-attachments/assets/cde9d88c-a7c3-4648-bc0e-ce7464994117

## Test plan

Run bottom accessory SFTs. You can additionally check `Test3288`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
