### PR TITLE
chore(test): Strip all whitespace from scenarioGroup in single-feature-tests helpers

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -88,6 +88,7 @@ export async function selectSingleFeatureTestsScreen(
   scenarioGroup: string,
   screenKey: string,
 ) {
+  const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
   await scrollUntilVisible(
     'root-screen-single-feature-tests',
     'root-screen-examples-scrollview',
@@ -98,17 +99,17 @@ export async function selectSingleFeatureTestsScreen(
     .withTimeout(3000);
 
   await scrollUntilVisible(
-    `single-feature-tests-${scenarioGroup}`,
+    `single-feature-tests-${scenarioGroupId}`,
     'single-feature-tests-scrollview',
   );
-  await element(by.id(`single-feature-tests-${scenarioGroup}`)).tap();
-  await waitFor(element(by.id(`${scenarioGroup}-scenarios-scrollview`)))
+  await element(by.id(`single-feature-tests-${scenarioGroupId}`)).tap();
+  await waitFor(element(by.id(`${scenarioGroupId}-scenarios-scrollview`)))
     .toBeVisible()
     .withTimeout(3000);
 
   await scrollUntilVisible(
     `${screenKey}`,
-    `${scenarioGroup}-scenarios-scrollview`,
+    `${scenarioGroupId}-scenarios-scrollview`,
   );
   await element(by.id(`${screenKey}`)).tap();
 }

--- a/apps/src/tests/single-feature-tests/index.tsx
+++ b/apps/src/tests/single-feature-tests/index.tsx
@@ -46,7 +46,10 @@ export function HomeScreen() {
           title={scenarioGroup.name}
           route={key}
           details={scenarioGroup.details}
-          testID={`single-feature-tests-${scenarioGroup.name}`}
+          testID={`single-feature-tests-${scenarioGroup.name.replace(
+            /\s/g,
+            '',
+          )}`}
         />
       ))}
     </ScrollView>


### PR DESCRIPTION
## Description
Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1625

Single-feature-test (SFT) navigation helpers built Detox `testID`s by interpolating `scenarioGroup` names directly. When a scenario group name contains whitespace, the runtime `testID` and the `by.id(...)` selector diverged from each other, making the helper unable to locate and tap the group. This normalizes the group name by stripping whitespace on both sides so the selector always matches the rendered `testID`.

## Changes

- **`FabricExample/e2e/e2e-utils.ts`** - In `selectSingleFeatureTestsScreen`, derive `scenarioGroupId = scenarioGroup.replace(/\s/g, '')` and use it for the `single-feature-tests-*`, `*-scenarios-scrollview`, and tap selectors instead of the raw `scenarioGroup`.
- **`apps/src/tests/single-feature-tests/index.tsx`** - Render the group entry `testID` as `single-feature-tests-${scenarioGroup.name.replace(/\s/g, '')}` so the emitted id matches the trimmed selector used by the helper.
