### PR TITLE
feat(Stack v5, iOS): Add sizing to placeholder image for async load

### DIFF
--- a/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderContentFactory.mm
@@ -62,7 +62,7 @@
                                               }
                                               weakBarButtonItem.image = image;
                                             }];
-    barButtonItem.image = syncImage ? syncImage : [UIImage imageWithCIImage:[CIImage emptyImage]];
+    barButtonItem.image = syncImage ? syncImage : [RNSStackHeaderIconResolver placeholderImageForIcon:item.icon];
   }
 
   return barButtonItem;

--- a/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
+++ b/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates a transparent placeholder image matching the size declared in iconData's jsonSource.
- Falls back to 1x1 if size info is missing.
+ Falls back to 1x1 if size info is missing and returns nil if jsonSource is nil (sfSymbols, xcassets).
  */
 + (nullable UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData;
 

--- a/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
+++ b/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  Creates a transparent placeholder image matching the size declared in iconData's jsonSource.
  Falls back to 1x1 if size info is missing.
  */
-+ (UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData;
++ (nullable UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
+++ b/ios/gamma/stack/header/RNSStackHeaderIconResolver.h
@@ -20,6 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
                   withImageLoader:(id<RNSImageLoading>)imageLoader
              asyncCompletionBlock:(nullable void (^)(UIImage *_Nullable))completionBlock;
 
+/**
+ Creates a transparent placeholder image matching the size declared in iconData's jsonSource.
+ Falls back to 1x1 if size info is missing.
+ */
++ (UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderIconResolver.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderIconResolver.mm
@@ -46,4 +46,18 @@
   }
 }
 
++ (UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData
+{
+  CGFloat width = [iconData.jsonSource[@"width"] doubleValue];
+  CGFloat height = [iconData.jsonSource[@"height"] doubleValue];
+  CGFloat scale = [iconData.jsonSource[@"scale"] doubleValue] ?: 1.0;
+  CGSize size = (width > 0 && height > 0) ? CGSizeMake(width, height) : CGSizeMake(1, 1);
+
+  UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+  format.scale = scale;
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:format];
+  return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull ctx){
+  }];
+}
+
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderIconResolver.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderIconResolver.mm
@@ -46,8 +46,12 @@
   }
 }
 
-+ (UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData
++ (nullable UIImage *)placeholderImageForIcon:(RNSStackHeaderIconData *)iconData
 {
+  if (iconData.jsonSource == nil) {
+    return nil;
+  }
+
   CGFloat width = [iconData.jsonSource[@"width"] doubleValue];
   CGFloat height = [iconData.jsonSource[@"height"] doubleValue];
   CGFloat scale = [iconData.jsonSource[@"scale"] doubleValue] ?: 1.0;

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -65,13 +65,14 @@
 
   UIImage *menuImage = nil;
   if (data.icon != nil) {
-    menuImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
-                                        withImageLoader:imageLoader
-                                   asyncCompletionBlock:^(UIImage *_Nullable image) {
-                                     if (onMenuInvalidated) {
-                                       onMenuInvalidated();
-                                     }
-                                   }];
+    UIImage *syncImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
+                                                 withImageLoader:imageLoader
+                                            asyncCompletionBlock:^(UIImage *_Nullable image) {
+                                              if (onMenuInvalidated) {
+                                                onMenuInvalidated();
+                                              }
+                                            }];
+    menuImage = syncImage ? syncImage : [RNSStackHeaderIconResolver placeholderImageForIcon:data.icon];
   }
 
   return [UIMenu menuWithTitle:data.title image:menuImage identifier:nil options:options children:elements];
@@ -160,13 +161,14 @@
 
   UIImage *iconImage = nil;
   if (data.icon != nil) {
-    iconImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
-                                        withImageLoader:imageLoader
-                                   asyncCompletionBlock:^(UIImage *_Nullable image) {
-                                     if (onMenuInvalidated) {
-                                       onMenuInvalidated();
-                                     }
-                                   }];
+    UIImage *syncImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
+                                                 withImageLoader:imageLoader
+                                            asyncCompletionBlock:^(UIImage *_Nullable image) {
+                                              if (onMenuInvalidated) {
+                                                onMenuInvalidated();
+                                              }
+                                            }];
+    iconImage = syncImage ? syncImage : [RNSStackHeaderIconResolver placeholderImageForIcon:data.icon];
   }
 
   UIAction *toggleAction = [UIAction
@@ -218,13 +220,14 @@
 
   UIImage *iconImage = nil;
   if (data.icon != nil) {
-    iconImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
-                                        withImageLoader:imageLoader
-                                   asyncCompletionBlock:^(UIImage *_Nullable image) {
-                                     if (onMenuInvalidated) {
-                                       onMenuInvalidated();
-                                     }
-                                   }];
+    UIImage *syncImage = [RNSStackHeaderIconResolver resolveIcon:data.icon
+                                                 withImageLoader:imageLoader
+                                            asyncCompletionBlock:^(UIImage *_Nullable image) {
+                                              if (onMenuInvalidated) {
+                                                onMenuInvalidated();
+                                              }
+                                            }];
+    iconImage = syncImage ? syncImage : [RNSStackHeaderIconResolver placeholderImageForIcon:data.icon];
   }
 
   UIAction *action = [UIAction actionWithTitle:data.title


### PR DESCRIPTION
## Description

This PR adds sizing calculations for placeholder image size so that placeholders for images that are loaded asynchronously are not causing layout shifts.

## Changes

- added a method `RNSStackHeaderIconResolver.placeholderImageForIcon` that builds an empty image of target image's size and used for item and menu rendering

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b3b401ea-d22c-4063-9383-a1deda1b0b02" /> | <video src="https://github.com/user-attachments/assets/0cedf8dd-021f-4afe-a3e3-82c69e96568c" /> |
| <video src="https://github.com/user-attachments/assets/3d4cd395-95ae-4656-894c-abe812fa8572" /> | <video src="https://github.com/user-attachments/assets/58836fbc-b737-486e-8dd5-d003ddc11981" /> |

## Test plan

Use test-stack-header-item-ios SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
