### PR TITLE
feat(Stack v5, iOS): Add displayInline flag to menu

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -20,6 +20,7 @@ import TestStackToolbarMenuGroups from './test-stack-toolbar-menu-groups-android
 import TestStackToolbarNestedMenu from './test-stack-toolbar-nested-menu-android';
 import TestStackHeaderSubviewOnPress from './test-stack-header-subview-onpress-ios';
 import TestStackHeaderSelectiveUpdates from './test-stack-header-selective-updates-ios';
+import TestStackHeaderMenuOptionsIOS from './test-stack-header-menu-options-ios';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
@@ -39,6 +40,7 @@ export { default as TestStackToolbarMenuShowAsAction } from './test-stack-toolba
 export { default as TestStackToolbarMenuTitle } from './test-stack-toolbar-menu-title-android';
 export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-icon-android';
 export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nested-menu-android';
+export { default as TestStackHeaderMenuOptionsIOS } from './test-stack-header-menu-options-ios';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,
@@ -51,6 +53,7 @@ const scenarios = {
   TestStackHeaderIconIOS,
   TestStackHeaderSubviewOnPress,
   TestStackHeaderSelectiveUpdates,
+  TestStackHeaderMenuOptionsIOS,
   TestStackBackButton,
   TestStackToolbarMenuCommands,
   TestStackToolbarMenuDisabled,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
@@ -1,0 +1,168 @@
+import React, { useLayoutEffect, useMemo, useState } from 'react';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { StackHeaderConfigProps } from 'react-native-screens/components/gamma/stack/header';
+import { Button, ScrollView } from 'react-native';
+import { scenarioDescription } from './scenario-description';
+
+function TestStackHeaderMenuOptionsIOS() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Home',
+          Component: ConfigScreen,
+          options: {},
+        },
+      ]}
+    />
+  );
+}
+
+function buildHeaderConfig(
+  displayInline: boolean,
+  nestedDisplayInline: boolean,
+): StackHeaderConfigProps {
+  return {
+    title: 'Menu Options',
+    ios: {
+      trailingItems: [
+        {
+          type: 'item',
+          id: 'menu-button',
+          title: 'Options',
+          icon: { type: 'sfSymbol', name: 'ellipsis' },
+          menu: {
+            type: 'menu',
+            id: 'root-menu',
+            children: [
+              {
+                id: 'action-copy',
+                type: 'menuItem',
+                itemType: 'action',
+                title: 'Copy',
+                icon: { type: 'sfSymbol', name: 'doc.on.doc' },
+              },
+              {
+                id: 'action-paste',
+                type: 'menuItem',
+                itemType: 'action',
+                title: 'Paste',
+                icon: { type: 'sfSymbol', name: 'doc.on.clipboard' },
+              },
+              {
+                id: 'action-share',
+                type: 'menuItem',
+                itemType: 'action',
+                title: 'Share',
+                icon: { type: 'sfSymbol', name: 'square.and.arrow.up' },
+              },
+              {
+                id: 'submenu-sorting',
+                type: 'menu',
+                title: 'Sort By',
+                displayInline,
+                icon: { type: 'sfSymbol', name: 'arrow.up.arrow.down' },
+                singleSelection: true,
+                children: [
+                  {
+                    id: 'sort-name',
+                    type: 'menuItem',
+                    title: 'Name',
+                    icon: { type: 'sfSymbol', name: 'textformat.abc' },
+                    initialToggleState: true,
+                  },
+                  {
+                    id: 'sort-date',
+                    type: 'menuItem',
+                    title: 'Date',
+                    icon: { type: 'sfSymbol', name: 'calendar' },
+                  },
+                  {
+                    id: 'sort-size',
+                    type: 'menuItem',
+                    title: 'Size',
+                    icon: { type: 'sfSymbol', name: 'internaldrive' },
+                  },
+                  {
+                    id: 'submenu-rating',
+                    type: 'menu',
+                    title: 'Rating',
+                    displayInline: nestedDisplayInline,
+                    icon: { type: 'sfSymbol', name: 'star' },
+                    children: [
+                      {
+                        id: 'rating-best-reviews',
+                        type: 'menuItem',
+                        title: 'Best Reviews',
+                        icon: { type: 'sfSymbol', name: 'star.fill' },
+                      },
+                      {
+                        id: 'rating-most-reviews',
+                        type: 'menuItem',
+                        title: 'Most Reviews',
+                        icon: { type: 'sfSymbol', name: 'text.bubble' },
+                      },
+                      {
+                        id: 'rating-highest-rated',
+                        type: 'menuItem',
+                        title: 'Highest Rated',
+                        icon: { type: 'sfSymbol', name: 'hand.thumbsup' },
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'action-delete',
+                type: 'menuItem',
+                itemType: 'action',
+                title: 'Delete',
+                icon: { type: 'sfSymbol', name: 'trash' },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function ConfigScreen() {
+  const navigation = useStackNavigationContext();
+  const [displayInline, setDisplayInline] = useState(false);
+  const [nestedDisplayInline, setNestedDisplayInline] = useState(false);
+
+  const { setRouteOptions, routeKey } = navigation;
+  const headerConfig = useMemo(
+    () => buildHeaderConfig(displayInline, nestedDisplayInline),
+    [displayInline, nestedDisplayInline],
+  );
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig,
+    });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollView contentInsetAdjustmentBehavior="automatic">
+      <Button
+        title={`displayInline (Sort By): ${displayInline}`}
+        onPress={() => setDisplayInline(prev => !prev)}
+      />
+      <Button
+        title={`displayInline (Rating): ${nestedDisplayInline}`}
+        onPress={() => setNestedDisplayInline(prev => !prev)}
+      />
+    </ScrollView>
+  );
+}
+
+export default createScenario(
+  TestStackHeaderMenuOptionsIOS,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Header Menu Options (iOS)',
+  key: 'test-stack-header-menu-options-ios',
+  details: 'Tests menu options in nested submenus.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
@@ -1,0 +1,41 @@
+# Test Scenario: Stack Header Menu Options (iOS)
+
+## Details
+
+**Description:** This test verifies the menu options in nested submenus.
+
+**OS test creation version:** iOS 26.4, iPadOS 26.4
+
+## E2E test
+
+TBD
+
+## Prerequisites
+
+- iOS / iPadOS emulator
+
+## Steps on iPhone
+
+1. Ensure both toggles for display mode are set to off
+2. Tap the ellipsis (Options) button in the header
+  - [ ] Menu shows: Copy, Paste, Share, Sort By as a collapsed submenu, Delete
+3. Tap Sort By
+  - [ ] A nested submenu shows: Name, Date, Size and Rating as a collapsed submenu
+4. Tap Rating
+  - [ ] A nested submenu opens with: Best Reviews, Most Reviews, Highest Rated
+5. Dismiss the menu
+6. Toggle "displayInline (Rating)" to `true`
+7. Open the menu
+  - [ ] Menu shows: Copy, Paste, Share, Sort By as a collapsed submenu, Delete
+8. Tap Sort By
+  - [ ] Submenu opens with: Name, Date, Size, menu separator, Best Reviews, Most Reviews, Highest Rated (all inline)
+9. Dismiss the menu
+10. Toggle "displayInline (Rating)" back to `false` and "displayInline (Sort By): false" to `true`
+11. Open the menu
+  - [ ] Menu shows: Copy, Paste, Share, menu separator, Name, Date, Size, Rating as a collapsed submenu, menu separator, Delete
+12. Tap Rating
+  - [ ] A nested submenu opens with: Best Reviews, Most Reviews, Highest Rated
+13. Dismiss the menu
+14. Toggle "displayInline (Rating)" to `true` again
+15. Tap the ellipsis button
+  - [ ] Menu shows: Copy, Paste, Share, menu separator, Name, Date, Size, menu separator, Best Reviews, Most Reviews, Highest Rated, menu separator, Delete, all inline

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
@@ -12,7 +12,7 @@ TBD
 
 ## Prerequisites
 
-- iOS / iPadOS emulator
+- iOS / iPadOS simulator
 
 ## Steps on iPhone
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -47,6 +47,9 @@
     resolvedRoot = data;
     initialSingleSelectionStateClaimed = &newInitialSingleSelectionStateClaimed;
   }
+  if (data.displayInline) {
+    options |= UIMenuOptionsDisplayInline;
+  }
 
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
   for (id<RNSStackHeaderMenuElement> child in data.children) {

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -39,12 +39,14 @@ typedef NS_ENUM(NSInteger, RNSMenuItemType) {
 
 @property (nonatomic, copy, readonly, nullable) NSString *title;
 @property (nonatomic, readonly) BOOL singleSelection;
+@property (nonatomic, readonly) BOOL displayInline;
 @property (nonatomic, copy, readonly) NSArray<id<RNSStackHeaderMenuElement>> *children;
 @property (nonatomic, strong, readonly, nullable) RNSStackHeaderIconData *icon;
 
 - (instancetype)initWithId:(NSString *)menuElementId
                      title:(nullable NSString *)title
            singleSelection:(BOOL)singleSelection
+             displayInline:(BOOL)displayInline
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
                       icon:(nullable RNSStackHeaderIconData *)icon;
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
@@ -31,6 +31,7 @@
 - (instancetype)initWithId:(NSString *)menuElementId
                      title:(nullable NSString *)title
            singleSelection:(BOOL)singleSelection
+             displayInline:(BOOL)displayInline
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
                       icon:(nullable RNSStackHeaderIconData *)icon
 {
@@ -38,6 +39,7 @@
     _menuElementId = [menuElementId copy];
     _title = [title copy];
     _singleSelection = singleSelection;
+    _displayInline = displayInline;
     _children = [children copy];
     _icon = icon;
   }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -5,7 +5,7 @@
 #import <React/RCTLog.h>
 
 static NSSet<NSString *> *const kRNSAllowedMenuKeys =
-    [NSSet setWithObjects:@"id", @"type", @"title", @"children", @"singleSelection", @"icon", nil];
+    [NSSet setWithObjects:@"id", @"type", @"title", @"children", @"singleSelection", @"displayInline", @"icon", nil];
 static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
     setWithObjects:@"id", @"type", @"title", @"itemType", @"initialToggleState", @"keepsMenuPresented", @"icon", nil];
 
@@ -36,12 +36,14 @@ static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
   }
 
   BOOL singleSelection = [self boolForKey:@"singleSelection" in:dict];
+  BOOL displayInline = [self boolForKey:@"displayInline" in:dict];
 
   RNSStackHeaderIconData *icon = [RNSStackHeaderIconMapper iconFromDictionary:dict[@"icon"]];
 
   return [[RNSStackHeaderMenuData alloc] initWithId:[self stringForKey:@"id" in:dict]
                                               title:[self stringForKey:@"title" in:dict]
                                     singleSelection:singleSelection
+                                      displayInline:displayInline
                                            children:children
                                                icon:icon];
 }

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -177,6 +177,9 @@ export interface StackHeaderMenuIOS {
    * @description
    * A menu displayed inline is rendered directly inside its parent menu,
    * with horizontal bars separating it from the surrounding items.
+   *
+   * @default false
+   * @platform ios
    */
   displayInline?: boolean | undefined;
   /**

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -172,6 +172,14 @@ export interface StackHeaderMenuIOS {
    */
   icon?: PlatformIconIOS | undefined;
   /**
+   * @summary Displays the menu inline with parent menu instead of as a submenu.
+   *
+   * @description
+   * A menu displayed inline is rendered directly inside its parent menu,
+   * with horizontal bars separating it from the surrounding items.
+   */
+  displayInline?: boolean | undefined;
+  /**
    * @summary Child elements of this menu.
    *
    * @description

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -26,6 +26,9 @@ export type StackHeaderMenuIOS = {
   id: string;
   type: 'menu';
   title?: string | undefined;
+  singleSelection?: boolean | undefined;
+  icon?: object | undefined;
+  displayInline?: boolean | undefined;
   children: StackHeaderMenuElementIOS[];
 };
 


### PR DESCRIPTION
## Description

This PR adds support for `UIMenuOptionsDisplayInline` flag for menu.

## Changes

- added `displayInline` flag to menu types
- added SFT for testing menu options

Visual documentation

https://github.com/user-attachments/assets/5dc4ddcf-682c-4eac-96b9-79bf71d366a7

## Test plan

Use `test-stack-header-menu-options-ios` SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
