### PR TITLE
chore: bump minimal supported RN version to 0.84

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Here's a table with summary of supported `react-native` versions:
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 4.26.0+         | 0.84.0+              |
 | 4.25.0+         | 0.82.0+              |
 | 4.19.0+         | 0.81.0+              |
 | 4.14.0+         | 0.79.0+              |

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.82.0"
+    "react-native": ">=0.84.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION

## Description

Currently, latest stable version of RN is 0.86.
We support 0.86, 0.85, 0.84.

Likely, the library still works on lower versions, BUT we don't
test outside declared range.
