### PR TITLE
refactor(iOS, FormSheet v5): Set `RootNodeKind` trait for `FormSheet`, drop `contentOriginOffset`

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostShadowNode.cpp
@@ -4,9 +4,4 @@ namespace facebook::react {
 
 extern const char RNSFormSheetHostComponentName[] = "RNSFormSheetHost";
 
-Point RNSFormSheetHostShadowNode::getContentOriginOffset(
-    bool /*includeTransform*/) const {
-  return getStateData().contentOffset;
-}
-
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostShadowNode.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostShadowNode.h
@@ -19,7 +19,11 @@ class JSI_EXPORT RNSFormSheetHostShadowNode final
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  Point getContentOriginOffset(bool includeTransform) const override;
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostState.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostState.cpp
@@ -5,8 +5,7 @@ namespace facebook::react {
 #ifdef ANDROID
 folly::dynamic RNSFormSheetHostState::getDynamic() const {
   return folly::dynamic::object("frameWidth", frameSize.width)(
-      "frameHeight", frameSize.height)("contentOffsetX", contentOffset.x)(
-      "contentOffsetY", contentOffset.y);
+      "frameHeight", frameSize.height);
 }
 #endif // ANDROID
 

--- a/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostState.h
+++ b/common/cpp/react/renderer/components/rnscreens/RNSFormSheetHostState.h
@@ -2,7 +2,6 @@
 
 #include <jsi/jsi.h>
 #include <react/renderer/graphics/Float.h>
-#include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/Size.h>
 #ifdef ANDROID
 #include <folly/dynamic.h>
@@ -15,8 +14,7 @@ namespace facebook::react {
 class JSI_EXPORT RNSFormSheetHostState final {
  public:
   RNSFormSheetHostState() = default;
-  RNSFormSheetHostState(Size frameSize, Point contentOffset)
-      : frameSize(frameSize), contentOffset(contentOffset) {}
+  RNSFormSheetHostState(Size frameSize) : frameSize(frameSize) {}
 
 #ifdef ANDROID
   RNSFormSheetHostState(
@@ -25,11 +23,7 @@ class JSI_EXPORT RNSFormSheetHostState final {
       : frameSize(
             Size{
                 (Float)data["frameWidth"].getDouble(),
-                (Float)data["frameHeight"].getDouble()}),
-        contentOffset(
-            Point{
-                (Float)data["contentOffsetX"].getDouble(),
-                (Float)data["contentOffsetY"].getDouble()}) {}
+                (Float)data["frameHeight"].getDouble()}) {}
 
   folly::dynamic getDynamic() const;
   MapBuffer getMapBuffer() const {
@@ -38,7 +32,6 @@ class JSI_EXPORT RNSFormSheetHostState final {
 #endif // ANDROID
 
   Size frameSize{};
-  Point contentOffset{};
 };
 
 } // namespace facebook::react

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -151,7 +151,7 @@ namespace react = facebook::react;
 
 - (void)sheetControllerViewDidLayoutSubviews:(RNSFormSheetContentController *)controller
 {
-  [self syncTouchHandlerOrigin];
+  [self ensureTouchHandlerAttached];
   [self syncShadowNodeState];
 }
 
@@ -327,15 +327,7 @@ namespace react = facebook::react;
     return;
   }
 
-  // contentOriginOffset is the vector from the host view's origin to the content view's origin,
-  // both expressed in window space. It offsets child layout positions to account for the fact that
-  // React children are mounted in a separate UIViewController hierarchy.
-  CGPoint contentViewOriginInWindow = [_controller.contentView convertPoint:CGPointZero toView:nil];
-  CGPoint hostOriginInWindow = [self convertPoint:CGPointZero toView:nil];
-  CGPoint contentOriginOffset = CGPointMake(contentViewOriginInWindow.x - hostOriginInWindow.x,
-                                            contentViewOriginInWindow.y - hostOriginInWindow.y);
-
-  [_shadowStateProxy updateShadowStateWithBounds:_controller.contentView.bounds origin:contentOriginOffset];
+  [_shadowStateProxy updateShadowStateWithBounds:_controller.contentView.bounds];
 }
 
 #pragma mark - Touch Handling overrides
@@ -349,26 +341,14 @@ namespace react = facebook::react;
 
 #pragma mark - Touch Handling helpers
 
-- (void)syncTouchHandlerOrigin
+- (void)ensureTouchHandlerAttached
 {
-  if (_controller == nil || _controller.contentView == nil) {
+  if (_touchHandler != nil || _controller == nil || _controller.contentView == nil) {
     return;
   }
 
-  // Touch handler requires absolute positioning coordinates, relatively to root (UIWindow)
-  CGPoint contentViewOriginInWindow = [_controller.contentView convertPoint:CGPointZero toView:nil];
-  [self updateTouchHandlerWithOrigin:contentViewOriginInWindow];
-}
-
-- (void)updateTouchHandlerWithOrigin:(CGPoint)origin
-{
-  if (_touchHandler == nil) {
-    _touchHandler = [RCTSurfaceTouchHandler new];
-    [_touchHandler attachToView:_controller.contentView];
-  }
-
-  // Aligns touch coordinate space with window coordinate space
-  _touchHandler.viewOriginOffset = origin;
+  _touchHandler = [RCTSurfaceTouchHandler new];
+  [_touchHandler attachToView:_controller.contentView];
 }
 
 #pragma mark - Dynamic frameworks support

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostShadowStateProxy.h
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostShadowStateProxy.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
            oldState:(facebook::react::State::Shared const &)oldState;
 #endif
 
-- (void)updateShadowStateWithBounds:(CGRect)bounds origin:(CGPoint)origin;
+- (void)updateShadowStateWithBounds:(CGRect)bounds;
 
 @end
 

--- a/ios/gamma/modals/form-sheet/RNSFormSheetHostShadowStateProxy.mm
+++ b/ios/gamma/modals/form-sheet/RNSFormSheetHostShadowStateProxy.mm
@@ -8,13 +8,13 @@ namespace react = facebook::react;
 
 @implementation RNSFormSheetHostShadowStateProxy {
   react::RNSFormSheetHostShadowNode::ConcreteState::Shared _state;
-  CGRect _lastScheduledFrame;
+  CGSize _lastScheduledSize;
 }
 
 - (instancetype)init
 {
   if (self = [super init]) {
-    _lastScheduledFrame = CGRectNull;
+    _lastScheduledSize = CGSizeZero;
   }
   return self;
 }
@@ -24,20 +24,20 @@ namespace react = facebook::react;
   _state = std::static_pointer_cast<const react::RNSFormSheetHostShadowNode::ConcreteState>(state);
 }
 
-- (void)updateShadowStateWithBounds:(CGRect)bounds origin:(CGPoint)origin
+- (void)updateShadowStateWithBounds:(CGRect)bounds
 {
   if (_state == nullptr) {
     return;
   }
 
-  CGRect frame = {origin, bounds.size};
+  CGSize size = bounds.size;
 
-  if (!CGRectEqualToRect(frame, _lastScheduledFrame)) {
-    auto newState = react::RNSFormSheetHostState{RCTSizeFromCGSize(bounds.size), RCTPointFromCGPoint(origin)};
+  if (!CGSizeEqualToSize(size, _lastScheduledSize)) {
+    auto newState = react::RNSFormSheetHostState{RCTSizeFromCGSize(size)};
 
     _state->updateState(std::move(newState), facebook::react::EventQueue::UpdateMode::unstable_Immediate);
 
-    _lastScheduledFrame = frame;
+    _lastScheduledSize = size;
   }
 }
 


### PR DESCRIPTION
## Description

RN's `ModalHostViewShadowNode` sets the `RootNodeKind` trait, which makes `getRelativeLayoutMetrics` treat the modal content as a root at (0,0).
FormSheet was taking care of that manually by injecting `contentOffset` into the shadow node via `getContentOriginOffset` and setting the touch handler's `viewOriginOffset` to the content view's window position, re-synced on every layout pass, which was fragile.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1421

## Changes

- Added `RootNodeKind` trait to FormSheet shadow node.
- Removed contentOriginOffset references from shadow state update.

## Before & after - visual documentation

N/A - refactor

## Test plan

Verify on any already existing example.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
