### PR TITLE
feat(Stack v5, iOS): Add displayAsPalette flag for menu

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
@@ -229,8 +229,8 @@ function ConfigScreen() {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
       <Text style={styles.label}>
-        To test <Text style={styles.code}>displayInline</Text> try different
-        combination with nested menus:
+        To test <Text style={styles.code}>displayInline</Text> (iOS 17.0+) try
+        different combinations with nested menus:
       </Text>
       <Button
         title={`displayInline (Sort By): ${displayInline}`}

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
@@ -5,8 +5,9 @@ import {
   useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
 import { StackHeaderConfigProps } from 'react-native-screens/components/gamma/stack/header';
-import { Button, ScrollView } from 'react-native';
+import { Button, Platform, ScrollView, StyleSheet, Text } from 'react-native';
 import { scenarioDescription } from './scenario-description';
+import { Colors } from '@apps/shared/styling';
 
 function TestStackHeaderMenuOptionsIOS() {
   return (
@@ -25,6 +26,8 @@ function TestStackHeaderMenuOptionsIOS() {
 function buildHeaderConfig(
   displayInline: boolean,
   nestedDisplayInline: boolean,
+  displayAsPalette: boolean,
+  paletteDisplayInline: boolean,
 ): StackHeaderConfigProps {
   return {
     title: 'Menu Options',
@@ -126,6 +129,68 @@ function buildHeaderConfig(
             ],
           },
         },
+        {
+          type: 'spacer',
+          id: 'palette-spacer',
+          sizing: 'flexible',
+        },
+        {
+          type: 'item',
+          id: 'palette-button',
+          title: 'Palette',
+          icon: { type: 'sfSymbol', name: 'paintpalette' },
+          menu: {
+            type: 'menu',
+            id: 'palette-root',
+            children: [
+              {
+                id: 'palette-submenu',
+                type: 'menu',
+                title: 'Text Style',
+                displayAsPalette,
+                displayInline: paletteDisplayInline,
+                icon: { type: 'sfSymbol', name: 'textformat' },
+                children: [
+                  {
+                    id: 'style-bold',
+                    type: 'menuItem',
+                    itemType: 'action',
+                    title: 'Bold',
+                    icon: { type: 'sfSymbol', name: 'bold' },
+                  },
+                  {
+                    id: 'style-italic',
+                    type: 'menuItem',
+                    itemType: 'action',
+                    title: 'Italic',
+                    icon: { type: 'sfSymbol', name: 'italic' },
+                  },
+                  {
+                    id: 'style-underline',
+                    type: 'menuItem',
+                    itemType: 'action',
+                    title: 'Underline',
+                    icon: { type: 'sfSymbol', name: 'underline' },
+                  },
+                  {
+                    id: 'style-strikethrough',
+                    type: 'menuItem',
+                    itemType: 'action',
+                    title: 'Strikethrough',
+                    icon: { type: 'sfSymbol', name: 'strikethrough' },
+                  },
+                ],
+              },
+              {
+                id: 'palette-action-reset',
+                type: 'menuItem',
+                itemType: 'action',
+                title: 'Reset Formatting',
+                icon: { type: 'sfSymbol', name: 'clear' },
+              },
+            ],
+          },
+        },
       ],
     },
   };
@@ -135,11 +200,24 @@ function ConfigScreen() {
   const navigation = useStackNavigationContext();
   const [displayInline, setDisplayInline] = useState(false);
   const [nestedDisplayInline, setNestedDisplayInline] = useState(false);
+  const [displayAsPalette, setDisplayAsPalette] = useState(false);
+  const [paletteDisplayInline, setPaletteDisplayInline] = useState(false);
 
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(
-    () => buildHeaderConfig(displayInline, nestedDisplayInline),
-    [displayInline, nestedDisplayInline],
+    () =>
+      buildHeaderConfig(
+        displayInline,
+        nestedDisplayInline,
+        displayAsPalette,
+        paletteDisplayInline,
+      ),
+    [
+      displayInline,
+      nestedDisplayInline,
+      displayAsPalette,
+      paletteDisplayInline,
+    ],
   );
 
   useLayoutEffect(() => {
@@ -150,6 +228,10 @@ function ConfigScreen() {
 
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
+      <Text style={styles.label}>
+        To test <Text style={styles.code}>displayInline</Text> try different
+        combination with nested menus:
+      </Text>
       <Button
         title={`displayInline (Sort By): ${displayInline}`}
         onPress={() => setDisplayInline(prev => !prev)}
@@ -157,6 +239,18 @@ function ConfigScreen() {
       <Button
         title={`displayInline (Rating): ${nestedDisplayInline}`}
         onPress={() => setNestedDisplayInline(prev => !prev)}
+      />
+      <Text style={styles.label}>
+        <Text style={styles.code}>displayAsPalette</Text> works best combined
+        with <Text style={styles.code}>displayInline</Text>:
+      </Text>
+      <Button
+        title={`displayAsPalette (Text Style): ${displayAsPalette}`}
+        onPress={() => setDisplayAsPalette(prev => !prev)}
+      />
+      <Button
+        title={`displayInline (Text Style): ${paletteDisplayInline}`}
+        onPress={() => setPaletteDisplayInline(prev => !prev)}
       />
     </ScrollView>
   );
@@ -166,3 +260,17 @@ export default createScenario(
   TestStackHeaderMenuOptionsIOS,
   scenarioDescription,
 );
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 16,
+    padding: 20,
+  },
+  code: {
+    backgroundColor: Colors.OffWhite,
+    fontSize: 16,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    padding: 4,
+    borderRadius: 4,
+  },
+});

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
@@ -16,7 +16,9 @@ TBD
 
 ## Steps on iPhone
 
-1. Ensure both toggles for display mode are set to off
+### displayInline
+
+1. Ensure both toggles are set to `false`
 2. Tap the ellipsis (Options) button in the header
   - [ ] Menu shows: Copy, Paste, Share, Sort By as a collapsed submenu, Delete
 3. Tap Sort By
@@ -39,3 +41,21 @@ TBD
 14. Toggle "displayInline (Rating)" to `true` again
 15. Tap the ellipsis button
   - [ ] Menu shows: Copy, Paste, Share, menu separator, Name, Date, Size, menu separator, Best Reviews, Most Reviews, Highest Rated, menu separator, Delete, all inline
+
+### displayAsPalette
+
+1. Ensure both toggles are set to `false`
+2. Tap the Palette button in the header
+  - [ ] Menu shows: Text Style as a collapsed submenu, Reset Formatting
+3. Tap Text Style
+  - [ ] A nested submenu opens with: Bold, Italic, Underline, Strikethrough as a (regular) vertical list
+4. Dismiss the menu
+5. Toggle "displayAsPalette (Text Style)" to `true`
+6. Tap the Palette button
+  - [ ] Menu still shows: Text Style as a collapsed submenu, Reset Formatting
+7. Tap Text Style
+  - [ ] Menu shows a horizontal palette row with Bold, Italic, Underline, Strikethrough icons
+8. Dismiss the menu
+9. Toggle "displayInline (Text Style)" to `true`
+10. Tap the Palette button
+  - [ ] Menu shows: Text Style as a horizontal palette row with Bold, Italic, Underline, Strikethrough icons, and Reset Formatting below

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -51,7 +51,11 @@
     options |= UIMenuOptionsDisplayInline;
   }
   if (data.displayAsPalette) {
-    options |= UIMenuOptionsDisplayAsPalette;
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0) || (TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 170000)
+    if (@available(iOS 17.0, tvOS 17.0, *)) {
+      options |= UIMenuOptionsDisplayAsPalette;
+    }
+#endif
   }
 
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -50,13 +50,13 @@
   if (data.displayInline) {
     options |= UIMenuOptionsDisplayInline;
   }
-  if (data.displayAsPalette) {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0) || (TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 170000)
-    if (@available(iOS 17.0, tvOS 17.0, *)) {
+  if (@available(iOS 17.0, tvOS 17.0, *)) {
+    if (data.displayAsPalette) {
       options |= UIMenuOptionsDisplayAsPalette;
     }
-#endif
   }
+#endif
 
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
   for (id<RNSStackHeaderMenuElement> child in data.children) {

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -50,6 +50,9 @@
   if (data.displayInline) {
     options |= UIMenuOptionsDisplayInline;
   }
+  if (data.displayAsPalette) {
+    options |= UIMenuOptionsDisplayAsPalette;
+  }
 
   NSMutableArray<UIMenuElement *> *elements = [NSMutableArray arrayWithCapacity:data.children.count];
   for (id<RNSStackHeaderMenuElement> child in data.children) {

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, RNSMenuItemType) {
 @property (nonatomic, copy, readonly, nullable) NSString *title;
 @property (nonatomic, readonly) BOOL singleSelection;
 @property (nonatomic, readonly) BOOL displayInline;
+@property (nonatomic, readonly) BOOL displayAsPalette;
 @property (nonatomic, copy, readonly) NSArray<id<RNSStackHeaderMenuElement>> *children;
 @property (nonatomic, strong, readonly, nullable) RNSStackHeaderIconData *icon;
 
@@ -47,6 +48,7 @@ typedef NS_ENUM(NSInteger, RNSMenuItemType) {
                      title:(nullable NSString *)title
            singleSelection:(BOOL)singleSelection
              displayInline:(BOOL)displayInline
+          displayAsPalette:(BOOL)displayAsPalette
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
                       icon:(nullable RNSStackHeaderIconData *)icon;
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuData.mm
@@ -32,6 +32,7 @@
                      title:(nullable NSString *)title
            singleSelection:(BOOL)singleSelection
              displayInline:(BOOL)displayInline
+          displayAsPalette:(BOOL)displayAsPalette
                   children:(NSArray<id<RNSStackHeaderMenuElement>> *)children
                       icon:(nullable RNSStackHeaderIconData *)icon
 {
@@ -40,6 +41,7 @@
     _title = [title copy];
     _singleSelection = singleSelection;
     _displayInline = displayInline;
+    _displayAsPalette = displayAsPalette;
     _children = [children copy];
     _icon = icon;
   }

--- a/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuMapper.mm
@@ -4,8 +4,15 @@
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 
-static NSSet<NSString *> *const kRNSAllowedMenuKeys =
-    [NSSet setWithObjects:@"id", @"type", @"title", @"children", @"singleSelection", @"displayInline", @"icon", nil];
+static NSSet<NSString *> *const kRNSAllowedMenuKeys = [NSSet setWithObjects:@"id",
+                                                                            @"type",
+                                                                            @"title",
+                                                                            @"children",
+                                                                            @"singleSelection",
+                                                                            @"displayInline",
+                                                                            @"displayAsPalette",
+                                                                            @"icon",
+                                                                            nil];
 static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
     setWithObjects:@"id", @"type", @"title", @"itemType", @"initialToggleState", @"keepsMenuPresented", @"icon", nil];
 
@@ -37,6 +44,7 @@ static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
 
   BOOL singleSelection = [self boolForKey:@"singleSelection" in:dict];
   BOOL displayInline = [self boolForKey:@"displayInline" in:dict];
+  BOOL displayAsPalette = [self boolForKey:@"displayAsPalette" in:dict];
 
   RNSStackHeaderIconData *icon = [RNSStackHeaderIconMapper iconFromDictionary:dict[@"icon"]];
 
@@ -44,6 +52,7 @@ static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
                                               title:[self stringForKey:@"title" in:dict]
                                     singleSelection:singleSelection
                                       displayInline:displayInline
+                                   displayAsPalette:displayAsPalette
                                            children:children
                                                icon:icon];
 }

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -183,6 +183,17 @@ export interface StackHeaderMenuIOS {
    */
   displayInline?: boolean | undefined;
   /**
+   * @summary Displays the menu as a row of compact items (palette).
+   *
+   * @description
+   * When enabled, the menu children are rendered as a horizontal palette
+   * row instead of a vertical list. Best suited for menus with icon-only items.
+   *
+   * @default false
+   * @platform ios
+   */
+  displayAsPalette?: boolean | undefined;
+  /**
    * @summary Child elements of this menu.
    *
    * @description

--- a/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
+++ b/src/components/gamma/stack/header/ios/StackHeaderMenu.ios.types.ts
@@ -189,8 +189,14 @@ export interface StackHeaderMenuIOS {
    * When enabled, the menu children are rendered as a horizontal palette
    * row instead of a vertical list. Best suited for menus with icon-only items.
    *
+   * @remarks
+   * Requires iOS 17.0 or later. On older versions, this option is ignored.
+   *
    * @default false
+   *
    * @platform ios
+   *
+   * @supported iOS 17.0 or higher
    */
   displayAsPalette?: boolean | undefined;
   /**

--- a/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderItemIOSNativeComponent.ts
@@ -29,6 +29,7 @@ export type StackHeaderMenuIOS = {
   singleSelection?: boolean | undefined;
   icon?: object | undefined;
   displayInline?: boolean | undefined;
+  displayAsPalette?: boolean | undefined;
   children: StackHeaderMenuElementIOS[];
 };
 


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1182

## Description

This PR is a followup to https://github.com/software-mansion/react-native-screens/pull/4300 and adds `displayAsPalette` boolean flag.

## Changes

- added `displayAsPalette` flag
- updated SFT for menu options

## Before & after - visual documentation

https://github.com/user-attachments/assets/a123c336-6dde-4b15-9d2f-d689be8b21b2

## Test plan

Use `test-stack-header-menu-options-ios` SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
