### PR TITLE
refactor(test): Correct and clarify tabs test scenarios

### DIFF
--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/scenario.md
@@ -3,11 +3,11 @@
 ## Details
 
 **Description:**
-This test verifies interaction between `ScrollViewMarker`, `Stack` and `Tabs` components. 
-The primary goal is to verify that the tabs special effects (scroll-to-top, pop-to-top) do work in 
+This test verifies interaction between `ScrollViewMarker`, `Stack` and `Tabs` components.
+The primary goal is to verify that the tabs special effects (scroll-to-top, pop-to-top) do work in
 nested container scenario.
 
-**OS test creation version:** 
+**OS test creation version:**
 iOS: 26.5, Android: API Level 36.
 
 ## E2E test
@@ -23,7 +23,7 @@ Full: All manual test steps covered.
 
 Android does not yet support pop-to-root - it is unimplemented. Scroll-to-top should work.
 
-iOS implementation doesn't currently support nested container interaction yet. 
+iOS implementation doesn't currently support nested container interaction yet.
 This test needs to be updated after such interaction is supported.
 
 ## Steps
@@ -37,25 +37,25 @@ This test needs to be updated after such interaction is supported.
 
 2. Scroll down a bit.
 
-    Doesn't really matter how much you scroll - the distance should be "noticeable". 
+    Doesn't really matter how much you scroll - the distance should be "noticeable".
 
 3. Press `Home` tab item (repeated tab selection) to trigger the special effect.
 
-    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling 
+    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling
     to its top.
 
 ### Nested stack
 
 4. Change tab to `Stack`.
 
-    - [ ] The `Stack` screen should be displayed. 
+    - [ ] The `Stack` screen should be displayed.
     - [ ] Scroll-view should be visible and scrolled to top.
-    
+
 5. Scroll down a bit.
 
-    Doesn't really matter how much you scroll - the distance should be "noticeable". 
+    Doesn't really matter how much you scroll - the distance should be "noticeable".
 
 6. Press `Stack` tab item (repeated tab selection) to trigger the special effect.
 
-    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling 
+    - [ ] *scroll-to-top* should be triggered and you should observe the scroll-view scrolling
     to its top.

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-svm-tabs-scroll-edge-effects/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-svm-tabs-scroll-edge-effects/scenario.md
@@ -4,10 +4,10 @@
 
 **Description:**
 This test verifies interaction between `ScrollViewMarker` and `Tabs` in scope of scroll-edge-effects.
-It allows to test both whether the scroll-edge-effect is correctly applied AND whether it is correctly 
-updated between different tabs. 
+It allows to test both whether the scroll-edge-effect is correctly applied AND whether it is correctly
+updated between different tabs.
 
-**OS test creation version:** 
+**OS test creation version:**
 iOS 26.5
 
 ## E2E test
@@ -20,10 +20,10 @@ iOS: simulator with iOS 26+ is enough
 
 ## Note
 
-Seemingly the edge effect is applied correctly no matter the integration with the scrollview marker. 
-Likely UITabBarController uses some different logic to UIViewController.contentScrollView to detect scrollview, 
-because even when I have had returned nil from the method, the edge effect had still been applied. 
-Nevertheless, I decided to include this test case here, just to make sure it works. 
+Seemingly the edge effect is applied correctly no matter the integration with the scrollview marker.
+Likely UITabBarController uses some different logic to UIViewController.contentScrollView to detect scrollview,
+because even when I have had returned nil from the method, the edge effect had still been applied.
+Nevertheless, I decided to include this test case here, just to make sure it works.
 Also this allows us to test that different ScrollViewMarkers from different tab update the edge effect correctly on tab change.
 
 ## Steps

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/scenario.md
@@ -41,7 +41,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Nested container state preservation 
+### Nested container state preservation
 
 5. Navigate to the *Stack* tab.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -42,7 +42,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] The FormSheet expands to take up the maximum available height (respecting the top inset). The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded view area.
+- [ ] The FormSheet expands to take up the maximum available height (respecting the top inset). The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remains perfectly centered within the newly expanded view area.
 
 ---
 
@@ -74,7 +74,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
 
-- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remain perfectly centered within the newly expanded panel.
+- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remains perfectly centered within the newly expanded panel.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/tabs/index.ts
+++ b/apps/src/tests/single-feature-tests/tabs/index.ts
@@ -4,7 +4,7 @@ import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 // scenario group consumed by the selection menu.
 import TestTabsSimpleNav from './test-tabs-simple-nav';
 import TestTabsPreventNativeSelection from './test-tabs-prevent-native-selection';
-import TestTabsStaleStateUpdateRejection from './test-tabs-stale-update-rejection';
+import TestTabsStaleUpdateRejection from './test-tabs-stale-update-rejection';
 import TestTabsAppearanceDefinedBySelectedTab from './test-tabs-appearance-defined-by-selected-tab';
 import TestTabsTabBarColorScheme from './test-tabs-tab-bar-color-scheme';
 import TestTabsOverrideScrollViewContentInset from './test-tabs-override-scroll-view-content-inset-ios';
@@ -24,7 +24,7 @@ import TestTabsSystemItem from './test-tabs-system-item-ios';
 import TestTabsMoreNavigationController from './test-tabs-more-navigation-controller-ios';
 import TestTabsTabBarMinimizeBehavior from './test-tabs-tab-bar-minimize-behavior-ios';
 import TestTabsTabBarControllerMode from './test-tabs-tab-bar-controller-mode-ios';
-import TestTabsBottomAccessory from './test-tabs-bottom-accessory-layout-ios';
+import TestTabsBottomAccessoryLayout from './test-tabs-bottom-accessory-layout-ios';
 import TestTabsBottomAccessoryVisibility from './test-tabs-bottom-accessory-visibility-ios';
 import TestTabsScreenOrientation from './test-tabs-screen-orientation';
 import TestTabsTabBarExperimentalUserInterfaceStyle from './test-tabs-tab-bar-experimental-user-interface-style-ios';
@@ -33,7 +33,7 @@ import TestTabsTabBarExperimentalUserInterfaceStyle from './test-tabs-tab-bar-ex
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
 export { default as TestTabsSimpleNav } from './test-tabs-simple-nav';
 export { default as TestTabsPreventNativeSelection } from './test-tabs-prevent-native-selection';
-export { default as TestTabsStaleStateUpdateRejection } from './test-tabs-stale-update-rejection';
+export { default as TestTabsStaleUpdateRejection } from './test-tabs-stale-update-rejection';
 export { default as TestTabsAppearanceDefinedBySelectedTab } from './test-tabs-appearance-defined-by-selected-tab';
 export { default as TestTabsTabBarColorScheme } from './test-tabs-tab-bar-color-scheme';
 export { default as TestTabsOverrideScrollViewContentInset } from './test-tabs-override-scroll-view-content-inset-ios';
@@ -53,7 +53,7 @@ export { default as TestTabsSystemItem } from './test-tabs-system-item-ios';
 export { default as TestTabsMoreNavigationController } from './test-tabs-more-navigation-controller-ios';
 export { default as TestTabsTabBarMinimizeBehavior } from './test-tabs-tab-bar-minimize-behavior-ios';
 export { default as TestTabsTabBarControllerMode } from './test-tabs-tab-bar-controller-mode-ios';
-export { default as TestTabsBottomAccessory } from './test-tabs-bottom-accessory-layout-ios';
+export { default as TestTabsBottomAccessoryLayout } from './test-tabs-bottom-accessory-layout-ios';
 export { default as TestTabsBottomAccessoryVisibility } from './test-tabs-bottom-accessory-visibility-ios';
 export { default as TestTabsScreenOrientation } from './test-tabs-screen-orientation';
 export { default as TestTabsTabBarExperimentalUserInterfaceStyle } from './test-tabs-tab-bar-experimental-user-interface-style-ios';
@@ -61,7 +61,7 @@ export { default as TestTabsTabBarExperimentalUserInterfaceStyle } from './test-
 const scenarios = {
   TestTabsSimpleNav,
   TestTabsPreventNativeSelection,
-  TestTabsStaleStateUpdateRejection,
+  TestTabsStaleUpdateRejection,
   TestTabsAppearanceDefinedBySelectedTab,
   TestTabsTabBarColorScheme,
   TestTabsOverrideScrollViewContentInset,
@@ -81,7 +81,7 @@ const scenarios = {
   TestTabsMoreNavigationController,
   TestTabsTabBarMinimizeBehavior,
   TestTabsTabBarControllerMode,
-  TestTabsBottomAccessory,
+  TestTabsBottomAccessoryLayout,
   TestTabsBottomAccessoryVisibility,
   TestTabsScreenOrientation,
   TestTabsTabBarExperimentalUserInterfaceStyle,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
@@ -175,7 +175,7 @@ function TestTabsAppearanceDefinedBySelectedTab() {
                 tabBarItemTitleFontStyle: 'italic',
                 tabBarItemTitleFontWeight: 700,
                 tabBarBackgroundColor: Colors.PurpleDark100,
-                tabBarItemRippleColor: Colors.PurpleDark40,
+                tabBarItemRippleColor: Colors.GreenDark100,
                 normal: {
                   tabBarItemIconColor: Colors.YellowDark100,
                   tabBarItemTitleFontColor: Colors.YellowDark40,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
@@ -145,7 +145,7 @@ icons and titles are blue.
 - [ ] The tab bar background changes to purple.
 - [ ] The selected Tab2 icon and title change to red.
 - [ ] Unselected tab icons and titles are yellow.
-- [ ] The active indicator pill changes to purple.
+- [ ] The active indicator pill changes to dark purple.
 - [ ] Tab bar labels use the monospace italic font at the configured
   small (10pt) and large (16pt) label sizes.
 - [ ] The Tab3 badge still has value "123" in white text and green background.
@@ -153,8 +153,9 @@ icons and titles are blue.
 4. Press and hold a non-selected tab item in the tab bar to
    observe the ripple color while Tab2 is active.
 
-- [ ] A transient purple ripple is visible during the press; it
+- [ ] A transient green ripple is visible during the press; it
   fades on release.
+- [ ] After releasing the long press, the tab should not switch; Tab2 remains selected.
 - [ ] (Compare to Tab1's white translucent ripple when selected.)
 
 5. Tap the **"Select tab 1"** button on the Tab2 screen.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
@@ -210,7 +210,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
 ];
 
-function TestTabsBottomAccessory() {
+function TestTabsBottomAccessoryLayout() {
   return <TabsContainerWithHostConfigContext routeConfigs={ROUTE_CONFIGS} />;
 }
 
@@ -259,4 +259,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createScenario(TestTabsBottomAccessory, scenarioDescription);
+export default createScenario(
+  TestTabsBottomAccessoryLayout,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario-description.ts
@@ -1,9 +1,9 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Bottom Accessory',
+  name: 'Bottom Accessory Layout',
   key: 'test-tabs-bottom-accessory-layout-ios',
-  details: 'Test tabs bottom accessory with various contents',
+  details: 'Test tabs bottom accessory layout with various contents',
   platforms: ['ios'],
   e2eCoverage: 'incomplete',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: bottomAccessory
+# Test Scenario: Bottom Accessory Layout
 
 ## Details
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/scenario.md
@@ -113,7 +113,7 @@ is not applied to the full-size app.
 - [ ] The **ScrollDown** tab content (a 40-row list) is displayed.
   The Center accessory remains visible below the content and above tab bar.
 
-9.  Tap the **Config** tab.
+9. Tap the **Config** tab.
 
 - [ ] The **Config** tab is displayed. The Center accessory is still
   visible. The **Center** card still has a blue border.
@@ -127,7 +127,7 @@ is not applied to the full-size app.
 - [ ] The tab bar is fully visible. The Center accessory is visible in
 its `regular` position above the tab bar.
 
-11.  Scroll the list **down** on the **ScrollDown** tab.
+11. Scroll the list **down** on the **ScrollDown** tab.
 
 - [ ] The tab bar minimizes as content scrolls down. The accessory
   transitions to the `inline` environment layout (rendered inside the
@@ -161,10 +161,10 @@ its `regular` position above the tab bar.
 
 ### Switch with minimized tab bar
 
-16.  Scroll the **ScrollUp** tab so the tab bar minimizes.
+16. Scroll the **ScrollUp** tab so the tab bar minimizes.
 
 - [ ] The tab bar collapses. The bottom accessory transitions to
-the `inline` layout inside the collapsed bar.  
+the `inline` layout inside the collapsed bar.
 
 17. Tap on the collapsed tab bar to expand it.
 
@@ -184,7 +184,7 @@ still has a blue border.
 
 ### iPad only - full-size app
 
-20.  Resize app to full-size and perform steps 1-7.
+20. Resize app to full-size and perform steps 1-7.
 
 - [ ] Tab bar is displayed at the top of screen. Different bottom
 accessory content variants should be displayed correctly at the bottom of the screen.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-android/scenario.md
@@ -20,7 +20,6 @@ Other properties cannot be verified using Detox since it lacks access to color
 or visibility attributes on Android views. Therefore, it is not possible to
 programmatically assert whether a label is hidden or if a specific color value has been applied.
 
-
 ## Prerequisites
 
 - Android emulator or physical device.
@@ -130,19 +129,19 @@ unconstrained yellow circle that expands and smoothly fades outward.
 - [ ] A persistent green pill-shaped indicator is visible behind the "Indicator"
 tab icon in the tab bar.
 
-13.  Tap the **Default** tab, then the **Indicator** tab.
+13. Tap the **Default** tab, then the **Indicator** tab.
 
 - [ ] The yellow ripple effect is visible on the Indicator tab item,
 contained within the pill-shaped active indicator frame.
 - [ ] After the ripple animation ends, the indicator color remains green.
 
-14.  Tap the **Indicator** tab. Then press and hold the **Default**
+14. Tap the **Indicator** tab. Then press and hold the **Default**
     tab item for approximately one second, then release.
 
 - [ ] While pressing, a transient yellow ripple is visible.
 - [ ] The ripple is contained within the pill-shaped indicator frame.
 
-15.  Rapidly tap between **Default**, **Label**, and **Ripple** tabs
+15. Rapidly tap between **Default**, **Label**, and **Ripple** tabs
     several times.
 
 - [ ] Per-tab tab bar custom appearance configurations are applied correctly while switching tabs.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
@@ -134,8 +134,8 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 grayish or milky cast.
 - [ ] At the bottom edge of the content, `scrollEdgeAppearance` activates:
 transparent dark purple background, a bright purple shadow, and the `systemChromeMaterialDark` blur effect.
-- [ ] The final appearance is a blend of the  `scrollEdgeAppearance` configuration mixed with the underlying view's green background.
-  
+- [ ] The final appearance is a blend of the `scrollEdgeAppearance` configuration mixed with the underlying view's green background.
+
 9. Scroll **back to the top** of Tab2.
 
 - [ ] The background returns to solid dark blue with a red shadow line.
@@ -177,9 +177,9 @@ Tab2 until the trees image and end of content are visible.
 grayish or milky cast.
 - [ ] At the bottom edge of the content, `scrollEdgeAppearance` activates:
 transparent dark purple background, a bright purple shadow, and the `systemChromeMaterialDark` blur effect.
-- [ ] The final appearance is a blend of the  `scrollEdgeAppearance` configuration mixed with the underlying view's green background. 
+- [ ] The final appearance is a blend of the `scrollEdgeAppearance` configuration mixed with the underlying view's green background.
 
-13.  Re-enable both toggles to restore Tab2 default state before
+13. Re-enable both toggles to restore Tab2 default state before
     proceeding.
 
 - [ ] Both toggles are true; scrollEdgeAppearance and

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets-android/scenario.md
@@ -41,7 +41,7 @@ and text frame Y-positions.
 2. Tap inside the TextInput box.
 
 - [ ] The soft keyboard (IME) slides up.
-- [ ] The tab bar stays anchored at the bottom of the window frame and is hidden behind the keyboard. 
+- [ ] The tab bar stays anchored at the bottom of the window frame and is hidden behind the keyboard.
 - [ ] The layout text "TabsScreen bottom" at the end of the container is covered by the keyboard.
 
 3. Dismiss the keyboard.
@@ -87,5 +87,5 @@ remains tucked behind the tab bar layer.
 11. Tap inside the TextInput box again.
 
 - [ ] The soft keyboard (IME) slides up.
-- [ ] The tab bar stays anchored at the bottom of the window frame and is hidden behind the keyboard. 
+- [ ] The tab bar stays anchored at the bottom of the window frame and is hidden behind the keyboard.
 - [ ] The layout text "TabsScreen bottom" at the end of the container is covered by the keyboard.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -23,8 +23,8 @@ _UIBarBadgeView on iOS 26).
 Not covered:
 
 - All steps for Android, and most iOS steps except for the initial badge text validation.
-- Badge background and text colors (all tabs, all states). Detox does not expose color 
-  attributes for native tab bar badge views, meaning color validation requires a 
+- Badge background and text colors (all tabs, all states). Detox does not expose color
+  attributes for native tab bar badge views, meaning color validation requires a
   screenshot-diff approach that is not yet implemented.
 
 ## Prerequisites

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -34,6 +34,9 @@ Not covered:
 
 ## Note
 
+- On Android: Text color properties cannot be observed on Tab1 (empty badge) and Tab4 (icon).
+Validate background color only for these tabs.
+
 `badgeValue`:
 
 - On Android the maximum badge string length rendered verbatim is 4
@@ -158,8 +161,8 @@ maximum and is truncated by the system).
 
 2. Confirm Tab1 is active. Observe the Tab1 badge in the tab bar.
 
-- [ ] Badge shows as a small dot.
-- [ ] The badge renders with the Android system default: red background with white text.
+- [ ] Selected tab: Badge shows as a small dot.
+- [ ] Unselected tabs: The badge renders with the Android system default: red background with white text.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -139,7 +139,7 @@ tabBarItemTitleFontColor - it's reported native bug.
   the filled image. Unselected tab icon changes to sym_call_missed.
   Selected tab icon is **red** and unselected icon renders in **green**.
 
-3.  While **Image** tab is selected, use the Tab key on keyboard to
+3. While **Image** tab is selected, use the Tab key on keyboard to
 switch focus to the **DrawableResource** tab.
 
 - [ ] Focused tab icon is dark blue while selected tab icon
@@ -151,6 +151,6 @@ remains red.
 
 4. Switch between two tabs few times.
 
-- [ ] Each tab swaps between its `icon` and `selectedIcon` consistently on selection. 
-- [ ] The correct colors are applied each time: red for **Image**'s selected state and green for 
+- [ ] Each tab swaps between its `icon` and `selectedIcon` consistently on selection.
+- [ ] The correct colors are applied each time: red for **Image**'s selected state and green for
    **DrawableResource**'s unselected state.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -37,7 +37,7 @@ tabBarItemTitleFontColor - it's reported native bug.
   colors regardless of `tabBarTintColor` or `tabBarItemIconColor` (rendering as black in this scenario).
   Conversely, `templateSource`, `xcasset` and `sfSymbol` icons are tintable.
 - System Theme Colors: The default unselected tab title and icon color is gray on
-iOS 18 and lower, and black on iOS 26.
+  iOS 18 and lower, and black on iOS 26.
 
 ## Steps - iOS
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -34,8 +34,9 @@ iOS specific notes:
 tabBarItemTitleFontColor - it's reported native bug.
 - `tabBarTintColor` is applied only to selected tab bar item icon and title.
 - **`imageSource` icons are non-tintable:** they render in their original
-  colors regardless of `tabBarTintColor` or `tabBarItemIconColor`.
-  `templateSource`, `xcasset` and `sfSymbol` icons are tintable.
+  colors regardless of `tabBarTintColor` or `tabBarItemIconColor` (rendering as black in this scenario).
+  Conversely, `templateSource`, `xcasset` and `sfSymbol` icons are tintable.
+- System Theme Colors: The default unselected tab title color is gray on iOS 18 and lower, and black on iOS 26.
 
 ## Steps - iOS
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -142,7 +142,7 @@ tabBarItemTitleFontColor - it's reported native bug.
 3.  While **Image** tab is selected, use the Tab key on keyboard to
 switch focus to the **DrawableResource** tab.
 
-- [ ] Focused tab title is dark blue while selected tab title
+- [ ] Focused tab icon is dark blue while selected tab icon
 remains red.
 
 ---

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -36,7 +36,8 @@ tabBarItemTitleFontColor - it's reported native bug.
 - **`imageSource` icons are non-tintable:** they render in their original
   colors regardless of `tabBarTintColor` or `tabBarItemIconColor` (rendering as black in this scenario).
   Conversely, `templateSource`, `xcasset` and `sfSymbol` icons are tintable.
-- System Theme Colors: The default unselected tab title color is gray on iOS 18 and lower, and black on iOS 26.
+- System Theme Colors: The default unselected tab title and icon color is gray on
+iOS 18 and lower, and black on iOS 26.
 
 ## Steps - iOS
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/scenario.md
@@ -58,7 +58,7 @@ simulated device is required for all steps.
 1. Launch the app and navigate to the **Tab Bar Layout Appearances (iOS)**
    screen. Use an **iPhone** simulator in **portrait** orientation.
 
-- [ ] Expected: Four tabs are visible (Info, Tab1, Tab2, Tab3). The first
+- [ ] Four tabs are visible (Info, Tab1, Tab2, Tab3). The first
   tab (Info) is selected by default. Its title **"Info"** should appear in
   a **red** italic font. On iOS18, unselected tabs
   should have normal (non-italic) titles in **darker red**.
@@ -67,14 +67,14 @@ simulated device is required for all steps.
 
 2. Tap **Tab1**.
 
-- [ ] Expected: "Tab1" title becomes **italic** and **red**.
+- [ ] "Tab1" title becomes **italic** and **red**.
   On iOS18, the previously selected "Info" tab title becomes normal
   and darker red. On iOS 26, "Info" tab use system
   default appearance.
 
 3. Tap **Tab2**, then **Tab3**, then back to **Tab1**.
 
-- [ ] Expected: Each selected tab displays an italic, red title.
+- [ ] Each selected tab displays an italic, red title.
   All other tabs display normal titles (iOS 18: darker red, iOS 26: system
 default color)
 
@@ -84,13 +84,13 @@ default color)
 
 4. On an **iPhone Pro** simulator, rotate to **landscape** and navigate to the screen.
 
-- [ ] Expected: Selected tab title appears in the **italic**, **green**.
+- [ ] Selected tab title appears in the **italic**, **green**.
 Unselected tab titles: display normal, on iOS 18: darker green, on iOS 26: system
 default color.
 
 5. Tap **Tab1**, **Tab2**, **Tab3** in turn.
 
-- [ ] Expected: Each tapped tab's title becomes italic and green. All other tab
+- [ ] Each tapped tab's title becomes italic and green. All other tab
 (unselected) display normal titles, on iOS 18: darker green, on iOS 26: system
 default color.
 
@@ -101,7 +101,7 @@ default color.
 6. On an **iPhone Pro** simulator, start in portrait (red stacked),
    then rotate to landscape (green compactInline), then rotate back to portrait.
 
-- [ ] Expected: Title colors and italic/normal styles update instantly with each
+- [ ] Title colors and italic/normal styles update instantly with each
 rotation to match the newly active layout appearance.
 
 ---
@@ -111,12 +111,12 @@ rotation to match the newly active layout appearance.
 7. On an **iPhone Pro Max**,
    rotate to **landscape** orientation and navigate to the screen.
 
-- [ ] Expected: Selected tab title appears in the **italic**, **blue**.
+- [ ] Selected tab title appears in the **italic**, **blue**.
 Unselected tab titles: display normal, darker blue.
 
 8. Tap **Tab1**, **Tab2**, **Tab3** in turn.
 
-- [ ] Expected: Each tapped tab's title becomes italic and blue.
+- [ ] Each tapped tab's title becomes italic and blue.
 Unselected tabs remain normal and darker blue.
 
 ---
@@ -126,5 +126,5 @@ Unselected tabs remain normal and darker blue.
 9. On an **iPhone Pro Max** simulator, start in portrait (red stacked),
    then rotate to landscape (blue inline), then rotate back to portrait.
 
-- [ ] Expected: Title colors and italic/normal styles update instantly with each
+- [ ] Title colors and italic/normal styles update instantly with each
 rotation to match the newly active layout appearance.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/scenario.md
@@ -9,7 +9,7 @@ and both item states (`normal` unselected, `selected`).
 `tabBarItemTitleFontColor` is used as the visual discriminator — color
 identifies which display-mode bucket is active:
 
-- **Red**  → `stacked`
+- **Red** → `stacked`
 - **Blue** → `inline`
 - **Green** → `compactInline`
 
@@ -47,7 +47,7 @@ simulated device is required for all steps.
 - On **iOS 26**, configuring the `inline` bucket has no visible effect on
   iPhone because the system never activates the `inlineLayoutAppearance` on
   that platform version. Testers should not expect blue titles to appear on
-  an iPhone running iOS 26.  Instead, the `compactInline` configuration is displayed.
+  an iPhone running iOS 26. Instead, the `compactInline` configuration is displayed.
 - Icon color is set to the system default: blue for the selected tab, and
   black or gray for unselected tabs, depending on the iOS version.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/scenario.md
@@ -7,7 +7,7 @@
 switches, covering happy-path transitions, re-tapping the active tab, and
 rapid switching.
 
-**OS test creation version:** iOS: 18.6 and 26.2, Android: 18.6.
+**OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
 
 ## E2E test
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:**  Validates the native iOS More navigation controller - the overflow mechanism UIKit creates when a tab bar has more than five tabs. Tests cover user-driven and JS-driven navigation to overflow tabs (Fifth, Sixth), correct onMoreTabSelected event lifecycle (fires only when opening the More list, not on subsequent selections within it), and iPad resize transitions between compact and regular size classes.
+**Description:** Validates the native iOS More navigation controller - the overflow mechanism UIKit creates when a tab bar has more than five tabs. Tests cover user-driven and JS-driven navigation to overflow tabs (Fifth, Sixth), correct onMoreTabSelected event lifecycle (fires only when opening the More list, not on subsequent selections within it), and iPad resize transitions between compact and regular size classes.
 
 **OS test creation version:** iOS: 18.6 and 26.2
 
@@ -132,7 +132,7 @@ TBD: Ongoing research.
 
 - [ ] **Second** tab becomes active. Tab bar selection updates, and the route key label reads `Second`. A blue toast appears at the bottom with the message `onTabSelected:"Second"`.
 
-12.  Tap **"More"** tab bar item and select **"Sixth"** from the More list.
+12. Tap **"More"** tab bar item and select **"Sixth"** from the More list.
 
 - [ ] **Sixth** tab content is shown, and the route key label reads `Sixth`. The **More** tab is selected in the tab bar. No crash or blank screen.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
@@ -82,7 +82,7 @@ TBD: Ongoing research.
 
 ## Steps - iPad
 
-### Baseline - without More navigation controler displayed
+### Baseline - without More navigation controller displayed
 
 1. Open app on iPad in full size and navigate to the **More navigation controller** scenario.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/scenario.md
@@ -84,7 +84,7 @@ TBD: Ongoing research.
 
 ### Baseline - without More navigation controler displayed
 
-1. Open app on iPad in full size and navigate to the **More navigation controller** scenario. Open DevTools.
+1. Open app on iPad in full size and navigate to the **More navigation controller** scenario.
 
 - [ ] Tab bar shows all six tabs. The **First** tab is selected. The content area displays `First` as the route key.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-native-container-style/scenario.md
@@ -30,8 +30,8 @@ manually.
 - On Android the color fills the `FrameLayout` that wraps currently focused
 screen and the `BottomNavigationView`.
 - On Android and iOS 18 and earlier, the tab bar may obscure the native container
-  background color unless a transparent or semi-transparent tab bar background  
-  color is configured.  
+  background color unless a transparent or semi-transparent tab bar background
+  color is configured.
 - On iOS 26, while the "liquid glass" tab bar partially obscures the color, it
   remains inherently visible through the material.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
@@ -55,8 +55,8 @@ is blocked.
 1. Launch the app and navigate to **Prevent native selection**.
 
 - [ ] Android: six tabs visible in the tab bar.
-- [ ] iOS: four tabs and a **More** item visible.The **First** tab is selected
-and displays `preventNativeSelection: false` under its name on the screen.
+- [ ] iOS: four tabs and a **More** item visible. The **First** tab is selected
+  and displays `preventNativeSelection: false` under its name on the screen.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
@@ -102,7 +102,7 @@ navigation is not blocked by `preventNativeSelection`.
 
 - [ ] Third tab label shows `preventNativeSelection: true`.
 
-9. Navigate to  the **Fourth** tab and tap **Toggle preventNativeSelection**.
+9. Navigate to the **Fourth** tab and tap **Toggle preventNativeSelection**.
 
 - [ ] Fourth tab label shows `preventNativeSelection: true`.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
@@ -54,8 +54,8 @@ is blocked.
 
 1. Launch the app and navigate to **Prevent native selection**.
 
-- [ ] On Android — six tabs visible in the tab bar. On iOS — four tabs
-and a **More** item visible.The **First** tab is selected
+- [ ] Android: six tabs visible in the tab bar.
+- [ ] iOS: four tabs and a **More** item visible.The **First** tab is selected
 and displays `preventNativeSelection: false` under its name on the screen.
 
 ---

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/scenario.md
@@ -117,73 +117,78 @@ still `false`.
 - [ ] First tab label shows `preventNativeSelection: false`. Tapping it
 from another tab works normally.
 
+12. Navigate to the **Fourth** tab via the **Select Fourth** button (programmatic).
+    Tap **Toggle preventNativeSelection** to disable it.
+
+- [ ] Fourth tab label shows `preventNativeSelection: false`.
+
 ---
 
 ### iOS only — More navigation controller (for iPad resize app)
 
-12. Navigate to the **Fifth** tab via the **Select Fifth** button (programmatic).
+13. Navigate to the **Fifth** tab via the **Select Fifth** button (programmatic).
 
 - [ ] **Fifth** tab is displayed normally.
 
-13. Tap **Toggle preventNativeSelection** on the **Fifth** tab.
+14. Tap **Toggle preventNativeSelection** on the **Fifth** tab.
 
 - [ ] Label updates to `preventNativeSelection: true`.
 
-14. Tap **Select Sixth**, then tap **Toggle preventNativeSelection**.
+15. Tap **Select Sixth**, then tap **Toggle preventNativeSelection**.
 
 - [ ] Label updates to `preventNativeSelection: true`.
 
-15. Tap **Select First**, then tap **More** in the tab bar.
+16. Tap **Select First**, then tap **More** in the tab bar.
 
 - [ ] Navigation to **Sixth** is blocked. Toast appears with
 `onTabSelectionPrevented: Sixth`. The More list is displayed.
 
-16. Tap **Fifth** in the More list.
+17. Tap **Fifth** in the More list.
 
 - [ ] Navigation to **Fifth** is blocked. Toast appears with `onTabSelectionPrevented: Fifth`. The More list remains displayed.
 
-17. Tap **Fourth** tab and navigate to **Fifth** via **Select Fifth**, tap
+18. Tap **Fourth** tab and navigate to **Fifth** via **Select Fifth**, tap
 **Toggle preventNativeSelection** to disable it.
 
 - [ ] Fifth tab label shows `preventNativeSelection: false`.
 
-18. Navigate away, then tap **More**.
+19. Navigate away, then tap **More**.
 
 - [ ] Navigation to **Fifth** proceeds normally. No toast appears.
 
-19. Tap **More** again and tap **Fifth** from list.
+20. Tap **More** again and tap **Fifth** from list.
 
 - [ ] Navigation to **Fifth** proceeds normally. No toast appears.
 
 ### iPad only - Sidebar behavior
 
-20. Resize app to full screen width.
+21. Resize app to full screen width.
 
 - [ ] More tab disappear. **Fifth** tab is selected.
 
-21. Open Sidebar and select **Sixth** from the list.
+22. Open Sidebar and select **Sixth** from the list.
 
 - [ ] Navigation to **Sixth** is blocked. Toast appears with
 `onTabSelectionPrevented: Sixth`.
 The **Fifth** tab is selected and its content remains displayed.
 
-22. Open Sidebar.
+23. Open Sidebar.
 
 - [ ] **Fifth** tab is selected.
 
-23. Tap **Second** from Sidebar list and tap **Toggle preventNativeSelection**.
+24. Tap **Second** from Sidebar list and tap **Toggle preventNativeSelection**.
 
 - [ ] Label updates to `preventNativeSelection: true`.
 
-24. Tap **Select Sixth** and tap **Toggle preventNativeSelection**.
+25. Tap **Select Sixth** and tap **Toggle preventNativeSelection**.
 
 - [ ] Label updates to `preventNativeSelection: false`.
 
-25. Tap **Fourth** and then from the Sidebar tap **Sixth**.
+26. Tap **Fourth** and then from the Sidebar tap **Sixth**.
 
 - [ ] Tab switches normally. No toast appears.
 
-26. Tap **Second** from tab bar.
+27. Tap **Second** from tab bar.
 
 - [ ] Navigation to **Second** is blocked. Toast appears with
 `onTabSelectionPrevented: Second`.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario-description.ts
@@ -3,6 +3,7 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 export const scenarioDescription: ScenarioDescription = {
   name: 'Tabs Screen Orientation',
   key: 'test-tabs-screen-orientation',
+  details: 'Test screen orientation behavior for TabsScreen',
   platforms: ['ios', 'android'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
@@ -10,7 +10,7 @@ WIP: This file is placeholder for future test. Currently waiting for fix issues 
 
 ## E2E test
 
-**TBD:**  Probably won't be implemented but it's to be decide when functionality will work.
+**TBD:** Probably won't be implemented but it's to be decide when functionality will work.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
@@ -10,7 +10,7 @@ WIP: Placeholder scenario for a future test. Currently waiting for fixes on iOS 
 
 ## E2E test
 
-**TBD:** Probably won't be implemented but it's to be decide when functionality will work.
+**TBD:** Probably won't be implemented; this will be decided once the functionality works.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
@@ -1,0 +1,19 @@
+# Test Scenario: Tabs screen orientation
+
+WIP: This file is placeholder for future test. Currently waiting for fix issues for iOS and implementation for Android.
+
+## Details
+
+**Description:**
+
+**OS test creation version:**
+
+## E2E test
+
+**TBD:**  Probably won't be implemented but it's to be decide when functionality will work.
+
+## Prerequisites
+
+## Note
+
+## Steps

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/scenario.md
@@ -1,6 +1,6 @@
 # Test Scenario: Tabs screen orientation
 
-WIP: This file is placeholder for future test. Currently waiting for fix issues for iOS and implementation for Android.
+WIP: Placeholder scenario for a future test. Currently waiting for fixes on iOS and an Android implementation.
 
 ## Details
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/scenario.md
@@ -33,7 +33,7 @@ transition animation finishes.
 
 1. Launch the app and navigate to **Test simple navigation**.
 
-- [ ] Expected: Three tabs are visible in the tab bar -
+- [ ] Three tabs are visible in the tab bar -
   **First**, **Second**, and **Third**. The **First** tab is
   active. The content area displays the label `First`.
 
@@ -43,17 +43,17 @@ transition animation finishes.
 
 2. Tap the **Second** tab in the tab bar.
 
-- [ ] Expected: The **Second** tab becomes active. The content
+- [ ] The **Second** tab becomes active. The content
   area displays the label `Second`.
 
 3. Tap the **Third** tab in the tab bar.
 
-- [ ] Expected: The **Third** tab becomes active. The content
+- [ ] The **Third** tab becomes active. The content
   area displays the label `Third`.
 
 4. Tap the **First** tab in the tab bar.
 
-- [ ] Expected: The **First** tab becomes active. The content
+- [ ] The **First** tab becomes active. The content
   area displays the label `First`.
 
 ---
@@ -62,17 +62,17 @@ transition animation finishes.
 
 5. While on the **First** tab, tap **Select Second**.
 
-- [ ] Expected: The **Second** tab becomes active. The content
+- [ ] The **Second** tab becomes active. The content
   area displays the label `Second`.
 
 6. While on the **Second** tab, tap **Select Third**.
 
-- [ ] Expected: The **Third** tab becomes active. The content
+- [ ] The **Third** tab becomes active. The content
   area displays the label `Third`.
 
 7. While on the **Third** tab, tap **Select First**.
 
-- [ ] Expected: The **First** tab becomes active. The content
+- [ ] The **First** tab becomes active. The content
   area displays the label `First`.
 
 ---
@@ -81,13 +81,13 @@ transition animation finishes.
 
 8. While on the **First** tab, tap **Select Third**.
 
-- [ ] Expected: The **Third** tab becomes active directly,
+- [ ] The **Third** tab becomes active directly,
   skipping **Second**. The content area displays the label
   `Third`.
 
 9. While on the **Third** tab, tap **First** tab in the tab bar.
 
-- [ ] Expected: The **First** tab becomes active directly,
+- [ ] The **First** tab becomes active directly,
   skipping **Second**. The content area displays the label
   `First`.
 
@@ -97,12 +97,12 @@ transition animation finishes.
 
 10. Tap the **Second** tab in the tab bar.
 
-- [ ] Expected: The **Second** tab is active, label shows
+- [ ] The **Second** tab is active, label shows
   `Second`.
 
 11. Tap **Select First** in the content area.
 
-- [ ] Expected: The **First** tab becomes active. The content
+- [ ] The **First** tab becomes active. The content
   area displays the label `First`. The tab-bar item for
   **First** is visually selected.
 
@@ -113,13 +113,13 @@ transition animation finishes.
 12. While on the **First** tab, tap the **First** tab bar item
     again.
 
-- [ ] Expected: The **First** tab remains selected. The content
+- [ ] The **First** tab remains selected. The content
   area still displays `First`. No crash or unexpected transition
   occurs.
 
 13. While on the **First** tab, tap **Select First**.
 
-- [ ] Expected: The **First** tab remains selected. The content
+- [ ] The **First** tab remains selected. The content
   area still displays `First`. No crash or unexpected state
   change occurs.
 
@@ -130,6 +130,6 @@ transition animation finishes.
 14. From the **First** tab, tap **Select Second** and immediately
     tap **Select Third** before the transition completes.
 
-- [ ] Expected: The final active tab is **Third**. The content
+- [ ] The final active tab is **Third**. The content
   area displays the label `Third`. No crash or inconsistent
   label is shown.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
@@ -131,7 +131,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
 ];
 
-function TestTabsStaleStateUpdateRejection() {
+function TestTabsStaleUpdateRejection() {
   return (
     <ToastProvider>
       <AppContents />
@@ -187,6 +187,6 @@ function blockThread(ms: number) {
 }
 
 export default createScenario(
-  TestTabsStaleStateUpdateRejection,
+  TestTabsStaleUpdateRejection,
   scenarioDescription,
 );

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-system-item-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-system-item-ios/scenario.md
@@ -172,7 +172,7 @@ iPhone Pro models (for iOS 18 excluding Max).
 
 - [ ] The tab bar item shows the `heart` SF Symbol icon (custom
   icon overrides the system search icon)
-- [ ] iOS 18: The label reads  `Custom`.
+- [ ] iOS 18: The label reads `Custom`.
 - [ ] iOS 26: No visible title label; the tab bar item is
   detached from the Bookmarks item.
 
@@ -180,7 +180,7 @@ iPhone Pro models (for iOS 18 excluding Max).
 
 - [ ] While Bookmarks is selected, the second tab bar item shows the unselected `heart` SF Symbol.
 - [ ] iOS 26: The second tab bar item remains detached.
-  
+
 16. Tap second tab again. Change systemItem to **history** while keeping title as
     **custom** and icon as **heart**.
 
@@ -211,7 +211,7 @@ iPhone Pro models (for iOS 18 excluding Max).
 
 ### Orientation smoke test
 
-20.  Select **Bookmarks** tab and rotate device to landscape orientation.
+20. Select **Bookmarks** tab and rotate device to landscape orientation.
 
 - [ ] The layout adapts to landscape.
 - [ ] The tab bar switches to a compact inline layout
@@ -225,14 +225,14 @@ iPhone Pro models (for iOS 18 excluding Max).
 - [ ] iOS 18 KI: Custom SF Symbol overrides may revert to the system icon in compactInline appearance.
 - [ ] iOS 26: The icon changes to `house.fill`.
 
-22. Change systemItem to **search** and icon to **heart**. Keep title set to **custom**. 
+22. Change systemItem to **search** and icon to **heart**. Keep title set to **custom**.
 
 - [ ] The tab bar label remains `Custom`.
 - [ ] iOS 18 KI: Custom SF Symbol overrides may revert to the system icon in compactInline appearance.
 - [ ] iOS 26: The icon changes to `heart.fill`. No visible title label; the Search tab bar item is
   detached from the other items.
 
-23.  Rotate the device back to portrait orientation.
+23. Rotate the device back to portrait orientation.
 
 - [ ] The tab bar reverts to its portrait layout.
 - [ ] The second tab bar item shows the `heart.fill` icon

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
@@ -21,7 +21,7 @@ Incomplete: Not automated. Detox does not have access to color attributes, so it
 
 - Each of the below steps must be executed twice: once with a system color scheme setting, and once with the color scheme forced via the React Native API.
 - For React Native settings, use the toggle displayed on the test screen.
-  
+
 Assumption:
 
 - System and RN color scheme settings are working correctly.
@@ -32,7 +32,7 @@ Assumption:
 ### Baseline
 
 1. Launch the app and navigate to the **Tab Bar Color Scheme** screen.
-   
+
 - [ ] Config tab is shown. Pickers default to `unspecified` / `inherit`
 
 ---
@@ -40,11 +40,11 @@ Assumption:
 ### TabsHost `inherit` — follows RN/system
 
 2. Set system/RN to **light**, TabsHost colorScheme = `inherit`
-   
+
 - [ ] Tab bar appears **light**
 
 3. Set system/RN to **dark**, keep TabsHost colorScheme = `inherit`
-   
+
 - [ ] Tab bar appears **dark** — TabsHost defers to RN/system
 
 ---
@@ -52,15 +52,15 @@ Assumption:
 ### TabsHost `light` — overrides RN/system
 
 4. Set system/RN to **dark**, set TabsHost colorScheme = `light`
-   
+
 - [ ] Tab bar appears **light** — TabsHost overrides dark from RN/system
 
 5. Set system/RN to **light**, keep TabsHost colorScheme = `light`
-   
+
 - [ ] Tab bar stays **light**
 
 6. Cycle through `inherit` → `dark` → `light` → `dark` → `inherit`
-   
+
 - [ ] Tab bar color scheme updates immediately with each change, no crash or layout freeze
 
 ---
@@ -68,11 +68,11 @@ Assumption:
 ### TabsHost `dark` — overrides RN/system
 
 7. Set system/RN to **light**, set TabsHost colorScheme = `dark`
-   
+
 - [ ] Tab bar appears **dark** — TabsHost overrides light from RN/system
 
 8. Set system/RN to **dark**, keep TabsHost colorScheme = `dark`
-   
+
 - [ ] Tab bar stays **dark**
 
 9. Cycle through `inherit` → `light` → `dark` → `light` → `inherit`
@@ -82,6 +82,6 @@ Assumption:
 ### Keyboard tab — simple check
 
 10. Switch to the **Keyboard** tab, open the keyboard via TextInput (or Cmd+K on iOS simulator)
-   
+
 - [ ] iOS: Keyboard appearance matches the currently active color scheme — verify for both light and dark values.
 - [ ] Android: Keyboard appearance matches the system color scheme.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
@@ -83,4 +83,5 @@ Assumption:
 
 10. Switch to the **Keyboard** tab, open the keyboard via TextInput (or Cmd+K on iOS simulator)
    
-- [ ] Keyboard appearance matches the currently active color scheme — verify for both light and dark values.
+- [ ] iOS: Keyboard appearance matches the currently active color scheme — verify for both light and dark values.
+- [ ] Android: Keyboard appearance matches the system color scheme.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/scenario.md
@@ -79,14 +79,14 @@ Not automated:
 
 - [ ] Tab bar displayed at the bottom with Tab1 and Tab2. Picker defaults to `automatic`
 
-12.   Set tabBarControllerMode = `automatic`
+12. Set tabBarControllerMode = `automatic`
 
 - [ ] Tab bar displayed at the **bottom**
 
-13.  Set tabBarControllerMode = `tabBar`
+13. Set tabBarControllerMode = `tabBar`
 
 - [ ] Tab bar displayed at the **bottom**
 
-14.  Set tabBarControllerMode = `tabSidebar`
+14. Set tabBarControllerMode = `tabSidebar`
 
 - [ ] Tab bar displayed at the **bottom**

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
@@ -35,7 +35,7 @@ Occasional flashes of the back button in the header are expected behavior and ar
 3. On `Home` screen click `Dark` button.
 
   - [ ] Screen is shown with a black background. A single button to push the screen with dark style is visible.
- 
+
 4. Tap **"Push screen with style: dark"** and observe tab bar.
 
 - [ ] The dark-styled tab screen is pushed, showing **Tab1** and **Tab2**. The tab bar reflects a **dark** style and appears without flash, flicker, or reversion to light style.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/scenario.md
@@ -139,7 +139,7 @@ result described as expected above.
 
 ### iOS only: System RTL / RN LTR
 
-> Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`, 
+> Setup: iOS system: System language is RTL (e.g. Arabic or Hebrew). Disable RN RTL `forceRTL = false`,
 > `allowRTL = false` and restart the app. `I18nManager.isRTL == false` and `TabsHost direction = ltr`.
 
 10. Set `TabsHost direction = inherit`.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
@@ -81,10 +81,10 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 ### Tab switching behavior
 
-10.  Set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2**, scroll down so the tab bar minimizes. Then tap minimized tab bar.
+10. Set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2**, scroll down so the tab bar minimizes. Then tap minimized tab bar.
 
 - [ ] Tab bar should reappeaer with two tabs.
 
-11.  Navigate to **Tab1** and switch back to **Tab2**.
+11. Navigate to **Tab1** and switch back to **Tab2**.
 
 - [ ] **Tab2** scroll position is preserved — no crash or blank screen.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
@@ -16,7 +16,7 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 ## Note
 
-- Behavior is only observable on iOS 26+; on older versions the tab bar should remain visible regardless of setting.
+- Behavior is only observable on iOS 26+; on older versions the tab bar should remains visible regardless of setting.
 - Scrolling **down** means moving content upward (revealing items below); scrolling **up** means moving content downward (revealing items above).
 - For test on iPad remember to resize app to state where down tab bar is display.
 - Tab bar minimize behavior should be updated immediately after each change with no crash, layout freeze, or visual glitch.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
@@ -81,9 +81,9 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 ### Tab switching behavior
 
-10. Set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2**, scroll down so the tab bar minimizes. Then tap minimized tab bar.
+10. Set `tabBarMinimizeBehavior` = `onScrollDown`. Switch to **Tab2**, scroll down so the tab bar minimizes. Then tap the minimized tab bar.
 
-- [ ] Tab bar should reappeaer with two tabs.
+- [ ] Tab bar should reappear, showing two tabs.
 
 11. Navigate to **Tab1** and switch back to **Tab2**.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/scenario.md
@@ -16,9 +16,9 @@ Incomplete: Not automated. Standard view-hierarchy testing is insufficient becau
 
 ## Note
 
-- Behavior is only observable on iOS 26+; on older versions the tab bar should remains visible regardless of setting.
+- Behavior is only observable on iOS 26+; on older versions the tab bar should remain visible regardless of the setting.
 - Scrolling **down** means moving content upward (revealing items below); scrolling **up** means moving content downward (revealing items above).
-- For test on iPad remember to resize app to state where down tab bar is display.
+- For testing on iPad, remember to resize the app until the bottom tab bar is displayed.
 - Tab bar minimize behavior should be updated immediately after each change with no crash, layout freeze, or visual glitch.
 
 ## Steps


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1634

This branch corrects and clarifies the manual test **scenarios** for the tabs single-feature tests (and a few adjacent tests). The changes are documentation-only for the QA scenarios - no library source is touched. The goal is to make each `scenario.md` executable and unambiguous, align keys/names/descriptions with their directory names, and fix small wording issues that made steps hard to follow or impossible to verify.

## Changelog

- Aligned test screen names, registration keys, function names, and descriptions with their directory names.
- Reformatted scenarios so iOS and Android expected results are stated as separate points, and removed leftover `Expected:` phrasing.
- Clarified platform-specific behavior notes:
  - Keyboard color follows the system color scheme on Android, but the highest active color scheme on iOS (overridden by TabsHost when set).
  - Badge test steps clarified for Android (tab 1 and tab 4 have no text, so text color can't be verified).
  - Added notes about system theme colors to make the iOS color-scheme test clearer.
- Fixed several steps that were unexecutable or inaccurate:
  - `preventNativeSelection`: added a step to disable it on the 4th tab so the scenario can be completed.
  - Corrected Android OS version, `rippleColor` for tab 2 (easier to verify), and title→icon wording for the checked element.
- Added a scenario placeholder and details for the screen-orientation test, plus `scenario-description` updates.
- Removed an unused "open devtools" action.
- Assorted whitespace/spacing/typo fixes (e.g. "remain"→"remains", double-whitespace cleanup).
- In `test-tabs-appearance-defined-by-selected-tab/index.tsx` Ripple Color for Tab2 was changed to make it more visible.

Files touched are limited to `apps/src/tests/single-feature-tests/**` scenario/test files.
