### PR TITLE
fix(iOS, Split): Fix ShadowState inside SplitView columns after transition

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 
-// import Example from './Example';
+import Example from './Example';
 
-import { TestSplitPressables as Example } from './src/tests/single-feature-tests';
+// import { TestTabsSimpleNav as Example } from './src/tests/single-feature-tests';
 // import { TestTabsInStackStableEnterTransition as Example } from './src/tests/component-integration-tests';
 // import { Test42 as Example } from './src/tests/issue-tests';
 

--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 
-import Example from './Example';
+// import Example from './Example';
 
-// import { TestTabsSimpleNav as Example } from './src/tests/single-feature-tests';
+import { TestSplitPressables as Example } from './src/tests/single-feature-tests';
 // import { TestTabsInStackStableEnterTransition as Example } from './src/tests/component-integration-tests';
 // import { Test42 as Example } from './src/tests/issue-tests';
 

--- a/apps/src/tests/single-feature-tests/split/index.ts
+++ b/apps/src/tests/single-feature-tests/split/index.ts
@@ -2,15 +2,18 @@ import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestSplitTopColumnForCollapsing from './test-top-column-for-collapsing';
 import TestSplitCommandShowColumn from './test-command-show-column';
 import TestSplitColorScheme from './test-split-color-scheme-ios';
+import TestSplitPressables from './test-split-pressables-ios';
 
 export { default as TestSplitTopColumnForCollapsing } from './test-top-column-for-collapsing';
 export { default as TestSplitCommandShowColumn } from './test-command-show-column';
 export { default as TestSplitColorScheme } from './test-split-color-scheme-ios';
+export { default as TestSplitPressables } from './test-split-pressables-ios';
 
 const scenarios = {
   TestSplitTopColumnForCollapsing,
   TestSplitCommandShowColumn,
   TestSplitColorScheme,
+  TestSplitPressables,
 };
 
 const SplitScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
@@ -1,27 +1,24 @@
 import React from 'react';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
-import { Split, SplitHostCommands } from 'react-native-screens/experimental';
+import { Split } from 'react-native-screens/experimental';
 import { StyleSheet, Text, View } from 'react-native';
 import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
 
 function TestSplitPressables() {
-  const hostRef = React.useRef<SplitHostCommands>(null);
-
   return (
-    <Split.Host preferredDisplayMode="oneBesideSecondary" ref={hostRef}>
+    <Split.Host preferredDisplayMode="oneBesideSecondary">
       <Split.Column>
-        <ColumnContent column="primary" columnTitle="Primary column" hostRef={hostRef} />
+        <ColumnContent column="primary" columnTitle="Primary column" />
       </Split.Column>
       <Split.Column>
         <ColumnContent
           column="supplementary"
           columnTitle="Supplementary column"
-          hostRef={hostRef}
         />
       </Split.Column>
       <Split.Column>
-        <ColumnContent column="secondary" columnTitle="Secondary column" hostRef={hostRef} />
+        <ColumnContent column="secondary" columnTitle="Secondary column" />
       </Split.Column>
     </Split.Host>
   );
@@ -30,16 +27,10 @@ function TestSplitPressables() {
 function ColumnContent(props: {
   column: 'primary' | 'supplementary' | 'secondary';
   columnTitle: string;
-  hostRef: React.RefObject<SplitHostCommands | null>;
 }) {
-  const onPress =
-    props.column === 'primary'
-      ? undefined
-      : () => props.hostRef.current?.show('primary');
-
   return (
     <View style={styles.container}>
-      <PressableWithFeedback style={styles.pressable} onPress={onPress}>
+      <PressableWithFeedback style={styles.pressable}>
         <Text style={styles.columnTitle}>{props.columnTitle}</Text>
       </PressableWithFeedback>
     </View>

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
@@ -11,25 +11,35 @@ function TestSplitPressables() {
   return (
     <Split.Host preferredDisplayMode="oneBesideSecondary" ref={hostRef}>
       <Split.Column>
-        <ColumnContent columnTitle="Primary column" hostRef={hostRef} />
+        <ColumnContent column="primary" columnTitle="Primary column" hostRef={hostRef} />
       </Split.Column>
       <Split.Column>
-        <ColumnContent columnTitle="Supplementary column" hostRef={hostRef} />
+        <ColumnContent
+          column="supplementary"
+          columnTitle="Supplementary column"
+          hostRef={hostRef}
+        />
       </Split.Column>
       <Split.Column>
-        <ColumnContent columnTitle="Secondary column" hostRef={hostRef} />
+        <ColumnContent column="secondary" columnTitle="Secondary column" hostRef={hostRef} />
       </Split.Column>
     </Split.Host>
   );
 }
 
 function ColumnContent(props: {
+  column: 'primary' | 'supplementary' | 'secondary';
   columnTitle: string;
   hostRef: React.RefObject<SplitHostCommands | null>;
 }) {
+  const onPress =
+    props.column === 'primary'
+      ? undefined
+      : () => props.hostRef.current?.show('primary');
+
   return (
     <View style={styles.container}>
-      <PressableWithFeedback style={styles.pressable}>
+      <PressableWithFeedback style={styles.pressable} onPress={onPress}>
         <Text style={styles.columnTitle}>{props.columnTitle}</Text>
       </PressableWithFeedback>
     </View>

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Split, SplitHostCommands } from 'react-native-screens/experimental';
+import { StyleSheet, Text, View } from 'react-native';
+import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
+
+function TestSplitPressables() {
+  const hostRef = React.useRef<SplitHostCommands>(null);
+
+  return (
+    <Split.Host preferredDisplayMode='oneBesideSecondary' ref={hostRef}>
+      <Split.Column>
+        <ColumnContent columnTitle="Primary column" hostRef={hostRef} />
+      </Split.Column>
+      <Split.Column>
+        <ColumnContent columnTitle="Supplementary column" hostRef={hostRef} />
+      </Split.Column>
+      <Split.Column>
+        <ColumnContent columnTitle="Secondary column" hostRef={hostRef} />
+      </Split.Column>
+    </Split.Host>
+  );
+}
+
+function ColumnContent(props: {
+  columnTitle: string;
+  hostRef: React.RefObject<SplitHostCommands | null>;
+}) {
+  return (
+    <View style={styles.container}>
+      <PressableWithFeedback style={styles.pressable}>
+        <Text style={styles.columnTitle}>{props.columnTitle}</Text>
+      </PressableWithFeedback>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pressable: {
+    height: 150,
+    width: 200,
+  },
+  columnTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default createScenario(TestSplitPressables, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/index.tsx
@@ -9,7 +9,7 @@ function TestSplitPressables() {
   const hostRef = React.useRef<SplitHostCommands>(null);
 
   return (
-    <Split.Host preferredDisplayMode='oneBesideSecondary' ref={hostRef}>
+    <Split.Host preferredDisplayMode="oneBesideSecondary" ref={hostRef}>
       <Split.Column>
         <ColumnContent columnTitle="Primary column" hostRef={hostRef} />
       </Split.Column>

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario-description.ts
@@ -3,8 +3,7 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 export const scenarioDescription: ScenarioDescription = {
   name: 'Split pressables',
   key: 'test-split-pressables-ios',
-  details:
-    'Allows to test pressability of components inside Split columns.',
+  details: 'Allows to test pressability of components inside Split columns.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Split pressables',
+  key: 'test-split-pressables-ios',
+  details:
+    'Allows to test pressability of components inside Split columns.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify the rendering and interaction of `Split.Column` components inside a `Split.Host`. This test ensures that when a previously hidden column (e.g., the Primary column) transitions into window, the React Native hit-testing is correctly updated and `Pressable` components inside it remain fully interactive.
+**Description:** Verify the rendering and interaction of `Split.Column` components inside a `Split.Host`. This test ensures that when a previously hidden column (e.g., the Primary column) transitions into the window, the React Native hit-testing is correctly updated and `Pressable` components inside it remain fully interactive.
 
 **OS test creation version:** iOS: 18.6 and 26.4
 

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
@@ -1,0 +1,44 @@
+# Test Scenario: Split command show column
+
+## Details
+
+**Description:** Verify the rendering and interaction of `Split.Column` components inside a `Split.Host`. This test ensures that when a previously hidden column (e.g., the Primary column) transitions into window, the React Native hit-testing is correctly updated and `Pressable` components inside it remain fully interactive.
+
+**OS test creation version:** iOS: 18.6 and 26.4
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iOS device or simulator (iPad is recommended to fully utilize `oneBesideSecondary` display mode).
+
+## Steps
+
+### Baseline
+
+1. Launch the **TestSplitPressables** SFT from the top-level of the application.
+
+- [ ] The `Split.Host` is rendered. Depending on the device orientation and size, the "Supplementary column" and/or "Secondary column" are visible.
+- [ ] The "Primary column" is initially hidden or collapsed (based on the `oneBesideSecondary` preferred display mode).
+
+---
+
+### Initial Interaction Validation
+
+2. Tap the text inside the currently visible columns (e.g., "Supplementary column" or "Secondary column").
+
+- [ ] The `PressableWithFeedback` correctly registers the touch and provides visual feedback.
+
+---
+
+### Column Transition & Hit-Testing Validation
+
+3. Reveal the "Primary column" (tap the toggle button in the navigation bar).
+
+- [ ] The Primary column smoothly slides into view.
+
+4. Once the animation is fully completed, tap the "Primary column" text inside the newly revealed column.
+
+- [ ] The `PressableWithFeedback` correctly registers the touch and provides visual feedback. The press must NOT be ignored or cancelled.

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
@@ -27,10 +27,9 @@ TBD: Planned, but will be implemented separately.
 
 ### Interaction & Column Transition Validation
 
-2. Tap the "Supplementary column" (or "Secondary column") text.
+2. Tap display mode change button in the top left corner.
 
-- [ ] The `PressableWithFeedback` correctly registers the touch and provides visual feedback.
-- [ ] The Primary column is revealed as a result of the press.
+- [ ] The Primary column is revealed.
 
 3. Once the animation is fully completed, tap the "Primary column" text inside the newly revealed column.
 

--- a/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/split/test-split-pressables-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Split command show column
+# Test Scenario: Split pressables - iOS
 
 ## Details
 
@@ -25,20 +25,13 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Initial Interaction Validation
+### Interaction & Column Transition Validation
 
-2. Tap the text inside the currently visible columns (e.g., "Supplementary column" or "Secondary column").
+2. Tap the "Supplementary column" (or "Secondary column") text.
 
 - [ ] The `PressableWithFeedback` correctly registers the touch and provides visual feedback.
+- [ ] The Primary column is revealed as a result of the press.
 
----
-
-### Column Transition & Hit-Testing Validation
-
-3. Reveal the "Primary column" (tap the toggle button in the navigation bar).
-
-- [ ] The Primary column smoothly slides into view.
-
-4. Once the animation is fully completed, tap the "Primary column" text inside the newly revealed column.
+3. Once the animation is fully completed, tap the "Primary column" text inside the newly revealed column.
 
 - [ ] The `PressableWithFeedback` correctly registers the touch and provides visual feedback. The press must NOT be ignored or cancelled.

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -550,6 +550,10 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
           controller.columnPositioningDidChangeIn(splitViewController: self)
         }
       }
+    } else {
+      for controller in self.splitScreenControllers {
+        controller.columnPositioningDidChangeIn(splitViewController: self)
+      }
     }
   }
 

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -542,18 +542,19 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
       reactEventEmitter.emitOnDisplayModeWillChange(from: self.displayMode, to: displayMode)
     }
 
-    if let coordinator = svc.transitionCoordinator {
-      coordinator.animate(alongsideTransition: nil) { [weak self] _ in
-        guard let self = self else { return }
-
-        for controller in self.splitScreenControllers {
-          controller.columnPositioningDidChangeIn(splitViewController: self)
-        }
-      }
-    } else {
+    let notifyColumnPositioningDidChange = { [weak self] in
+      guard let self = self else { return }
       for controller in self.splitScreenControllers {
         controller.columnPositioningDidChangeIn(splitViewController: self)
       }
+    }
+
+    if let coordinator = svc.transitionCoordinator {
+      coordinator.animate(alongsideTransition: nil) { _ in
+        notifyColumnPositioningDidChange()
+      }
+    } else {
+      notifyColumnPositioningDidChange()
     }
   }
 

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -545,7 +545,7 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
     if let coordinator = svc.transitionCoordinator {
       coordinator.animate(alongsideTransition: nil) { [weak self] _ in
         guard let self = self else { return }
-        
+
         for controller in self.splitScreenControllers {
           controller.columnPositioningDidChangeIn(splitViewController: self)
         }

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -541,6 +541,16 @@ extension RNSSplitHostController: UISplitViewControllerDelegate {
     if self.displayMode != displayMode {
       reactEventEmitter.emitOnDisplayModeWillChange(from: self.displayMode, to: displayMode)
     }
+
+    if let coordinator = svc.transitionCoordinator {
+      coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+        guard let self = self else { return }
+        
+        for controller in self.splitScreenControllers {
+          controller.columnPositioningDidChangeIn(splitViewController: self)
+        }
+      }
+    }
   }
 
   public func splitViewController(


### PR DESCRIPTION
## Description

Fixes an issue where `Pressable` components inside a newly revealed column (e.g., the Primary column) in `UISplitViewController` fail to register touches correctly on Fabric.

When attempting to interact with the newly revealed column, the touches were immediately cancelled.

Note: I don't know the exact reason why KVO for the frame hasn't detected that change. For now, I am not investigating it further, if any other problem with desynchronization occurs, I'll consider researching a different approach.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1636

## Changes

- Registered on `transitionCooridnator` completion callback to ensure that the shadow state is synchronized after the display mode change.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bceb5215-0550-421c-bcc5-47f077bf5384" /> | <video src="https://github.com/user-attachments/assets/f8f32d3a-0554-42d8-852b-c818257de529" /> |

## Test plan

Added dedicated SFT for pressables.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
