### PR TITLE
refactor(test): add missing export for TestStackTabsStackInTabsBaseNavigation

### DIFF
--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/index.ts
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/index.ts
@@ -3,6 +3,7 @@ import TestTabsInStackStableEnterTransition from './test-stack-tabs-tabs-in-stac
 import { default as TestStackTabsStackInTabsBaseNavigation } from './test-stack-tabs-stack-in-tabs-base-navigation';
 
 export { default as TestTabsInStackStableEnterTransition } from './test-stack-tabs-tabs-in-stack-stable-enter-transition';
+export { default as TestStackTabsStackInTabsBaseNavigation } from './test-stack-tabs-stack-in-tabs-base-navigation';
 
 const scenarios = {
   TestTabsInStackStableEnterTransition,


### PR DESCRIPTION
## Description

Adds the missing named export for `TestStackTabsStackInTabsBaseNavigation` in the `tabs-stack-v5` component-integration-tests index. The scenario was already imported and registered in the `scenarios` map, but not re-exported, so it could not be referenced by name from outside the module.

## Changes

- Export `TestStackTabsStackInTabsBaseNavigation` from `apps/src/tests/component-integration-tests/tabs-stack-v5/index.ts`.
