### PR TITLE
fix(types): make published Screen typing independent of RN's Animated types

### DIFF
--- a/src/components/Screen.web.tsx
+++ b/src/components/Screen.web.tsx
@@ -39,7 +39,9 @@ export class NativeScreen extends React.Component<ScreenProps> {
   }
 }
 
-const Screen = Animated.createAnimatedComponent(NativeScreen);
+const Screen = Animated.createAnimatedComponent(
+  NativeScreen,
+) as unknown as React.ComponentType<ScreenProps & React.RefAttributes<View>>;
 
 export const ScreenContext = React.createContext(Screen);
 


### PR DESCRIPTION
> [!NOTE]
> **This PR description was AI generated** (Claude Code), based on an investigation and fix prototyped together with @tjzel.

## Description

Starting with `react-native@0.88.0-nightly-20260711-042833e69`, React Native ships the generated Strict API types as the default `types` export condition, with the legacy hand-written types moved behind the new `react-native-legacy-deep-imports` condition.

This broke the published web typing of `Screen`. Since `Screen.web.tsx` had no explicit annotation, tsc printed the inferred type into the published declaration file:

```ts
declare const Screen: Animated.AnimatedComponent<typeof NativeScreen>;
```

That alias is not portable across the two RN type systems:

- **Legacy types**: `AnimatedComponent<T extends React.ComponentType<any>>` takes a *component* type — `typeof NativeScreen` was correct.
- **Strict API types**: `Animated.AnimatedComponent` re-exports `AnimatedComponentType<Props extends {}>`, which takes a *props* type — so `typeof NativeScreen` gets mapped over the class statics, and every consumer rendering `<Screen>` gets:

```
error TS2741: Property 'prototype' is missing in type '{ children: Element[]; }'
but required in type 'Omit<AnimatedProps<typeof NativeScreen>, "ref">'.
```

This is what currently fails Reanimated's nightly TypeScript compatibility CI job: https://github.com/software-mansion/react-native-reanimated/actions/runs/29206873570/job/86687720063

## Test plan

- `yarn check-types` and `yarn bob build` pass; the emitted `lib/typescript/components/Screen.web.d.ts` no longer references `Animated`.
- Verified end-to-end against the react-native-reanimated monorepo (which type-checks its example app for web with `moduleSuffixes: [".web", ""]`, resolving this declaration):
  - `react-native@0.88.0-nightly-20260713` + unpatched declaration → reproduces the `TS2741` error above (control).
  - `react-native@0.88.0-nightly-20260713` + this patch → web type check passes.
  - `react-native@0.86.0` (legacy types) + this patch → native, web, and strict-API type checks all pass.

## Checklist

- [x] Included code example that can be used to test this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
