### PR TITLE
fix(iOS, Stack v4): Prevent accounting header in contentHeight when it's transparent

### DIFF
--- a/apps/src/tests/issue-tests/Test4276.tsx
+++ b/apps/src/tests/issue-tests/Test4276.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LongText from '@apps/shared/LongText';
+
+type RootStackParamList = {
+  Home: undefined;
+  ModalOpaque: undefined;
+  ModalTransparent: undefined;
+  ModalTransparentWithPadding: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+function HomeScreen({ navigation }: any) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>fitToContents & transparent header issue</Text>
+      <Text style={styles.text}>
+        With "sheetAllowedDetents: 'fitToContents'", the modal should adjust its
+        height to fit its text.
+      </Text>
+      <Button
+        title="Opaque Header"
+        onPress={() => navigation.navigate('ModalOpaque')}
+      />
+      <Button
+        title="Transparent Header"
+        onPress={() => navigation.navigate('ModalTransparent')}
+      />
+      <Button
+        title="Transparent Header (with padding)"
+        onPress={() => navigation.navigate('ModalTransparentWithPadding')}
+      />
+    </View>
+  );
+}
+
+function ModalContent() {
+  return (
+    <View>
+      <LongText size="xs" />
+    </View>
+  );
+}
+
+function ModalContentWithPadding() {
+  return (
+    <View style={styles.modalContent}>
+      <LongText size="xs" />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ title: 'Home Screen' }}
+        />
+
+        <Stack.Screen
+          name="ModalOpaque"
+          component={ModalContent}
+          options={{
+            presentation: 'formSheet',
+            sheetAllowedDetents: 'fitToContents',
+            headerTransparent: false,
+            title: 'Opaque Header',
+          }}
+        />
+
+        <Stack.Screen
+          name="ModalTransparent"
+          component={ModalContent}
+          options={{
+            presentation: 'formSheet',
+            sheetAllowedDetents: 'fitToContents',
+            headerTransparent: true,
+            title: 'Transparent Header',
+          }}
+        />
+
+        <Stack.Screen
+          name="ModalTransparentWithPadding"
+          component={ModalContentWithPadding}
+          options={{
+            presentation: 'formSheet',
+            sheetAllowedDetents: 'fitToContents',
+            headerTransparent: true,
+            title: 'Transparent Header (with padding)',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 24,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  text: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  modalContent: {
+    paddingTop: 60,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -203,6 +203,7 @@ export { default as Test4244 } from './Test4244';
 export { default as Test4258 } from './Test4258';
 export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
+export { default as Test4276 } from './Test4276';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -56,7 +56,7 @@ namespace react = facebook::react;
       UINavigationBar *navigationBar = navigationController.navigationBar;
 
       RNSScreenStackHeaderConfig *headerConfig = [self headerConfigForNavigationController:navigationController];
-      if (!headerConfig.translucent) {
+      if (headerConfig != nil && !headerConfig.translucent) {
         headerHeightErrata += navigationBar.frame.size.height * !navigationBar.isHidden;
       }
     }

--- a/ios/RNSScreenContentWrapper.mm
+++ b/ios/RNSScreenContentWrapper.mm
@@ -10,6 +10,7 @@
 #import "RNSSafeAreaViewComponentView.h"
 #import "RNSScreen.h"
 #import "RNSScreenStack.h"
+#import "RNSScreenStackHeaderConfig.h"
 
 namespace react = facebook::react;
 
@@ -51,12 +52,27 @@ namespace react = facebook::react;
         break;
       }
     } else if ([controller isKindOfClass:RNSNavigationController.class]) {
-      UINavigationBar *navigationBar = static_cast<RNSNavigationController *>(controller).navigationBar;
-      headerHeightErrata += navigationBar.frame.size.height * !navigationBar.isHidden;
+      RNSNavigationController *navigationController = static_cast<RNSNavigationController *>(controller);
+      UINavigationBar *navigationBar = navigationController.navigationBar;
+
+      RNSScreenStackHeaderConfig *headerConfig = [self headerConfigForNavigationController:navigationController];
+      if (!headerConfig.translucent) {
+        headerHeightErrata += navigationBar.frame.size.height * !navigationBar.isHidden;
+      }
     }
 
     controller = controller.parentViewController;
   } while (controller != nil);
+}
+
+- (nullable RNSScreenStackHeaderConfig *)headerConfigForNavigationController:
+    (nonnull RNSNavigationController *)navigationController
+{
+  UIViewController *topViewController = navigationController.topViewController;
+  if (![topViewController isKindOfClass:RNSScreen.class]) {
+    return nil;
+  }
+  return [static_cast<RNSScreen *>(topViewController).screenView findHeaderConfig];
 }
 
 - (void)attachToAncestorScreenView


### PR DESCRIPTION
## Description

> [!IMPORTANT]  
> As stack nesting (native header creates nested stack) wasn't planned for FormSheets in v4, I am opening this PR for further discussion whether we should consider applying this fix to v4 or focus on making it work properly in v5.

For 'fitToContents', the sheet's detent height is computed as:
```
detentHeight = reactFrame.size.height + contentHeightErrata
```
`contentHeightErrata` is accumulated while walking up the ViewController tree, where the navigation bar's height was unconditionally added whenever the bar was visible.
In `RNSScreenContentWrapper.mm`, I gate the navbar-height addition to the visible screen's header not being transparent.

Closes: https://github.com/software-mansion/react-native-screens/issues/4276

## Changes

- prevent calculating headerHeightErrata when the header is transparent

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f32a48f6-deeb-44c8-9c31-8e417d162103" /> | <video src="https://github.com/user-attachments/assets/24b06607-5a5c-4263-bf2d-42798a5d772e" /> |

## Test plan

Added a dedicated example.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
