### PR TITLE
fix(Android, Stack v4): default consume*Inset props to true

### DIFF
--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -84,7 +84,7 @@ export interface NativeProps extends ViewProps {
 
   // Experimental
   userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;
-  consumeTopInset?: CT.WithDefault<boolean, true>;
+  consumeTopInset?: CT.WithDefault<boolean, false>;
   consumeLeftInset?: CT.WithDefault<boolean, true>;
   consumeRightInset?: CT.WithDefault<boolean, true>;
   consumeBottomInset?: CT.WithDefault<boolean, true>;

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -84,10 +84,10 @@ export interface NativeProps extends ViewProps {
 
   // Experimental
   userInterfaceStyle?: CT.WithDefault<UserInterfaceStyle, 'unspecified'>;
-  consumeTopInset?: boolean | undefined;
-  consumeLeftInset?: boolean | undefined;
-  consumeRightInset?: boolean | undefined;
-  consumeBottomInset?: boolean | undefined;
+  consumeTopInset?: CT.WithDefault<boolean, true>;
+  consumeLeftInset?: CT.WithDefault<boolean, true>;
+  consumeRightInset?: CT.WithDefault<boolean, true>;
+  consumeBottomInset?: CT.WithDefault<boolean, true>;
   legacyTopInsetBehavior?: boolean | undefined;
 }
 


### PR DESCRIPTION
Follow-up to #4220 . The `consume*Inset` props on `ScreenStackHeaderConfig` are declared without a `WithDefault`, so Fabric codegen defaults them to `false`, while the Android native view manager (`ScreenStackHeaderConfig.kt`) defaults them to `true` (`Delegates.observable(true)`).

under prop-update reconciliation (`enablePropsUpdateReconciliationAndroid`) a prop equal to the codegen default is ommited on initial mount, so a `disable*InsetApplication` opt-out is dropped 

