### PR TITLE
chore(Stack v5, iOS): Add missing imports for iOS SFTs

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -30,8 +30,11 @@ export { default as TestStackAnimationAndroid } from './test-stack-animation-and
 export { default as TestStackSimpleNav } from './test-stack-simple-nav';
 export { default as TestStackSubviewsAndroid } from './test-stack-subviews-android';
 export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
-export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
 export { default as TestStackHeaderIconIOS } from './test-stack-header-icon-ios';
+export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
+export { default as TestStackHeaderMenuOptionsIOS } from './test-stack-header-menu-options-ios';
+export { default as TestStackHeaderSelectiveUpatesIOS } from './test-stack-header-selective-updates-ios';
+export { default as TestStackHeaderSubviewOnPressIOS } from './test-stack-header-subview-onpress-ios';
 export { default as TestStackBackButton } from './test-stack-back-button-android';
 export { default as TestStackToolbarMenuCommands } from './test-stack-toolbar-menu-commands-android';
 export { default as TestStackToolbarMenuDisabled } from './test-stack-toolbar-menu-disabled-android';
@@ -40,7 +43,6 @@ export { default as TestStackToolbarMenuShowAsAction } from './test-stack-toolba
 export { default as TestStackToolbarMenuTitle } from './test-stack-toolbar-menu-title-android';
 export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-icon-android';
 export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nested-menu-android';
-export { default as TestStackHeaderMenuOptionsIOS } from './test-stack-header-menu-options-ios';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
@@ -130,7 +130,7 @@ function buildHeaderConfig(
   };
 }
 
-export function App() {
+export function TestStackHeaderSelectiveUpdatesIOS() {
   return (
     <ToastProvider>
       <StackContainer
@@ -252,4 +252,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createScenario(App, scenarioDescription);
+export default createScenario(TestStackHeaderSelectiveUpdatesIOS, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
@@ -13,7 +13,7 @@ import { Colors } from '@apps/shared/styling';
 
 const MAX_ITEMS = 5;
 
-export function TestStackHeaderSubviewsOnpress() {
+export function TestStackHeaderSubviewsOnpressIOS() {
   return (
     <ToastProvider>
       <StackContainer
@@ -106,6 +106,6 @@ function ConfigScreen() {
 }
 
 export default createScenario(
-  TestStackHeaderSubviewsOnpress,
+  TestStackHeaderSubviewsOnpressIOS,
   scenarioDescription,
 );


### PR DESCRIPTION
## Description

This PR fixes the imports for iOS SFTs which I missed when writing.

## Changes

Added missing imports

## Before & after - visual documentation

n/a

## Test plan

Try intellisense in App.tsx and confirm that all tests are accessible

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
