### PR TITLE
chore: remove explicit react-native peer dependency version from package config

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.84.0"
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13492,7 +13492,7 @@ __metadata:
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
-    react-native: ">=0.84.0"
+    react-native: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Description

It turns out that RN repo does not use the value from our package json
for anything, and that was the main reason for us to set it to a specific version.

The disadvantages of setting it to a specific version are few:

1. It makes it harder for users to use our package with different versions of RN, even if they are compatible,
but we simply don't test them.

2. Different platforms have different supported minimal RN versions. Usually we keep the Android and iOS in sync,
however tvOS and Windows are often lagging behind and we end up in situation where there is no supported version!

## Changes

Set `peerDependencies.react-native` to `*` in package.json.

## Before & after - visual documentation

N/A

## Test plan

N/A

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
