### PR TITLE
feat(Android, FormSheet v5): Add support for preventNativeDismiss

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetBehaviorController.kt
@@ -12,6 +12,7 @@ internal class FormSheetBehaviorController(
 
     private var currentDetentsCount: Int = 1
     private var lastEmittedDetentIndex: Int = FORM_SHEET_UNKNOWN_DETENT_INDEX
+    private var lastStableState: Int = BottomSheetBehavior.STATE_COLLAPSED
 
     private val bottomSheetCallback =
         object : BottomSheetBehavior.BottomSheetCallback() {
@@ -19,6 +20,8 @@ internal class FormSheetBehaviorController(
                 bottomSheet: View,
                 newState: Int,
             ) {
+                rememberStateIfStable(newState)
+
                 val index = mapStateToDetentIndex(newState)
                 if (index != FORM_SHEET_UNKNOWN_DETENT_INDEX && index != lastEmittedDetentIndex) {
                     lastEmittedDetentIndex = index
@@ -34,6 +37,7 @@ internal class FormSheetBehaviorController(
 
     init {
         behavior.isHideable = true
+        rememberStateIfStable(behavior.state)
     }
 
     internal fun setup() {
@@ -42,6 +46,25 @@ internal class FormSheetBehaviorController(
 
     internal fun destroy() {
         behavior.removeBottomSheetCallback(bottomSheetCallback)
+    }
+
+    internal fun restoreLastStableState() {
+        if (behavior.state != BottomSheetBehavior.STATE_HIDDEN) {
+            return
+        }
+
+        behavior.state = lastStableState
+    }
+
+    private fun rememberStateIfStable(state: Int) {
+        val isVisibleRestingState =
+            state == BottomSheetBehavior.STATE_EXPANDED ||
+                state == BottomSheetBehavior.STATE_COLLAPSED ||
+                state == BottomSheetBehavior.STATE_HALF_EXPANDED
+
+        if (isVisibleRestingState) {
+            lastStableState = state
+        }
     }
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetConfig.kt
@@ -9,6 +9,9 @@ internal data class FormSheetConfig(
     val preventNativeDismiss: Boolean = false,
     val nativeContainerBackgroundColor: Int? = null,
 ) {
+    val shouldPreventNativeDismiss: Boolean
+        get() = preventNativeDismiss && isOpen
+
     companion object {
         const val SYSTEM_DEFAULT_CORNER_RADIUS = -1f
     }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetConfig.kt
@@ -6,6 +6,7 @@ internal data class FormSheetConfig(
     val prefersGrabberVisible: Boolean = false,
     val initialDetentIndex: Int = 0,
     val preferredCornerRadius: Float = SYSTEM_DEFAULT_CORNER_RADIUS,
+    val preventNativeDismiss: Boolean = false,
     val nativeContainerBackgroundColor: Int? = null,
 ) {
     companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
@@ -20,6 +20,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 internal class FormSheetDialog(
     context: Context,
 ) : BottomSheetDialog(context) {
+    internal var onPreventDismissRequested: (() -> Boolean)? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -33,6 +35,14 @@ internal class FormSheetDialog(
         super.onAttachedToWindow()
 
         forceEdgeToEdge()
+    }
+
+    override fun cancel() {
+        if (onPreventDismissRequested?.invoke() == true) {
+            return
+        }
+
+        super.cancel()
     }
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
@@ -24,8 +24,8 @@ internal class FormSheetDialog(
         /**
          * Invoked in place of the dialog's default cancellation whenever an interceptor is attached.
          *
-         * The interceptor fully owns the outcome - either for native dismissal prevention or driving
-         * a custom animated dismissal when is allowed. Either way the dialog skips
+         * The interceptor fully owns the outcome - either for native dismissal prevention or for driving
+         * a custom animated dismissal when allowed. Either way, the dialog skips
          * [BottomSheetDialog.cancel], which would tear the window down synchronously.
          */
         fun handleCancelRequest()

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
@@ -22,9 +22,13 @@ internal class FormSheetDialog(
 ) : BottomSheetDialog(context) {
     internal fun interface CancelRequestInterceptor {
         /**
-         * @return `true` when the cancel request was consumed and the dialog then stays visible.
+         * Invoked in place of the dialog's default cancellation whenever an interceptor is attached.
+         *
+         * The interceptor fully owns the outcome - either for native dismissal prevention or driving
+         * a custom animated dismissal when is allowed. Either way the dialog skips
+         * [BottomSheetDialog.cancel], which would tear the window down synchronously.
          */
-        fun consumeCancelRequest(): Boolean
+        fun handleCancelRequest()
     }
 
     internal var cancelRequestInterceptor: CancelRequestInterceptor? = null
@@ -45,11 +49,13 @@ internal class FormSheetDialog(
     }
 
     override fun cancel() {
-        if (cancelRequestInterceptor?.consumeCancelRequest() == true) {
+        val interceptor = cancelRequestInterceptor
+        if (interceptor == null) {
+            super.cancel()
             return
         }
 
-        super.cancel()
+        interceptor.handleCancelRequest()
     }
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialog.kt
@@ -20,7 +20,14 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 internal class FormSheetDialog(
     context: Context,
 ) : BottomSheetDialog(context) {
-    internal var onPreventDismissRequested: (() -> Boolean)? = null
+    internal fun interface CancelRequestInterceptor {
+        /**
+         * @return `true` when the cancel request was consumed and the dialog then stays visible.
+         */
+        fun consumeCancelRequest(): Boolean
+    }
+
+    internal var cancelRequestInterceptor: CancelRequestInterceptor? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,7 +45,7 @@ internal class FormSheetDialog(
     }
 
     override fun cancel() {
-        if (onPreventDismissRequested?.invoke() == true) {
+        if (cancelRequestInterceptor?.consumeCancelRequest() == true) {
             return
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogEventEmitter.kt
@@ -5,5 +5,7 @@ import com.swmansion.rnscreens.common.event.ViewAppearanceEventEmitter
 internal interface FormSheetDialogEventEmitter : ViewAppearanceEventEmitter {
     fun emitOnNativeDismissEvent()
 
+    fun emitOnNativeDismissPreventedEvent()
+
     fun emitOnDetentChanged(index: Int)
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogManager.kt
@@ -63,10 +63,10 @@ class FormSheetDialogManager(
     private val nativeDismissCoordinator =
         FormSheetNativeDismissCoordinator(
             dialog = dialog,
-            bottomSheetView = bottomSheetView,
+            behaviorController = behaviorController,
             dimmingManager = dimmingManager,
-            onNativeDismiss = { presentationManager.handleNativeDismiss() },
-            onNativeDismissPrevented = { eventEmitter?.emitOnNativeDismissPreventedEvent() },
+            onDismissAllowed = { presentationManager.handleNativeDismiss() },
+            onDismissPrevented = { eventEmitter?.emitOnNativeDismissPreventedEvent() },
         )
 
     internal var eventEmitter: FormSheetDialogEventEmitter? by Delegates.observable(null) { _, _, newValue ->
@@ -113,10 +113,8 @@ class FormSheetDialogManager(
             appearanceCoordinator.updateBackgroundColor(newConfig.nativeContainerBackgroundColor)
         }
 
-        val oldShouldPreventNativeDismiss = oldConfig.preventNativeDismiss && oldConfig.isOpen
-        val newShouldPreventNativeDismiss = newConfig.preventNativeDismiss && newConfig.isOpen
-        if (oldShouldPreventNativeDismiss != newShouldPreventNativeDismiss) {
-            nativeDismissCoordinator.shouldPreventNativeDismiss = newShouldPreventNativeDismiss
+        if (oldConfig.shouldPreventNativeDismiss != newConfig.shouldPreventNativeDismiss) {
+            nativeDismissCoordinator.shouldPreventDismiss = newConfig.shouldPreventNativeDismiss
         }
 
         if (oldConfig.isOpen != newConfig.isOpen) {

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetDialogManager.kt
@@ -60,6 +60,15 @@ class FormSheetDialogManager(
             onNativeDismiss = { eventEmitter?.emitOnNativeDismissEvent() },
         )
 
+    private val nativeDismissCoordinator =
+        FormSheetNativeDismissCoordinator(
+            dialog = dialog,
+            bottomSheetView = bottomSheetView,
+            dimmingManager = dimmingManager,
+            onNativeDismiss = { presentationManager.handleNativeDismiss() },
+            onNativeDismissPrevented = { eventEmitter?.emitOnNativeDismissPreventedEvent() },
+        )
+
     internal var eventEmitter: FormSheetDialogEventEmitter? by Delegates.observable(null) { _, _, newValue ->
         presentationManager.appearanceEventEmitter = newValue
     }
@@ -69,6 +78,7 @@ class FormSheetDialogManager(
 
     init {
         presentationManager.setup()
+        nativeDismissCoordinator.setup()
         appearanceCoordinator.setup()
         dimensionsCoordinator.setup()
         behaviorController?.setup()
@@ -103,6 +113,12 @@ class FormSheetDialogManager(
             appearanceCoordinator.updateBackgroundColor(newConfig.nativeContainerBackgroundColor)
         }
 
+        val oldShouldPreventNativeDismiss = oldConfig.preventNativeDismiss && oldConfig.isOpen
+        val newShouldPreventNativeDismiss = newConfig.preventNativeDismiss && newConfig.isOpen
+        if (oldShouldPreventNativeDismiss != newShouldPreventNativeDismiss) {
+            nativeDismissCoordinator.shouldPreventNativeDismiss = newShouldPreventNativeDismiss
+        }
+
         if (oldConfig.isOpen != newConfig.isOpen) {
             presentationManager.updatePresentationState(newConfig.isOpen)
         }
@@ -127,6 +143,7 @@ class FormSheetDialogManager(
 
     internal fun destroy() {
         behaviorController?.destroy()
+        nativeDismissCoordinator.destroy()
         presentationManager.destroy()
         dimensionsCoordinator.destroy()
         dialog.dismiss()

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHost.kt
@@ -23,6 +23,8 @@ class FormSheetHost(
 
     internal var preferredCornerRadius = FormSheetConfig.SYSTEM_DEFAULT_CORNER_RADIUS
 
+    internal var preventNativeDismiss = false
+
     internal var nativeContainerBackgroundColor: Int? = null
 
     internal var detents: List<Double> = emptyList()
@@ -94,6 +96,7 @@ class FormSheetHost(
                 prefersGrabberVisible = this.prefersGrabberVisible,
                 initialDetentIndex = this.initialDetentIndex,
                 preferredCornerRadius = this.preferredCornerRadius,
+                preventNativeDismiss = this.preventNativeDismiss,
                 nativeContainerBackgroundColor = this.nativeContainerBackgroundColor,
             )
         dialogManager.applyConfig(config)

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHostEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHostEventEmitter.kt
@@ -49,4 +49,10 @@ internal class FormSheetHostEventEmitter(
             FormSheetDetentChangedEvent(surfaceId, viewTag, index),
         )
     }
+
+    override fun emitOnNativeDismissPreventedEvent() {
+        reactEventDispatcher.dispatchEvent(
+            FormSheetNativeDismissPreventedEvent(surfaceId, viewTag),
+        )
+    }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetHostViewManager.kt
@@ -114,7 +114,7 @@ class FormSheetHostViewManager :
         view: FormSheetHost,
         value: Boolean,
     ) {
-        // TODO: @t0maboro - implement later
+        view.preventNativeDismiss = value
     }
 
     override fun setNativeContainerBackgroundColor(
@@ -133,6 +133,7 @@ class FormSheetHostViewManager :
             makeEventRegistrationInfo(FormSheetWillDisappearEvent),
             makeEventRegistrationInfo(FormSheetDidDisappearEvent),
             makeEventRegistrationInfo(FormSheetDetentChangedEvent),
+            makeEventRegistrationInfo(FormSheetNativeDismissPreventedEvent),
         )
 
     override fun updateState(

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
@@ -1,95 +1,52 @@
 package com.swmansion.rnscreens.modals.formsheet
 
-import android.view.View
 import androidx.activity.OnBackPressedCallback
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.modals.dimmingview.DimmingViewManager
 
 internal class FormSheetNativeDismissCoordinator(
     private val dialog: FormSheetDialog,
-    private val bottomSheetView: View?,
+    private val behaviorController: FormSheetBehaviorController?,
     private val dimmingManager: DimmingViewManager,
-    private val onNativeDismiss: () -> Unit,
-    private val onNativeDismissPrevented: () -> Unit,
-) {
-    internal var shouldPreventNativeDismiss: Boolean = false
-        set(value) {
-            field = value
-            backPressedCallback.isEnabled = value
-        }
-
-    private val behavior: BottomSheetBehavior<View>? by lazy {
-        bottomSheetView?.let { BottomSheetBehavior.from(it) }
-    }
-
-    private var lastStableState = BottomSheetBehavior.STATE_COLLAPSED
-
-    private val stateObserver =
-        object : BottomSheetBehavior.BottomSheetCallback() {
-            override fun onStateChanged(
-                bottomSheet: View,
-                newState: Int,
-            ) {
-                if (isStableState(newState)) lastStableState = newState
-            }
-
-            override fun onSlide(
-                bottomSheet: View,
-                slideOffset: Float,
-            ) = Unit
-        }
-
-    private val backPressedCallback =
+    private val onDismissAllowed: () -> Unit,
+    private val onDismissPrevented: () -> Unit,
+) : FormSheetDialog.CancelRequestInterceptor {
+    private val preventNativeDismissBackPressCallback =
         object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
-                tryPreventDismiss()
+                consumeCancelRequest()
             }
+        }
+
+    internal var shouldPreventDismiss: Boolean = false
+        set(value) {
+            field = value
+            preventNativeDismissBackPressCallback.isEnabled = value
         }
 
     internal fun setup() {
-        behavior?.let { behavior ->
-            if (isStableState(behavior.state)) lastStableState = behavior.state
-            behavior.addBottomSheetCallback(stateObserver)
-        }
-
-        dialog.onBackPressedDispatcher.addCallback(backPressedCallback)
-        dialog.onPreventDismissRequested = {
-            tryPreventDismiss()
-        }
-        dialog.setOnCancelListener {
-            onNativeDismiss()
-        }
-        dimmingManager.setOnBackdropClickListener {
-            dialog.cancel()
-        }
+        dialog.cancelRequestInterceptor = this
+        dialog.onBackPressedDispatcher.addCallback(preventNativeDismissBackPressCallback)
+        dialog.setOnCancelListener { onDismissAllowed() }
+        // Backdrop taps go through `cancel()` rather than dismissing directly, so that they are
+        // subject to the very same interception as the back press and the swipe down.
+        dimmingManager.setOnBackdropClickListener { dialog.cancel() }
     }
 
     internal fun destroy() {
-        behavior?.removeBottomSheetCallback(stateObserver)
-
-        backPressedCallback.remove()
-        dialog.onPreventDismissRequested = null
+        dialog.cancelRequestInterceptor = null
+        preventNativeDismissBackPressCallback.remove()
         dialog.setOnCancelListener(null)
         dimmingManager.setOnBackdropClickListener(null)
     }
 
-    private fun tryPreventDismiss(): Boolean {
-        if (!shouldPreventNativeDismiss) {
+    override fun consumeCancelRequest(): Boolean {
+        if (!shouldPreventDismiss) {
             return false
         }
 
-        onNativeDismissPrevented()
+        onDismissPrevented()
+        behaviorController?.restoreLastStableState()
 
-        behavior?.let { behavior ->
-            if (behavior.state == BottomSheetBehavior.STATE_HIDDEN) {
-                behavior.state = lastStableState
-            }
-        }
         return true
     }
-
-    private fun isStableState(state: Int): Boolean =
-        state == BottomSheetBehavior.STATE_EXPANDED ||
-            state == BottomSheetBehavior.STATE_COLLAPSED ||
-            state == BottomSheetBehavior.STATE_HALF_EXPANDED
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
@@ -1,25 +1,95 @@
 package com.swmansion.rnscreens.modals.formsheet
 
-import com.google.android.material.bottomsheet.BottomSheetDialog
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.modals.dimmingview.DimmingViewManager
 
 internal class FormSheetNativeDismissCoordinator(
-    private val dialog: BottomSheetDialog,
+    private val dialog: FormSheetDialog,
+    private val bottomSheetView: View?,
     private val dimmingManager: DimmingViewManager,
     private val onNativeDismiss: () -> Unit,
+    private val onNativeDismissPrevented: () -> Unit,
 ) {
+    internal var shouldPreventNativeDismiss: Boolean = false
+        set(value) {
+            field = value
+            backPressedCallback.isEnabled = value
+        }
+
+    private val behavior: BottomSheetBehavior<View>? by lazy {
+        bottomSheetView?.let { BottomSheetBehavior.from(it) }
+    }
+
+    private var lastStableState = BottomSheetBehavior.STATE_COLLAPSED
+
+    private val stateObserver =
+        object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(
+                bottomSheet: View,
+                newState: Int,
+            ) {
+                if (isStableState(newState)) lastStableState = newState
+            }
+
+            override fun onSlide(
+                bottomSheet: View,
+                slideOffset: Float,
+            ) = Unit
+        }
+
+    private val backPressedCallback =
+        object : OnBackPressedCallback(false) {
+            override fun handleOnBackPressed() {
+                tryPreventDismiss()
+            }
+        }
+
     internal fun setup() {
+        behavior?.let { behavior ->
+            if (isStableState(behavior.state)) lastStableState = behavior.state
+            behavior.addBottomSheetCallback(stateObserver)
+        }
+
+        dialog.onBackPressedDispatcher.addCallback(backPressedCallback)
+        dialog.onPreventDismissRequested = {
+            tryPreventDismiss()
+        }
         dialog.setOnCancelListener {
             onNativeDismiss()
         }
-
         dimmingManager.setOnBackdropClickListener {
-            onNativeDismiss()
+            dialog.cancel()
         }
     }
 
     internal fun destroy() {
-        dimmingManager.setOnBackdropClickListener {}
+        behavior?.removeBottomSheetCallback(stateObserver)
+
+        backPressedCallback.remove()
+        dialog.onPreventDismissRequested = null
         dialog.setOnCancelListener(null)
+        dimmingManager.setOnBackdropClickListener(null)
     }
+
+    private fun tryPreventDismiss(): Boolean {
+        if (!shouldPreventNativeDismiss) {
+            return false
+        }
+
+        onNativeDismissPrevented()
+
+        behavior?.let { behavior ->
+            if (behavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+                behavior.state = lastStableState
+            }
+        }
+        return true
+    }
+
+    private fun isStableState(state: Int): Boolean =
+        state == BottomSheetBehavior.STATE_EXPANDED ||
+            state == BottomSheetBehavior.STATE_COLLAPSED ||
+            state == BottomSheetBehavior.STATE_HALF_EXPANDED
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissCoordinator.kt
@@ -13,7 +13,7 @@ internal class FormSheetNativeDismissCoordinator(
     private val preventNativeDismissBackPressCallback =
         object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
-                consumeCancelRequest()
+                handleCancelRequest()
             }
         }
 
@@ -26,7 +26,6 @@ internal class FormSheetNativeDismissCoordinator(
     internal fun setup() {
         dialog.cancelRequestInterceptor = this
         dialog.onBackPressedDispatcher.addCallback(preventNativeDismissBackPressCallback)
-        dialog.setOnCancelListener { onDismissAllowed() }
         // Backdrop taps go through `cancel()` rather than dismissing directly, so that they are
         // subject to the very same interception as the back press and the swipe down.
         dimmingManager.setOnBackdropClickListener { dialog.cancel() }
@@ -35,18 +34,16 @@ internal class FormSheetNativeDismissCoordinator(
     internal fun destroy() {
         dialog.cancelRequestInterceptor = null
         preventNativeDismissBackPressCallback.remove()
-        dialog.setOnCancelListener(null)
         dimmingManager.setOnBackdropClickListener(null)
     }
 
-    override fun consumeCancelRequest(): Boolean {
-        if (!shouldPreventDismiss) {
-            return false
+    override fun handleCancelRequest() {
+        if (shouldPreventDismiss) {
+            onDismissPrevented()
+            behaviorController?.restoreLastStableState()
+            return
         }
 
-        onDismissPrevented()
-        behaviorController?.restoreLastStableState()
-
-        return true
+        onDismissAllowed()
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissPreventedEvent.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetNativeDismissPreventedEvent.kt
@@ -1,0 +1,29 @@
+package com.swmansion.rnscreens.modals.formsheet
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.rnscreens.common.event.NamingAwareEventType
+
+class FormSheetNativeDismissPreventedEvent(
+    surfaceId: Int,
+    viewId: Int,
+) : Event<FormSheetNativeDismissPreventedEvent>(surfaceId, viewId),
+    NamingAwareEventType {
+    override fun getEventName(): String = EVENT_NAME
+
+    override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+
+    override fun getEventData(): WritableMap? = Arguments.createMap()
+
+    override fun canCoalesce(): Boolean = false
+
+    companion object : NamingAwareEventType {
+        const val EVENT_NAME = "topNativeDismissPrevented"
+        const val EVENT_REGISTRATION_NAME = "onNativeDismissPrevented"
+
+        override fun getEventName() = EVENT_NAME
+
+        override fun getEventRegistrationName() = EVENT_REGISTRATION_NAME
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/FormSheetPresentationManager.kt
@@ -21,18 +21,10 @@ internal class FormSheetPresentationManager(
     private val animatorFactory = FormSheetAnimatorFactory(dimmingManager)
     private var currentSheetAnimator: Animator? = null
 
-    private val nativeDismissCoordinator =
-        FormSheetNativeDismissCoordinator(
-            dialog = dialog,
-            dimmingManager = dimmingManager,
-            onNativeDismiss = { handleNativeDismiss() },
-        )
-
     internal fun setup() {
         bottomSheetView?.let { view ->
             dimmingManager.attachToBehavior(BottomSheetBehavior.from(view))
         }
-        nativeDismissCoordinator.setup()
     }
 
     internal fun updatePresentationState(isOpen: Boolean) {
@@ -164,7 +156,7 @@ internal class FormSheetPresentationManager(
         }
     }
 
-    private fun handleNativeDismiss() {
+    internal fun handleNativeDismiss() {
         if (state == FormSheetPresentationState.DISMISSING || state == FormSheetPresentationState.DISMISSED) {
             return
         }
@@ -201,7 +193,5 @@ internal class FormSheetPresentationManager(
         dialog.setOnShowListener(null)
 
         state = FormSheetPresentationState.DISMISSED
-
-        nativeDismissCoordinator.destroy()
     }
 }

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -14,7 +14,7 @@ import TestFormSheetNativeContainerStyle from './test-form-sheet-native-containe
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state';
-import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss-ios';
+import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss';
 import TestFormSheetStacking from './test-form-sheet-stacking-ios';
 
 // Scenario entry-point components — each scenario's default export re-exported
@@ -31,7 +31,7 @@ export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-
 export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';
 export { default as TestFormSheetPreferredCornerRadius } from './test-form-sheet-preferred-corner-radius';
 export { default as TestFormSheetPresentationState } from './test-form-sheet-presentation-state';
-export { default as TestFormSheetPreventNativeDismiss } from './test-form-sheet-prevent-native-dismiss-ios';
+export { default as TestFormSheetPreventNativeDismiss } from './test-form-sheet-prevent-native-dismiss';
 export { default as TestFormSheetStacking } from './test-form-sheet-stacking-ios';
 
 const scenarios = {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
@@ -1,17 +1,9 @@
 import React, { useState } from 'react';
 import { Alert, Button, StyleSheet, Switch, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
-import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
-
-const scenarioDescription: ScenarioDescription = {
-  name: 'PreventNativeDismiss',
-  key: 'test-form-sheet-prevent-native-dismiss-ios',
-  details:
-    'Allows testing the preventNativeDismiss property and firing the onNativeDismissPrevented event.',
-  platforms: ['ios'],
-};
+import { scenarioDescription } from './scenario-description';
 
 function TestFormSheetPreventNativeDismiss() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
@@ -98,7 +98,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
@@ -1,0 +1,11 @@
+import { ScenarioDescription } from "@apps/tests/shared/helpers";
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'PreventNativeDismiss',
+  key: 'test-form-sheet-prevent-native-dismiss',
+  details:
+    'Allows testing the preventNativeDismiss property and firing the onNativeDismissPrevented event.',
+  platforms: ['android', 'ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
@@ -1,4 +1,4 @@
-import { ScenarioDescription } from "@apps/tests/shared/helpers";
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
   name: 'PreventNativeDismiss',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the `preventNativeDismiss` property and the `onNativeDismissPrevented` event of the `FormSheet` component. This test ensures that when the property is set to `true`, the user cannot dismiss the sheet natively by swiping it down or tapping the backdrop behind the sheet. Instead, the sheet fires an event that displays an Alert. However, the user can still swipe between detents, and programmatic dismissals triggered by React state changes will still work. When set to `false`, the sheet can be dismissed natively without triggering the prevented event.
 
-**OS test creation version:** iOS: 18.6 and 26.4
+**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
 
 ## E2E test
 
@@ -13,6 +13,7 @@ Other: Planned, but will be implemented separately.
 ## Prerequisites
 
 - iOS device or simulator (iPhone)
+- Android emulator
 
 ## Steps
 

--- a/src/components/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/modals/form-sheet/FormSheet.types.ts
@@ -131,7 +131,7 @@ export interface FormSheetProps {
    * remaining on the resting detent. Programmatically dismissing the sheet via `isOpen={false}` will still work.
    *
    * @default false
-   * @platform ios
+   * @platform android, ios
    */
   preventNativeDismiss?: boolean | undefined;
 
@@ -215,7 +215,7 @@ export interface FormSheetProps {
    * It is useful for triggering custom feedback, such as an alert
    * to inform the user why the sheet cannot be closed.
    *
-   * @platform ios
+   * @platform android, ios
    */
   onNativeDismissPrevented?:
     | FormSheetEventHandler<EmptyEventPayload>


### PR DESCRIPTION
## Description

Adding the `preventNativeDismiss` support on Android together with `onNativeDismissPrevented` event. When `preventNativeDismiss` is enabled, all native dismissal paths - tapping the backdrop, swiping the sheet down, and pressing the hardware back button - are intercepted. Instead of closing, the sheet stays in the latest stable (visible) state and fires an event that 3p developer might handle. Programmatic dismissal keeps working as before.
When the prop is disabled, native dismissal behaves as it did previously.

Also, I needed to refine the approach for native dismissal handling. The "test-form-sheet-presentation-state" had a regression that was dismissing the FormSheet again after the quick state toggle. The extra dismiss came from Material's `BottomSheetDialog`, which installs an internal callback that calls `cancel()` whenever the sheet reaches `STATE_HIDDEN`. Our own exit animation ends by setting `STATE_HIDDEN`. Previously, `cancel()` was not overridden, so it was going through the `Dialog.cancel()`, which dispatched the `OnCancelListener` **asynchronously**. During a rapid dismiss-present toggle:
1. `setIsOpen(false)` caused the presentation state update to `DISMISSING` and the exit animation starts.
2. `setIsOpen(true)` calls `presentIfNeeded()` is seeing the `DISMISSING` state, so it returns early and just records `targetIsOpen = true`.
3. The exit animation ends; behavior state is set to `STATE_HIDDEN`, so Material calls `cancel()` internally and posts the `OnCancelListener` message.
4. In the meantime, `onDismissComplete` changes the presentation state to `DISMISSED` but our `targetIsOpen` is set to `true`, so the next FormSheet presentation is started, the presentation state updates to `PRESENTING`.
5. When the Looper picks the queued `OnCancelListener` message, it finally runs `handleNativeDismiss()`, so the state will flip to`DISMISSING/DISMISSED` after the presentation completes.

With this PR, I am introducing the cancel interceptor for preventNativeDismiss, which also runs `handleNativeDismiss` **synchronously** at the `STATE_HIDDEN` trigger, preventing the race condition where someone has opened the sheet again, while the **asynchronous** `handleNativeDismiss` callback hasn't been processed yet.

> [!CAUTION]
> I started noticing an occasional content flickering, probably because of wrong timing of the translateY application before starting the enter transition. Noticed that it's reproducible on the main branch as well, so I'll handle that separately: https://github.com/software-mansion/react-native-screens-labs/issues/1689

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1563
Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1669

## Changes

- Added a `CancelRequestInterceptor` to override `cancel()`; when an interceptor is attached, it fully owns the
  outcome and decides whether to allow or prevent the dismissal request.
- `FormSheetNativeDismissCoordinator` was integrated with that interceptor. It routes backdrop taps and swipe-down and hardware back button (via`OnBackPressedCallback`) through the same path, and decides about the outcome. When prevented, emit an event and restore the sheet's last stable detent. Otherwise, drive the animated dismissal via the presentation manager.

## Before & after - visual documentation

https://github.com/user-attachments/assets/38ca81f4-32ee-4f5c-a655-633df71ecff0

## Test plan

Marked SFT as applicable on Android

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
