### PR TITLE
refactor(test): update existing stack test scenarios

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/scenario.md
@@ -14,7 +14,7 @@ TBD
 
 - iOS / iPadOS simulator
 
-## Note (Optional)
+## Note
 
 - Crossfade doesn't work when changing between async images.
 - Changing items in menu while it is presented (default for this test) results in visible layout shifts.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -14,7 +14,7 @@ TBD
 
 - iOS / iPadOS emulator
 
-## Note (Optional)
+## Note
 
 - For now, menus don't appear on items with custom views
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -20,29 +20,28 @@ TBD
 
 ## Steps on iPhone
 
-1. Open Dev Console
-2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
-3. Click on the Menu 1 item
+1. Launch the app and navigate to the **Stack Header Menu (iOS)** screen.
+2. Click on the Menu 1 item
   - [ ] The bubble morphs into a menu with two items and a submenu
-4. Click on Action 1-1
+3. Click on Action 1-1
   - [ ] A toast "Clicked Action 1-1" is displayed
-5. Click on Toggle 1-1 inside Menu
+4. Click on Toggle 1-1 inside Menu
   - [ ] Menu is hidden
   - [ ] A toast "Selected "toggle 1-1"" is displayed
   - [ ] When Menu 1 is reopened, a checkmark is displayed next to Toggle 1-1
-6. Click on Toggle 1-3 inside Menu
+5. Click on Toggle 1-3 inside Menu
   - [ ] Menu is hidden
   - [ ] A toast "Selected "toggle 1-1", "toggle 1-3"" is displayed
   - [ ] When Menu 1 is reopened, a checkmark is displayed next to Toggle 1-1 and Toggle 1-3
-7. Click on Toggle 1-1 inside Menu again
+6. Click on Toggle 1-1 inside Menu again
   - [ ] Menu is hidden
   - [ ] A toast "Selected "toggle 1-3"" is displayed
   - [ ] When Menu 1 is reopened, a checkmark is displayed only next to Toggle 1-3
-8. Click on Submenu with Radio
+7. Click on Submenu with Radio
   - [ ] Radio 1-1 is selected by default
-9. Click on Radio 1-1 again
+8. Click on Radio 1-1 again
   - [ ] No toast is displayed
-10. Click on SubSubmenu with Radio, click on Radio 1-2
+9.  Click on SubSubmenu with Radio, click on Radio 1-2
   - [ ] Whole menu is hidden
   - [ ] A toast "Selected unique "radio 1-2"" is displayed
   - [ ] When Menu 1 > Submenu with Radio is reopened, Radio 1-1 is no longer checked

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
@@ -19,7 +19,7 @@ TBD
 ### displayInline
 
 1. Ensure both toggles are set to `false`
-2. Tap the ellipsis (Options) button in the header
+2. Tap the overflow menu button (three dots)in the header
   - [ ] Menu shows: Copy, Paste, Share, Sort By as a collapsed submenu, Delete
 3. Tap Sort By
   - [ ] A nested submenu shows: Name, Date, Size and Rating as a collapsed submenu

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/scenario.md
@@ -19,7 +19,7 @@ TBD
 ### displayInline
 
 1. Ensure both toggles are set to `false`
-2. Tap the overflow menu button (three dots)in the header
+2. Tap the overflow menu button (three dots) in the header
   - [ ] Menu shows: Copy, Paste, Share, Sort By as a collapsed submenu, Delete
 3. Tap Sort By
   - [ ] A nested submenu shows: Name, Date, Size and Rating as a collapsed submenu

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/scenario.md
@@ -28,7 +28,7 @@ TBD
 5. Change Menu picker for Item 1 to "multi"
   - [ ] Menu can be opened and the default first option is selected
 6. Select Option-0-B in Item 1 menu
-  - [ ] A toast `Item 1 \[multi]: "Option-0-A", "Option-0-B"` selected appears
+  - [ ] A toast `Item 1 \[multi]: "Option-0-A", "Option-0-B"` appears
   - [ ] When opened again, both Option-0-A and Option-0-B are checked
 7. Enable "Custom view" for Item 1
   - [ ] Item 1 flashes and shows a purple pressable square
@@ -37,7 +37,7 @@ TBD
   - [ ] Neither items flash
 9. Press "Add Item 3"
   - [ ] A third item appears
-  - [ ] Items 2 and 3 flash
+  - [ ] All items flash
 10. Press "Remove Item 3"
-  - [ ] Items 2 and 3 flash
+  - [ ] All items flash
   - [ ] Item 3 disappears under Item 2

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/scenario.md
@@ -20,7 +20,7 @@ TBD
   - [ ] A toast "onPress Item 0" is displayed
 2. Tap on Menu 1
   - [ ] A menu with two items (Action 1-1, Action 1-2) is displayed
-3. Long-press on Item 0
+3. Dismiss the menu and long-press on Item 0
   - [ ] A menu with two items (Action 0-1, Action 0-2) is displayed
 4. Dismiss the menu
 
@@ -29,9 +29,9 @@ TBD
 5. Click "Toggle items count (2/5)" three times to reach 5 items
   - [ ] Item 0 and Menu 1 are no longer visible in the header — they have been moved to the overflow menu
 6. Tap the overflow menu button (three dots)
-  - [ ] Item 0 and Item 1 appear as entries in the overflow menu
+  - [ ] Item 0 and Menu 1 appear as entries in the overflow menu
 7. Tap on Item 0 in the overflow menu
   - [ ] A submenu with three items (Item 0, Action 0-1, Action 0-2) is displayed
   - [ ] Tapping on Item 0 displays "onPress Item 0" toast
 8. Tap on Menu 1 in the overflow menu
-  - [ ] A submenu with two items (Action 0-1, Action 0-2) is displayed
+  - [ ] A submenu with two items (Action 1-1, Action 1-2) is displayed

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
@@ -14,7 +14,7 @@ Other - the subview API is still subject to significant changes.
 
 - Android emulator
 
-## Note (Optional)
+## Note
 
 This feature is still WIP.
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
@@ -17,7 +17,7 @@ TBD
 
 - iOS / iPadOS emulator
 
-## Note (Optional)
+## Note
 
 - "Position of items on device matches element tree" means that the DevTools overlay the item highlight with correct position and size. Alternatively, this could be checked by pressing and moving the cursor over the button to see if the whole visible area works, not triggering onPressOut immediately
 - on iOS 26, view may move to overflow menu if there is no space for them, iOS 18 tries to render all of them (including the header)

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -24,7 +24,7 @@ Other — automation is not implemented yet.
 
 - Android emulator or device
 
-## Note (Optional)
+## Note
 
 - `StackHeaderToolbarMenuElementOptionsAndroid` semantics:
   - A field missing from the options object means "preserve current

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -217,7 +217,7 @@ function MainScreen() {
           cmdDisabled === 'undefined' ? undefined : cmdDisabled === 'true',
       }),
     };
-    headerConfigRef.current?.android?.setToolbarMenuItemOptions(
+    headerConfigRef.current?.android?.setToolbarMenuElementOptions(
       cmdTargetId,
       options,
     );

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/scenario.md
@@ -18,7 +18,7 @@ Full: Covers all manual scenario steps.
 - iOS device or simulator
 - Android emulator
 
-## Note (Optional)
+## Note
 
 Tab1 has `scrollToTop: true`, Tab2 has `scrollToTop: false`, and Tab3 has no
 `specialEffects` configured (default behavior). All three tabs display a scrollable

--- a/apps/src/tests/template/scenario.md
+++ b/apps/src/tests/template/scenario.md
@@ -25,7 +25,7 @@ List of devices or platforms required to run this test.
 
 Example: iOS physical device, Android emulator
 
-## Note (Optional)
+## Note
 
 Include any critical information for scenario execution not covered elsewhere. Use this section to document Known Issues (KI) or specific behaviors that might appear misleading but are considered expected results. Define rules that apply to the entire scenario to avoid repetition in individual steps.
 


### PR DESCRIPTION
## Description

Updates existing stack (v5) test scenarios and one test screen to keep manual QA steps accurate and consistent. No library/runtime code is affected — this touches example-app test scenarios and one test-screen helper call.

## Changes

**Scenario cleanups**
- Drop the `(Optional)` suffix from the `## Note` heading across scenarios and the scenario template, standardizing the section title.

**`test-stack-header-menu-ios`**
- Replace the "Open Dev Console / reload" steps with a single step to launch the app and navigate to the **Stack Header Menu (iOS)** screen; renumber the remaining steps.

**`test-stack-header-menu-options-ios`**
- Clarify step 2: "ellipsis (Options) button" → "overflow menu button (three dots)".

**`test-stack-header-selective-updates-ios`**
- Fix the toast expectation wording for the multi-select case.
- Correct steps 9 & 10 expectations: all items flash (not only items 2 and 3).

**`test-stack-header-subview-onpress-ios`**
- Add an explicit "dismiss the menu" step before the long-press.
- Fix overflow-menu expectations to reference **Menu 1** and the correct **Action 1-1 / Action 1-2** entries.

**`test-stack-toolbar-menu-disabled-android`**
- Update the test screen to call the renamed `setToolbarMenuElementOptions` (was `setToolbarMenuItemOptions`).
