### PR TITLE
refactor(test): render Toast above the system navigation bar

### DIFF
--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -6,6 +6,7 @@ import {
   Dimensions,
   View,
   Platform,
+  ViewStyle,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
 import { SafeAreaView } from 'react-native-screens/experimental';
@@ -15,6 +16,7 @@ interface ToastProps {
   id: string;
   backgroundColor: string;
   message: string;
+  style?: ViewStyle;
   remove: (_: string) => void;
 }
 
@@ -25,6 +27,7 @@ const Toast = ({
   id,
   backgroundColor,
   message,
+  style,
   remove,
 }: ToastProps): React.JSX.Element => {
   useEffect(() => {
@@ -35,7 +38,9 @@ const Toast = ({
   }, []);
 
   return (
-    <TouchableOpacity style={styles.container} onPress={() => remove(id)}>
+    <TouchableOpacity
+      style={[styles.container, style]}
+      onPress={() => remove(id)}>
       <View style={{ ...styles.alert, backgroundColor }}>
         <Text style={styles.text}>
           {`${index + 1}. `}
@@ -80,15 +85,13 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
     <ToastContext.Provider value={{ push }}>
       {children}
       {/*
-        Toasts live in a full-screen `box-none` overlay (so touches pass through
-        to `children`) that bottom-anchors them in a content-sized SafeAreaView
-        (`flex: 0`), whose Android `bottom` inset lifts them above the system
-        navigation bar.
-        The overlay stays permanently mounted so the native SafeAreaView's
-        asynchronously-resolved inset is ready before the first toast appears.
-        Note: While a toast is visible, the SafeAreaView spans the screen and 
-        swallows taps on the content behind it (such as the tab bar). When idle, the container only 
-        spans the safe navigation area where there is no interactive content.
+        Toasts render in a bottom-anchored, content-sized SafeAreaView whose
+        Android `bottom` inset keeps them above the system navigation bar. It
+        stays mounted even with no toasts: the native SafeAreaView needs a
+        layout pass to apply its bottom inset, so mounting it together with the
+        first toast renders that toast over the navigation bar (it only lifts
+        above once a later re-layout applies the inset). Keeping it mounted
+        means the inset is already applied when the first toast appears.
       */}
       <View style={styles.overlay} pointerEvents="box-none">
         <SafeAreaView

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -70,12 +70,12 @@ interface ToastProviderProps {
 
 function ToastContainer({ toasts, remove, anchorSide }: { toasts: IToast[]; remove: (id: string) => void; anchorSide?: 'top' | 'bottom' }) {
   return (
-    <View style={styles.overlay} pointerEvents="box-none">
+    <View style={[styles.overlay, anchorSide === 'top' ? { justifyContent: 'flex-start' } : { justifyContent: 'flex-end' }]} pointerEvents="box-none">
       <SafeAreaView
         pointerEvents='box-none'
         collapsable={false}
         edges={{ top: true, bottom: true, }}
-        style={[styles.toastArea, anchorSide === 'top' ? { justifyContent: 'flex-start' } : { justifyContent: 'flex-end' }]}
+        style={[styles.toastArea]}
       >
         {toasts.map((toast, i) => (
           <Toast index={i} key={toast.id} {...toast} remove={remove} />

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Dimensions,
   View,
+  ViewStyle,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
 import { SafeAreaView } from 'react-native-screens/experimental';
@@ -25,7 +26,7 @@ const Toast = ({
   id,
   backgroundColor,
   message,
-  style,
+  style ={},
   remove,
 }: ToastProps): React.JSX.Element => {
   useEffect(() => {

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -86,10 +86,9 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
         navigation bar.
         The overlay stays permanently mounted so the native SafeAreaView's
         asynchronously-resolved inset is ready before the first toast appears.
-        Note: the native SafeAreaView ignores `pointerEvents`, so while a toast
-        is visible it swallows taps on whatever is directly behind it (e.g. the
-        tab bar) until the toast is tapped or auto-dismissed. When idle it only
-        spans the navigation bar area, which has no interactive content.
+        Note: While a toast is visible, the SafeAreaView spans the screen and 
+        swallows taps on the content behind it (such as the tab bar). When idle, the container only 
+        spans the safe navigation area where there is no interactive content.
       */}
       <View style={styles.overlay} pointerEvents="box-none">
         <SafeAreaView

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -88,7 +88,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
         Toasts live in a full-screen `box-none` overlay (so touches pass through
         to `children`) that bottom-anchors them in a content-sized SafeAreaView
         (`flex: 0`), whose Android `bottom` inset lifts them above the system
-        navigation bar — avoiding the ugly gap from wrapping the whole app.
+        navigation bar.
         The overlay stays permanently mounted so the native SafeAreaView's
         asynchronously-resolved inset is ready before the first toast appears.
       */}

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   Dimensions,
   View,
-  ViewStyle,
   Platform,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
@@ -16,7 +15,6 @@ interface ToastProps {
   id: string;
   backgroundColor: string;
   message: string;
-  style?: ViewStyle;
   remove: (_: string) => void;
 }
 
@@ -27,7 +25,6 @@ const Toast = ({
   id,
   backgroundColor,
   message,
-  style = {},
   remove,
 }: ToastProps): React.JSX.Element => {
   useEffect(() => {
@@ -38,9 +35,7 @@ const Toast = ({
   }, []);
 
   return (
-    <TouchableOpacity
-      style={{ ...styles.container, ...style }}
-      onPress={() => remove(id)}>
+    <TouchableOpacity style={styles.container} onPress={() => remove(id)}>
       <View style={{ ...styles.alert, backgroundColor }}>
         <Text style={styles.text}>
           {`${index + 1}. `}
@@ -91,6 +86,10 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
         navigation bar.
         The overlay stays permanently mounted so the native SafeAreaView's
         asynchronously-resolved inset is ready before the first toast appears.
+        Note: the native SafeAreaView ignores `pointerEvents`, so while a toast
+        is visible it swallows taps on whatever is directly behind it (e.g. the
+        tab bar) until the toast is tapped or auto-dismissed. When idle it only
+        spans the navigation bar area, which has no interactive content.
       */}
       <View style={styles.overlay} pointerEvents="box-none">
         <SafeAreaView
@@ -108,8 +107,6 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
 export const useToast = () => useContext(ToastContext);
 
 const styles = StyleSheet.create({
-  // Full-screen, `box-none` overlay: it lets touches through and only serves to
-  // push the toast stack to the bottom center of the screen.
   overlay: {
     position: 'absolute',
     top: 0,

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -82,33 +82,49 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   };
 
   return (
-    <SafeAreaView edges={{ bottom: Platform.OS === 'android' }}>
-      <ToastContext.Provider value={{ push }}>
-        <>
-          {children}
+    <ToastContext.Provider value={{ push }}>
+      {children}
+      {/*
+        Toasts live in a full-screen `box-none` overlay (so touches pass through
+        to `children`) that bottom-anchors them in a content-sized SafeAreaView
+        (`flex: 0`), whose Android `bottom` inset lifts them above the system
+        navigation bar — avoiding the ugly gap from wrapping the whole app.
+        The overlay stays permanently mounted so the native SafeAreaView's
+        asynchronously-resolved inset is ready before the first toast appears.
+      */}
+      <View style={styles.overlay} pointerEvents="box-none">
+        <SafeAreaView
+          edges={{ bottom: Platform.OS === 'android' }}
+          style={styles.toastArea}>
           {toasts.map((toast, i) => (
-            <Toast
-              index={i}
-              key={toast.id}
-              style={{ marginBottom: i * 25 }}
-              {...toast}
-              remove={remove}
-            />
+            <Toast index={i} key={toast.id} {...toast} remove={remove} />
           ))}
-        </>
-      </ToastContext.Provider>
-    </SafeAreaView>
+        </SafeAreaView>
+      </View>
+    </ToastContext.Provider>
   );
 };
 
 export const useToast = () => useContext(ToastContext);
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  // Full-screen, `box-none` overlay: it lets touches through and only serves to
+  // push the toast stack to the bottom center of the screen.
+  overlay: {
     position: 'absolute',
-    alignSelf: 'center',
-    bottom: 5,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  toastArea: {
+    flex: 0,
+    alignItems: 'center',
+  },
+  container: {
+    marginBottom: 5,
   },
   alert: {
     alignItems: 'center',

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -76,7 +76,7 @@ function ToastContainer({ toasts, remove, anchorSide }: { toasts: IToast[]; remo
         pointerEvents='box-none'
         collapsable={false}
         edges={{ top: true, bottom: true, }}
-        style={[styles.toastArea]}
+        style={styles.toastArea}
       >
         {toasts.map((toast, i) => (
           <Toast index={i} key={toast.id} {...toast} remove={remove} />

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   Dimensions,
   View,
-  Platform,
 } from 'react-native';
 import { nanoid } from 'nanoid/non-secure';
 import { SafeAreaView } from 'react-native-screens/experimental';
@@ -62,9 +61,27 @@ const ToastContext = createContext({
 
 interface ToastProviderProps {
   children: React.ReactNode;
+  anchorSide?: 'top' | 'bottom';
 }
 
-export const ToastProvider = ({ children }: ToastProviderProps) => {
+function ToastContainer({ toasts, remove, anchorSide }: { toasts: IToast[]; remove: (id: string) => void; anchorSide?: 'top' | 'bottom' }) {
+  return (
+    <View style={styles.overlay} pointerEvents="box-none">
+      <SafeAreaView
+        pointerEvents='box-none'
+        collapsable={false}
+        edges={{ top: true, bottom: true, }}
+        style={[styles.toastArea, anchorSide === 'top' ? { justifyContent: 'flex-start' } : { justifyContent: 'flex-end' }]}
+      >
+        {toasts.map((toast, i) => (
+          <Toast index={i} key={toast.id} {...toast} remove={remove} />
+        ))}
+      </SafeAreaView>
+    </View>
+  );
+}
+
+export function ToastProvider({ children, anchorSide }: ToastProviderProps) {
   const [toasts, setToasts] = useState(initialState);
 
   const remove = (id: string) => {
@@ -79,29 +96,11 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   return (
     <ToastContext.Provider value={{ push }}>
       {children}
-      {/*
-        Toasts live in a full-screen `box-none` overlay (so touches pass through
-        to `children`) that bottom-anchors them in a content-sized SafeAreaView
-        (`flex: 0`), whose Android `bottom` inset lifts them above the system
-        navigation bar.
-        The overlay stays permanently mounted so the native SafeAreaView's
-        asynchronously-resolved inset is ready before the first toast appears.
-        Note: While a toast is visible, the SafeAreaView spans the screen and 
-        swallows taps on the content behind it (such as the tab bar). When idle, the container only 
-        spans the safe navigation area where there is no interactive content.
-      */}
-      <View style={styles.overlay} pointerEvents="box-none">
-        <SafeAreaView
-          edges={{ bottom: Platform.OS === 'android' }}
-          style={styles.toastArea}>
-          {toasts.map((toast, i) => (
-            <Toast index={i} key={toast.id} {...toast} remove={remove} />
-          ))}
-        </SafeAreaView>
-      </View>
+      <ToastContainer toasts={toasts} remove={remove} anchorSide={anchorSide ?? 'bottom'} />
     </ToastContext.Provider>
   );
-};
+
+}
 
 export const useToast = () => useContext(ToastContext);
 
@@ -112,7 +111,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    justifyContent: 'flex-end',
     alignItems: 'center',
   },
   toastArea: {

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -26,7 +26,7 @@ const Toast = ({
   id,
   backgroundColor,
   message,
-  style ={},
+  style = {},
   remove,
 }: ToastProps): React.JSX.Element => {
   useEffect(() => {

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -69,9 +69,16 @@ interface ToastProviderProps {
   anchorSide?: 'top' | 'bottom';
 }
 
-function ToastContainer({ toasts, remove, anchorSide }: { toasts: IToast[]; remove: (id: string) => void; anchorSide?: 'top' | 'bottom' }) {
+interface ToastContainerProps {
+  toasts: IToast[];
+  remove: (id: string) => void;
+  anchorSide?: 'top' | 'bottom';
+}
+
+function ToastContainer({ toasts, remove, anchorSide }: ToastContainerProps) {
   return (
     <View style={[styles.overlay, anchorSide === 'top' ? { justifyContent: 'flex-start' } : { justifyContent: 'flex-end' }]} pointerEvents="box-none">
+      {/* `pointerEvents` does not currently work on Android  */}
       <SafeAreaView
         pointerEvents='box-none'
         collapsable={false}

--- a/apps/src/shared/Toast.tsx
+++ b/apps/src/shared/Toast.tsx
@@ -72,19 +72,25 @@ interface ToastProviderProps {
 interface ToastContainerProps {
   toasts: IToast[];
   remove: (id: string) => void;
-  anchorSide?: 'top' | 'bottom';
+  anchorSide: 'top' | 'bottom';
 }
 
 function ToastContainer({ toasts, remove, anchorSide }: ToastContainerProps) {
   return (
-    <View style={[styles.overlay, anchorSide === 'top' ? { justifyContent: 'flex-start' } : { justifyContent: 'flex-end' }]} pointerEvents="box-none">
+    <View
+      style={[
+        styles.overlay,
+        anchorSide === 'top'
+          ? { justifyContent: 'flex-start' }
+          : { justifyContent: 'flex-end' },
+      ]}
+      pointerEvents="box-none">
       {/* `pointerEvents` does not currently work on Android  */}
       <SafeAreaView
-        pointerEvents='box-none'
+        pointerEvents="box-none"
         collapsable={false}
-        edges={{ top: true, bottom: true, }}
-        style={styles.toastArea}
-      >
+        edges={{ top: true, bottom: true }}
+        style={styles.toastArea}>
         {toasts.map((toast, i) => (
           <Toast index={i} key={toast.id} {...toast} remove={remove} />
         ))}
@@ -93,7 +99,10 @@ function ToastContainer({ toasts, remove, anchorSide }: ToastContainerProps) {
   );
 }
 
-export function ToastProvider({ children, anchorSide }: ToastProviderProps) {
+export function ToastProvider({
+  children,
+  anchorSide = 'bottom',
+}: ToastProviderProps) {
   const [toasts, setToasts] = useState(initialState);
 
   const remove = (id: string) => {
@@ -108,10 +117,9 @@ export function ToastProvider({ children, anchorSide }: ToastProviderProps) {
   return (
     <ToastContext.Provider value={{ push }}>
       {children}
-      <ToastContainer toasts={toasts} remove={remove} anchorSide={anchorSide ?? 'bottom'} />
+      <ToastContainer toasts={toasts} remove={remove} anchorSide={anchorSide} />
     </ToastContext.Provider>
   );
-
 }
 
 export const useToast = () => useContext(ToastContext);

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
@@ -100,7 +100,7 @@ function AppContents() {
 
 function TestTabsLifecycleEvents() {
   return (
-    <ToastProvider>
+    <ToastProvider anchorSide='top'>
       <AppContents />
     </ToastProvider>
   );

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
@@ -100,7 +100,7 @@ function AppContents() {
 
 function TestTabsLifecycleEvents() {
   return (
-    <ToastProvider anchorSide='top'>
+    <ToastProvider anchorSide="top">
       <AppContents />
     </ToastProvider>
   );


### PR DESCRIPTION
## Description

The `ToastProvider` used in the example apps wrapped the **whole view hierarchy** in a `SafeAreaView` (provided in https://github.com/software-mansion/react-native-screens/pull/3944), which applied the bottom inset to the entire app and pushed the content (e.g. a tab bar) up — leaving an ugly gap above the system navigation bar on Android.

This reworks the provider to render the toasts in an absolutely positioned **sibling overlay** instead of padding the whole app, as suggested in the issue. It also adds an `anchorSide` prop so a screen can choose whether the toast stack sits at the top or the bottom of the screen.

Closes software-mansion/react-native-screens-labs#1657

## Changes

- Render `children` directly (no longer wrapped in a `SafeAreaView`), so the app is no longer padded and the tab bar sits flush above the navigation bar — no gap.
- Extract a `ToastContainer` component that renders the toasts in a full-screen `box-none` overlay `View` (touches pass straight through to the app). The overlay bottom- or top-anchors a **content-sized** `SafeAreaView` (`flex: 0`) with `top`/`bottom` edges enabled, so the toasts are lifted above the system navigation bar (and below the status bar).
- Add an `anchorSide?: 'top' | 'bottom'` prop to `ToastProvider` (defaults to `'bottom'`) that controls whether the toast stack is anchored to the top or bottom of the screen.
- Keep the overlay permanently mounted so the native `SafeAreaView`'s asynchronously-resolved inset is ready before the first toast appears (otherwise the first toast would render behind the navigation bar until a re-layout).
- Use `anchorSide='top'` in the `test-tabs-lifecycle-events` screen so its toasts appear at the top, clear of the tab bar.

## Test 

Existing e2e test using toast are passing 