### PR TITLE
fix(android): Fix stale padding after orientation change in screens below the top screen

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledViewGroup.kt
@@ -22,6 +22,12 @@ abstract class FabricEnabledViewGroup(
         mStateWrapper = wrapper
     }
 
+    protected fun resetLastSizes() {
+        lastWidth = 0f
+        lastHeight = 0f
+        lastHeaderHeight = 0f
+    }
+
     @UiThread
     fun updateState(
         width: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
@@ -236,7 +236,7 @@ class Screen(
     ) {
         // In case of form sheet we get layout notification a bit later, in `onBottomSheetBehaviorDidLayout`
         // after the attached behaviour laid out this view.
-        if (changed && isNativeStackScreen && !usesFormSheetPresentation()) {
+        if (isNativeStackScreen && !usesFormSheetPresentation()) {
             val width = r - l
             val height = b - t
 
@@ -577,6 +577,16 @@ class Screen(
                 )
             }
         }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        // When pushing a screen on top another screen, reset the stored sizes
+        // This is important because when orientation changes, the commit hook resets
+        // the screen's shadow state for the frame sizes, which causes placeholder
+        // padding to be applied which then should be reset with updateShadowNodeScreenSize()
+        // inside onLayout(), but there is no change there (current size equals last size)
+        resetLastSizes()
     }
 
     private fun dispatchSheetDetentChanged(

--- a/apps/src/tests/issue-tests/Test4336.tsx
+++ b/apps/src/tests/issue-tests/Test4336.tsx
@@ -1,0 +1,238 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  Button,
+  FlatList,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+
+type StackParamList = {
+  Home: undefined;
+  Video: undefined;
+  Fullscreen: undefined;
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+type Row = {
+  id: number;
+  label: string;
+};
+
+const rows: Row[] = Array.from({ length: 30 }, (_, i) => ({
+  id: i,
+  label: `Row ${i + 1}`,
+}));
+
+function HomeScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Home'>) {
+  const [totalTaps, setTotalTaps] = useState(0);
+  const [rowTaps, setRowTaps] = useState<Record<number, number>>({});
+  const [lastTap, setLastTap] = useState<string>('None');
+
+  const onRowPress = (row: Row) => {
+    setTotalTaps(v => v + 1);
+    setRowTaps(v => ({ ...v, [row.id]: (v[row.id] ?? 0) + 1 }));
+    setLastTap(row.label);
+  };
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Text style={styles.instructions}>
+          Steps to reproduce:{'\n'}1. Tap rows below to verify taps work{'\n'}2.
+          Press "Go to Video Screen"{'\n'}3. Press "Enter Fullscreen" — forces
+          landscape{'\n'}4. Press "Exit Fullscreen" — back to portrait{'\n'}5.
+          Press "Go Back" — returns here{'\n'}6. Try tapping rows — Pressables
+          may fail
+        </Text>
+        <Text style={styles.counter}>Total taps: {totalTaps}</Text>
+        <Text style={styles.counter}>Last tap: {lastTap}</Text>
+        <View style={styles.navButton}>
+          <Button
+            title="Go to Video Screen"
+            onPress={() => navigation.navigate('Video')}
+          />
+        </View>
+      </View>
+      <FlatList
+        data={rows}
+        keyExtractor={item => String(item.id)}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item }) => (
+          <Pressable style={styles.row} onPress={() => onRowPress(item)}>
+            <Text style={styles.rowLabel}>{item.label}</Text>
+            <Text style={styles.rowCount}>
+              Taps: {rowTaps[item.id] ?? 0}
+            </Text>
+          </Pressable>
+        )}
+      />
+    </View>
+  );
+}
+
+function VideoScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Video'>) {
+  return (
+    <View style={styles.centered}>
+      <Text style={styles.title}>Video Screen</Text>
+      <Text style={styles.subtitle}>
+        This simulates a video player screen.
+      </Text>
+      <View style={styles.buttonGap}>
+        <Button
+          title="Enter Fullscreen (landscape)"
+          onPress={() => navigation.navigate('Fullscreen')}
+        />
+        <Button title="Go Back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+}
+
+function FullscreenScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Fullscreen'>) {
+  return (
+    <View style={styles.fullscreen}>
+      <Text style={styles.fullscreenTitle}>Fullscreen Landscape Mode</Text>
+      <Text style={styles.fullscreenSubtitle}>
+        Simulates a fullscreen video player overlay
+      </Text>
+      <Button
+        title="Exit Fullscreen"
+        color="#ffffff"
+        onPress={() => navigation.goBack()}
+      />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ title: 'TestFullscreenPressables', orientation: 'portrait' }}
+        />
+        <Stack.Screen
+          name="Video"
+          component={VideoScreen}
+          options={{ title: 'Video', orientation: 'portrait' }}
+        />
+        <Stack.Screen
+          name="Fullscreen"
+          component={FullscreenScreen}
+          options={{
+            presentation: 'fullScreenModal',
+            orientation: 'landscape',
+            headerShown: false,
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  header: {
+    padding: 16,
+    gap: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d1d5db',
+    backgroundColor: '#ffffff',
+  },
+  instructions: {
+    fontSize: 13,
+    lineHeight: 20,
+    color: '#4b5563',
+  },
+  counter: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  navButton: {
+    marginTop: 8,
+  },
+  listContent: {
+    padding: 12,
+    gap: 8,
+  },
+  row: {
+    minHeight: 56,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d1d5db',
+    backgroundColor: '#ffffff',
+  },
+  rowLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  rowCount: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#2563eb',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    gap: 12,
+    backgroundColor: '#f8fafc',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  subtitle: {
+    fontSize: 15,
+    color: '#4b5563',
+    textAlign: 'center',
+  },
+  buttonGap: {
+    gap: 12,
+    marginTop: 16,
+  },
+  fullscreen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+    backgroundColor: '#111827',
+  },
+  fullscreenTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  fullscreenSubtitle: {
+    fontSize: 15,
+    color: '#9ca3af',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -206,6 +206,7 @@ export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
 export { default as Test4314 } from './Test4314';
+export { default as Test4336 } from './Test4336';
 export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';


### PR DESCRIPTION
## Description

The issue that PR tries to patch is that the commit hook introduced in https://github.com/software-mansion/react-native-screens/pull/3295 resets the size information on orientation change on all screens in stack, but only the ones that have native `onLayout` called can respond correctly.

### More detailed explanation:

The original case that the commit hook fixes focused on currently displayed screen. We're setting the screen size by hand to account for header and the set size is outdated for a brief time after rotating, until native calls `onLayout` which calls state update. The commit hook's purpose is to reset the size to undefined when it detects that the orientation of the screen's parent views (they are not set by hand and therefore not affected) are different than the stale orientation of the screen. Yoga can then immediately relayout the contents of the screen as if it was the first render, with padding for the header and no offset and the content looks good this way. Later `onLayout` is called and the values are set again correctly.

The above depends on the `onLayout` call success. But for the following scenario:

- Home screen initially rendered
- push Second screen
- push Third screen which forces landscape

`onLayout` is called on the Third screen so it goes as expected. After leaving the landscape we're back to portrait, so `onLayout` triggers for the Second screen and it goes as expected. However, going back to the Home screen, we're detecting no change - it was portrait earlier, and it is portrait now, but the commit hook reset has happened and we're having undefined size and top padding, with `onLayout` call skipped due to no apparent change. We're left with incorrect padding and misplacement of shadow nodes which breaks pressables.

To solve this, we need to somehow differentiate between a screen that is on top and rotated, which requires commit hook treatment, and the screen below that may not need it. It can't be for 100% because user might stay in landscape, but that should trigger `onLayout` anyways and things should be good.

There is however no simple way to differentiate the screens, so instead of skipping the commit hook, we're resetting the last known sizes for the screen that is put below the new screen so when going back to it, the size change is actually detected and the code runs correctly.

## Changes

Added a way to force state update in `onLayout` for screens that user goes back to

## Before & after - visual documentation

n/a

## Test plan

Use the provided test, observe the positions of pressables in Home screen after going to fullscreen in third screen and going back to Home

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
