### PR TITLE
fix(iOS): defer mid-transition header updates to stop iOS 26 glass button stretch

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -59,6 +59,10 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   /// transaction via RCTMountingTransactionObserving protocol.
   bool _addedReactSubviewsInCurrentTransaction;
   RCTImageLoader *_imageLoader;
+
+  /// Whether a header-config update is already queued behind an in-flight push/pop transition. Coalesces every prop
+  /// change that lands during one transition into a single post-transition re-apply (see updateViewControllerIfNeeded).
+  BOOL _hasDeferredTransitionUpdate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -142,6 +146,49 @@ RNS_IGNORE_SUPER_CALL_END
     // point to the controller that is going to be revealed after transition. This check fixes the
     // problem when config gets updated while the transition is ongoing.
     nextVC = nav.topViewController;
+#if !TARGET_OS_TV
+    if (@available(iOS 26.0, *)) {
+      // On iOS 26 the navigation bar buttons use the liquid-glass appearance. Re-applying the header config while a
+      // push/pop transition is running rebuilds the `UIBarButtonItem`s from scratch, and a freshly created glass item
+      // animates its glass in from the transition's merged/expanded state — intermittently it gets stuck stretched
+      // across the whole navigation bar (see #3834, worst on interactive back-swipes). Defer the update until the
+      // transition (including a cancelled interactive pop) settles, then re-apply once.
+      //
+      // The re-apply always hops one runloop turn via `dispatch_async`: UIKit can still expose the finished
+      // coordinator inside its own completion phase, and registering a new alongside block on a finished coordinator
+      // never fires, so hopping a turn lets that coordinator tear down first. `_hasDeferredTransitionUpdate` coalesces
+      // every prop change that lands during one transition into a single re-apply (the re-run reads the config's
+      // current props, so nothing is lost). We must never apply synchronously here: a synchronous mid-transition
+      // rebuild is exactly what produces the stretched-glass artifact, so this branch always returns and only the
+      // deferred re-apply touches the bar.
+      if (_hasDeferredTransitionUpdate) {
+        return;
+      }
+      _hasDeferredTransitionUpdate = YES;
+      __weak __typeof(self) weakSelf = self;
+      void (^reapplyAfterTransition)(void) = ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+          __typeof(self) strongSelf = weakSelf;
+          if (strongSelf == nil) {
+            return;
+          }
+          strongSelf->_hasDeferredTransitionUpdate = NO;
+          [strongSelf updateViewControllerIfNeeded];
+        });
+      };
+      BOOL queued = [nav.transitionCoordinator
+          animateAlongsideTransition:nil
+                          completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+                            reapplyAfterTransition();
+                          }];
+      if (!queued) {
+        // The coordinator refused the block (interactive/non-animated window, or already completing), so its completion
+        // won't fire. Re-run on the next runloop turn instead of applying now mid-transition.
+        reapplyAfterTransition();
+      }
+      return;
+    }
+#endif
   }
 
   // we want updates sent to the VC directly below modal too since it is also visible


### PR DESCRIPTION
## Description

Closes #3834.

On iOS 26 the navigation-bar buttons render with the liquid-glass appearance. `updateViewControllerIfNeeded` can run **while a push/pop transition is in flight** — e.g. a screen re-renders its `headerRight` items during an interactive back-swipe (focus change, a badge/count refetch, etc.). When that happens mid-transition, the header config is re-applied and the `UIBarButtonItem`s are rebuilt from scratch. A freshly created glass item then animates its glass in **from the transition's merged/expanded state**, and intermittently gets stuck **stretched across the whole navigation bar** instead of settling to the button's size.

It's timing-dependent and most reproducible on a **physical device** during interactive back-swipes to a screen whose header items re-render — which matches the `missing-repro` reports in #3834 (hard to hit on the simulator).

### Mechanism

`updateViewControllerIfNeeded` already special-cases the in-transition case (it reads `nav.topViewController` instead of `visibleViewController`) but still applies the update synchronously. On iOS ≤ 18 rebuilding the bar buttons mid-transition was invisible; with iOS 26 liquid glass, rebuilding an item mid glass-morph produces the stretched-glass artifact.

## Changes

In `RNSScreenStackHeaderConfig.updateViewControllerIfNeeded`, on **iOS 26+** with an active `transitionCoordinator` (scoped to `!TARGET_OS_TV`):

- Never apply the header update synchronously while the transition is in flight — always defer it and `return`.
- The deferred re-apply runs **one runloop turn after** the transition settles (`dispatch_async`), whether it fires from the coordinator's alongside-completion or is self-scheduled when the coordinator refuses the block (interactive/non-animated window, or already-completing phase). This guarantees the update is never dropped **and** never applied mid-transition.
- `_hasDeferredTransitionUpdate` coalesces every prop change that lands during a single transition into one re-apply (the re-run reads the config's current props, so nothing is lost).

No behavior change below iOS 26; tvOS is unaffected.

## Before & after - visual documentation

Behavior on a physical device (iPhone Air, iOS 26.5.2), navigating with `headerRight` glass buttons and swiping back:

| Before | After |
| --- | --- |
| On interactive back-swipe, a `headerRight` glass button's background intermittently stretches into a full-width, header-height blob that sticks. | The glass button always settles at its normal size; the background is re-applied one frame after the bar settles. No stretched-glass artifact across repeated swipe cycles. |

(Happy to add a screen recording — it needs a physical iOS 26 device to reproduce, so it can't be captured on the simulator.)

## Test plan

Manual, on a physical iOS 26 device (the artifact does not reproduce reliably on the simulator):

1. A native stack where a screen sets `headerRight` items that re-render during navigation (e.g. a value that changes on focus, or an async badge).
2. Push a child screen, then **interactively swipe back** to the screen with the glass `headerRight` button. Repeat several times.
3. Before: the button's liquid-glass background intermittently stretches full-width and sticks. After: it always renders at the correct size.

Verified across repeated `search → back` and `inbox → back` cycles on a downstream app (Expo Router / `react-native-screens` 4.25.2 backport of this exact change).

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types. _(No public API change.)_
- [ ] Ensured that CI passes.