### PR TITLE
feat(Stack v5, iOS): Implement basic view commands for iOS header menu

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -10,12 +10,12 @@ import {
   StackContainer,
   useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
-import { StackHeaderConfigProps } from 'react-native-screens/components/gamma/stack/header';
+import { StackHeaderConfigProps } from 'react-native-screens/experimental';
 import type {
   StackHeaderConfigRef,
-  StackHeaderMenuActionOptionsIOS,
+  StackHeaderMenuItemOptionsIOS,
   StackHeaderMenuOptionsIOS,
-} from 'react-native-screens/components/gamma/stack/header';
+} from 'react-native-screens/experimental';
 import { Button, ScrollView, StyleSheet, Text } from 'react-native';
 import LongText from '@apps/shared/LongText';
 import { scenarioDescription } from './scenario-description';
@@ -62,14 +62,14 @@ const NO_CHANGE = 'NO_CHANGE';
 
 function resolveTitle(
   option: TitleOption,
-): StackHeaderMenuActionOptionsIOS['title'] | typeof NO_CHANGE {
+): StackHeaderMenuItemOptionsIOS['title'] | typeof NO_CHANGE {
   if (option === 'no change') return NO_CHANGE;
   return option === 'undefined' ? undefined : option;
 }
 
 function resolveIcon(
   option: IconOption,
-): StackHeaderMenuActionOptionsIOS['icon'] | typeof NO_CHANGE {
+): StackHeaderMenuItemOptionsIOS['icon'] | typeof NO_CHANGE {
   if (option === 'no change') return NO_CHANGE;
   if (option === 'undefined') return undefined;
   return { type: 'sfSymbol', name: option };
@@ -238,7 +238,7 @@ function ConfigScreen() {
   const [menuIcon, setMenuIcon] = useState<IconOption>('no change');
 
   const sendActionCommand = useCallback(() => {
-    const options: StackHeaderMenuActionOptionsIOS = {};
+    const options: StackHeaderMenuItemOptionsIOS = {};
     const resolvedTitle = resolveTitle(actionTitle);
     if (resolvedTitle !== NO_CHANGE) options.title = resolvedTitle;
     const resolvedIcon = resolveIcon(actionIcon);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -1,18 +1,86 @@
-import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
   StackContainer,
   useStackNavigationContext,
 } from '@apps/shared/gamma/containers/stack';
 import { StackHeaderConfigProps } from 'react-native-screens/components/gamma/stack/header';
-import { Button, ScrollView } from 'react-native';
+import type {
+  StackHeaderConfigRef,
+  StackHeaderMenuActionOptionsIOS,
+  StackHeaderMenuOptionsIOS,
+} from 'react-native-screens/components/gamma/stack/header';
+import { Button, ScrollView, StyleSheet, Text } from 'react-native';
 import LongText from '@apps/shared/LongText';
 import { scenarioDescription } from './scenario-description';
 import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
-import { ToastProvider, useToast } from '@apps/shared';
+import { SettingsPicker, ToastProvider, useToast } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
 
+const ACTION_IDS = [
+  'subitem-1-1',
+  'toggle-1-1',
+  'toggle-1-2',
+  'toggle-1-3',
+  'radio-1-1',
+  'radio-1-2',
+  'radio-1-3',
+] as const;
+type ActionId = (typeof ACTION_IDS)[number];
+
+const MENU_IDS = ['menu-1', 'submenu-1', 'subsubmenu-1'] as const;
+type MenuId = (typeof MENU_IDS)[number];
+
+const TITLE_OPTIONS = [
+  'no change',
+  'Changed',
+  'New Title',
+  'undefined',
+] as const;
+type TitleOption = (typeof TITLE_OPTIONS)[number];
+
+const ICON_OPTIONS = [
+  'no change',
+  'star.fill',
+  'heart.fill',
+  'bell.fill',
+  'undefined',
+] as const;
+type IconOption = (typeof ICON_OPTIONS)[number];
+
+const TOGGLE_STATE_OPTIONS = ['no change', 'true', 'false'] as const;
+type ToggleStateOption = (typeof TOGGLE_STATE_OPTIONS)[number];
+
 const DEFAULT_TRAILING_ITEMS_COUNT = 2;
+const NO_CHANGE = 'NO_CHANGE';
+
+function resolveTitle(
+  option: TitleOption,
+): StackHeaderMenuActionOptionsIOS['title'] | typeof NO_CHANGE {
+  if (option === 'no change') return NO_CHANGE;
+  return option === 'undefined' ? undefined : option;
+}
+
+function resolveIcon(
+  option: IconOption,
+): StackHeaderMenuActionOptionsIOS['icon'] | typeof NO_CHANGE {
+  if (option === 'no change') return NO_CHANGE;
+  if (option === 'undefined') return undefined;
+  return { type: 'sfSymbol', name: option };
+}
+
+function resolveToggleState(
+  option: ToggleStateOption,
+): boolean | undefined | typeof NO_CHANGE {
+  if (option === 'no change') return NO_CHANGE;
+  return option === 'true';
+}
 
 function TestStackHeaderMenuIOS() {
   return (
@@ -144,6 +212,8 @@ function ConfigScreen() {
     [toast],
   );
 
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(
     () => buildHeaderConfig(trailingItemsCount, showToast, keepsMenuPresented),
@@ -153,8 +223,41 @@ function ConfigScreen() {
   useLayoutEffect(() => {
     setRouteOptions(routeKey, {
       headerConfig,
+      headerConfigRef,
     });
   }, [headerConfig, setRouteOptions, routeKey]);
+
+  const [actionId, setActionId] = useState<ActionId>('subitem-1-1');
+  const [actionTitle, setActionTitle] = useState<TitleOption>('no change');
+  const [actionIcon, setActionIcon] = useState<IconOption>('no change');
+  const [actionToggle, setActionToggle] =
+    useState<ToggleStateOption>('no change');
+
+  const [menuId, setMenuId] = useState<MenuId>('submenu-1');
+  const [menuTitle, setMenuTitle] = useState<TitleOption>('no change');
+  const [menuIcon, setMenuIcon] = useState<IconOption>('no change');
+
+  const sendActionCommand = useCallback(() => {
+    const options: StackHeaderMenuActionOptionsIOS = {};
+    const resolvedTitle = resolveTitle(actionTitle);
+    if (resolvedTitle !== NO_CHANGE) options.title = resolvedTitle;
+    const resolvedIcon = resolveIcon(actionIcon);
+    if (resolvedIcon !== NO_CHANGE) options.icon = resolvedIcon;
+    const resolvedToggleState = resolveToggleState(actionToggle);
+    if (resolvedToggleState !== NO_CHANGE) options.toggleState = resolvedToggleState;
+
+    headerConfigRef.current?.ios?.setMenuItemOptions(actionId, options);
+  }, [actionId, actionTitle, actionIcon, actionToggle]);
+
+  const sendMenuCommand = useCallback(() => {
+    const options: StackHeaderMenuOptionsIOS = {};
+    const resolvedTitle = resolveTitle(menuTitle);
+    if (resolvedTitle !== NO_CHANGE) options.title = resolvedTitle;
+    const resolvedIcon = resolveIcon(menuIcon);
+    if (resolvedIcon !== NO_CHANGE) options.icon = resolvedIcon;
+
+    headerConfigRef.current?.ios?.setMenuOptions(menuId, options);
+  }, [menuId, menuTitle, menuIcon]);
 
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
@@ -166,9 +269,68 @@ function ConfigScreen() {
         title={`keepsMenuPresented: ${keepsMenuPresented}`}
         onPress={() => setKeepsMenuPresented(prev => !prev)}
       />
+
+      <Text style={styles.heading}>setMenuItemOptions (Menu 1)</Text>
+      <SettingsPicker<ActionId>
+        label="target id"
+        value={actionId}
+        items={[...ACTION_IDS]}
+        onValueChange={setActionId}
+      />
+      <SettingsPicker<TitleOption>
+        label="title"
+        value={actionTitle}
+        items={[...TITLE_OPTIONS]}
+        onValueChange={setActionTitle}
+      />
+      <SettingsPicker<IconOption>
+        label="icon"
+        value={actionIcon}
+        items={[...ICON_OPTIONS]}
+        onValueChange={setActionIcon}
+      />
+      <SettingsPicker<ToggleStateOption>
+        label="toggleState"
+        value={actionToggle}
+        items={[...TOGGLE_STATE_OPTIONS]}
+        onValueChange={setActionToggle}
+      />
+      <Button title="Send setMenuItemOptions" onPress={sendActionCommand} />
+
+      <Text style={styles.heading}>setMenuOptions (Menu 1)</Text>
+      <SettingsPicker<MenuId>
+        label="target id"
+        value={menuId}
+        items={[...MENU_IDS]}
+        onValueChange={setMenuId}
+      />
+      <SettingsPicker<TitleOption>
+        label="title"
+        value={menuTitle}
+        items={[...TITLE_OPTIONS]}
+        onValueChange={setMenuTitle}
+      />
+      <SettingsPicker<IconOption>
+        label="icon"
+        value={menuIcon}
+        items={[...ICON_OPTIONS]}
+        onValueChange={setMenuIcon}
+      />
+      <Button title="Send setMenuOptions" onPress={sendMenuCommand} />
+
       <LongText />
     </ScrollView>
   );
 }
 
 export default createScenario(TestStackHeaderMenuIOS, scenarioDescription);
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginTop: 16,
+    marginBottom: 4,
+    paddingHorizontal: 10,
+  },
+});

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -24,7 +24,7 @@ TBD
 
 1. Launch the app and navigate to the **Stack Header Menu (iOS)** screen.
 2. Click on the Menu 1 item
-  - [ ] The bubble morphs into a menu with two items and a submenu
+  - [ ] The bubble morphs into a menu with four items and a submenu
 3. Click on Action 1-1
   - [ ] A toast "Clicked Action 1-1" is displayed
 4. Click on Toggle 1-1 inside Menu

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -20,6 +20,8 @@ TBD
 
 ## Steps on iPhone
 
+### Menu interactions
+
 1. Launch the app and navigate to the **Stack Header Menu (iOS)** screen.
 2. Click on the Menu 1 item
   - [ ] The bubble morphs into a menu with two items and a submenu
@@ -46,3 +48,27 @@ TBD
   - [ ] A toast "Selected unique "radio 1-2"" is displayed
   - [ ] When Menu 1 > Submenu with Radio is reopened, Radio 1-1 is no longer checked
   - [ ] When Menu 1 > Submenu with Radio > SubSubmenu with Radio is reopened, Radio 1-2 is checked
+
+### setMenuItemOptions view command
+
+1. Relaunch the app and navigate to the **Stack Header Menu (iOS)** screen.
+2. In `setMenuItemOptions`, select `title` to be "New Title" and click `Send setMenuItemOptions`
+  - [ ] When Menu 1 is opened, first item is New Title
+3. Close the menu. Select `title` to be "no change", `icon` to be "star.fill" and click `Send setMenuItemOptions`
+  - [ ] When Menu 1 is opened, first item is New Title and has star icon
+4. Close the menu. Select `target id` to be "toggle-1-1", `toggleState` to be "true" and click `Send setMenuItemOptions`
+  - [ ] When Menu 1 is opened, Toggle 1-1 is checked
+  - [ ] A toast "Selected "toggle 1-1"" is displayed
+5. Close the menu. Select `target id` to be "radio-1-1", `toggleState` to be "false" and click `Send setMenuItemOptions`
+  - [ ] When Menu 1 > Submenu with Radio is opened, Radio 1-1 is still selected (no change)
+6. Close the menu. Select `target id` to be "radio-1-2", `toggleState` to be "true" and click `Send setMenuItemOptions`
+  - [ ] When Menu 1 > Submenu with Radio > SubSubMenu with Radio is opened, Radio 1-1 is deselected and Radio 1-2 is selected instead
+  - [ ] A toast "Selected unique "radio 1-2"" is displayed
+
+  ### setMenuOptions view command
+
+1. Relaunch the app and navigate to the **Stack Header Menu (iOS)** screen.
+2. In `setMenuOptions`, select `title` to be "New Title" and click `Send setMenuOptions`
+  - [ ] When Menu 1 is opened, the submenu is named "New Title"
+3. Close the menu. Select `title` to be "no change", `icon` to be "bell.fill" and click `Send setMenuOptions`
+  - [ ] When Menu 1 is opened, the submenu is still named "New Title" and has bell icon

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -358,7 +358,11 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     return nil;
   }
   id first = options[0];
-  return [first isKindOfClass:[NSDictionary class]] ? first : nil;
+  if (![first isKindOfClass:[NSDictionary class]]) {
+    return nil;
+  }
+  NSDictionary *dict = (NSDictionary *)first;
+  return dict.count > 0 ? dict : nil;
 }
 
 - (NSArray<RNSStackHeaderItemComponentView *> *)headerItems

--- a/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -4,6 +4,8 @@
 #import "RNSStackHeaderConfigShadowStateProxy.h"
 #import "RNSStackHeaderItemComponentView.h"
 #import "RNSStackHeaderItemSpacerComponentView.h"
+#import "RNSStackHeaderMenuFinder.h"
+#import "RNSStackHeaderMenuUpdateOptions.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackScreenComponentView.h"
 #import "RNSStackScreenController.h"
@@ -29,6 +31,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
             RNSStackHeaderItemComponentView.class,
             RNSStackHeaderItemSpacerComponentView.class);
 }
+
+@interface RNSStackHeaderConfigComponentView () <RCTRNSStackHeaderConfigIOSViewProtocol>
+@end
 
 @implementation RNSStackHeaderConfigComponentView {
   std::shared_ptr<const react::RNSStackHeaderConfigShadowNode::ConcreteState> _state;
@@ -187,6 +192,20 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   [coordinator reapplyMenuForItemWithId:itemId];
 }
 
+/**
+ * Same as headerItemDidInvalidateWithId, but handles view commands and doesn't reset the tracker
+ */
+- (void)headerItemMenuDidUpdateFromCommandWithId:(NSString *)itemId
+{
+  if (itemId == nil) {
+    RCTLogWarn(
+        @"[RNScreens] headerItemMenuDidUpdateFromCommandWithId called with nil id, will run full header rebuild");
+    [[self headerCoordinator] rebuild];
+    return;
+  }
+  [[self headerCoordinator] reapplyMenuForItemWithId:itemId];
+}
+
 - (void)headerItemSpacerDidInvalidate
 {
   [[self headerCoordinator] rebuild];
@@ -234,6 +253,123 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   UIView *screenView = self.superview;
   CGRect navBarFrame = [navigationBar convertRect:navigationBar.bounds toView:screenView];
   [_shadowStateProxy updateShadowStateWithFrame:navBarFrame];
+}
+
+#pragma mark - Commands
+
+- (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
+{
+  RCTRNSStackHeaderConfigIOSHandleCommand(self, commandName, args);
+}
+
+- (void)setMenuItemOptions:(NSString *)menuItemId options:(const NSArray *)options
+{
+  NSDictionary *dict = [self extractOptionsDict:options];
+  if (menuItemId == nil || dict == nil) {
+    return;
+  }
+
+  RNSMenuElementLocator *locator = [RNSStackHeaderMenuFinder findMenuElementWithId:menuItemId
+                                                                     inHeaderItems:[self headerItems]];
+  if (locator == nil) {
+    RCTLogWarn(@"[RNScreens] setMenuItemOptions: element with id \"%@\" not found", menuItemId);
+    return;
+  }
+  if (![locator.searchResult.element isKindOfClass:[RNSStackHeaderMenuItemData class]]) {
+    RCTLogWarn(@"[RNScreens] setMenuItemOptions: element \"%@\" is a menu, expected menuItem", menuItemId);
+    return;
+  }
+
+  RNSMenuItemUpdateOptions *updateOptions = [RNSMenuItemUpdateOptions fromDictionary:dict];
+  RNSStackHeaderMenuItemData *oldItemData = (RNSStackHeaderMenuItemData *)locator.searchResult.element;
+  RNSStackHeaderMenuItemData *newItemData = [RNSMenuItemUpdateOptions applyOptions:updateOptions
+                                                                        toMenuItem:oldItemData];
+
+  if (updateOptions.hasToggleState) {
+    BOOL isToggle = oldItemData.itemType == RNSMenuItemTypeToggle ||
+        (oldItemData.itemType == RNSMenuItemTypeAutomatic && locator.headerItem.menu != nil &&
+         [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:menuItemId
+                                                                inMenu:locator.headerItem.menu] != nil);
+    if (isToggle) {
+      [[self headerCoordinator] setToggleState:updateOptions.toggleState
+                              forMenuElementId:menuItemId
+                                    withItemId:locator.headerItem.itemId
+                                    parentMenu:locator.searchResult.parentMenu];
+    }
+  }
+
+  switch (locator.position) {
+    case RNSMenuElementPositionItem:
+      RCTAssert([locator.headerItem isKindOfClass:RNSStackHeaderItemComponentView.class],
+                @"[RNScreens] headerItem is expected to be of type RNSStackHeaderItemComponentView");
+      [static_cast<RNSStackHeaderItemComponentView *>(locator.headerItem)
+          updateMenuElementWithId:menuItemId
+                      withElement:newItemData
+                       parentMenu:locator.searchResult.parentMenu];
+      break;
+    case RNSMenuElementPositionTitle:
+    case RNSMenuElementPositionOverflow:
+      // TODO: handle title menu and overflow menu
+      break;
+  }
+}
+
+- (void)setMenuOptions:(NSString *)menuElementId options:(const NSArray *)options
+{
+  NSDictionary *dict = [self extractOptionsDict:options];
+  if (menuElementId == nil || dict == nil) {
+    return;
+  }
+
+  RNSMenuElementLocator *locator = [RNSStackHeaderMenuFinder findMenuElementWithId:menuElementId
+                                                                     inHeaderItems:[self headerItems]];
+  if (locator == nil) {
+    RCTLogWarn(@"[RNScreens] setMenuOptions: element with id \"%@\" not found", menuElementId);
+    return;
+  }
+  if (![locator.searchResult.element isKindOfClass:[RNSStackHeaderMenuData class]]) {
+    RCTLogWarn(@"[RNScreens] setMenuOptions: element \"%@\" is a menuItem, expected menu", menuElementId);
+    return;
+  }
+
+  RNSMenuUpdateOptions *updateOptions = [RNSMenuUpdateOptions fromDictionary:dict];
+  RNSStackHeaderMenuData *oldMenuItem = (RNSStackHeaderMenuData *)locator.searchResult.element;
+  RNSStackHeaderMenuData *newMenuItem = [RNSMenuUpdateOptions applyOptions:updateOptions toMenu:oldMenuItem];
+
+  switch (locator.position) {
+    case RNSMenuElementPositionItem:
+      RCTAssert([locator.headerItem isKindOfClass:RNSStackHeaderItemComponentView.class],
+                @"[RNScreens] headerItem is expected to be of type RNSStackHeaderItemComponentView");
+      [static_cast<RNSStackHeaderItemComponentView *>(locator.headerItem)
+          updateMenuElementWithId:menuElementId
+                      withElement:newMenuItem
+                       parentMenu:locator.searchResult.parentMenu];
+      break;
+    case RNSMenuElementPositionTitle:
+    case RNSMenuElementPositionOverflow:
+      // TODO: handle title menu and overflow menu
+      break;
+  }
+}
+
+- (nullable NSDictionary *)extractOptionsDict:(const NSArray *)options
+{
+  if (options.count == 0) {
+    return nil;
+  }
+  id first = options[0];
+  return [first isKindOfClass:[NSDictionary class]] ? first : nil;
+}
+
+- (NSArray<RNSStackHeaderItemComponentView *> *)headerItems
+{
+  NSMutableArray<RNSStackHeaderItemComponentView *> *items = [NSMutableArray new];
+  for (UIView *child in _children) {
+    if ([child isKindOfClass:RNSStackHeaderItemComponentView.class]) {
+      [items addObject:(RNSStackHeaderItemComponentView *)child];
+    }
+  }
+  return items;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) UIView *customView;
 @property (nonatomic, readonly) BOOL respondsToOnPress;
 
+@property (nonatomic, nullable) NSString *titleProp;
+@property (nonatomic, nullable) RNSStackHeaderIconData *iconProp;
+@property (nonatomic, nullable) RNSStackHeaderMenuData *menuProp;
+
 @property (nonatomic, weak, nullable) id<RNSStackHeaderItemInvalidationDelegate> invalidationDelegate;
 
 - (void)emitOnPress;

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.h
@@ -22,6 +22,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)emitOnPress;
 
+/**
+ * Replaces a menu element in the item's menu tree with a new element constructed from command options.
+ * If parentMenu is nil, the element is the root menu and is replaced directly.
+ */
+- (void)updateMenuElementWithId:(NSString *)elementId
+                    withElement:(id<RNSStackHeaderMenuElement>)newElement
+                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
@@ -45,12 +45,30 @@ namespace react = facebook::react;
 - (void)resetProps
 {
   _itemId = nil;
-  _title = nil;
-  _icon = nil;
-  _menu = nil;
+  [self setTitleProp:nil];
+  [self setIconProp:nil];
+  [self setMenuProp:nil];
   _placement = RNSHeaderItemPlacementTrailing;
   _didSetHeaderItemPlacement = NO;
   _respondsToOnPress = NO;
+}
+
+- (void)setTitleProp:(NSString *)titleProp
+{
+  _titleProp = titleProp;
+  _title = titleProp;
+}
+
+- (void)setIconProp:(RNSStackHeaderIconData *)iconProp
+{
+  _iconProp = iconProp;
+  _icon = iconProp;
+}
+
+- (void)setMenuProp:(RNSStackHeaderMenuData *)menuProp
+{
+  _menuProp = menuProp;
+  _menu = menuProp;
 }
 
 - (void)emitOnPress
@@ -175,19 +193,19 @@ RNS_IGNORE_SUPER_CALL_END
   _didSetHeaderItemPlacement = YES;
 
   if (oldItemProps.title != newItemProps.title) {
-    _title = RCTNSStringFromStringNilIfEmpty(newItemProps.title);
+    [self setTitleProp:RCTNSStringFromStringNilIfEmpty(newItemProps.title)];
     needsUpdate = YES;
   }
 
   if (oldItemProps.icon != newItemProps.icon) {
-    _icon = [RNSStackHeaderIconMapper
-        iconFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.icon)];
+    [self setIconProp:[RNSStackHeaderIconMapper
+                          iconFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.icon)]];
     needsUpdate = YES;
   }
 
   if (oldItemProps.menu != newItemProps.menu) {
-    _menu = [RNSStackHeaderMenuMapper
-        menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.menu)];
+    [self setMenuProp:[RNSStackHeaderMenuMapper
+                          menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.menu)]];
     menuDidChange = YES;
   }
 

--- a/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderItemComponentView.mm
@@ -5,6 +5,7 @@
 #import "RNSStackHeaderIconMapper.h"
 #import "RNSStackHeaderItemEventEmitter.h"
 #import "RNSStackHeaderItemShadowStateProxy.h"
+#import "RNSStackHeaderMenuCoordinator.h"
 #import "RNSStackHeaderMenuData.h"
 #import "RNSStackHeaderMenuMapper.h"
 
@@ -55,6 +56,18 @@ namespace react = facebook::react;
 - (void)emitOnPress
 {
   [_headerItemEventEmitter emitOnPress];
+}
+
+- (void)updateMenuElementWithId:(NSString *)elementId
+                    withElement:(id<RNSStackHeaderMenuElement>)newElement
+                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
+{
+  if (parentMenu == nil) {
+    _menu = (RNSStackHeaderMenuData *)newElement;
+  } else {
+    _menu = [RNSStackHeaderMenuCoordinator menu:_menu replacingChildWithId:elementId withElement:newElement];
+  }
+  [_invalidationDelegate headerItemMenuDidUpdateFromCommandWithId:_itemId];
 }
 
 #pragma mark - RNSStackHeaderItemDataProviding

--- a/ios/gamma/stack/header/RNSStackHeaderItemInvalidationDelegate.h
+++ b/ios/gamma/stack/header/RNSStackHeaderItemInvalidationDelegate.h
@@ -10,6 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)headerItemMenuDidChangeWithId:(NSString *)itemId;
 
+- (void)headerItemMenuDidUpdateFromCommandWithId:(NSString *)itemId;
+
 - (void)headerItemSpacerDidInvalidate;
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.h
@@ -12,11 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderMenuCoordinator : NSObject
 
 /**
- Applies menu specification to the item. Sets up event delegate to receive
- menu updates when user selects options or clicks actions. Since menu needs
- to be rebuilt after user changes selection or after async icon load,
- the `menuInvalidatedCallback` is triggered and the caller is expected
- to reapply the menu there.
+ * Applies menu specification to the item. Sets up event delegate to receive
+ * menu updates when user selects options or clicks actions. Since menu needs
+ * to be rebuilt after user changes selection or after async icon load,
+ * the `menuInvalidatedCallback` is triggered and the caller is expected
+ * to reapply the menu there.
  */
 + (void)applyMenu:(RNSStackHeaderMenuData *)data
              toBarButtonItem:(UIBarButtonItem *)item
@@ -24,6 +24,24 @@ NS_ASSUME_NONNULL_BEGIN
                 stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
              withImageLoader:(id<RNSImageLoading>)imageLoader
      menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated;
+
+/**
+ * Collects IDs of all toggle items in a single selection hierarchy rooted at the given menu.
+ */
++ (NSArray<NSString *> *)getAllToggleItemsIdsInSingleSelectionHierarchy:(RNSStackHeaderMenuData *)menu;
+
+/**
+ * Collects IDs of toggle items that are direct children of the given menu.
+ */
++ (NSArray<NSString *> *)getToggleItemsIdsInMenu:(RNSStackHeaderMenuData *)menu;
+
+/**
+ * Constructs a new menu tree with the child matching `elementId` replaced by `newElement`.
+ * Returns the original menu unchanged if no matching child is found in the subtree.
+ */
++ (RNSStackHeaderMenuData *)menu:(RNSStackHeaderMenuData *)menu
+            replacingChildWithId:(NSString *)elementId
+                     withElement:(id<RNSStackHeaderMenuElement>)newElement;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -189,7 +189,12 @@
                 NSArray<NSString *> *toggleItemsIds = insideSingleSelection
                     ? [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInSingleSelectionHierarchy:singleSelectionRoot]
                     : [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu];
+
                 if (insideSingleSelection) {
+                  if ([tracker toggleStateEquals:YES forItemWithId:data.menuElementId]) {
+                    return;
+                  }
+
                   [tracker selectItemWithId:data.menuElementId fromIds:toggleItemsIds];
                 } else {
                   [tracker toggleItemWithId:data.menuElementId];
@@ -202,13 +207,7 @@
                   }
                 }
 
-                // the state might be unchanged if user e.g. clicks on the same selected
-                // radio
-                if ([tracker toggleStateChanged]) {
-                  [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
-
-                  [tracker setToggleStateChanged:NO];
-                }
+                [weakDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
 
                 if (onMenuInvalidated) {
                   onMenuInvalidated();

--- a/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -307,4 +307,41 @@
   }
 }
 
++ (RNSStackHeaderMenuData *)menu:(RNSStackHeaderMenuData *)menu
+            replacingChildWithId:(NSString *)elementId
+                     withElement:(id<RNSStackHeaderMenuElement>)newElement
+{
+  BOOL changed = NO;
+  NSMutableArray<id<RNSStackHeaderMenuElement>> *newChildren = [NSMutableArray arrayWithCapacity:menu.children.count];
+
+  for (id<RNSStackHeaderMenuElement> child in menu.children) {
+    if ([child.menuElementId isEqualToString:elementId]) {
+      [newChildren addObject:newElement];
+      changed = YES;
+    } else if ([child isKindOfClass:[RNSStackHeaderMenuData class]]) {
+      RNSStackHeaderMenuData *rebuilt = [self menu:(RNSStackHeaderMenuData *)child
+                              replacingChildWithId:elementId
+                                       withElement:newElement];
+      [newChildren addObject:rebuilt];
+      if (rebuilt != child) {
+        changed = YES;
+      }
+    } else {
+      [newChildren addObject:child];
+    }
+  }
+
+  if (!changed) {
+    return menu;
+  }
+
+  return [[RNSStackHeaderMenuData alloc] initWithId:menu.menuElementId
+                                              title:menu.title
+                                    singleSelection:menu.singleSelection
+                                      displayInline:menu.displayInline
+                                   displayAsPalette:menu.displayAsPalette
+                                           children:newChildren
+                                               icon:menu.icon];
+}
+
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuFinder.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuFinder.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import "RNSStackHeaderItemComponentView.h"
+#import "RNSStackHeaderMenuData.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSStackHeaderMenuElementSearchResult : NSObject
+
+@property (nonatomic, strong, readonly) id<RNSStackHeaderMenuElement> element;
+@property (nonatomic, strong, readonly, nullable) RNSStackHeaderMenuData *parentMenu;
+
+- (instancetype)initWithElement:(id<RNSStackHeaderMenuElement>)element
+                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu;
+
+@end
+
+typedef NS_ENUM(NSInteger, RNSMenuElementPosition) {
+  RNSMenuElementPositionItem,
+  RNSMenuElementPositionTitle,
+  RNSMenuElementPositionOverflow,
+};
+
+@interface RNSMenuElementLocator : NSObject
+
+@property (nonatomic, strong, readonly) RNSStackHeaderMenuElementSearchResult *searchResult;
+@property (nonatomic, readonly) RNSMenuElementPosition position;
+@property (nonatomic, weak, readonly, nullable) id<RNSStackHeaderItemDataProviding> headerItem;
+
+- (instancetype)initWithSearchResult:(RNSStackHeaderMenuElementSearchResult *)searchResult
+                            position:(RNSMenuElementPosition)position
+                          headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem;
+
+@end
+
+@interface RNSStackHeaderMenuFinder : NSObject
+
+/**
+ * Searches all header items' menus for a menu element with the given ID.
+ */
++ (nullable RNSMenuElementLocator *)findMenuElementWithId:(NSString *)elementId
+                                            inHeaderItems:(NSArray<id<RNSStackHeaderItemDataProviding>> *)items;
+
+/**
+ * Recursively searches a single menu tree for an element with the given ID.
+ */
++ (nullable RNSStackHeaderMenuElementSearchResult *)findElementWithId:(NSString *)elementId
+                                                               inMenu:(RNSStackHeaderMenuData *)menu;
+/**
+ * Finds the single selection root menu that contains the element with the given ID.
+ */
++ (nullable RNSStackHeaderMenuData *)singleSelectionRootForElementWithId:(NSString *)elementId
+                                                                  inMenu:(RNSStackHeaderMenuData *)menu;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuFinder.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuFinder.mm
@@ -1,0 +1,124 @@
+#import "RNSStackHeaderMenuFinder.h"
+
+#pragma mark - RNSStackHeaderMenuElementSearchResult
+
+@implementation RNSStackHeaderMenuElementSearchResult
+
+- (instancetype)initWithElement:(id<RNSStackHeaderMenuElement>)element
+                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
+{
+  if (self = [super init]) {
+    _element = element;
+    _parentMenu = parentMenu;
+  }
+  return self;
+}
+
+@end
+
+#pragma mark - RNSMenuElementLocator
+
+@implementation RNSMenuElementLocator
+
+- (instancetype)initWithSearchResult:(RNSStackHeaderMenuElementSearchResult *)searchResult
+                            position:(RNSMenuElementPosition)position
+                          headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem
+{
+  if (self = [super init]) {
+    _searchResult = searchResult;
+    _position = position;
+    _headerItem = headerItem;
+  }
+  return self;
+}
+
+@end
+
+#pragma mark - RNSStackHeaderMenuFinder
+
+@implementation RNSStackHeaderMenuFinder
+
++ (nullable RNSMenuElementLocator *)findMenuElementWithId:(NSString *)elementId
+                                            inHeaderItems:(NSArray<id<RNSStackHeaderItemDataProviding>> *)items
+{
+  for (id<RNSStackHeaderItemDataProviding> item in items) {
+    if (item.menu == nil || item.itemId == nil) {
+      continue;
+    }
+    RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId inMenu:item.menu];
+    if (result != nil) {
+      return [[RNSMenuElementLocator alloc] initWithSearchResult:result
+                                                        position:RNSMenuElementPositionItem
+                                                      headerItem:item];
+    }
+  }
+  // TODO: search title menu (RNSMenuElementPositionTitle)
+  // and overflow menu (RNSMenuElementPositionOverflow)
+  return nil;
+}
+
++ (nullable RNSStackHeaderMenuElementSearchResult *)findElementWithId:(NSString *)elementId
+                                                               inMenu:(RNSStackHeaderMenuData *)menu
+{
+  if ([menu.menuElementId isEqualToString:elementId]) {
+    return [[RNSStackHeaderMenuElementSearchResult alloc] initWithElement:menu parentMenu:nil];
+  }
+
+  for (id<RNSStackHeaderMenuElement> child in menu.children) {
+    if ([child.menuElementId isEqualToString:elementId]) {
+      return [[RNSStackHeaderMenuElementSearchResult alloc] initWithElement:child parentMenu:menu];
+    }
+
+    if ([child isKindOfClass:[RNSStackHeaderMenuData class]]) {
+      RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId
+                                                                       inMenu:(RNSStackHeaderMenuData *)child];
+      if (result != nil) {
+        return result;
+      }
+    }
+  }
+
+  return nil;
+}
+
++ (nullable RNSStackHeaderMenuData *)singleSelectionRootForElementWithId:(NSString *)elementId
+                                                                  inMenu:(RNSStackHeaderMenuData *)menu
+{
+  RNSStackHeaderMenuData *root = nil;
+  if ([self searchForElementWithId:elementId
+                              inMenu:menu
+          currentSingleSelectionRoot:menu.singleSelection ? menu : nil
+                           foundRoot:&root]) {
+    return root;
+  }
+  return nil;
+}
+
++ (BOOL)searchForElementWithId:(NSString *)elementId
+                        inMenu:(RNSStackHeaderMenuData *)menu
+    currentSingleSelectionRoot:(nullable RNSStackHeaderMenuData *)currentRoot
+                     foundRoot:(RNSStackHeaderMenuData *_Nullable *_Nonnull)outRoot
+{
+  RNSStackHeaderMenuData *resolvedRoot = currentRoot;
+  if (resolvedRoot == nil && menu.singleSelection) {
+    resolvedRoot = menu;
+  }
+
+  for (id<RNSStackHeaderMenuElement> child in menu.children) {
+    if ([child.menuElementId isEqualToString:elementId]) {
+      *outRoot = resolvedRoot;
+      return YES;
+    }
+    if ([child isKindOfClass:[RNSStackHeaderMenuData class]]) {
+      if ([self searchForElementWithId:elementId
+                                  inMenu:(RNSStackHeaderMenuData *)child
+              currentSingleSelectionRoot:resolvedRoot
+                               foundRoot:outRoot]) {
+        return YES;
+      }
+    }
+  }
+  return NO;
+}
+
+@end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
@@ -6,8 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSStackHeaderMenuToggleStateTracker : NSObject
 
-@property (nonatomic, assign, readwrite) BOOL toggleStateChanged;
-
 - (BOOL)getToggleStateForItemWithId:(NSString *)menuItemId initialState:(BOOL)initialState;
 
 - (BOOL)toggleItemWithId:(NSString *)menuItemId;
@@ -15,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)selectItemWithId:(NSString *)menuItemId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
 
 - (void)setToggleState:(BOOL)state forItemWithId:(NSString *)menuItemId;
+
+- (BOOL)toggleStateEquals:(BOOL)state forItemWithId:(NSString *)menuItemId;
 
 @end
 

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)selectItemWithId:(NSString *)menuItemId fromIds:(NSArray<NSString *> *)allItemIdsInMenu;
 
+- (void)setToggleState:(BOOL)state forItemWithId:(NSString *)menuItemId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -54,4 +54,9 @@
       givenItemIsSelected, @"[RNScreens] Attempt to select item \"%@\" that is not present in the list", menuItemId);
 }
 
+- (void)setToggleState:(BOOL)state forItemWithId:(NSString *)menuItemId
+{
+  _states[menuItemId] = @(state);
+}
+
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuToggleStateTracker.mm
@@ -9,7 +9,6 @@
 {
   if (self = [super init]) {
     _states = [NSMutableDictionary new];
-    _toggleStateChanged = NO;
   }
   return self;
 }
@@ -33,14 +32,12 @@
   NSNumber *existing = _states[menuItemId];
   BOOL newValue = !(existing != nil ? existing.boolValue : NO);
   _states[menuItemId] = @(newValue);
-  _toggleStateChanged = YES;
   return newValue;
 }
 
 - (void)selectItemWithId:(NSString *)menuItemId fromIds:(NSArray<NSString *> *)allItemIdsInMenu
 {
   BOOL givenItemIsSelected = NO;
-  _toggleStateChanged = ![_states[menuItemId] boolValue];
   for (NSString *itemId in allItemIdsInMenu) {
     if ([itemId isEqualToString:menuItemId]) {
       _states[itemId] = @YES;
@@ -57,6 +54,15 @@
 - (void)setToggleState:(BOOL)state forItemWithId:(NSString *)menuItemId
 {
   _states[menuItemId] = @(state);
+}
+
+- (BOOL)toggleStateEquals:(BOOL)state forItemWithId:(nonnull NSString *)menuItemId
+{
+  if (_states[menuItemId] == nil) {
+    return NO;
+  }
+
+  return [_states[menuItemId] boolValue] == state;
 }
 
 @end

--- a/ios/gamma/stack/header/RNSStackHeaderMenuUpdateOptions.h
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuUpdateOptions.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import "RNSStackHeaderIconData.h"
+#import "RNSStackHeaderMenuData.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Typed options parsed from command dictionary for menu item updates.
+ * `has*` flags distinguish "no change" (key absent) from "reset" (key present, null value).
+ */
+@interface RNSMenuItemUpdateOptions : NSObject
+
+@property (nonatomic, readonly) BOOL hasTitle;
+@property (nonatomic, copy, readonly, nullable) NSString *title;
+@property (nonatomic, readonly) BOOL hasIcon;
+@property (nonatomic, strong, readonly, nullable) RNSStackHeaderIconData *icon;
+@property (nonatomic, readonly) BOOL hasToggleState;
+@property (nonatomic, readonly) BOOL toggleState;
+
++ (instancetype)fromDictionary:(NSDictionary *)dict;
+
++ (RNSStackHeaderMenuItemData *)applyOptions:(RNSMenuItemUpdateOptions *)options
+                                  toMenuItem:(RNSStackHeaderMenuItemData *)old;
+
+@end
+
+/**
+ * Typed options parsed from command dictionary for submenu updates.
+ * `has*` flags distinguish "no change" (key absent) from "reset" (key present, null value).
+ */
+@interface RNSMenuUpdateOptions : NSObject
+
+@property (nonatomic, readonly) BOOL hasTitle;
+@property (nonatomic, copy, readonly, nullable) NSString *title;
+@property (nonatomic, readonly) BOOL hasIcon;
+@property (nonatomic, strong, readonly, nullable) RNSStackHeaderIconData *icon;
+
++ (instancetype)fromDictionary:(NSDictionary *)dict;
+
++ (RNSStackHeaderMenuData *)applyOptions:(RNSMenuUpdateOptions *)options toMenu:(RNSStackHeaderMenuData *)old;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/stack/header/RNSStackHeaderMenuUpdateOptions.mm
+++ b/ios/gamma/stack/header/RNSStackHeaderMenuUpdateOptions.mm
@@ -1,0 +1,145 @@
+#import "RNSStackHeaderMenuUpdateOptions.h"
+#import "RNSStackHeaderIconMapper.h"
+
+#pragma mark - Helpers
+
+static BOOL RNSDictHasKey(NSDictionary *dict, NSString *key)
+{
+  return [dict objectForKey:key] != nil;
+}
+
+static NSString *_Nullable RNSResolveStringFromDict(NSDictionary *dict, NSString *key, NSString *_Nullable fallback)
+{
+  id value = dict[key];
+  if (value == nil) {
+    return fallback;
+  }
+  if ([value isKindOfClass:[NSNull class]]) {
+    return nil;
+  }
+  if ([value isKindOfClass:[NSString class]]) {
+    return value;
+  }
+  return fallback;
+}
+
+static RNSStackHeaderIconData *_Nullable RNSResolveIconFromDict(NSDictionary *dict,
+                                                                NSString *key,
+                                                                RNSStackHeaderIconData *_Nullable fallback)
+{
+  id value = dict[key];
+  if (value == nil) {
+    return fallback;
+  }
+  if ([value isKindOfClass:[NSNull class]]) {
+    return nil;
+  }
+  return [RNSStackHeaderIconMapper iconFromDictionary:value] ?: fallback;
+}
+
+#pragma mark - RNSMenuItemUpdateOptions
+
+@implementation RNSMenuItemUpdateOptions
+
+- (instancetype)initWithTitle:(nullable NSString *)title
+                     hasTitle:(BOOL)hasTitle
+                         icon:(nullable RNSStackHeaderIconData *)icon
+                      hasIcon:(BOOL)hasIcon
+               hasToggleState:(BOOL)hasToggleState
+                  toggleState:(BOOL)toggleState
+{
+  if (self = [super init]) {
+    _title = [title copy];
+    _hasTitle = hasTitle;
+    _icon = icon;
+    _hasIcon = hasIcon;
+    _hasToggleState = hasToggleState;
+    _toggleState = toggleState;
+  }
+  return self;
+}
+
++ (instancetype)fromDictionary:(NSDictionary *)dict
+{
+  BOOL hasTitle = RNSDictHasKey(dict, @"title");
+  NSString *title = hasTitle ? RNSResolveStringFromDict(dict, @"title", nil) : nil;
+
+  BOOL hasIcon = RNSDictHasKey(dict, @"icon");
+  RNSStackHeaderIconData *icon = hasIcon ? RNSResolveIconFromDict(dict, @"icon", nil) : nil;
+
+  BOOL hasToggleState = NO;
+  BOOL toggleState = NO;
+  id toggleValue = dict[@"toggleState"];
+  if ([toggleValue isKindOfClass:[NSNumber class]]) {
+    hasToggleState = YES;
+    toggleState = [toggleValue boolValue];
+  }
+
+  return [[RNSMenuItemUpdateOptions alloc] initWithTitle:title
+                                                hasTitle:hasTitle
+                                                    icon:icon
+                                                 hasIcon:hasIcon
+                                          hasToggleState:hasToggleState
+                                             toggleState:toggleState];
+}
+
++ (RNSStackHeaderMenuItemData *)applyOptions:(RNSMenuItemUpdateOptions *)options
+                                  toMenuItem:(RNSStackHeaderMenuItemData *)old
+{
+  NSString *title = options.hasTitle ? options.title : old.title;
+  RNSStackHeaderIconData *icon = options.hasIcon ? options.icon : old.icon;
+
+  return [[RNSStackHeaderMenuItemData alloc] initWithId:old.menuElementId
+                                                  title:title
+                                               itemType:old.itemType
+                                     initialToggleState:old.initialToggleState
+                                     keepsMenuPresented:old.keepsMenuPresented
+                                                   icon:icon];
+}
+
+@end
+
+#pragma mark - RNSMenuUpdateOptions
+
+@implementation RNSMenuUpdateOptions
+
+- (instancetype)initWithTitle:(nullable NSString *)title
+                     hasTitle:(BOOL)hasTitle
+                         icon:(nullable RNSStackHeaderIconData *)icon
+                      hasIcon:(BOOL)hasIcon
+{
+  if (self = [super init]) {
+    _title = [title copy];
+    _hasTitle = hasTitle;
+    _icon = icon;
+    _hasIcon = hasIcon;
+  }
+  return self;
+}
+
++ (instancetype)fromDictionary:(NSDictionary *)dict
+{
+  BOOL hasTitle = RNSDictHasKey(dict, @"title");
+  NSString *title = hasTitle ? RNSResolveStringFromDict(dict, @"title", nil) : nil;
+
+  BOOL hasIcon = RNSDictHasKey(dict, @"icon");
+  RNSStackHeaderIconData *icon = hasIcon ? RNSResolveIconFromDict(dict, @"icon", nil) : nil;
+
+  return [[RNSMenuUpdateOptions alloc] initWithTitle:title hasTitle:hasTitle icon:icon hasIcon:hasIcon];
+}
+
++ (RNSStackHeaderMenuData *)applyOptions:(RNSMenuUpdateOptions *)options toMenu:(RNSStackHeaderMenuData *)old
+{
+  NSString *title = options.hasTitle ? options.title : old.title;
+  RNSStackHeaderIconData *icon = options.hasIcon ? options.icon : old.icon;
+
+  return [[RNSStackHeaderMenuData alloc] initWithId:old.menuElementId
+                                              title:title
+                                    singleSelection:old.singleSelection
+                                      displayInline:old.displayInline
+                                   displayAsPalette:old.displayAsPalette
+                                           children:old.children
+                                               icon:icon];
+}
+
+@end

--- a/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.h
+++ b/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.h
@@ -4,6 +4,7 @@
 #import "RNSImageLoading.h"
 #import "RNSStackHeaderConfigDataProviding.h"
 #import "RNSStackHeaderEventsDelegate.h"
+#import "RNSStackHeaderMenuData.h"
 #import "RNSViewFrameChangeDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -28,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reapplyMenuForItemWithId:(nullable NSString *)itemId;
 
 - (void)resetTrackerForItemWithId:(nullable NSString *)itemId;
+
+- (void)setToggleState:(BOOL)state
+      forMenuElementId:(NSString *)elementId
+            withItemId:(NSString *)itemId
+            parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu;
 
 - (void)clearHeaderConfiguration;
 

--- a/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -211,6 +211,10 @@
 
   RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:itemId];
 
+  if ([tracker toggleStateEquals:state forItemWithId:elementId]) {
+    return;
+  }
+
   id<RNSStackHeaderItemDataProviding> item = [self findItemWithId:itemId];
   if (item == nil || item.menu == nil) {
     return;

--- a/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -5,6 +5,7 @@
 #import "RNSStackHeaderItemDataProviding.h"
 #import "RNSStackHeaderItemSpacerDataProviding.h"
 #import "RNSStackHeaderMenuCoordinator.h"
+#import "RNSStackHeaderMenuFinder.h"
 #import "RNSStackHeaderMenuTrackerRegistry.h"
 #import "RNSStackNavigationBarCoordinator.h"
 #import "RNSStackNavigationController.h"
@@ -196,6 +197,53 @@
 {
   if (itemId != nil) {
     [_trackerRegistry resetTrackerForItemId:itemId];
+  }
+}
+
+- (void)setToggleState:(BOOL)state
+      forMenuElementId:(NSString *)elementId
+            withItemId:(NSString *)itemId
+            parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
+{
+  if (_configDataProvider == nil || elementId == nil || itemId == nil) {
+    return;
+  }
+
+  RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:itemId];
+
+  id<RNSStackHeaderItemDataProviding> item = [self findItemWithId:itemId];
+  if (item == nil || item.menu == nil) {
+    return;
+  }
+
+  RNSStackHeaderMenuData *singleSelectionRoot =
+      [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:elementId inMenu:item.menu];
+
+  NSString *eventMenuId = nil;
+  NSArray<NSString *> *toggleIds = nil;
+
+  if (singleSelectionRoot != nil) {
+    if (!state) {
+      // Setting false in singleSelection is ignored — one item must always be selected.
+      return;
+    }
+    toggleIds = [RNSStackHeaderMenuCoordinator getAllToggleItemsIdsInSingleSelectionHierarchy:singleSelectionRoot];
+    [tracker selectItemWithId:elementId fromIds:toggleIds];
+    eventMenuId = singleSelectionRoot.menuElementId;
+  } else {
+    [tracker setToggleState:state forItemWithId:elementId];
+    toggleIds = parentMenu != nil ? [RNSStackHeaderMenuCoordinator getToggleItemsIdsInMenu:parentMenu] : @[ elementId ];
+    eventMenuId = parentMenu != nil ? parentMenu.menuElementId : nil;
+  }
+
+  if (eventMenuId != nil) {
+    NSMutableArray<NSString *> *selectedIds = [NSMutableArray new];
+    for (NSString *toggleId in toggleIds) {
+      if ([tracker getToggleStateForItemWithId:toggleId initialState:NO]) {
+        [selectedIds addObject:toggleId];
+      }
+    }
+    [_eventsDelegate didChangeSelectionForMenu:eventMenuId selectedMenuItemIds:selectedIds];
   }
 }
 

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -1,6 +1,18 @@
-import React, { useCallback, useEffect } from 'react';
-import type { StackHeaderConfigProps } from './StackHeaderConfig.types';
+import React, {
+  type ComponentRef,
+  type Ref,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import type {
+  StackHeaderConfigProps,
+  StackHeaderConfigRef,
+} from './StackHeaderConfig.types';
 import StackHeaderConfigIOSNativeComponent, {
+  Commands as StackHeaderConfigIOSNativeCommands,
   MenuItemPressEvent,
   MenuSelectionChangeEvent,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
@@ -12,15 +24,57 @@ import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import type {
   StackHeaderInlineCustomItemIOS,
   StackHeaderInlineItemIOS,
+  StackHeaderMenuActionOptionsIOS,
+  StackHeaderMenuOptionsIOS,
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
 import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
+import { resolveIconAssetSources } from './ios/iconUtils.ios';
+
+function parseMenuElementOptionsToNative(
+  options: StackHeaderMenuActionOptionsIOS | StackHeaderMenuOptionsIOS,
+): object[] {
+  const nativeOptions: Record<string, unknown> = Object.fromEntries(
+    Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
+      const typedKey = key as keyof (
+        | StackHeaderMenuActionOptionsIOS
+        | StackHeaderMenuOptionsIOS
+      );
+      switch (typedKey) {
+        case 'icon':
+          return [
+            [
+              'icon',
+              options.icon === undefined
+                ? null
+                : resolveIconAssetSources(options.icon),
+            ],
+          ];
+        default:
+          return [
+            [
+              key,
+              // We need to replace explicit `undefined` with `null`
+              // so that we're able to read that information on the native side.
+              value === undefined ? null : value,
+            ],
+          ];
+      }
+    }),
+  );
+
+  // passing array here -- see android implementation
+  return [nativeOptions];
+}
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
-export default function StackHeaderConfig(props: StackHeaderConfigProps) {
+function StackHeaderConfig(
+  props: StackHeaderConfigProps,
+  forwardedRef: Ref<StackHeaderConfigRef>,
+) {
   // android props are safely dropped
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { ios, android, ...restProps } = props;
@@ -35,6 +89,46 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
     largeSubtitle,
     largeTitleEnabled,
   } = ios ?? {};
+
+  const nativeRef =
+    useRef<ComponentRef<typeof StackHeaderConfigIOSNativeComponent>>(null);
+
+  useImperativeHandle(forwardedRef, () => ({
+    ios: {
+      setMenuItemOptions: (
+        menuElementId: string,
+        options: StackHeaderMenuActionOptionsIOS,
+      ) => {
+        if (!nativeRef.current) {
+          console.warn(
+            '[RNScreens] Reference to native header config component has not been updated yet.',
+          );
+          return;
+        }
+        StackHeaderConfigIOSNativeCommands.setMenuItemOptions(
+          nativeRef.current,
+          menuElementId,
+          parseMenuElementOptionsToNative(options),
+        );
+      },
+      setMenuOptions: (
+        menuElementId: string,
+        options: StackHeaderMenuOptionsIOS,
+      ) => {
+        if (!nativeRef.current) {
+          console.warn(
+            '[RNScreens] Reference to native header config component has not been updated yet.',
+          );
+          return;
+        }
+        StackHeaderConfigIOSNativeCommands.setMenuOptions(
+          nativeRef.current,
+          menuElementId,
+          parseMenuElementOptionsToNative(options),
+        );
+      },
+    },
+  }));
 
   const handleMenuItemPress = useCallback(
     (event: NativeSyntheticEvent<MenuItemPressEvent>) => {
@@ -80,6 +174,7 @@ export default function StackHeaderConfig(props: StackHeaderConfigProps) {
 
   return (
     <StackHeaderConfigIOSNativeComponent
+      ref={nativeRef}
       {...restProps}
       collapsable={false}
       largeTitle={largeTitle}
@@ -139,3 +234,7 @@ const styles = StyleSheet.create({
     top: 0,
   },
 });
+
+export default forwardRef<StackHeaderConfigRef, StackHeaderConfigProps>(
+  StackHeaderConfig,
+);

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.tsx
@@ -15,6 +15,7 @@ import StackHeaderConfigIOSNativeComponent, {
   Commands as StackHeaderConfigIOSNativeCommands,
   MenuItemPressEvent,
   MenuSelectionChangeEvent,
+  NativeMenuElementOptionsIOS,
 } from '../../../../fabric/gamma/stack/StackHeaderConfigIOSNativeComponent';
 import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
@@ -24,49 +25,13 @@ import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import type {
   StackHeaderInlineCustomItemIOS,
   StackHeaderInlineItemIOS,
-  StackHeaderMenuActionOptionsIOS,
+  StackHeaderMenuItemOptionsIOS,
   StackHeaderMenuOptionsIOS,
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
 import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
 import { resolveIconAssetSources } from './ios/iconUtils.ios';
-
-function parseMenuElementOptionsToNative(
-  options: StackHeaderMenuActionOptionsIOS | StackHeaderMenuOptionsIOS,
-): object[] {
-  const nativeOptions: Record<string, unknown> = Object.fromEntries(
-    Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
-      const typedKey = key as keyof (
-        | StackHeaderMenuActionOptionsIOS
-        | StackHeaderMenuOptionsIOS
-      );
-      switch (typedKey) {
-        case 'icon':
-          return [
-            [
-              'icon',
-              options.icon === undefined
-                ? null
-                : resolveIconAssetSources(options.icon),
-            ],
-          ];
-        default:
-          return [
-            [
-              key,
-              // We need to replace explicit `undefined` with `null`
-              // so that we're able to read that information on the native side.
-              value === undefined ? null : value,
-            ],
-          ];
-      }
-    }),
-  );
-
-  // passing array here -- see android implementation
-  return [nativeOptions];
-}
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -97,7 +62,7 @@ function StackHeaderConfig(
     ios: {
       setMenuItemOptions: (
         menuElementId: string,
-        options: StackHeaderMenuActionOptionsIOS,
+        options: StackHeaderMenuItemOptionsIOS,
       ) => {
         if (!nativeRef.current) {
           console.warn(
@@ -225,6 +190,50 @@ function makeItemViewFromItem(
   return (
     <StackHeaderItem key={id} itemId={id} placement={placement} {...rest} />
   );
+}
+
+function parseMenuElementOptionsToNative(
+  options: StackHeaderMenuItemOptionsIOS | StackHeaderMenuOptionsIOS,
+): NativeMenuElementOptionsIOS[] {
+  const nativeOptions: NativeMenuElementOptionsIOS = Object.fromEntries(
+    Object.entries(options).flatMap(([key, value]): [string, unknown][] => {
+      const typedKey = key as keyof (
+        | StackHeaderMenuItemOptionsIOS
+        | StackHeaderMenuOptionsIOS
+      );
+      switch (typedKey) {
+        case 'icon':
+          return [
+            [
+              'icon',
+              options.icon === undefined
+                ? null
+                : resolveIconAssetSources(options.icon),
+            ],
+          ];
+        default:
+          if (
+            typeof value === 'object' &&
+            value !== null &&
+            !Array.isArray(value)
+          ) {
+            throw new Error(`[RNScreens] Unexpected nested object.`);
+          }
+
+          return [
+            [
+              key,
+              // We need to replace explicit `undefined` with `null`
+              // so that we're able to read that information on the native side.
+              value === undefined ? null : value,
+            ],
+          ];
+      }
+    }),
+  );
+
+  // passing array here -- see android implementation
+  return [nativeOptions];
 }
 
 const styles = StyleSheet.create({

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -2,6 +2,63 @@ import type { ReactElement } from 'react';
 import type { PlatformIconIOS } from '../../../../types';
 import type { StackHeaderMenuIOS } from './ios/StackHeaderMenu.ios.types';
 
+/**
+ * @summary Options for updating a menu action (leaf item) at runtime.
+ *
+ * @description
+ * Omitted keys preserve current values. Explicit `undefined` resets to default.
+ *
+ * @platform ios
+ */
+export interface StackHeaderMenuActionOptionsIOS {
+  /**
+   * @summary New title for the menu action.
+   *
+   * @platform ios
+   */
+  title?: string | undefined;
+  /**
+   * @summary New icon for the menu action.
+   *
+   * @platform ios
+   */
+  icon?: PlatformIconIOS | undefined;
+  /**
+   * @summary Sets the toggle state of the menu item.
+   *
+   * @description
+   * When inside a single selection hierarchy, setting `true` deselects the
+   * previously selected item and selects this one. Setting `false` is a noop
+   * in this case - only has effect for regular toggles.
+   *
+   * @platform ios
+   */
+  toggleState?: boolean | undefined;
+}
+
+/**
+ * @summary Options for updating a submenu at runtime.
+ *
+ * @description
+ * Omitted keys preserve current values. Explicit `undefined` resets to default.
+ *
+ * @platform ios
+ */
+export interface StackHeaderMenuOptionsIOS {
+  /**
+   * @summary New title for the submenu.
+   *
+   * @platform ios
+   */
+  title?: string | undefined;
+  /**
+   * @summary New icon for the submenu.
+   *
+   * @platform ios
+   */
+  icon?: PlatformIconIOS | undefined;
+}
+
 export interface StackHeaderBaseItemIOS {
   /**
    * @summary A unique identifier within the screen header.
@@ -283,5 +340,31 @@ export interface StackHeaderConfigPropsIOS {
   largeSubtitleItem?: StackHeaderTitleCustomItemIOS | undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface StackHeaderConfigCommandsIOS {}
+export interface StackHeaderConfigCommandsIOS {
+  /**
+   * @summary Updates properties of a menu action (leaf item) at runtime.
+   *
+   * @param menuElementId The ID of the menu action to update.
+   * @param options Object with properties to change. Omitted keys preserve current
+   *        values. Explicit `undefined` resets to default.
+   *
+   * @platform ios
+   */
+  setMenuItemOptions: (
+    menuElementId: string,
+    options: StackHeaderMenuActionOptionsIOS,
+  ) => void;
+  /**
+   * @summary Updates properties of a submenu at runtime.
+   *
+   * @param menuElementId The ID of the submenu to update.
+   * @param options Object with properties to change. Omitted keys preserve current
+   *        values. Explicit `undefined` resets to default.
+   *
+   * @platform ios
+   */
+  setMenuOptions: (
+    menuElementId: string,
+    options: StackHeaderMenuOptionsIOS,
+  ) => void;
+}

--- a/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/gamma/stack/header/StackHeaderConfig.ios.types.ts
@@ -10,7 +10,7 @@ import type { StackHeaderMenuIOS } from './ios/StackHeaderMenu.ios.types';
  *
  * @platform ios
  */
-export interface StackHeaderMenuActionOptionsIOS {
+export interface StackHeaderMenuItemOptionsIOS {
   /**
    * @summary New title for the menu action.
    *
@@ -352,7 +352,7 @@ export interface StackHeaderConfigCommandsIOS {
    */
   setMenuItemOptions: (
     menuElementId: string,
-    options: StackHeaderMenuActionOptionsIOS,
+    options: StackHeaderMenuItemOptionsIOS,
   ) => void;
   /**
    * @summary Updates properties of a submenu at runtime.

--- a/src/components/gamma/stack/header/ios/StackHeaderItem.ios.tsx
+++ b/src/components/gamma/stack/header/ios/StackHeaderItem.ios.tsx
@@ -1,37 +1,13 @@
 import React, { useCallback, useMemo } from 'react';
 import StackHeaderItemIOSNativeComponent from '../../../../../fabric/gamma/stack/StackHeaderItemIOSNativeComponent';
-import type {
-  HeaderItemPressEvent,
-  PlatformIconIOS as ResolvedPlatformIconIOS,
-} from '../../../../../fabric/gamma/stack/StackHeaderItemIOSNativeComponent';
+import type { HeaderItemPressEvent } from '../../../../../fabric/gamma/stack/StackHeaderItemIOSNativeComponent';
 import type { StackHeaderItemProps } from './StackHeaderItem.ios.types';
-import type { PlatformIconIOS } from '../../../../../types';
 import type {
   StackHeaderMenuIOS,
   StackHeaderMenuElementIOS,
 } from './StackHeaderMenu.ios.types';
-import { Image, NativeSyntheticEvent, StyleSheet } from 'react-native';
-
-function resolveIconAssetSources(
-  icon: PlatformIconIOS | undefined,
-): ResolvedPlatformIconIOS | undefined {
-  if (icon == null) {
-    return undefined;
-  }
-  if (icon.type === 'imageSource') {
-    return {
-      type: 'imageSource',
-      imageSource: Image.resolveAssetSource(icon.imageSource),
-    };
-  }
-  if (icon.type === 'templateSource') {
-    return {
-      type: 'templateSource',
-      templateSource: Image.resolveAssetSource(icon.templateSource),
-    };
-  }
-  return icon;
-}
+import { NativeSyntheticEvent, StyleSheet } from 'react-native';
+import { resolveIconAssetSources } from './iconUtils.ios';
 
 function resolveMenuElementIcons(
   element: StackHeaderMenuElementIOS,

--- a/src/components/gamma/stack/header/ios/iconUtils.ios.ts
+++ b/src/components/gamma/stack/header/ios/iconUtils.ios.ts
@@ -1,0 +1,24 @@
+import type { PlatformIconIOS as ResolvedPlatformIconIOS } from '../../../../../fabric/gamma/stack/StackHeaderItemIOSNativeComponent';
+import type { PlatformIconIOS } from '../../../../../types';
+import { Image } from 'react-native';
+
+export function resolveIconAssetSources(
+  icon: PlatformIconIOS | undefined,
+): ResolvedPlatformIconIOS | undefined {
+  if (icon == null) {
+    return undefined;
+  }
+  if (icon.type === 'imageSource') {
+    return {
+      type: 'imageSource',
+      imageSource: Image.resolveAssetSource(icon.imageSource),
+    };
+  }
+  if (icon.type === 'templateSource') {
+    return {
+      type: 'templateSource',
+      templateSource: Image.resolveAssetSource(icon.templateSource),
+    };
+  }
+  return icon;
+}

--- a/src/components/gamma/stack/index.ts
+++ b/src/components/gamma/stack/index.ts
@@ -43,6 +43,8 @@ export type {
   StackHeaderMenuIOS,
   StackHeaderMenuItemIOS,
   StackHeaderMenuElementIOS,
+  StackHeaderMenuItemOptionsIOS,
+  StackHeaderMenuOptionsIOS,
 } from './header';
 
 /**

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -1,7 +1,11 @@
 'use client';
 
-import type { CodegenTypes as CT, ViewProps } from 'react-native';
-import { codegenNativeComponent } from 'react-native';
+import type {
+  CodegenTypes as CT,
+  HostComponent,
+  ViewProps,
+} from 'react-native';
+import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
@@ -27,6 +31,37 @@ export interface NativeProps extends ViewProps {
     | CT.DirectEventHandler<MenuSelectionChangeEvent>
     | undefined;
 }
+
+type ComponentType = HostComponent<NativeProps>;
+
+// Codegen requires a concrete interface — bare `object` causes
+// "Unknown primitive type TSObjectKeyword". Fields are intentionally
+// loose (all optional) because the native side uses 3-state semantics
+// (key absent = no change, null = reset, value = set).
+export interface NativeMenuElementOptionsIOS {
+  title?: string | null | undefined;
+  icon?: string | null | undefined;
+  toggleState?: boolean | null | undefined;
+}
+
+export interface NativeCommands {
+  setMenuItemOptions: (
+    viewRef: React.ComponentRef<ComponentType>,
+    menuElementId: string,
+    // Array wrapper due to codegen limitation — only the first element is used.
+    options: NativeMenuElementOptionsIOS[],
+  ) => void;
+  setMenuOptions: (
+    viewRef: React.ComponentRef<ComponentType>,
+    menuElementId: string,
+    // Array wrapper due to codegen limitation — only the first element is used.
+    options: NativeMenuElementOptionsIOS[],
+  ) => void;
+}
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['setMenuItemOptions', 'setMenuOptions'],
+});
 
 export default codegenNativeComponent<NativeProps>('RNSStackHeaderConfigIOS', {
   interfaceOnly: true,

--- a/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/gamma/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -6,6 +6,8 @@ import type {
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
+import { PlatformIconIOS } from './StackHeaderItemIOSNativeComponent';
+import { UnsafeMixed } from '../../codegenUtils';
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
@@ -40,8 +42,8 @@ type ComponentType = HostComponent<NativeProps>;
 // (key absent = no change, null = reset, value = set).
 export interface NativeMenuElementOptionsIOS {
   title?: string | null | undefined;
-  icon?: string | null | undefined;
-  toggleState?: boolean | null | undefined;
+  icon?: UnsafeMixed<PlatformIconIOS> | null | undefined;
+  toggleState?: boolean | undefined;
 }
 
 export interface NativeCommands {


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1189

## Description

This PR adds view commands support. With the provided imperative API user is able to change `title`, `icon`, and `toggleState` (the latter is for menu items only)

## Changes

- added `setMenuOptions` and `setMenuItemOptions` view commands
- updated `test-stack-header-menu-ios` SFT to include buttons for calling view commands

## Before & after - visual documentation

n/a

## Test plan

Use `test-stack-header-menu-ios` SFT.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
