### PR TITLE
fix(Android, Tabs): fix potential crash with container state restoration

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/container/TabsContainer.kt
@@ -686,12 +686,10 @@ class TabsContainer internal constructor(
                 .filter { it in tabsModel }
                 .toList()
 
-        val fragmentsWithAttachedUI = currentFragments.filterNot { it.isDetached }
-
-        if (currentFragments.size == tabsModel.size &&
-            fragmentsWithAttachedUI.size == 1 &&
-            fragmentsWithAttachedUI.first() === selectedTab
-        ) {
+        // We expect at most a single fragment added (detached fragments are not returned from
+        // FragmentManager.getFragments call) and it being the currently selected tab.
+        val isInUpToDateState = currentFragments.size == 1 && currentFragments.first() === selectedTab
+        if (isInUpToDateState) {
             return
         } else if (currentFragments.isEmpty()) {
             applyInitialStateToFragmentManagerSync(selectedTab)


### PR DESCRIPTION
## Description

**Reportedly** (reported by @satya164) we have a crash in tabs when using
`react-navigation@8` and some specific setup leveraging React suspense.

Here's the reproducer using `react-navigation@8`:

<details>

  <summary>Code</summary>

  ```tsx
import * as React from 'react';
import { View, Text } from 'react-native';
import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import { NavigationContainer } from '@react-navigation/native';
let isLoaded = false;
let promise: Promise<void> | null = null;
function useFakeSuspense() {
  if (!isLoaded) {
    if (!promise) {
      promise = new Promise(resolve => {
        setTimeout(() => {
          isLoaded = true;
          resolve();
        }, 3000);
      });
    }
    throw promise;
  }
}
function DinoCatalogScreen() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>1. You are in DinoCatalogScreen</Text>
      <Text>2. Click the "DinoTeam" tab to trigger the bug</Text>
    </View>
  );
}
function DinoTeamScreen() {
  useFakeSuspense();
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Data loaded! (Tab 2)</Text>
    </View>
  );
}
const Layout = ({ children }: { children: React.ReactNode }) => (
  <React.Suspense
    fallback={
      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
        <Text style={{ color: 'red', fontSize: 16 }}>Loading...</Text>
        <Text>TabsContainer is gone</Text>
      </View>
    }>
    {children}
  </React.Suspense>
);
const Tab = createNativeBottomTabNavigator();
const Stack = createNativeStackNavigator();
function LoaderTabs() {
  return (
    <Tab.Navigator screenOptions={{ lazy: true }}>
      <Tab.Screen name="DinoList" component={DinoCatalogScreen} />
      <Tab.Screen name="DinoTeam" component={DinoTeamScreen} />
    </Tab.Navigator>
  );
}
export default function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator
        screenLayout={({ children }) => <Layout>{children}</Layout>}>
        <Stack.Screen name="DinoCatalogTabs" component={LoaderTabs} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

  ```

</details>

We haven't yet been able to reproduce the problem on plain `TabsContainer`, however.

Despite that, it seems that the crash arises from an incorrect condition in `TabsContainer`
native implementation. Namely, when we re-attach the `TabsContainer` to window, we
restore the current navigation state to the `FragmentManager`. Before doing that we verify
whether `FragmentManager.getFragments().size == TabsContainer.tabsModel.size` and this can not be true.

Currently, we add all fragments from `TabsContainer.tabsModel` to `FragmentManager`, but we
detach (not remove!) all BUT the currently selected one. As it turns out - `FragmetnManager.getFragments()`
does NOT return added fragments for which `Fragment.isDetached() == true`. Therefore, this condition
above is not satisfied and we crash hitting the assertion.

## Changes

To fix this I've decided to just remove the incorrect part of the check.

## Before & after - visual documentation

N/A

## Test plan

Test that these changes do not re-introduce the bugs fixed by:

* <https://github.com/software-mansion/react-native-screens/pull/4202>

Confirmed:

* [x] `test-stack-tabs-stack-in-tabs-base-navigation`
* [x] `Test4027`

## Checklist

* [x] Included code example that can be used to test this change.
* [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
* [x] For API changes, updated relevant public types.
* [x] Ensured that CI passes
