### PR TITLE
fix(Android, Stack v5): Prevent screen unmounting on fast navigation (fix transition finalization)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
@@ -89,6 +89,8 @@ internal class ScreensCoordinatorLayout(
     }
 
     override fun clearAnimation() {
+        // The framework cancelled the transition (e.g., quick forward-and-backward navigation), so the transition
+        // also should be cancelled, preventing finalizing the screen removal which we manage manually in `onAnimationEnd`.
         blockFrameworkTransitionFinalization = false
         needsTransitionFinalization = false
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
@@ -88,6 +88,13 @@ internal class ScreensCoordinatorLayout(
         }
     }
 
+    override fun clearAnimation() {
+        blockFrameworkTransitionFinalization = false
+        needsTransitionFinalization = false
+
+        super.clearAnimation()
+    }
+
     /**
      * This method implements a workaround for RN's autoFocus functionality. Because of the way
      * autoFocus is implemented it dismisses soft keyboard in fragment transition

--- a/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/views/ScreensCoordinatorLayout.kt
@@ -89,8 +89,9 @@ internal class ScreensCoordinatorLayout(
     }
 
     override fun clearAnimation() {
-        // The framework cancelled the transition (e.g., quick forward-and-backward navigation), so the transition
-        // also should be cancelled, preventing finalizing the screen removal which we manage manually in `onAnimationEnd`.
+        // Called when the system aborts a transition (e.g., fast forward/backward navigation).
+        // We must reset our manual finalization flags here to ensure our `onAnimationEnd` listener
+        // doesn't detach the view that the should be kept alive after navigating back.
         blockFrameworkTransitionFinalization = false
         needsTransitionFinalization = false
 


### PR DESCRIPTION
## Description

This PR fixes a regression on Android where fast forward/backward navigation causes the underlying screen to unmount.
This issue is a side effect of the workaround introduced previously https://github.com/software-mansion/react-native-screens/pull/4161 .
When a screen is being removed, we set `blockFrameworkTransitionFinalization = true` to prevent the Android framework from removing the view prematurely. Instead, we take responsibility and manually finalize the transition inside our `AnimationListener.onAnimationEnd`.
However, during a quick toggle, the system cancels the ongoing operation by calling `view.clearAnimation()` on the disappearing view.  Then, our `AnimationListener` receives `onAnimationEnd` and incorrectly assumes the exit transition has naturally completed. Since the `blockFrameworkTransitionFinalization` lock is still active, our code manually forces the view detachment.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1658

## Changes

- Overrode the `clearAnimation()` method in `ScreensCoordinatorLayout` to intercept the cancellation signal and clear flags responsible for ending the removal transition.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f19ee26d-716d-4b17-a16d-0356d89acdba" /> | <video src="https://github.com/user-attachments/assets/5b86e896-0ae0-4539-bf59-968bbb701739" /> |

## Test plan

Any stack v4 example.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
