### PR TITLE
chore(Android): bump Material to 1.14.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -202,6 +202,6 @@ dependencies {
     implementation 'androidx.transition:transition-ktx:1.7.0'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.14.0'
     implementation "androidx.core:core-ktx:1.17.0"
 }


### PR DESCRIPTION
## Description

Bumps Material library to 1.14.0 that exposes M3 Expressive components and theming.

Material 1.14.0 bumps `minSdkVersion` to 23 (https://github.com/material-components/material-components-android/commit/cd3f114a3f66459e2179a6bdf509b6d898ed81bf) which is still lower than `react-native`'s `minSdkVersion=24`.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1479.

## Changes

- bump Material to 1.14.0 in `build.gradle`

## Before & after - visual documentation

N/A

## Test plan

### Stack v4, Stack v5, Tabs, FormSheet v5

- Stack v4
  - [x] Example app
  - [x] StackPresentation
  - [x] BottomTabsAndStack
  - [x] TestHeader
  - [x] TestHeaderTitle
- Stack v5
  - [x] Stack Subviews
  - [x] Stack Back Button
  - [x] Stack Toolbar Menu Icon
  - [x] Stack Toolbar Nested Menu
- Tabs
  - [x] Test Simple Navigation
  - [x] Tab-Specific Appearance
  - [x] Tab Bar General Appearance
- FormSheet v5
  - [x] Basic functionality
  - [x] Fit to contents
  - [x] Grabber visibility
  - [x] Sheet preferred corner radius
  - [ ] Presentation state - found a bug but it's unrelated to Material bump (https://github.com/software-mansion/react-native-screens-labs/issues/1669)

### FormSheet v4

#### A. Core set

| ✔ | Test file | PR | What to verify | Concern |
|---|---|---|---|---|
| [x] | `Test4244.tsx` | [#4244](https://github.com/software-mansion/react-native-screens/pull/4244) | Refine keyboard avoidance to prevent layout reflows with SafeAreaView | Keyboard + insets |
| [x] | `Test4240.tsx` | [#4240](https://github.com/software-mansion/react-native-screens/pull/4240) | Prevent FormSheet over-translation on keyboard appear in nested containers | Keyboard |
| [x] | `Test3910.tsx` | [#3912](https://github.com/software-mansion/react-native-screens/pull/3912) | Prevent `BottomSheetBehavior` override when using FormSheets | **Material core** / detents |
| [ ] found a regression but it's related to API 37, not Material bump (https://github.com/software-mansion/react-native-screens-labs/issues/1662) | `Test3617.tsx` | [#3617](https://github.com/software-mansion/react-native-screens/pull/3617) | Dismiss keyboard when the BottomSheet is presented | Keyboard |
| [x] | `Test3611.tsx` | [#3611](https://github.com/software-mansion/react-native-screens/pull/3611) | Workaround for controlling insets on `BottomSheetBehavior` | **Material core** / insets |
| [x] | `Test3566.tsx` | [#3566](https://github.com/software-mansion/react-native-screens/pull/3566) | Constrain sheet calculations by screen size | Detents / sizing |
| [ ] found a bug but it's unrelated to Material bump (https://github.com/software-mansion/react-native-screens-labs/issues/1665) | `Test3564.tsx` | [#3564](https://github.com/software-mansion/react-native-screens/pull/3564) | Account initial `translationY` for the default open animation | **Animation** |
| [x] | `Test3522.tsx` | [#3522](https://github.com/software-mansion/react-native-screens/pull/3522) | Fix Y-translation when `fitToContents` content overflows screen size | Sizing / animation |
| [x] | `Test2560.tsx` | [#3484](https://github.com/software-mansion/react-native-screens/pull/3484) | Fix dynamic height change for `fitToContents` (file is **Test2560**, not Test3484) | Detents / sizing |
| [x] | `Test3346.tsx` | [#3346](https://github.com/software-mansion/react-native-screens/pull/3346) | Fix `flex-end` positioning in formSheet | Layout / sizing |
| [x] | `Test3336.tsx` | [#3336](https://github.com/software-mansion/react-native-screens/pull/3336) | FormSheet ↔ SafeAreaView integration (also covers #3435 pressables, #3503 overflow inset) | Keyboard + insets |
| [ ] found a *bug* but it's unrelated to Material bump (https://github.com/software-mansion/react-native-screens-labs/issues/1667) | `Test3248.tsx` | [#3248](https://github.com/software-mansion/react-native-screens/pull/3248) | Moving formSheet above the keyboard (+ keyboard-nav focus #3245) | Keyboard |

##### Test3336
- SAV disabled
  - [x] sheetShouldOverflowTopInset: false
  - [x] sheetShouldOverflowTopInset: true
- SAV enabled
  - sheetShouldOverflowTopInset: false
    - [x] top: false, bottom: false
    - [x] top: true, bottom: false
    - [x] top: false, bottom: true
    - [x] top: true, bottom: true
  - sheetShouldOverflowTopInset: true
    - [x] top: false, bottom: false
    - [x] top: true, bottom: false
    - [x] top: false, bottom: true
    - [x] top: true, bottom: true

#### B. Additional Material-relevant tests

| ✔ | Test file | PR(s) | What to verify |
|---|---|---|---|
| [x] | `Test2895.tsx` | #2895 | Form inputs + keyboard, detents `[0.5, 0.85]` |
| [x] | `TestScreenFooterKeyboardInsets.tsx` | [#4149](https://github.com/software-mansion/react-native-screens/pull/4149) | Keyboard insets driving `ScreenFooter` from the sheet |
| [x] | `TestFormSheet.tsx` | — | General FormSheet showcase (detents, fitToContents, scroll) |
| [ ] found a bug but it's unrelated to Material bump (https://github.com/software-mansion/react-native-screens-labs/issues/1668) | `TestAndroidTransitions.tsx` | — | Android modal/FormSheet/screen transition animations |

## Checklist

- [x] Ensured that CI passes
