### PR TITLE
feat(Stack v5, iOS): Add titleMenu

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -31,10 +31,12 @@ const ACTION_IDS = [
   'radio-1-1',
   'radio-1-2',
   'radio-1-3',
+  'title-action-1',
+  'title-action-2',
 ] as const;
 type ActionId = (typeof ACTION_IDS)[number];
 
-const MENU_IDS = ['menu-1', 'submenu-1', 'subsubmenu-1'] as const;
+const MENU_IDS = ['menu-1', 'submenu-1', 'subsubmenu-1', 'title-menu'] as const;
 type MenuId = (typeof MENU_IDS)[number];
 
 const TITLE_OPTIONS = [
@@ -193,6 +195,28 @@ function buildHeaderConfig(
     title: 'Header Menu',
     ios: {
       trailingItems,
+      titleMenu: {
+        type: 'menu',
+        id: 'title-menu',
+        onSelectionChange: selection =>
+          showToast('Title menu selected "' + selection.join('", "') + '"'),
+        children: [
+          {
+            id: 'title-action-1',
+            type: 'menuItem',
+            itemType: 'action',
+            title: 'Title Action 1',
+            onPress: () => showToast('Clicked "Title Action 1"'),
+          },
+          {
+            id: 'title-action-2',
+            type: 'menuItem',
+            itemType: 'action',
+            title: 'Title Action 2',
+            onPress: () => showToast('Clicked "Title Action 2"'),
+          },
+        ],
+      },
     },
   };
 }

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -198,8 +198,6 @@ function buildHeaderConfig(
       titleMenu: {
         type: 'menu',
         id: 'title-menu',
-        onSelectionChange: selection =>
-          showToast('Title menu selected "' + selection.join('", "') + '"'),
         children: [
           {
             id: 'title-action-1',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Header Menu (iOS)',
   key: 'test-stack-header-menu-ios',
   details:
-    'Tests header item menus: action items, toggle items, singleSelection, and nested menus.',
+    'Tests header item menus and title menu: action items, toggle items, singleSelection, and nested menus.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -48,6 +48,9 @@ TBD
   - [ ] A toast "Selected unique "radio 1-2"" is displayed
   - [ ] When Menu 1 > Submenu with Radio is reopened, Radio 1-1 is no longer checked
   - [ ] When Menu 1 > Submenu with Radio > SubSubmenu with Radio is reopened, Radio 1-2 is checked
+10. Click on screen title
+  - [ ] The title should transform into a menu with two actions
+  - [ ] Clicking either actions should display a toast
 
 ### setMenuItemOptions view command
 

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.h
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *largeTitle;
 @property (nonatomic, readonly, nullable) NSString *largeSubtitle;
 @property (nonatomic, readonly) BOOL largeTitleEnabled;
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *titleMenu;
 @property (nonatomic, readonly) NSArray<id> *children;
 
 - (void)resetProps;

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -1,10 +1,13 @@
 #import "RNSStackHeaderConfigComponentView.h"
+#import "RNSConversions.h"
 #import "RNSImageLoadingHelper.h"
 #import "RNSStackHeaderConfigEventEmitter.h"
 #import "RNSStackHeaderConfigShadowStateProxy.h"
 #import "RNSStackHeaderItemComponentView.h"
 #import "RNSStackHeaderItemSpacerComponentView.h"
+#import "RNSStackHeaderMenuCoordinator.h"
 #import "RNSStackHeaderMenuFinder.h"
+#import "RNSStackHeaderMenuMapper.h"
 #import "RNSStackHeaderMenuUpdateOptions.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackScreenComponentView.h"
@@ -64,6 +67,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   _largeTitle = nil;
   _largeSubtitle = nil;
   _largeTitleEnabled = NO;
+  _titleMenu = nil;
 }
 
 - (NSArray<id> *)children
@@ -270,7 +274,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   }
 
   RNSMenuElementLocator *locator = [RNSStackHeaderMenuFinder findMenuElementWithId:menuItemId
-                                                                     inHeaderItems:[self headerItems]];
+                                                                     inHeaderItems:[self headerItems]
+                                                                         titleMenu:_titleMenu];
   if (locator == nil) {
     RCTLogWarn(@"[RNScreens] setMenuItemOptions: element with id \"%@\" not found", menuItemId);
     return;
@@ -285,15 +290,15 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   RNSStackHeaderMenuItemData *newItemData = [RNSMenuItemUpdateOptions applyOptions:updateOptions
                                                                         toMenuItem:oldItemData];
 
-  if (updateOptions.hasToggleState) {
+  if (updateOptions.hasToggleState && locator.rootMenu != nil && locator.trackerItemId != nil) {
     BOOL isToggle = oldItemData.itemType == RNSMenuItemTypeToggle ||
-        (oldItemData.itemType == RNSMenuItemTypeAutomatic && locator.headerItem.menu != nil &&
-         [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:menuItemId
-                                                                inMenu:locator.headerItem.menu] != nil);
+        (oldItemData.itemType == RNSMenuItemTypeAutomatic &&
+         [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:menuItemId inMenu:locator.rootMenu] != nil);
     if (isToggle) {
       [[self headerCoordinator] setToggleState:updateOptions.toggleState
                               forMenuElementId:menuItemId
-                                    withItemId:locator.headerItem.itemId
+                                 trackerItemId:locator.trackerItemId
+                                      rootMenu:locator.rootMenu
                                     parentMenu:locator.searchResult.parentMenu];
     }
   }
@@ -308,8 +313,15 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
                        parentMenu:locator.searchResult.parentMenu];
       break;
     case RNSMenuElementPositionTitle:
+      if (locator.searchResult.parentMenu != nil) {
+        _titleMenu = [RNSStackHeaderMenuCoordinator menu:_titleMenu
+                                    replacingChildWithId:menuItemId
+                                             withElement:newItemData];
+      }
+      [[self headerCoordinator] reapplyTitleMenu];
+      break;
     case RNSMenuElementPositionOverflow:
-      // TODO: handle title menu and overflow menu
+      // TODO: handle overflow menu
       break;
   }
 }
@@ -322,7 +334,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   }
 
   RNSMenuElementLocator *locator = [RNSStackHeaderMenuFinder findMenuElementWithId:menuElementId
-                                                                     inHeaderItems:[self headerItems]];
+                                                                     inHeaderItems:[self headerItems]
+                                                                         titleMenu:_titleMenu];
   if (locator == nil) {
     RCTLogWarn(@"[RNScreens] setMenuOptions: element with id \"%@\" not found", menuElementId);
     return;
@@ -346,8 +359,17 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
                        parentMenu:locator.searchResult.parentMenu];
       break;
     case RNSMenuElementPositionTitle:
+      if (locator.searchResult.parentMenu == nil) {
+        _titleMenu = (RNSStackHeaderMenuData *)newMenuItem;
+      } else {
+        _titleMenu = [RNSStackHeaderMenuCoordinator menu:_titleMenu
+                                    replacingChildWithId:menuElementId
+                                             withElement:newMenuItem];
+      }
+      [[self headerCoordinator] reapplyTitleMenu];
+      break;
     case RNSMenuElementPositionOverflow:
-      // TODO: handle title menu and overflow menu
+      // TODO: handle overflow menu
       break;
   }
 }
@@ -396,6 +418,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   const auto &newHeaderProps = *std::static_pointer_cast<const react::RNSStackHeaderConfigIOSProps>(props);
   const auto &oldHeaderProps = *std::static_pointer_cast<const react::RNSStackHeaderConfigIOSProps>(_props);
 
+  BOOL titleMenuDidChange = NO;
+
   if (oldHeaderProps.title != newHeaderProps.title) {
     _title = RCTNSStringFromStringNilIfEmpty(newHeaderProps.title);
   }
@@ -420,9 +444,23 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     _largeTitleEnabled = newHeaderProps.largeTitleEnabled;
   }
 
+  if (oldHeaderProps.titleMenu != newHeaderProps.titleMenu) {
+    _titleMenu = [RNSStackHeaderMenuMapper
+        menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newHeaderProps.titleMenu)];
+    titleMenuDidChange = YES;
+  }
+
   [super updateProps:props oldProps:oldProps];
 
   [[self headerCoordinator] applyConfigProperties];
+
+  if (titleMenuDidChange) {
+    // title menu is a prop on the navigation item, not on one of the bar button items
+    // thus it is not configured with matching RNSStackHeaderItemComponentView
+    // but here directly
+    [[self headerCoordinator] resetTitleMenuTracker];
+    [[self headerCoordinator] reapplyTitleMenu];
+  }
 }
 
 + (react::ComponentDescriptorProvider)componentDescriptorProvider

--- a/ios/stack/header/RNSStackHeaderConfigDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderConfigDataProviding.h
@@ -2,6 +2,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class RNSStackHeaderMenuData;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RNSStackHeaderConfigDataProviding <NSObject>
@@ -12,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *largeTitle;
 @property (nonatomic, readonly, nullable) NSString *largeSubtitle;
 @property (nonatomic, readonly) BOOL largeTitleEnabled;
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *titleMenu;
 
 /**
  Children are expected to conform to either RNSStackHeaderItemDataProviding

--- a/ios/stack/header/RNSStackHeaderMenuCoordinator.h
+++ b/ios/stack/header/RNSStackHeaderMenuCoordinator.h
@@ -36,6 +36,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSString *> *)getToggleItemsIdsInMenu:(RNSStackHeaderMenuData *)menu;
 
 /**
+ * Builds a UIMenu from the given menu data. Used for `UINavigationItem.titleMenuProvider`.
+ */
++ (UIMenu *)buildUIMenuFromData:(RNSStackHeaderMenuData *)data
+       withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
+                   stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                withImageLoader:(id<RNSImageLoading>)imageLoader
+        menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated;
+
+/**
  * Constructs a new menu tree with the child matching `elementId` replaced by `newElement`.
  * Returns the original menu unchanged if no matching child is found in the subtree.
  */

--- a/ios/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -88,6 +88,21 @@
   return [UIMenu menuWithTitle:data.title image:menuImage identifier:nil options:options children:elements];
 }
 
++ (UIMenu *)buildUIMenuFromData:(RNSStackHeaderMenuData *)data
+       withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
+                   stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                withImageLoader:(id<RNSImageLoading>)imageLoader
+        menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated
+{
+  return [self buildMenuFromData:data
+                withHeaderEventsDelegate:delegate
+                            stateTracker:tracker
+                     singleSelectionRoot:nil
+      initialSingleSelectionStateClaimed:NULL
+                         withImageLoader:imageLoader
+                 menuInvalidatedCallback:onMenuInvalidated];
+}
+
 + (nullable UIMenuElement *)buildElementFromData:(id<RNSStackHeaderMenuElement>)element
                         withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
                                     stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker

--- a/ios/stack/header/RNSStackHeaderMenuFinder.h
+++ b/ios/stack/header/RNSStackHeaderMenuFinder.h
@@ -7,6 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static NSString *const RNSTitleMenuTrackerItemId = @"__titleMenu__";
+
 @interface RNSStackHeaderMenuElementSearchResult : NSObject
 
 @property (nonatomic, strong, readonly) id<RNSStackHeaderMenuElement> element;
@@ -29,19 +31,32 @@ typedef NS_ENUM(NSInteger, RNSMenuElementPosition) {
 @property (nonatomic, readonly) RNSMenuElementPosition position;
 @property (nonatomic, weak, readonly, nullable) id<RNSStackHeaderItemDataProviding> headerItem;
 
+/**
+ * Root menu tree that contains the found element. Used for singleSelectionRoot lookups.
+ */
+@property (nonatomic, strong, readonly, nullable) RNSStackHeaderMenuData *rootMenu;
+
+/**
+ * Tracker key for the toggle state tracker registry.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *trackerItemId;
+
 - (instancetype)initWithSearchResult:(RNSStackHeaderMenuElementSearchResult *)searchResult
                             position:(RNSMenuElementPosition)position
-                          headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem;
+                          headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem
+                            rootMenu:(nullable RNSStackHeaderMenuData *)rootMenu
+                       trackerItemId:(nullable NSString *)trackerItemId;
 
 @end
 
 @interface RNSStackHeaderMenuFinder : NSObject
 
 /**
- * Searches all header items' menus for a menu element with the given ID.
+ * Searches all header items' menus and the title menu for a menu element with the given ID.
  */
 + (nullable RNSMenuElementLocator *)findMenuElementWithId:(NSString *)elementId
-                                            inHeaderItems:(NSArray<id<RNSStackHeaderItemDataProviding>> *)items;
+                                            inHeaderItems:(NSArray<id<RNSStackHeaderItemDataProviding>> *)items
+                                                titleMenu:(nullable RNSStackHeaderMenuData *)titleMenu;
 
 /**
  * Recursively searches a single menu tree for an element with the given ID.

--- a/ios/stack/header/RNSStackHeaderMenuFinder.mm
+++ b/ios/stack/header/RNSStackHeaderMenuFinder.mm
@@ -23,11 +23,15 @@
 - (instancetype)initWithSearchResult:(RNSStackHeaderMenuElementSearchResult *)searchResult
                             position:(RNSMenuElementPosition)position
                           headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem
+                            rootMenu:(nullable RNSStackHeaderMenuData *)rootMenu
+                       trackerItemId:(nullable NSString *)trackerItemId
 {
   if (self = [super init]) {
     _searchResult = searchResult;
     _position = position;
     _headerItem = headerItem;
+    _rootMenu = rootMenu;
+    _trackerItemId = [trackerItemId copy];
   }
   return self;
 }
@@ -40,6 +44,7 @@
 
 + (nullable RNSMenuElementLocator *)findMenuElementWithId:(NSString *)elementId
                                             inHeaderItems:(NSArray<id<RNSStackHeaderItemDataProviding>> *)items
+                                                titleMenu:(nullable RNSStackHeaderMenuData *)titleMenu
 {
   for (id<RNSStackHeaderItemDataProviding> item in items) {
     if (item.menu == nil || item.itemId == nil) {
@@ -49,11 +54,24 @@
     if (result != nil) {
       return [[RNSMenuElementLocator alloc] initWithSearchResult:result
                                                         position:RNSMenuElementPositionItem
-                                                      headerItem:item];
+                                                      headerItem:item
+                                                        rootMenu:item.menu
+                                                   trackerItemId:item.itemId];
     }
   }
-  // TODO: search title menu (RNSMenuElementPositionTitle)
-  // and overflow menu (RNSMenuElementPositionOverflow)
+
+  if (titleMenu != nil) {
+    RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId inMenu:titleMenu];
+    if (result != nil) {
+      return [[RNSMenuElementLocator alloc] initWithSearchResult:result
+                                                        position:RNSMenuElementPositionTitle
+                                                      headerItem:nil
+                                                        rootMenu:titleMenu
+                                                   trackerItemId:RNSTitleMenuTrackerItemId];
+    }
+  }
+
+  // TODO: search overflow menu (RNSMenuElementPositionOverflow)
   return nil;
 }
 

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.h
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.h
@@ -30,9 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)resetTrackerForItemWithId:(nullable NSString *)itemId;
 
+- (void)reapplyTitleMenu;
+
+- (void)resetTitleMenuTracker;
+
 - (void)setToggleState:(BOOL)state
       forMenuElementId:(NSString *)elementId
-            withItemId:(NSString *)itemId
+         trackerItemId:(NSString *)trackerItemId
+              rootMenu:(RNSStackHeaderMenuData *)rootMenu
             parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu;
 
 - (void)clearHeaderConfiguration;

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -103,6 +103,7 @@
               largeSubtitleView:largeSubtitleView
                   forController:controller];
 
+  [self applyTitleMenuForController:controller];
   [self applyNavigationBarProperties];
 }
 
@@ -200,28 +201,33 @@
   }
 }
 
+- (void)reapplyTitleMenu
+{
+  if (_configDataProvider == nil) {
+    return;
+  }
+  [self applyTitleMenuForController:[self requireScreenController]];
+}
+
+- (void)resetTitleMenuTracker
+{
+  [_trackerRegistry resetTrackerForItemId:RNSTitleMenuTrackerItemId];
+}
+
 - (void)setToggleState:(BOOL)state
       forMenuElementId:(NSString *)elementId
-            withItemId:(NSString *)itemId
+         trackerItemId:(NSString *)trackerItemId
+              rootMenu:(RNSStackHeaderMenuData *)rootMenu
             parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
 {
-  if (_configDataProvider == nil || elementId == nil || itemId == nil) {
+  if (_configDataProvider == nil || elementId == nil || trackerItemId == nil) {
     return;
   }
 
-  RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:itemId];
+  RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:trackerItemId];
 
-  if ([tracker toggleStateEquals:state forItemWithId:elementId]) {
-    return;
-  }
-
-  id<RNSStackHeaderItemDataProviding> item = [self findItemWithId:itemId];
-  if (item == nil || item.menu == nil) {
-    return;
-  }
-
-  RNSStackHeaderMenuData *singleSelectionRoot =
-      [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:elementId inMenu:item.menu];
+  RNSStackHeaderMenuData *singleSelectionRoot = [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:elementId
+                                                                                                       inMenu:rootMenu];
 
   NSString *eventMenuId = nil;
   NSArray<NSString *> *toggleIds = nil;
@@ -269,6 +275,12 @@
   navItem.titleView = nil;
   [navItem setLeftBarButtonItems:@[] animated:YES];
   [navItem setRightBarButtonItems:@[] animated:YES];
+
+#if !TARGET_OS_TV
+  if (@available(iOS 16.0, *)) {
+    navItem.titleMenuProvider = nil;
+  }
+#endif // !TARGET_OS_TV
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   if (@available(iOS 26.0, *)) {
@@ -413,6 +425,39 @@
     navItem.largeSubtitleView = largeSubtitleView;
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+}
+
+- (void)applyTitleMenuForController:(RNSStackScreenController *)controller
+{
+#if !TARGET_OS_TV
+  if (@available(iOS 16.0, *)) {
+    RNSStackHeaderMenuData *titleMenuData = _configDataProvider.titleMenu;
+    UINavigationItem *navItem = controller.navigationItem;
+
+    if (titleMenuData == nil) {
+      navItem.titleMenuProvider = nil;
+      return;
+    }
+
+    RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:RNSTitleMenuTrackerItemId];
+    __weak auto weakSelf = self;
+    __weak auto weakEventsDelegate = _eventsDelegate;
+    __weak auto weakImageLoader = _imageLoader;
+
+    navItem.titleMenuProvider = ^UIMenu *(NSArray<UIMenuElement *> *suggestedActions) {
+      if (weakEventsDelegate == nil || weakImageLoader == nil) {
+        return [UIMenu menuWithChildren:@[]];
+      }
+      return [RNSStackHeaderMenuCoordinator buildUIMenuFromData:titleMenuData
+                                       withHeaderEventsDelegate:weakEventsDelegate
+                                                   stateTracker:tracker
+                                                withImageLoader:weakImageLoader
+                                        menuInvalidatedCallback:^{
+                                          [weakSelf reapplyTitleMenu];
+                                        }];
+    };
+  }
+#endif // !TARGET_OS_TV
 }
 
 - (UIBarButtonItem *)buildBarButtonItemForItem:(id<RNSStackHeaderItemDataProviding>)item

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -220,7 +220,7 @@
               rootMenu:(RNSStackHeaderMenuData *)rootMenu
             parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
 {
-  if (_configDataProvider == nil || elementId == nil || trackerItemId == nil) {
+  if (_configDataProvider == nil || elementId == nil || trackerItemId == nil || rootMenu == nil) {
     return;
   }
 

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -450,7 +450,7 @@
 
     navItem.titleMenuProvider = ^UIMenu *(NSArray<UIMenuElement *> *suggestedActions) {
       if (weakEventsDelegate == nil || weakImageLoader == nil) {
-        return [UIMenu menuWithChildren:@[]];
+        return nil;
       }
       return [RNSStackHeaderMenuCoordinator buildUIMenuFromData:titleMenuData
                                        withHeaderEventsDelegate:weakEventsDelegate

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -226,6 +226,10 @@
 
   RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:trackerItemId];
 
+  if ([tracker toggleStateEquals:state forItemWithId:elementId]) {
+    return;
+  }
+
   RNSStackHeaderMenuData *singleSelectionRoot = [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:elementId
                                                                                                        inMenu:rootMenu];
 

--- a/src/components/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/stack/header/StackHeaderConfig.ios.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
 import type {
@@ -30,8 +31,12 @@ import type {
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
-import { findMenuElementByIdInItems, validateMenuCallbacks } from './utils';
-import { resolveIconAssetSources } from './ios/iconUtils.ios';
+import {
+  findMenuElementById,
+  findMenuElementByIdInItems,
+  validateMenuCallbacks,
+} from './utils';
+import { resolveIconAssetSources, resolveMenuIcons } from './ios/iconUtils.ios';
 
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
@@ -48,6 +53,7 @@ function StackHeaderConfig(
     leadingItems,
     trailingItems,
     titleItem,
+    titleMenu,
     subtitleItem,
     largeSubtitleItem,
     largeTitle,
@@ -101,15 +107,21 @@ function StackHeaderConfig(
         ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
         ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
       );
-      const menuElement = findMenuElementByIdInItems(
+      let menuElement = findMenuElementByIdInItems(
         items,
         event.nativeEvent.menuItemId,
       );
+      if (!menuElement && titleMenu) {
+        menuElement = findMenuElementById(
+          titleMenu,
+          event.nativeEvent.menuItemId,
+        );
+      }
       if (menuElement && menuElement.type === 'menuItem') {
         menuElement.onPress?.();
       }
     },
-    [leadingItems, trailingItems],
+    [leadingItems, trailingItems, titleMenu],
   );
 
   const allMenuItems = [
@@ -120,12 +132,15 @@ function StackHeaderConfig(
   const handleSelectionChange = useCallback(
     (event: NativeSyntheticEvent<MenuSelectionChangeEvent>) => {
       const { menuId, selectedMenuItemIds } = event.nativeEvent;
-      const menu = findMenuElementByIdInItems(allMenuItems, menuId);
+      let menu = findMenuElementByIdInItems(allMenuItems, menuId);
+      if (!menu && titleMenu) {
+        menu = findMenuElementById(titleMenu, menuId);
+      }
       if (menu && menu.type === 'menu') {
         menu.onSelectionChange?.(selectedMenuItemIds);
       }
     },
-    [allMenuItems],
+    [allMenuItems, titleMenu],
   );
 
   useEffect(() => {
@@ -134,8 +149,16 @@ function StackHeaderConfig(
         validateMenuCallbacks(item.menu);
       }
     }
+    if (titleMenu) {
+      validateMenuCallbacks(titleMenu);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leadingItems, trailingItems]);
+  }, [leadingItems, trailingItems, titleMenu]);
+
+  const resolvedTitleMenu = useMemo(
+    () => (titleMenu != null ? resolveMenuIcons(titleMenu) : undefined),
+    [titleMenu],
+  );
 
   return (
     <StackHeaderConfigIOSNativeComponent
@@ -145,6 +168,7 @@ function StackHeaderConfig(
       largeTitle={largeTitle}
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
+      titleMenu={resolvedTitleMenu}
       style={styles.config}
       onMenuItemPress={handleMenuItemPress}
       onMenuSelectionChange={handleSelectionChange}>

--- a/src/components/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/stack/header/StackHeaderConfig.ios.tsx
@@ -31,11 +31,7 @@ import type {
   StackHeaderSpacerItemIOS,
   StackHeaderTitleCustomItemIOS,
 } from './StackHeaderConfig.ios.types';
-import {
-  findMenuElementById,
-  findMenuElementByIdInItems,
-  validateMenuCallbacks,
-} from './utils';
+import { findMenuElementByIdInMenus, validateMenuCallbacks } from './utils';
 import { resolveIconAssetSources, resolveMenuIcons } from './ios/iconUtils.ios';
 
 /**
@@ -101,59 +97,49 @@ function StackHeaderConfig(
     },
   }));
 
+  const allMenus = useMemo(
+    () =>
+      [
+        ...(leadingItems ?? [])
+          .filter(it => it && it.type === 'item')
+          .map(it => it.menu),
+        ...(trailingItems ?? [])
+          .filter(it => it && it.type === 'item')
+          .map(it => it.menu),
+        titleMenu,
+      ].filter(it => !!it),
+    [leadingItems, trailingItems, titleMenu],
+  );
+
   const handleMenuItemPress = useCallback(
     (event: NativeSyntheticEvent<MenuItemPressEvent>) => {
-      const items = Array.of(
-        ...(leadingItems ?? []).filter(it => it && it.type === 'item'),
-        ...(trailingItems ?? []).filter(it => it && it.type === 'item'),
-      );
-      let menuElement = findMenuElementByIdInItems(
-        items,
+      const menuElement = findMenuElementByIdInMenus(
+        allMenus,
         event.nativeEvent.menuItemId,
       );
-      if (!menuElement && titleMenu) {
-        menuElement = findMenuElementById(
-          titleMenu,
-          event.nativeEvent.menuItemId,
-        );
-      }
       if (menuElement && menuElement.type === 'menuItem') {
         menuElement.onPress?.();
       }
     },
-    [leadingItems, trailingItems, titleMenu],
+    [allMenus],
   );
-
-  const allMenuItems = [
-    ...(leadingItems ?? []),
-    ...(trailingItems ?? []),
-  ].filter(it => it && it.type === 'item');
 
   const handleSelectionChange = useCallback(
     (event: NativeSyntheticEvent<MenuSelectionChangeEvent>) => {
       const { menuId, selectedMenuItemIds } = event.nativeEvent;
-      let menu = findMenuElementByIdInItems(allMenuItems, menuId);
-      if (!menu && titleMenu) {
-        menu = findMenuElementById(titleMenu, menuId);
-      }
+      const menu = findMenuElementByIdInMenus(allMenus, menuId);
       if (menu && menu.type === 'menu') {
         menu.onSelectionChange?.(selectedMenuItemIds);
       }
     },
-    [allMenuItems, titleMenu],
+    [allMenus],
   );
 
   useEffect(() => {
-    for (const item of allMenuItems) {
-      if ('menu' in item && item.menu) {
-        validateMenuCallbacks(item.menu);
-      }
+    for (const menu of allMenus) {
+      validateMenuCallbacks(menu);
     }
-    if (titleMenu) {
-      validateMenuCallbacks(titleMenu);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leadingItems, trailingItems, titleMenu]);
+  }, [allMenus]);
 
   const resolvedTitleMenu = useMemo(
     () => (titleMenu != null ? resolveMenuIcons(titleMenu) : undefined),

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -288,6 +288,19 @@ export interface StackHeaderConfigPropsIOS {
    */
   titleItem?: StackHeaderTitleCustomItemIOS | undefined;
   /**
+   * @summary Menu definition for the title context menu.
+   *
+   * @description
+   * Configures a dropdown menu attached to the navigation bar title area.
+   * Works independently of {@link titleItem}; the menu appears for both
+   * plain text and custom view title.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 16 and higher
+   */
+  titleMenu?: StackHeaderMenuIOS | undefined;
+  /**
    * @summary A list of items placed starting from the trailing edge.
    * If there is not enough space to fit some items, they are moved to the overflow menu, one by one.
    *

--- a/src/components/stack/header/ios/StackHeaderItem.ios.tsx
+++ b/src/components/stack/header/ios/StackHeaderItem.ios.tsx
@@ -2,30 +2,8 @@ import React, { useCallback, useMemo } from 'react';
 import StackHeaderItemIOSNativeComponent from '../../../../fabric/stack/StackHeaderItemIOSNativeComponent';
 import type { HeaderItemPressEvent } from '../../../../fabric/stack/StackHeaderItemIOSNativeComponent';
 import type { StackHeaderItemProps } from './StackHeaderItem.ios.types';
-import type {
-  StackHeaderMenuIOS,
-  StackHeaderMenuElementIOS,
-} from './StackHeaderMenu.ios.types';
 import { NativeSyntheticEvent, StyleSheet } from 'react-native';
-import { resolveIconAssetSources } from './iconUtils.ios';
-
-function resolveMenuElementIcons(
-  element: StackHeaderMenuElementIOS,
-): StackHeaderMenuElementIOS {
-  if (element.type === 'menuItem') {
-    if (element.icon == null) {
-      return element;
-    }
-    return { ...element, icon: resolveIconAssetSources(element.icon) };
-  }
-  return resolveMenuIcons(element);
-}
-
-function resolveMenuIcons(menu: StackHeaderMenuIOS): StackHeaderMenuIOS {
-  const resolvedIcon = resolveIconAssetSources(menu.icon);
-  const resolvedChildren = menu.children.map(resolveMenuElementIcons);
-  return { ...menu, icon: resolvedIcon, children: resolvedChildren };
-}
+import { resolveIconAssetSources, resolveMenuIcons } from './iconUtils.ios';
 
 export default function StackHeaderItem(props: StackHeaderItemProps) {
   const { render, onPress, icon, menu, ...rest } = props;

--- a/src/components/stack/header/ios/iconUtils.ios.ts
+++ b/src/components/stack/header/ios/iconUtils.ios.ts
@@ -1,5 +1,9 @@
 import type { PlatformIconIOS as ResolvedPlatformIconIOS } from '../../../../fabric/stack/StackHeaderItemIOSNativeComponent';
 import type { PlatformIconIOS } from '../../../shared/types';
+import type {
+  StackHeaderMenuIOS,
+  StackHeaderMenuElementIOS,
+} from './StackHeaderMenu.ios.types';
 import { Image } from 'react-native';
 
 export function resolveIconAssetSources(
@@ -21,4 +25,22 @@ export function resolveIconAssetSources(
     };
   }
   return icon;
+}
+
+export function resolveMenuElementIcons(
+  element: StackHeaderMenuElementIOS,
+): StackHeaderMenuElementIOS {
+  if (element.type === 'menuItem') {
+    if (element.icon == null) {
+      return element;
+    }
+    return { ...element, icon: resolveIconAssetSources(element.icon) };
+  }
+  return resolveMenuIcons(element);
+}
+
+export function resolveMenuIcons(menu: StackHeaderMenuIOS): StackHeaderMenuIOS {
+  const resolvedIcon = resolveIconAssetSources(menu.icon);
+  const resolvedChildren = menu.children.map(resolveMenuElementIcons);
+  return { ...menu, icon: resolvedIcon, children: resolvedChildren };
 }

--- a/src/components/stack/header/utils.ts
+++ b/src/components/stack/header/utils.ts
@@ -2,20 +2,15 @@ import {
   StackHeaderMenuElementIOS,
   StackHeaderMenuIOS,
 } from './ios/StackHeaderMenu.ios.types';
-import { SupportsMenuIOS } from './StackHeaderConfig.ios.types';
 
-export function findMenuElementByIdInItems(
-  items: SupportsMenuIOS[],
+export function findMenuElementByIdInMenus(
+  menus: StackHeaderMenuIOS[],
   id: string,
 ): StackHeaderMenuElementIOS | null {
-  for (const item of items) {
-    if (item.menu === undefined) {
-      continue;
-    }
-
-    const menu = findMenuElementById(item.menu, id);
-    if (menu !== null) {
-      return menu;
+  for (const menu of menus) {
+    const element = findMenuElementById(menu, id);
+    if (element !== null) {
+      return element;
     }
   }
 

--- a/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -6,7 +6,7 @@ import type {
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
-import {
+import type {
   PlatformIconIOS,
   StackHeaderMenuIOS,
 } from './StackHeaderItemIOSNativeComponent';

--- a/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -6,7 +6,10 @@ import type {
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
-import { PlatformIconIOS } from './StackHeaderItemIOSNativeComponent';
+import {
+  PlatformIconIOS,
+  StackHeaderMenuIOS,
+} from './StackHeaderItemIOSNativeComponent';
 import { UnsafeMixed } from '../codegenUtils';
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
@@ -27,6 +30,8 @@ export interface NativeProps extends ViewProps {
   largeTitle?: string | undefined;
   largeSubtitle?: string | undefined;
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
+
+  titleMenu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
 
   onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;
   onMenuSelectionChange?:


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1523

## Description

This PR adds `titleMenu` prop that defines a menu that displays when header is tapped. The menu has identical features as header item menus and responds to view commands in the same way.

## Changes

- added `titleMenu`
- updated menu search functions to include title menu
- updated test case

## Before & after - visual documentation

https://github.com/user-attachments/assets/fbbcf1c7-8e59-4252-b056-46e7b8269160

## Test plan

Use `test-stack-header-menu-ios` SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
