### PR TITLE
Fix type error in TabsContainerStateInitArg with exactOptionalPropertyTypes

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/reducer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/reducer.tsx
@@ -150,7 +150,7 @@ function createTabRouteFromConfig(config: TabRouteConfig): TabRoute {
 
 export type TabsContainerStateInitArg = {
   routeConfigs: TabRouteConfig[];
-  defaultRouteName?: string;
+  defaultRouteName?: string | undefined;
 };
 
 export function determineInitialTabsContainerState(


### PR DESCRIPTION
## Summary
- Fix type error in `TabsContainerStateInitArg` that surfaced after enabling `exactOptionalPropertyTypes: true` in tsconfig
- With `exactOptionalPropertyTypes`, `defaultRouteName?: string` only allows the property to be absent — it does not allow explicitly passing `undefined`. Adding `| undefined` to the type restores the intended behavior

## Test plan
- [ ] `yarn check-types` passes
- [ ] Verify that callers passing `defaultRouteName: undefined` explicitly no longer produce a type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)