### PR TITLE
chore(examples): allow explicit undefined for defaultRouteName in TabsContainerStateInitArg

### DIFF
--- a/apps/src/shared/gamma/containers/tabs/reducer.tsx
+++ b/apps/src/shared/gamma/containers/tabs/reducer.tsx
@@ -150,7 +150,7 @@ function createTabRouteFromConfig(config: TabRouteConfig): TabRoute {
 
 export type TabsContainerStateInitArg = {
   routeConfigs: TabRouteConfig[];
-  defaultRouteName?: string;
+  defaultRouteName?: string | undefined;
 };
 
 export function determineInitialTabsContainerState(


### PR DESCRIPTION
## Description

With `exactOptionalPropertyTypes: true`, the type `defaultRouteName?: string` only allows the property to be absent — it does not permit explicitly passing `undefined`. This causes a type error at call sites that pass `defaultRouteName: undefined`.

Adding `| undefined` to the type restores the intended behavior: the property can be omitted, set to a string, or explicitly set to `undefined`.

## Changes

- Updated `defaultRouteName` type in `TabsContainerStateInitArg` from `?: string` to `?: string | undefined`

## Test plan

- `yarn check-types` passes with `exactOptionalPropertyTypes: true`
- Callers passing `defaultRouteName: undefined` no longer produce a type error

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes