### PR TITLE
fix freeze boundary

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -202,82 +202,82 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
         (shouldFreeze !== undefined ? shouldFreeze : activityState === 0);
 
       return (
-        <DelayedFreeze freeze={freeze}>
-          <AnimatedScreen
-            {...props}
-            /**
-             * This messy override is to conform NativeProps used by codegen and
-             * our Public API. To see reasoning go to this PR:
-             * https://github.com/software-mansion/react-native-screens/pull/2423#discussion_r1810616995
-             */
-            onAppear={onAppear as NativeProps['onAppear']}
-            onDisappear={onDisappear as NativeProps['onDisappear']}
-            onWillAppear={onWillAppear as NativeProps['onWillAppear']}
-            onWillDisappear={onWillDisappear as NativeProps['onWillDisappear']}
-            onGestureCancel={
-              (onGestureCancel as NativeProps['onGestureCancel']) ??
-              (() => {
-                // for internal use
-              })
-            }
-            //
-            // Hierarchy of screens is handled on the native side and setting zIndex value causes this issue:
-            // https://github.com/software-mansion/react-native-screens/issues/2345
-            // With below change of zIndex, we force RN diffing mechanism to NOT include detaching and attaching mutation in one transaction.
-            // Detailed information can be found here https://github.com/software-mansion/react-native-screens/pull/2351
-            style={[style, { zIndex: undefined }]}
-            activityState={activityState}
-            screenId={screenId}
-            sheetAllowedDetents={resolvedSheetAllowedDetents}
-            sheetLargestUndimmedDetent={resolvedSheetLargestUndimmedDetent}
-            sheetElevation={sheetElevation}
-            sheetShouldOverflowTopInset={sheetShouldOverflowTopInset}
-            sheetDefaultResizeAnimationEnabled={
-              sheetDefaultResizeAnimationEnabled
-            }
-            sheetGrabberVisible={sheetGrabberVisible}
-            sheetCornerRadius={sheetCornerRadius}
-            sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
-            sheetInitialDetent={resolvedSheetInitialDetentIndex}
-            fullScreenSwipeEnabled={parseBooleanToOptionalBooleanNativeProp(
-              fullScreenSwipeEnabled,
-            )}
-            gestureResponseDistance={{
-              start: gestureResponseDistance?.start ?? -1,
-              end: gestureResponseDistance?.end ?? -1,
-              top: gestureResponseDistance?.top ?? -1,
-              bottom: gestureResponseDistance?.bottom ?? -1,
-            }}
-            // This prevents showing blank screen when navigating between multiple screens with freezing
-            // https://github.com/software-mansion/react-native-screens/pull/1208
-            ref={handleRef}
-            onTransitionProgress={
-              !isNativeStack
-                ? undefined
-                : Animated.event(
-                    [
-                      {
-                        nativeEvent: {
-                          progress,
-                          closing,
-                          goingForward,
-                        },
+        <AnimatedScreen
+          {...props}
+          /**
+           * This messy override is to conform NativeProps used by codegen and
+           * our Public API. To see reasoning go to this PR:
+           * https://github.com/software-mansion/react-native-screens/pull/2423#discussion_r1810616995
+           */
+          onAppear={onAppear as NativeProps['onAppear']}
+          onDisappear={onDisappear as NativeProps['onDisappear']}
+          onWillAppear={onWillAppear as NativeProps['onWillAppear']}
+          onWillDisappear={onWillDisappear as NativeProps['onWillDisappear']}
+          onGestureCancel={
+            (onGestureCancel as NativeProps['onGestureCancel']) ??
+            (() => {
+              // for internal use
+            })
+          }
+          //
+          // Hierarchy of screens is handled on the native side and setting zIndex value causes this issue:
+          // https://github.com/software-mansion/react-native-screens/issues/2345
+          // With below change of zIndex, we force RN diffing mechanism to NOT include detaching and attaching mutation in one transaction.
+          // Detailed information can be found here https://github.com/software-mansion/react-native-screens/pull/2351
+          style={[style, { zIndex: undefined }]}
+          activityState={activityState}
+          screenId={screenId}
+          sheetAllowedDetents={resolvedSheetAllowedDetents}
+          sheetLargestUndimmedDetent={resolvedSheetLargestUndimmedDetent}
+          sheetElevation={sheetElevation}
+          sheetShouldOverflowTopInset={sheetShouldOverflowTopInset}
+          sheetDefaultResizeAnimationEnabled={
+            sheetDefaultResizeAnimationEnabled
+          }
+          sheetGrabberVisible={sheetGrabberVisible}
+          sheetCornerRadius={sheetCornerRadius}
+          sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
+          sheetInitialDetent={resolvedSheetInitialDetentIndex}
+          fullScreenSwipeEnabled={parseBooleanToOptionalBooleanNativeProp(
+            fullScreenSwipeEnabled,
+          )}
+          gestureResponseDistance={{
+            start: gestureResponseDistance?.start ?? -1,
+            end: gestureResponseDistance?.end ?? -1,
+            top: gestureResponseDistance?.top ?? -1,
+            bottom: gestureResponseDistance?.bottom ?? -1,
+          }}
+          // This prevents showing blank screen when navigating between multiple screens with freezing
+          // https://github.com/software-mansion/react-native-screens/pull/1208
+          ref={handleRef}
+          onTransitionProgress={
+            !isNativeStack
+              ? undefined
+              : Animated.event(
+                  [
+                    {
+                      nativeEvent: {
+                        progress,
+                        closing,
+                        goingForward,
                       },
-                    ],
-                    { useNativeDriver: true },
-                  )
-            }
-            bottomScrollEdgeEffect={scrollEdgeEffects?.bottom}
-            leftScrollEdgeEffect={scrollEdgeEffects?.left}
-            rightScrollEdgeEffect={scrollEdgeEffects?.right}
-            topScrollEdgeEffect={scrollEdgeEffects?.top}
-            synchronousShadowStateUpdatesEnabled={
-              featureFlags.experiment.synchronousScreenUpdatesEnabled
-            }
-            androidResetScreenShadowStateOnOrientationChangeEnabled={
-              featureFlags.experiment
-                .androidResetScreenShadowStateOnOrientationChangeEnabled
-            }>
+                    },
+                  ],
+                  { useNativeDriver: true },
+                )
+          }
+          bottomScrollEdgeEffect={scrollEdgeEffects?.bottom}
+          leftScrollEdgeEffect={scrollEdgeEffects?.left}
+          rightScrollEdgeEffect={scrollEdgeEffects?.right}
+          topScrollEdgeEffect={scrollEdgeEffects?.top}
+          synchronousShadowStateUpdatesEnabled={
+            featureFlags.experiment.synchronousScreenUpdatesEnabled
+          }
+          androidResetScreenShadowStateOnOrientationChangeEnabled={
+            featureFlags.experiment
+              .androidResetScreenShadowStateOnOrientationChangeEnabled
+          }>
+          <DelayedFreeze freeze={freeze}>
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
               children
             ) : (
@@ -290,8 +290,8 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
                 {children}
               </TransitionProgressContext.Provider>
             )}
-          </AnimatedScreen>
-        </DelayedFreeze>
+          </DelayedFreeze>
+        </AnimatedScreen>
       );
     } else {
       // same reason as above


### PR DESCRIPTION
## Description

Move `DelayedFreeze` inside `AnimatedScreen`.

Currently, the freeze boundary wraps the native screen host. During rapid tab switches, this can prevent native props such as `activityState`, z-index, and pointer-event updates from reaching the native screen while it is frozen. Freezing only the screen content preserves the intended content-freezing behavior while keeping the native host responsive to navigation state changes.

## Changes

- Moved `DelayedFreeze` from around `AnimatedScreen` to its children.
- Kept the `AnimatedScreen` props and native event wiring outside the freeze boundary.
- Did not change the public API.

## Test plan

Use the following minimal example, then tap **Toggle screen state** repeatedly:

```tsx
import React, { useState } from 'react';
import { Button, View } from 'react-native';
import {
  enableFreeze,
  Screen,
  ScreenContainer,
} from 'react-native-screens';

enableFreeze(true);

export function App() {
  const [activityState, setActivityState] = useState<0 | 2>(2);

  return (
    <View style={{ flex: 1 }}>
      <Button
        title="Toggle screen state"
        onPress={() =>
          setActivityState((currentState) =>
            currentState === 2 ? 0 : 2,
          )
        }
      />
      <ScreenContainer style={{ flex: 1 }}>
        <Screen activityState={activityState} freezeOnBlur>
          <View style={{ flex: 1 }} />
        </Screen>
      </ScreenContainer>
    </View>
  );
}
```

Expected result: the native screen host receives every `activityState` update while its children remain frozen when inactive.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types. Not applicable - no public API changes.
- [ ] Ensured that CI passes.
