### PR TITLE
fix(Android): don't crash in Screen.onLayout when DecorView is unavai…

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -357,12 +357,13 @@ class Screen(
             val height = b - t
 
             if (!insetsApplied && headerConfig?.isHeaderHidden == false && headerConfig?.isHeaderTranslucent == false) {
-                val topLevelDecorView =
-                    requireNotNull(
-                        reactContext.currentActivity?.window?.decorView,
-                    ) { "[RNScreens] DecorView is required for applying inset correction, but was null." }
 
-                val topInset = getDecorViewTopInset(topLevelDecorView)
+                // The activity can be momentarily unavailable during recreation
+                // (e.g. backgrounding during startup). Skip the inset correction
+                // for this pass instead of crashing. See #4311.
+                val topLevelDecorView = reactContext.currentActivity?.window?.decorView
+                val topInset = topLevelDecorView?.let { getDecorViewTopInset(it) } ?: 0
+
                 val correctedHeight = height - topInset
                 val correctedOffsetY = t + topInset
 


### PR DESCRIPTION
## Description

  On the 4.23.x line, `Screen.onLayout` applies header inset correction using:

  ```kotlin
  val topLevelDecorView =
      requireNotNull(reactContext.currentActivity?.window?.decorView) { ... }

  currentActivity (and therefore its window.decorView) can be momentarily null
  while the Activity is being re-created — e.g. the app is backgrounded during startup,
  or the "Don't keep activities" developer option is enabled. In that window,
  requireNotNull throws a fatal IllegalArgumentException on the main thread.

  This is hitting Expo SDK 55 apps in production (SDK 55 pins react-native-screens@~4.23.0):
  ~26 crashes across ~22 users over two weeks. Those apps can't move to 4.25.x within
  Expo's approved version range, hence a 4.23.1 patch.

  Closes #4311.
  
  Changes

  Replaced the requireNotNull assertion with a null-safe read that falls back to a
  0 inset when the DecorView is unavailable:

  val topLevelDecorView = reactContext.currentActivity?.window?.decorView
  val topInset = topLevelDecorView?.let { getDecorViewTopInset(it) } ?: 0

  When the DecorView is null, topInset is 0, which produces the same result as the
  existing else branch (no correction) for that frame; when it's available, behavior is
  unchanged.

  Note: main fixed this in #3793 (e74d69f0) by removing the inset-correction block
  entirely and moving the work into CustomToolbar's new pre-layout mechanism. That
  refactor isn't present on 4.23, so this is a minimal, behavior-preserving guard rather
  than a port of that change.

  Test plan

  Reproduction repo (minimal, complete): https://github.com/gperler/rnscreens-decorview-repro-

  Steps:
  1. Enable Settings → Developer options → Don't keep activities (or background the app
  during startup).
  2. Launch the app onto a native-stack screen with a visible, non-translucent header.
  3. Before the fix: crashes with IllegalArgumentException: [RNScreens] DecorView is required....
  After the fix: no crash; header inset behaves normally once the Activity is available.

  This is a native Android crash guard on a transient layout race; no automated test file
  was added (the null currentActivity window is not reproducible in the JS/detox layer).

  Checklist

  - [x] Included code example that can be used to test this change.
  - [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. — N/A, no visual changes
  - [ ] For API changes, updated relevant public types. — N/A, no API changes
  - [ ] Ensured that CI passes
