### PR TITLE
feat(Android, Stack v5): use M3 Expressive theme for App Bar

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -175,7 +175,7 @@ internal class StackHeaderCoordinatorLayout(
     private val wrappedContext =
         ContextThemeWrapper(
             context,
-            R.style.Theme_Material3_DayNight_NoActionBar,
+            R.style.Theme_Material3Expressive_DayNight_NoActionBar,
         )
 
     private val applicator = StackHeaderApplicator(wrappedContext)


### PR DESCRIPTION
## Description

Changes app bar's theme to M3 Expressive for Stack v5 header on Android.

This is a follow-up to https://github.com/software-mansion/react-native-screens/pull/4348.

## Changes

- change theme to M3 Expressive in `StackHeaderCoordinatorLayout.wrappedContext`

## Before & after - visual documentation

Changes are described here: https://github.com/material-components/material-components-android/blob/master/docs/components/TopAppBar.md#m3-expressive-update. New M3 Expressive features (subtitles, ...) are going to be added in future PRs.

Here is an example of visual change for large header (header height, font size):

| M3 | M3 Expressive |
| --- | --- |
| <img width="1280" height="2856" alt="Screenshot_20260720_104111" src="https://github.com/user-attachments/assets/294d2ff4-c21a-4ff4-acdf-dfc6ef35f83a" /> | <img width="1280" height="2856" alt="Screenshot_20260720_104040" src="https://github.com/user-attachments/assets/f5bf9b71-5fff-449d-be01-684be276c8ed" /> |

## Test plan

Regression testing on Stack v5 SFTs.

## Checklist

- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
