### PR TITLE
chore: block the possibility to create plain-text issues and update agents instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -45,7 +45,7 @@ body:
       description: |
         Please provide a Snack (https://snack.expo.io/) or a link to a repository on GitHub under your username that reproduces the issue.
         Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
-        Treat the reproducer as MANDATORY. Issues without a reproduction are HIGHLY likely to stale and might be closed w/o a response.
+        Treat the reproducer as mandatory. Issues without a reproduction are highly likely to go stale and might be closed without a response.
       placeholder: Link to a Snack or a GitHub repository
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -45,7 +45,7 @@ body:
       description: |
         Please provide a Snack (https://snack.expo.io/) or a link to a repository on GitHub under your username that reproduces the issue.
         Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
-        Issues without a reproduction are likely to stale.
+        Treat the reproducer as MANDATORY. Issues without a reproduction are HIGHLY likely to stale and might be closed w/o a response.
       placeholder: Link to a Snack or a GitHub repository
     validations:
       required: true
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Screens version
       description: What version of react-native-screens are you using?
-      placeholder: 3.16.0
+      placeholder: 4.26.0
     validations:
       required: true
 
@@ -64,7 +64,7 @@ body:
     attributes:
       label: React Native version
       description: What version of react-native are you using?
-      placeholder: 0.69.0
+      placeholder: 0.86.0
     validations:
       required: true
 
@@ -109,15 +109,6 @@ body:
         - React Native (without Expo)
         - Expo bare workflow
         - Expo managed workflow
-
-  - type: dropdown
-    id: architecture
-    attributes:
-      label: Architecture
-      description: What React Native architecture your application is running on? Currently, the default architecture on React Native is Paper so if you haven't changed it in your application select this option.
-      options:
-        - Paper (Old Architecture)
-        - Fabric (New Architecture)
 
   - type: dropdown
     id: build-type

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Question
     url: https://github.com/software-mansion/react-native-screens/discussions/categories/q-a

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,1 +1,0 @@
-## Description

--- a/.github/ISSUE_TEMPLATE/pick-request.md
+++ b/.github/ISSUE_TEMPLATE/pick-request.md
@@ -1,0 +1,17 @@
+---
+name: Pick request
+labels: "type:pick-request"
+about: MAINTAINER ONLY. Pick request thread for a version release.
+---
+
+## Description
+
+This is an pick request thread for release: <version>.
+
+If you want to have anything picked, please post in in the issue thread below.
+If accepted by the maintainer it'll end up in the list below and likely in the 
+version release.
+
+## Pick list
+
+1. [ ] <PR / commit link>

--- a/.github/ISSUE_TEMPLATE/pick-request.md
+++ b/.github/ISSUE_TEMPLATE/pick-request.md
@@ -6,12 +6,12 @@ about: MAINTAINER ONLY. Pick request thread for a version release.
 
 ## Description
 
-This is an pick request thread for release: <version>.
+This is a pick request thread for release `<version>`.
 
-If you want to have anything picked, please post in in the issue thread below.
-If accepted by the maintainer it'll end up in the list below and likely in the 
+If you want to have anything picked, please post it in the issue thread below.
+If accepted by a maintainer, it'll end up in the list below and likely in the
 version release.
 
 ## Pick list
 
-1. [ ] <PR / commit link>
+1. [ ] `<PR / commit link>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,10 @@ Runs `tsc --noEmit` against the root `tsconfig.json` (covers `./src/`).
 ## Code review guidelines
 
 Be extremely frank and focused on thoroughness.
+
+## Issue creation
+
+If you intend to create an issue on this repository, adhere to templates from `./.github/ISSUE_TEMPLATE/`!
+Issues that fail to conform will likely become stale or closed w/o a response.
+
+This applies in particular to bug reports without a reproducer. A reproducer is MANDATORY.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,6 @@ Be extremely frank and focused on thoroughness.
 ## Issue creation
 
 If you intend to create an issue on this repository, adhere to templates from `./.github/ISSUE_TEMPLATE/`!
-Issues that fail to conform will likely become stale or closed w/o a response.
+Issues that fail to conform will likely go stale or be closed without a response.
 
 This applies in particular to bug reports without a reproducer. A reproducer is MANDATORY.


### PR DESCRIPTION
## Description

I remove here blank issue template. This will be less convenient for us, e.g. when opening new
pick request thread (~but we can create another dedicated template for that purpose~ - I've done that).

People (mostly via LLMs) are abusing it. There are numerous cases
recently with LLM produced issue reports that do not adhere to our template
and use the blank one instead, failing to provide the required
information.

I've also updated instructions in AGENTS.md with hope that in certain cases this
will guide agents and result in better output.

