### PR TITLE
feat(Android, Stack v5): expose `liftOnScroll` prop for `small` header, integrate with SVM

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -247,6 +247,10 @@ internal class StackHeaderApplicator(
      * setter (re-read on the next layout / nested-scroll pass), so this needs
      * no header rebuild.
      *
+     * Only the small header participates: medium/large (collapsing) headers
+     * derive their elevation from the `CollapsingToolbarLayout` content scrim,
+     * not from lift-on-scroll, so we leave their app bar untouched.
+     *
      * [targetScrollView] is the resolved content scroll view (see
      * [com.swmansion.rnscreens.common.container.ContainerItem.findContentScrollView]).
      * Without it, Material's `findFirstScrollingChild` only inspects the
@@ -259,12 +263,10 @@ internal class StackHeaderApplicator(
         enabled: Boolean,
         targetScrollView: ViewGroup?,
     ) {
+        if (appBar !is StackHeaderAppBarLayout.Small) return
+
         appBar.isLiftOnScroll = enabled
         appBar.setLiftOnScrollTargetView(if (enabled) targetScrollView else null)
-        if (!enabled) {
-            // Reset the elevation promptly when disabling while currently lifted.
-            appBar.setLifted(false)
-        }
         appBar.requestLayout()
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -6,6 +6,7 @@ import android.text.TextUtils
 import android.util.Log
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
@@ -239,6 +240,32 @@ internal class StackHeaderApplicator(
         target.layoutParams = params
         // Snap back to expanded so the visible state matches the new flags.
         appBar.setExpanded(true, false)
+    }
+
+    /**
+     * Applies lift-on-scroll in-place. `setLiftOnScroll` is a plain field
+     * setter (re-read on the next layout / nested-scroll pass), so this needs
+     * no header rebuild.
+     *
+     * [targetScrollView] is the resolved content scroll view (see
+     * [com.swmansion.rnscreens.common.container.ContainerItem.findContentScrollView]).
+     * Without it, Material's `findFirstScrollingChild` only inspects the
+     * CoordinatorLayout's direct children — which is our wrapper `FrameLayout`,
+     * not the (deeply nested) scroll view — so the lifted state is miscomputed
+     * and the small header flashes while scrolling.
+     */
+    internal fun applyLiftOnScroll(
+        appBar: StackHeaderAppBarLayout,
+        enabled: Boolean,
+        targetScrollView: ViewGroup?,
+    ) {
+        appBar.isLiftOnScroll = enabled
+        appBar.setLiftOnScrollTargetView(if (enabled) targetScrollView else null)
+        if (!enabled) {
+            // Reset the elevation promptly when disabling while currently lifted.
+            appBar.setLifted(false)
+        }
+        appBar.requestLayout()
     }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -194,6 +194,17 @@ internal class StackHeaderCoordinatorLayout(
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.SCROLL_FLAGS)
             }
 
+            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)) {
+                // Lift-on-scroll is disabled in transparent mode: there is no content
+                // scrolling behavior installed and the app bar overlays the content.
+                applicator.applyLiftOnScroll(
+                    appBar,
+                    enabled = provider.liftOnScroll && !provider.transparent,
+                    targetScrollView = stackScreen.findContentScrollView(),
+                )
+                provider.clearInvalidationFlags(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)
+            }
+
             if (provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TOOLBAR_MENU)) {
                 val (forwardIdMap, reverseIdMap) =
                     StackHeaderToolbarMenuApplicator.generateToolbarMenuItemMappings(

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -24,11 +24,6 @@ internal sealed class StackHeaderAppBarLayout(
                 behavior = StackHeaderAppBarLayoutBehavior()
             }
 
-        // TODO: this should be exposed in the future via prop. Also, it might not work correctly
-        //       until we set liftOnScrollView manually. Also, we should disable it in transparent
-        //       mode or set elevation higher.
-        isLiftOnScroll = true
-
         // TODO: this won't work with nested header but there were some problems with lift on scroll
         //       without it when I was researching this.
         fitsSystemWindows = true

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -141,6 +141,11 @@ internal class StackHeaderConfig(
     }
         internal set
 
+    override var liftOnScroll: Boolean by Delegates.observable(true) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)
+    }
+        internal set
+
     override var toolbarMenu: StackHeaderToolbarMenuConfig
         by Delegates.observable(StackHeaderToolbarMenuConfig(emptyList(), emptyList())) { _, old, new ->
             if (old != new) invalidate(StackHeaderInvalidationFlags.TOOLBAR_MENU)
@@ -154,6 +159,23 @@ internal class StackHeaderConfig(
 
     override val isRTL: Boolean
         get() = layoutDirection == LayoutDirection.RTL
+
+    // endregion
+
+    // region Content scroll view
+
+    /**
+     * Called by the owning [com.swmansion.rnscreens.stack.screen.StackScreen]
+     * when its content scroll view changes (e.g. a `ScrollViewMarker` registered
+     * one). Re-triggers lift-on-scroll so the coordinator can resolve and apply
+     * the up-to-date `liftOnScrollTargetView`.
+     */
+    internal fun onContentScrollViewChanged() {
+        invalidate(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)
+        if (!isInsideMountTransaction) {
+            flushUpdates()
+        }
+    }
 
     // endregion
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
@@ -218,6 +218,13 @@ internal open class StackHeaderConfigViewManager :
         view.scrollFlagSnap = value
     }
 
+    override fun setLiftOnScroll(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.liftOnScroll = value
+    }
+
     override fun setToolbarMenuGroupDividerEnabled(
         view: StackHeaderConfig,
         value: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -19,6 +19,7 @@ internal interface StackHeaderConfigurationProviding {
     val scrollFlagEnterAlwaysCollapsed: Boolean
     val scrollFlagExitUntilCollapsed: Boolean
     val scrollFlagSnap: Boolean
+    val liftOnScroll: Boolean
     val leadingSubview: StackHeaderSubviewProviding?
     val centerSubview: StackHeaderSubviewProviding?
     val trailingSubview: StackHeaderSubviewProviding?

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
@@ -12,9 +12,10 @@ internal value class StackHeaderInvalidationFlags(
         val BACK_BUTTON = StackHeaderInvalidationFlags(1 shl 3)
         val SCROLL_FLAGS = StackHeaderInvalidationFlags(1 shl 4)
         val TOOLBAR_MENU = StackHeaderInvalidationFlags(1 shl 5)
+        val LIFT_ON_SCROLL = StackHeaderInvalidationFlags(1 shl 6)
 
         val APPEARANCE = TITLE or BACK_BUTTON
-        val ALL = STRUCTURE or SUBVIEWS or APPEARANCE or SCROLL_FLAGS or TOOLBAR_MENU
+        val ALL = STRUCTURE or SUBVIEWS or APPEARANCE or SCROLL_FLAGS or TOOLBAR_MENU or LIFT_ON_SCROLL
     }
 
     infix fun or(other: StackHeaderInvalidationFlags) = StackHeaderInvalidationFlags(raw or other.raw)

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
@@ -131,6 +131,7 @@ class StackScreen(
         scrollView: ViewGroup,
     ) {
         containerItemSupport.registerScrollView(scrollView)
+        headerConfig?.onContentScrollViewChanged()
     }
 
     // endregion

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/index.ts
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/index.ts
@@ -1,13 +1,16 @@
 import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 import TestSvmTabsScrollEdgeEffects from './test-svm-tabs-scroll-edge-effects';
 import TestStackSvmTabsSpecialEffects from './test-stack-svm-tabs-special-effects';
+import TestStackSvmLiftOnScroll from './test-stack-svm-lift-on-scroll';
 
 export { default as TestSvmTabsScrollEdgeEffects } from './test-svm-tabs-scroll-edge-effects';
 export { default as TestStackSvmTabsSpecialEffects } from './test-stack-svm-tabs-special-effects';
+export { default as TestStackSvmLiftOnScroll } from './test-stack-svm-lift-on-scroll';
 
 const scenarios = {
   TestSvmTabsScrollEdgeEffects,
   TestStackSvmTabsSpecialEffects,
+  TestStackSvmLiftOnScroll,
 };
 
 const TestSvmScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  type StackRouteConfig,
+} from '@apps/shared/containers/stack';
+import { ScrollViewMarker } from 'react-native-screens';
+import { Rectangle } from '@apps/shared/Rectangle';
+import { Colors } from '@apps/shared/styling';
+import { scenarioDescription } from './scenario-description';
+
+const ITEM_COUNT = 40;
+
+export function TestStackSvmLiftOnScroll() {
+  return <StackContainer routeConfigs={ROUTE_CONFIGS} />;
+}
+
+const ROUTE_CONFIGS: StackRouteConfig[] = [
+  {
+    name: 'LiftOnScroll',
+    Component: ContentScreen,
+    options: {
+      headerConfig: {
+        title: 'Lift on scroll',
+        android: {
+          type: 'small',
+          scrollFlagScroll: true,
+          scrollFlagEnterAlways: true,
+          liftOnScroll: true,
+        },
+      },
+    },
+  },
+];
+
+function ContentScreen() {
+  return (
+    <View style={[styles.fillParent, { backgroundColor: Colors.White }]}>
+      <ScrollViewMarker style={styles.fillParent}>
+        <ScrollView
+          nestedScrollEnabled
+          testID="lift-on-scroll-scrollview"
+          contentInsetAdjustmentBehavior="automatic"
+          style={styles.fillParent}>
+          {Array.from({ length: ITEM_COUNT }).map((_, index) => (
+            <View key={index.toString()} style={styles.item}>
+              <Rectangle
+                testID={`item-${index + 1}`}
+                color={Colors.RedDark100}
+                width={'100%'}
+                height={96}
+              />
+            </View>
+          ))}
+        </ScrollView>
+      </ScrollViewMarker>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fillParent: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+  },
+  item: {
+    width: '100%',
+    marginBottom: 12,
+  },
+});
+
+export default createScenario(TestStackSvmLiftOnScroll, scenarioDescription);

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario-description.ts
@@ -1,0 +1,14 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'SVM lift-on-scroll',
+  key: 'test-stack-svm-lift-on-scroll',
+  details:
+    'Small Material 3 header with scroll flags + liftOnScroll whose content ' +
+    'ScrollView is wrapped in a ScrollViewMarker. Verifies the header lifted ' +
+    '(tonal/elevation) state stays stable — does not flash — while scrolling, ' +
+    'because the marker lets the app bar resolve the correct scroll view.',
+  platforms: ['android'],
+  e2eCoverage: 'incomplete',
+  smokeTest: false,
+};

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario.md
@@ -27,7 +27,8 @@ Incomplete - we can't detect color flash with Detox.
    lift-on-scroll (small header, no flash)**.
 
 - [ ] A small header titled `Lift on scroll` is shown above a scrollable list.
-- [ ] At rest (content at top), the header sits flat — not lifted (lighter color).
+- [ ] At rest (content at top), the header sits flat — not lifted (lighter
+      color).
 
 2. Slowly scroll the list up (content moves under the header).
 

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario.md
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/scenario.md
@@ -1,0 +1,46 @@
+# Test Scenario: Integration: SVM + Stack small header lift-on-scroll
+
+## Details
+
+**Description:**
+This test verifies the interaction between `ScrollViewMarker` and a Stack v5
+Material 3 header in the scope of lift-on-scroll. A `small` header is configured
+with `scrollFlagScroll`, `scrollFlagEnterAlways` and `liftOnScroll` enabled, and
+its content `ScrollView` is wrapped in a `ScrollViewMarker`. The goal is to
+confirm that the header's lifted (tonal/elevation) state stays stable while
+scrolling — it must not flash.
+
+**OS test creation version:**
+Android API 36
+
+## E2E test
+
+Incomplete - we can't detect color flash with Detox.
+
+## Prerequisites
+
+- Android emulator or device.
+
+## Steps
+
+1. Launch the app and navigate to **ScrollViewMarker Integration Tests → SVM
+   lift-on-scroll (small header, no flash)**.
+
+- [ ] A small header titled `Lift on scroll` is shown above a scrollable list.
+- [ ] At rest (content at top), the header sits flat — not lifted (lighter color).
+
+2. Slowly scroll the list up (content moves under the header).
+
+- [ ] The header lifts once (single tonal/elevation change) and then stays
+  lifted (darker color).
+- [ ] The header does NOT flash — its elevation does not flicker on/off during
+  the scroll.
+
+3. Fling / scroll quickly up and down repeatedly.
+
+- [ ] The lifted state tracks scroll position smoothly with no flashing.
+- [ ] The header keeps darker color (unless scrolled to the very top).
+
+4. Scroll all the way back to the top.
+
+- [ ] The header returns to its flat (non-lifted) state (lighter color).

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -8,6 +8,7 @@ import TestStackLifecycleEvents from './test-stack-lifecycle-events';
 import TestStackAnimationAndroid from './test-stack-animation-android';
 import TestStackSimpleNav from './test-stack-simple-nav';
 import TestStackSubviewsAndroid from './test-stack-subviews-android';
+import TestStackLiftOnScrollAndroid from './test-stack-lift-on-scroll-android';
 import TestStackSubviewsIOS from './test-stack-subviews-ios';
 import TestStackHeaderMenuIOS from './test-stack-header-menu-ios';
 import TestStackHeaderIconIOS from './test-stack-header-icon-ios';
@@ -33,6 +34,7 @@ export { default as TestStackLifecycleEvents } from './test-stack-lifecycle-even
 export { default as TestStackAnimationAndroid } from './test-stack-animation-android';
 export { default as TestStackSimpleNav } from './test-stack-simple-nav';
 export { default as TestStackSubviewsAndroid } from './test-stack-subviews-android';
+export { default as TestStackLiftOnScrollAndroid } from './test-stack-lift-on-scroll-android';
 export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
 export { default as TestStackHeaderIconIOS } from './test-stack-header-icon-ios';
 export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
@@ -57,6 +59,7 @@ const scenarios = {
   TestStackAnimationAndroid,
   TestStackSimpleNav,
   TestStackSubviewsAndroid,
+  TestStackLiftOnScrollAndroid,
   TestStackSubviewsIOS,
   TestStackHeaderMenuIOS,
   TestStackHeaderIconIOS,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -8,9 +8,10 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigProps,
-  StackHeaderConfigPropsAndroid,
+import {
+  type StackHeaderConfigProps,
+  type StackHeaderConfigPropsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 
 type TintColorOption = 'default' | 'purple' | 'red' | 'green';
@@ -184,11 +185,13 @@ function RootScreen() {
   useApplyHeaderConfig();
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <ConfigControls />
-      <Text style={styles.heading}>Navigation</Text>
-      <Button title="Push screen" onPress={() => push('Pushed')} />
-    </ScrollView>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <ConfigControls />
+        <Text style={styles.heading}>Navigation</Text>
+        <Button title="Push screen" onPress={() => push('Pushed')} />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 
@@ -197,11 +200,13 @@ function PushedScreen() {
   useApplyHeaderConfig();
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <ConfigControls />
-      <Text style={styles.heading}>Navigation</Text>
-      <Button title="Push another" onPress={() => push('Pushed')} />
-    </ScrollView>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <ConfigControls />
+        <Text style={styles.heading}>Navigation</Text>
+        <Button title="Push another" onPress={() => push('Pushed')} />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -185,7 +185,7 @@ function RootScreen() {
   useApplyHeaderConfig();
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <ConfigControls />
         <Text style={styles.heading}>Navigation</Text>
@@ -200,7 +200,7 @@ function PushedScreen() {
   useApplyHeaderConfig();
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <ConfigControls />
         <Text style={styles.heading}>Navigation</Text>
@@ -211,6 +211,9 @@ function PushedScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
@@ -1,0 +1,135 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text } from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import {
+  type StackHeaderConfigProps,
+  ScrollViewMarker,
+} from 'react-native-screens';
+import LongText from '@apps/shared/LongText';
+
+type TriState = 'undefined' | 'true' | 'false';
+
+const TRI_STATE_VALUES: TriState[] = ['undefined', 'true', 'false'];
+
+interface Config {
+  enabled: boolean;
+  liftOnScroll: TriState;
+  transparent: boolean;
+  hidden: boolean;
+}
+
+const DEFAULT_CONFIG: Config = {
+  enabled: true,
+  liftOnScroll: 'undefined', // -> default (true)
+  transparent: false,
+  hidden: false,
+};
+
+function resolveTriState(value: TriState): boolean | undefined {
+  return value === 'undefined' ? undefined : value === 'true';
+}
+
+function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
+  if (!config.enabled) {
+    return undefined;
+  }
+
+  return {
+    title: 'Lift on scroll',
+    hidden: config.hidden,
+    transparent: config.transparent,
+    android: {
+      type: 'small',
+      liftOnScroll: resolveTriState(config.liftOnScroll),
+    },
+  };
+}
+
+function TestStackLiftOnScrollAndroid() {
+  return (
+    <StackContainer
+      routeConfigs={[{ name: 'Home', Component: ConfigScreen, options: {} }]}
+    />
+  );
+}
+
+function ConfigScreen() {
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+
+  const updateConfig = useCallback(
+    <K extends keyof Config>(key: K, value: Config[K]) => {
+      setConfig(prev => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const headerConfig = useMemo(() => buildHeaderConfig(config), [config]);
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollViewMarker>
+      <ScrollView
+        nestedScrollEnabled
+        style={styles.scroll}
+        contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Header config</Text>
+        <SettingsSwitch
+          label="headerConfig enabled (attach/detach)"
+          value={config.enabled}
+          onValueChange={v => updateConfig('enabled', v)}
+        />
+        <SettingsPicker<TriState>
+          label="liftOnScroll"
+          value={config.liftOnScroll}
+          onValueChange={v => updateConfig('liftOnScroll', v)}
+          items={TRI_STATE_VALUES}
+        />
+        <SettingsSwitch
+          label="transparent"
+          value={config.transparent}
+          onValueChange={v => updateConfig('transparent', v)}
+        />
+        <SettingsSwitch
+          label="hidden"
+          value={config.hidden}
+          onValueChange={v => updateConfig('hidden', v)}
+        />
+
+        <Text style={styles.heading}>Scroll to observe lift</Text>
+        <LongText size="xl" />
+      </ScrollView>
+    </ScrollViewMarker>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+});
+
+export default createScenario(
+  TestStackLiftOnScrollAndroid,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
@@ -78,7 +78,7 @@ function ConfigScreen() {
   }, [headerConfig, setRouteOptions, routeKey]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView
         nestedScrollEnabled
         style={styles.scroll}
@@ -114,6 +114,9 @@ function ConfigScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Lift on scroll (Android)',
+  key: 'test-stack-lift-on-scroll-android',
+  details: 'Verify the Android header lift-on-scroll effect.',
+  platforms: ['android'],
+  e2eCoverage: 'incomplete',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario.md
@@ -1,0 +1,75 @@
+# Test Scenario: Header lift-on-scroll (Android)
+
+## Details
+
+**Description:** Exercises the Android Material 3 header **lift-on-scroll**
+effect — the app bar's tonal/elevation shift applied when scrollable content
+moves beneath the pinned `small` header.
+
+`liftOnScroll` only applies to the `small` header, so this scenario fixes the
+type to `small`.
+
+For `medium`/`large` headers the collapsing app bar instead paints a
+`CollapsingToolbarLayout` content scrim (driven by collapse, not by this prop),
+so `liftOnScroll` has no effect there; that path is out of scope for this test.
+
+**OS test creation version:** API 36
+
+## E2E test
+
+Incomplete - we can't detect the elevation/color flash with Detox.
+
+## Prerequisites
+
+- Android emulator or device.
+
+## Note
+
+- `liftOnScroll` defaults to `true`.
+- `liftOnScroll` has no effect while the header is `transparent` (no scrolling
+  content behavior is installed in that mode).
+
+## Steps
+
+### Baseline
+
+1. Navigate to **Stack v5 → Lift on scroll (Android)**. Leave defaults
+   (`liftOnScroll` = `undefined`).
+
+- [ ] At rest the small header is flat (not lifted, lighter color).
+- [ ] Scrolling the content up lifts the header once (tonal/elevation shift,
+  darker color) and it stays lifted; scrolling back to the top returns it to
+  flat.
+- [ ] No flashing/flicker of the header elevation while scrolling.
+
+2. Set `liftOnScroll` = `false`, then scroll.
+
+- [ ] The header does not lift — it stays flat regardless of scroll position.
+
+3. Set `liftOnScroll` = `true` (or `undefined`) again, then scroll.
+
+- [ ] Lift is restored and re-applies without a visible header rebuild/flash.
+
+### Transparent
+
+4. Set `transparent` = `true`, then scroll.
+
+- [ ] Lift is suppressed while transparent (no elevation shift).
+
+5. Set `transparent` = `false`, then scroll.
+
+- [ ] Lift behavior is restored.
+
+### Hidden (detach / re-show the header)
+
+6. Set `hidden` = `true`, scroll, then set `hidden` = `false`.
+
+- [ ] While hidden there is no header. After re-showing, lift-on-scroll works
+  again (the target scroll view is re-resolved).
+
+### Attach / detach headerConfig
+
+7. Toggle `headerConfig enabled` off, then on.
+
+- [ ] Off removes the whole header. On re-attaches it and lift-on-scroll works
+  again after re-attach.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -223,7 +223,7 @@ function ConfigScreen() {
   }, [headerConfig, setRouteOptions, routeKey]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView
         nestedScrollEnabled
         style={styles.scroll}
@@ -342,6 +342,9 @@ function ConfigScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -18,10 +18,11 @@ import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
 import { Colors } from '@apps/shared/styling';
 import LongText from '@apps/shared/LongText';
-import type {
-  StackHeaderConfigProps,
-  StackHeaderTypeAndroid,
-  StackHeaderBackgroundSubviewCollapseModeAndroid,
+import {
+  type StackHeaderConfigProps,
+  type StackHeaderTypeAndroid,
+  type StackHeaderBackgroundSubviewCollapseModeAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 
 const SHORT_TITLE = I18nManager.isRTL ? 'مرحبا' : 'Hello';
@@ -222,119 +223,121 @@ function ConfigScreen() {
   }, [headerConfig, setRouteOptions, routeKey]);
 
   return (
-    <ScrollView
-      nestedScrollEnabled
-      style={styles.scroll}
-      contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>General</Text>
-      <SettingsSwitch
-        label="headerConfig enabled"
-        value={config.enabled}
-        onValueChange={v => updateConfig('enabled', v)}
-      />
-      <SettingsPicker<StackHeaderTypeAndroid>
-        label="type"
-        value={config.type}
-        onValueChange={v => updateConfig('type', v)}
-        items={HEADER_TYPES}
-      />
-      <SettingsSwitch
-        label="transparent"
-        value={config.transparent}
-        onValueChange={v => updateConfig('transparent', v)}
-      />
-      <SettingsSwitch
-        label="hidden"
-        value={config.hidden}
-        onValueChange={v => updateConfig('hidden', v)}
-      />
-      <SettingsPicker<TitleOption>
-        label="title"
-        value={config.title}
-        onValueChange={v => updateConfig('title', v)}
-        items={TITLE_OPTIONS}
-      />
-      <Text style={styles.heading}>Toolbar Subviews</Text>
-      <SettingsPicker<SubviewSize>
-        label="leading"
-        value={config.leadingSize}
-        onValueChange={v => updateConfig('leadingSize', v)}
-        items={SUBVIEW_SIZES}
-      />
-      <SettingsPicker<SubviewSize>
-        label="center"
-        value={config.centerSize}
-        onValueChange={v => updateConfig('centerSize', v)}
-        items={SUBVIEW_SIZES}
-      />
-      <SettingsPicker<SubviewSize>
-        label="trailing"
-        value={config.trailingSize}
-        onValueChange={v => updateConfig('trailingSize', v)}
-        items={SUBVIEW_SIZES}
-      />
-      <Text style={styles.heading}>Background Subview</Text>
-      <SettingsSwitch
-        label="background enabled"
-        value={config.backgroundEnabled}
-        onValueChange={v => updateConfig('backgroundEnabled', v)}
-      />
-      <SettingsPicker<StackHeaderBackgroundSubviewCollapseModeAndroid>
-        label="collapseMode"
-        value={config.backgroundCollapseMode}
-        onValueChange={v => updateConfig('backgroundCollapseMode', v)}
-        items={COLLAPSE_MODES}
-      />
-      <Text style={styles.heading}>Scroll Flags</Text>
-      <SettingsPicker<ScrollFlagValue>
-        label="scrollFlagScroll"
-        value={config.scrollFlagScroll}
-        onValueChange={v => updateConfig('scrollFlagScroll', v)}
-        items={SCROLL_FLAG_VALUES}
-      />
-      <SettingsPicker<ScrollFlagValue>
-        label="scrollFlagEnterAlways"
-        value={config.scrollFlagEnterAlways}
-        onValueChange={v => updateConfig('scrollFlagEnterAlways', v)}
-        items={SCROLL_FLAG_VALUES}
-      />
-      <SettingsPicker<ScrollFlagValue>
-        label="scrollFlagEnterAlwaysCollapsed"
-        value={config.scrollFlagEnterAlwaysCollapsed}
-        onValueChange={v => updateConfig('scrollFlagEnterAlwaysCollapsed', v)}
-        items={SCROLL_FLAG_VALUES}
-      />
-      <SettingsPicker<ScrollFlagValue>
-        label="scrollFlagExitUntilCollapsed"
-        value={config.scrollFlagExitUntilCollapsed}
-        onValueChange={v => updateConfig('scrollFlagExitUntilCollapsed', v)}
-        items={SCROLL_FLAG_VALUES}
-      />
-      <SettingsPicker<ScrollFlagValue>
-        label="scrollFlagSnap"
-        value={config.scrollFlagSnap}
-        onValueChange={v => updateConfig('scrollFlagSnap', v)}
-        items={SCROLL_FLAG_VALUES}
-      />
-      <Text style={styles.heading}>Pressable Settings</Text>
-      <SettingsPicker<HitSlopValue>
-        label="hitSlop"
-        value={config.hitSlop}
-        onValueChange={v => updateConfig('hitSlop', v)}
-        items={HIT_SLOP_VALUES}
-      />
-      <SettingsPicker<PressRetentionValue>
-        label="pressRetentionOffset"
-        value={config.pressRetentionOffset}
-        onValueChange={v => updateConfig('pressRetentionOffset', v)}
-        items={PRESS_RETENTION_VALUES}
-      />
-      <Text style={styles.heading}>Push screen</Text>
-      <Button title="Push screen" onPress={() => push('Home')} />
+    <ScrollViewMarker>
+      <ScrollView
+        nestedScrollEnabled
+        style={styles.scroll}
+        contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>General</Text>
+        <SettingsSwitch
+          label="headerConfig enabled"
+          value={config.enabled}
+          onValueChange={v => updateConfig('enabled', v)}
+        />
+        <SettingsPicker<StackHeaderTypeAndroid>
+          label="type"
+          value={config.type}
+          onValueChange={v => updateConfig('type', v)}
+          items={HEADER_TYPES}
+        />
+        <SettingsSwitch
+          label="transparent"
+          value={config.transparent}
+          onValueChange={v => updateConfig('transparent', v)}
+        />
+        <SettingsSwitch
+          label="hidden"
+          value={config.hidden}
+          onValueChange={v => updateConfig('hidden', v)}
+        />
+        <SettingsPicker<TitleOption>
+          label="title"
+          value={config.title}
+          onValueChange={v => updateConfig('title', v)}
+          items={TITLE_OPTIONS}
+        />
+        <Text style={styles.heading}>Toolbar Subviews</Text>
+        <SettingsPicker<SubviewSize>
+          label="leading"
+          value={config.leadingSize}
+          onValueChange={v => updateConfig('leadingSize', v)}
+          items={SUBVIEW_SIZES}
+        />
+        <SettingsPicker<SubviewSize>
+          label="center"
+          value={config.centerSize}
+          onValueChange={v => updateConfig('centerSize', v)}
+          items={SUBVIEW_SIZES}
+        />
+        <SettingsPicker<SubviewSize>
+          label="trailing"
+          value={config.trailingSize}
+          onValueChange={v => updateConfig('trailingSize', v)}
+          items={SUBVIEW_SIZES}
+        />
+        <Text style={styles.heading}>Background Subview</Text>
+        <SettingsSwitch
+          label="background enabled"
+          value={config.backgroundEnabled}
+          onValueChange={v => updateConfig('backgroundEnabled', v)}
+        />
+        <SettingsPicker<StackHeaderBackgroundSubviewCollapseModeAndroid>
+          label="collapseMode"
+          value={config.backgroundCollapseMode}
+          onValueChange={v => updateConfig('backgroundCollapseMode', v)}
+          items={COLLAPSE_MODES}
+        />
+        <Text style={styles.heading}>Scroll Flags</Text>
+        <SettingsPicker<ScrollFlagValue>
+          label="scrollFlagScroll"
+          value={config.scrollFlagScroll}
+          onValueChange={v => updateConfig('scrollFlagScroll', v)}
+          items={SCROLL_FLAG_VALUES}
+        />
+        <SettingsPicker<ScrollFlagValue>
+          label="scrollFlagEnterAlways"
+          value={config.scrollFlagEnterAlways}
+          onValueChange={v => updateConfig('scrollFlagEnterAlways', v)}
+          items={SCROLL_FLAG_VALUES}
+        />
+        <SettingsPicker<ScrollFlagValue>
+          label="scrollFlagEnterAlwaysCollapsed"
+          value={config.scrollFlagEnterAlwaysCollapsed}
+          onValueChange={v => updateConfig('scrollFlagEnterAlwaysCollapsed', v)}
+          items={SCROLL_FLAG_VALUES}
+        />
+        <SettingsPicker<ScrollFlagValue>
+          label="scrollFlagExitUntilCollapsed"
+          value={config.scrollFlagExitUntilCollapsed}
+          onValueChange={v => updateConfig('scrollFlagExitUntilCollapsed', v)}
+          items={SCROLL_FLAG_VALUES}
+        />
+        <SettingsPicker<ScrollFlagValue>
+          label="scrollFlagSnap"
+          value={config.scrollFlagSnap}
+          onValueChange={v => updateConfig('scrollFlagSnap', v)}
+          items={SCROLL_FLAG_VALUES}
+        />
+        <Text style={styles.heading}>Pressable Settings</Text>
+        <SettingsPicker<HitSlopValue>
+          label="hitSlop"
+          value={config.hitSlop}
+          onValueChange={v => updateConfig('hitSlop', v)}
+          items={HIT_SLOP_VALUES}
+        />
+        <SettingsPicker<PressRetentionValue>
+          label="pressRetentionOffset"
+          value={config.pressRetentionOffset}
+          onValueChange={v => updateConfig('pressRetentionOffset', v)}
+          items={PRESS_RETENTION_VALUES}
+        />
+        <Text style={styles.heading}>Push screen</Text>
+        <Button title="Push screen" onPress={() => push('Home')} />
 
-      <Text style={styles.heading}>ScrollView content</Text>
-      <LongText size="xl" />
-    </ScrollView>
+        <Text style={styles.heading}>ScrollView content</Text>
+        <LongText size="xl" />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
@@ -7,10 +7,11 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuElementAndroid,
-  StackHeaderToolbarMenuElementOptionsAndroid,
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuElementAndroid,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 
@@ -131,31 +132,33 @@ function MainScreen() {
   }, [cmdTargetId, cmdLabel]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<AllIds>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ALL_IDS]}
-        onValueChange={setCmdTargetId}
-        testID="cmd-target-picker"
-      />
-      <SettingsPicker<LabelOption>
-        label="accessibilityLabel"
-        value={cmdLabel}
-        items={LABEL_OPTIONS}
-        onValueChange={setCmdLabel}
-        testID="cmd-label-picker"
-      />
-      <Button
-        title="Send Command"
-        onPress={sendCommand}
-        testID="send-command-button"
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<AllIds>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ALL_IDS]}
+          onValueChange={setCmdTargetId}
+          testID="cmd-target-picker"
+        />
+        <SettingsPicker<LabelOption>
+          label="accessibilityLabel"
+          value={cmdLabel}
+          items={LABEL_OPTIONS}
+          onValueChange={setCmdLabel}
+          testID="cmd-label-picker"
+        />
+        <Button
+          title="Send Command"
+          onPress={sendCommand}
+          testID="send-command-button"
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
@@ -132,7 +132,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdLabel]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Result</Text>
         <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
@@ -163,6 +163,9 @@ function MainScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -6,9 +6,10 @@ import {
   useStackNavigationContext,
 } from '@apps/shared/containers/stack';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuBaseAndroid,
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuBaseAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
@@ -250,64 +251,69 @@ function MainScreen() {
   }, [failingIcon, nextPhotoIcon]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Batch Commands</Text>
-      <View style={styles.buttons}>
-        <Button title="Select All (1 event)" onPress={selectAll} />
-        <Button title="Deselect All (1 event)" onPress={deselectAll} />
-        <Button
-          title="Batch across groups (2 events)"
-          onPress={batchAcrossGroups}
-        />
-        <Button
-          title="Single object update (1 event)"
-          onPress={singleObjectUpdate}
-        />
-        <Button
-          title={
-            appleInToolbar ? 'Move Apple to overflow' : 'Move Apple to toolbar'
-          }
-          onPress={toggleAppleShowAsAction}
-        />
-        <Button
-          title="Batch: image + check (atomic)"
-          onPress={batchWithImageLoad}
-        />
-        <Button
-          title="Ordering race (last: Apple absent)"
-          onPress={runOrderingRace}
-        />
-        <Button
-          title="Failing image + follow-up"
-          onPress={runFailingImageRepro}
-        />
-        <Button
-          title="Duplicate id: merge + last icon"
-          onPress={runDuplicateIdRepro}
-        />
-        <Button title="Reset log (menu state kept)" onPress={resetLog} />
-      </View>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Batch Commands</Text>
+        <View style={styles.buttons}>
+          <Button title="Select All (1 event)" onPress={selectAll} />
+          <Button title="Deselect All (1 event)" onPress={deselectAll} />
+          <Button
+            title="Batch across groups (2 events)"
+            onPress={batchAcrossGroups}
+          />
+          <Button
+            title="Single object update (1 event)"
+            onPress={singleObjectUpdate}
+          />
+          <Button
+            title={
+              appleInToolbar
+                ? 'Move Apple to overflow'
+                : 'Move Apple to toolbar'
+            }
+            onPress={toggleAppleShowAsAction}
+          />
+          <Button
+            title="Batch: image + check (atomic)"
+            onPress={batchWithImageLoad}
+          />
+          <Button
+            title="Ordering race (last: Apple absent)"
+            onPress={runOrderingRace}
+          />
+          <Button
+            title="Failing image + follow-up"
+            onPress={runFailingImageRepro}
+          />
+          <Button
+            title="Duplicate id: merge + last icon"
+            onPress={runDuplicateIdRepro}
+          />
+          <Button title="Reset log (menu state kept)" onPress={resetLog} />
+        </View>
 
-      <Text style={styles.hint}>
-        Move Apple to the toolbar to see its loaded icon (overflow items
-        don&apos;t render icons); its checkbox is only visible in the overflow
-        menu. Icon &amp; showAsAction changes emit no events. Menu checked state
-        persists across taps — Reset log clears only the counter and log.
-      </Text>
+        <Text style={styles.hint}>
+          Move Apple to the toolbar to see its loaded icon (overflow items
+          don&apos;t render icons); its checkbox is only visible in the overflow
+          menu. Icon &amp; showAsAction changes emit no events. Menu checked
+          state persists across taps — Reset log clears only the counter and
+          log.
+        </Text>
 
-      <Text style={styles.heading}>Events received: {eventCount}</Text>
-      <Text style={styles.subheading}>Newest first</Text>
-      {eventLog.length === 0 ? (
-        <Text style={styles.result}>—</Text>
-      ) : (
-        eventLog.map((entry, i) => (
-          <Text key={`${i}-${entry}`} style={styles.result}>
-            {i === 0 ? '▶ ' : '  '}
-            {entry}
-          </Text>
-        ))
-      )}
-    </ScrollView>
+        <Text style={styles.heading}>Events received: {eventCount}</Text>
+        <Text style={styles.subheading}>Newest first</Text>
+        {eventLog.length === 0 ? (
+          <Text style={styles.result}>—</Text>
+        ) : (
+          eventLog.map((entry, i) => (
+            <Text key={`${i}-${entry}`} style={styles.result}>
+              {i === 0 ? '▶ ' : '  '}
+              {entry}
+            </Text>
+          ))
+        )}
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -251,7 +251,7 @@ function MainScreen() {
   }, [failingIcon, nextPhotoIcon]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Batch Commands</Text>
         <View style={styles.buttons}>
@@ -318,6 +318,9 @@ function MainScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -7,10 +7,11 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderToolbarMenuElementAndroid,
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuElementOptionsAndroid,
+import {
+  type StackHeaderToolbarMenuElementAndroid,
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 
@@ -163,37 +164,39 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdHidden]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<IdOption>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ID_OPTIONS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdTitleOption>
-        label="title"
-        value={cmdTitle}
-        items={CMD_TITLE_OPTIONS}
-        onValueChange={setCmdTitle}
-      />
-      <SettingsPicker<CmdHiddenOption>
-        label="hidden"
-        value={cmdHidden}
-        items={CMD_HIDDEN_OPTIONS}
-        onValueChange={setCmdHidden}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<IdOption>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ID_OPTIONS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdTitleOption>
+          label="title"
+          value={cmdTitle}
+          items={CMD_TITLE_OPTIONS}
+          onValueChange={setCmdTitle}
+        />
+        <SettingsPicker<CmdHiddenOption>
+          label="hidden"
+          value={cmdHidden}
+          items={CMD_HIDDEN_OPTIONS}
+          onValueChange={setCmdHidden}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Menu Items — Props</Text>
-      <SlotControls
-        slots={slots}
-        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Items — Props</Text>
+        <SlotControls
+          slots={slots}
+          updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -164,7 +164,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdHidden]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Send Command</Text>
         <SettingsPicker<IdOption>
@@ -237,6 +237,9 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -7,10 +7,11 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuBaseAndroid,
-  StackHeaderToolbarMenuElementOptionsAndroid,
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuBaseAndroid,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
@@ -224,35 +225,37 @@ function MainScreen() {
   }, [cmdTargetId, cmdDisabled]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Last Event</Text>
-      <Text style={styles.result}>{lastEvent ?? '—'}</Text>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Last Event</Text>
+        <Text style={styles.result}>{lastEvent ?? '—'}</Text>
 
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<AllIds>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ALL_IDS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdDisabledOption>
-        label="disabled"
-        value={cmdDisabled}
-        items={CMD_DISABLED_OPTIONS}
-        onValueChange={setCmdDisabled}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
-
-      <Text style={styles.heading}>Menu Items — Props</Text>
-      {ALL_IDS.map(id => (
-        <SettingsSwitch
-          key={id}
-          label={`disable ${ITEM_LABELS[id]}`}
-          value={disabledById[id]}
-          onValueChange={v => applyDisabled({ ...disabledById, [id]: v })}
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<AllIds>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ALL_IDS]}
+          onValueChange={setCmdTargetId}
         />
-      ))}
-    </ScrollView>
+        <SettingsPicker<CmdDisabledOption>
+          label="disabled"
+          value={cmdDisabled}
+          items={CMD_DISABLED_OPTIONS}
+          onValueChange={setCmdDisabled}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
+
+        <Text style={styles.heading}>Menu Items — Props</Text>
+        {ALL_IDS.map(id => (
+          <SettingsSwitch
+            key={id}
+            label={`disable ${ITEM_LABELS[id]}`}
+            value={disabledById[id]}
+            onValueChange={v => applyDisabled({ ...disabledById, [id]: v })}
+          />
+        ))}
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -225,7 +225,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdDisabled]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Last Event</Text>
         <Text style={styles.result}>{lastEvent ?? '—'}</Text>
@@ -260,6 +260,9 @@ function MainScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -12,11 +12,12 @@ import {
   useToast,
 } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuBaseAndroid,
-  StackHeaderToolbarMenuElementAndroid,
-  StackHeaderToolbarMenuElementOptionsAndroid,
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuBaseAndroid,
+  type StackHeaderToolbarMenuElementAndroid,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 
@@ -283,56 +284,58 @@ function MainScreen() {
   }, [cmdTargetId, cmdChecked, cmdTitle, cmdHidden]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Last Event</Text>
-      <Text style={styles.result}>{lastEvent ?? '—'}</Text>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Last Event</Text>
+        <Text style={styles.result}>{lastEvent ?? '—'}</Text>
 
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<AllIds>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ALL_IDS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdCheckedOption>
-        label="checked"
-        value={cmdChecked}
-        items={CMD_CHECKED_OPTIONS}
-        onValueChange={setCmdChecked}
-      />
-      <SettingsPicker<CmdTitleOption>
-        label="title"
-        value={cmdTitle}
-        items={CMD_TITLE_OPTIONS}
-        onValueChange={setCmdTitle}
-      />
-      <SettingsPicker<CmdHiddenOption>
-        label="hidden"
-        value={cmdHidden}
-        items={CMD_HIDDEN_OPTIONS}
-        onValueChange={setCmdHidden}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<AllIds>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ALL_IDS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdCheckedOption>
+          label="checked"
+          value={cmdChecked}
+          items={CMD_CHECKED_OPTIONS}
+          onValueChange={setCmdChecked}
+        />
+        <SettingsPicker<CmdTitleOption>
+          label="title"
+          value={cmdTitle}
+          items={CMD_TITLE_OPTIONS}
+          onValueChange={setCmdTitle}
+        />
+        <SettingsPicker<CmdHiddenOption>
+          label="hidden"
+          value={cmdHidden}
+          items={CMD_HIDDEN_OPTIONS}
+          onValueChange={setCmdHidden}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Menu Config — Props</Text>
-      <SettingsSwitch
-        label="singleSelection on colors"
-        value={config.singleSelectionOnColors}
-        onValueChange={v =>
-          applyConfig({ ...config, singleSelectionOnColors: v })
-        }
-      />
-      <SettingsSwitch
-        label="include Blue"
-        value={config.includeBlue}
-        onValueChange={v => applyConfig({ ...config, includeBlue: v })}
-      />
-      <SettingsSwitch
-        label="divider enabled"
-        value={config.dividerEnabled}
-        onValueChange={v => applyConfig({ ...config, dividerEnabled: v })}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Config — Props</Text>
+        <SettingsSwitch
+          label="singleSelection on colors"
+          value={config.singleSelectionOnColors}
+          onValueChange={v =>
+            applyConfig({ ...config, singleSelectionOnColors: v })
+          }
+        />
+        <SettingsSwitch
+          label="include Blue"
+          value={config.includeBlue}
+          onValueChange={v => applyConfig({ ...config, includeBlue: v })}
+        />
+        <SettingsSwitch
+          label="divider enabled"
+          value={config.dividerEnabled}
+          onValueChange={v => applyConfig({ ...config, dividerEnabled: v })}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -284,7 +284,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdChecked, cmdTitle, cmdHidden]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Last Event</Text>
         <Text style={styles.result}>{lastEvent ?? '—'}</Text>
@@ -340,6 +340,9 @@ function MainScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -262,7 +262,7 @@ function MainScreen() {
   ]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Send Command</Text>
         <SettingsPicker<IdOption>
@@ -388,6 +388,9 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -8,10 +8,11 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuItemAndroid,
-  StackHeaderToolbarMenuElementOptionsAndroid,
+import {
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuItemAndroid,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
@@ -261,61 +262,63 @@ function MainScreen() {
   ]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<IdOption>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ID_OPTIONS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdIconOption>
-        label="icon"
-        value={cmdIcon}
-        items={CMD_ICON_OPTIONS}
-        onValueChange={setCmdIcon}
-      />
-      <SettingsPicker<CmdTintColorOption>
-        label="tintColorNormal"
-        value={cmdTintColorNormal}
-        items={CMD_TINT_COLOR_OPTIONS}
-        onValueChange={setCmdTintColorNormal}
-      />
-      <SettingsPicker<CmdTintColorOption>
-        label="tintColorPressed"
-        value={cmdTintColorPressed}
-        items={CMD_TINT_COLOR_OPTIONS}
-        onValueChange={setCmdTintColorPressed}
-      />
-      <SettingsPicker<CmdTintColorOption>
-        label="tintColorFocused"
-        value={cmdTintColorFocused}
-        items={CMD_TINT_COLOR_OPTIONS}
-        onValueChange={setCmdTintColorFocused}
-      />
-      <SettingsPicker<CmdTintColorOption>
-        label="tintColorDisabled"
-        value={cmdTintColorDisabled}
-        items={CMD_TINT_COLOR_OPTIONS}
-        onValueChange={setCmdTintColorDisabled}
-      />
-      <SettingsPicker<CmdDisabledOption>
-        label="disabled"
-        value={cmdDisabled}
-        items={CMD_DISABLED_OPTIONS}
-        onValueChange={setCmdDisabled}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<IdOption>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ID_OPTIONS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdIconOption>
+          label="icon"
+          value={cmdIcon}
+          items={CMD_ICON_OPTIONS}
+          onValueChange={setCmdIcon}
+        />
+        <SettingsPicker<CmdTintColorOption>
+          label="tintColorNormal"
+          value={cmdTintColorNormal}
+          items={CMD_TINT_COLOR_OPTIONS}
+          onValueChange={setCmdTintColorNormal}
+        />
+        <SettingsPicker<CmdTintColorOption>
+          label="tintColorPressed"
+          value={cmdTintColorPressed}
+          items={CMD_TINT_COLOR_OPTIONS}
+          onValueChange={setCmdTintColorPressed}
+        />
+        <SettingsPicker<CmdTintColorOption>
+          label="tintColorFocused"
+          value={cmdTintColorFocused}
+          items={CMD_TINT_COLOR_OPTIONS}
+          onValueChange={setCmdTintColorFocused}
+        />
+        <SettingsPicker<CmdTintColorOption>
+          label="tintColorDisabled"
+          value={cmdTintColorDisabled}
+          items={CMD_TINT_COLOR_OPTIONS}
+          onValueChange={setCmdTintColorDisabled}
+        />
+        <SettingsPicker<CmdDisabledOption>
+          label="disabled"
+          value={cmdDisabled}
+          items={CMD_DISABLED_OPTIONS}
+          onValueChange={setCmdDisabled}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Menu Items — Props</Text>
-      <SlotControls
-        slots={slots}
-        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Items — Props</Text>
+        <SlotControls
+          slots={slots}
+          updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -191,7 +191,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdIcon, cmdShowAsAction]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Send Command</Text>
         <SettingsPicker<IdOption>
@@ -264,6 +264,9 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -7,11 +7,12 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker, SettingsSwitch } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderToolbarMenuElementAndroid,
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuElementOptionsAndroid,
-  StackHeaderToolbarMenuItemShowAsActionAndroid,
+import {
+  type StackHeaderToolbarMenuElementAndroid,
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  type StackHeaderToolbarMenuItemShowAsActionAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
@@ -190,37 +191,39 @@ function MainScreen() {
   }, [cmdTargetId, cmdIcon, cmdShowAsAction]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<IdOption>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ID_OPTIONS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdIconOption>
-        label="icon"
-        value={cmdIcon}
-        items={CMD_ICON_OPTIONS}
-        onValueChange={setCmdIcon}
-      />
-      <SettingsPicker<CmdShowAsActionOption>
-        label="showAsAction"
-        value={cmdShowAsAction}
-        items={CMD_SHOW_AS_ACTION_OPTIONS}
-        onValueChange={setCmdShowAsAction}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<IdOption>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ID_OPTIONS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdIconOption>
+          label="icon"
+          value={cmdIcon}
+          items={CMD_ICON_OPTIONS}
+          onValueChange={setCmdIcon}
+        />
+        <SettingsPicker<CmdShowAsActionOption>
+          label="showAsAction"
+          value={cmdShowAsAction}
+          items={CMD_SHOW_AS_ACTION_OPTIONS}
+          onValueChange={setCmdShowAsAction}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Menu Items — Props</Text>
-      <SlotControls
-        slots={slots}
-        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Items — Props</Text>
+        <SlotControls
+          slots={slots}
+          updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -236,7 +236,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdCondensed, cmdTooltip]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Send Command</Text>
         <SettingsPicker<IdOption>
@@ -322,6 +322,9 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -7,11 +7,12 @@ import {
 } from '@apps/shared/containers/stack';
 import { SettingsPicker } from '@apps/shared';
 import { Colors } from '@apps/shared/styling';
-import type {
-  StackHeaderToolbarMenuElementAndroid,
-  StackHeaderConfigRef,
-  StackHeaderToolbarMenuElementOptionsAndroid,
-  StackHeaderToolbarMenuItemShowAsActionAndroid,
+import {
+  type StackHeaderToolbarMenuElementAndroid,
+  type StackHeaderConfigRef,
+  type StackHeaderToolbarMenuElementOptionsAndroid,
+  type StackHeaderToolbarMenuItemShowAsActionAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import type { PlatformIconAndroid } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
@@ -235,43 +236,45 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdCondensed, cmdTooltip]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<IdOption>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ID_OPTIONS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdTitleOption>
-        label="title"
-        value={cmdTitle}
-        items={CMD_TITLE_OPTIONS}
-        onValueChange={setCmdTitle}
-      />
-      <SettingsPicker<CmdCondensedOption>
-        label="titleCondensed"
-        value={cmdCondensed}
-        items={CMD_CONDENSED_OPTIONS}
-        onValueChange={setCmdCondensed}
-      />
-      <SettingsPicker<CmdTooltipOption>
-        label="tooltipText"
-        value={cmdTooltip}
-        items={CMD_TOOLTIP_OPTIONS}
-        onValueChange={setCmdTooltip}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<IdOption>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ID_OPTIONS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdTitleOption>
+          label="title"
+          value={cmdTitle}
+          items={CMD_TITLE_OPTIONS}
+          onValueChange={setCmdTitle}
+        />
+        <SettingsPicker<CmdCondensedOption>
+          label="titleCondensed"
+          value={cmdCondensed}
+          items={CMD_CONDENSED_OPTIONS}
+          onValueChange={setCmdCondensed}
+        />
+        <SettingsPicker<CmdTooltipOption>
+          label="tooltipText"
+          value={cmdTooltip}
+          items={CMD_TOOLTIP_OPTIONS}
+          onValueChange={setCmdTooltip}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Menu Items — Props</Text>
-      <SlotControls
-        slots={slots}
-        updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Items — Props</Text>
+        <SlotControls
+          slots={slots}
+          updateSlot={(i, patch) => applySlots(updateSlotAt(slots, i, patch))}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -11,6 +11,7 @@ import {
   type StackHeaderConfigRef,
   type StackHeaderToolbarMenuElementAndroid,
   type StackHeaderToolbarMenuElementOptionsAndroid,
+  ScrollViewMarker,
 } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 
@@ -257,66 +258,68 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdHidden, cmdMenuTitle]);
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
-      <Text style={styles.heading}>Result</Text>
-      <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+    <ScrollViewMarker>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Result</Text>
+        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
 
-      <Text style={styles.heading}>Send Command</Text>
-      <SettingsPicker<AllIds>
-        label="target id"
-        value={cmdTargetId}
-        items={[...ALL_IDS]}
-        onValueChange={setCmdTargetId}
-      />
-      <SettingsPicker<CmdTitleOption>
-        label="title"
-        value={cmdTitle}
-        items={CMD_TITLE_OPTIONS}
-        onValueChange={setCmdTitle}
-      />
-      <SettingsPicker<CmdHiddenOption>
-        label="hidden"
-        value={cmdHidden}
-        items={CMD_HIDDEN_OPTIONS}
-        onValueChange={setCmdHidden}
-      />
-      <SettingsPicker<CmdMenuTitleOption>
-        label="menuTitle"
-        value={cmdMenuTitle}
-        items={CMD_MENU_TITLE_OPTIONS}
-        onValueChange={setCmdMenuTitle}
-      />
-      <Button title="Send Command" onPress={sendCommand} />
+        <Text style={styles.heading}>Send Command</Text>
+        <SettingsPicker<AllIds>
+          label="target id"
+          value={cmdTargetId}
+          items={[...ALL_IDS]}
+          onValueChange={setCmdTargetId}
+        />
+        <SettingsPicker<CmdTitleOption>
+          label="title"
+          value={cmdTitle}
+          items={CMD_TITLE_OPTIONS}
+          onValueChange={setCmdTitle}
+        />
+        <SettingsPicker<CmdHiddenOption>
+          label="hidden"
+          value={cmdHidden}
+          items={CMD_HIDDEN_OPTIONS}
+          onValueChange={setCmdHidden}
+        />
+        <SettingsPicker<CmdMenuTitleOption>
+          label="menuTitle"
+          value={cmdMenuTitle}
+          items={CMD_MENU_TITLE_OPTIONS}
+          onValueChange={setCmdMenuTitle}
+        />
+        <Button title="Send Command" onPress={sendCommand} />
 
-      <Text style={styles.heading}>Menu Structure — Props</Text>
-      <SettingsSwitch
-        label="include submenu-1"
-        value={config.includeSubmenu1}
-        onValueChange={v => applyConfig({ ...config, includeSubmenu1: v })}
-      />
-      <SettingsPicker<Submenu1TitleOption>
-        label="submenu-1 title"
-        value={config.submenu1Title}
-        items={[...SUBMENU1_TITLE_OPTIONS]}
-        onValueChange={v => applyConfig({ ...config, submenu1Title: v })}
-      />
-      <SettingsPicker<Submenu1MenuTitleOption>
-        label="submenu-1 menuTitle"
-        value={config.submenu1MenuTitle}
-        items={[...SUBMENU1_MENU_TITLE_OPTIONS]}
-        onValueChange={v => applyConfig({ ...config, submenu1MenuTitle: v })}
-      />
-      <SettingsSwitch
-        label="add extra item to submenu-1"
-        value={config.addExtraItem}
-        onValueChange={v => applyConfig({ ...config, addExtraItem: v })}
-      />
-      <SettingsSwitch
-        label="include submenu-2"
-        value={config.includeSubmenu2}
-        onValueChange={v => applyConfig({ ...config, includeSubmenu2: v })}
-      />
-    </ScrollView>
+        <Text style={styles.heading}>Menu Structure — Props</Text>
+        <SettingsSwitch
+          label="include submenu-1"
+          value={config.includeSubmenu1}
+          onValueChange={v => applyConfig({ ...config, includeSubmenu1: v })}
+        />
+        <SettingsPicker<Submenu1TitleOption>
+          label="submenu-1 title"
+          value={config.submenu1Title}
+          items={[...SUBMENU1_TITLE_OPTIONS]}
+          onValueChange={v => applyConfig({ ...config, submenu1Title: v })}
+        />
+        <SettingsPicker<Submenu1MenuTitleOption>
+          label="submenu-1 menuTitle"
+          value={config.submenu1MenuTitle}
+          items={[...SUBMENU1_MENU_TITLE_OPTIONS]}
+          onValueChange={v => applyConfig({ ...config, submenu1MenuTitle: v })}
+        />
+        <SettingsSwitch
+          label="add extra item to submenu-1"
+          value={config.addExtraItem}
+          onValueChange={v => applyConfig({ ...config, addExtraItem: v })}
+        />
+        <SettingsSwitch
+          label="include submenu-2"
+          value={config.includeSubmenu2}
+          onValueChange={v => applyConfig({ ...config, includeSubmenu2: v })}
+        />
+      </ScrollView>
+    </ScrollViewMarker>
   );
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -258,7 +258,7 @@ function MainScreen() {
   }, [cmdTargetId, cmdTitle, cmdHidden, cmdMenuTitle]);
 
   return (
-    <ScrollViewMarker>
+    <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={styles.heading}>Result</Text>
         <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
@@ -324,6 +324,9 @@ function MainScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
   scroll: {
     backgroundColor: Colors.cardBackground,
   },

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -661,6 +661,24 @@ export interface StackHeaderConfigPropsAndroid {
    */
   scrollFlagSnap?: boolean | undefined;
   /**
+   * @summary Whether the app bar lifts (applies a tonal/elevation shift) when
+   * content is scrolled beneath it.
+   *
+   * @description
+   * For reliable behavior the content scroll view should be designated with a
+   * `ScrollViewMarker`. Without it, the app bar cannot always locate the scroll
+   * view, which can cause the lifted state to flicker while scrolling.
+   *
+   * @remarks
+   * Has no effect while the header is `transparent` (there is no scrolling
+   * content behavior installed in that mode).
+   *
+   * @default true
+   *
+   * @platform android
+   */
+  liftOnScroll?: boolean | undefined;
+  /**
    * @summary Toolbar menu configuration.
    *
    * @description

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -670,6 +670,12 @@ export interface StackHeaderConfigPropsAndroid {
    * view, which can cause the lifted state to flicker while scrolling.
    *
    * @remarks
+   * Applies to the `small` header only. For `medium` and `large` headers the
+   * Material `CollapsingToolbarLayout` uses a fade title-collapse mode that
+   * installs its own content scrim and disables the app bar's lift-on-scroll,
+   * so this prop has no effect there. The collapsed appearance of those headers
+   * is instead controlled by that content scrim, which is not exposed yet.
+   *
    * Has no effect while the header is `transparent` (there is no scrolling
    * content behavior installed in that mode).
    *

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -103,6 +103,8 @@ export interface NativeProps extends ViewProps {
   scrollFlagExitUntilCollapsed?: CT.WithDefault<boolean, false>;
   scrollFlagSnap?: CT.WithDefault<boolean, false>;
 
+  liftOnScroll?: CT.WithDefault<boolean, true>;
+
   toolbarMenu?: UnsafeMixed<StackHeaderToolbarMenuBaseAndroid> | undefined;
   toolbarMenuGroupDividerEnabled?: CT.WithDefault<boolean, false>;
   onToolbarMenuItemPress?:


### PR DESCRIPTION
## Description

Adds support for controlling `liftOnScroll` property. It is relevant only for `small` non-transparent header. `medium` and `large` headers use content scrim and disable `liftOnScroll` in its Material implementation. Customizing content scrim will be exposed to the user in future PRs.

Integrates with ScrollViewMarker in order to set valid `liftOnScrollTargetView` (content scroll view) which mitigates `small` header flashes when `scrollFlagsScroll` is enabled.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1422.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/893.

## Changes

- expose `liftOnScroll` property and handle it in native implementation with separate invalidation flag
- integrate with SVM
  - notify `StackHeaderConfig` when new `ScrollView` is attached to `StackScreen`
  - find content scroll view in `StackHeaderCoordinatorLayout` by using `stackScreen.findContentScrollView`
- adapt previous Android Stack v5 tests to use SVM

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/1a66bcf4-0420-4667-9092-d9adf77e7738" /> | <video src="https://github.com/user-attachments/assets/79d5a3ce-1dc7-4431-89d5-1ee23fd7473c" /> |

## Test plan

Run `test-stack-svm-lift-on-scroll` CIT and `test-stack-lift-on-scroll-android` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
