### PR TITLE
feat(Android, Stack v5): add support for subtitle and title/subtitle positioning

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -1,8 +1,8 @@
 package com.swmansion.rnscreens.stack.header
 
+import android.annotation.SuppressLint
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
-import android.text.TextUtils
 import android.util.Log
 import android.view.Gravity
 import android.view.View
@@ -15,8 +15,6 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.widget.TextViewCompat
-import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS_COLLAPSED
@@ -44,7 +42,12 @@ internal class StackHeaderApplicator(
         coordinatorLayout: StackHeaderCoordinatorLayout,
         config: StackHeaderConfigurationProviding,
     ): StackHeaderAppBarLayout {
-        val appBar = StackHeaderAppBarLayout.create(wrappedContext, config.type)
+        val appBar =
+            StackHeaderAppBarLayout.create(
+                wrappedContext,
+                config.type,
+                config.collapsedTitleGravityMode,
+            )
 
         if (config.transparent) {
             coordinatorLayout.removeContentBehavior()
@@ -85,30 +88,21 @@ internal class StackHeaderApplicator(
             toolbar.addView(it.view, Toolbar.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity.END))
         }
 
-        populateTitleOrCenter(appBar, toolbar, config)
+        populateCenterSubview(appBar, toolbar, config)
         populateBackground(appBar, config)
     }
 
-    private fun populateTitleOrCenter(
+    private fun populateCenterSubview(
         appBar: StackHeaderAppBarLayout,
         toolbar: Toolbar,
         config: StackHeaderConfigurationProviding,
     ) {
-        val centerSubview = config.centerSubview
-        if (centerSubview != null) {
-            if (appBar is StackHeaderAppBarLayout.Small) {
-                centerSubview.view.detachFromCurrentParent()
-                toolbar.addView(centerSubview.view, Toolbar.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity.CENTER_HORIZONTAL))
-            } else {
-                Log.e(TAG, "[RNScreens] Center subview is supported only for small header type.")
-            }
-        } else if (appBar is StackHeaderAppBarLayout.Small) {
-            // Small header needs a managed title view because we can't use Toolbar's native
-            // title — it would be laid out to the leading side of leading subview.
-            val titleView = createManagedTitleView(toolbar)
-            appBar.managedTitleView = titleView
-            val index = if (config.isRTL) 0 else -1
-            toolbar.addView(titleView, index, Toolbar.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity.START))
+        val centerSubview = config.centerSubview ?: return
+        if (appBar is StackHeaderAppBarLayout.Small) {
+            centerSubview.view.detachFromCurrentParent()
+            toolbar.addView(centerSubview.view, Toolbar.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity.CENTER_HORIZONTAL))
+        } else {
+            Log.e(TAG, "[RNScreens] Center subview is supported only for small header type.")
         }
     }
 
@@ -145,47 +139,60 @@ internal class StackHeaderApplicator(
         )
     }
 
-    private fun createManagedTitleView(toolbar: Toolbar): AppCompatTextView =
-        AppCompatTextView(toolbar.context).apply {
-            setSingleLine()
-            ellipsize = TextUtils.TruncateAt.END
-            TextViewCompat.setTextAppearance(
-                this,
-                R.style.TextAppearance_Material3_TitleLarge,
-            )
-            layoutParams =
-                Toolbar
-                    .LayoutParams(
-                        WRAP_CONTENT,
-                        WRAP_CONTENT,
-                        Gravity.START,
-                    ).apply {
-                        // TODO: there seems to be a problem with collapsing margins.
-                        //       We will expose customization either way but we should
-                        //       have consistent behavior and defaults.
-                        marginStart = toolbar.titleMarginStart + toolbar.contentInsetStart
-                        marginEnd = toolbar.titleMarginEnd
-                        topMargin = toolbar.titleMarginTop
-                        bottomMargin = toolbar.titleMarginBottom
-                    }
-        }
-
     // endregion
 
     // region In-place updates
 
-    internal fun applyTitle(
+    // ctl.setMaxLines() is listed in Material docs in the same way as other props but for some
+    // reason it's restricted.
+    @SuppressLint("RestrictedApi")
+    internal fun applyTitleAndSubtitle(
         appBar: StackHeaderAppBarLayout,
         config: StackHeaderConfigurationProviding,
     ) {
         when (appBar) {
             is StackHeaderAppBarLayout.Small -> {
-                appBar.managedTitleView?.text = config.title
-                appBar.managedTitleView?.requestLayout()
+                appBar.toolbar.title = config.title
+                appBar.toolbar.subtitle = config.subtitle
             }
 
             is StackHeaderAppBarLayout.Collapsing -> {
-                appBar.collapsingToolbarLayout.title = config.title
+                val ctl = appBar.collapsingToolbarLayout
+
+                // Due to a bug in Material's CollapsingToolbarLayout implementation, showing
+                // subtitle in runtime while header is collapsed results in incorrect scroll offset
+                // unless more than 1 line is used. See CollapsingToolbarLayout.java:783
+                // (material-1.14.0). For now, we're hardcoding number of lines to 2. In the future,
+                // we're planning to expose this prop to the user. We should consider what the
+                // default value should be.
+                ctl.maxLines = 2
+
+                ctl.title = config.title
+                ctl.subtitle = config.subtitle
+
+                // setText only recomputes draw offsets within the existing bounds; the
+                // title/subtitle vertical split is recomputed only in onLayout. Force a layout
+                // so toggling the subtitle at runtime reclaims the title space.
+                ctl.requestLayout()
+            }
+        }
+    }
+
+    internal fun applyTitlePositioning(
+        appBar: StackHeaderAppBarLayout,
+        config: StackHeaderConfigurationProviding,
+    ) {
+        when (appBar) {
+            is StackHeaderAppBarLayout.Small -> {
+                appBar.toolbar.isTitleCentered = config.titleCentered
+                appBar.toolbar.isSubtitleCentered = config.subtitleCentered
+            }
+
+            is StackHeaderAppBarLayout.Collapsing -> {
+                appBar.collapsingToolbarLayout.expandedTitleGravity =
+                    config.expandedTitleHorizontalGravity or config.expandedTitleVerticalGravity
+                appBar.collapsingToolbarLayout.collapsedTitleGravity =
+                    config.collapsedTitleHorizontalGravity or config.collapsedTitleVerticalGravity
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.AppCompatImageView
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.graphics.drawable.DrawableCompat
 import com.google.android.material.appbar.AppBarLayout

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -182,8 +182,13 @@ internal class StackHeaderCoordinatorLayout(
         val appBar = appBarLayout
         if (appBar != null) {
             if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE)) {
-                applicator.applyTitle(appBar, provider)
+                applicator.applyTitleAndSubtitle(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE)
+            }
+
+            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE_POSITIONING)) {
+                applicator.applyTitlePositioning(appBar, provider)
+                provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE_POSITIONING)
             }
 
             if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.BACK_BUTTON)) {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -2,14 +2,14 @@ package com.swmansion.rnscreens.stack.header.appbar
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.LayoutInflater
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
+import com.swmansion.rnscreens.stack.header.config.StackHeaderCollapsedTitleGravityMode
 import com.swmansion.rnscreens.stack.header.config.StackHeaderType
 import com.swmansion.rnscreens.utils.resolveDimensionAttr
 
@@ -38,9 +38,6 @@ internal sealed class StackHeaderAppBarLayout(
                 layoutParams = LayoutParams(MATCH_PARENT, WRAP_CONTENT)
             }
 
-        // We need to manually manage the title to handle leading subview's positioning.
-        internal var managedTitleView: AppCompatTextView? = null
-
         init {
             addView(toolbar)
         }
@@ -50,6 +47,7 @@ internal sealed class StackHeaderAppBarLayout(
     internal class Collapsing(
         context: Context,
         val type: StackHeaderType,
+        collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode,
     ) : StackHeaderAppBarLayout(context) {
         override val toolbar =
             MaterialToolbar(context).apply {
@@ -64,25 +62,15 @@ internal sealed class StackHeaderAppBarLayout(
                         }
             }
 
+        // collapsedTitleGravityMode is a construction-time-only attr (no public setter), so both
+        // gravity modes are inflated from XML — differing only in that attribute — to stay 1:1.
         internal val collapsingToolbarLayout: CollapsingToolbarLayout =
-            run {
-                val (styleAttr, sizeAttr) =
-                    when (type) {
-                        StackHeaderType.MEDIUM ->
-                            Pair(R.attr.collapsingToolbarLayoutMediumStyle, R.attr.collapsingToolbarLayoutMediumSize)
-                        StackHeaderType.LARGE ->
-                            Pair(R.attr.collapsingToolbarLayoutLargeStyle, R.attr.collapsingToolbarLayoutLargeSize)
-                        else -> error("[RNScreens] Invalid header mode.")
-                    }
-                CollapsingToolbarLayout(context, null, styleAttr).apply {
-                    layoutParams =
-                        LayoutParams(
-                            MATCH_PARENT,
-                            resolveDimensionAttr(context, sizeAttr),
-                        )
-                    addView(toolbar)
-                }
-            }
+            (
+                LayoutInflater
+                    .from(context)
+                    .inflate(layoutResFor(type, collapsedTitleGravityMode), this, false)
+                    as CollapsingToolbarLayout
+            ).apply { addView(toolbar) }
 
         init {
             require(
@@ -93,16 +81,42 @@ internal sealed class StackHeaderAppBarLayout(
             }
             addView(collapsingToolbarLayout)
         }
+
+        private companion object {
+            fun layoutResFor(
+                type: StackHeaderType,
+                mode: StackHeaderCollapsedTitleGravityMode,
+            ): Int =
+                when (type) {
+                    StackHeaderType.MEDIUM ->
+                        when (mode) {
+                            StackHeaderCollapsedTitleGravityMode.ENTIRE_SPACE ->
+                                com.swmansion.rnscreens.R.layout.rns_collapsing_toolbar_medium_entire_space
+                            StackHeaderCollapsedTitleGravityMode.AVAILABLE_SPACE ->
+                                com.swmansion.rnscreens.R.layout.rns_collapsing_toolbar_medium_available_space
+                        }
+                    StackHeaderType.LARGE ->
+                        when (mode) {
+                            StackHeaderCollapsedTitleGravityMode.ENTIRE_SPACE ->
+                                com.swmansion.rnscreens.R.layout.rns_collapsing_toolbar_large_entire_space
+                            StackHeaderCollapsedTitleGravityMode.AVAILABLE_SPACE ->
+                                com.swmansion.rnscreens.R.layout.rns_collapsing_toolbar_large_available_space
+                        }
+                    else -> error("[RNScreens] Invalid header mode.")
+                }
+        }
     }
 
     companion object {
         fun create(
             context: Context,
             type: StackHeaderType,
+            collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode,
         ): StackHeaderAppBarLayout =
             when (type) {
                 StackHeaderType.SMALL -> Small(context)
-                StackHeaderType.MEDIUM, StackHeaderType.LARGE -> Collapsing(context, type)
+                StackHeaderType.MEDIUM, StackHeaderType.LARGE ->
+                    Collapsing(context, type, collapsedTitleGravityMode)
             }
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderCollapsedTitleGravityMode.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderCollapsedTitleGravityMode.kt
@@ -1,0 +1,6 @@
+package com.swmansion.rnscreens.stack.header.config
+
+internal enum class StackHeaderCollapsedTitleGravityMode {
+    ENTIRE_SPACE,
+    AVAILABLE_SPACE,
+}

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -214,7 +214,7 @@ internal class StackHeaderConfig(
         internal set
 
     override var collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode
-        by Delegates.observable(StackHeaderCollapsedTitleGravityMode.ENTIRE_SPACE) { _, old, new ->
+        by Delegates.observable(StackHeaderCollapsedTitleGravityMode.AVAILABLE_SPACE) { _, old, new ->
             if (old != new) invalidate(StackHeaderInvalidationFlags.STRUCTURE)
         }
         internal set

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -3,6 +3,7 @@ package com.swmansion.rnscreens.stack.header.config
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 import android.util.LayoutDirection
+import android.view.Gravity
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
@@ -77,6 +78,11 @@ internal class StackHeaderConfig(
         internal set
 
     override var title: String by Delegates.observable("") { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE)
+    }
+        internal set
+
+    override var subtitle: String by Delegates.observable("") { _, old, new ->
         if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE)
     }
         internal set
@@ -175,6 +181,42 @@ internal class StackHeaderConfig(
     override var toolbarMenuGroupDividerEnabled: Boolean by Delegates.observable(false) { _, old, new ->
         if (old != new) invalidate(StackHeaderInvalidationFlags.TOOLBAR_MENU)
     }
+        internal set
+
+    override var titleCentered: Boolean by Delegates.observable(false) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var subtitleCentered: Boolean by Delegates.observable(false) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var expandedTitleHorizontalGravity: Int by Delegates.observable(Gravity.START) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var expandedTitleVerticalGravity: Int by Delegates.observable(Gravity.BOTTOM) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var collapsedTitleHorizontalGravity: Int by Delegates.observable(Gravity.START) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var collapsedTitleVerticalGravity: Int by Delegates.observable(Gravity.CENTER_VERTICAL) { _, old, new ->
+        if (old != new) invalidate(StackHeaderInvalidationFlags.TITLE_POSITIONING)
+    }
+        internal set
+
+    override var collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode
+        by Delegates.observable(StackHeaderCollapsedTitleGravityMode.ENTIRE_SPACE) { _, old, new ->
+            if (old != new) invalidate(StackHeaderInvalidationFlags.STRUCTURE)
+        }
         internal set
 
     override val isRTL: Boolean

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.stack.header.config
 
 import android.util.Log
+import android.view.Gravity
 import android.view.View
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
@@ -126,6 +127,69 @@ internal open class StackHeaderConfigViewManager :
         value: String?,
     ) {
         view.title = value ?: ""
+    }
+
+    override fun setSubtitle(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.subtitle = value ?: ""
+    }
+
+    override fun setTitleCentered(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.titleCentered = value
+    }
+
+    override fun setSubtitleCentered(
+        view: StackHeaderConfig,
+        value: Boolean,
+    ) {
+        view.subtitleCentered = value
+    }
+
+    override fun setExpandedTitleHorizontalGravity(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.expandedTitleHorizontalGravity = parseHorizontalGravity(value)
+    }
+
+    override fun setExpandedTitleVerticalGravity(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.expandedTitleVerticalGravity = parseVerticalGravity(value)
+    }
+
+    override fun setCollapsedTitleHorizontalGravity(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.collapsedTitleHorizontalGravity = parseHorizontalGravity(value)
+    }
+
+    override fun setCollapsedTitleVerticalGravity(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.collapsedTitleVerticalGravity = parseVerticalGravity(value)
+    }
+
+    override fun setCollapsedTitleGravityMode(
+        view: StackHeaderConfig,
+        value: String?,
+    ) {
+        view.collapsedTitleGravityMode =
+            when (value) {
+                "entireSpace" -> StackHeaderCollapsedTitleGravityMode.ENTIRE_SPACE
+                "availableSpace" -> StackHeaderCollapsedTitleGravityMode.AVAILABLE_SPACE
+                else -> throw JSApplicationIllegalArgumentException(
+                    "[RNScreens] Invalid StackHeaderConfig collapsedTitleGravityMode: $value.",
+                )
+            }
     }
 
     override fun setHidden(
@@ -303,6 +367,26 @@ internal open class StackHeaderConfigViewManager :
         }
         view.dispatchMenuElementUpdates(parsed)
     }
+
+    private fun parseHorizontalGravity(value: String?): Int =
+        when (value) {
+            "start" -> Gravity.START
+            "center" -> Gravity.CENTER_HORIZONTAL
+            "end" -> Gravity.END
+            else -> throw JSApplicationIllegalArgumentException(
+                "[RNScreens] Invalid StackHeaderConfig title horizontal gravity: $value.",
+            )
+        }
+
+    private fun parseVerticalGravity(value: String?): Int =
+        when (value) {
+            "top" -> Gravity.TOP
+            "center" -> Gravity.CENTER_VERTICAL
+            "bottom" -> Gravity.BOTTOM
+            else -> throw JSApplicationIllegalArgumentException(
+                "[RNScreens] Invalid StackHeaderConfig title vertical gravity: $value.",
+            )
+        }
 
     companion object {
         private const val TAG = "StackHeaderConfigViewManager"

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -7,6 +7,7 @@ import com.swmansion.rnscreens.stack.header.toolbar.model.StackHeaderToolbarMenu
 internal interface StackHeaderConfigurationProviding {
     val type: StackHeaderType
     val title: String
+    val subtitle: String
     val hidden: Boolean
     val transparent: Boolean
     val backButtonHidden: Boolean
@@ -30,6 +31,15 @@ internal interface StackHeaderConfigurationProviding {
     val backgroundSubview: StackHeaderSubviewProviding?
     val toolbarMenu: StackHeaderToolbarMenuConfig
     val toolbarMenuGroupDividerEnabled: Boolean
+
+    val titleCentered: Boolean
+    val subtitleCentered: Boolean
+    val expandedTitleHorizontalGravity: Int
+    val expandedTitleVerticalGravity: Int
+    val collapsedTitleHorizontalGravity: Int
+    val collapsedTitleVerticalGravity: Int
+    val collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode
+
     val isRTL: Boolean
 
     val invalidationFlags: StackHeaderInvalidationFlags

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
@@ -14,8 +14,8 @@ internal value class StackHeaderInvalidationFlags(
         val TOOLBAR_MENU = StackHeaderInvalidationFlags(1 shl 5)
         val LIFT_ON_SCROLL = StackHeaderInvalidationFlags(1 shl 6)
         val OVERFLOW_ICON = StackHeaderInvalidationFlags(1 shl 7)
-
-        val APPEARANCE = TITLE or BACK_BUTTON or OVERFLOW_ICON
+        val TITLE_POSITIONING = StackHeaderInvalidationFlags(1 shl 8)
+        val APPEARANCE = TITLE or BACK_BUTTON or OVERFLOW_ICON or TITLE_POSITIONING
         val ALL = STRUCTURE or SUBVIEWS or APPEARANCE or SCROLL_FLAGS or TOOLBAR_MENU or LIFT_ON_SCROLL
     }
 

--- a/android/src/main/res/base/layout/rns_collapsing_toolbar_large_available_space.xml
+++ b/android/src/main/res/base/layout/rns_collapsing_toolbar_large_available_space.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.CollapsingToolbarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/collapsingToolbarLayoutLargeStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/collapsingToolbarLayoutLargeSize"
+    app:collapsedTitleGravityMode="availableSpace" />

--- a/android/src/main/res/base/layout/rns_collapsing_toolbar_large_entire_space.xml
+++ b/android/src/main/res/base/layout/rns_collapsing_toolbar_large_entire_space.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.CollapsingToolbarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/collapsingToolbarLayoutLargeStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/collapsingToolbarLayoutLargeSize"
+    app:collapsedTitleGravityMode="entireSpace" />

--- a/android/src/main/res/base/layout/rns_collapsing_toolbar_medium_available_space.xml
+++ b/android/src/main/res/base/layout/rns_collapsing_toolbar_medium_available_space.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.CollapsingToolbarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/collapsingToolbarLayoutMediumStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+    app:collapsedTitleGravityMode="availableSpace" />

--- a/android/src/main/res/base/layout/rns_collapsing_toolbar_medium_entire_space.xml
+++ b/android/src/main/res/base/layout/rns_collapsing_toolbar_medium_entire_space.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.CollapsingToolbarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/collapsingToolbarLayoutMediumStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+    app:collapsedTitleGravityMode="entireSpace" />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -85,7 +85,7 @@ const DEFAULT_CONFIG: Config = {
   expandedTitleVerticalGravity: 'bottom',
   collapsedTitleHorizontalGravity: 'start',
   collapsedTitleVerticalGravity: 'center',
-  collapsedTitleGravityMode: 'entireSpace',
+  collapsedTitleGravityMode: 'availableSpace',
   leadingSize: 'none',
   centerSize: 'none',
   trailingSize: 'none',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -21,6 +21,9 @@ import LongText from '@apps/shared/LongText';
 import {
   type StackHeaderConfigProps,
   type StackHeaderTypeAndroid,
+  type StackHeaderTitleHorizontalGravityAndroid,
+  type StackHeaderTitleVerticalGravityAndroid,
+  type StackHeaderCollapsedTitleGravityModeAndroid,
   type StackHeaderBackgroundSubviewCollapseModeAndroid,
   ScrollViewMarker,
 } from 'react-native-screens';
@@ -30,10 +33,15 @@ const LONG_TITLE = I18nManager.isRTL
   ? 'عنوان طويل جدا يجب أن يتم اقتطاعه عندما لا تتوفر مساحة كافية لعرضه بالكامل'
   : 'A Very Long Title That Should Ellipsize When There Is Not Enough Space Available';
 
-type SubviewSize = 'none' | 'sm' | 'md' | 'lg';
+const SHORT_SUBTITLE = I18nManager.isRTL ? 'عنوان فرعي' : 'Subtitle';
+const LONG_SUBTITLE = I18nManager.isRTL
+  ? 'عنوان فرعي طويل جدا يجب أن يتم اقتطاعه عندما لا تتوفر مساحة كافية لعرضه'
+  : 'A Very Long Subtitle That Should Ellipsize When There Is Not Enough Space';
+
+type SubviewSize = 'none' | 'sm' | 'md' | 'lg' | 'xl';
 type HitSlopValue = '0' | '10' | '30';
 type PressRetentionValue = '0' | '20' | '50';
-type TitleOption = 'short' | 'long';
+type TextOption = 'undefined' | 'short' | 'long';
 type ScrollFlagValue = 'undefined' | 'true' | 'false';
 
 interface Config {
@@ -41,7 +49,15 @@ interface Config {
   type: StackHeaderTypeAndroid;
   transparent: boolean;
   hidden: boolean;
-  title: TitleOption;
+  title: TextOption;
+  subtitle: TextOption;
+  titleCentered: boolean;
+  subtitleCentered: boolean;
+  expandedTitleHorizontalGravity: StackHeaderTitleHorizontalGravityAndroid;
+  expandedTitleVerticalGravity: StackHeaderTitleVerticalGravityAndroid;
+  collapsedTitleHorizontalGravity: StackHeaderTitleHorizontalGravityAndroid;
+  collapsedTitleVerticalGravity: StackHeaderTitleVerticalGravityAndroid;
+  collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityModeAndroid;
   leadingSize: SubviewSize;
   centerSize: SubviewSize;
   trailingSize: SubviewSize;
@@ -62,6 +78,14 @@ const DEFAULT_CONFIG: Config = {
   transparent: false,
   hidden: false,
   title: 'short',
+  subtitle: 'short',
+  titleCentered: false,
+  subtitleCentered: false,
+  expandedTitleHorizontalGravity: 'start',
+  expandedTitleVerticalGravity: 'bottom',
+  collapsedTitleHorizontalGravity: 'start',
+  collapsedTitleVerticalGravity: 'center',
+  collapsedTitleGravityMode: 'entireSpace',
   leadingSize: 'none',
   centerSize: 'none',
   trailingSize: 'none',
@@ -76,7 +100,7 @@ const DEFAULT_CONFIG: Config = {
   scrollFlagSnap: 'undefined',
 };
 
-const SUBVIEW_SIZES: SubviewSize[] = ['none', 'sm', 'md', 'lg'];
+const SUBVIEW_SIZES: SubviewSize[] = ['none', 'sm', 'md', 'lg', 'xl'];
 const HEADER_TYPES: StackHeaderTypeAndroid[] = ['small', 'medium', 'large'];
 const COLLAPSE_MODES: StackHeaderBackgroundSubviewCollapseModeAndroid[] = [
   'off',
@@ -84,8 +108,22 @@ const COLLAPSE_MODES: StackHeaderBackgroundSubviewCollapseModeAndroid[] = [
 ];
 const HIT_SLOP_VALUES: HitSlopValue[] = ['0', '10', '30'];
 const PRESS_RETENTION_VALUES: PressRetentionValue[] = ['0', '20', '50'];
-const TITLE_OPTIONS: TitleOption[] = ['short', 'long'];
+const TEXT_OPTIONS: TextOption[] = ['undefined', 'short', 'long'];
 const SCROLL_FLAG_VALUES: ScrollFlagValue[] = ['undefined', 'true', 'false'];
+const HORIZONTAL_GRAVITY_OPTIONS: StackHeaderTitleHorizontalGravityAndroid[] = [
+  'start',
+  'center',
+  'end',
+];
+const VERTICAL_GRAVITY_OPTIONS: StackHeaderTitleVerticalGravityAndroid[] = [
+  'top',
+  'center',
+  'bottom',
+];
+const GRAVITY_MODE_OPTIONS: StackHeaderCollapsedTitleGravityModeAndroid[] = [
+  'availableSpace',
+  'entireSpace',
+];
 
 function resolveScrollFlag(value: ScrollFlagValue): boolean | undefined {
   switch (value) {
@@ -93,6 +131,21 @@ function resolveScrollFlag(value: ScrollFlagValue): boolean | undefined {
       return true;
     case 'false':
       return false;
+    default:
+      return undefined;
+  }
+}
+
+function resolveText(
+  value: TextOption,
+  short: string,
+  long: string,
+): string | undefined {
+  switch (value) {
+    case 'short':
+      return short;
+    case 'long':
+      return long;
     default:
       return undefined;
   }
@@ -109,6 +162,8 @@ function getSubviewDimensions(size: SubviewSize): {
       return { width: 24, height: 40 };
     case 'lg':
       return { width: 80, height: 40 };
+    case 'xl':
+      return { width: 250, height: 40 };
     default:
       return { width: 0, height: 0 };
   }
@@ -162,7 +217,8 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
     : undefined;
 
   return {
-    title: config.title === 'short' ? SHORT_TITLE : LONG_TITLE,
+    title: resolveText(config.title, SHORT_TITLE, LONG_TITLE),
+    subtitle: resolveText(config.subtitle, SHORT_SUBTITLE, LONG_SUBTITLE),
     hidden: config.hidden,
     transparent: config.transparent,
     android: {
@@ -171,6 +227,13 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       leadingSubview: makeToolbarSubview(config.leadingSize, 'L'),
       centerSubview: makeToolbarSubview(config.centerSize, 'C'),
       trailingSubview: makeToolbarSubview(config.trailingSize, 'T'),
+      titleCentered: config.titleCentered,
+      subtitleCentered: config.subtitleCentered,
+      expandedTitleHorizontalGravity: config.expandedTitleHorizontalGravity,
+      expandedTitleVerticalGravity: config.expandedTitleVerticalGravity,
+      collapsedTitleHorizontalGravity: config.collapsedTitleHorizontalGravity,
+      collapsedTitleVerticalGravity: config.collapsedTitleVerticalGravity,
+      collapsedTitleGravityMode: config.collapsedTitleGravityMode,
       scrollFlagScroll: resolveScrollFlag(config.scrollFlagScroll),
       scrollFlagEnterAlways: resolveScrollFlag(config.scrollFlagEnterAlways),
       scrollFlagEnterAlwaysCollapsed: resolveScrollFlag(
@@ -249,12 +312,86 @@ function ConfigScreen() {
           value={config.hidden}
           onValueChange={v => updateConfig('hidden', v)}
         />
-        <SettingsPicker<TitleOption>
+        <SettingsPicker<TextOption>
           label="title"
           value={config.title}
           onValueChange={v => updateConfig('title', v)}
-          items={TITLE_OPTIONS}
+          items={TEXT_OPTIONS}
         />
+        <SettingsPicker<TextOption>
+          label="subtitle"
+          value={config.subtitle}
+          onValueChange={v => updateConfig('subtitle', v)}
+          items={TEXT_OPTIONS}
+        />
+        <Text style={styles.heading}>Title Positioning</Text>
+        {config.type === 'small' ? (
+          <>
+            <SettingsSwitch
+              label="titleCentered"
+              value={config.titleCentered}
+              onValueChange={v => updateConfig('titleCentered', v)}
+            />
+            <SettingsSwitch
+              label="subtitleCentered"
+              value={config.subtitleCentered}
+              onValueChange={v => updateConfig('subtitleCentered', v)}
+            />
+          </>
+        ) : (
+          <>
+            <View style={styles.row}>
+              <View style={styles.rowItem}>
+                <SettingsPicker<StackHeaderTitleHorizontalGravityAndroid>
+                  label="expanded H"
+                  value={config.expandedTitleHorizontalGravity}
+                  onValueChange={v =>
+                    updateConfig('expandedTitleHorizontalGravity', v)
+                  }
+                  items={HORIZONTAL_GRAVITY_OPTIONS}
+                />
+              </View>
+              <View style={styles.rowItem}>
+                <SettingsPicker<StackHeaderTitleVerticalGravityAndroid>
+                  label="expanded V"
+                  value={config.expandedTitleVerticalGravity}
+                  onValueChange={v =>
+                    updateConfig('expandedTitleVerticalGravity', v)
+                  }
+                  items={VERTICAL_GRAVITY_OPTIONS}
+                />
+              </View>
+            </View>
+            <View style={styles.row}>
+              <View style={styles.rowItem}>
+                <SettingsPicker<StackHeaderTitleHorizontalGravityAndroid>
+                  label="collapsed H"
+                  value={config.collapsedTitleHorizontalGravity}
+                  onValueChange={v =>
+                    updateConfig('collapsedTitleHorizontalGravity', v)
+                  }
+                  items={HORIZONTAL_GRAVITY_OPTIONS}
+                />
+              </View>
+              <View style={styles.rowItem}>
+                <SettingsPicker<StackHeaderTitleVerticalGravityAndroid>
+                  label="collapsed V"
+                  value={config.collapsedTitleVerticalGravity}
+                  onValueChange={v =>
+                    updateConfig('collapsedTitleVerticalGravity', v)
+                  }
+                  items={VERTICAL_GRAVITY_OPTIONS}
+                />
+              </View>
+            </View>
+            <SettingsPicker<StackHeaderCollapsedTitleGravityModeAndroid>
+              label="collapsedTitleGravityMode"
+              value={config.collapsedTitleGravityMode}
+              onValueChange={v => updateConfig('collapsedTitleGravityMode', v)}
+              items={GRAVITY_MODE_OPTIONS}
+            />
+          </>
+        )}
         <Text style={styles.heading}>Toolbar Subviews</Text>
         <SettingsPicker<SubviewSize>
           label="leading"
@@ -356,6 +493,12 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginTop: 12,
     marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  rowItem: {
+    flex: 1,
   },
   subviewLabel: {
     fontSize: 10,

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -877,13 +877,16 @@ export interface StackHeaderConfigPropsAndroid {
    * @remarks
    * Applies to `medium` / `large` headers only and only affects the collapsed
    * state; it is only visually meaningful with `center`
-   * `collapsedTitleHorizontalGravity`. Because the underlying Material field is
-   * set at construction time, changing this prop rebuilds the header.
+   * `collapsedTitleHorizontalGravity`.
    *
-   * Even though Material's default value for this prop is `availableSpace`,
-   * we decided that `entireSpace` is the better default for most use cases.
+   * Because the underlying Material field is set at construction time, changing
+   * this prop rebuilds the header.
    *
-   * @default entireSpace
+   * If header is laid out during screen transition, due to native bug, title
+   * and subtitle might be laid out incorrectly when `entireSpace` gravity mode
+   * is used.
+   *
+   * @default availableSpace
    * @platform android
    */
   collapsedTitleGravityMode?:

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -787,10 +787,9 @@ export interface StackHeaderConfigPropsAndroid {
    * @remarks
    * Applies to the `small` header only; ignored for `medium` / `large` (use
    * `expandedTitleHorizontalGravity` / `collapsedTitleHorizontalGravity`
-   * instead). The title is centered independently of the subtitle and clamped
-   * so it does not overlap the navigation icon, menu, or leading/trailing
-   * subviews. Combining a centered title with a center subview is not
-   * recommended — they may overlap.
+   * instead). The title is centered independently of the subtitle. Combining
+   * a centered title with left and/or center subviews is not recommended — they
+   * may overlap or be laid out incorrectly.
    *
    * @default false
    * @platform android
@@ -827,8 +826,7 @@ export interface StackHeaderConfigPropsAndroid {
    * state.
    *
    * @remarks
-   * Applies to `medium` / `large` headers only. The default `bottom` matches
-   * the Material 3 expanded app bar look.
+   * Applies to `medium` / `large` headers only; ignored for `small`.
    *
    * @default bottom
    * @platform android
@@ -842,8 +840,8 @@ export interface StackHeaderConfigPropsAndroid {
    *
    * @remarks
    * Applies to `medium` / `large` headers only; ignored for `small`. The
-   * subtitle always follows the title's alignment. `center` / `end` are further
-   * affected by `collapsedTitleGravityMode`.
+   * subtitle always follows the title's alignment. `center` is further affected
+   * by `collapsedTitleGravityMode`.
    *
    * @default start
    * @platform android
@@ -856,7 +854,7 @@ export interface StackHeaderConfigPropsAndroid {
    * state.
    *
    * @remarks
-   * Applies to `medium` / `large` headers only.
+   * Applies to `medium` / `large` headers only; ignored for `small`.
    *
    * @default center
    * @platform android
@@ -871,14 +869,14 @@ export interface StackHeaderConfigPropsAndroid {
    * @description
    * The following values are available:
    * - `availableSpace` - gravity is computed over the space left after the
-   *   navigation icon and menu are laid out,
+   *   navigation icon, menu and subviews are laid out,
    * - `entireSpace` - gravity is computed over the whole app bar, so a centered
    *   title is centered relative to the app bar and pushed aside only if it
-   *   would overlap another view (toolbar-center behavior).
+   *   would overlap another view.
    *
    * @remarks
    * Applies to `medium` / `large` headers only and only affects the collapsed
-   * state; it is only visually meaningful with `center` / `end`
+   * state; it is only visually meaningful with `center`
    * `collapsedTitleHorizontalGravity`. Because the underlying Material field is
    * set at construction time, changing this prop rebuilds the header.
    *

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -5,6 +5,20 @@ import type { PlatformIconAndroid } from '../../shared/types';
 
 export type StackHeaderTypeAndroid = 'small' | 'medium' | 'large';
 
+export type StackHeaderTitleHorizontalGravityAndroid =
+  | 'start'
+  | 'center'
+  | 'end';
+
+export type StackHeaderTitleVerticalGravityAndroid =
+  | 'top'
+  | 'center'
+  | 'bottom';
+
+export type StackHeaderCollapsedTitleGravityModeAndroid =
+  | 'entireSpace'
+  | 'availableSpace';
+
 export type StackHeaderBackgroundSubviewCollapseModeAndroid =
   StackHeaderSubviewCollapseModeAndroid;
 
@@ -767,4 +781,114 @@ export interface StackHeaderConfigPropsAndroid {
    * @supported API 28 or higher
    */
   toolbarMenuGroupDividerEnabled?: boolean | undefined;
+  /**
+   * @summary Horizontally centers the title within the app bar.
+   *
+   * @remarks
+   * Applies to the `small` header only; ignored for `medium` / `large` (use
+   * `expandedTitleHorizontalGravity` / `collapsedTitleHorizontalGravity`
+   * instead). The title is centered independently of the subtitle and clamped
+   * so it does not overlap the navigation icon, menu, or leading/trailing
+   * subviews. Combining a centered title with a center subview is not
+   * recommended — they may overlap.
+   *
+   * @default false
+   * @platform android
+   */
+  titleCentered?: boolean | undefined;
+  /**
+   * @summary Horizontally centers the subtitle within the app bar.
+   *
+   * @remarks
+   * Applies to the `small` header only. The subtitle is centered independently
+   * of the title. See {@link titleCentered}.
+   *
+   * @default false
+   * @platform android
+   */
+  subtitleCentered?: boolean | undefined;
+  /**
+   * @summary Horizontal alignment of the title (and subtitle) in the expanded
+   * state.
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only; ignored for `small` (use
+   * `titleCentered` instead). The subtitle always follows the title's
+   * alignment.
+   *
+   * @default start
+   * @platform android
+   */
+  expandedTitleHorizontalGravity?:
+    | StackHeaderTitleHorizontalGravityAndroid
+    | undefined;
+  /**
+   * @summary Vertical alignment of the title (and subtitle) in the expanded
+   * state.
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only. The default `bottom` matches
+   * the Material 3 expanded app bar look.
+   *
+   * @default bottom
+   * @platform android
+   */
+  expandedTitleVerticalGravity?:
+    | StackHeaderTitleVerticalGravityAndroid
+    | undefined;
+  /**
+   * @summary Horizontal alignment of the title (and subtitle) in the collapsed
+   * state.
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only; ignored for `small`. The
+   * subtitle always follows the title's alignment. `center` / `end` are further
+   * affected by `collapsedTitleGravityMode`.
+   *
+   * @default start
+   * @platform android
+   */
+  collapsedTitleHorizontalGravity?:
+    | StackHeaderTitleHorizontalGravityAndroid
+    | undefined;
+  /**
+   * @summary Vertical alignment of the title (and subtitle) in the collapsed
+   * state.
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only.
+   *
+   * @default center
+   * @platform android
+   */
+  collapsedTitleVerticalGravity?:
+    | StackHeaderTitleVerticalGravityAndroid
+    | undefined;
+  /**
+   * @summary Anchor used when resolving the collapsed title's horizontal
+   * gravity.
+   *
+   * @description
+   * The following values are available:
+   * - `availableSpace` - gravity is computed over the space left after the
+   *   navigation icon and menu are laid out,
+   * - `entireSpace` - gravity is computed over the whole app bar, so a centered
+   *   title is centered relative to the app bar and pushed aside only if it
+   *   would overlap another view (toolbar-center behavior).
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only and only affects the collapsed
+   * state; it is only visually meaningful with `center` / `end`
+   * `collapsedTitleHorizontalGravity`. Because the underlying Material field is
+   * set at construction time, changing this prop rebuilds the header.
+   *
+   * Even though Material's default value for this prop is `availableSpace`,
+   * we decided that `entireSpace` is the better default for most use cases.
+   *
+   * @default entireSpace
+   * @platform android
+   */
+  collapsedTitleGravityMode?:
+    | StackHeaderCollapsedTitleGravityModeAndroid
+    | undefined;
 }

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -875,16 +875,16 @@ export interface StackHeaderConfigPropsAndroid {
    *   would overlap another view.
    *
    * @remarks
-   * Applies to `medium` / `large` headers only and only affects the collapsed
-   * state; it is only visually meaningful with `center`
-   * `collapsedTitleHorizontalGravity`.
+   * Applies to `medium` / `large` headers only and affects only the collapsed
+   * state; it is only visually meaningful with
+   * `collapsedTitleHorizontalGravity: 'center'`.
    *
    * Because the underlying Material field is set at construction time, changing
    * this prop rebuilds the header.
    *
-   * If header is laid out during screen transition, due to native bug, title
-   * and subtitle might be laid out incorrectly when `entireSpace` gravity mode
-   * is used.
+   * If the header is laid out during a screen transition, due to a native bug,
+   * the title and the subtitle might be laid out incorrectly when `entireSpace`
+   * gravity mode is used.
    *
    * @default availableSpace
    * @platform android

--- a/src/components/stack/header/StackHeaderConfig.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.types.ts
@@ -11,9 +11,9 @@ export interface StackHeaderConfigPropsBase {
    */
   title?: string | undefined;
   /**
-   * @summary Subtitle displayed in the header. Currently unsupported on Android.
+   * @summary Subtitle displayed in the header.
    *
-   * @platform ios
+   * @platform android, ios
    */
   subtitle?: string | undefined;
   /**

--- a/src/components/stack/index.ts
+++ b/src/components/stack/index.ts
@@ -19,6 +19,9 @@ export type {
   StackHeaderConfigRef,
   // Android
   StackHeaderTypeAndroid,
+  StackHeaderTitleHorizontalGravityAndroid,
+  StackHeaderTitleVerticalGravityAndroid,
+  StackHeaderCollapsedTitleGravityModeAndroid,
   StackHeaderBackgroundSubviewCollapseModeAndroid,
   StackHeaderToolbarSubviewAndroid,
   StackHeaderBackgroundSubviewAndroid,

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -13,6 +13,14 @@ import type { UnsafeMixed } from '../codegenUtils';
 
 type StackHeaderTypeAndroid = 'small' | 'medium' | 'large';
 
+type StackHeaderTitleHorizontalGravityAndroid = 'start' | 'center' | 'end';
+
+type StackHeaderTitleVerticalGravityAndroid = 'top' | 'center' | 'bottom';
+
+type StackHeaderCollapsedTitleGravityModeAndroid =
+  | 'entireSpace'
+  | 'availableSpace';
+
 export type StackHeaderToolbarMenuItemPressEventAndroid = Readonly<{
   id: string;
 }>;
@@ -84,12 +92,37 @@ export type StackHeaderToolbarMenuElementAndroid =
 
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
+  subtitle?: string | undefined;
   hidden?: CT.WithDefault<boolean, false>;
   transparent?: CT.WithDefault<boolean, false>;
   backButtonHidden?: CT.WithDefault<boolean, false>;
 
   // Android-specific props
   type?: CT.WithDefault<StackHeaderTypeAndroid, 'small'>;
+
+  titleCentered?: CT.WithDefault<boolean, false>;
+  subtitleCentered?: CT.WithDefault<boolean, false>;
+
+  expandedTitleHorizontalGravity?: CT.WithDefault<
+    StackHeaderTitleHorizontalGravityAndroid,
+    'start'
+  >;
+  expandedTitleVerticalGravity?: CT.WithDefault<
+    StackHeaderTitleVerticalGravityAndroid,
+    'bottom'
+  >;
+  collapsedTitleHorizontalGravity?: CT.WithDefault<
+    StackHeaderTitleHorizontalGravityAndroid,
+    'start'
+  >;
+  collapsedTitleVerticalGravity?: CT.WithDefault<
+    StackHeaderTitleVerticalGravityAndroid,
+    'center'
+  >;
+  collapsedTitleGravityMode?: CT.WithDefault<
+    StackHeaderCollapsedTitleGravityModeAndroid,
+    'entireSpace'
+  >;
 
   backButtonTintColorNormal?: ColorValue | undefined;
   backButtonTintColorPressed?: ColorValue | undefined;

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -121,7 +121,7 @@ export interface NativeProps extends ViewProps {
   >;
   collapsedTitleGravityMode?: CT.WithDefault<
     StackHeaderCollapsedTitleGravityModeAndroid,
-    'entireSpace'
+    'availableSpace'
   >;
 
   backButtonTintColorNormal?: ColorValue | undefined;


### PR DESCRIPTION
## Description

Adds support for subtitle and title/subtitle positioning in Stack v5 on Android. Removes a workaround for switching order of left subview and title in small header and makes title/subtitle appear independently of center subview in small header. 

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1676.
Closes https://github.com/software-mansion/react-native-screens-labs/issues/911.

### Details

#### `small` header positioning

`titleCentered`/`subtitleCentered` props are a feature of `MaterialToolbar` and they apply the layout correction for the title after regular `Toolbar`'s `onLayout` runs. Prior to this PR, we used a workaround to make title position relative to `leftSubview` consistent with `medium/large` header - keep subview to the left of the title (see https://github.com/software-mansion/react-native-screens/pull/3796) by adding our own managed title view instead of using one provided by the `Toolbar`. Expanding this workaround to centering title/subtitle would require further divergence from native implementation. We decided that for now the best course of action is to rely on native behavior instead of introducing further workarounds. We reverted the workaround and allow the user to set the `title/subtitle/leftSubview/centerSubview/titleCentered/subtitleCentered` as they wish. Not all combinations of these props work well, e.g. left and center subviews don't work well with centering the title/subtitle - this is a native `MaterialToolbar` limitation. For now we only documented the problems in JSDocs.

#### `medium/large` header positioning

Positioning of `medium/large` title & subtitle is determined by `{collapsed/expanded}Title{Horizontal/Vertical}Gravity` and `collapsedTitleGravityMode` props. The latter one is exposed by the Material library only via XML therefore we needed to add XML layouts for  `{entireSpace, availableSpace} x {medium, large}` `CollapsingToolbarLayout`s and inflate them programmatically. This requires full header rebuild.

##### `entireSpace` bug

When `collapsedTitleGravityMode: 'entireSpace'` is used, we found a bug with `CollapsingToolbarLayout` is laid out while fragment transition is ongoing. Report to `material-components-android` library with details about the bug is available [here](https://github.com/material-components/material-components-android/issues/5094).

https://github.com/user-attachments/assets/f72c4b9f-781b-4cd3-b39a-6e9e4d851e7e

Unfortunately, for now this bug makes the `entireSpace` not really usable. `availableSpace` (Material's default) will be the default value in `screens` for now (even though we think that `entireSpace` would be a better choice, if it worked correctly).

With this comes one problem. By default, `MaterialToolbar` uses `contentInsetStart=16dp`. This offsets the dummy view that `CollapsingToolbarLayout` uses for drawing the title from the leading edge, resulting in this asymmetric title relative to the display cutout/center of the device.

<img width="345" height="767" alt="Screenshot 2026-07-24 at 14 53 46" src="https://github.com/user-attachments/assets/cd1ed845-19ca-4712-9916-040b3541d94f" />

We're planning to expose `contentInset` configuration in a follow-up PR that will allow to mitigate this.

##### Changing subtitle in runtime bug

When `medium/large` title is collapsed and subtitle is changed in runtime from `undefined` to some value, incorrect scroll offset is applied to the header.

| `maxLines = 1` | `maxLines = 2` |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e2c90a8f-e6dc-4cf1-9593-0fffeb2eac59" /> | <video src="https://github.com/user-attachments/assets/509db183-5ded-44fe-8386-93dbf56a827f" />

This also seems to be Material limitation. By setting `collapsingToolbarLayout.maxLines` to 2, we can force `CollapsingToolbarLayout.onMeasure` to enforce the correct offset:

```java
// CollapsingToolbarLayout.java:779

// onMeasure

// When extra multiline height is enabled, the height of the CollapsingToolbarLayout can change
// dynamically. If the height changes while the view is collapsed, we need to ensure that the
// AppBarLayout updates its collapse state to match the new height, otherwise it may try to
// scroll to an invalid offset based on the old height.
if (extraMultilineHeightEnabled
    && collapsingTitleHelper.getExpandedMaxLines() > 1
    && collapsingTitleHelper.getExpansionFraction() == 1f) {
  maybeSetPendingActionCollapsed();
}
```

For now, we decided to hardcode `maxLines = 2`. In the future PR we plan to expose this property to the user. The default value for this prop will need to be considered.

## Changes

- handle Platform-shared `subtitle` prop on Android
- add title positioning props:
  - `small` header:
    - `{title/subtitle}Centered`
  - `medium/large` header:
    - `{collapsed/expanded}Title{Horizontal/Vertical}Gravity`
    - `collapsedTitleGravityMode`
- to support `collapsedTitleGravityMode`, changed creating `CollapsingToolbarLayout` to XML inflation; added 4 XML layouts {entireSpace, availableSpace} x {medium, large}
- removed code preventing center subview with title - decided that with configurable positioning it's better to allow full configuration and document limitations
- removed a workaround for `small` header with managed title view instead of native one - now left subview for `small` header is to the right of the title
- set `collapsingToolbarLayout.maxLines = 2` to mitigate a bug with incorrect header scroll offset when changing subtitle in runtime from undefined to some value

## Before & after - visual documentation

| `small` | `large` |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4af82047-4fbe-4410-a3f4-37758e8ca0cf" /> | <video src="https://github.com/user-attachments/assets/5a85cc7f-d0f8-4f30-973d-748df8ba2d87" /> |

## Test plan

Run `test-stack-subviews-android` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
