### PR TITLE
chore: Update software-mansion/npm-package-publish and add toggle to force publish from main

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -64,6 +64,18 @@ jobs:
           cache: "yarn"
           registry-url: https://registry.npmjs.org/
 
+      # With validation bypassed there is no release branch to infer the
+      # version from, so an explicit version is required. The publish action
+      # would fail on this anyway, but only after checkout and setup — fail
+      # fast here with a clear message instead. Nightly is exempt: it infers
+      # the version from the npm latest tag.
+      - name: Require explicit version when bypassing validation
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.bypass-branch-validation-rules && inputs.release-type != 'nightly' && inputs.version == '' }}
+        shell: bash
+        run: |
+          echo "::error::bypass-branch-validation-rules requires an explicit 'version' input for ${{ inputs.release-type }} releases."
+          exit 1
+
       # Guards against publishing a stable / beta / rc release from an
       # inappropriate target. Intentionally skipped for nightly releases,
       # which are published from main by design.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,7 @@ on:
         options:
           - stable
           - nightly
+          - alpha
           - beta
           - rc
         default: stable

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Publish manual release
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
+        uses: software-mansion/npm-package-publish@d347fc2b353b9ffc6e80ac7a149a49171274d1a4
         with:
           package-name: "react-native-screens"
           package-json-path: "package.json"
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish automatic nightly release
         if: ${{ github.event_name == 'schedule' }}
-        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
+        uses: software-mansion/npm-package-publish@d347fc2b353b9ffc6e80ac7a149a49171274d1a4
         with:
           package-name: "react-native-screens"
           package-json-path: "package.json"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,6 +28,13 @@ on:
         type: string
         required: false
         default: ""
+      bypass-branch-validation-rules:
+        description: >-
+          [DANGER ZONE] Make sure you know what you're doing! This skips
+          the publish-target validation (branch and version checks),
+          allowing a publish from any branch, including main.
+        type: boolean
+        default: false
 
 jobs:
   npm-publish:
@@ -61,7 +68,7 @@ jobs:
       # inappropriate target. Intentionally skipped for nightly releases,
       # which are published from main by design.
       - name: Validate publish target
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' && !inputs.bypass-branch-validation-rules }}
         shell: bash
         env:
           BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -76,9 +76,9 @@ jobs:
           echo "::error::bypass-branch-validation-rules requires an explicit 'version' input for ${{ inputs.release-type }} releases."
           exit 1
 
-      # Guards against publishing a stable / beta / rc release from an
+      # Guards against publishing a stable / alpha / beta / rc release from an
       # inappropriate target. Intentionally skipped for nightly releases,
-      # which are published from main by design.
+      # which are published from main by design, and when explicit bypass is toggled on.
       - name: Validate publish target
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' && !inputs.bypass-branch-validation-rules }}
         shell: bash

--- a/scripts/validate-publish-target.sh
+++ b/scripts/validate-publish-target.sh
@@ -3,11 +3,11 @@
 # Validates that the current branch and package.json version are appropriate
 # for publishing the requested release.
 #
-# Handles all four release types:
+# Handles all five release types:
 #   - nightly: always valid — nightly publishes are allowed from any branch
 #     per the release guide; the script returns success without running the
 #     branch/version checks.
-#   - stable / beta / rc: rejects the main-branch sentinel version, refuses
+#   - stable / alpha / beta / rc: rejects the main-branch sentinel version, refuses
 #     publishes from `main`, and requires the branch to match a documented
 #     release-branch pattern.
 #
@@ -21,7 +21,7 @@
 # Requires `jq` on PATH (pre-installed on GitHub-hosted ubuntu runners).
 #
 # Usage: scripts/validate-publish-target.sh <branch> <release-type>
-#   <release-type>: one of stable | beta | rc | nightly
+#   <release-type>: one of stable | alpha | beta | rc | nightly
 
 set -euo pipefail
 
@@ -34,9 +34,9 @@ BRANCH="$1"
 RELEASE_TYPE="$2"
 
 case "$RELEASE_TYPE" in
-  stable|beta|rc|nightly) ;;
+  stable|alpha|beta|rc|nightly) ;;
   *)
-    echo "error: unknown release-type '$RELEASE_TYPE' (expected: stable | beta | rc | nightly)" >&2
+    echo "error: unknown release-type '$RELEASE_TYPE' (expected: stable | alpha | beta | rc | nightly)" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Description

This PR updates the `npm-package-publish` package to include `alpha` versioning and adds a way to publish a version even if there is no dedicated branch for it (via a toggle labeled [DANGER ZONE]).

## Changes

- updated package
- added toggle

## Before & after - visual documentation

n/a

## Test plan

n/a

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
