### PR TITLE
chore: Remove nightly publishing flows from v4 and bump npm-package-publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,7 +1,5 @@
 name: Publish release to npm
 on:
-  schedule:
-    - cron: "27 23 * * *" # at 23:27 every day
   workflow_dispatch:
     inputs:
       dry-run:
@@ -15,7 +13,6 @@ on:
         type: choice
         options:
           - stable
-          - nightly
           - beta
           - rc
         default: stable
@@ -60,7 +57,7 @@ jobs:
       # inappropriate target. Intentionally skipped for nightly releases,
       # which are published from main by design.
       - name: Validate publish target
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type != 'nightly' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         env:
           BRANCH: ${{ github.ref_name }}
@@ -69,7 +66,7 @@ jobs:
 
       - name: Publish manual release
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
+        uses: software-mansion/npm-package-publish@bbfbcdf3f27e2dc288d7d56f5989a731efc79e6f
         with:
           package-name: "react-native-screens"
           package-json-path: "package.json"
@@ -78,13 +75,3 @@ jobs:
           version: ${{ inputs.version }}
           dry-run: ${{ inputs.dry-run }}
           perform-git-operations: false # We do it manually in more predictive manner
-
-      - name: Publish automatic nightly release
-        if: ${{ github.event_name == 'schedule' }}
-        uses: software-mansion/npm-package-publish@264013301cc21350186b190f1f6dd10ae4c8ee04
-        with:
-          package-name: "react-native-screens"
-          package-json-path: "package.json"
-          install-dependencies-command: "yarn install --immutable"
-          release-type: "nightly"
-          dry-run: false


### PR DESCRIPTION
## Description

This PR removes nightly publishing from v4 branch. I'm not refactoring this entirely, just removing what we don't need, in order to not introduce bugs.

I decided to also bump npm-package-publish to match current (as of writing) version on main branch. I don't think something crucial changed, but let's have it consistent.

## Changes

- update publishing workflow
- bumped npm-package-publish

## Before & after - visual documentation

n/a

## Test plan

n/a
## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
