### PR TITLE
fix(iOS, Stack v4): fall back to inheriting orientation if it's not defined on the screen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenViewManager.kt
@@ -323,6 +323,11 @@ open class ScreenViewManager :
         value: Boolean,
     ) = Unit
 
+    override fun setIosOrientationInheritanceFixEnabled(
+        view: Screen?,
+        value: Boolean,
+    ) = Unit
+
     // END mark: iOS-only
 
     override fun setAndroidResetScreenShadowStateOnOrientationChangeEnabled(

--- a/apps/src/tests/issue-tests/Test4351.tsx
+++ b/apps/src/tests/issue-tests/Test4351.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+type StackParamList = {
+  Home: undefined;
+  Plain: undefined;
+  Tabs: undefined;
+};
+
+type NavigationProp<ParamList extends ParamListBase> = {
+  navigation: NativeStackNavigationProp<ParamList>;
+};
+
+type StackNavigationProp = NavigationProp<StackParamList>;
+
+const Stack = createNativeStackNavigator<StackParamList>();
+const Tab = createBottomTabNavigator();
+
+function HomeScreen({ navigation }: StackNavigationProp) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Issue #4351 – orientation inheritance</Text>
+      <Text style={styles.paragraph}>
+        The stack is locked to portrait. Push each screen and rotate the device
+        to landscape to compare behavior.
+      </Text>
+      <View style={styles.buttons}>
+        <Button
+          title="Push plain screen (control)"
+          onPress={() => navigation.push('Plain')}
+        />
+        <Button
+          title="Push screen with tabs (repro)"
+          onPress={() => navigation.push('Tabs')}
+        />
+      </View>
+    </View>
+  );
+}
+
+function PlainScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Plain screen</Text>
+      <Text style={styles.paragraph}>
+        This leaf stack screen inherits `portrait` from the stack. It should
+        stay portrait whether the fix is enabled or not.
+      </Text>
+    </View>
+  );
+}
+
+function TabContent({ name }: { name: string }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Tab {name}</Text>
+      <Text style={styles.paragraph}>
+        These tab screens do not set `orientation`.{'\n\n'}
+        Fix ON (default): stays portrait (defers to the stack's `portrait`).
+        {'\n\n'}
+        Fix OFF: the tab screen forces `allButUpsideDown`, so the device can
+        rotate to landscape – reproducing the bug.
+      </Text>
+    </View>
+  );
+}
+
+function TabsScreen() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="A">{() => <TabContent name="A" />}</Tab.Screen>
+      <Tab.Screen name="B">{() => <TabContent name="B" />}</Tab.Screen>
+    </Tab.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ orientation: 'portrait' }}>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Plain" component={PlainScreen} />
+        <Stack.Screen
+          name="Tabs"
+          component={TabsScreen}
+          options={{ headerShown: true }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  paragraph: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  buttons: {
+    gap: 12,
+  },
+});

--- a/apps/src/tests/issue-tests/Test4351.tsx
+++ b/apps/src/tests/issue-tests/Test4351.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import {
+  NavigationContainer,
+  type ParamListBase,
+} from '@react-navigation/native';
 import {
   createNativeStackNavigator,
-  NativeStackNavigationProp,
+  type NativeStackNavigationProp,
 } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -204,6 +204,7 @@ export { default as Test4258 } from './Test4258';
 export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
+export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -192,6 +192,15 @@ exception for iPad devices, where it resolves to [UIInterfaceOrientationMaskAll]
 
 Defaults to `default` on iOS.
 
+> [!NOTE]
+> iOS only: when `screenOrientation` is **not set at all** and the
+> `featureFlags.experiment.iosOrientationInheritanceFixEnabled` flag is enabled
+> (the default), a legacy (Stack v4) screen defers to its parent screen's
+> orientation instead of forcing `UIInterfaceOrientationMaskAllButUpsideDown`,
+> ultimately falling back to the orientations declared in `Info.plist`. Setting
+> `screenOrientation` to `default` explicitly keeps the previous behavior. See
+> [#4351](https://github.com/software-mansion/react-native-screens/issues/4351).
+
 ### `sheetAllowedDetents`
 
 Describes heights where a sheet can rest.

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -199,7 +199,7 @@ Defaults to `default` on iOS.
 > orientation instead of forcing `UIInterfaceOrientationMaskAllButUpsideDown`,
 > ultimately falling back to the orientations declared in `Info.plist`. Setting
 > `screenOrientation` to `default` explicitly keeps the previous behavior. See
-> [#4351](https://github.com/software-mansion/react-native-screens/issues/4351).
+> [#4408](https://github.com/software-mansion/react-native-screens/pull/4408).
 
 ### `sheetAllowedDetents`
 

--- a/ios/legacy/RNSScreen.h
+++ b/ios/legacy/RNSScreen.h
@@ -87,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) RNSScrollEdgeEffect rightScrollEdgeEffect;
 @property (nonatomic) RNSScrollEdgeEffect topScrollEdgeEffect;
 @property (nonatomic, readwrite) BOOL synchronousShadowStateUpdatesEnabled;
+@property (nonatomic, readwrite) BOOL iosOrientationInheritanceFixEnabled;
 
 @property (nonatomic, retain) NSNumber *transitionDuration;
 @property (nonatomic, readonly) BOOL dismissed;

--- a/ios/legacy/RNSScreen.mm
+++ b/ios/legacy/RNSScreen.mm
@@ -1990,7 +1990,7 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   // If flag is enabled, we're doing same evaluation as `[self supportedInterfaceOrientations]`
   // but we fall back to `RNSOrientationInherit` if orientation is not set in order not to
   // override parent's orientation. For more details see:
-  // https://github.com/software-mansion/react-native-screens/issues/4351
+  // https://github.com/software-mansion/react-native-screens/pull/4408
   if (self.screenView.iosOrientationInheritanceFixEnabled) {
     UIViewController *orientationVC = [self findChildVCForConfigAndTrait:RNSWindowTraitOrientation includingModals:YES];
     if ([orientationVC isKindOfClass:[RNSScreen class]]) {

--- a/ios/legacy/RNSScreen.mm
+++ b/ios/legacy/RNSScreen.mm
@@ -102,6 +102,7 @@ struct ContentWrapperBox {
   _sheetContentHeight = 0.0;
   _markedForUnmountInCurrentTransaction = NO;
   _synchronousShadowStateUpdatesEnabled = YES;
+  _iosOrientationInheritanceFixEnabled = YES;
 }
 
 - (BOOL)getFullScreenSwipeShadowEnabled
@@ -1259,6 +1260,8 @@ RNS_IGNORE_SUPER_CALL_END
 
   [self setSynchronousShadowStateUpdatesEnabled:newScreenProps.synchronousShadowStateUpdatesEnabled];
 
+  [self setIosOrientationInheritanceFixEnabled:newScreenProps.iosOrientationInheritanceFixEnabled];
+
 #if !TARGET_OS_TV
   if (newScreenProps.statusBarHidden != oldScreenProps.statusBarHidden) {
     [self setStatusBarHidden:newScreenProps.statusBarHidden];
@@ -1982,6 +1985,19 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     if (childOrientation != RNSOrientationInherit) {
       return childOrientation;
     }
+  }
+
+  // If flag is enabled, we're doing same evaluation as `[self supportedInterfaceOrientations]`
+  // but we fall back to `RNSOrientationInherit` if orientation is not set in order not to
+  // override parent's orientation. For more details see:
+  // https://github.com/software-mansion/react-native-screens/issues/4351
+  if (self.screenView.iosOrientationInheritanceFixEnabled) {
+    UIViewController *orientationVC = [self findChildVCForConfigAndTrait:RNSWindowTraitOrientation includingModals:YES];
+    if ([orientationVC isKindOfClass:[RNSScreen class]]) {
+      return rnscreens::conversion::RNSOrientationFromUIInterfaceOrientationMask(
+          ((RNSScreen *)orientationVC).screenView.screenOrientation);
+    }
+    return RNSOrientationInherit;
   }
 
   return rnscreens::conversion::RNSOrientationFromUIInterfaceOrientationMask([self supportedInterfaceOrientations]);

--- a/src/components/tabs/screen/TabsScreen.types.ts
+++ b/src/components/tabs/screen/TabsScreen.types.ts
@@ -116,7 +116,7 @@ export interface TabsScreenPropsBase {
    *   and `featureFlags.experiment.iosOrientationInheritanceFixEnabled` is
    *   enabled (the default), in which case it returns `inherit` and no longer
    *   overrides the parent (see
-   *   https://github.com/software-mansion/react-native-screens/issues/4351).
+   *   https://github.com/software-mansion/react-native-screens/pull/4408).
    *
    * The following values are currently supported:
    *

--- a/src/components/tabs/screen/TabsScreen.types.ts
+++ b/src/components/tabs/screen/TabsScreen.types.ts
@@ -110,9 +110,13 @@ export interface TabsScreenPropsBase {
    * Note that:
    * - some components (like `SplitHost`) may choose not to query
    *   its child components,
-   * - Stack v4 implementation **ALWAYS** returns some supported
-   *   orientations (`allButUpsideDown` by default), overriding
-   *   orientation from tab screen.
+   * - Stack v4 (legacy) implementation returns some supported orientations,
+   *   overriding orientation from the tab screen **unless** the Stack v4
+   *   screen has no explicit `orientation`
+   *   and `featureFlags.experiment.iosOrientationInheritanceFixEnabled` is
+   *   enabled (the default), in which case it returns `inherit` and no longer
+   *   overrides the parent (see
+   *   https://github.com/software-mansion/react-native-screens/issues/4351).
    *
    * The following values are currently supported:
    *

--- a/src/components/tabs/screen/TabsScreen.types.ts
+++ b/src/components/tabs/screen/TabsScreen.types.ts
@@ -112,10 +112,10 @@ export interface TabsScreenPropsBase {
    *   its child components,
    * - Stack v4 (legacy) implementation returns some supported orientations,
    *   overriding orientation from the tab screen **unless** the Stack v4
-   *   screen has no explicit `orientation`
-   *   and `featureFlags.experiment.iosOrientationInheritanceFixEnabled` is
-   *   enabled (the default), in which case it returns `inherit` and no longer
-   *   overrides the parent (see
+   *   screen has no explicit `screenOrientation` prop and
+   *   `featureFlags.experiment.iosOrientationInheritanceFixEnabled` is
+   *   enabled (the default), in which case it returns `inherit` and no
+   *   longer overrides the parent (see
    *   https://github.com/software-mansion/react-native-screens/pull/4408).
    *
    * The following values are currently supported:

--- a/src/fabric/legacy/ModalScreenNativeComponent.ts
+++ b/src/fabric/legacy/ModalScreenNativeComponent.ts
@@ -122,6 +122,7 @@ export interface NativeProps extends ViewProps {
   rightScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   topScrollEdgeEffect?: CT.WithDefault<ScrollEdgeEffect, 'automatic'>;
   synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, true>;
+  iosOrientationInheritanceFixEnabled?: CT.WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSModalScreen', {

--- a/src/fabric/legacy/ScreenNativeComponent.ts
+++ b/src/fabric/legacy/ScreenNativeComponent.ts
@@ -126,6 +126,7 @@ export interface NativeProps extends ViewProps {
     boolean,
     true
   >;
+  iosOrientationInheritanceFixEnabled?: CT.WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSScreen', {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -221,7 +221,7 @@ export const featureFlags = {
      * hosting bottom tabs). With the fix enabled, such a screen defers to its
      * parent screen / the app's `Info.plist` supported orientations instead.
      *
-     * Issue: https://github.com/software-mansion/react-native-screens/issues/4351
+     * PR: https://github.com/software-mansion/react-native-screens/pull/4408
      * @platform ios
      */
     get iosOrientationInheritanceFixEnabled() {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,6 +4,7 @@ const RNS_SYNCHRONOUS_HEADER_SUBVIEW_STATE_UPDATES_DEFAULT = true;
 const RNS_ANDROID_LEGACY_TOP_INSET_BEHAVIOR_DEFAULT = false;
 const RNS_ANDROID_RESET_SCREEN_SHADOW_STATE_ON_ORIENTATION_CHANGE_DEFAULT =
   true;
+const RNS_IOS_ORIENTATION_INHERITANCE_FIX_DEFAULT = true;
 const RNS_DEBUG_LOGGING = false;
 
 // TODO: Migrate freeze here
@@ -80,6 +81,8 @@ const _featureFlags = {
       RNS_ANDROID_LEGACY_TOP_INSET_BEHAVIOR_DEFAULT,
     androidResetScreenShadowStateOnOrientationChangeEnabled:
       RNS_ANDROID_RESET_SCREEN_SHADOW_STATE_ON_ORIENTATION_CHANGE_DEFAULT,
+    iosOrientationInheritanceFixEnabled:
+      RNS_IOS_ORIENTATION_INHERITANCE_FIX_DEFAULT,
   },
   stable: {
     debugLogging: RNS_DEBUG_LOGGING,
@@ -157,6 +160,11 @@ const androidResetScreenShadowStateOnOrientationChangeAccessor =
     'androidResetScreenShadowStateOnOrientationChangeEnabled',
     RNS_ANDROID_RESET_SCREEN_SHADOW_STATE_ON_ORIENTATION_CHANGE_DEFAULT,
   );
+const iosOrientationInheritanceFixAccessor =
+  createExperimentalFeatureFlagAccessor(
+    'iosOrientationInheritanceFixEnabled',
+    RNS_IOS_ORIENTATION_INHERITANCE_FIX_DEFAULT,
+  );
 const rnsDebugLoggingAccessor = createStableFeatureFlagAccessor(
   'debugLogging',
   RNS_DEBUG_LOGGING,
@@ -203,6 +211,24 @@ export const featureFlags = {
       value: boolean,
     ) {
       androidResetScreenShadowStateOnOrientationChangeAccessor.set(value);
+    },
+    /**
+     * Fixes legacy (Stack v4) screen orientation evaluation on iOS. On by default.
+     *
+     * Before this fix, a legacy `Screen` without an explicit `screenOrientation`
+     * always reported `allButUpsideDown` (iPhone) / `all` (iPad), which overrode
+     * the orientation set by an ancestor screen (e.g. a portrait-locked stack
+     * hosting bottom tabs). With the fix enabled, such a screen defers to its
+     * parent screen / the app's `Info.plist` supported orientations instead.
+     *
+     * Issue: https://github.com/software-mansion/react-native-screens/issues/4351
+     * @platform ios
+     */
+    get iosOrientationInheritanceFixEnabled() {
+      return iosOrientationInheritanceFixAccessor.get();
+    },
+    set iosOrientationInheritanceFixEnabled(value: boolean) {
+      iosOrientationInheritanceFixAccessor.set(value);
     },
     /**
      * Enables the fix for native / JS state desynchronization in Stack. On by default.

--- a/src/legacy/components/Screen.tsx
+++ b/src/legacy/components/Screen.tsx
@@ -277,6 +277,9 @@ export const InnerScreen = React.forwardRef<View, ScreenProps>(
             androidResetScreenShadowStateOnOrientationChangeEnabled={
               featureFlags.experiment
                 .androidResetScreenShadowStateOnOrientationChangeEnabled
+            }
+            iosOrientationInheritanceFixEnabled={
+              featureFlags.experiment.iosOrientationInheritanceFixEnabled
             }>
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
               children

--- a/src/legacy/types.ts
+++ b/src/legacy/types.ts
@@ -371,7 +371,7 @@ export interface ScreenProps extends ViewProps {
    * orientation, ultimately falling back to the app's `Info.plist` supported
    * orientations. Setting `screenOrientation: "default"` explicitly keeps the
    * previous "all-but-upside-down" (iPhone) / "all" (iPad) behavior.
-   * See https://github.com/software-mansion/react-native-screens/issues/4351
+   * See https://github.com/software-mansion/react-native-screens/pull/4408
    */
   screenOrientation?: ScreenOrientationTypes | undefined;
   /**

--- a/src/legacy/types.ts
+++ b/src/legacy/types.ts
@@ -362,6 +362,16 @@ export interface ScreenProps extends ViewProps {
    * - "landscape" – landscape orientations are permitted
    * - "landscape_left" – landscape-left orientation is permitted
    * - "landscape_right" – landscape-right orientation is permitted
+   *
+   * @remarks
+   * iOS only: when `screenOrientation` is omitted entirely and the
+   * `featureFlags.experiment.iosOrientationInheritanceFixEnabled` flag is
+   * enabled (the default), a legacy `Screen` no longer forces
+   * "all-but-upside-down". Instead it defers to its parent screen's
+   * orientation, ultimately falling back to the app's `Info.plist` supported
+   * orientations. Setting `screenOrientation: "default"` explicitly keeps the
+   * previous "all-but-upside-down" (iPhone) / "all" (iPad) behavior.
+   * See https://github.com/software-mansion/react-native-screens/issues/4351
    */
   screenOrientation?: ScreenOrientationTypes | undefined;
   /**


### PR DESCRIPTION
## Description

Fixes orientation evaluation for Stack v4 when orientation prop is not defined. It now falls back to `RNSOrientationInherit` instead of `RNSOrientationAll`/`RNSOrientationAllButUpsideDown`.

Closes https://github.com/software-mansion/react-native-screens/issues/4351.

### Details

In https://github.com/software-mansion/react-native-screens/pull/3014 we introduced a mechanism for evaluating orientation across nested containers. For backward compatibility, we used `RNSScreen.supportedInterfaceOrientations` for evaluating orientation in Stack v4 which returns hard-coded `UIInterfaceOrientationMaskAll`/`UIInterfaceOrientationMaskAllButUpsideDown` if the screen and its children doesn't set any orientation. Due to new bottom-up evaluation behavior, the lowest `RNSScreen`'s `supportedInterfaceOrientations` would be queried and if it returned the default hard-coded value, it would override parent's defined orientation.

In this PR, we're still performing similar evaluation as `RNSScreen.supportedInterfaceOrientations` but we fall back to `RNSOrientationInherit` when no orientation is set so that we don't override any parent's defined orientation.

This brings one other change in behavior - if orientation is not defined at all, we fall back to supported orientations from `Info.plist` instead of using hard-coded `UIInterfaceOrientationMaskAll`/`UIInterfaceOrientationMaskAllButUpsideDown`. If the configuration in `Info.plist` is different that hard-coded defaults, the behavior will be different.

To mitigate this and any potential unforseen problems, we added a feature flag (enabled by default) that controls this behavior. Disabling it restores behavior prior to this PR.

## Changes

- return `RNSOrientationInherit` in `RNSScreen.evaluateOrientation` when no orientation is defined in children subtree instead of hard-coded defaults
- add `iosOrientationInheritanceFixEnabled` to control this behavior
- update in-code docs, `GUIDE_FOR_LIBRARY_AUTHORS.md`

## Before & after - visual documentation

| before           | after            |
| ---------------- | ---------------- |
| <video src="https://github.com/user-attachments/assets/cc6a8d6b-f4ee-4423-9cc8-2f790eb3b116" /> | <video src="https://github.com/user-attachments/assets/1b1d55dd-1c5f-4cbb-b58a-7bcdbb128729" /> |

## Test plan

Run `Test4351`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
