### PR TITLE
chore(test, Android): add e2e test for Stack v5 toolbar menu commands

### DIFF
--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -64,3 +64,5 @@ export const CLASS_NAME_UI_LABEL = 'UILabel';
 
 export const CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON =
   'androidx.appcompat.widget.AppCompatImageButton';
+export const CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW =
+  'androidx.appcompat.widget.MenuPopupWindow$MenuDropDownListView';

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -1,0 +1,389 @@
+import { device, expect, element, by } from 'detox';
+import {
+  describeIfAndroid,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
+import { CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW } from '../../native-class-names';
+
+const SCROLLVIEW_ID = 'toolbar-menu-commands-scrollview';
+const HEADER_TITLE = 'Toolbar Menu Commands Test';
+
+/**
+ * Budget for the overflow popup's open / dismiss animation. Detox's idle sync
+ * does not cover popup window animations, so every assertion that straddles one
+ * has to wait it out explicitly instead of asserting on the spot.
+ */
+const MENU_ANIMATION_TIMEOUT = 2000;
+
+/**
+ * Every title this scenario can ever put into the toolbar menu. Each assertion
+ * checks the full set — the expected titles must be visible and every other one
+ * must not exist — so a stale/leaked menu entry fails the test instead of
+ * slipping through an "only check what I expect" assertion.
+ */
+const ALL_TITLES = [
+  'Title A',
+  'Title B',
+  'Title C',
+  'Changed',
+  'Long Title',
+] as const;
+
+type MenuTitle = (typeof ALL_TITLES)[number];
+
+/**
+ * Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
+ * @see apps/src/shared/SettingsPicker.tsx
+ */
+function optionId(pickerLabel: string, option: string): string {
+  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
+}
+
+/**
+ * Rewinds to the top before scrolling down, so a target that sits *above* the
+ * current offset is still reachable (`whileElement` only scrolls one way).
+ */
+async function scrollIntoView(id: string) {
+  await element(by.id(SCROLLVIEW_ID)).scrollTo('top');
+  await waitFor(element(by.id(id)))
+    .toBeVisible()
+    .whileElement(by.id(SCROLLVIEW_ID))
+    .scroll(300, 'down', Number.NaN, 0.85);
+}
+
+/**
+ * Opens the picker, taps an option, closes it again. Closing matters: an open
+ * picker leaves its option rows in the hierarchy, where they would collide with
+ * the `by.text` matchers used for the toolbar menu items.
+ */
+async function selectOption(
+  pickerId: string,
+  pickerLabel: string,
+  option: string,
+) {
+  await scrollIntoView(pickerId);
+  await element(by.id(pickerId)).tap();
+
+  const rowId = optionId(pickerLabel, option);
+  await scrollIntoView(rowId);
+  await element(by.id(rowId)).tap();
+
+  await scrollIntoView(pickerId);
+  await element(by.id(pickerId)).tap();
+
+  await expect(element(by.id(pickerId))).toHaveText(
+    `${pickerLabel}: ${option}`,
+  );
+}
+
+type CmdTitle =
+  | 'no change'
+  | 'Title A'
+  | 'Title B'
+  | 'Title C'
+  | 'Long Title'
+  | 'Changed'
+  | 'undefined';
+type CmdHidden = 'no change' | 'true' | 'false' | 'undefined';
+
+async function sendCommand(options: {
+  target: 'item-1' | 'item-2' | 'item-3';
+  title: CmdTitle;
+  hidden: CmdHidden;
+}) {
+  await selectOption('cmd-target-picker', 'target id', options.target);
+  await selectOption('cmd-title-picker', 'cmd title', options.title);
+  await selectOption('cmd-hidden-picker', 'cmd hidden', options.hidden);
+
+  await scrollIntoView('send-command-button');
+  await element(by.id('send-command-button')).tap();
+}
+
+async function setSlotTitle(slot: number, title: string) {
+  await selectOption(`slot-${slot}-title-picker`, `slot ${slot} title`, title);
+}
+
+/**
+ * Flips a slot's `include` switch and verifies the resulting state. The switch
+ * only toggles, so `include` is what the caller expects to see afterwards — a
+ * swallowed tap fails here instead of surfacing as a confusing wrong-menu
+ * assertion several steps later.
+ */
+async function setSlotInclude(slot: number, include: boolean) {
+  const switchId = `slot-${slot}-include-switch`;
+  await scrollIntoView(switchId);
+  await element(by.id(switchId)).tap();
+
+  await expect(
+    element(by.text(`slot ${slot} include: ${include}`)),
+  ).toBeVisible();
+}
+
+/**
+ * Taps the overflow button. The popup animates in, so the caller must wait for
+ * an entry it expects before asserting anything.
+ */
+async function openMenu() {
+  await element(by.label('More options')).tap();
+}
+
+/** Waits out the popup's open animation by gating on an entry it must contain. */
+async function waitForMenuItem(title: MenuTitle) {
+  await waitFor(
+    element(
+      by
+        .text(title)
+        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+    ),
+  )
+    .toBeVisible()
+    .withTimeout(MENU_ANIMATION_TIMEOUT);
+}
+
+/**
+ * Waits until the popup window is gone and the screen behind it is addressable
+ * again. Espresso resolves matchers against a single window — while the popup
+ * holds focus, nothing in the screen below it is in the searched hierarchy, so
+ * the menu entry disappearing is not enough: the next action against the screen
+ * would fail with "No views in hierarchy found". Gating on the scroll view
+ * retries until the root switches back.
+ */
+async function waitForScreen() {
+  await waitFor(element(by.id(SCROLLVIEW_ID)))
+    .toBeVisible()
+    .withTimeout(MENU_ANIMATION_TIMEOUT);
+}
+
+/** Taps a menu entry and waits for the popup to finish dismissing. */
+async function tapMenuItem(title: MenuTitle) {
+  await waitForMenuItem(title);
+  await element(
+    by
+      .text(title)
+      .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+  ).tap();
+  await waitFor(
+    element(
+      by
+        .text(title)
+        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+    ),
+  )
+    .not.toExist()
+    .withTimeout(MENU_ANIMATION_TIMEOUT);
+  await waitForScreen();
+}
+
+/**
+ * Asserts the exact contents of the overflow menu, then closes it. Every
+ * expected title is checked for visibility and every other known title for
+ * absence, so neither a missing entry nor a leaked one can slip through.
+ *
+ * `expectedVisible` is a non-empty list of `ALL_TITLES` members: a title
+ * outside that set would otherwise go unasserted, and the first entry gates the
+ * open animation.
+ */
+async function expectMenuItems(
+  expectedVisible: [MenuTitle, ...MenuTitle[]],
+): Promise<void> {
+  await openMenu();
+
+  try {
+    // The menu is populated in a single layout pass, so once the first expected
+    // entry is up the `not.toExist()` checks below cannot pass prematurely.
+    await waitForMenuItem(expectedVisible[0]);
+
+    for (const title of expectedVisible) {
+      await expect(
+        element(
+          by
+            .text(title)
+            .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+        ),
+      ).toBeVisible();
+    }
+
+    for (const title of ALL_TITLES) {
+      if (!expectedVisible.includes(title)) {
+        await expect(
+          element(
+            by
+              .text(title)
+              .withAncestor(
+                by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW),
+              ),
+          ),
+        ).not.toExist();
+      }
+    }
+  } finally {
+    // Closed in `finally` so a failed assertion — including the gate above —
+    // does not leave the popup covering the screen. This suite is stateful, so
+    // every later step would otherwise fail on an unrelated error.
+    await device.pressBack();
+    await waitForScreen();
+  }
+}
+
+async function expectLastClicked(id: string) {
+  await scrollIntoView('last-clicked-text');
+  await expect(element(by.id('last-clicked-text'))).toHaveText(
+    `Last clicked: ${id}`,
+  );
+}
+
+describeIfAndroid('Stack Toolbar Menu Commands', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Stackv5',
+      'test-stack-toolbar-menu-commands-android',
+    );
+  });
+
+  describe('baseline — initial render from props', () => {
+    it('renders the header title and the three prop-configured menu items', async () => {
+      await expect(element(by.text(HEADER_TITLE))).toBeVisible();
+      await expectMenuItems(['Title A', 'Title B', 'Title C']);
+    });
+
+    it('closes the menu and reports item-1 when tapping "Title A"', async () => {
+      await openMenu();
+      await tapMenuItem('Title A');
+
+      await expect(element(by.text('Title B'))).not.toExist();
+      await expect(element(by.text('Title C'))).not.toExist();
+      await expectLastClicked('item-1');
+    });
+
+    it('reports item-3 when tapping "Title C"', async () => {
+      await openMenu();
+      await tapMenuItem('Title C');
+
+      await expect(element(by.text('Title A'))).not.toExist();
+      await expectLastClicked('item-3');
+    });
+  });
+
+  describe('imperative command — "no change" is a no-op', () => {
+    it('leaves the menu untouched when every field is "no change"', async () => {
+      await sendCommand({
+        target: 'item-1',
+        title: 'no change',
+        hidden: 'no change',
+      });
+
+      await expectMenuItems(['Title A', 'Title B', 'Title C']);
+      await expectLastClicked('item-3');
+    });
+  });
+
+  describe('imperative command — change title only', () => {
+    it('retitles item-2 to "Changed" and leaves items 1 and 3 alone', async () => {
+      await sendCommand({
+        target: 'item-2',
+        title: 'Changed',
+        hidden: 'no change',
+      });
+
+      await expectMenuItems(['Title A', 'Changed', 'Title C']);
+    });
+
+    it('keeps the id stable across a title change — "Changed" still reports item-2', async () => {
+      await openMenu();
+      await tapMenuItem('Changed');
+
+      await expect(element(by.text('Title A'))).not.toExist();
+      await expectLastClicked('item-2');
+    });
+  });
+
+  describe('imperative command — change hidden only', () => {
+    it('hides item-2 when hidden = true', async () => {
+      await sendCommand({
+        target: 'item-2',
+        title: 'no change',
+        hidden: 'true',
+      });
+
+      await expectMenuItems(['Title A', 'Title C']);
+    });
+
+    it('restores item-2 with its command-applied title when hidden = false', async () => {
+      await sendCommand({
+        target: 'item-2',
+        title: 'no change',
+        hidden: 'false',
+      });
+      await expectMenuItems(['Title A', 'Changed', 'Title C']);
+    });
+  });
+
+  describe('imperative command — reset hidden to its regular default', () => {
+    it('hides item-1 when hidden = true', async () => {
+      await sendCommand({
+        target: 'item-1',
+        title: 'no change',
+        hidden: 'true',
+      });
+
+      await expectMenuItems(['Changed', 'Title C']);
+    });
+
+    it('clears the hidden override and falls back to the default when hidden = undefined', async () => {
+      await sendCommand({
+        target: 'item-1',
+        title: 'no change',
+        hidden: 'undefined',
+      });
+
+      await expectMenuItems(['Title A', 'Changed', 'Title C']);
+    });
+  });
+
+  describe('props update — replaces command state across ALL items', () => {
+    it('retitles item-1 to "Long Title" while item-2 keeps "Changed"', async () => {
+      await sendCommand({
+        target: 'item-1',
+        title: 'Long Title',
+        hidden: 'no change',
+      });
+
+      await expectMenuItems(['Long Title', 'Changed', 'Title C']);
+    });
+
+    it('drops every command override once a single slot prop changes', async () => {
+      await setSlotTitle(3, 'Long Title');
+      await expectMenuItems(['Title A', 'Title B', 'Long Title']);
+    });
+
+    it('reverts slot 3 to "Title C" while items 1 and 2 stay props-configured', async () => {
+      await setSlotTitle(3, 'Title C');
+
+      await expectMenuItems(['Title A', 'Title B', 'Title C']);
+    });
+  });
+
+  describe('excluded / unknown id — safe targeting', () => {
+    it('removes item-3 from the menu when slot 3 include = false', async () => {
+      await setSlotInclude(3, false);
+
+      await expectMenuItems(['Title A', 'Title B']);
+    });
+
+    it('does not crash or leak when commanding an id that is not in the menu', async () => {
+      await sendCommand({
+        target: 'item-3',
+        title: 'Changed',
+        hidden: 'false',
+      });
+
+      await expectMenuItems(['Title A', 'Title B']);
+    });
+
+    it('re-includes slot 3 with its props title, not the command title', async () => {
+      await setSlotInclude(3, true);
+      await expectMenuItems(['Title A', 'Title B', 'Title C']);
+    });
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -1,3 +1,4 @@
+import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
 import {
   describeIfAndroid,
@@ -170,11 +171,36 @@ async function closeMenuIfOpen() {
   await waitForScreen();
 }
 
+// Rows are stacked vertically, so their on-screen positions carry the order the
+// menu was built in. Only callable while the menu is open.
+async function expectMenuOrder(titles: readonly MenuTitle[]): Promise<void> {
+  const rows: { title: MenuTitle; top: number }[] = [];
+
+  for (const title of titles) {
+    const attributes = await element(
+      by
+        .text(title)
+        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+    ).getAttributes();
+
+    if ('elements' in attributes) {
+      throw new Error(`Expected a single menu row titled "${title}".`);
+    }
+
+    rows.push({ title, top: attributes.frame.y });
+  }
+
+  const topToBottom = [...rows].sort((a, b) => a.top - b.top).map(r => r.title);
+  jestExpect(topToBottom).toEqual([...titles]);
+}
+
 // Asserts the exact menu contents, then closes it. `expectedVisible` is a
 // non-empty subset of ALL_TITLES — a title outside that set would go unasserted,
-// and the first entry gates the open animation.
+// and the first entry gates the open animation. With `checkOrder`, the entries
+// must also appear top to bottom in the order given.
 async function expectMenuItems(
   expectedVisible: [MenuTitle, ...MenuTitle[]],
+  { checkOrder = false }: { checkOrder?: boolean } = {},
 ): Promise<void> {
   await openMenu();
 
@@ -193,6 +219,10 @@ async function expectMenuItems(
             .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
         ),
       ).toBeVisible();
+    }
+
+    if (checkOrder) {
+      await expectMenuOrder(expectedVisible);
     }
 
     for (const title of ALL_TITLES) {
@@ -242,9 +272,11 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
   });
 
   describe('baseline — initial render from props', () => {
-    it('renders the header title and the three prop-configured menu items', async () => {
+    it('renders the header title and the three prop-configured menu items in order', async () => {
       await expect(element(by.text(HEADER_TITLE))).toBeVisible();
-      await expectMenuItems(['Title A', 'Title B', 'Title C']);
+      await expectMenuItems(['Title A', 'Title B', 'Title C'], {
+        checkOrder: true,
+      });
     });
 
     it('closes the menu and reports item-1 when tapping "Title A"', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -8,19 +8,16 @@ import { CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW } from '../../native-class-
 const SCROLLVIEW_ID = 'toolbar-menu-commands-scrollview';
 const HEADER_TITLE = 'Toolbar Menu Commands Test';
 
-/**
- * Budget for the overflow popup's open / dismiss animation. Detox's idle sync
- * does not cover popup window animations, so every assertion that straddles one
- * has to wait it out explicitly instead of asserting on the spot.
- */
+// Detox's idle sync does not cover popup window animations, so every wait that
+// straddles the overflow menu opening or dismissing has to be explicit.
 const MENU_ANIMATION_TIMEOUT = 2000;
 
-/**
- * Every title this scenario can ever put into the toolbar menu. Each assertion
- * checks the full set — the expected titles must be visible and every other one
- * must not exist — so a stale/leaked menu entry fails the test instead of
- * slipping through an "only check what I expect" assertion.
- */
+// Probes an already-settled popup rather than an animation — by the time it is
+// used the menu is either up or was never opened.
+const MENU_PRESENCE_TIMEOUT = 250;
+
+// Every title this scenario can put into the menu. Assertions check the full
+// set — expected titles visible, all others absent — so a leaked entry fails.
 const ALL_TITLES = [
   'Title A',
   'Title B',
@@ -31,18 +28,14 @@ const ALL_TITLES = [
 
 type MenuTitle = (typeof ALL_TITLES)[number];
 
-/**
- * Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
- * @see apps/src/shared/SettingsPicker.tsx
- */
+// Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
+// @see apps/src/shared/SettingsPicker.tsx
 function optionId(pickerLabel: string, option: string): string {
   return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
 }
 
-/**
- * Rewinds to the top before scrolling down, so a target that sits *above* the
- * current offset is still reachable (`whileElement` only scrolls one way).
- */
+// Rewinds to the top first, so a target above the current offset is still
+// reachable — `whileElement` only scrolls one way.
 async function scrollIntoView(id: string) {
   await element(by.id(SCROLLVIEW_ID)).scrollTo('top');
   await waitFor(element(by.id(id)))
@@ -51,11 +44,8 @@ async function scrollIntoView(id: string) {
     .scroll(300, 'down', Number.NaN, 0.85);
 }
 
-/**
- * Opens the picker, taps an option, closes it again. Closing matters: an open
- * picker leaves its option rows in the hierarchy, where they would collide with
- * the `by.text` matchers used for the toolbar menu items.
- */
+// Closing the picker again matters: its option rows stay in the hierarchy and
+// would collide with the `by.text` matchers used for the toolbar menu items.
 async function selectOption(
   pickerId: string,
   pickerLabel: string,
@@ -103,12 +93,8 @@ async function setSlotTitle(slot: number, title: string) {
   await selectOption(`slot-${slot}-title-picker`, `slot ${slot} title`, title);
 }
 
-/**
- * Flips a slot's `include` switch and verifies the resulting state. The switch
- * only toggles, so `include` is what the caller expects to see afterwards — a
- * swallowed tap fails here instead of surfacing as a confusing wrong-menu
- * assertion several steps later.
- */
+// The switch only toggles, so `include` is the state expected afterwards — a
+// swallowed tap fails here instead of as a wrong-menu assertion steps later.
 async function setSlotInclude(slot: number, include: boolean) {
   const switchId = `slot-${slot}-include-switch`;
   await scrollIntoView(switchId);
@@ -119,15 +105,10 @@ async function setSlotInclude(slot: number, include: boolean) {
   ).toBeVisible();
 }
 
-/**
- * Taps the overflow button. The popup animates in, so the caller must wait for
- * an entry it expects before asserting anything.
- */
 async function openMenu() {
   await element(by.label('More options')).tap();
 }
 
-/** Waits out the popup's open animation by gating on an entry it must contain. */
 async function waitForMenuItem(title: MenuTitle) {
   await waitFor(
     element(
@@ -140,21 +121,15 @@ async function waitForMenuItem(title: MenuTitle) {
     .withTimeout(MENU_ANIMATION_TIMEOUT);
 }
 
-/**
- * Waits until the popup window is gone and the screen behind it is addressable
- * again. Espresso resolves matchers against a single window — while the popup
- * holds focus, nothing in the screen below it is in the searched hierarchy, so
- * the menu entry disappearing is not enough: the next action against the screen
- * would fail with "No views in hierarchy found". Gating on the scroll view
- * retries until the root switches back.
- */
+// Detox resolves matchers against a single window: while the popup holds focus
+// nothing behind it is in the searched hierarchy, so the entry going away is
+// not enough — the screen itself has to become addressable again.
 async function waitForScreen() {
   await waitFor(element(by.id(SCROLLVIEW_ID)))
     .toBeVisible()
     .withTimeout(MENU_ANIMATION_TIMEOUT);
 }
 
-/** Taps a menu entry and waits for the popup to finish dismissing. */
 async function tapMenuItem(title: MenuTitle) {
   await waitForMenuItem(title);
   await element(
@@ -174,23 +149,40 @@ async function tapMenuItem(title: MenuTitle) {
   await waitForScreen();
 }
 
-/**
- * Asserts the exact contents of the overflow menu, then closes it. Every
- * expected title is checked for visibility and every other known title for
- * absence, so neither a missing entry nor a leaked one can slip through.
- *
- * `expectedVisible` is a non-empty list of `ALL_TITLES` members: a title
- * outside that set would otherwise go unasserted, and the first entry gates the
- * open animation.
- */
+// Presses Back only when the popup is actually up: a menu that never opened
+// would otherwise take the Back press itself and pop the test screen.
+async function closeMenuIfOpen() {
+  const isOpen = await waitFor(
+    element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
+  )
+    .toExist()
+    .withTimeout(MENU_PRESENCE_TIMEOUT)
+    .then(
+      () => true,
+      () => false,
+    );
+
+  if (!isOpen) {
+    return;
+  }
+
+  await device.pressBack();
+  await waitForScreen();
+}
+
+// Asserts the exact menu contents, then closes it. `expectedVisible` is a
+// non-empty subset of ALL_TITLES — a title outside that set would go unasserted,
+// and the first entry gates the open animation.
 async function expectMenuItems(
   expectedVisible: [MenuTitle, ...MenuTitle[]],
 ): Promise<void> {
   await openMenu();
 
+  let assertionFailed = false;
+
   try {
-    // The menu is populated in a single layout pass, so once the first expected
-    // entry is up the `not.toExist()` checks below cannot pass prematurely.
+    // Populated in a single layout pass, so once the first expected entry is up
+    // the `not.toExist()` checks below cannot pass prematurely.
     await waitForMenuItem(expectedVisible[0]);
 
     for (const title of expectedVisible) {
@@ -216,12 +208,20 @@ async function expectMenuItems(
         ).not.toExist();
       }
     }
+  } catch (error) {
+    assertionFailed = true;
+    throw error;
   } finally {
-    // Closed in `finally` so a failed assertion — including the gate above —
-    // does not leave the popup covering the screen. This suite is stateful, so
-    // every later step would otherwise fail on an unrelated error.
-    await device.pressBack();
-    await waitForScreen();
+    // Closed here so a failed assertion does not leave the popup covering the
+    // screen — this suite is stateful and every later step would then fail.
+    try {
+      await closeMenuIfOpen();
+    } catch (cleanupError) {
+      // A throw from `finally` would replace the error that actually failed.
+      if (!assertionFailed) {
+        throw cleanupError;
+      }
+    }
   }
 }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -165,30 +165,42 @@ function MainScreen() {
 
   return (
     <ScrollViewMarker style={styles.scrollViewMarker}>
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        testID="toolbar-menu-commands-scrollview">
         <Text style={styles.heading}>Send Command</Text>
         <SettingsPicker<IdOption>
           label="target id"
           value={cmdTargetId}
           items={[...ID_OPTIONS]}
           onValueChange={setCmdTargetId}
+          testID="cmd-target-picker"
         />
         <SettingsPicker<CmdTitleOption>
-          label="title"
+          label="cmd title"
           value={cmdTitle}
           items={CMD_TITLE_OPTIONS}
           onValueChange={setCmdTitle}
+          testID="cmd-title-picker"
         />
         <SettingsPicker<CmdHiddenOption>
-          label="hidden"
+          label="cmd hidden"
           value={cmdHidden}
           items={CMD_HIDDEN_OPTIONS}
           onValueChange={setCmdHidden}
+          testID="cmd-hidden-picker"
         />
-        <Button title="Send Command" onPress={sendCommand} />
+        <Button
+          title="Send Command"
+          onPress={sendCommand}
+          testID="send-command-button"
+        />
 
         <Text style={styles.heading}>Result</Text>
-        <Text style={styles.result}>Last clicked: {lastClicked ?? '—'}</Text>
+        <Text testID="last-clicked-text" style={styles.result}>
+          Last clicked: {lastClicked ?? '—'}
+        </Text>
 
         <Text style={styles.heading}>Menu Items — Props</Text>
         <SlotControls
@@ -214,21 +226,24 @@ function SlotControls({ slots, updateSlot }: SlotControlsProps) {
             Slot {i + 1} (item-{i + 1})
           </Text>
           <SettingsSwitch
-            label="include"
+            label={`slot ${i + 1} include`}
             value={slot.include}
             onValueChange={v => updateSlot(i, { include: v })}
+            testID={`slot-${i + 1}-include-switch`}
           />
           <SettingsPicker<TitleOption>
-            label="title"
+            label={`slot ${i + 1} title`}
             value={slot.title}
             items={[...TITLE_OPTIONS]}
             onValueChange={v => updateSlot(i, { title: v })}
+            testID={`slot-${i + 1}-title-picker`}
           />
           <SettingsPicker<HiddenOption>
-            label="hidden"
+            label={`slot ${i + 1} hidden`}
             value={slot.hidden}
             items={[...HIDDEN_OPTIONS]}
             onValueChange={v => updateSlot(i, { hidden: v })}
+            testID={`slot-${i + 1}-hidden-picker`}
           />
         </React.Fragment>
       ))}

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-description.ts
@@ -8,6 +8,6 @@ export const scenarioDescription: ScenarioDescription = {
     'It focuses on the flow of updates rather than testing specific props ' +
     'but it covers the hidden prop.',
   platforms: ['android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario-description.ts
@@ -8,6 +8,6 @@ export const scenarioDescription: ScenarioDescription = {
     'It focuses on the flow of updates rather than testing specific props ' +
     'but it covers the hidden prop.',
   platforms: ['android'],
-  e2eCoverage: 'incomplete',
+  e2eCoverage: 'full',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -17,7 +17,10 @@ whose prop changed.
 
 ## E2E test
 
-Other — automation is not implemented yet.
+Incomplete.
+
+- All steps are covered, except for checking the order of the overflow entries
+("Title A", "Title B", "Title C"). Presence and visibility are checked instead.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/scenario.md
@@ -17,10 +17,7 @@ whose prop changed.
 
 ## E2E test
 
-Incomplete.
-
-- All steps are covered, except for checking the order of the overflow entries
-("Title A", "Title B", "Title C"). Presence and visibility are checked instead.
+Full: All steps are covered.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1694

Adds Detox e2e coverage for the existing `test-stack-toolbar-menu-commands-android` scenario (Android toolbar menu items on the v5 stack header — the `toolbarMenu` prop plus the imperative `updateToolbarMenuElements` command).

The test automates all 16 scenario steps, covering:

- initial menu render from props and `onPress` reporting the correct item id,
- imperative commands: absent fields preserve the current value, `undefined` (sent as `null`) resets to the prop's regular default,
- a props update on any single slot rebuilding the whole menu and dropping command-applied state on **all** items,
- safe targeting of an id that is not currently in the menu (excluded slot / unknown id) — no crash, no state leaking into the re-included slot.

The only thing left uncovered is the **order** of the overflow entries; presence and visibility are asserted instead. `e2eCoverage` in `scenario-description.ts` is therefore bumped from `tbd` to `incomplete`, and `scenario.md` documents the gap.

## Changes

- Added `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts`.
- Added `CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW` to `FabricExample/e2e/native-class-names.ts` — every menu-entry matcher is scoped with `withAncestor` to this class so entries in the popup window are not confused with same-titled text elsewhere in the hierarchy.
- Test screen (`apps/src/tests/.../test-stack-toolbar-menu-commands-android/index.tsx`): added `testID`s to the scroll view, the command pickers, the *Send Command* button, the result text and the per-slot switches/pickers; made the picker/switch labels unique (`title` → `cmd title`, `title` → `slot N title`, …) so they no longer collide between the command section and the three slot sections.
- Updated `scenario.md` (E2E test section) and `scenario-description.ts` (`e2eCoverage: 'tbd'` → `'incomplete'`).

No library code is touched — this is test-only.