### PR TITLE
fix(iOS): stable identifiers for header bar button items so iOS 26 morphs them across transitions

### DIFF
--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -59,10 +59,12 @@
 
       switch (item.placement) {
         case RNSHeaderItemPlacementLeading:
-          [_leadingBarButtonItems addObject:[self buildBarButtonItemForItem:item]];
+          [_leadingBarButtonItems addObject:[self buildBarButtonItemForItem:item
+                                                                    atIndex:_leadingBarButtonItems.count]];
           break;
         case RNSHeaderItemPlacementTrailing:
-          [_trailingBarButtonItems addObject:[self buildBarButtonItemForItem:item]];
+          [_trailingBarButtonItems addObject:[self buildBarButtonItemForItem:item
+                                                                     atIndex:_trailingBarButtonItems.count]];
           break;
         case RNSHeaderItemPlacementTitle:
           if (item.customView != nil) {
@@ -136,10 +138,12 @@
 
   switch (targetItem.placement) {
     case RNSHeaderItemPlacementLeading: {
-      UIBarButtonItem *newBarButtonItem = [self buildBarButtonItemForItem:targetItem];
+      NSUInteger index =
+          oldBarButtonItem != nil ? [_leadingBarButtonItems indexOfObject:oldBarButtonItem] : NSNotFound;
+      UIBarButtonItem *newBarButtonItem = [self buildBarButtonItemForItem:targetItem
+                                                                  atIndex:index != NSNotFound ? index : 0];
 
       if (oldBarButtonItem != nil) {
-        NSUInteger index = [_leadingBarButtonItems indexOfObject:oldBarButtonItem];
         if (index != NSNotFound) {
           _leadingBarButtonItems[index] = newBarButtonItem;
         } else {
@@ -151,10 +155,12 @@
       break;
     }
     case RNSHeaderItemPlacementTrailing: {
-      UIBarButtonItem *newBarButtonItem = [self buildBarButtonItemForItem:targetItem];
+      NSUInteger index =
+          oldBarButtonItem != nil ? [_trailingBarButtonItems indexOfObject:oldBarButtonItem] : NSNotFound;
+      UIBarButtonItem *newBarButtonItem = [self buildBarButtonItemForItem:targetItem
+                                                                  atIndex:index != NSNotFound ? index : 0];
 
       if (oldBarButtonItem != nil) {
-        NSUInteger index = [_trailingBarButtonItems indexOfObject:oldBarButtonItem];
         if (index != NSNotFound) {
           _trailingBarButtonItems[index] = newBarButtonItem;
         } else {
@@ -416,11 +422,24 @@
 }
 
 - (UIBarButtonItem *)buildBarButtonItemForItem:(id<RNSStackHeaderItemDataProviding>)item
+                                      atIndex:(NSUInteger)index
 {
   UIBarButtonItem *barButtonItem = [RNSStackHeaderContentFactory barButtonItemForHeaderItem:item
                                                                     withFrameChangeDelegate:_frameChangeDelegate
                                                                    withHeaderEventsDelegate:_eventsDelegate
                                                                             withImageLoader:_imageLoader];
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    // Give every item a stable identifier derived from the slot it occupies. Without it UIKit falls
+    // back to content-based heuristics and treats the items of the pushed screen as a brand new set,
+    // replaying the item appear animation on every transition instead of morphing them in place.
+    barButtonItem.identifier = [NSString
+        stringWithFormat:@"rns-header-item-%@-%lu",
+                         item.placement == RNSHeaderItemPlacementLeading ? @"leading" : @"trailing",
+                         (unsigned long)index];
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 
   if (item.menu != nil && item.itemId != nil) {
     RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:item.itemId];


### PR DESCRIPTION
## Description

On iOS 26, custom header items replay the bar-item appear animation (assemble/expand) on every
push and pop, instead of morphing in place the way stock bar items do. It is most visible on a stack
where consecutive screens have header items in the same slots: the items visibly re-assemble on each
transition even when nothing about them changed.

The cause is that we never set `UIBarButtonItem.identifier`. From the iOS 26 SDK:

> An identifier used to match bar button items across transitions in a navigation bar or toolbar.
>
> When the set of bar button items in a navigation bar or toolbar changes (for example, when pushing
> or popping view controllers), UIKit automatically animates the transition between the different
> sets of items. By default, UIKit uses heuristics based on item position and content to determine
> which items should be matched for these transitions.
>
> Set this property with the same value on two different bar button items in different navigation
> item configurations to indicate that they should be treated as the same item during transitions.
>
> The default value is `nil`, which means UIKit will use its default heuristics for transitions.

With `identifier == nil` the fallback heuristics are content-based, and for React-rendered custom
views (`initWithCustomView:`) there is not enough stable content for UIKit to match anything, so
every screen's items look like a brand new set.

## Changes

`RNSStackScreenHeaderCoordinator`:

- `buildBarButtonItemForItem:` takes the item's index within its slot and, on iOS 26+, sets
  `identifier` to `rns-header-item-{leading|trailing}-{index}`.
- `rebuild` passes the index the item is appended at.
- `rebuildItemWithId:` resolves the index of the item being replaced *before* building the
  replacement, so a rebuilt item keeps the identifier it had.

Positional identity (slot + index) is deliberate: it is what makes "the left-most trailing item of
screen A" morph into "the left-most trailing item of screen B", which is the animation UIKit is
trying to produce. It is a no-op below iOS 26.

## Open question

Should this instead (or additionally) be exposed to JS, e.g. an optional `identifier` prop on
header items, so apps can opt two items into being the same item across screens even when their
positions differ? Happy to extend the PR if you'd prefer that shape — this version only replaces the
`nil` default with something UIKit can actually match on.

## Test code and steps to reproduce

Any stack where two consecutive screens both render custom header items in the same slot; push and
pop between them on an iOS 26 device or simulator with slow animations enabled. Before: the items
re-assemble on each transition. After: they morph in place.

## Checklist

- [ ] Ensured that CI passes
