### PR TITLE
refactor(examples, stack v5): erase options as required from StackRouteConfig

### DIFF
--- a/apps/src/shared/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/containers/stack/StackContainer.tsx
@@ -66,7 +66,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
     <Stack.Host ref={hostRef}>
       {stackNavState.stack.map(
         ({
-          options: { headerConfig, headerConfigRef, ...options },
+          options: { headerConfig, headerConfigRef, ...options } = {},
           activityMode,
           routeKey,
           name,

--- a/apps/src/shared/containers/stack/StackContainer.types.ts
+++ b/apps/src/shared/containers/stack/StackContainer.types.ts
@@ -21,7 +21,7 @@ export type StackRouteOptions = Omit<
 export type StackRouteConfig = {
   name: string;
   Component: React.ComponentType;
-  options: StackRouteOptions;
+  options?: StackRouteOptions;
 };
 
 export type StackRoute = Omit<StackRouteConfig, 'Component'> & {

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
@@ -38,7 +38,6 @@ function StackSetup() {
         {
           name: 'Home',
           Component: HomeScreen,
-          options: {},
         },
         {
           name: 'A',

--- a/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
@@ -58,7 +58,6 @@ const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Screen1',
     Component: ConfigScreen,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
@@ -81,7 +81,6 @@ const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Screen1',
     Component: TabsScreen,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -48,12 +48,10 @@ const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'First',
     Component: StackContents,
-    options: {},
   },
   {
     name: 'Second',
     Component: StackContents,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
@@ -48,17 +48,14 @@ const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'First',
     Component: FirstStackScreen,
-    options: {},
   },
   {
     name: 'Second',
     Component: SecondStackScreen,
-    options: {},
   },
   {
     name: 'Third',
     Component: ThirdStackScreen,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/issue-tests/Test3576.tsx
+++ b/apps/src/tests/issue-tests/Test3576.tsx
@@ -176,12 +176,10 @@ const routeConfigs: StackRouteConfig[] = [
   {
     name: 'Menu',
     Component: MenuScreen,
-    options: {},
   },
   ...ALPHABET.map(name => ({
     name,
     Component: TemplateScreen,
-    options: {},
   })),
 ];
 

--- a/apps/src/tests/issue-tests/Test4155.tsx
+++ b/apps/src/tests/issue-tests/Test4155.tsx
@@ -84,7 +84,6 @@ const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Tabs',
     Component: TabsScreen,
-    options: {},
   },
   {
     name: 'Test',

--- a/apps/src/tests/issue-tests/TestScreenStack/index.tsx
+++ b/apps/src/tests/issue-tests/TestScreenStack/index.tsx
@@ -27,12 +27,10 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'A',
     Component: TemplateScreen,
-    options: {},
   },
   {
     name: 'B',
     Component: TemplateScreen,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/issue-tests/TestStackNesting.tsx
+++ b/apps/src/tests/issue-tests/TestStackNesting.tsx
@@ -109,12 +109,10 @@ const ROUTE_CONFIGS_NESTED_STACK: StackRouteConfig[] = [
   {
     name: 'NestedA',
     Component: NestedTemplateScreen,
-    options: {},
   },
   {
     name: 'NestedB',
     Component: NestedTemplateScreen,
-    options: {},
   },
 ];
 

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
@@ -152,7 +152,6 @@ function TestScrollToTopGuardHeaderSubviewsIOS() {
         {
           name: 'Screen1',
           Component: Screen1,
-          options: {},
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
@@ -15,7 +15,6 @@ function TestSvmConfiguresScrollView() {
         {
           name: 'Content',
           Component: ContentScreen,
-          options: {},
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/index.tsx
@@ -17,22 +17,18 @@ function StackSetup() {
         {
           name: 'Home',
           Component: HomeScreen,
-          options: {},
         },
         {
           name: 'Blue',
           Component: BlueScreen,
-          options: {},
         },
         {
           name: 'Red',
           Component: RedScreen,
-          options: {},
         },
         {
           name: 'NestedHost',
           Component: NestedHostScreen,
-          options: {},
         },
       ]}
     />
@@ -79,17 +75,14 @@ function NestedHostScreen() {
         {
           name: 'NestedHome',
           Component: NestedHomeScreen,
-          options: {},
         },
         {
           name: 'NestedBlue',
           Component: NestedBlueScreen,
-          options: {},
         },
         {
           name: 'NestedRed',
           Component: NestedRedScreen,
-          options: {},
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -118,12 +118,10 @@ function TestStackBackButton() {
           {
             name: 'Root',
             Component: RootScreen,
-            options: {},
           },
           {
             name: 'Pushed',
             Component: PushedScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/index.tsx
@@ -224,7 +224,6 @@ function TestStackHeaderIconIOS() {
           {
             name: 'Home',
             Component: ConfigScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -90,7 +90,6 @@ function TestStackHeaderMenuIOS() {
           {
             name: 'Home',
             Component: ConfigScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
@@ -16,7 +16,6 @@ function TestStackHeaderMenuOptionsIOS() {
         {
           name: 'Home',
           Component: ConfigScreen,
-          options: {},
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
@@ -138,7 +138,6 @@ export function TestStackHeaderSelectiveUpdatesIOS() {
           {
             name: 'Home',
             Component: ConfigScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
@@ -21,7 +21,6 @@ export function TestStackHeaderSubviewsOnpressIOS() {
           {
             name: 'Home',
             Component: ConfigScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
@@ -55,7 +55,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
 function TestStackLiftOnScrollAndroid() {
   return (
     <StackContainer
-      routeConfigs={[{ name: 'Home', Component: ConfigScreen, options: {} }]}
+      routeConfigs={[{ name: 'Home', Component: ConfigScreen }]}
     />
   );
 }

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/index.tsx
@@ -29,7 +29,6 @@ function StackSetup() {
         {
           name: 'Home',
           Component: HomeScreen,
-          options: {},
         },
         {
           name: 'A',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -29,7 +29,6 @@ function StackSetup() {
         {
           name: 'Home',
           Component: HomeScreen,
-          options: {},
         },
         {
           name: 'A',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -195,7 +195,6 @@ function StackSetup() {
         {
           name: 'Home',
           Component: ConfigScreen,
-          options: {},
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -151,12 +151,10 @@ function StackSetup() {
           {
             name: 'Home',
             Component: ConfigScreen,
-            options: {},
           },
           {
             name: 'Second',
             Component: ConfigScreen,
-            options: {},
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
@@ -40,11 +40,11 @@ function LightRootScreenContent() {
 }
 
 const ROUTE_CONFIGS: StackRouteConfig[] = [
-  { name: 'home', Component: HomeScreen, options: {} },
-  { name: 'darkRoot', Component: DarkRootScreenContent, options: {} },
-  { name: 'darkPushed', Component: DarkInterfaceStyleScreen, options: {} },
-  { name: 'lightRoot', Component: LightRootScreenContent, options: {} },
-  { name: 'lightPushed', Component: LightInterfaceStyleScreen, options: {} },
+  { name: 'home', Component: HomeScreen },
+  { name: 'darkRoot', Component: DarkRootScreenContent },
+  { name: 'darkPushed', Component: DarkInterfaceStyleScreen },
+  { name: 'lightRoot', Component: LightRootScreenContent },
+  { name: 'lightPushed', Component: LightInterfaceStyleScreen },
 ];
 
 function TestTabsTabBarExperimentalUserInterfaceStyle() {


### PR DESCRIPTION
## Description

Set options as optional in StackRouteConfig to avoid unnecessary empty arguments

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1544

## Changes

- Update StackContainer.types.ts (set options as optional)
- Update StackContainer.tsx (add default argument)
- Update tests

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
