### PR TITLE
fix(ios): deallocate screens on Fabric pop (break RNSScreen<->RNSScreenView retain cycle)

### DIFF
--- a/ios/legacy/RNSScreenStack.mm
+++ b/ios/legacy/RNSScreenStack.mm
@@ -1317,6 +1317,16 @@ RNS_IGNORE_SUPER_CALL_END
   RNSScreenView *screenChildComponent = (RNSScreenView *)childComponentView;
   [screenChildComponent.controller addSnapshotToView];
 
+  // Break the RNSScreenView <-> RNSScreen (controller) retain cycle when a screen
+  // is popped. `invalidateImpl` nils `_controller` on the next main-queue tick, so
+  // the running pop animation (which uses the snapshot added above) is unaffected;
+  // once it completes and the navigation controller releases the RNSScreen, the
+  // whole screen (view + controller + its React subtree) deallocates. Its usual
+  // trigger `-invalidate` (RCTInvalidating) is never called on the New
+  // Architecture, so without this the cycle leaks every pushed screen (see #1754).
+  // `+shouldBeRecycled` is NO, so the view is never reused after this.
+  [screenChildComponent invalidateImpl];
+
   RCTAssert(screenChildComponent.reactSuperview == self,
             @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
             self,


### PR DESCRIPTION
## Description

On the New Architecture (Fabric), a native-stack screen is **never deallocated after it is popped** — the `RNSScreen` view controller, its `RNSScreenView`, and the entire React subtree they retain stay alive for the rest of the process. Over a long session this grows until the app runs out of memory (in our app it surfaced as a Hermes `GCBase::oom`).

The cause is a retain cycle:

- `RNSScreenView` holds its controller strongly — `RNSScreen.h`: `@property (nonatomic, retain) RNSScreen *controller;`
- `RNSScreen` holds the view back strongly — `self.view` **and** the non-`__weak` `_initialView` ivar (set in `initWithView:`).

The library already contains the break: `-[RNSScreenView invalidateImpl]` nils `_controller` (deferred to the main queue). But its only trigger is `-invalidate` (`RCTInvalidating`), which is a Paper-era hook that is **never called on Fabric**, so the cycle is never broken and every popped screen leaks.

Refs #1754.

## Changes

- Call `[screenChildComponent invalidateImpl]` from `-[RNSScreenStack unmountChildComponentView:index:]` (right after `addSnapshotToView`), so the existing teardown runs on the Fabric unmount path.
- The `_controller = nil` is deferred to the next main-queue tick (unchanged `invalidateImpl` behavior), so the in-flight pop animation — which uses the snapshot added just above — is unaffected. Once the pop finishes and the navigation controller releases the `RNSScreen`, the whole screen deallocates.
- `+[RNSScreenView shouldBeRecycled]` returns `NO`, so the component view is never reused after unmount — nilling the controller here is safe.

No JS/public API change.

## Test plan

Minimal repro: a `@react-navigation/native-stack` with two screens; repeatedly push then pop the second screen while recording **Xcode Instruments → Allocations**, filtered to `RNSScreen` / `RNSScreenView`.

- **Before:** `# Persistent` for `RNSScreen` / `RNSScreenView` increases by one on every push/pop and never decreases.
- **After:** those instances become transient — deallocated on pop; `# Persistent` stays flat.

Verified on iOS with RN New Architecture (Fabric) enabled.

## Checklist

- [x] For API changes, updated relevant public types. — n/a, no API change
- [x] Included steps that can be used to test this change (Instruments repro above).
- [ ] For visual changes, included screenshots / GIFs / recordings. — n/a, no visual change
- [ ] Ensured that CI passes.
