### PR TITLE
feat(Android, Stack v5): expose maxLines prop, add workaround for subtitle runtime change

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -176,12 +176,12 @@ internal class StackHeaderApplicator(
                 // so toggling the subtitle at runtime reclaims the title space.
                 ctl.requestLayout()
 
-                // Material re-asserts the collapsed offset after a height change only when
-                // maxLines > 1 (CollapsingToolbarLayout.onMeasure); with maxLines == 1, toggling
-                // the subtitle at runtime while collapsed leaves a stale offset. setExpanded(false,
-                // false) is the closest public equivalent of Material's private
-                // maybeSetPendingActionCollapsed() and recomputes it for the new height.
-                if (isAppBarFullyCollapsed) {
+                // Material re-asserts the collapsed offset after a height change itself, but only
+                // when maxLines > 1 (CollapsingToolbarLayout.onMeasure). With maxLines == 1 it never
+                // does, so toggling the subtitle at runtime while collapsed leaves a stale offset —
+                // setExpanded(false, false) is the closest public equivalent of Material's private
+                // maybeSetPendingActionCollapsed().
+                if (config.maxLines == 1 && isAppBarFullyCollapsed) {
                     appBar.setExpanded(false, false)
                 }
             }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -155,6 +155,7 @@ internal class StackHeaderApplicator(
     internal fun applyTitleAndSubtitle(
         appBar: StackHeaderAppBarLayout,
         config: StackHeaderConfigurationProviding,
+        isAppBarFullyCollapsed: Boolean,
     ) {
         when (appBar) {
             is StackHeaderAppBarLayout.Small -> {
@@ -165,13 +166,7 @@ internal class StackHeaderApplicator(
             is StackHeaderAppBarLayout.Collapsing -> {
                 val ctl = appBar.collapsingToolbarLayout
 
-                // Due to a bug in Material's CollapsingToolbarLayout implementation, showing
-                // subtitle in runtime while header is collapsed results in incorrect scroll offset
-                // unless more than 1 line is used. See CollapsingToolbarLayout.java:783
-                // (material-1.14.0). For now, we're hardcoding number of lines to 2. In the future,
-                // we're planning to expose this prop to the user. We should consider what the
-                // default value should be.
-                ctl.maxLines = 2
+                ctl.maxLines = config.maxLines
 
                 ctl.title = config.title
                 ctl.subtitle = config.subtitle
@@ -180,6 +175,15 @@ internal class StackHeaderApplicator(
                 // title/subtitle vertical split is recomputed only in onLayout. Force a layout
                 // so toggling the subtitle at runtime reclaims the title space.
                 ctl.requestLayout()
+
+                // Material re-asserts the collapsed offset after a height change only when
+                // maxLines > 1 (CollapsingToolbarLayout.onMeasure); with maxLines == 1, toggling
+                // the subtitle at runtime while collapsed leaves a stale offset. setExpanded(false,
+                // false) is the closest public equivalent of Material's private
+                // maybeSetPendingActionCollapsed() and recomputes it for the new height.
+                if (isAppBarFullyCollapsed) {
+                    appBar.setExpanded(false, false)
+                }
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -109,7 +109,8 @@ internal class StackHeaderCoordinatorLayout(
     // region Layout callbacks
 
     private val appBarOffsetListener =
-        AppBarLayout.OnOffsetChangedListener { _, _ ->
+        AppBarLayout.OnOffsetChangedListener { appBar, verticalOffset ->
+            evaluateCollapseState(appBar, verticalOffset)
             onMaybeHeaderLayoutChanged()
         }
 
@@ -133,6 +134,20 @@ internal class StackHeaderCoordinatorLayout(
         val provider = currentProvider ?: return
         val appBar = appBarLayout ?: return
         StackHeaderFrameSynchronizer.sync(appBar, provider, delegate)
+    }
+
+    // Tracks whether the app bar is currently scrolled to its fully collapsed offset. Used to work
+    // around a Material offset bug when the title/subtitle changes at runtime — see
+    // StackHeaderApplicator.applyTitleAndSubtitle. This should be equivalent to Material's
+    // `collapsingTitleHelper.getExpansionFraction() == 1f` condition.
+    private var isAppBarFullyCollapsed = false
+
+    private fun evaluateCollapseState(
+        appBar: AppBarLayout,
+        verticalOffset: Int
+    ) {
+        val totalScrollRange = appBar.totalScrollRange
+        isAppBarFullyCollapsed = totalScrollRange > 0 && -verticalOffset >= totalScrollRange
     }
 
     // endregion
@@ -182,7 +197,7 @@ internal class StackHeaderCoordinatorLayout(
         val appBar = appBarLayout
         if (appBar != null) {
             if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE)) {
-                applicator.applyTitleAndSubtitle(appBar, provider)
+                applicator.applyTitleAndSubtitle(appBar, provider, isAppBarFullyCollapsed)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE)
             }
 
@@ -286,6 +301,8 @@ internal class StackHeaderCoordinatorLayout(
             removeView(it)
         }
         appBarLayout = null
+        // A rebuilt header starts fully expanded; drop any stale collapsed state from the old one.
+        isAppBarFullyCollapsed = false
         selectionController.clear()
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -144,7 +144,7 @@ internal class StackHeaderCoordinatorLayout(
 
     private fun evaluateCollapseState(
         appBar: AppBarLayout,
-        verticalOffset: Int
+        verticalOffset: Int,
     ) {
         val totalScrollRange = appBar.totalScrollRange
         isAppBarFullyCollapsed = totalScrollRange > 0 && -verticalOffset >= totalScrollRange

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -82,6 +82,10 @@ internal class StackHeaderConfig(
     override var subtitle: String by invalidatingProperty("", StackHeaderInvalidationFlags.TITLE)
         internal set
 
+    // Requires header rebuild due to bug in Material implementation
+    override var maxLines: Int by invalidatingProperty(1, StackHeaderInvalidationFlags.STRUCTURE)
+        internal set
+
     override var hidden: Boolean by invalidatingProperty(false, StackHeaderInvalidationFlags.STRUCTURE)
         internal set
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
@@ -136,6 +136,13 @@ internal open class StackHeaderConfigViewManager :
         view.subtitle = value ?: ""
     }
 
+    override fun setMaxLines(
+        view: StackHeaderConfig,
+        value: Int,
+    ) {
+        view.maxLines = value.coerceAtLeast(1)
+    }
+
     override fun setTitleCentered(
         view: StackHeaderConfig,
         value: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -9,6 +9,7 @@ internal interface StackHeaderConfigurationProviding {
     val type: StackHeaderType
     val title: String
     val subtitle: String
+    val maxLines: Int
     val hidden: Boolean
     val transparent: Boolean
     val backButtonHidden: Boolean

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -43,6 +43,7 @@ type HitSlopValue = '0' | '10' | '30';
 type PressRetentionValue = '0' | '20' | '50';
 type TextOption = 'undefined' | 'short' | 'long';
 type ScrollFlagValue = 'undefined' | 'true' | 'false';
+type MaxLinesValue = '1' | '2' | '3';
 
 interface Config {
   enabled: boolean;
@@ -51,6 +52,7 @@ interface Config {
   hidden: boolean;
   title: TextOption;
   subtitle: TextOption;
+  maxLines: MaxLinesValue;
   titleCentered: boolean;
   subtitleCentered: boolean;
   expandedTitleHorizontalGravity: StackHeaderTitleHorizontalGravityAndroid;
@@ -79,6 +81,7 @@ const DEFAULT_CONFIG: Config = {
   hidden: false,
   title: 'short',
   subtitle: 'short',
+  maxLines: '1',
   titleCentered: false,
   subtitleCentered: false,
   expandedTitleHorizontalGravity: 'start',
@@ -110,6 +113,7 @@ const HIT_SLOP_VALUES: HitSlopValue[] = ['0', '10', '30'];
 const PRESS_RETENTION_VALUES: PressRetentionValue[] = ['0', '20', '50'];
 const TEXT_OPTIONS: TextOption[] = ['undefined', 'short', 'long'];
 const SCROLL_FLAG_VALUES: ScrollFlagValue[] = ['undefined', 'true', 'false'];
+const MAX_LINES_OPTIONS: MaxLinesValue[] = ['1', '2', '3'];
 const HORIZONTAL_GRAVITY_OPTIONS: StackHeaderTitleHorizontalGravityAndroid[] = [
   'start',
   'center',
@@ -234,6 +238,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       collapsedTitleHorizontalGravity: config.collapsedTitleHorizontalGravity,
       collapsedTitleVerticalGravity: config.collapsedTitleVerticalGravity,
       collapsedTitleGravityMode: config.collapsedTitleGravityMode,
+      maxLines: Number(config.maxLines),
       scrollFlagScroll: resolveScrollFlag(config.scrollFlagScroll),
       scrollFlagEnterAlways: resolveScrollFlag(config.scrollFlagEnterAlways),
       scrollFlagEnterAlwaysCollapsed: resolveScrollFlag(
@@ -389,6 +394,12 @@ function ConfigScreen() {
               value={config.collapsedTitleGravityMode}
               onValueChange={v => updateConfig('collapsedTitleGravityMode', v)}
               items={GRAVITY_MODE_OPTIONS}
+            />
+            <SettingsPicker<MaxLinesValue>
+              label="maxLines"
+              value={config.maxLines}
+              onValueChange={v => updateConfig('maxLines', v)}
+              items={MAX_LINES_OPTIONS}
             />
           </>
         )}

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -906,7 +906,7 @@ export interface StackHeaderConfigPropsAndroid {
    * A value less than `1` is invalid and falls back to `1`.
    *
    * Changing this value at runtime rebuilds the header. This is required due to
-   * native platfom limitation.
+   * a native platform limitation.
    *
    * @default 1
    * @platform android

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -893,6 +893,26 @@ export interface StackHeaderConfigPropsAndroid {
     | StackHeaderCollapsedTitleGravityModeAndroid
     | undefined;
   /**
+   * @summary Maximum number of lines for the expanded title and subtitle.
+   *
+   * @description
+   * A single shared value: the same limit applies to both the expanded title
+   * and the expanded subtitle. Text exceeding the limit is ellipsized.
+   *
+   * @remarks
+   * Applies to `medium` / `large` headers only; ignored for `small`. The
+   * collapsed title is always a single line regardless of this value.
+   *
+   * A value less than `1` is invalid and falls back to `1`.
+   *
+   * Changing this value at runtime rebuilds the header. This is required due to
+   * native platfom limitation.
+   *
+   * @default 1
+   * @platform android
+   */
+  maxLines?: number | undefined;
+  /**
    * @summary Color of the title text. Applies to `small` header only.
    *
    * @remarks

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -93,6 +93,7 @@ export type StackHeaderToolbarMenuElementAndroid =
 export interface NativeProps extends ViewProps {
   title?: string | undefined;
   subtitle?: string | undefined;
+  maxLines?: CT.WithDefault<CT.Int32, 1>;
   hidden?: CT.WithDefault<boolean, false>;
   transparent?: CT.WithDefault<boolean, false>;
   backButtonHidden?: CT.WithDefault<boolean, false>;


### PR DESCRIPTION
## Description

Exposes `maxLines` property. Changes default value to match Material's default to `1`. Previous default was used as a workaround for preventing app bar scroll after subtitle runtime change (more details in https://github.com/software-mansion/react-native-screens/pull/4387). In this PR, we're introducing a workaround that allows us to restore Material's default for `maxLines` prop.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1712.

### Workaround

Material's implementation adjusts the scrolling offset only if `maxLines > 1` and the app bar is expanded:

```java
// CollapsingToolbarLayout.java:779

// onMeasure

// When extra multiline height is enabled, the height of the CollapsingToolbarLayout can change
// dynamically. If the height changes while the view is collapsed, we need to ensure that the
// AppBarLayout updates its collapse state to match the new height, otherwise it may try to
// scroll to an invalid offset based on the old height.
if (extraMultilineHeightEnabled
    && collapsingTitleHelper.getExpandedMaxLines() > 1
    && collapsingTitleHelper.getExpansionFraction() == 1f) {
  maybeSetPendingActionCollapsed();
}
```

In this PR, we're adding a workaround that mimics this behavior.

Here are some details from Claude:

<details>
    <summary>Details</summary>

```
What Material does automatically when maxLines = 2 (i.e. > 1)

When a runtime title/subtitle change alters the collapsing header's height, CollapsingToolbarLayout.onMeasure re-asserts the collapsed offset — but only when maxLines > 1:

sources/material-1.14.0/…/CollapsingToolbarLayout.java:783-787
if (extraMultilineHeightEnabled
    && collapsingTitleHelper.getExpandedMaxLines() > 1   // ← never true at maxLines == 1
    && collapsingTitleHelper.getExpansionFraction() == 1f) {  // == 1f means fully collapsed
  maybeSetPendingActionCollapsed();
}

That helper just posts a PENDING_ACTION_COLLAPSED to the parent AppBarLayout:

CollapsingToolbarLayout.java:554-562
private void maybeSetPendingActionCollapsed() {
  ViewParent parent = getParent();
  if (parent instanceof AppBarLayout) {
    AppBarLayout appBarLayout = (AppBarLayout) parent;
    if (appBarLayout.getPendingAction() == AppBarLayout.PENDING_ACTION_NONE) {
      appBarLayout.setPendingAction(AppBarLayout.PENDING_ACTION_COLLAPSED);
    }
  }
}

What our workaround does at maxLines = 1

StackHeaderApplicator.applyTitleAndSubtitle (Collapsing branch), when we've detected the header is fully collapsed:
appBar.setExpanded(false, false)

The public setExpanded posts the same pending action (plus a FORCE bit):

sources/material-1.14.0/…/AppBarLayout.java:803-813
public void setExpanded(boolean expanded, boolean animate) {
  setExpanded(expanded, animate, true);           // force = true
}

private void setExpanded(boolean expanded, boolean animate, boolean force) {
  pendingAction =
      (expanded ? PENDING_ACTION_EXPANDED : PENDING_ACTION_COLLAPSED)   // ← PENDING_ACTION_COLLAPSED
          | (animate ? PENDING_ACTION_ANIMATE_ENABLED : 0)             // animate=false ⇒ no bit
          | (force ? PENDING_ACTION_FORCE : 0);
  requestLayout();
}

Why they're equivalent

Both funnel into the same branch of the AppBarLayout.Behavior, which resolves the pending action to the identical collapsed offset target:

AppBarLayout.java:1931-1939
} else if (pendingAction != PENDING_ACTION_NONE) {
  final boolean animate = (pendingAction & PENDING_ACTION_ANIMATE_ENABLED) != 0;   // false in both cases
  if ((pendingAction & PENDING_ACTION_COLLAPSED) != 0) {
    final int offset = -abl.getUpNestedPreScrollRange();   // ← same target offset for both paths
    if (animate) {
      animateOffsetTo(parent, abl, offset, 0);
    } else {
      setHeaderTopBottomOffset(parent, abl, offset);       // ← non-animated snap, both paths
    }
  }

So Material's maxLines > 1 path and our setExpanded(false, false) both land on PENDING_ACTION_COLLAPSED → non-animated snap to -getUpNestedPreScrollRange().

The only differences, both intentional and safe:
- FORCE bit — our call sets PENDING_ACTION_FORCE; Material's helper doesn't. Since we invoke it only after confirming isAppBarFullyCollapsed (totalScrollRange > 0 && -verticalOffset >= totalScrollRange, matching Material's own fully-collapsed test at AppBarLayout.java:1996-1997), forcing the already-current collapsed state is a no-op when the offset is already valid.
- Unconditional vs. PENDING_ACTION_NONE guard — Material's helper skips if another action is already pending; ours overrides. That's stronger, not weaker, and only runs in the collapsed state we explicitly want to preserve.

Net: at maxLines = 1 we reproduce exactly the offset correction Material performs for itself at maxLines > 1, which is why dropping the hardcoded maxLines = 2 no longer regresses the runtime-subtitle-while-collapsed bug.

---

Why collapsingTitleHelper.getExpansionFraction() == 1f is equivalent to our isAppBarFullyCollapsed

Same input

Both signals are driven by the same verticalOffset — Material's CTL registers its own AppBarLayout.OnOffsetChangedListener on the app bar, and our appBarOffsetListener is another listener on that same app bar. Both get 0 when fully expanded and -totalScrollRange when fully collapsed.

Material's signal (the misleadingly-named one)

Despite the name, getExpansionFraction() is collapse progress, not expansion: in CollapsingTextHelper it's the interpolation factor between the expanded title position (0f) and the collapsed title position (1f). So == 1f means the title is drawn at its fully-collapsed spot.

It's computed straight from the offset — CollapsingToolbarLayout.java:2222-2226:
int height = getHeight();
final int expandRange = height - getMinimumHeight() - insetTop;      // CTL height − collapsed height − top inset
final float expansionFraction = Math.abs(verticalOffset) / (float) expandRange;
So expansionFraction == 1f ⟺ |verticalOffset| == expandRange.

Our signal

StackHeaderCoordinatorLayout.evaluateCollapseState:
isAppBarFullyCollapsed = totalScrollRange > 0 && -verticalOffset >= totalScrollRange
Since verticalOffset ≤ 0, -verticalOffset is |verticalOffset|, so this is |verticalOffset| >= totalScrollRange.

The one thing left to prove: expandRange == totalScrollRange

For our collapsing header the app bar has exactly one scrollable child — the CTL, flagged SCROLL | EXIT_UNTIL_COLLAPSED and fitsSystemWindows. AppBarLayout.getTotalScrollRange() (AppBarLayout.java:869-886) computes for that child:
range += childHeight (+ margins);   // CTL measured height
range -= getTopInset();             // first child, fitsSystemWindows
range -= child.getMinimumHeight();  // EXIT_UNTIL_COLLAPSED, then break
= ctlHeight − topInset − ctlMinHeight.

That is the same expression as the CTL's expandRange = height − getMinimumHeight() − insetTop (line 2223) — same measured CTL height, same CTL minimum height, same top inset. So AppBarLayout.totalScrollRange == CTL.expandRange.

Putting it together

- Material: fully collapsed ⟺ |verticalOffset| == expandRange
- Ours: fully collapsed ⟺ |verticalOffset| >= totalScrollRange, and totalScrollRange == expandRange

The Behavior clamps the offset into [-totalScrollRange, 0] (AppBarLayout.java:1955), so |verticalOffset| can never exceed the range — meaning our >= can only ever be satisfied by equality. Both conditions therefore flip true at the exact same instant: when the offset hits the full scroll range. This is also Material's own definition of "completely collapsed" used elsewhere (getTopBottomOffsetForScrollingSibling() != -getTotalScrollRange(), AppBarLayout.java:1996-1997).

Two deliberate, harmless differences on our side:
- We compare integers (-verticalOffset >= totalScrollRange) instead of a float == 1f, sidestepping any float-rounding worry (at full collapse the division is exactly expandRange/expandRange, so Material's == 1f is also safe, but we don't rely on it).
- The totalScrollRange > 0 guard is the counterpart of avoiding Material's divide-by-expandRange when there's nothing to scroll (a degenerate non-collapsing header), where "fully collapsed" is meaningless.
```

</details>

### Rebuild on `maxLines` prop change

When `maxLines` prop is changed in runtime from value more than `1` to `1`, the header doesn't shrink to correct height. To mitigate this, we're rebuilding the header on each `maxLines` prop change. This prop shouldn't be changed in runtime in a production app so this shouldn't be a problem. Rebuilding on runtime change will help with prototyping.

Here is Claude's investigation about the bug:

<details>
    <summary>Details</summary>

```
The extra height added for a multi-line expanded title is stored in a private field extraMultilineTitleHeight. Both the place that computes it and the place that resets it to 0 live inside the getExpandedMaxLines() > 1 guard:

sources/material-1.14.0/…/CollapsingToolbarLayout.java:730-756
if (extraMultilineHeightEnabled) {
  if (collapsingTitleHelper.getExpandedMaxLines() > 1) {   // ← the guard
    int lineCount = collapsingTitleHelper.getExpandedLineCount();
    if (lineCount > 1) {
      extraMultilineTitleHeight = expandedTextHeight * (lineCount - 1);  // grow
    } else {
      extraMultilineTitleHeight = 0;                        // ← the ONLY reset
    }
  }
  if (collapsingSubtitleHelper.getExpandedMaxLines() > 1) { // same guard for subtitle
    ...
  }
}

// stale value is still added here:
if (extraHeightForTitles + extraMultilineTitleHeight + extraMultilineSubtitleHeight > 0) {
  ... super.onMeasure(... originalHeight + extraHeightForTitles
                          + extraMultilineTitleHeight + extraMultilineSubtitleHeight ...);
}

- 1 → 3 grows correctly: getExpandedMaxLines() is 3 (> 1), so the block runs, recomputes lineCount, and sets extraMultilineTitleHeight to the right value.
- 3 → 1 doesn't shrink: getExpandedMaxLines() is now 1, so the whole if (... > 1) block is skipped — including the else { extraMultilineTitleHeight = 0; } reset. The field keeps its stale expandedTextHeight * 2 from when it was 3, and line 758 keeps adding it, so the header stays tall. requestLayout()/re-measure can't help because every re-measure hits the same skipped branch.

The reset is gated behind the exact condition that becomes false when you shrink to 1 — a genuine Material defect. It can't be fixed cleanly with public API either: the fields are private with no setter, the reset path is unreachable at maxLines == 1, and the only related lever, setExtraMultilineHeightEnabled, is @RestrictTo(LIBRARY_GROUP) and merely flips the flag without clearing the fields.
```

</details>

### Programmatic `maxLines` change limitation

While XML layout exposes `titleMaxLines` and `subtitleMaxLines`, programmatically we can only set `maxLines` prop which applies the same value for both title and subtitle.

Creating custom XML layouts would require us to limit the possible values of the prop (as XML layout file needs some value and the prop is an `int` with value `>= 1`) but going over `3` lines for title/subtitle doesn't seem very reasonable - we could limit the number of possible values. For example, we can allow only values `{1, 2, 3}` for both props but this would require `2 (medium, large) * 2 (gravity mode) * 3 (options for title) * 3 (options for subtitle) = 36` XML layout files. This wouldn't be the cleanest solution. Even `{1, 2}` values would result in `16` XML layouts.

But if the feature is desired by many users, we can consider going with this approach.

## Changes

- add `maxLines` prop and require header rebuild when this prop changes
- add `evaluateCollapseState` function that runs in `OnOffsetChangedListener` to evaluate if the header is collapsed or not which is used to decide if we need to apply a workaround in `applyTitleAndSubtitle` for title/subtitle runtime change
- add `maxLines` prop to `test-stack-subviews-android` SFT

## Before & after - visual documentation

https://github.com/user-attachments/assets/7ed2651e-f100-4e05-8450-2621646c203f

## Test plan

Run `test-stack-subviews-android` SFT. Check:

1. Changing `maxLines` prop with long title/subtitle,
2. With `maxLines=1, type=medium/large`, set `subtitle=undefined`, collapse the header and set `subtitle=short/long`. The header should remain collapsed.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes