### PR TITLE
feat(Stack v5, iOS): Add identifier for header items animation

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -25,6 +25,7 @@ import TestStackToolbarMenuA11y from './test-stack-toolbar-menu-a11y-android';
 import TestStackHeaderSubviewOnPress from './test-stack-header-subview-onpress-ios';
 import TestStackHeaderSelectiveUpdates from './test-stack-header-selective-updates-ios';
 import TestStackHeaderMenuOptionsIOS from './test-stack-header-menu-options-ios';
+import TestStackHeaderItemIdentifierIOS from './test-stack-header-item-identifier-ios';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
@@ -37,6 +38,7 @@ export { default as TestStackSubviewsAndroid } from './test-stack-subviews-andro
 export { default as TestStackLiftOnScrollAndroid } from './test-stack-lift-on-scroll-android';
 export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
 export { default as TestStackHeaderIconIOS } from './test-stack-header-icon-ios';
+export { default as TestStackHeaderItemIdentifierIOS } from './test-stack-header-item-identifier-ios';
 export { default as TestStackHeaderMenuIOS } from './test-stack-header-menu-ios';
 export { default as TestStackHeaderMenuOptionsIOS } from './test-stack-header-menu-options-ios';
 export { default as TestStackHeaderSelectiveUpdatesIOS } from './test-stack-header-selective-updates-ios';
@@ -63,6 +65,7 @@ const scenarios = {
   TestStackSubviewsIOS,
   TestStackHeaderMenuIOS,
   TestStackHeaderIconIOS,
+  TestStackHeaderItemIdentifierIOS,
   TestStackHeaderSubviewOnPress,
   TestStackHeaderSelectiveUpdates,
   TestStackHeaderMenuOptionsIOS,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -1,0 +1,190 @@
+import React, {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import { SettingsSwitch } from '@apps/shared';
+import type {
+  StackHeaderConfigProps,
+  StackHeaderInlineItemIOS,
+  StackHeaderSpacerItemIOS,
+} from 'react-native-screens/components/stack/header';
+import type { PlatformIconIOS } from 'react-native-screens';
+
+type ItemId = 'alpha' | 'bravo' | 'charlie';
+
+const SYMBOL_CYCLES: Record<ItemId, string[]> = {
+  alpha: ['1.circle.fill', '2.circle.fill', '3.circle.fill'],
+  bravo: ['fish.fill', 'birthday.cake.fill', 'carrot.fill'],
+  charlie: ['carrot.fill', 'fish.fill', 'birthday.cake.fill'],
+};
+
+function iconForItem(id: ItemId, screenIndex: number): PlatformIconIOS {
+  const cycle = SYMBOL_CYCLES[id];
+  return { type: 'sfSymbol', name: cycle[screenIndex % cycle.length]! };
+}
+
+const ROUTE_NAMES = ['One', 'Two', 'Three'];
+
+const LAYOUTS: Record<string, ItemId[]> = {
+  One: ['charlie', 'bravo', 'alpha'],
+  Two: ['charlie', 'alpha', 'bravo'],
+  Three: ['alpha', 'charlie', 'bravo'],
+};
+
+type Toggles = {
+  identifiersEnabled: boolean;
+  separatorsEnabled: boolean;
+  setIdentifiersEnabled: (value: boolean) => void;
+  setSeparatorsEnabled: (value: boolean) => void;
+};
+
+const ToggleContext = createContext<Toggles>({
+  identifiersEnabled: true,
+  separatorsEnabled: false,
+  setIdentifiersEnabled: () => {},
+  setSeparatorsEnabled: () => {},
+});
+
+function makeItem(
+  id: ItemId,
+  screenIndex: number,
+  withIdentifier: boolean,
+): StackHeaderInlineItemIOS {
+  return {
+    type: 'item',
+    id,
+    icon: iconForItem(id, screenIndex),
+    ...(withIdentifier ? { identifier: id } : {}),
+  };
+}
+
+function buildItems(
+  ids: ItemId[],
+  screenIndex: number,
+  withIdentifier: boolean,
+  withSeparators: boolean,
+): (StackHeaderInlineItemIOS | StackHeaderSpacerItemIOS)[] {
+  const result: (StackHeaderInlineItemIOS | StackHeaderSpacerItemIOS)[] = [];
+  ids.forEach((id, index) => {
+    if (withSeparators && index > 0) {
+      result.push({
+        id: `sep-${index}`,
+        type: 'spacer',
+        sizing: 'fixed',
+        width: 12,
+      });
+    }
+    result.push(makeItem(id, screenIndex, withIdentifier));
+  });
+  return result;
+}
+
+function makeScreen(routeName: string) {
+  return function Screen() {
+    const {
+      identifiersEnabled,
+      separatorsEnabled,
+      setIdentifiersEnabled,
+      setSeparatorsEnabled,
+    } = useContext(ToggleContext);
+    const navigation = useStackNavigationContext();
+    const { setRouteOptions, routeKey } = navigation;
+    const screenIndex = ROUTE_NAMES.indexOf(routeName);
+
+    const headerConfig = useMemo<StackHeaderConfigProps>(
+      () => ({
+        title: routeName,
+        ios: {
+          trailingItems: buildItems(
+            LAYOUTS[routeName]!,
+            screenIndex,
+            identifiersEnabled,
+            separatorsEnabled,
+          ),
+        },
+      }),
+      [identifiersEnabled, separatorsEnabled, screenIndex],
+    );
+
+    useLayoutEffect(() => {
+      setRouteOptions(routeKey, { headerConfig });
+    }, [headerConfig, setRouteOptions, routeKey]);
+
+    const nextRoute = ROUTE_NAMES[screenIndex + 1];
+
+    return (
+      <View style={styles.container}>
+        <SettingsSwitch
+          label="Identifiers"
+          testID="toggle-identifiers"
+          value={identifiersEnabled}
+          onValueChange={setIdentifiersEnabled}
+        />
+        <SettingsSwitch
+          label="Separators"
+          testID="toggle-separators"
+          value={separatorsEnabled}
+          onValueChange={setSeparatorsEnabled}
+        />
+        {nextRoute && (
+          <Button title="Next" onPress={() => navigation.push(nextRoute)} />
+        )}
+        {routeName !== 'One' && (
+          <Button title="Go back" onPress={() => navigation.pop(routeKey)} />
+        )}
+      </View>
+    );
+  };
+}
+
+function TestStackHeaderItemIdentifierIOS() {
+  const [identifiersEnabled, setIdentifiersEnabled] = useState(true);
+  const [separatorsEnabled, setSeparatorsEnabled] = useState(false);
+
+  const toggles = useMemo<Toggles>(
+    () => ({
+      identifiersEnabled,
+      separatorsEnabled,
+      setIdentifiersEnabled,
+      setSeparatorsEnabled,
+    }),
+    [identifiersEnabled, separatorsEnabled],
+  );
+
+  const routeConfigs = useMemo(
+    () =>
+      ROUTE_NAMES.map(routeName => ({
+        name: routeName,
+        Component: makeScreen(routeName),
+      })),
+    [],
+  );
+
+  return (
+    <ToggleContext.Provider value={toggles}>
+      <StackContainer routeConfigs={routeConfigs} />
+    </ToggleContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});
+
+export default createScenario(
+  TestStackHeaderItemIdentifierIOS,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -86,7 +86,9 @@ function makeItem(
     return {
       type: 'item',
       id,
-      render: () => <View style={[styles.customItem, { backgroundColor: color }]} />,
+      render: () => (
+        <View style={[styles.customItem, { backgroundColor: color }]} />
+      ),
       ...identifierProp,
     };
   }
@@ -120,71 +122,70 @@ function buildItems(
   return result;
 }
 
-function makeScreen(routeName: string) {
-  return function Screen() {
-    const {
-      identifiersEnabled,
-      separatorsEnabled,
-      customViewsEnabled,
-      setIdentifiersEnabled,
-      setSeparatorsEnabled,
-      setCustomViewsEnabled,
-    } = useContext(ToggleContext);
-    const navigation = useStackNavigationContext();
-    const { setRouteOptions, routeKey } = navigation;
-    const screenIndex = ROUTE_NAMES.indexOf(routeName);
+function Screen(props: { routeName: string }) {
+  const { routeName } = props;
+  const {
+    identifiersEnabled,
+    separatorsEnabled,
+    customViewsEnabled,
+    setIdentifiersEnabled,
+    setSeparatorsEnabled,
+    setCustomViewsEnabled,
+  } = useContext(ToggleContext);
+  const navigation = useStackNavigationContext();
+  const { setRouteOptions, routeKey } = navigation;
+  const screenIndex = ROUTE_NAMES.indexOf(routeName);
 
-    const headerConfig = useMemo<StackHeaderConfigProps>(
-      () => ({
-        title: routeName,
-        ios: {
-          trailingItems: buildItems(
-            LAYOUTS[routeName]!,
-            screenIndex,
-            identifiersEnabled,
-            separatorsEnabled,
-            customViewsEnabled,
-          ),
-        },
-      }),
-      [identifiersEnabled, separatorsEnabled, customViewsEnabled, screenIndex],
-    );
+  const headerConfig = useMemo<StackHeaderConfigProps>(
+    () => ({
+      title: routeName,
+      ios: {
+        trailingItems: buildItems(
+          LAYOUTS[routeName]!,
+          screenIndex,
+          identifiersEnabled,
+          separatorsEnabled,
+          customViewsEnabled,
+        ),
+      },
+    }),
+    [routeName, identifiersEnabled, separatorsEnabled, customViewsEnabled, screenIndex],
+  );
 
-    useLayoutEffect(() => {
-      setRouteOptions(routeKey, { headerConfig });
-    }, [headerConfig, setRouteOptions, routeKey]);
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
 
-    const nextRoute = ROUTE_NAMES[screenIndex + 1];
+  const nextRoute = ROUTE_NAMES[screenIndex + 1];
 
-    return (
-      <View style={styles.container}>
-        <SettingsSwitch
-          label="Identifiers"
-          testID="toggle-identifiers"
-          value={identifiersEnabled}
-          onValueChange={setIdentifiersEnabled}
-        />
-        <SettingsSwitch
-          label="Separators"
-          testID="toggle-separators"
-          value={separatorsEnabled}
-          onValueChange={setSeparatorsEnabled}
-        />
-        <SettingsSwitch
-          label="Custom views"
-          testID="toggle-custom-views"
-          value={customViewsEnabled}
-          onValueChange={setCustomViewsEnabled}
-        />
-        {nextRoute && (
-          <Button title="Next" onPress={() => navigation.push(nextRoute)} />
-        )}
-        {routeName !== 'One' && (
-          <Button title="Go back" onPress={() => navigation.pop(routeKey)} />
-        )}
-      </View>
-    );
-  };
+  return (
+    <View style={styles.container}>
+      <SettingsSwitch
+        label="Identifiers"
+        testID="toggle-identifiers"
+        value={identifiersEnabled}
+        onValueChange={setIdentifiersEnabled}
+      />
+      <SettingsSwitch
+        label="Separators"
+        testID="toggle-separators"
+        value={separatorsEnabled}
+        onValueChange={setSeparatorsEnabled}
+      />
+      <SettingsSwitch
+        label="Custom views"
+        testID="toggle-custom-views"
+        value={customViewsEnabled}
+        onValueChange={setCustomViewsEnabled}
+      />
+      {nextRoute && (
+        <Button title="Next" onPress={() => navigation.push(nextRoute)} />
+      )}
+      {routeName !== 'One' && (
+        <Button title="Go back" onPress={() => navigation.pop(routeKey)} />
+      )}
+    </View>
+  );
 }
 
 function TestStackHeaderItemIdentifierIOS() {
@@ -208,7 +209,7 @@ function TestStackHeaderItemIdentifierIOS() {
     () =>
       ROUTE_NAMES.map(routeName => ({
         name: routeName,
-        Component: makeScreen(routeName),
+        element: <Screen routeName={routeName} />,
       })),
     [],
   );
@@ -224,6 +225,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+    backgroundColor: Colors.OffWhite,
   },
   customItem: {
     width: 24,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -13,8 +13,10 @@ import {
   useStackNavigationContext,
 } from '@apps/shared/containers/stack';
 import { SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
 import type {
   StackHeaderConfigProps,
+  StackHeaderInlineCustomItemIOS,
   StackHeaderInlineItemIOS,
   StackHeaderSpacerItemIOS,
 } from 'react-native-screens/components/stack/header';
@@ -28,9 +30,20 @@ const SYMBOL_CYCLES: Record<ItemId, string[]> = {
   charlie: ['carrot.fill', 'fish.fill', 'birthday.cake.fill'],
 };
 
+const COLOR_CYCLES: Record<ItemId, string[]> = {
+  alpha: [Colors.RedLight100, Colors.YellowLight100, Colors.NavyLight100],
+  bravo: [Colors.GreenLight100, Colors.BlueLight100, Colors.PurpleLight100],
+  charlie: [Colors.BlueLight100, Colors.PurpleLight100, Colors.GreenLight100],
+};
+
 function iconForItem(id: ItemId, screenIndex: number): PlatformIconIOS {
   const cycle = SYMBOL_CYCLES[id];
   return { type: 'sfSymbol', name: cycle[screenIndex % cycle.length]! };
+}
+
+function colorForItem(id: ItemId, screenIndex: number): string {
+  const cycle = COLOR_CYCLES[id];
+  return cycle[screenIndex % cycle.length]!;
 }
 
 const ROUTE_NAMES = ['One', 'Two', 'Three'];
@@ -44,27 +57,44 @@ const LAYOUTS: Record<string, ItemId[]> = {
 type Toggles = {
   identifiersEnabled: boolean;
   separatorsEnabled: boolean;
+  customViewsEnabled: boolean;
   setIdentifiersEnabled: (value: boolean) => void;
   setSeparatorsEnabled: (value: boolean) => void;
+  setCustomViewsEnabled: (value: boolean) => void;
 };
 
 const ToggleContext = createContext<Toggles>({
   identifiersEnabled: true,
   separatorsEnabled: false,
+  customViewsEnabled: false,
   setIdentifiersEnabled: () => {},
   setSeparatorsEnabled: () => {},
+  setCustomViewsEnabled: () => {},
 });
+
+type HeaderItem = StackHeaderInlineItemIOS | StackHeaderInlineCustomItemIOS;
 
 function makeItem(
   id: ItemId,
   screenIndex: number,
   withIdentifier: boolean,
-): StackHeaderInlineItemIOS {
+  withCustomView: boolean,
+): HeaderItem {
+  const identifierProp = withIdentifier ? { identifier: id } : {};
+  if (withCustomView) {
+    const color = colorForItem(id, screenIndex);
+    return {
+      type: 'item',
+      id,
+      render: () => <View style={[styles.customItem, { backgroundColor: color }]} />,
+      ...identifierProp,
+    };
+  }
   return {
     type: 'item',
     id,
     icon: iconForItem(id, screenIndex),
-    ...(withIdentifier ? { identifier: id } : {}),
+    ...identifierProp,
   };
 }
 
@@ -73,8 +103,9 @@ function buildItems(
   screenIndex: number,
   withIdentifier: boolean,
   withSeparators: boolean,
-): (StackHeaderInlineItemIOS | StackHeaderSpacerItemIOS)[] {
-  const result: (StackHeaderInlineItemIOS | StackHeaderSpacerItemIOS)[] = [];
+  withCustomView: boolean,
+): (HeaderItem | StackHeaderSpacerItemIOS)[] {
+  const result: (HeaderItem | StackHeaderSpacerItemIOS)[] = [];
   ids.forEach((id, index) => {
     if (withSeparators && index > 0) {
       result.push({
@@ -84,7 +115,7 @@ function buildItems(
         width: 12,
       });
     }
-    result.push(makeItem(id, screenIndex, withIdentifier));
+    result.push(makeItem(id, screenIndex, withIdentifier, withCustomView));
   });
   return result;
 }
@@ -94,8 +125,10 @@ function makeScreen(routeName: string) {
     const {
       identifiersEnabled,
       separatorsEnabled,
+      customViewsEnabled,
       setIdentifiersEnabled,
       setSeparatorsEnabled,
+      setCustomViewsEnabled,
     } = useContext(ToggleContext);
     const navigation = useStackNavigationContext();
     const { setRouteOptions, routeKey } = navigation;
@@ -110,10 +143,11 @@ function makeScreen(routeName: string) {
             screenIndex,
             identifiersEnabled,
             separatorsEnabled,
+            customViewsEnabled,
           ),
         },
       }),
-      [identifiersEnabled, separatorsEnabled, screenIndex],
+      [identifiersEnabled, separatorsEnabled, customViewsEnabled, screenIndex],
     );
 
     useLayoutEffect(() => {
@@ -136,6 +170,12 @@ function makeScreen(routeName: string) {
           value={separatorsEnabled}
           onValueChange={setSeparatorsEnabled}
         />
+        <SettingsSwitch
+          label="Custom views"
+          testID="toggle-custom-views"
+          value={customViewsEnabled}
+          onValueChange={setCustomViewsEnabled}
+        />
         {nextRoute && (
           <Button title="Next" onPress={() => navigation.push(nextRoute)} />
         )}
@@ -150,15 +190,18 @@ function makeScreen(routeName: string) {
 function TestStackHeaderItemIdentifierIOS() {
   const [identifiersEnabled, setIdentifiersEnabled] = useState(true);
   const [separatorsEnabled, setSeparatorsEnabled] = useState(false);
+  const [customViewsEnabled, setCustomViewsEnabled] = useState(false);
 
   const toggles = useMemo<Toggles>(
     () => ({
       identifiersEnabled,
       separatorsEnabled,
+      customViewsEnabled,
       setIdentifiersEnabled,
       setSeparatorsEnabled,
+      setCustomViewsEnabled,
     }),
-    [identifiersEnabled, separatorsEnabled],
+    [identifiersEnabled, separatorsEnabled, customViewsEnabled],
   );
 
   const routeConfigs = useMemo(
@@ -181,6 +224,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+  },
+  customItem: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
   },
 });
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
@@ -1,0 +1,13 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Header Item Identifier (iOS)',
+  key: 'test-stack-header-item-identifier-ios',
+  details:
+    'Three screens each hold the same three header items (shared `identifier`) ' +
+    'reordered across leading/trailing edges. On iOS 26+ matched items animate ' +
+    'between positions instead of cross-fading. Not supported on iOS 18 and below.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
@@ -5,7 +5,7 @@ export const scenarioDescription: ScenarioDescription = {
   key: 'test-stack-header-item-identifier-ios',
   details:
     'Three screens each hold the same three header items (shared `identifier`) ' +
-    'reordered across leading/trailing edges. On iOS 26+ matched items animate ' +
+    'ordered differently and with different icons across screens. On iOS 26+ matched items animate ' +
     'between positions instead of cross-fading. Not supported on iOS 18 and below.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -1,0 +1,46 @@
+# Test Scenario: Stack Header Item Identifier (iOS)
+
+## Details
+
+**Description:** Three screens hold the same three trailing header items. Each item
+keeps a stable `identifier` across screens, but its SF Symbol and position change per
+screen. With identifiers on, iOS matches items by `identifier` and animates them
+between positions instead of falling back to a crossfade. Look for the item that counts
+1, 2, 3 and that it moves from left to right when pushing screens, and the others
+stay put, only changing their appearance.
+
+**OS test creation version:** iOS 26 (feature requires iOS 26)
+
+## E2E test
+
+TBD.
+
+## Prerequisites
+
+- iOS simulator or device running iOS 26 or higher
+
+## Note
+
+- LTR layout is assumed when describing position
+
+## Steps on iPhone
+
+1. Inspect the trailing header items
+  - [ ] Three items are visible: "1", "fish", "carrot"
+2. Tap "Next"
+  - [ ] The numbered item swaps position with center item and now shows "2"
+  - [ ] The two food items change their symbols and don't flash
+3. Tap "Next"
+  - [ ] The numbered item swaps position with right item and now shows "3"
+  - [ ] The two food items change their symbols and don't flash
+4. Go back to screen One, toggle "Identifiers" OFF, then repeat steps 2–3
+  - [ ] Without `identifier`, matching falls back to the heuristic: items crossfade /
+        mis-match on transition instead of the numbered item cleanly moving
+
+## Steps with separators
+
+5. Go back to screen One, toggle "Identifiers" back ON and "Separators" ON
+  - [ ] Each header item now sits in its own liquid-glass bubble
+6. Tap "Next" through the screens (One → Two → Three)
+  - [ ] On each transition, the two items that swap positions blur / crossfade
+  - [ ] The item that keeps its position does not flash

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -33,14 +33,16 @@ TBD.
 3. Tap "Next"
   - [ ] The numbered item swaps position with right item and now shows "3"
   - [ ] The two food items change their symbols and don't flash
-4. Go back to screen One, toggle "Identifiers" OFF, then repeat steps 2–3
+4. Go back to screen One, toggle "Custom views" to `true`, repeat steps 2–3
+  - [ ] Observe the same behavior as for sfSymbols
+5. Go back to screen One, toggle "Custom views" to `false`, "Identifiers" to `false`, repeat steps 2–3
   - [ ] Without `identifier`, matching falls back to the heuristic: items crossfade /
         mis-match on transition instead of the numbered item cleanly moving
 
 ## Steps with separators
 
-5. Go back to screen One, toggle "Identifiers" back ON and "Separators" ON
+6. Go back to screen One, toggle "Identifiers" and "Separators" to `true`
   - [ ] Each header item now sits in its own liquid-glass bubble
-6. Tap "Next" through the screens (One → Two → Three)
+7. Tap "Next" through the screens (One → Two → Three)
   - [ ] On each transition, the two items that swap positions blur / crossfade
   - [ ] The item that keeps its position does not flash

--- a/ios/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) RNSHeaderItemPlacement placement;
 @property (nonatomic, readonly, nullable) NSString *itemId;
+@property (nonatomic, readonly, nullable) NSString *identifier;
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderIconData *icon;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;

--- a/ios/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.mm
@@ -45,6 +45,7 @@ namespace react = facebook::react;
 - (void)resetProps
 {
   _itemId = nil;
+  _identifier = nil;
   [self setTitleProp:nil];
   [self setIconProp:nil];
   [self setMenuProp:nil];
@@ -181,6 +182,11 @@ RNS_IGNORE_SUPER_CALL_END
 
   if (oldItemProps.itemId != newItemProps.itemId) {
     _itemId = RCTNSStringFromStringNilIfEmpty(newItemProps.itemId);
+  }
+
+  if (oldItemProps.identifier != newItemProps.identifier) {
+    _identifier = RCTNSStringFromStringNilIfEmpty(newItemProps.identifier);
+    needsUpdate = YES;
   }
 
   if (oldItemProps.placement != newItemProps.placement) {

--- a/ios/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderItemDataProviding.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) RNSHeaderItemPlacement placement;
 @property (nonatomic, readonly, nullable) NSString *itemId;
+@property (nonatomic, readonly, nullable) NSString *identifier;
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderIconData *icon;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -471,6 +471,14 @@
                                                                    withHeaderEventsDelegate:_eventsDelegate
                                                                             withImageLoader:_imageLoader];
 
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    if (item.identifier != nil) {
+      barButtonItem.identifier = item.identifier;
+    }
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
   if (item.menu != nil && item.itemId != nil) {
     RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:item.itemId];
     __weak auto weakSelf = self;

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -94,6 +94,25 @@ export interface SupportsMenuIOS {
   menu?: StackHeaderMenuIOS | undefined;
 }
 
+export interface SupportsIdentifierIOS {
+  /**
+   * @summary Stable identifier used to match the item across different screens
+   * for more intelligent animation on transition.
+   *
+   * @description
+   * When navigating between screens, iOS tries to match similarly looking items (i.e. same sfSymbol)
+   * and animate between them. If the heuristic fails, a simpler crossfade is applied.
+   * In a situation where visually different items should be logically considered the same across screens,
+   * you may use this prop to tell this fact to the system. The identifier shouldn't be updated at runtime;
+   * doing so will results in item rebuild and visual flash.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 26 and higher
+   */
+  identifier?: string | undefined;
+}
+
 /**
  * @summary Native header item with text label.
  *
@@ -101,7 +120,8 @@ export interface SupportsMenuIOS {
  */
 export interface StackHeaderInlineItemIOS
   extends StackHeaderBaseItemIOS,
-    SupportsMenuIOS {
+    SupportsMenuIOS,
+    SupportsIdentifierIOS {
   /**
    * @summary Marks this object as a header item definition.
    *
@@ -126,7 +146,9 @@ export interface StackHeaderInlineItemIOS
  *
  * @platform iOS
  */
-export interface StackHeaderInlineCustomItemIOS extends SupportsMenuIOS {
+export interface StackHeaderInlineCustomItemIOS
+  extends SupportsMenuIOS,
+    SupportsIdentifierIOS {
   /**
    * @summary A unique identifier within the screen header.
    *

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -104,7 +104,7 @@ export interface SupportsIdentifierIOS {
    * and animate between them. If the heuristic fails, a simpler crossfade is applied.
    * In a situation where visually different items should be logically considered the same across screens,
    * you may use this prop to tell this fact to the system. The identifier shouldn't be updated at runtime;
-   * doing so will results in item rebuild and visual flash.
+   * doing so will result in item rebuild and visual flash.
    *
    * @platform iOS
    *

--- a/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
+++ b/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
@@ -12,6 +12,7 @@ export type StackHeaderItemPlacement =
 export type StackHeaderItemProps = {
   placement: StackHeaderItemPlacement;
   itemId?: string | undefined;
+  identifier?: string | undefined;
   title?: string | undefined;
   icon?: PlatformIconIOS | undefined;
   render?: (() => ReactElement) | undefined;

--- a/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
@@ -70,6 +70,7 @@ export type PlatformIconIOS =
 export interface NativeProps extends ViewProps {
   placement?: CT.WithDefault<Placement, 'trailing'>;
   itemId?: string | undefined;
+  identifier?: string | undefined;
   title?: string | undefined;
   icon?: UnsafeMixed<PlatformIconIOS> | undefined;
   menu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1711

## Description

This PR adds `identifier` prop to new iOS header implementation. The default heuristic uses visual similarity when animating items between screens. When the item that should be considered logically the same looks differently between screens, it probably going to be crossfaded instead, but when identifier is added, UIKit knows to match those 2.

> [!note]
> For now, user is expected to give valid values for identifier, with 1:1 matches between, no extra validation is present.

## Changes

- added `identifier` prop
- added SFT for testing

## Before & after - visual documentation

> [!note]
> Having the "same" items across screens with different symbols / views is required to break the heuristic, otherwise it works without the identifier. See the video attached.


https://github.com/user-attachments/assets/daf8d133-52a2-4411-8691-714079f0af5e


## Test plan

Use the SFT added in the PR. Validate the flow present in the video.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
