### PR TITLE
refactor(e2e): remove duplicated native class name definition

### DIFF
--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -66,7 +66,6 @@ export const CLASS_NAME_UI_REFRESH_CONTROL = 'UIRefreshControl';
 export const CLASS_NAME_UI_SEARCH_BAR_TEXT_FIELD = 'UISearchBarTextField';
 export const CLASS_NAME_UI_LIST_CONTENT_IMAGE_VIEW = '_UIListContentImageView';
 export const CLASS_NAME_UI_LABEL = 'UILabel';
-export const CLASS_NAME_UI_CONTEXT_MENU_CELL = '_UIContextMenuCell';
 
 // --- Android ---
 


### PR DESCRIPTION
## Description

Fixes a duplicated constant definition introduced in #4389 — `CLASS_NAME_UI_CONTEXT_MENU_CELL` was declared twice in `FabricExample/e2e/native-class-names.ts` (once in the existing context-menu block, once again further down in the same file).

## Changes

- Removed the redundant `CLASS_NAME_UI_CONTEXT_MENU_CELL` export, keeping the original declaration next to `CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW`.