### PR TITLE
fix(Android): Fix crash when header gets update during screen removal

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
@@ -64,6 +64,11 @@ class NativeProxy {
 
         val screen = weakScreeRef.get()
         if (screen is Screen) {
+            // Fabric's mounting transaction removes the screen on a Choreographer frame callback,
+            // which can execute before `startRemovalTransition` (scheduled via `Handler.post`).
+            // To prevent `Screen.isBeingRemoved` from being read as false during teardown,
+            // we must set this flag synchronously here.
+            screen.markAsBeingRemoved()
             val isScheduled =
                 screen.post {
                     screen.startRemovalTransition()

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
@@ -71,7 +71,14 @@ class Screen(
         private set
     var screenId: String? = null
     var isStatusBarAnimated: Boolean? = null
+
+    // Can be set on the mounting coordinator's thread (see `markAsBeingRemoved`), read on the UI thread.
+    @Volatile
     var isBeingRemoved = false
+        private set
+
+    // Keeps `startTransitionRecursive` / `endTransitionRecursive` calls paired. Should be used on UI thread only.
+    private var isRemovalTransitionStarted = false
 
     // Props for controlling modal presentation
     var isSheetGrabberVisible: Boolean = false
@@ -439,19 +446,28 @@ class Screen(
 
     var nativeBackButtonDismissalEnabled: Boolean = true
 
+    /**
+     * Marks this screen as being removed from the native stack. Safe to call off the UI thread;
+     * must run before the mount transaction removing this screen executes.
+     */
+    fun markAsBeingRemoved() {
+        isBeingRemoved = true
+    }
+
     fun startRemovalTransition() {
-        if (!isBeingRemoved) {
-            isBeingRemoved = true
+        isBeingRemoved = true
+        if (!isRemovalTransitionStarted) {
+            isRemovalTransitionStarted = true
             startTransitionRecursive(this)
         }
     }
 
     fun endRemovalTransition() {
-        if (!isBeingRemoved) {
-            return
-        }
         isBeingRemoved = false
-        endTransitionRecursive(this)
+        if (isRemovalTransitionStarted) {
+            isRemovalTransitionStarted = false
+            endTransitionRecursive(this)
+        }
     }
 
     private fun endTransitionRecursive(parent: ViewGroup) {

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
@@ -463,9 +463,9 @@ class Screen(
     }
 
     fun endRemovalTransition() {
-        isBeingRemoved = false
         if (isRemovalTransitionStarted) {
             isRemovalTransitionStarted = false
+            isBeingRemoved = false
             endTransitionRecursive(this)
         }
     }

--- a/apps/src/tests/issue-tests/Test4314.tsx
+++ b/apps/src/tests/issue-tests/Test4314.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
+
+export type RootTabParamList = {
+  Home: undefined;
+  Settings: undefined;
+};
+
+export type SettingsStackParamList = {
+  SettingsHome: undefined;
+  SettingsFirst: undefined;
+};
+
+type SettingsHomeNavigationProp = NativeStackNavigationProp<
+  SettingsStackParamList,
+  'SettingsHome'
+>;
+type SettingsFirstNavigationProp = NativeStackNavigationProp<
+  SettingsStackParamList,
+  'SettingsFirst'
+>;
+
+const Tabs = createNativeBottomTabNavigator<RootTabParamList>();
+const Stack = createNativeStackNavigator<SettingsStackParamList>();
+
+function StackContentHome() {
+  const navigation = useNavigation<SettingsHomeNavigationProp>();
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Go to SettingsFirst"
+        onPress={() => navigation.navigate('SettingsFirst')}
+      />
+    </View>
+  );
+}
+
+function StackContentFirst() {
+  const navigation = useNavigation<SettingsFirstNavigationProp>();
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Go to SettingsHome"
+        onPress={() => navigation.navigate('SettingsHome')}
+      />
+    </View>
+  );
+}
+
+function SettingsScreen() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerRight: () => (
+          <View collapsable={false} style={styles.headerRightBox} />
+        ),
+        headerBackIcon: {
+          type: 'image',
+          source: require('@assets/variableIcons/icon_fill.png'),
+        },
+      }}>
+      <Stack.Screen name="SettingsHome" component={StackContentHome} />
+      <Stack.Screen name="SettingsFirst" component={StackContentFirst} />
+    </Stack.Navigator>
+  );
+}
+
+function TabsScreen() {
+  return (
+    <Tabs.Navigator>
+      <Tabs.Screen name="Home" component={SettingsScreen} />
+      <Tabs.Screen name="Settings" component={SettingsScreen} />
+    </Tabs.Navigator>
+  );
+}
+
+function AppContent() {
+  return (
+    <NavigationContainer>
+      <TabsScreen />
+    </NavigationContainer>
+  );
+}
+
+export default function App() {
+  return <AppContent />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingBottom: 100,
+  },
+  headerRightBox: {
+    backgroundColor: 'red',
+    width: 100,
+    height: 100,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -204,6 +204,7 @@ export { default as Test4258 } from './Test4258';
 export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
+export { default as Test4314 } from './Test4314';
 export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';


### PR DESCRIPTION
## Description

On Android quickly tapping a push button from JS and then on the active native bottom tab (which triggers `popToTop` operation) - crashes with:

```
com.facebook.react.bridge.JSApplicationIllegalArgumentException: Back button header config view should have Image as first child
```

whenever the popped screen's header has a BACK subview (custom back icon) and at least one other subview at a higher config index (`headerRight`).

`ScreenStackHeaderConfig.maybeUpdate()` guards header updates with `screen?.isBeingRemoved == false`.

The mount transaction that removes the screen executes on the UI thread inside a **Choreographer frame callback**. When a frame is already pending, the frame callback preempts messages that were posted earlier, so the mount batch runs **before** the posted `startRemovalTransition`, observing `isBeingRemoved == false`. Inside that batch, React removes the deleted subtree bottom-up. So by the time `removeConfigSubview(<RIGHT>)` runs `maybeUpdate() -> onUpdate()`, the BACK subview is still registered in `configSubviews` but its `Image` child is already gone, resulting in a crash. The screen's own `removeViewAt` executes at the very end of the same batch, so `startRemovalTransition` is also called too late from that path.

Closes #4314.

## Changes

- `NativeProxy.notifyScreenRemoved` now sets the removal flag **synchronously** on the mounting coordinator's thread via `Screen.markAsBeingRemoved()`, before the transaction is handed off to the UI thread.
- `Screen.isBeingRemoved` is now `@Volatile` (due to writing the value on the mounting coordinator's thread, read on the UI thread).
- Transition bookkeeping was moved into `isRemovalTransitionStarted`.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fd599dd3-9243-4983-8380-c6d5252d72cd" /> | <video src="https://github.com/user-attachments/assets/dbf32a2d-4805-456e-a731-ecbff25ef273" /> |

## Test plan

Repro added as `Test4314`. Quickly tap **Go to SettingsFirst** and then the active **Home** tab while the push transition is still running (the tab press triggers `popToTop`).

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
