### PR TITLE
fix(Android, FormSheet v4): Cleanup inset and layout listener

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackFragment.kt
@@ -85,6 +85,12 @@ class ScreenStackFragment :
 
     private var lastInsetsCompat: WindowInsetsCompat? = null
 
+    // Container reference is captured at registration, because `screen.container` is already
+    // null during teardown. Necessary for unregistering inset & layout listeners in `onDestroyView`.
+    private var containerWithSheetListeners: ScreenContainer? = null
+    private var containerOnLayoutChangeListener: View.OnLayoutChangeListener? = null
+    private var containerOnApplyWindowInsetsListener: View.OnApplyWindowInsetsListener? = null
+
     @SuppressLint("ValidFragment")
     constructor(screenView: Screen) : super(screenView)
 
@@ -337,6 +343,7 @@ class ScreenStackFragment :
         // - Screen.fragment
         lastActiveHeaderConfig?.clearActionBarIfOwned(activity as? AppCompatActivity)
         lastActiveHeaderConfig = null
+        detachInsetsAndLayoutListenersFromContainer()
         super.onDestroyView()
     }
 
@@ -522,15 +529,20 @@ class ScreenStackFragment :
     // Mark: Avoiding top inset by BottomSheet
 
     private fun attachInsetsAndLayoutListenersToBottomSheet(sheetTransitionCoordinator: BottomSheetTransitionCoordinator) {
-        screen.container?.apply {
+        screen.container?.let { container ->
+            containerWithSheetListeners = container
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                setOnApplyWindowInsetsListener { _, insets ->
-                    val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets, this)
-                    handleInsetsUpdateAndNotifyTransition(
-                        insetsCompat,
-                    )
-                    insets
-                }
+                val insetsListener =
+                    View.OnApplyWindowInsetsListener { _, insets ->
+                        val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets, container)
+                        handleInsetsUpdateAndNotifyTransition(
+                            insetsCompat,
+                        )
+                        insets
+                    }
+                containerOnApplyWindowInsetsListener = insetsListener
+                container.setOnApplyWindowInsetsListener(insetsListener)
             } else {
                 val bottomSheetWindowInsetListenerChain = requireBottomSheetWindowInsetsListenerChain()
                 bottomSheetWindowInsetListenerChain.addListener { _, windowInsets ->
@@ -540,11 +552,28 @@ class ScreenStackFragment :
                     windowInsets
                 }
             }
-        }
 
-        screen.container?.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+            val layoutChangeListener =
+                View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                    sheetTransitionCoordinator.onScreenContainerLayoutChanged(screen)
+                }
+            containerOnLayoutChangeListener = layoutChangeListener
+            container.addOnLayoutChangeListener(layoutChangeListener)
         }
+    }
+
+    private fun detachInsetsAndLayoutListenersFromContainer() {
+        containerWithSheetListeners?.let { container ->
+            if (containerOnLayoutChangeListener != null) {
+                container.removeOnLayoutChangeListener(containerOnLayoutChangeListener)
+            }
+            if (containerOnApplyWindowInsetsListener != null) {
+                container.setOnApplyWindowInsetsListener(null)
+            }
+        }
+        containerWithSheetListeners = null
+        containerOnLayoutChangeListener = null
+        containerOnApplyWindowInsetsListener = null
     }
 
     private fun handleInsetsUpdateAndNotifyTransition(insetsCompat: WindowInsetsCompat) {


### PR DESCRIPTION
## Description

`ScreenStackFragment.attachInsetsAndLayoutListenersToBottomSheet` registers two listeners on `screen.container`and never removes them:
- an `OnApplyWindowInsetsListener` whose lambda captures the fragment - container retains one dismissed fragment,
- an `OnLayoutChangeListener` capturing the fragment via `screen`

## Changes

- Cleanup listeners in `onDestroyView`

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7cbbdfd6-23a8-4fbc-a7b2-739595089d1a" /> | <video src="https://github.com/user-attachments/assets/61019bd8-5e05-451a-a106-d29e23e62d47" /> |

## Test plan

Tested on `TestFormSheet`: open & close the sheet, then use the profiler from Android Studio (Analyze Memory Usage - Heap Dump) and verify that there are no leaks.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
