### PR TITLE
chore: backport #4357

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/utils/ScreenDummyLayoutHelper.kt
@@ -176,6 +176,11 @@ internal class ScreenDummyLayoutHelper(
      * the cache while a measurement is in progress.
      *
      * @param fontSize font size value as passed from JS
+     * @param isTitleEmpty whether the header title is empty
+     * @param applyTopInset whether the native header applies the top inset (mirrors
+     * `legacyTopInsetBehavior || consumeTopInset` from [CustomToolbar]). When `false`
+     * (e.g. `disableTopInsetApplication`), the top inset must be excluded so the reported
+     * header height matches what actually renders.
      * @return header height in dp as consumed by Yoga
      */
     @DoNotStrip
@@ -183,6 +188,7 @@ internal class ScreenDummyLayoutHelper(
     private fun computeDummyLayout(
         fontSize: Int,
         isTitleEmpty: Boolean,
+        applyTopInset: Boolean,
     ): Float {
         if (!isLayoutInitialized) {
             val reactContext =
@@ -198,7 +204,7 @@ internal class ScreenDummyLayoutHelper(
             }
         }
 
-        if (cache.hasKey(CacheKey(fontSize, isTitleEmpty))) {
+        if (cache.hasKey(CacheKey(fontSize, isTitleEmpty, applyTopInset))) {
             return cache.headerHeight
         }
 
@@ -212,7 +218,7 @@ internal class ScreenDummyLayoutHelper(
         }
 
         val topLevelDecorView = currentActivity.window.decorView
-        val topInset = getDecorViewTopInset(topLevelDecorView)
+        val topInset = if (applyTopInset) getDecorViewTopInset(topLevelDecorView) else 0
 
         // These dimensions are not accurate, as they do include navigation bar, however
         // it is ok for our purposes.
@@ -242,11 +248,13 @@ internal class ScreenDummyLayoutHelper(
         // scenarios when layout violates measured dimensions.
         currentCoordinatorLayout.layout(0, 0, decorViewWidth, decorViewHeight)
 
-        // Include the top inset to account for the extra padding manually applied to the CustomToolbar.
+        // Include the top inset to account for the extra padding manually applied to the
+        // CustomToolbar. When the header opts out of the top inset (`applyTopInset == false`),
+        // `topInset` is 0 here so the measured height matches the rendered header.
         val totalAppBarLayoutHeight = currentAppBarLayout.height.toFloat() + topInset
 
         val headerHeight = PixelUtil.toDIPFromPixel(totalAppBarLayoutHeight)
-        cache = CacheEntry(CacheKey(fontSize, isTitleEmpty), headerHeight)
+        cache = CacheEntry(CacheKey(fontSize, isTitleEmpty, applyTopInset), headerHeight)
         return headerHeight
     }
 
@@ -359,6 +367,7 @@ internal class ScreenDummyLayoutHelper(
 private data class CacheKey(
     val fontSize: Int,
     val isTitleEmpty: Boolean,
+    val applyTopInset: Boolean,
 )
 
 private class CacheEntry(
@@ -368,6 +377,6 @@ private class CacheEntry(
     fun hasKey(key: CacheKey) = cacheKey.fontSize != Int.MIN_VALUE && cacheKey == key
 
     companion object {
-        val EMPTY = CacheEntry(CacheKey(Int.MIN_VALUE, false), 0f)
+        val EMPTY = CacheEntry(CacheKey(Int.MIN_VALUE, false, true), 0f)
     }
 }

--- a/apps/src/tests/issue-tests/Test4357.tsx
+++ b/apps/src/tests/issue-tests/Test4357.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Colors } from '@apps/shared/styling';
+
+const Stack = createNativeStackNavigator();
+
+const DummyContent = () => <View style={styles.contentContainer} />;
+
+function Screen1() {
+  return <DummyContent />;
+}
+
+function NavigationStack() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Screen1"
+          component={Screen1}
+          options={{ unstable_headerInsets: { top: false } }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default function App() {
+  const [show, setShow] = useState(false);
+
+  if (show) {
+    return <NavigationStack />;
+  }
+
+  return (
+    <View style={styles.centerLayout}>
+      <Button title="Mount Navigation Stack" onPress={() => setShow(true)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centerLayout: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  screen: {
+    flex: 1,
+  },
+  contentContainer: {
+    flex: 1,
+    backgroundColor: Colors.NavyDark100,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -204,6 +204,7 @@ export { default as Test4258 } from './Test4258';
 export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
+export { default as Test4357 } from './Test4357';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -32,7 +32,8 @@ static constexpr const char *kScreenDummyLayoutHelperClass =
 
 std::optional<float> findHeaderHeight(
     const int fontSize,
-    const bool isTitleEmpty) {
+    const bool isTitleEmpty,
+    const bool applyTopInset) {
   JNIEnv *env = facebook::jni::Environment::current();
 
   if (env == nullptr) {
@@ -49,7 +50,7 @@ std::optional<float> findHeaderHeight(
   }
 
   jmethodID computeDummyLayoutID =
-      env->GetMethodID(layoutHelperClass, "computeDummyLayout", "(IZ)F");
+      env->GetMethodID(layoutHelperClass, "computeDummyLayout", "(IZZ)F");
 
   if (computeDummyLayoutID == nullptr) {
     LOG(ERROR) << "[RNScreens] Failed to retrieve computeDummyLayout method ID";
@@ -76,7 +77,7 @@ std::optional<float> findHeaderHeight(
   }
 
   jfloat headerHeight = env->CallFloatMethod(
-      packageInstance, computeDummyLayoutID, fontSize, isTitleEmpty);
+      packageInstance, computeDummyLayoutID, fontSize, isTitleEmpty, applyTopInset);
 
   return {headerHeight};
 }
@@ -101,13 +102,23 @@ void RNSScreenShadowNode::appendChild(
           *std::static_pointer_cast<const RNSScreenStackHeaderConfigProps>(
               headerConfigChild->getProps());
 
+      // The native CustomToolbar only pads itself with the top inset when
+      // `legacyTopInsetBehavior || consumeTopInset` holds (see CustomToolbar.kt).
+      // The dummy measurement must mirror that condition, otherwise the header
+      // height is over-reported by the top inset whenever a header opts out via
+      // `disableTopInsetApplication` (consumeTopInset == false).
+      const bool applyTopInset =
+          headerProps.legacyTopInsetBehavior || headerProps.consumeTopInset;
+
       // Translucent headers do not reserve vertical space, so applying the
       // estimated header correction can expose the previous screen at the
       // bottom during the first Fabric layout.
       const auto headerHeight = (headerProps.hidden || headerProps.translucent)
           ? 0.f
           : findHeaderHeight(
-                headerProps.titleFontSize, headerProps.title.empty())
+                headerProps.titleFontSize,
+                headerProps.title.empty(),
+                applyTopInset)
                 .value_or(0.f);
 
       screenShadowNode.setPadding({0, 0, 0, headerHeight});


### PR DESCRIPTION
## Description

When a header opts out of the top inset on Android (`disableTopInsetApplication`, which sets `consumeTopInset = false`), the measured header height still includes the status bar / cutout inset, so it comes back too tall.

The native `CustomToolbar` only pads itself with the top inset when `legacyTopInsetBehavior || consumeTopInset` is true. But the dummy layout used to report the header height back to the shadow tree always adds the decor view top inset, regardless of that prop. So the height it reports doesn't match what the toolbar actually renders, and the screen content ends up pushed down by roughly the status bar height on the first Fabric layout.

This looks like it was just missed when the `disable*InsetApplication` props landed in #4220 — the toolbar learned about `consumeTopInset` but the measurement path didn't.

## Changes

- `RNSScreenShadowNode.cpp`: read the same header props the toolbar uses (`legacyTopInsetBehavior || consumeTopInset`) and pass the result down to the measurement as `applyTopInset`. The JNI signature changes from `(IZ)F` to `(IZZ)F`.
- `ScreenDummyLayoutHelper.kt`: only add the decor view top inset when `applyTopInset` is true, and include the flag in the measurement cache key so screens with different settings don't share a stale cached height.

## Test plan

Reproducible with the existing `Test4220` scenario:

1. Open `Test4220` on Android.
2. Go to the Details screen and toggle `disableTopInsetApplication` on.

Before this change the screen content sits about a status bar's height too low (the header reserves space it isn't actually using). After, the content sits directly under the header.

## Checklist

- [x] Included code example that can be used to test this change. (existing `Test4220`)
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types. (no public API change)
- [ ] Ensured that CI passes
