### PR TITLE
chore: backport #4405

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -77,7 +77,11 @@ std::optional<float> findHeaderHeight(
   }
 
   jfloat headerHeight = env->CallFloatMethod(
-      packageInstance, computeDummyLayoutID, fontSize, isTitleEmpty, applyTopInset);
+      packageInstance,
+      computeDummyLayoutID,
+      fontSize,
+      isTitleEmpty,
+      applyTopInset);
 
   return {headerHeight};
 }
@@ -103,10 +107,11 @@ void RNSScreenShadowNode::appendChild(
               headerConfigChild->getProps());
 
       // The native CustomToolbar only pads itself with the top inset when
-      // `legacyTopInsetBehavior || consumeTopInset` holds (see CustomToolbar.kt).
-      // The dummy measurement must mirror that condition, otherwise the header
-      // height is over-reported by the top inset whenever a header opts out via
-      // `disableTopInsetApplication` (consumeTopInset == false).
+      // `legacyTopInsetBehavior || consumeTopInset` holds (see
+      // CustomToolbar.kt). The dummy measurement must mirror that condition,
+      // otherwise the header height is over-reported by the top inset whenever
+      // a header opts out via `disableTopInsetApplication` (consumeTopInset ==
+      // false).
       const bool applyTopInset =
           headerProps.legacyTopInsetBehavior || headerProps.consumeTopInset;
 


### PR DESCRIPTION
## Description

It seems like changes to `RNSScreenShadowNode.cpp` file in #4357 weren't formatted properly.

I updated `clang-format` to `22.1.8` locally to make sure it's not due to outdated formatter on my side.

## Changes

- run `yarn format`

## Before & after - visual documentation

N/A

## Test plan

Library should build correctly.

## Checklist

- [x] Ensured that CI passes

(cherry picked from commit 6459116a58114de85a70b16ebae0689a2b6ccf69)