### PR TITLE
chore: backport #4363

### DIFF
--- a/apps/src/tests/single-feature-tests/index.tsx
+++ b/apps/src/tests/single-feature-tests/index.tsx
@@ -12,6 +12,7 @@ import StackV5ScenarioGroup from './stack-v5';
 import StackV4ScenarioGroup from './stack-v4';
 import ScrollViewMarkerScenarioGroup from './scroll-view-marker';
 import FormSheetScenarioGroup from './form-sheet';
+import ScrollToTopGuardScenarioGroup from './scroll-to-top-guard';
 import { ScenarioButton } from '@apps/tests/shared/ScenarioButton';
 import ScenarioSelectionScreen from '@apps/tests/shared/ScenarioScreen';
 
@@ -21,6 +22,7 @@ export * from './stack-v5';
 export * from './stack-v4';
 export * from './scroll-view-marker';
 export * from './form-sheet';
+export * from './scroll-to-top-guard';
 
 export const COMPONENT_SCENARIOS = {
   Tabs: TabsScenarioGroup,
@@ -29,6 +31,7 @@ export const COMPONENT_SCENARIOS = {
   StackV4: StackV4ScenarioGroup,
   ScrollViewMarker: ScrollViewMarkerScenarioGroup,
   FormSheet: FormSheetScenarioGroup,
+  ScrollToTopGuard: ScrollToTopGuardScenarioGroup,
 } as const;
 
 type ParamsList = { [k: keyof typeof COMPONENT_SCENARIOS]: undefined } & {

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/index.ts
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/index.ts
@@ -1,0 +1,21 @@
+import type { ScenarioGroup } from '@apps/tests/shared/helpers';
+
+// Scenario objects (default exports) — carry metadata, used to build the
+// scenario group consumed by the selection menu.
+import TestScrollToTopGuardHeaderSubviewsIOS from './test-scroll-to-top-guard-header-subviews-ios';
+
+// Scenario entry-point components — each scenario's default export re-exported
+// under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
+export { default as TestScrollToTopGuardHeaderSubviewsIOS } from './test-scroll-to-top-guard-header-subviews-ios';
+
+const scenarios = {
+  TestScrollToTopGuardHeaderSubviewsIOS,
+};
+
+const ScrollToTopGuardScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {
+  name: 'Scroll to Top Guard',
+  details: 'Single feature tests for the ScrollToTopGuard component',
+  scenarios,
+};
+
+export default ScrollToTopGuardScenarioGroup;

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
@@ -1,0 +1,189 @@
+import React, {
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+} from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollToTopGuard } from 'react-native-screens/experimental';
+import { StackHeaderConfigProps } from 'react-native-screens/components/gamma/stack/header';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/gamma/containers/stack';
+import { SettingsSwitch, SettingsPicker } from '@apps/shared';
+import LongText from '@apps/shared/LongText';
+import { Colors } from '@apps/shared/styling';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { scenarioDescription } from './scenario-description';
+import PressableWithFeedback from '@apps/shared/PressableWithFeedback';
+
+const HIT_SLOP_VALUES = ['0', '10', '30'] as const;
+type HitSlopValue = (typeof HIT_SLOP_VALUES)[number];
+
+// Per-subview configuration.
+interface SubviewConfig {
+  guarded: boolean;
+  hitSlop: HitSlopValue;
+}
+
+const DEFAULT_SUBVIEW_CONFIG: SubviewConfig = {
+  guarded: true,
+  hitSlop: '0',
+};
+
+// Builds the header subview element. When `guarded` is set, the button is
+// wrapped in <ScrollToTopGuard> so tapping it does NOT scroll the underlying
+// list to top on iPadOS 26+ / iPhone iOS 27+.
+//
+// The `key` (composed from the config) forces a full remount of the subview
+// whenever a value changes. This is required because the guard / hitSlop are
+// applied when the native subview mounts and do not update in place (the same
+// remount-by-key pattern is used in Test3446 and test-stack-subviews-ios).
+function renderSubview(label: string, config: SubviewConfig): ReactElement {
+  const button = (
+    <PressableWithFeedback
+      onPress={() => console.log(`${label} pressed`)}
+      hitSlop={Number(config.hitSlop)}
+      pressRetentionOffset={0}>
+      <Text>{label}</Text>
+    </PressableWithFeedback>
+  );
+
+  const key = `${config.guarded}_${config.hitSlop}`;
+
+  if (config.guarded) {
+    return <ScrollToTopGuard key={key}>{button}</ScrollToTopGuard>;
+  }
+
+  return <View key={key}>{button}</View>;
+}
+
+interface SubviewSettingsProps {
+  label: string;
+  config: SubviewConfig;
+  onChange: (config: SubviewConfig) => void;
+}
+
+function SubviewSettings({ label, config, onChange }: SubviewSettingsProps) {
+  return (
+    <View style={styles.group}>
+      <Text style={styles.groupHeading}>{label}</Text>
+      <SettingsSwitch
+        label="guarded"
+        value={config.guarded}
+        onValueChange={value => onChange({ ...config, guarded: value })}
+      />
+      <SettingsPicker<HitSlopValue>
+        label="hitSlop"
+        value={config.hitSlop}
+        onValueChange={value => onChange({ ...config, hitSlop: value })}
+        items={[...HIT_SLOP_VALUES]}
+      />
+    </View>
+  );
+}
+
+function Screen1() {
+  const { routeKey, setRouteOptions } = useStackNavigationContext();
+
+  const [left, setLeft] = useState<SubviewConfig>(DEFAULT_SUBVIEW_CONFIG);
+  const [right, setRight] = useState<SubviewConfig>(DEFAULT_SUBVIEW_CONFIG);
+  const [title, setTitle] = useState<SubviewConfig>(DEFAULT_SUBVIEW_CONFIG);
+
+  const headerConfig = useMemo<StackHeaderConfigProps>(
+    () => ({
+      transparent: true,
+      ios: {
+        titleItem: {
+          id: 'title',
+          render: () => renderSubview('Title', title),
+        },
+        leadingItems: [
+          {
+            type: 'item',
+            id: 'left',
+            render: () => renderSubview('Left', left),
+          },
+        ],
+        trailingItems: [
+          {
+            type: 'item',
+            id: 'right',
+            render: () => renderSubview('Right', right),
+          },
+        ],
+      },
+    }),
+    [left, right, title],
+  );
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      contentInsetAdjustmentBehavior="automatic">
+      <Text style={styles.heading}>
+        Use iPadOS 26+ or iPhone (iOS 27+). Scroll down, then tap a header
+        subview. A subview with `guarded` enabled (wrapped in
+        &lt;ScrollToTopGuard&gt;) must NOT scroll the list to top. Unguarded
+        subviews and the bare header area still scroll to top.
+      </Text>
+
+      <SubviewSettings label="Left" config={left} onChange={setLeft} />
+      <SubviewSettings label="Right" config={right} onChange={setRight} />
+      <SubviewSettings label="Title" config={title} onChange={setTitle} />
+
+      <LongText size="xl" />
+      <LongText size="xl" />
+      <LongText size="xl" />
+    </ScrollView>
+  );
+}
+
+function TestScrollToTopGuardHeaderSubviewsIOS() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Screen1',
+          Component: Screen1,
+          options: {},
+        },
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 8,
+  },
+  heading: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  group: {
+    gap: 4,
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: Colors.cardBorder,
+  },
+  groupHeading: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+
+export default createScenario(
+  TestScrollToTopGuardHeaderSubviewsIOS,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/scenario-description.ts
@@ -1,0 +1,12 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Scroll to Top Guard Header Subviews (iOS)',
+  key: 'test-scroll-to-top-guard-header-subviews-ios',
+  details:
+    'Wraps Stack v5 header left/right/title subviews in <ScrollToTopGuard> to prevent the ' +
+    'iPadOS 26+ / iPhone iOS 27+ tap-to-scroll-to-top. Per-subview: guard on/off, hitSlop.',
+  platforms: ['ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/scenario.md
@@ -1,0 +1,37 @@
+# Test Scenario: Scroll to Top Guard Header Subviews (iOS)
+
+## Details
+
+**Description:** This test verifies the experimental `ScrollToTopGuard` component
+(`react-native-screens/experimental`). On iPadOS 26+ and iPhone (iOS 27+) the system
+scrolls the underlying `ScrollView` to top when the navigation bar area is tapped.
+Wrapping a header subview in `<ScrollToTopGuard>` consumes that tap so the guarded
+subview does NOT trigger scroll to top, while unguarded subviews and the bare header
+area still do.
+
+**OS test creation version:** iOS 27, iPadOS 26
+
+## E2E test
+
+TBD
+
+## Prerequisites
+
+- iOS / iPadOS simulator or device on **iPadOS 26+** or **iPhone iOS 27+**.
+
+## Steps
+
+1. Open the test. Scroll the list down so scroll-to-top is observable.
+2. With **Left** `guarded` enabled (default), tap the **Left** subview.
+  - [ ] The list does NOT scroll to top.
+3. Toggle **Left** `guarded` off. Scroll down and tap the **Left** subview.
+  - [ ] The list scrolls to top.
+4. Scroll down and tap the **bare header area** (outside any subview).
+  - [ ] The list scrolls to top.
+5. Repeat steps 2–3 for the **Right** subview.
+  - [ ] Guarded Right does NOT scroll to top; unguarded Right does.
+6. Repeat steps 2–3 for the **Title** subview.
+  - [ ] Guarded Title does NOT scroll to top; unguarded Title does.
+7. Set a guarded subview's `hitSlop` to `30`, scroll down, and tap just
+   outside the subview.
+  - [ ] The press is registered and the list does NOT scroll to top.

--- a/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuard.h
+++ b/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuard.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#import "RNSReactBaseView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Backing native view for the experimental, iOS-only `ScrollToTopGuard` component. It wraps its
+ * children and attaches an `RNSScrollToTopGuardGestureRecognizer` to itself on OS versions where
+ * the system "scroll to top" navigation-bar interaction exists (iPadOS 26+, iPhone iOS 27+), so
+ * that tapping the wrapped content does not scroll the underlying scroll view to top.
+ */
+@interface RNSScrollToTopGuard : RNSReactBaseView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuard.mm
+++ b/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuard.mm
@@ -1,0 +1,57 @@
+#import "RNSScrollToTopGuard.h"
+#import <react/renderer/components/rnscreens/ComponentDescriptors.h>
+#import <react/renderer/components/rnscreens/EventEmitters.h>
+#import <react/renderer/components/rnscreens/Props.h>
+#import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
+#import "RNSDefines.h"
+#import "RNSScrollToTopGuardGestureRecognizer.h"
+
+namespace react = facebook::react;
+
+@implementation RNSScrollToTopGuard
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    [self initState];
+  }
+  return self;
+}
+
+- (void)initState
+{
+  static const auto defaultProps = std::make_shared<const react::RNSScrollToTopGuardProps>();
+  _props = defaultProps;
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  // Attach the guard once on mount, only on OS versions where the system scroll-to-top
+  // interaction exists. On other versions this view is a plain passthrough.
+  if ([RNSScrollToTopGuardGestureRecognizer shouldGuardScrollToTop]) {
+    [RNSScrollToTopGuardGestureRecognizer applyToView:self];
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+}
+
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return react::concreteComponentDescriptorProvider<react::RNSScrollToTopGuardComponentDescriptor>();
+}
+
+#pragma mark - Dynamic frameworks support
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [super load];
+}
+#endif // RCT_DYNAMIC_FRAMEWORKS
+
+@end
+
+#pragma mark - View class exposure
+
+Class<RCTComponentViewProtocol> RNSScrollToTopGuardCls(void)
+{
+  return RNSScrollToTopGuard.class;
+}

--- a/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuardGestureRecognizer.h
+++ b/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuardGestureRecognizer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This gesture recognizer is necessary to handle views placed in the navigation bar area on OS
+ * versions where the system triggers "scroll to top" by tapping that area (iPadOS 26+ and iPhone
+ * iOS 27+). Otherwise, tapping such a view results in a scroll to top action even if there is a
+ * pressable inside it.
+ */
+@interface RNSScrollToTopGuardGestureRecognizer : UITapGestureRecognizer <UIGestureRecognizerDelegate>
+
+/**
+ * Returns YES on OS versions / device idioms where the system scroll-to-top-on-header interaction
+ * exists (iPad: iOS 26+, iPhone: iOS 27+); NO otherwise.
+ */
++ (BOOL)shouldGuardScrollToTop;
+
+/**
+ * Creates the scroll to top guard gesture recognizer and adds it to the given view.
+ */
++ (void)applyToView:(UIView *)view;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuardGestureRecognizer.mm
+++ b/ios/gamma/scroll-to-top-guard/RNSScrollToTopGuardGestureRecognizer.mm
@@ -1,0 +1,64 @@
+#import "RNSScrollToTopGuardGestureRecognizer.h"
+#import "RNSDefines.h"
+
+@implementation RNSScrollToTopGuardGestureRecognizer
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
+- (instancetype)init
+{
+  if (self = [super initWithTarget:self action:nil]) {
+    self.cancelsTouchesInView = NO;
+    self.delegate = self;
+  }
+  return self;
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  // We want to target tap gesture recognizers only (one responsible for scroll to top must be one).
+  if (![otherGestureRecognizer isKindOfClass:[UITapGestureRecognizer class]]) {
+    return NO;
+  }
+
+  // We don't know the exact recognizer responsible for scroll to top so we block all
+  // gesture recognizers above us.
+  return ![otherGestureRecognizer.view isDescendantOfView:gestureRecognizer.view];
+}
+
+#pragma mark - Class methods
+
++ (BOOL)shouldGuardScrollToTop
+{
+  // The system scroll-to-top-on-header interaction has been present on iPadOS since iOS 26...
+  if (@available(iOS 26.0, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      return YES;
+    }
+  }
+  // ...and was extended to iPhone in iOS 27.
+  if (@available(iOS 27.0, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
++ (void)applyToView:(nonnull UIView *)view
+{
+  [view addGestureRecognizer:[RNSScrollToTopGuardGestureRecognizer new]];
+}
+
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
+@end

--- a/package.json
+++ b/package.json
@@ -173,6 +173,9 @@
         "RNSScreenFooter": {
           "className": "RNSScreenFooter"
         },
+        "RNSScrollToTopGuard": {
+          "className": "RNSScrollToTopGuard"
+        },
         "RNSScreen": {
           "className": "RNSScreenView"
         },

--- a/src/components/gamma/scroll-to-top-guard/ScrollToTopGuard.ios.tsx
+++ b/src/components/gamma/scroll-to-top-guard/ScrollToTopGuard.ios.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+import type { ViewProps } from 'react-native';
+import ScrollToTopGuardNativeComponent from '../../../fabric/gamma/scroll-to-top-guard/ScrollToTopGuardNativeComponent';
+
+/**
+ * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
+ *
+ * This is an **experimental, unstable** component which might be subject to
+ * breaking changes and will be removed in the future. It is meant to be used
+ * only as a temporary workaround until the issue is fixed on `react-native`'s
+ * side. The issue report: https://github.com/react/react-native/issues/56061.
+ */
+export function ScrollToTopGuard(props: ViewProps) {
+  return <ScrollToTopGuardNativeComponent {...props} collapsable={false} />;
+}

--- a/src/components/gamma/scroll-to-top-guard/ScrollToTopGuard.tsx
+++ b/src/components/gamma/scroll-to-top-guard/ScrollToTopGuard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ViewProps } from 'react-native';
+
+/**
+ * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
+ *
+ * This is an **experimental, unstable** component which might be subject to
+ * breaking changes and will be removed in the future. It is meant to be used
+ * only as a temporary workaround until the issue is fixed on `react-native`'s
+ * side. The issue report: https://github.com/react/react-native/issues/56061.
+ *
+ * Falls back to `React.Fragment` on platforms other than iOS.
+ */
+function ScrollToTopGuard({ children }: ViewProps) {
+  return <>{children}</>;
+}
+
+export { ScrollToTopGuard };

--- a/src/components/gamma/scroll-to-top-guard/index.ts
+++ b/src/components/gamma/scroll-to-top-guard/index.ts
@@ -1,0 +1,1 @@
+export { ScrollToTopGuard } from './ScrollToTopGuard';

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -10,3 +10,4 @@ export * from '../components/gamma/split';
 export * from '../components/safe-area';
 export * from '../components/gamma/scroll-view-marker';
 export * from '../components/gamma/modals/form-sheet';
+export * from '../components/gamma/scroll-to-top-guard';

--- a/src/fabric/gamma/scroll-to-top-guard/ScrollToTopGuardNativeComponent.ts
+++ b/src/fabric/gamma/scroll-to-top-guard/ScrollToTopGuardNativeComponent.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { codegenNativeComponent } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+export interface NativeProps extends ViewProps {}
+
+export default codegenNativeComponent<NativeProps>('RNSScrollToTopGuard', {
+  excludedPlatforms: ['android'],
+});


### PR DESCRIPTION
Adds **experimental** ScrollToTopGuard component for iOS. The component
is meant to be used as a wrapper for `Pressable`s in custom header
subviews (headerLeft/Right/Title) that should prevent native
scroll-to-top interaction on tap (which has been added on iPadOS 26+ and
on iOS 27+ for iPhone as well).

> [!CAUTION]
> This is an **experimental, unstable** component which might be subject
to breaking changes and will be removed in the future. It is meant to be
used only as a temporary workaround until the issue is fixed on
`react-native`'s side. The issue report is available
[here](https://github.com/react/react-native/issues/56061).

Supersedes
https://github.com/software-mansion/react-native-screens/pull/3731.

For details about the interaction please see
https://github.com/software-mansion/react-native-screens/pull/3731#issue-4028929535.
Starting from iOS 27, tapping on the header on iPhone also performs
scroll-to-top interaction.

- add **experimental** ScrollToTopGuard component
- add SFT

https://github.com/user-attachments/assets/c6828f8a-fb6c-4093-abbc-dd48cf3c9404

Run `test-scroll-to-top-guard-header-subviews-ios` SFT.

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes

(cherry picked from commit da120cc8c87c645e5bec00f441a4eb1fd5dd9da4)