### PR TITLE
chore: backport #4407

### DIFF
--- a/apps/src/tests/issue-tests/Test4361.tsx
+++ b/apps/src/tests/issue-tests/Test4361.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet, ScrollView } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
+import { enableFreeze } from 'react-native-screens';
+import { Colors } from '@apps/shared/styling';
+
+enableFreeze(true);
+
+const Stack = createNativeStackNavigator();
+const Tab = createNativeBottomTabNavigator();
+
+function HomeScreen({ navigation }: any) {
+  return (
+    <View style={styles.screen}>
+      <Text>Home (Tab A)</Text>
+      <Text>
+        1. Press "Push Calendar" below{'\n'}
+        2. Press back{'\n'}
+        3. Immediately tap another tab during the pop animation
+      </Text>
+      <Pressable
+        style={styles.button}
+        onPress={() => navigation.getParent()?.navigate('Calendar')}>
+          <Text style={styles.buttonText}>Push Calendar</Text>
+        </Pressable>
+    </View>
+  );
+}
+
+function MyPetsScreen() {
+  return (
+    <View style={styles.screen}>
+      <Text>My Pets (Tab B)</Text>
+      <ScrollView style={styles.scrollArea}>
+        {Array.from({ length: 30 }, (_, i) =>
+          <Pressable
+            key={i}
+            style={styles.listItem}
+            onPress={() => console.log(`pressed pet item ${i}`)}>
+              <Text style={styles.listItemText}>Pet item {i}</Text>
+            </Pressable>
+        )}
+      </ScrollView>
+      <Text>
+        If touches are broken, tapping items above will produce NO console logs.
+      </Text>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  return (
+    <View style={styles.screen}>
+      <Text>Profile (Tab C)</Text>
+      <Pressable
+        style={styles.button}
+        onPress={() => console.log('Profile button pressed')}>
+          <Text style={styles.buttonText}>Press me</Text>
+        </Pressable>
+        <Text>
+          If touches are broken, pressing the button above will produce NO console
+          log.
+        </Text>
+    </View>
+  );
+}
+
+function TabsNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen
+      name="MyPets"
+      component={MyPetsScreen}
+      options={{ title: 'My Pets' }}
+      />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
+
+function CalendarScreen({ navigation }: any) {
+  return (
+    <View style={styles.screen}>
+      <Text>Calendar (pushed screen)</Text>
+      <Text>
+        Press the header back button, then IMMEDIATELY tap a different tab.
+      </Text>
+      <Pressable style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>Go Back (alternative)</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+        name="Tabs"
+        component={TabsNavigator}
+        options={{ headerShown: false }}
+        />
+        <Stack.Screen
+        name="Calendar"
+        component={CalendarScreen}
+        options={{ title: 'Calendar' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  button: {
+    backgroundColor: Colors.BlueDark100,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginVertical: 8,
+  },
+  buttonText: {
+    color: Colors.White,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  scrollArea: {
+    flex: 1,
+    width: '100%',
+  },
+  listItem: {
+    padding: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.NavyDark120,
+  },
+  listItemText: {
+    fontSize: 16,
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -206,6 +206,7 @@ export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
 export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
+export { default as Test4361 } from './Test4361';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal;
 - (void)notifyFinishTransitioning;
 - (RNSScreenView *)screenView;
-- (void)setViewToSnapshot;
+- (void)addSnapshotToView;
 - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal;
 - (BOOL)isRemovedFromParent;
 - (void)notifyPresentedControllerDismissed;
@@ -91,6 +91,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, retain) NSNumber *transitionDuration;
 @property (nonatomic, readonly) BOOL dismissed;
+
+/**
+ * Whether React has already deleted this component. The view may still be part of the view
+ * hierarchy at that point, backing the remainder of an ongoing native transition.
+ */
+@property (nonatomic, readonly, getter=isInvalidated) BOOL invalidated;
 @property (nonatomic) BOOL hideKeyboardOnSwipe;
 @property (nonatomic) BOOL customAnimationOnSwipe;
 @property (nonatomic) BOOL preventNativeDismiss;

--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -770,6 +770,8 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)invalidateImpl
 {
+  _invalidated = YES;
+
   // Since the scroll view might get immediately recycled we remove ourselves
   // immediately.
   if (_sheetsScrollView != nil) {
@@ -1410,7 +1412,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 @implementation RNSScreen {
   __weak id _previousFirstResponder;
   CGRect _lastViewFrame;
-  RNSScreenView *_initialView;
   UIView *_fakeView;
   CADisplayLink *_animationTimer;
   CGFloat _currentAlpha;
@@ -1431,7 +1432,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
     _fakeView = [UIView new];
     _shouldNotify = YES;
     _isRemovedFromParent = NO;
-    _initialView = (RNSScreenView *)view;
   }
   return self;
 }
@@ -1754,9 +1754,13 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward
 {
-  if ([self.view isKindOfClass:[RNSScreenView class]]) {
-    // if the view is already snapshot, there is not sense in sending progress since on JS side
-    // the component is already not present
+  if (![self.view isKindOfClass:[RNSScreenView class]]) {
+    return;
+  }
+
+  // if the screen was already deleted by React, there is no sense in sending progress
+  // since on JS side the component is already not present
+  if (!static_cast<RNSScreenView *>(self.view).isInvalidated) {
     [(RNSScreenView *)self.view notifyTransitionProgress:progress closing:closing goingForward:goingForward];
   }
 }
@@ -1910,11 +1914,9 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   return (int)[[self.screenView.reactSuperview reactSubviews] indexOfObject:view];
 }
 
-// Since the view of the controller can be a snapshot of type `UIView`,
-// when we want to check props of ScreenView, we need to get them from _initialView
 - (RNSScreenView *)screenView
 {
-  return _initialView;
+  return static_cast<RNSScreenView *>(self.view);
 }
 
 - (void)hideHeaderIfNecessary
@@ -2007,18 +2009,22 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
 
 #pragma mark - Fabric specific
 
-- (void)setViewToSnapshot
+- (void)addSnapshotToView
 {
-  UIView *superView = self.view.superview;
   // if we dismissed the view natively, it will already be detached from view hierarchy
-  if (self.view.window != nil) {
-    auto afterUpdates = self.screenView.snapshotAfterUpdates;
-    UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:afterUpdates];
-    snapshot.frame = self.view.frame;
-    [self.view removeFromSuperview];
-    self.view = snapshot;
-    [superView addSubview:snapshot];
+  if (self.view.window == nil) {
+    return;
   }
+
+  // The snapshot is added inside the screen view instead of replacing it, so `self.view` remains
+  // the view UIKit captured for the ongoing transition and is torn down (with the snapshot)
+  // consistently. Replacing the view mid-transition made iOS 26 teardown re-insert the original
+  // view into the hierarchy and remove only the snapshot, leaving a view that blocked all touches.
+  UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:self.screenView.snapshotAfterUpdates];
+  snapshot.frame = self.view.bounds;
+  // fill the whole screen view with the snapshot
+  snapshot.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self.view addSubview:snapshot];
 }
 
 @end

--- a/ios/RNSScreenStack.mm
+++ b/ios/RNSScreenStack.mm
@@ -244,8 +244,10 @@ namespace react = facebook::react;
       willShowViewController:(UIViewController *)viewController
                     animated:(BOOL)animated
 {
-  if (![viewController.view isKindOfClass:[RNSScreenView class]]) {
-    // if the current view is a snapshot, config was already removed so we don't trigger the method
+  if (![viewController.view isKindOfClass:[RNSScreenView class]] ||
+      static_cast<RNSScreenView *>(viewController.view).isInvalidated) {
+    // if the screen was already deleted by React, its config was already removed
+    // so we don't trigger the method
     return;
   }
   auto *screenView = static_cast<RNSScreenView *>(viewController.view);
@@ -1313,7 +1315,7 @@ RNS_IGNORE_SUPER_CALL_END
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   RNSScreenView *screenChildComponent = (RNSScreenView *)childComponentView;
-  [screenChildComponent.controller setViewToSnapshot];
+  [screenChildComponent.controller addSnapshotToView];
 
   RCTAssert(screenChildComponent.reactSuperview == self,
             @"Attempt to unmount a view which is mounted inside different view. (parent: %@, child: %@, index: %@)",
@@ -1330,7 +1332,10 @@ RNS_IGNORE_SUPER_CALL_END
       @([[_reactSubviews objectAtIndex:index] tag]));
   screenChildComponent.reactSuperview = nil;
   [_reactSubviews removeObject:screenChildComponent];
-  [screenChildComponent removeFromSuperview];
+
+  if (screenChildComponent.window == nil) {
+    [screenChildComponent removeFromSuperview];
+  }
 }
 
 - (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction


### PR DESCRIPTION
Fixes
https://github.com/software-mansion/react-native-screens/issues/4361

## Description

This PR fixes empty native stack screen view hanging after overlapping
stack / tabs transitions. For full problem description see the linked
issue. Running the provided repro with added lifecycle logs, the
following happens when trying to pop the screen with back button and
quickly tapping the second tab before the stack dismissed the top screen
fully:

```
** 1. **
screen 'Calendar-S-6H596y9u5jAlqieB7Of' willMoveToParentViewController (null)!
Unable to simultaneously satisfy constraints.
[...]
[DEBUG] screen 'Calendar-S-6H596y9u5jAlqieB7Of' viewWillDisappear!
[DEBUG] screen 'Tabs-r0nvm3owqzZ0ngsCQLvpW' viewWillAppear!
[DEBUG] screen 'Tabs-r0nvm3owqzZ0ngsCQLvpW' did move to window <UIWindow: 0x104b9b660; frame = (0 0; 390 844); gestureRecognizers = <NSArray: 0x1263c5080>; layer = <UIWindowLayer: 0x1282d6340>>, superview <UIView: 0x1263ce680; frame = (0 0; 390 844); clipsToBounds = YES; autoresize = W+H; layer = <CALayer: 0x1263c6c10>>
TabsScreen [2066] onWillAppear received
TabBar: <UITabBar: 0x128381680; frame = (0 761; 390 83); autoresize = W+TM; tintColor = UIExtendedSRGBColorSpace 0 0.478431 1 1; gestureRecognizers = <NSArray: 0x1256e2080>; layer = <CALayer: 0x125d31ce0>> standardAppearance=0x11b0b2520 didSelectItem: <UITabBarItem: 0x12835fa80> title='My Pets' standardAppearance=0x11b0b22e0 scrollEdgeAppearance=0x11b0b2340 selected
TabsHost [2072] onTabSelected: {"selectedScreenKey":"MyPets-lV7gQMdoOKmHOwiYuK8BO","provenance":1,"isRepeated":false,"hasTriggeredSpecialEffect":false,"actionOrigin":"user","target":2072,"timeStamp":76803034.52725}
TabsScreen [2068] onWillAppear received
TabsScreen [2066] onWillDisappear received
TabsHost render
TabsScreen [2066] render; screenKey: Home-EJSjwXWA38st7IPuzYkHS
TabsScreen [2068] render; screenKey: MyPets-lV7gQMdoOKmHOwiYuK8BO
TabsScreen [2070] render; screenKey: Profile-CneTd9bfupq-UefLAhFf5
I0727 11:22:56.968006 1837248512 UIManagerBinding.cpp:143] instanceHandle is null, event of type topTransitionProgress will be dropped
TabBarCtrl mountintTransactionWillMount
** 2. **
[DEBUG] screen 'Calendar-S-6H596y9u5jAlqieB7Of' did move to window (null), superview (null)
[DEBUG] screen snapshot taken!
TabBarCtrl mountintTransactionDidMount running updates
** 3. **
TabBarCtrl updateSelectedViewController
[DEBUG] screen 'Calendar-S-6H596y9u5jAlqieB7Of' did move to window <UIWindow: 0x104b9b660; frame = (0 0; 390 844); autoresize = W+H; gestureRecognizers = <NSArray: 0x1263c5080>; layer = <UIWindowLayer: 0x1282d6340>>, superview <UIViewControllerWrapperView: 0x12620d500; frame = (0 0; 390 844); layer = <CALayer: 0x125786c40>>
** 4. **
[DEBUG] screen 'Calendar-S-6H596y9u5jAlqieB7Of' viewDidDisappear!
[DEBUG] screen 'Calendar-S-6H596y9u5jAlqieB7Of' dismissed event sent!
screen 'Calendar-S-6H596y9u5jAlqieB7Of' didMoveToParentViewController (null)!
** 5. **
[DEBUG] screen 'Tabs-r0nvm3owqzZ0ngsCQLvpW' viewDidAppear!
TabsScreen [2068] onDidAppear received
TabsScreen [2066] onDidDisappear received
** 6. **
I0727 11:22:59.416013 1837248512 UIManagerBinding.cpp:143] instanceHandle is null, event of type topTouchEnd will be dropped
I0727 11:23:00.200285 1837248512 UIManagerBinding.cpp:143] instanceHandle is null, event of type topTouchEnd will be dropped
I0727 11:23:01.017321 1837248512 UIManagerBinding.cpp:143] instanceHandle is null, event of type topTouchEnd will be dropped
```
1. top screen is being popped with back button, we get lifecycle events
for Calendar screen moving out and Tabs screen moving in
2. Calendar screen is detached from window and replaced with snapshot as
the controller.view
3. active tab is switched - mid screen transition; **but the screen view
is attached to window again, in another parent and this is the view that
causes the bug**
4. Calendar screen is fully dismissed from the stack point of view and
dismiss event is sent (viewDidX, viewWillX are methods on the
controller)
5. transition between tabs is fully completed
6. we can see the bug - clicks are not registered

---

The bug seems to be caused by the snapshot function. If controller.view
is not replaced with a snapshot, there is no bug. With a breakpoint
inside the problematic `didMoveToWindow` we see the following trace:

<img width="483" height="794" alt="image"
src="https://github.com/user-attachments/assets/cbd9db04-2523-40d7-9b20-d6869c40b616"
/>

These are UIKit internals. Supposedly, UIKit tracks both "from" and "to"
views during transition, and changing them causes UIKit to readd them in
the wrong place. I found out that adding the snapshot inside the already
empty screen view instead of replacing it is a possible solution and I
decided to move forward with it.

## Changes

- instead of replacing screen controller's view with snapshot directly,
the snapshot is added as a child of the view

## Before & after - visual documentation

No visual changes. See the logs in the repro instead: after performing
the navigation, each press should be logged correctly.

## Test plan

Use Test4361.

> [!important]
> To test this you need physical device.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

(cherry picked from commit ef1ea510a54261dd06cbd18899a12924bc36b855)