### PR TITLE
chore: backport #4423

### DIFF
--- a/apps/src/tests/issue-tests/Test4423.tsx
+++ b/apps/src/tests/issue-tests/Test4423.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { View, Text, Button } from 'react-native';
+import {
+  Screen,
+  ScreenStack,
+  ScreenStackHeaderConfig,
+} from 'react-native-screens';
+
+type ScreenKey = 'home' | 'detailWithBackTitle' | 'detailWithoutBackTitle';
+
+type DetailRouteConfig = {
+  title: string;
+  backTitleVisible: boolean;
+  backTitle: string;
+  description: string;
+};
+
+const DETAIL_ROUTE_CONFIGS: Record<
+  Exclude<ScreenKey, 'home'>,
+  DetailRouteConfig
+> = {
+  detailWithBackTitle: {
+    title: 'Detail with back title',
+    backTitleVisible: true,
+    backTitle: 'Hi',
+    description: 'title',
+  },
+  detailWithoutBackTitle: {
+    title: 'Detail without back title',
+    backTitleVisible: false,
+    backTitle: 'Hi',
+    description: 'no title',
+  },
+};
+
+export default function App() {
+  const [pushedScreenKey, setPushedScreenKey] =
+    React.useState<ScreenKey>('home');
+
+  const popToHome = () => {
+    setPushedScreenKey('home');
+  };
+
+  const detailRouteConfig =
+    pushedScreenKey === 'home'
+      ? null
+      : DETAIL_ROUTE_CONFIGS[pushedScreenKey];
+
+  return (
+    <ScreenStack style={{ flex: 1 }}>
+      <Screen key="home" activityState={2} isNativeStack>
+        <ScreenStackHeaderConfig title="Home" />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <Button
+            title="Push with back title"
+            onPress={() => setPushedScreenKey('detailWithBackTitle')}
+          />
+          <Button
+            title="Push without back title"
+            onPress={() => setPushedScreenKey('detailWithoutBackTitle')}
+          />
+        </View>
+      </Screen>
+      {detailRouteConfig != null && (
+        <Screen
+          key={pushedScreenKey}
+          activityState={2}
+          isNativeStack
+          onDismissed={popToHome}>
+          <ScreenStackHeaderConfig
+            title={detailRouteConfig.title}
+            backTitleVisible={detailRouteConfig.backTitleVisible}
+            backTitle={detailRouteConfig.backTitle}
+          />
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <Text>
+              Back chevron should have {detailRouteConfig.description}
+            </Text>
+            <Button title="Pop" onPress={popToHome} />
+          </View>
+        </Screen>
+      )}
+    </ScreenStack>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -207,6 +207,7 @@ export { default as Test4276 } from './Test4276';
 export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
+export { default as Test4423 } from './Test4423';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -47,7 +47,7 @@ export interface NativeProps extends ViewProps {
   backTitle?: string | undefined;
   backTitleFontFamily?: string | undefined;
   backTitleFontSize?: CT.Int32 | undefined;
-  backTitleVisible?: CT.WithDefault<boolean, 'true'>;
+  backTitleVisible?: CT.WithDefault<boolean, true>;
   color?: ColorValue | undefined;
   direction?: CT.WithDefault<DirectionType, 'ltr'>;
   hidden?: boolean | undefined;


### PR DESCRIPTION
## Description

The default boolean value of 'backTitleVisible' was set as string
'true', I changed it to boolean true. It is correct because codegen cast
it as expected.

Closes
https://github.com/software-mansion/react-native-screens-labs/issues/755

## Changes

Updated 'ScreenStackHeaderConfigNativeComponent.ts'

## Test plan

New issue test: 'Test4423.tsx'
It is checking if the back title is visible depending on the flag.

https://github.com/user-attachments/assets/9b870450-56cc-4cb6-8f35-90ce04e2f257

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

(cherry picked from commit 87b4cd42792a971ba1bab355465cf8bc20a26e0c)