### PR TITLE
chore: backport #4420

### DIFF
--- a/ios/RNSReactMountingTransactionObserving.h
+++ b/ios/RNSReactMountingTransactionObserving.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RNSReactMountingTransactionObserving
+
+- (void)reactMountingTransactionWillMount;
+
+- (void)reactMountingTransactionDidMount;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/bridging/Swift-Bridging.h
+++ b/ios/bridging/Swift-Bridging.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#import "RNSReactMountingTransactionObserving.h"
+
 #if __has_include(<RNScreens/RNScreens-Swift.h>)
 #import <RNScreens/RNScreens-Swift.h>
 #else

--- a/ios/gamma/ReactMountingTransactionObserving.swift
+++ b/ios/gamma/ReactMountingTransactionObserving.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-@objc
-public protocol ReactMountingTransactionObserving {
-  func reactMountingTransactionWillMount()
-  func reactMountingTransactionDidMount()
-}

--- a/ios/gamma/split/RNSSplitHostController.swift
+++ b/ios/gamma/split/RNSSplitHostController.swift
@@ -7,7 +7,7 @@ import UIKit
 /// Manages a collection of RNSSplitScreenComponentView instances,
 /// synchronizes appearance settings with props, observes component lifecycle, and emits events.
 @objc
-public class RNSSplitHostController: UISplitViewController, ReactMountingTransactionObserving,
+public class RNSSplitHostController: UISplitViewController, RNSReactMountingTransactionObserving,
   RNSOrientationProvidingSwift
 {
   private var needsChildViewControllersUpdate = false
@@ -259,7 +259,7 @@ public class RNSSplitHostController: UISplitViewController, ReactMountingTransac
     }
   }
 
-  // MARK: ReactMountingTransactionObserving
+  // MARK: RNSReactMountingTransactionObserving
 
   ///
   /// @brief Called before mounting transaction.

--- a/ios/gamma/stack/host/RNSStackHostComponentView.mm
+++ b/ios/gamma/stack/host/RNSStackHostComponentView.mm
@@ -15,7 +15,6 @@
 #import "RNSStackNavigationController.h"
 #import "RNSStackOperationCoordinator.h"
 #import "RNSStackScreenComponentView.h"
-#import "Swift-Bridging.h"
 
 namespace react = facebook::react;
 

--- a/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenComponentView.mm
@@ -16,8 +16,6 @@
 #import "RNSStackScreenController.h"
 #import "RNSStackScreenHeaderCoordinator.h"
 
-#import "Swift-Bridging.h"
-
 namespace react = facebook::react;
 
 @interface RNSStackScreenComponentView () <RCTMountingTransactionObserving, RNSScrollViewSeeking>

--- a/ios/tabs/host/RNSTabBarController.h
+++ b/ios/tabs/host/RNSTabBarController.h
@@ -2,6 +2,7 @@
 
 #import <UIKit/UIKit.h>
 #import "RNSContainer.h"
+#import "RNSReactMountingTransactionObserving.h"
 #import "RNSTabBarAppearanceCoordinator.h"
 #import "RNSTabsNavigationState.h"
 #import "RNSTabsScreenViewController.h"
@@ -15,14 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class RNSTabsHostComponentView;
 @class RNSTabBarController;
 
-@protocol RNSReactTransactionObserving
-
-- (void)reactMountingTransactionWillMount;
-
-- (void)reactMountingTransactionDidMount;
-
-@end
-
 /**
  * UITabBarController subclass that backs `<TabsHost>` on iOS.
  *
@@ -30,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  * fact of inheritance from `UITabBarController`. It is limited only to the child view controllers
  * of type `RNSTabsScreenViewController`, however.
  *
- * Updates made by this controller are synchronized by `RNSReactTransactionObserving` protocol,
+ * Updates made by this controller are synchronized by `RNSReactMountingTransactionObserving` protocol,
  * i.e. if you made changes through one of signals method, unless you flush them immediately, they
  * will be executed only after react finishes the transaction (from within transaction execution
  * block).
@@ -51,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Members under `#pragma mark - Internal API` are host-only (`RNSTabsHostComponentView`)
  * implementation detail and may change without notice. Do not call from third-party code.
  */
-@interface RNSTabBarController : UITabBarController <RNSReactTransactionObserving,
+@interface RNSTabBarController : UITabBarController <RNSReactMountingTransactionObserving,
                                                      RNSContainer
 #if !TARGET_OS_TV
                                                      ,
@@ -75,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Request a tab change. The transition is recorded with `RNSTabsActionOriginProgrammaticNative`,
  * and is built against the current `navigationState.provenance` so it is never treated as stale.
  *
- * The update is applied on the next `RNSReactTransactionObserving` callback, or call
+ * The update is applied on the next `RNSReactMountingTransactionObserving` callback, or call
  * `flushPendingUpdates` to apply it immediately. If you want to execute multiple updates in
  * sequence you must flush the container after each one separately.
  */
@@ -154,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Pass nil to clear any queued update.
  *
- * The update is applied on the next `RNSReactTransactionObserving` callback, or call
+ * The update is applied on the next `RNSReactMountingTransactionObserving` callback, or call
  * `flushPendingUpdates` to apply it immediately. If you want to execute multiple updates in
  * sequence you must flush the container after each one separately.
  *

--- a/ios/tabs/host/RNSTabBarController.mm
+++ b/ios/tabs/host/RNSTabBarController.mm
@@ -257,7 +257,7 @@ static void rns_pushViewController(__unsafe_unretained id self,
   _needsLayoutDirectionUpdateBelowIOS17 = needsLayoutDirectionUpdate;
 }
 
-#pragma mark - RNSReactTransactionObserving
+#pragma mark - RNSReactMountingTransactionObserving
 
 - (void)reactMountingTransactionWillMount
 {

--- a/ios/utils/RNSLog.swift
+++ b/ios/utils/RNSLog.swift
@@ -1,6 +1,0 @@
-public func rnsLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-  #if RNS_DEBUG_LOGGING
-    let output = items.map { "\($0)" }.joined(separator: separator)
-    Swift.print(output, terminator: terminator)
-  #endif
-}


### PR DESCRIPTION
The 1st part of the Split migration to Objective-C to avoid the
necessity to move swift to another target. I am moving the protocol to
Obj-C and unifying it with Tabs. Also, RNSLog is dropped as it's a dead
symbol.

Closes:
https://github.com/software-mansion/react-native-screens-labs/issues/1700

- protocol moved from swift to obj-c and unified with tabs

N/A

Go through Split tests.

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

(cherry picked from commit 749df7a71dda2fb9f16eeaf370337208d1056b8f)