### PR TITLE
chore: backport #4411

### DIFF
--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -163,6 +163,13 @@
   if ([screenParentViewController isKindOfClass:[UITabBarController class]]) {
     UITabBarController *tabBarVC = (UITabBarController *)screenParentViewController;
     [tabBarVC.tabBar setNeedsLayout];
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+    if (@available(iOS 26, *)) {
+      // Without this the deferred pass can measure the label slot before the
+      // image lands, truncating the label until a tab is tapped.
+      [tabBarVC.tabBar layoutIfNeeded];
+    }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   }
 }
 


### PR DESCRIPTION
## Description

On iOS 26, `RNSTabBarAppearanceCoordinator` assigns `tabBarItem.image`
from an asynchronous image-loader completion block and calls
`setNeedsLayout` without `layoutIfNeeded`. The deferred pass can run
before the image lands, leaving the label slot measured for the wrong
content — the label renders ellipsised (e.g. `Главная` → `Гла…`) until
the user selects that tab, which forces the bar to lay out again.

It heals **per item**: only the tab you select re-lays out, so an
unselected tab stays clipped. It isn't length-driven either — in my app
`Профиль` (7 chars) renders fine while `Главная` (7 chars) clips.

Reported downstream as:
- react-navigation/react-navigation#12908
- expo/expo#42364

## Changes

One layout invalidation: after the async image is assigned, force the
pass that a tab tap would have triggered, so the slot is re-measured
with the image in place. Guarded to iOS 26.

## Test plan

Production Expo app using `expo-router/unstable-native-tabs`
(react-native-screens 4.26.1 + this change via patch-package), iPhone 17
Pro, iOS 26.4. The app loads 10 raster tab icons at mount, so the async
path fires reliably.

- **Unpatched:** two of four labels truncated on the very first entry
into the tabs. Tapping tabs healed them one at a time; an unselected tab
stayed clipped.
- **Patched:** all labels render fully on first mount, and after an
in-session language switch (full navigator remount + restore push) with
no tab tap in between.
- No regressions in cold launch, tab switching, badge updates, or a full
native-host remount.

## Notes

An earlier revision of this PR also patched `RNSTabsScreenComponentView`
(title writes) and `RNSTabsScreenViewController` (`viewDidAppear`). Both
are removed. I could not reproduce a title-change truncation in a
minimal app across seven configurations — raster icons, SF Symbols, no
icons, shorter labels, navigator remount, an uncached icon swap in the
same commit, and my app's full `NativeTabs` prop set — and neither hunk
is needed to fix the app once the async-image path is handled.

I have only verified iOS 26.4. Whether 18.x is affected is unconfirmed;
happy to test and lift the guard if it is.

---------

Co-authored-by: Konrad Michalik <63911178+kmichalikk@users.noreply.github.com>
(cherry picked from commit 2fc92e817efef2e91fc71dc59339c2caf5d163d9)
