### PR TITLE
chore: backport #4443

### DIFF
--- a/FabricExample/android/settings.gradle
+++ b/FabricExample/android/settings.gradle
@@ -4,3 +4,16 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex -> ex.autol
 rootProject.name = 'FabricExample'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
+
+// Kotlin 2.2 incremental compilation can't see a module's own `internal` declarations 
+// when the project path goes through a symlink (see: https://youtrack.jetbrains.com/issue/KT-80039): 
+// KGP registers the previous compilation output as a canonicalized
+// "friend path" while the classpath keeps the symlinked path, so the visibility
+// check never matches. node_modules/react-native-screens is a symlink to the repo
+// root, so resolve autolinked project dirs to their real paths.
+// TODO: Can be removed when RN ships Kotlin >= 2.3.0 which resolved the issue.
+gradle.settingsEvaluated { settings ->
+    settings.rootProject.children.each { p ->
+        p.projectDir = p.projectDir.canonicalFile
+    }
+}


### PR DESCRIPTION
## Description

Since the RN `0.87`, which moved Kotlin `2.1.* - 2.2.*`, incremental
Kotlin builds inside `FabricExample` fail with visibility errors
whenever the edited file references `internal` declarations from other
files in the same module.

These errors are caused by an upstream compiler bug
https://youtrack.jetbrains.com/issue/KT-80039: during incremental
compilation, KGP registers the module's previous output as a
canonicalized path, while the classpath keeps the symlinked path. In
`FabricExample`, `react-native-screens` is a symlink to the repo root
(`link:../` dependency), so the two paths never match, and every
`internal` reference fails. This issue is fixed in Kotlin `2.3.*`, but
RN 0.87 pins Kotlin `2.2.*`, so I work around it locally to be as close
as possible to the template.

## Changes

- after autolinking, resolve RNS directory to its real path.

## Before & after - visual documentation

### Before

```
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:33:71 Cannot access 'class PointerEventsBoxNoneImpl : ReactPointerEventsView': it is internal in file.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:261:32 Cannot access 'fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?): Unit': it is internal in 'com/swmansion/rnscreens/legacy/ScreenWindowTraits'.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:358:75 Cannot access 'var isHiddenBySearchBar: Boolean': it is internal in 'com/swmansion/rnscreens/legacy/ScreenStackHeaderSubview'.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:359:22 Cannot access 'fun setHiddenBySearchBar(hidden: Boolean): Unit': it is internal in 'com/swmansion/rnscreens/legacy/ScreenStackHeaderSubview'.
```

### After

compiles successfully after making a change in the code

## Test plan

Just modify RNS Android sources and try to compile FabricExample.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

(cherry picked from commit cc174f4ed1b5db458825b1d32acabcfd71791db9)
