### PR TITLE
chore: backport #4107

### DIFF
--- a/apps/src/tests/issue-tests/Test4107.tsx
+++ b/apps/src/tests/issue-tests/Test4107.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { Alert, Text, View } from 'react-native';
+import {
+  Screen,
+  ScreenStack,
+  ScreenStackHeaderConfig,
+  type HeaderBarButtonItem,
+} from 'react-native-screens';
+
+const headerRightBarButtonItems: HeaderBarButtonItem[] = [
+  {
+    type: 'menu',
+    title: 'Menu',
+    menu: {
+      title: 'Context menu',
+      items: [
+        {
+          type: 'submenu',
+          title: 'Submenu with subtitle',
+          subtitle: 'Submenu subtitle',
+          icon: { type: 'sfSymbol', name: 'folder' },
+          items: [
+            {
+              type: 'submenu',
+              title: 'Nested submenu with subtitle',
+              subtitle: 'Nested submenu subtitle',
+              items: [
+                {
+                  type: 'action',
+                  title: 'Deeply nested action',
+                  onPress: () => Alert.alert('Deeply nested action pressed'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+export default function App() {
+  return (
+    <ScreenStack style={{ flex: 1 }}>
+      <Screen key="home" activityState={2} isNativeStack>
+        <ScreenStackHeaderConfig
+          title="Menu subtitles"
+          headerRightBarButtonItems={headerRightBarButtonItems}
+        />
+        <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+          <Text>
+            iOS only. Tap the "Menu" button in the header and verify that:
+          </Text>
+          <Text>
+            1. "Submenu with subtitle" shows its subtitle below the label.
+          </Text>
+          <Text>
+            2. Inside the submenu, the nested submenu shows a subtitle as well.
+          </Text>
+        </View>
+      </Screen>
+    </ScreenStack>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -195,6 +195,7 @@ export { default as Test3910 } from './Test3910';
 export { default as Test4027 } from './Test4027';
 export { default as Test4064 } from './Test4064';
 export { default as Test4090 } from './Test4090';
+export { default as Test4107 } from './Test4107';
 export { default as Test4155 } from './Test4155';
 export { default as Test4161 } from './Test4161';
 export { default as Test4220 } from './Test4220';

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -672,6 +672,7 @@ menu?: {
     | {
       label?: string;
       type: 'submenu';
+      subtitle?: string; // Subtitle of the submenu, displayed below its label - https://developer.apple.com/documentation/uikit/uimenuelement/subtitle?language=objc
       icon?: PlatformIconIOSSfSymbol;
       displayInline?: boolean; // Whether to display submenu inline - https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/displayinline
       destructive?: boolean; // Attribute indicating destructive style. Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/destructive

--- a/ios/RNSBarButtonItem.mm
+++ b/ios/RNSBarButtonItem.mm
@@ -188,11 +188,18 @@ static UIMenuOptions RNSMakeUIMenuOptionsFromConfig(NSDictionary *config);
                  image = img;
                }];
 
-  return [UIMenu menuWithTitle:dict[@"title"]
-                         image:image
-                    identifier:nil
-                       options:RNSMakeUIMenuOptionsFromConfig(dict)
-                      children:elements];
+  UIMenu *menu = [UIMenu menuWithTitle:dict[@"title"]
+                                 image:image
+                            identifier:nil
+                               options:RNSMakeUIMenuOptionsFromConfig(dict)
+                              children:elements];
+
+  NSString *subtitle = dict[@"subtitle"];
+  if (subtitle != nil) {
+    menu.subtitle = subtitle;
+  }
+
+  return menu;
 }
 
 + (UIAction *)createActionItemFromConfig:(NSDictionary *)dict

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1307,6 +1307,7 @@ export interface HeaderBarButtonItemMenuAction {
 export interface HeaderBarButtonItemSubmenu {
   type: 'submenu';
   title?: string | undefined;
+  subtitle?: string | undefined;
   icon?: PlatformIconIOS | undefined;
   items: HeaderBarButtonItemWithMenu['menu']['items'];
   displayInline?: boolean | undefined;


### PR DESCRIPTION
## Description

`UIMenuElement.subtitle` is a writable property available since iOS 15.
This adds support for setting a subtitle on `UIMenu` (submenus) in
header bar button items, mirroring the existing subtitle support already
present for `UIAction` items (added in #3396).

**The approach is straightforward:** after creating the `UIMenu` via the
existing initializer, we assign `menu.subtitle` if the `subtitle` key is
present in the config dictionary.

```objc
UIMenu *menu = [UIMenu menuWithTitle:...];
NSString *subtitle = dict[@"subtitle"];
if (subtitle != nil && @available(iOS 15.0, *)) {
  menu.subtitle = subtitle;
}
return menu;
```

**TypeScript:** adds `subtitle?: string` to
`HeaderBarButtonItemSubmenu`.

## Use case

Showing the currently selected filter value below a submenu label — the
same pattern used in Apple's own apps (e.g. Photos).

## Changes

- `ios/RNSBarButtonItem.mm` — assign `subtitle` on `UIMenu` after
creation (iOS 15+)
- `src/types.tsx` — add `subtitle?: string | undefined` to
`HeaderBarButtonItemSubmenu`

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types

---------

Co-authored-by: Tomasz Boroń <tomasz.boron@swmansion.com>
Co-authored-by: Tomasz Boroń <tomaszboron2k@gmail.com>
Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
(cherry picked from commit 378734048c7fa7df610f71687e38fefeefd183c4)
