### PR TITLE
chore: backport #4447

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Animated, Platform, type ViewInstance } from 'react-native';
+import { Animated, Platform, View } from 'react-native';
 
 import TransitionProgressContext from '../TransitionProgressContext';
 import DelayedFreeze from './helpers/DelayedFreeze';
@@ -41,7 +41,7 @@ const AnimatedNativeModalScreen = Animated.createAnimatedComponent(
 
 // Incomplete type, all accessible properties available at:
 // react-native/Libraries/Components/View/ReactNativeViewViewConfig.js
-interface ViewConfig extends ViewInstance {
+interface ViewConfig extends React.ComponentRef<typeof View> {
   viewConfig: {
     validAttributes: {
       style: {
@@ -65,10 +65,10 @@ interface ViewConfig extends ViewInstance {
   };
 }
 
-// Nominal instance type for screen refs. RN's `ViewInstance` is an alias that
+// Nominal instance type for screen refs. `React.ComponentRef<typeof View>`
 // declaration emit resolves down to the non-public `ReactNativeElement` class.
 // An interface stops that resolution at a name this package can emit.
-export interface ScreenInstance extends ViewInstance {}
+export interface ScreenInstance extends React.ComponentRef<typeof View> {}
 
 export const InnerScreen = React.forwardRef<ScreenInstance, ScreenProps>(
   function InnerScreen(props, ref) {

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -13,7 +13,7 @@ import {
   NativeSyntheticEvent,
   Platform,
   StyleSheet,
-  type ViewInstance,
+  View,
   ViewProps,
 } from 'react-native';
 import featureFlags from '../flags';
@@ -30,10 +30,11 @@ import { useEdgeInsetApplication } from './contexts/EdgeInsetApplicationContext'
 export const ScreenStackHeaderSubview: React.ComponentType<ScreenStackHeaderSubviewNativeProps> =
   ScreenStackHeaderSubviewNativeComponent;
 
-// Nominal instance type for header config refs. RN's `ViewInstance` is an alias that
+// Nominal instance type for header config refs. `React.ComponentRef<typeof View>`
 // declaration emit resolves down to the non-public `ReactNativeElement` class.
 // An interface stops that resolution at a name this package can emit.
-export interface ScreenStackHeaderConfigInstance extends ViewInstance {}
+export interface ScreenStackHeaderConfigInstance
+  extends React.ComponentRef<typeof View> {}
 
 export const ScreenStackHeaderConfig = React.forwardRef<
   ScreenStackHeaderConfigInstance,

--- a/src/gesture-handler/fabricUtils.ts
+++ b/src/gesture-handler/fabricUtils.ts
@@ -1,6 +1,7 @@
 'use strict';
 
-import { type ViewInstance } from 'react-native';
+import type { ComponentRef } from 'react';
+import type { View } from 'react-native';
 
 /* eslint-disable */
 
@@ -16,7 +17,9 @@ export type HostInstance = {
   _viewConfig: Record<string, unknown>;
 };
 
-export function getShadowNodeWrapperAndTagFromRef(ref: ViewInstance | null): {
+export function getShadowNodeWrapperAndTagFromRef(
+  ref: ComponentRef<typeof View> | null,
+): {
   shadowNodeWrapper: any;
   tag: number;
 } {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -4,7 +4,6 @@ import {
   NativeSyntheticEvent,
   ViewProps,
   View,
-  type ViewInstance,
   TargetedEvent,
   ColorValue,
   ImageSourcePropType,
@@ -367,7 +366,7 @@ export interface ScreenProps extends ViewProps {
    * @platform ios
    */
   preventNativeDismiss?: boolean | undefined;
-  ref?: React.Ref<ViewInstance> | undefined;
+  ref?: React.Ref<React.ComponentRef<typeof View>> | undefined;
   /**
    * How should the screen replacing another screen animate. Defaults to `pop`.
    * The following values are currently supported:
@@ -1393,7 +1392,10 @@ export type AnimatedScreenTransition = {
   ) => Record<string, unknown>;
 };
 
-export type ScreensRefsHolder = Record<string, React.RefObject<ViewInstance>>;
+export type ScreensRefsHolder = Record<
+  string,
+  React.RefObject<React.ComponentRef<typeof View>>
+>;
 
 export interface GestureProps {
   screensRefs?: React.MutableRefObject<ScreensRefsHolder> | undefined;


### PR DESCRIPTION
## Description

`ViewInstance` became a public type since RN 0.87, but we need to
support versions 0.84+. Following the RN guidance:
https://reactnative.dev/docs/next/strict-typescript-api I am converting
it to `React.ComponentRef<typeof View>` which, under the hood, resolves
to `ReactNativeElement` (which is an alias for `ViewInstance` as well).

## Changes

- updated type definitions in some files

## Before & after - visual documentation

N/A

## Test plan

- `yarn check-types` passes
- `npm pack` passes

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

---------

Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
(cherry picked from commit 3dc5beb101a9f9ef576c8fba337f4a0cb7ee1dc0)
