### PR TITLE
chore: backport #4402

### DIFF
--- a/ios/gamma/stack/host/RNSStackNavigationController.mm
+++ b/ios/gamma/stack/host/RNSStackNavigationController.mm
@@ -1,11 +1,11 @@
 #import "RNSStackNavigationController.h"
+#import <React/RCTAssert.h>
 #import "RNSContainer.h"
 #import "RNSLog.h"
 #import "RNSParentContainerItemRegistry.h"
 #import "RNSStackOperation.h"
 #import "RNSStackScreenController.h"
 #import "RNSViewFrameChangeDelegate.h"
-#import "React/RCTAssert.h"
 
 @implementation RNSStackNavigationController {
   NSMutableArray<RNSPushOperation *> *_Nonnull _pendingPushOperations;

--- a/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/gamma/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -1,5 +1,6 @@
 #import "RNSStackScreenHeaderCoordinator.h"
-#import "RCTAssert.h"
+#import <React/RCTAssert.h>
+#import <React/RCTLog.h>
 #import "RNSDefines.h"
 #import "RNSStackHeaderContentFactory.h"
 #import "RNSStackHeaderItemDataProviding.h"
@@ -10,7 +11,6 @@
 #import "RNSStackNavigationBarCoordinator.h"
 #import "RNSStackNavigationController.h"
 #import "RNSStackScreenController.h"
-#import "React/RCTLog.h"
 
 @implementation RNSStackScreenHeaderCoordinator {
   __weak RNSStackScreenController *_Nullable _screenController;


### PR DESCRIPTION
## Description

The `[ios] react-native-screens` job in
[react-native-community/nightly-tests](https://github.com/react-native-community/nightly-tests)
started failing on 2026-07-24
([run](https://github.com/react-native-community/nightly-tests/actions/runs/30072803584/job/89419595185)):

```
node_modules/react-native-screens/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm:2:9: fatal error: 'RCTAssert.h' file not found
    2 | #import "RCTAssert.h"
```

React Native nightlies ship prebuilt React core (`React-Core-prebuilt`),
where core headers are only reachable as framework-style imports
(`<React/...>`). The bare quote-form `#import "RCTAssert.h"` does not
resolve against it.

The import has been present since #3868 (June), but was latent: the file
lived under `ios/gamma/`, which the podspec excluded unless
`RNS_GAMMA_ENABLED=1` — nightly-tests never compiled it. The
`4.27.0-nightly-20260723` package is the first one containing
#4390/#4391 (gamma removal), so the file now compiles unconditionally
and the broken import fired. The RN side did not change between the
passing and failing runs (both used prebuilt core).

FabricExample CI does not catch this because it builds against pinned
stable RN with source-built `React-Core`, where the bare import happens
to resolve through CocoaPods header search paths.

Closes:
https://github.com/software-mansion/react-native-screens-labs/issues/1690

## Changes

- `RNSStackScreenHeaderCoordinator.mm`: `#import "RCTAssert.h"` →
`#import <React/RCTAssert.h>` (the actual fix) and `#import
"React/RCTLog.h"` → `#import <React/RCTLog.h>`
- `RNSStackNavigationController.mm`: `#import "React/RCTAssert.h"` →
`#import <React/RCTAssert.h>`

The two quote-form `"React/..."` imports likely resolved via clang's
fallback to framework search, but they are the same class of risk and
every other file in the codebase (17 occurrences) already uses the angle
form.

## Test plan

- Audited the whole native tree: no `#import "React/..."` or bare
React-core quote imports remain in `ios/`, `common/`, `cpp/`; the only
remaining `#import "RCT..."` occurrences are the library's own category
headers (`RCTConvert+RNSTabs.h`, `RCTSurfaceTouchHandler+RNSUtility.h`,
etc.).
- The change is import-form-only; the resulting imports are identical to
the ones already used by sibling files in the same target (e.g.
`ios/stack/header/RNSStackHeaderMenuCoordinator.mm`).
- Final confirmation comes from the next
`react-native-community/nightly-tests` run after this lands in a nightly
publish.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings
documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
(cherry picked from commit d372cb8e68efe0e6368e9f94b9ac7d527f3f9f1e)
