### PR TITLE
Revert "chore: backport #4411 (#4460)"

### DIFF
--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -163,13 +163,6 @@
   if ([screenParentViewController isKindOfClass:[UITabBarController class]]) {
     UITabBarController *tabBarVC = (UITabBarController *)screenParentViewController;
     [tabBarVC.tabBar setNeedsLayout];
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-    if (@available(iOS 26, *)) {
-      // Without this the deferred pass can measure the label slot before the
-      // image lands, truncating the label until a tab is tapped.
-      [tabBarVC.tabBar layoutIfNeeded];
-    }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   }
 }
 


### PR DESCRIPTION
This reverts commit 032517ff201a4d003e779c9ed958fb0c8a53badb.

#4411 introduces a regression in our examples.

At the moment, not only are the labels no longer laid out correctly, but there's also a visible flash in the tab bar when navigating to a screen nested inside the stack when the tab bar has appearance defined. Additionally, the title is not always positioned correctly.

Since this is a blocker for the 4.27 release and introduces a new regression, I'm reverting this PR and creating a follow-up task to further investigate the misaligned title and icon issue.

ticket: https://github.com/software-mansion/react-native-screens-labs/issues/1127

https://github.com/user-attachments/assets/886a32ab-291c-43bc-98e1-d42820b512f4