### PR TITLE
fix(iOS): Add missing RNSScrollToTopGuard stubs

### DIFF
--- a/ios/stubs/RNSGammaStubs.h
+++ b/ios/stubs/RNSGammaStubs.h
@@ -39,4 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderItemSpacerComponentView : NSObject
 @end
 
+@interface RNSScrollToTopGuard : NSObject
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/stubs/RNSGammaStubs.mm
+++ b/ios/stubs/RNSGammaStubs.mm
@@ -29,3 +29,6 @@
 
 @implementation RNSStackHeaderItemSpacerComponentView
 @end
+
+@implementation RNSScrollToTopGuard
+@end


### PR DESCRIPTION
While backporting RNSScrollToTopGuard, I have completely forgotten that we have gamma stubs