### PR TITLE
chore: 4.27.0 pick request thread

### DIFF
--- a/ios/stubs/RNSGammaStubs.h
+++ b/ios/stubs/RNSGammaStubs.h
@@ -39,4 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNSStackHeaderItemSpacerComponentView : NSObject
 @end
 
+@interface RNSScrollToTopGuard : NSObject
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/stubs/RNSGammaStubs.mm
+++ b/ios/stubs/RNSGammaStubs.mm
@@ -29,3 +29,6 @@
 
 @implementation RNSStackHeaderItemSpacerComponentView
 @end
+
+@implementation RNSScrollToTopGuard
+@end

--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -163,13 +163,6 @@
   if ([screenParentViewController isKindOfClass:[UITabBarController class]]) {
     UITabBarController *tabBarVC = (UITabBarController *)screenParentViewController;
     [tabBarVC.tabBar setNeedsLayout];
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-    if (@available(iOS 26, *)) {
-      // Without this the deferred pass can measure the label slot before the
-      // image lands, truncating the label until a tab is tapped.
-      [tabBarVC.tabBar layoutIfNeeded];
-    }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   }
 }
 


### PR DESCRIPTION
While testing 4.27.0 (after branch cut), some regressions have been observed; this PR is addressing them

- Reverted because it introduces a new regression: https://github.com/software-mansion/react-native-screens/pull/4477
- Fixed missing gamma stubs after backporting RNSScrollToTopGuard