### PR TITLE
chore(test, Android): add e2e test for Stack v5 prevent native dismiss (single stack)

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -241,62 +241,9 @@ export async function getTopmostMatch(
   return matches[matches.length - 1];
 }
 
-/**
- * Polls until `matcher` resolves and its last match is visible, then returns
- * that match's index.
- *
- * Resolving the topmost match takes two round-trips — count, then index — and
- * Detox retries neither: zero matches throw, `toBeVisible()` fails immediately,
- * and a screen attaching between the calls leaves the index stale. Native header
- * chrome can lag the pushed screen's content, so any of the three is reachable.
- * Their errors are indistinguishable, hence one poll over the whole predicate.
- */
-async function waitForSettledTopmostIndex(
-  matcher: NativeMatcher,
-  timeout: number,
-  interval: number,
-): Promise<number> {
-  const deadline = Date.now() + timeout;
-  let lastError: unknown = '<never attempted>';
-  while (Date.now() <= deadline) {
-    try {
-      const index = (await countMatches(matcher)) - 1;
-      await expect(element(matcher).atIndex(index)).toBeVisible();
-      return index;
-    } catch (error) {
-      lastError = error;
-      await new Promise(resolve => setTimeout(resolve, interval));
-    }
-  }
-  throw new Error(
-    `waitForSettledTopmostIndex timed out after ${timeout}ms waiting for the ` +
-      `topmost match to be visible; last failure: ${lastError}`,
-  );
-}
-
-/**
- * Asserts `matcher`'s last match — the topmost stacked screen's copy — is
- * visible, retrying until it settles. Scoped to the last match because a bare
- * `toBeVisible()` throws "matches N views" once several screens are attached.
- *
- * Only for elements expected to be present — absence burns the full timeout.
- * Use `not.toExist()` instead.
- */
-export async function waitForTopmostVisible(
-  matcher: NativeMatcher,
-  timeout = 3000,
-  interval = 100,
-): Promise<void> {
-  await waitForSettledTopmostIndex(matcher, timeout, interval);
-}
-
-/**
- * Taps `matcher`'s last match — the topmost stacked screen's copy. Only the
- * resolution is retried; the tap fires once, since a retried tap could
- * double-fire when the response fails after it landed — which suites counting
- * per-press side effects (toasts, pops) would read as an extra press.
- */
+/** Taps `matcher`'s last match — the topmost stacked screen's copy. */
 export async function tapTopmost(matcher: NativeMatcher): Promise<void> {
-  const index = await waitForSettledTopmostIndex(matcher, 3000, 100);
-  await element(matcher).atIndex(index).tap();
+  await element(matcher)
+    .atIndex((await countMatches(matcher)) - 1)
+    .tap();
 }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -241,9 +241,62 @@ export async function getTopmostMatch(
   return matches[matches.length - 1];
 }
 
-/** Taps `matcher`'s last match — the topmost stacked screen's copy. */
+/**
+ * Polls until `matcher` resolves and its last match is visible, then returns
+ * that match's index.
+ *
+ * Resolving the topmost match takes two round-trips — count, then index — and
+ * Detox retries neither: zero matches throw, `toBeVisible()` fails immediately,
+ * and a screen attaching between the calls leaves the index stale. Native header
+ * chrome can lag the pushed screen's content, so any of the three is reachable.
+ * Their errors are indistinguishable, hence one poll over the whole predicate.
+ */
+async function waitForSettledTopmostIndex(
+  matcher: NativeMatcher,
+  timeout: number,
+  interval: number,
+): Promise<number> {
+  const deadline = Date.now() + timeout;
+  let lastError: unknown = '<never attempted>';
+  while (Date.now() <= deadline) {
+    try {
+      const index = (await countMatches(matcher)) - 1;
+      await expect(element(matcher).atIndex(index)).toBeVisible();
+      return index;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, interval));
+    }
+  }
+  throw new Error(
+    `waitForSettledTopmostIndex timed out after ${timeout}ms waiting for the ` +
+      `topmost match to be visible; last failure: ${lastError}`,
+  );
+}
+
+/**
+ * Asserts `matcher`'s last match — the topmost stacked screen's copy — is
+ * visible, retrying until it settles. Scoped to the last match because a bare
+ * `toBeVisible()` throws "matches N views" once several screens are attached.
+ *
+ * Only for elements expected to be present — absence burns the full timeout.
+ * Use `not.toExist()` instead.
+ */
+export async function waitForTopmostVisible(
+  matcher: NativeMatcher,
+  timeout = 3000,
+  interval = 100,
+): Promise<void> {
+  await waitForSettledTopmostIndex(matcher, timeout, interval);
+}
+
+/**
+ * Taps `matcher`'s last match — the topmost stacked screen's copy. Only the
+ * resolution is retried; the tap fires once, since a retried tap could
+ * double-fire when the response fails after it landed — which suites counting
+ * per-press side effects (toasts, pops) would read as an extra press.
+ */
 export async function tapTopmost(matcher: NativeMatcher): Promise<void> {
-  await element(matcher)
-    .atIndex((await countMatches(matcher)) - 1)
-    .tap();
+  const index = await waitForSettledTopmostIndex(matcher, 3000, 100);
+  await element(matcher).atIndex(index).tap();
 }

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -219,6 +219,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   });
 
   it('should intercept the native header back button while prevent is enabled', async () => {
+    await expectStillOnB(bKey);
     await tapTopmost(backButtonMatcher);
 
     // Asserts the toast fired, then clears it so the next step starts from an
@@ -228,6 +229,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   });
 
   it('should intercept every back press individually while prevent is enabled', async () => {
+    await expectStillOnB(bKey);
     await tapTopmost(backButtonMatcher);
     await tapTopmost(backButtonMatcher);
     await tapTopmost(backButtonMatcher);
@@ -237,8 +239,22 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await expectStillOnB(bKey);
   });
 
+  it('should pop with the on-screen Pop button even while prevent is enabled', async () => {
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+    await tapTopmostButton(POP);
+
+    jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
+    await expectNoToast();
+    await tapTopmostButton(POP);
+
+    jestExpect(await waitForTopmostRoute('Home')).toBe(homeKey);
+    await expectNoToast();
+  });
+
   it('should flip the label when toggling prevent native dismiss at runtime', async () => {
+    await tapTopmostButton(PUSH_B);
     const currentBKey = await waitForTopmostRoute('B');
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
 
     // Off, then straight back on — the press must see the latest value.
     await tapTopmostButton(TOGGLE);
@@ -252,18 +268,5 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
     await dismissToasts(1);
     await expectStillOnB(currentBKey);
-  });
-
-  it('should pop with the on-screen Pop button even while prevent is enabled', async () => {
-    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-
-    await tapTopmostButton(POP);
-
-    jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
-    await expectNoToast();
-    await tapTopmostButton(POP);
-
-    jestExpect(await waitForTopmostRoute('Home')).toBe(homeKey);
-    await expectNoToast();
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -1,0 +1,284 @@
+import { expect as jestExpect } from '@jest/globals';
+import { device, expect, element, by } from 'detox';
+import { NativeMatcher } from 'detox/detox';
+import {
+  describeIfAndroid,
+  dismissToast,
+  getMatches,
+  getTopmostMatch,
+  selectSingleFeatureTestsScreen,
+  tapTopmost,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
+  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
+} from '../../native-class-names';
+
+/**
+ * Stack v5 `preventNativeDismiss` — single stack.
+ *
+ * Android only: `preventNativeDismiss` is not implemented for stack v5 on iOS
+ * (`ios/stack/` has no handling for it; only the Android side does), so there
+ * is nothing to assert there.
+ *
+ * This suite covers the interception itself — the native header back button is
+ * swallowed, the `onNativeDismissPrevented` toast fires, and the stack stays
+ * put. What it cannot cover is the *Disabled* half (scenario steps 7, 8, 10):
+ * this screen is opened through the example app's own navigation rather than
+ * launched directly via `App.tsx`, and a back press that the screen does not
+ * intercept escapes to the outer navigator instead of popping the gamma
+ * `StackContainer` — see issue #1459. Those steps would navigate out of the
+ * test screen and wreck the suite, so they stay manual (the scenario documents
+ * the direct-launch procedure for them).
+ *
+ * Interception is unaffected by #1459: `StackScreenFragment` registers its
+ * `PreventNativeDismissCallback` on the activity's `OnBackPressedDispatcher`
+ * after the outer navigator registered its own, and the dispatcher invokes
+ * enabled callbacks in reverse registration order — so while the flag is on,
+ * the top v5 screen gets the back press first.
+ */
+
+// The toast renders as `${index + 1}. ${message}`, so its label carries the
+// 1-based position of the toast in the (bottom-anchored) stack.
+const TOAST_MESSAGE = 'Native dismiss prevented';
+const toastLabel = (position: number) => `${position}. ${TOAST_MESSAGE}`;
+
+describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
+  // React Native's core `<Button>` uppercases its `title` on Android
+  // (`title.toUpperCase()`), so buttons are matched by their rendered text.
+  const PUSH_A = 'PUSH A';
+  const PUSH_B = 'PUSH B';
+  const POP = 'POP';
+  const TOGGLE = 'TOGGLE PREVENT NATIVE DISMISS';
+
+  // Scoped to the toolbar the Stack v5 (gamma) header builds — the legacy v4
+  // header used by the example app's own navigation is a `CustomToolbar`, which
+  // extends `Toolbar` but not `MaterialToolbar`, so it is not matched here.
+  const backButtonMatcher = by
+    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
+    .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
+
+  /**
+   * Covered screens stay attached on Android, so a matcher can resolve to one
+   * element per stacked screen and has to be normalized to the topmost match.
+   */
+  async function readTopmostText(testID: string): Promise<string> {
+    const top = await getTopmostMatch(by.id(testID));
+    return (top.text ?? top.label ?? '').trim();
+  }
+
+  const readRouteKey = () => readTopmostText('stack-route-key');
+  const readPreventInfo = () => readTopmostText('prevent-native-dismiss-info');
+
+  type RouteName = 'Home' | 'A' | 'B';
+
+  /**
+   * Matches the rendered `stack-route-key` label of any screen whose route is
+   * `routeName`. Keys are minted as `r-<routeName>-<id>` with a monotonically
+   * increasing id (`generateRouteKeyForRouteName` in the stack reducer), so the
+   * pattern pins the route while staying agnostic about which instance of it is
+   * on top.
+   */
+  const routeKeyPattern = (routeName: RouteName) =>
+    new RegExp(`^Key: r-${routeName}-\\d+$`);
+
+  /** Taps a Push/Pop/Toggle button on the topmost stacked screen. */
+  async function tapTopmostButton(title: string): Promise<void> {
+    await tapTopmost(by.text(title));
+  }
+
+  /**
+   * Asserts `matcher` resolves on the topmost stacked screen. Every stacked
+   * screen renders the same button labels, so a bare `toBeVisible()` throws
+   * "matches N views" once more than one is attached — the check is scoped to
+   * the last match, as `tapTopmost` does for taps.
+   *
+   * Only for elements expected to be present: `getMatches` throws when nothing
+   * matches at all. Use `not.toExist()` for absence.
+   */
+  async function expectTopmostVisible(matcher: NativeMatcher): Promise<void> {
+    const count = (await getMatches(matcher)).length;
+    await expect(element(matcher).atIndex(count - 1)).toBeVisible();
+  }
+
+  /** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
+  async function expectTopmostButtons(titles: string[]): Promise<void> {
+    for (const title of titles) {
+      await expectTopmostVisible(by.text(title));
+    }
+  }
+
+  /**
+   * Waits until the topmost stacked screen is `routeName`, and returns its route
+   * key. Matching the key by regex rather than the exact `Name: X` label means a
+   * single read identifies both the route and *which* instance of it is on top,
+   * so callers can assert continuity (same key) or a push (new key) without a
+   * second, separately-racing read.
+   *
+   * The pattern is applied to a polled `getTopmostMatch` read rather than handed
+   * to Detox as `by.text(routeKeyPattern(...))`. Covered screens stay attached on
+   * Android and Detox's visibility matcher only intersects a view with its
+   * *parents* (`IsDisplayingAtLeastDetoxMatcher`) — it has no notion of occlusion
+   * by a sibling — so `waitFor(...).toBeVisible()` on a screen sitting underneath
+   * the top one passes immediately and would not gate a pop at all. The iOS half
+   * of `test-stack-simple-nav` can hand the regex to Detox because iOS detaches
+   * covered screens; here the regex has to be evaluated against the topmost
+   * match.
+   */
+  async function waitForTopmostRoute(
+    routeName: RouteName,
+    timeout = 3000,
+    interval = 100,
+  ): Promise<string> {
+    const pattern = routeKeyPattern(routeName);
+    const deadline = Date.now() + timeout;
+    let lastSeen = '<never read>';
+    while (Date.now() <= deadline) {
+      lastSeen = await readRouteKey();
+      if (pattern.test(lastSeen)) {
+        return lastSeen;
+      }
+      await new Promise(resolve => setTimeout(resolve, interval));
+    }
+    throw new Error(
+      `waitForTopmostRoute timed out waiting for topmost route to be ` +
+        `"${routeName}"; topmost key was "${lastSeen}"`,
+    );
+  }
+
+  /**
+   * Asserts the app is still on B with its original key — i.e. the back press
+   * was swallowed rather than popping the stack.
+   */
+  async function expectStillOnB(expectedKey: string): Promise<void> {
+    jestExpect(await waitForTopmostRoute('B')).toBe(expectedKey);
+  }
+
+  /**
+   * Dismisses `count` toasts newest-first. The toast label carries the 1-based
+   * position in the list, and removal is by id, so clearing from the highest
+   * position down keeps the remaining labels stable.
+   */
+  async function dismissToasts(count: number): Promise<void> {
+    for (let position = count; position >= 1; position--) {
+      await dismissToast(toastLabel(position));
+    }
+  }
+
+  /**
+   * Asserts that no `onNativeDismissPrevented` toast is on screen. Every step
+   * that dismisses its toasts leaves the list empty, so checking position 1 is
+   * enough — a toast that fired unexpectedly always lands there.
+   */
+  async function expectNoToast(): Promise<void> {
+    await expect(element(by.label(toastLabel(1)))).not.toExist();
+  }
+
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Stackv5',
+      'test-stack-prevent-native-dismiss-single-stack',
+    );
+  });
+
+  // Captured as the suite progresses, so later steps can assert that a
+  // preserved screen keeps its key and every push produces a strictly new one.
+  let homeKey = '';
+  let aKey = '';
+  let bKey = '';
+
+  it('should show Home as the root screen with no back or Pop button', async () => {
+    homeKey = await waitForTopmostRoute('Home');
+    await expectTopmostButtons([PUSH_A, PUSH_B]);
+    await expect(element(by.text(POP))).not.toExist();
+    await expect(element(backButtonMatcher)).not.toExist();
+  });
+
+  it('should push A with prevent native dismiss disabled', async () => {
+    await tapTopmostButton(PUSH_A);
+
+    aKey = await waitForTopmostRoute('A');
+    jestExpect(aKey).not.toBe(homeKey);
+    jestExpect(await readPreventInfo()).toBe(
+      'Prevent native dismiss: Disabled',
+    );
+    await expectTopmostVisible(backButtonMatcher);
+    await expectTopmostButtons([PUSH_A, PUSH_B, POP]);
+  });
+
+  it('should push B with prevent native dismiss enabled', async () => {
+    await tapTopmostButton(PUSH_B);
+
+    bKey = await waitForTopmostRoute('B');
+    jestExpect(bKey).not.toBe(aKey);
+    jestExpect(bKey).not.toBe(homeKey);
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+    await expectTopmostVisible(backButtonMatcher);
+    await expectTopmostButtons([PUSH_A, PUSH_B, POP, TOGGLE]);
+  });
+
+  it('should intercept the native header back button while prevent is enabled', async () => {
+    await tapTopmost(backButtonMatcher);
+
+    // Asserts the toast fired, then clears it so the next step starts from an
+    // empty toast list.
+    await dismissToasts(1);
+    await expectStillOnB(bKey);
+  });
+
+  it('should intercept every back press individually while prevent is enabled', async () => {
+    await tapTopmost(backButtonMatcher);
+    await tapTopmost(backButtonMatcher);
+    await tapTopmost(backButtonMatcher);
+
+    // A new toast per press — three presses, three toasts, and B never popped.
+    await dismissToasts(3);
+    await expectStillOnB(bKey);
+  });
+
+  it('should flip the label when toggling prevent native dismiss at runtime', async () => {
+    await tapTopmostButton(TOGGLE);
+    jestExpect(await readPreventInfo()).toBe(
+      'Prevent native dismiss: Disabled',
+    );
+
+    // Toggled straight back on — with the flag off, a native back press would
+    // escape to the example app's navigation instead of popping this stack
+    // (#1459) and would leave the test screen. Scenario steps 7, 8 and 10 cover
+    // the Disabled half manually, via the direct launch.
+    await tapTopmostButton(TOGGLE);
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+  });
+
+  it('should pop with the on-screen Pop button even while prevent is enabled', async () => {
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+
+    await tapTopmostButton(POP);
+
+    jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
+    await expectNoToast();
+  });
+
+  it('should apply the most recent toggle to a back press that follows it', async () => {
+    await tapTopmostButton(PUSH_B);
+    const currentBKey = await waitForTopmostRoute('B');
+
+    // Off, then straight back on — the press must see the latest value.
+    await tapTopmostButton(TOGGLE);
+    jestExpect(await readPreventInfo()).toBe(
+      'Prevent native dismiss: Disabled',
+    );
+    await tapTopmostButton(TOGGLE);
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+
+    await tapTopmost(backButtonMatcher);
+
+    await dismissToasts(1);
+    await expectStillOnB(currentBKey);
+
+    // Unwind to A so the suite does not leave a prevent-enabled screen on top.
+    await tapTopmostButton(POP);
+    await waitForTopmostRoute('A');
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -1,12 +1,13 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
+import { NativeMatcher } from 'detox/detox';
 import {
   describeIfAndroid,
   dismissToast,
+  getMatches,
   getTopmostMatch,
   selectSingleFeatureTestsScreen,
   tapTopmost,
-  waitForTopmostVisible,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
@@ -14,28 +15,68 @@ import {
 } from '../../native-class-names';
 
 /**
- * Stack v5 `preventNativeDismiss` — single stack. Android only; `ios/stack/`
- * has no handling for the prop, so there is nothing to assert there.
+ * Stack v5 `preventNativeDismiss` — single stack. See the scenario for what is
+ * automated vs. manual, and for the direct-`App.tsx` launch Android needs.
  *
- * Covers the interception itself — the header back button is swallowed, the
- * `onNativeDismissPrevented` toast fires, the stack stays put — plus the
- * runtime toggle and the JS-driven Pop. Two groups stay manual: the
- * gesture-back steps (5, 8), since Detox cannot drive the system edge swipe,
- * and the *Disabled* chevron steps (7, 10), which need the direct `App.tsx`
- * launch the scenario documents — reached through the example app's own
- * navigation, an unintercepted back press navigates out to the system menu
- * instead of popping the gamma `StackContainer`
- * (software-mansion/react-native-screens-labs#1459).
- *
- * Interception is unaffected by #1459: `StackScreenFragment` registers its
- * `PreventNativeDismissCallback` after the outer navigator's, and the
- * `OnBackPressedDispatcher` invokes enabled callbacks in reverse order.
+ * Interception survives software-mansion/react-native-screens-labs#1459:
+ * `StackScreenFragment` registers its `PreventNativeDismissCallback` after the
+ * outer navigator's, and `OnBackPressedDispatcher` runs enabled callbacks in
+ * reverse order — so the chevron is swallowed here even though an unintercepted
+ * back press would navigate out of the example app's own navigation.
  */
 
 // The toast renders as `${index + 1}. ${message}`, so its label carries the
 // 1-based position of the toast in the (bottom-anchored) stack.
 const TOAST_MESSAGE = 'Native dismiss prevented';
 const toastLabel = (position: number) => `${position}. ${TOAST_MESSAGE}`;
+
+/**
+ * Only "nothing matched yet" / "not visible yet" are worth retrying. Anything
+ * else — a crashed app, a lost session, a bad matcher — must surface as itself,
+ * not as a settle timeout.
+ */
+function isTransientMatchError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('No views in hierarchy found matching') ||
+    message.includes('not visible')
+  );
+}
+
+/**
+ * Asserts `matcher`'s last match — the topmost stacked screen's copy — is
+ * visible. Indexed because a bare `toBeVisible()` throws "matches N views" once
+ * several screens are attached; polled because native header chrome can lag the
+ * screen's content and `getMatches` throws on the transient 0-match state.
+ *
+ * Only for elements expected to be present — absence burns the full timeout;
+ * use `not.toExist()` instead.
+ */
+async function expectTopmostVisible(
+  matcher: NativeMatcher,
+  timeout = 3000,
+  interval = 100,
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastError: unknown = '<never attempted>';
+  while (Date.now() <= deadline) {
+    try {
+      const count = (await getMatches(matcher)).length;
+      await expect(element(matcher).atIndex(count - 1)).toBeVisible();
+      return;
+    } catch (error) {
+      if (!isTransientMatchError(error)) {
+        throw error;
+      }
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, interval));
+    }
+  }
+  throw new Error(
+    `expectTopmostVisible timed out after ${timeout}ms waiting for the ` +
+      `topmost match to be visible; last failure: ${lastError}`,
+  );
+}
 
 describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   // React Native's core `<Button>` uppercases its `title` on Android
@@ -45,9 +86,8 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   const POP = 'POP';
   const TOGGLE = 'TOGGLE PREVENT NATIVE DISMISS';
 
-  // Scoped to the toolbar the Stack v5 (gamma) header builds — the example
-  // app's own v4 header is a `CustomToolbar`, which extends `Toolbar` but not
-  // `MaterialToolbar`, so it is not matched here.
+  // Scoped to the Stack v5 header's toolbar: the example app's own v4 header is
+  // a `CustomToolbar`, which extends `Toolbar` but not `MaterialToolbar`.
   const backButtonMatcher = by
     .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
     .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
@@ -67,8 +107,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   /**
    * Matches the `stack-route-key` label of any screen on `routeName`. Keys are
    * minted as `r-<routeName>-<id>` with an increasing id
-   * (`generateRouteKeyForRouteName`), so this pins the route while staying
-   * agnostic about which instance of it is on top.
+   * (`generateRouteKeyForRouteName`), so this pins the route, not the instance.
    */
   const routeKeyPattern = (routeName: RouteName) =>
     new RegExp(`^Key: r-${routeName}-\\d+$`);
@@ -81,21 +120,20 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   /** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
   async function expectTopmostButtons(titles: string[]): Promise<void> {
     for (const title of titles) {
-      await waitForTopmostVisible(by.text(title));
+      await expectTopmostVisible(by.text(title));
     }
   }
 
   /**
-   * Waits until the topmost stacked screen is `routeName` and returns its route
-   * key. Matching the key rather than the `Name: X` label lets one read identify
-   * both the route and *which* instance is on top, so callers can assert
-   * continuity (same key) or a push (new key) without a second racing read.
+   * Waits until the topmost screen is `routeName` and returns its route key.
+   * Reading the key rather than the `Name: X` label identifies the route *and*
+   * which instance is on top, so one read settles continuity (same key) or a
+   * push (new key).
    *
-   * The pattern is polled against `getTopmostMatch` rather than handed to Detox
-   * as `by.text(...)`: covered screens stay attached on Android and Detox's
-   * visibility matcher only intersects a view with its *parents*, never with an
-   * occluding sibling — so `toBeVisible()` on a screen underneath the top one
-   * passes immediately and would not gate a pop.
+   * Polled against `getTopmostMatch` rather than `by.text(...)`: covered screens
+   * stay attached, and Detox intersects a view only with its parents, never with
+   * an occluding sibling — so `toBeVisible()` on a buried screen passes at once
+   * and would not gate a pop.
    */
   async function waitForTopmostRoute(
     routeName: RouteName,
@@ -124,7 +162,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   }
 
   /**
-   * Dismisses `count` toasts newest-first. Labels carry the 1-based position,
+   * Dismisses `count` toasts newest-first — labels carry the 1-based position,
    * so clearing from the highest down keeps the remaining ones stable.
    */
   async function dismissToasts(count: number): Promise<void> {
@@ -135,7 +173,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
   /**
    * Asserts no `onNativeDismissPrevented` toast is on screen. Every step clears
-   * its toasts, so position 1 is enough — an unexpected toast always lands there.
+   * its own toasts, so an unexpected one always lands at position 1.
    */
   async function expectNoToast(): Promise<void> {
     await expect(element(by.label(toastLabel(1)))).not.toExist();
@@ -170,7 +208,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(await readPreventInfo()).toBe(
       'Prevent native dismiss: Disabled',
     );
-    await waitForTopmostVisible(backButtonMatcher);
+    await expectTopmostVisible(backButtonMatcher);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP]);
   });
 
@@ -181,7 +219,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(bKey).not.toBe(aKey);
     jestExpect(bKey).not.toBe(homeKey);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-    await waitForTopmostVisible(backButtonMatcher);
+    await expectTopmostVisible(backButtonMatcher);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP, TOGGLE]);
   });
 
@@ -189,8 +227,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await expectStillOnB(bKey);
     await tapTopmost(backButtonMatcher);
 
-    // Asserts the toast fired, then clears it so the next step starts from an
-    // empty toast list.
+    // Asserts the toast fired, then clears it for the next step.
     await dismissToasts(1);
     await expectStillOnB(bKey);
   });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -1,13 +1,12 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
-import { NativeMatcher } from 'detox/detox';
 import {
   describeIfAndroid,
   dismissToast,
-  getMatches,
   getTopmostMatch,
   selectSingleFeatureTestsScreen,
   tapTopmost,
+  waitForTopmostVisible,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
@@ -15,27 +14,22 @@ import {
 } from '../../native-class-names';
 
 /**
- * Stack v5 `preventNativeDismiss` — single stack.
+ * Stack v5 `preventNativeDismiss` — single stack. Android only; `ios/stack/`
+ * has no handling for the prop, so there is nothing to assert there.
  *
- * Android only: `preventNativeDismiss` is not implemented for stack v5 on iOS
- * (`ios/stack/` has no handling for it; only the Android side does), so there
- * is nothing to assert there.
- *
- * This suite covers the interception itself — the native header back button is
- * swallowed, the `onNativeDismissPrevented` toast fires, and the stack stays
- * put. What it cannot cover is the *Disabled* half (scenario steps 7, 8, 10):
- * this screen is opened through the example app's own navigation rather than
- * launched directly via `App.tsx`, and a back press that the screen does not
- * intercept escapes to the outer navigator instead of popping the gamma
- * `StackContainer` — see issue #1459. Those steps would navigate out of the
- * test screen and wreck the suite, so they stay manual (the scenario documents
- * the direct-launch procedure for them).
+ * Covers the interception itself — the header back button is swallowed, the
+ * `onNativeDismissPrevented` toast fires, the stack stays put — plus the
+ * runtime toggle and the JS-driven Pop. Two groups stay manual: the
+ * gesture-back steps (5, 8), since Detox cannot drive the system edge swipe,
+ * and the *Disabled* chevron steps (7, 10), which need the direct `App.tsx`
+ * launch the scenario documents — reached through the example app's own
+ * navigation, an unintercepted back press navigates out to the system menu
+ * instead of popping the gamma `StackContainer`
+ * (software-mansion/react-native-screens-labs#1459).
  *
  * Interception is unaffected by #1459: `StackScreenFragment` registers its
- * `PreventNativeDismissCallback` on the activity's `OnBackPressedDispatcher`
- * after the outer navigator registered its own, and the dispatcher invokes
- * enabled callbacks in reverse registration order — so while the flag is on,
- * the top v5 screen gets the back press first.
+ * `PreventNativeDismissCallback` after the outer navigator's, and the
+ * `OnBackPressedDispatcher` invokes enabled callbacks in reverse order.
  */
 
 // The toast renders as `${index + 1}. ${message}`, so its label carries the
@@ -51,17 +45,15 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   const POP = 'POP';
   const TOGGLE = 'TOGGLE PREVENT NATIVE DISMISS';
 
-  // Scoped to the toolbar the Stack v5 (gamma) header builds — the legacy v4
-  // header used by the example app's own navigation is a `CustomToolbar`, which
-  // extends `Toolbar` but not `MaterialToolbar`, so it is not matched here.
+  // Scoped to the toolbar the Stack v5 (gamma) header builds — the example
+  // app's own v4 header is a `CustomToolbar`, which extends `Toolbar` but not
+  // `MaterialToolbar`, so it is not matched here.
   const backButtonMatcher = by
     .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
     .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
 
-  /**
-   * Covered screens stay attached on Android, so a matcher can resolve to one
-   * element per stacked screen and has to be normalized to the topmost match.
-   */
+  // Covered screens stay attached on Android, so a matcher resolves to one
+  // element per stacked screen and has to be normalized to the topmost match.
   async function readTopmostText(testID: string): Promise<string> {
     const top = await getTopmostMatch(by.id(testID));
     return (top.text ?? top.label ?? '').trim();
@@ -73,11 +65,10 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   type RouteName = 'Home' | 'A' | 'B';
 
   /**
-   * Matches the rendered `stack-route-key` label of any screen whose route is
-   * `routeName`. Keys are minted as `r-<routeName>-<id>` with a monotonically
-   * increasing id (`generateRouteKeyForRouteName` in the stack reducer), so the
-   * pattern pins the route while staying agnostic about which instance of it is
-   * on top.
+   * Matches the `stack-route-key` label of any screen on `routeName`. Keys are
+   * minted as `r-<routeName>-<id>` with an increasing id
+   * (`generateRouteKeyForRouteName`), so this pins the route while staying
+   * agnostic about which instance of it is on top.
    */
   const routeKeyPattern = (routeName: RouteName) =>
     new RegExp(`^Key: r-${routeName}-\\d+$`);
@@ -87,43 +78,24 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await tapTopmost(by.text(title));
   }
 
-  /**
-   * Asserts `matcher` resolves on the topmost stacked screen. Every stacked
-   * screen renders the same button labels, so a bare `toBeVisible()` throws
-   * "matches N views" once more than one is attached — the check is scoped to
-   * the last match, as `tapTopmost` does for taps.
-   *
-   * Only for elements expected to be present: `getMatches` throws when nothing
-   * matches at all. Use `not.toExist()` for absence.
-   */
-  async function expectTopmostVisible(matcher: NativeMatcher): Promise<void> {
-    const count = (await getMatches(matcher)).length;
-    await expect(element(matcher).atIndex(count - 1)).toBeVisible();
-  }
-
   /** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
   async function expectTopmostButtons(titles: string[]): Promise<void> {
     for (const title of titles) {
-      await expectTopmostVisible(by.text(title));
+      await waitForTopmostVisible(by.text(title));
     }
   }
 
   /**
-   * Waits until the topmost stacked screen is `routeName`, and returns its route
-   * key. Matching the key by regex rather than the exact `Name: X` label means a
-   * single read identifies both the route and *which* instance of it is on top,
-   * so callers can assert continuity (same key) or a push (new key) without a
-   * second, separately-racing read.
+   * Waits until the topmost stacked screen is `routeName` and returns its route
+   * key. Matching the key rather than the `Name: X` label lets one read identify
+   * both the route and *which* instance is on top, so callers can assert
+   * continuity (same key) or a push (new key) without a second racing read.
    *
-   * The pattern is applied to a polled `getTopmostMatch` read rather than handed
-   * to Detox as `by.text(routeKeyPattern(...))`. Covered screens stay attached on
-   * Android and Detox's visibility matcher only intersects a view with its
-   * *parents* (`IsDisplayingAtLeastDetoxMatcher`) — it has no notion of occlusion
-   * by a sibling — so `waitFor(...).toBeVisible()` on a screen sitting underneath
-   * the top one passes immediately and would not gate a pop at all. The iOS half
-   * of `test-stack-simple-nav` can hand the regex to Detox because iOS detaches
-   * covered screens; here the regex has to be evaluated against the topmost
-   * match.
+   * The pattern is polled against `getTopmostMatch` rather than handed to Detox
+   * as `by.text(...)`: covered screens stay attached on Android and Detox's
+   * visibility matcher only intersects a view with its *parents*, never with an
+   * occluding sibling — so `toBeVisible()` on a screen underneath the top one
+   * passes immediately and would not gate a pop.
    */
   async function waitForTopmostRoute(
     routeName: RouteName,
@@ -146,18 +118,14 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     );
   }
 
-  /**
-   * Asserts the app is still on B with its original key — i.e. the back press
-   * was swallowed rather than popping the stack.
-   */
+  /** Asserts B is still on top with its original key — the press was swallowed. */
   async function expectStillOnB(expectedKey: string): Promise<void> {
     jestExpect(await waitForTopmostRoute('B')).toBe(expectedKey);
   }
 
   /**
-   * Dismisses `count` toasts newest-first. The toast label carries the 1-based
-   * position in the list, and removal is by id, so clearing from the highest
-   * position down keeps the remaining labels stable.
+   * Dismisses `count` toasts newest-first. Labels carry the 1-based position,
+   * so clearing from the highest down keeps the remaining ones stable.
    */
   async function dismissToasts(count: number): Promise<void> {
     for (let position = count; position >= 1; position--) {
@@ -166,9 +134,8 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   }
 
   /**
-   * Asserts that no `onNativeDismissPrevented` toast is on screen. Every step
-   * that dismisses its toasts leaves the list empty, so checking position 1 is
-   * enough — a toast that fired unexpectedly always lands there.
+   * Asserts no `onNativeDismissPrevented` toast is on screen. Every step clears
+   * its toasts, so position 1 is enough — an unexpected toast always lands there.
    */
   async function expectNoToast(): Promise<void> {
     await expect(element(by.label(toastLabel(1)))).not.toExist();
@@ -203,7 +170,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(await readPreventInfo()).toBe(
       'Prevent native dismiss: Disabled',
     );
-    await expectTopmostVisible(backButtonMatcher);
+    await waitForTopmostVisible(backButtonMatcher);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP]);
   });
 
@@ -214,7 +181,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(bKey).not.toBe(aKey);
     jestExpect(bKey).not.toBe(homeKey);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-    await expectTopmostVisible(backButtonMatcher);
+    await waitForTopmostVisible(backButtonMatcher);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP, TOGGLE]);
   });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -238,30 +238,6 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   });
 
   it('should flip the label when toggling prevent native dismiss at runtime', async () => {
-    await tapTopmostButton(TOGGLE);
-    jestExpect(await readPreventInfo()).toBe(
-      'Prevent native dismiss: Disabled',
-    );
-
-    // Toggled straight back on — with the flag off, a native back press would
-    // escape to the example app's navigation instead of popping this stack
-    // (#1459) and would leave the test screen. Scenario steps 7, 8 and 10 cover
-    // the Disabled half manually, via the direct launch.
-    await tapTopmostButton(TOGGLE);
-    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-  });
-
-  it('should pop with the on-screen Pop button even while prevent is enabled', async () => {
-    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-
-    await tapTopmostButton(POP);
-
-    jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
-    await expectNoToast();
-  });
-
-  it('should apply the most recent toggle to a back press that follows it', async () => {
-    await tapTopmostButton(PUSH_B);
     const currentBKey = await waitForTopmostRoute('B');
 
     // Off, then straight back on — the press must see the latest value.
@@ -276,9 +252,18 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
     await dismissToasts(1);
     await expectStillOnB(currentBKey);
+  });
 
-    // Unwind to A so the suite does not leave a prevent-enabled screen on top.
+  it('should pop with the on-screen Pop button even while prevent is enabled', async () => {
+    jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
+
     await tapTopmostButton(POP);
-    await waitForTopmostRoute('A');
+
+    jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
+    await expectNoToast();
+    await tapTopmostButton(POP);
+
+    jestExpect(await waitForTopmostRoute('Home')).toBe(homeKey);
+    await expectNoToast();
   });
 });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -82,8 +82,7 @@ function AScreen() {
 
 function BScreen() {
   return (
-    <CenteredLayoutView
-      style={{ backgroundColor: Colors.GreenLight100 }}>
+    <CenteredLayoutView style={{ backgroundColor: Colors.GreenLight100 }}>
       <StackRouteInformation routeName="B" />
       <PreventNativeDismissInfo />
       <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -82,7 +82,9 @@ function AScreen() {
 
 function BScreen() {
   return (
-    <CenteredLayoutView testID="b-screen" style={{ backgroundColor: Colors.GreenLight100 }}>
+    <CenteredLayoutView
+      testID="b-screen"
+      style={{ backgroundColor: Colors.GreenLight100 }}>
       <StackRouteInformation routeName="B" />
       <PreventNativeDismissInfo />
       <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -83,7 +83,6 @@ function AScreen() {
 function BScreen() {
   return (
     <CenteredLayoutView
-      testID="b-screen"
       style={{ backgroundColor: Colors.GreenLight100 }}>
       <StackRouteInformation routeName="B" />
       <PreventNativeDismissInfo />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -82,7 +82,7 @@ function AScreen() {
 
 function BScreen() {
   return (
-    <CenteredLayoutView style={{ backgroundColor: Colors.GreenLight100 }}>
+    <CenteredLayoutView testID="b-screen" style={{ backgroundColor: Colors.GreenLight100 }}>
       <StackRouteInformation routeName="B" />
       <PreventNativeDismissInfo />
       <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />
@@ -111,7 +111,9 @@ function PreventNativeDismissInfo() {
 
   return (
     <View>
-      <Text style={styles.routeInformation}>
+      <Text
+        style={styles.routeInformation}
+        testID="prevent-native-dismiss-info">
         Prevent native dismiss:{' '}
         {navContext.routeOptions.preventNativeDismiss ? 'Enabled' : 'Disabled'}
       </Text>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario-description.ts
@@ -6,6 +6,6 @@ export const scenarioDescription: ScenarioDescription = {
   details:
     'Test prevent native dismiss behavior in simple single-stack scenario',
   platforms: ['android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -20,13 +20,14 @@ directly to work around issue #1459.
 
 Incomplete. Covered:
 
-- Steps 1-4, 6, 9, 12, 13: the header back chevron while `preventNativeDismiss`
-  is **Enabled**, and the **Pop** actions.
+- Pop actions triggered by the Pop button.
+- Header back chevron/button behavior when `preventNativeDismiss` is Enabled.
 
-**Manual only (not automated):**
+Manual only (not automated):
 
-- Steps 5, 8: the system gesture-back (edge swipe).
-- Steps 7, 8, 10, 11: the header chevron while **Disabled**.
+- Pop actions triggered by the system back gesture (edge swipe).
+- Pop actions triggered by the header back chevron when `preventNativeDismiss`
+is Disabled.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -18,26 +18,21 @@ directly to work around issue #1459.
 
 ## E2E test
 
-Incomplete: Covered on **Android** (steps 1-4, 6, 9, 11-13): pushing A/B, the per-route
-flag labels, the native header back-button chevron being intercepted while
-Enabled (toast shown, no pop, `Key` unchanged) including repeated presses,
-the runtime toggle, the edge case in step 13, and the on-screen **Pop**
-bypassing the flag.
-
-**Not** covered, and still manual:
-
-- **Steps 7, 8, 10 (the Disabled half).** The e2e opens this screen through
-  the example app's own navigation rather than the direct `App.tsx` launch, so
-  a back press the screen does not intercept escapes to the outer navigator
-  instead of popping the stack (issue
-  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459))
-  and leaves the test screen entirely. Interception itself is unaffected,
-  which is why the Enabled half automates fine.
-- **The system gesture-back (edge swipe) on Android, steps 5 and 8.** Detox
-  cannot perform the OS-level edge gesture.
-
-The suite is Android-only - `preventNativeDismiss` is not implemented for
+Incomplete. Android only - `preventNativeDismiss` is not implemented for
 stack v5 on iOS, so there is nothing to assert there.
+
+- Steps 1-4, 6, 9, 11-13: the Enabled half - push navigation, the per-route
+  flag labels, the header chevron being intercepted, the runtime toggle, and
+  the on-screen **Pop** bypassing the flag.
+
+**Manual only (not automated):**
+
+- Steps 5, 8: the system gesture-back (edge swipe). Detox cannot perform the
+  OS-level edge gesture.
+- Steps 7, 8, 10: the header chevron while **Disabled**. The e2e reaches this
+  screen through the example app's own navigation, where an unintercepted back
+  press escapes to the outer navigator instead of popping the stack (issue
+  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)).
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -18,10 +18,26 @@ directly to work around issue #1459.
 
 ## E2E test
 
-TBD: Automation is plausible - the system back button, the native header
-back-button chevron, and the on-screen buttons are all Detox-drivable on
-Android - but no e2e test has been implemented yet. The system gesture-back
-(edge swipe) step may need platform-specific handling.
+Incomplete: Covered on **Android** (steps 1-4, 6, 9, 11-13): pushing A/B, the per-route
+flag labels, the native header back-button chevron being intercepted while
+Enabled (toast shown, no pop, `Key` unchanged) including repeated presses,
+the runtime toggle, the edge case in step 13, and the on-screen **Pop**
+bypassing the flag.
+
+**Not** covered, and still manual:
+
+- **Steps 7, 8, 10 (the Disabled half).** The e2e opens this screen through
+  the example app's own navigation rather than the direct `App.tsx` launch, so
+  a back press the screen does not intercept escapes to the outer navigator
+  instead of popping the stack (issue
+  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459))
+  and leaves the test screen entirely. Interception itself is unaffected,
+  which is why the Enabled half automates fine.
+- **The system gesture-back (edge swipe) on Android, steps 5 and 8.** Detox
+  cannot perform the OS-level edge gesture.
+
+The suite is Android-only - `preventNativeDismiss` is not implemented for
+stack v5 on iOS, so there is nothing to assert there.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -18,21 +18,15 @@ directly to work around issue #1459.
 
 ## E2E test
 
-Incomplete. Android only - `preventNativeDismiss` is not implemented for
-stack v5 on iOS, so there is nothing to assert there.
+Incomplete. Covered:
 
-- Steps 1-4, 6, 9, 11-13: the Enabled half - push navigation, the per-route
-  flag labels, the header chevron being intercepted, the runtime toggle, and
-  the on-screen **Pop** bypassing the flag.
+- Steps 1-4, 6, 9, 12, 13: the header back chevron while `preventNativeDismiss`
+  is **Enabled**, and the **Pop** actions.
 
 **Manual only (not automated):**
 
-- Steps 5, 8: the system gesture-back (edge swipe). Detox cannot perform the
-  OS-level edge gesture.
-- Steps 7, 8, 10: the header chevron while **Disabled**. The e2e reaches this
-  screen through the example app's own navigation, where an unintercepted back
-  press escapes to the outer navigator instead of popping the stack (issue
-  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)).
+- Steps 5, 8: the system gesture-back (edge swipe).
+- Steps 7, 8, 10, 11: the header chevron while **Disabled**.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -22,12 +22,14 @@ Incomplete. Covered:
 
 - Pop actions triggered by the Pop button.
 - Header back chevron/button behavior when `preventNativeDismiss` is Enabled.
+- Runtime toggling of the flag on **B**: the label flips in both directions,
+and a chevron press made immediately after a toggle honors the latest value.
 
 Manual only (not automated):
 
 - Pop actions triggered by the system back gesture (edge swipe).
 - Pop actions triggered by the header back chevron when `preventNativeDismiss`
-is Disabled.
+is Disabled - including the pop expected after toggling **B** to Disabled.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1717 

Adds Detox e2e coverage for the `preventNativeDismiss` route option on the v5
`StackContainer`, for the existing `test-stack-prevent-native-dismiss-single-stack`
test screen.

The suite is **Android only** - `preventNativeDismiss` is not implemented for
stack v5 on iOS (`ios/stack/` has no handling for it), so there is nothing to
assert there.

Coverage is **incomplete by design**; the scenario now documents exactly what is
automated and what stays manual:

- **Automated (steps 1-4, 6, 9, 12, 13)** - push navigation and the per-route
  flag labels, the native header back chevron being intercepted while
  `preventNativeDismiss` is Enabled (toast shown, no pop, `Key` unchanged)
  including repeated presses, the runtime toggle, and the on-screen **Pop**
  bypassing the flag.
- **Manual - steps 5, 8** - the system gesture-back (edge swipe). Detox cannot
  perform the OS-level edge gesture.
- **Manual - steps 7, 8, 10, 11** - the header chevron while Disabled. The e2e
  reaches this screen through the example app's own navigation rather than a
  direct `App.tsx` launch, so a back press the screen does not intercept escapes
  to the outer navigator instead of popping the gamma stack (issue
  [#1459](https://github.com/software-mansion/react-native-screens-labs/issues/1459)),
  which would navigate out of the test screen entirely. Interception itself is
  unaffected by `#1459`, which is why the Enabled half automates fine.

## Changes

- Added `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts`.
- Added `testID` (`prevent-native-dismiss-info`) to the test screen
  so the flag label and screen B can be matched.
- Updated `scenario.md` - replaced the `TBD` E2E section with the covered /
  manual-only breakdown above.
- Updated `scenario-description.ts` - `e2eCoverage: 'tbd'` -> `'incomplete'`.

No library code is touched - this is test-only.