### PR TITLE
feat: add iOS support for inputType prop on search bar

### DIFF
--- a/apps/src/tests/issue-tests/Test4484.tsx
+++ b/apps/src/tests/issue-tests/Test4484.tsx
@@ -1,0 +1,107 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useLayoutEffect, useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { SearchBarProps } from 'react-native-screens';
+
+type StackParamList = {
+  Home: undefined;
+  SearchBar: undefined;
+};
+
+type InputTypeMode = 'default' | SearchBarProps['inputType'];
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+const inputTypeModes: InputTypeMode[] = ['default', 'text', 'phone', 'number', 'email'];
+
+function getInputType(mode: InputTypeMode): SearchBarProps['inputType'] {
+  return mode === 'default' ? undefined : mode;
+}
+
+function Home({ navigation }: NativeStackScreenProps<StackParamList, 'Home'>) {
+  return (
+    <View style={styles.centeredContainer}>
+      <Text style={styles.title}>Test4484</Text>
+      <Button
+        title="Open search bar test"
+        onPress={() => navigation.navigate('SearchBar')}
+      />
+    </View>
+  );
+}
+
+function SearchBarScreen({
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'SearchBar'>) {
+  const [inputTypeMode, setInputTypeMode] = useState<InputTypeMode>('default');
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerSearchBarOptions: {
+        hideWhenScrolling: false,
+        inputType: getInputType(inputTypeMode),
+      },
+    });
+  }, [inputTypeMode, navigation]);
+
+  const currentModeIndex = inputTypeModes.indexOf(inputTypeMode);
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.contentContainer}>
+      <Text style={styles.title}>Search bar options</Text>
+      <Text>Input type: {inputTypeMode}</Text>
+
+      <Button
+        title="Cycle input type"
+        onPress={() =>
+          setInputTypeMode(
+            inputTypeModes[(currentModeIndex + 1) % inputTypeModes.length],
+          )
+        }
+      />
+      <Button
+        title="Restore default values"
+        onPress={() => setInputTypeMode('default')}
+      />
+    </ScrollView>
+  );
+}
+
+export default function App(): React.JSX.Element {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen
+          name="SearchBar"
+          component={SearchBarScreen}
+          options={{
+            headerLargeTitle: true,
+            title: 'Search bar',
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  centeredContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  contentContainer: {
+    padding: 16,
+    gap: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as Test4484 } from './Test4484';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
+++ b/guides/GUIDE_FOR_LIBRARY_AUTHORS.md
@@ -529,7 +529,7 @@ To render a search bar use `ScreenStackHeaderSearchBarView` with `<SearchBar>` c
 - `disableBackButtonOverride` - Default behavior is to prevent screen from going back when search bar is open (`disableBackButtonOverride: false`). If you don't want this to happen set `disableBackButtonOverride` to `true`. (Android only)
 - `hideNavigationBar` - Boolean indicating whether to hide the navigation bar during searching. Defaults to native behavior. (iOS only)
 - `hideWhenScrolling` - Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`. (iOS only)
-- `inputType` - Specifies type of input and keyboard for search bar. Can be one of `'text'`, `'phone'`, `'number'`, `'email'`. Defaults to `'text'`. (Android only)
+- `inputType` - Specifies type of input and keyboard for search bar. Can be one of `'text'`, `'phone'`, `'number'`, `'email'`. Defaults to `'text'`.
 - `obscureBackground` - Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to native behavior. (iOS only)
 - `onBlur` - A callback that gets called when search bar has lost focus.
 - `onChangeText` - A callback that gets called when the text changes. It receives the current text value of the search bar.

--- a/ios/legacy/RNSSearchBar.mm
+++ b/ios/legacy/RNSSearchBar.mm
@@ -17,6 +17,7 @@ namespace react = facebook::react;
 @implementation RNSSearchBar {
   UISearchController *_controller;
   UIColor *_textColor;
+  NSString *_inputType;
 
   // We use those booleans to log a warning if user attempts to restore
   // default behavior after setting explicit value for the prop.
@@ -149,6 +150,34 @@ namespace react = facebook::react;
   [_controller.searchBar setAutocapitalizationType:autoCapitalize];
 }
 
+- (void)setInputType:(NSString *)inputType
+{
+  _inputType = [inputType copy];
+  [self applyInputType];
+}
+
+- (void)applyInputType
+{
+#if !TARGET_OS_TV && !TARGET_OS_VISION
+  UITextField *searchTextField = _controller.searchBar.searchTextField;
+
+  if ([_inputType isEqualToString:@"phone"]) {
+    searchTextField.keyboardType = UIKeyboardTypePhonePad;
+  } else if ([_inputType isEqualToString:@"number"]) {
+    searchTextField.keyboardType = UIKeyboardTypeNumberPad;
+  } else if ([_inputType isEqualToString:@"email"]) {
+    searchTextField.keyboardType = UIKeyboardTypeEmailAddress;
+  } else if (_inputType == nil || [_inputType isEqualToString:@"text"]) {
+    searchTextField.keyboardType = UIKeyboardTypeDefault;
+  } else {
+    RCTLogWarn(@"[RNScreens] unsupported inputType: %@", _inputType);
+    searchTextField.keyboardType = UIKeyboardTypeDefault;
+  }
+
+  [searchTextField reloadInputViews];
+#endif
+}
+
 - (void)setPlaceholder:(NSString *)placeholder
 {
   [_controller.searchBar setPlaceholder:placeholder];
@@ -256,6 +285,8 @@ namespace react = facebook::react;
   if (_textColor != nil) {
     [_controller.searchBar.searchTextField setTextColor:_textColor];
   }
+
+  [self applyInputType];
 #endif
 
   [self showCancelButton];
@@ -362,6 +393,10 @@ namespace react = facebook::react;
     [self setAutoCapitalize:[RNSConvert UITextAutocapitalizationTypeFromCppEquivalent:newScreenProps.autoCapitalize]];
   }
 #endif
+
+  if (oldScreenProps.inputType != newScreenProps.inputType) {
+    [self setInputType:RCTNSStringFromStringNilIfEmpty(newScreenProps.inputType)];
+  }
 
   if (oldScreenProps.tintColor != newScreenProps.tintColor) {
     [self setTintColor:RCTUIColorFromSharedColor(newScreenProps.tintColor)];

--- a/src/fabric/legacy/SearchBarNativeComponent.ts
+++ b/src/fabric/legacy/SearchBarNativeComponent.ts
@@ -60,12 +60,12 @@ export interface NativeProps extends ViewProps {
   barTintColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
   textColor?: ColorValue | undefined;
+  // TODO: consider creating enum here
+  inputType?: string | undefined;
 
   // Android only
   autoFocus?: CT.WithDefault<boolean, false>;
   disableBackButtonOverride?: boolean | undefined;
-  // TODO: consider creating enum here
-  inputType?: string | undefined;
   onClose?: CT.DirectEventHandler<SearchBarEvent> | null | undefined;
   onOpen?: CT.DirectEventHandler<SearchBarEvent> | null | undefined;
   hintTextColor?: ColorValue | undefined;

--- a/src/legacy/types.ts
+++ b/src/legacy/types.ts
@@ -981,8 +981,6 @@ export interface SearchBarProps {
   hideWhenScrolling?: boolean | undefined;
   /**
    * Sets type of the input. Defaults to `text`.
-   *
-   * @platform android
    */
   inputType?: 'text' | 'phone' | 'number' | 'email' | undefined;
   /**


### PR DESCRIPTION
## Description

The `inputType` prop on the header search bar is currently **Android-only**: the codegen spec declares it (`RNSSearchBarProps.inputType`) and the Android manager implements it (`SearchBarManager.kt`), but `RNSSearchBar.mm` never reads it — setting `inputType` on iOS is a silent no-op.

This PR wires it up on iOS by mapping the prop to `UIKeyboardType` on the search text field, mirroring the Android semantics:

| `inputType` | Android | iOS (this PR) |
| --- | --- | --- |
| `text` (default) | `TYPE_CLASS_TEXT` | `UIKeyboardTypeDefault` |
| `phone` | `TYPE_CLASS_PHONE` | `UIKeyboardTypePhonePad` |
| `number` | `TYPE_CLASS_NUMBER` | `UIKeyboardTypeNumberPad` |
| `email` | `TYPE_TEXT_VARIATION_EMAIL_ADDRESS` | `UIKeyboardTypeEmailAddress` |
| unknown | throws | warns + falls back to default |

The keyboard type is also re-applied in `searchBarTextDidBeginEditing`, mirroring the existing `_textColor` re-apply, since UIKit may reset the field state when editing begins.

## Changes

- `ios/legacy/RNSSearchBar.mm`: add `setInputType:` / `applyInputType:` and wire `inputType` in `updateProps:`
- `src/fabric/legacy/SearchBarNativeComponent.ts`: move `inputType` out of the Android-only section
- `src/legacy/types.ts`: drop the `@platform android` annotation from `inputType`
- `guides/GUIDE_FOR_LIBRARY_AUTHORS.md`: drop "(Android only)" from `inputType`
- `apps/src/tests/issue-tests/Test4484.tsx`: test screen that cycles the search bar `inputType` (also registered in `apps/src/tests/issue-tests/index.ts`)

## Test plan

- `git diff --check`
- Add `Test4484` to `apps/App`, build `FabricExample` on iOS, open the search bar and cycle the input type — verify the keyboard switches to the phone pad / number pad / email keyboard accordingly, on both iOS 26 (toolbar-integrated search) and older iOS versions (header search bar).

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes