### PR TITLE
fix(Android, Tabs): let touches through the strip a hidden tab bar leaves behind

### DIFF
--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-hidden.e2e.ts
@@ -44,6 +44,38 @@ describe('Tab Bar Hidden', () => {
     }
   });
 
+  // Android-only. The bar is hidden there by setting its visibility to `GONE`,
+  // which leaves the bounds it was last laid out with in place. React Native
+  // hit-tests the native view tree without looking at visibility, so those
+  // retained bounds used to swallow every touch aimed at the strip the bar had
+  // occupied. See #4132. iOS does not hide the tab bar this way.
+  it('content in the strip freed by the hidden tab bar should receive touches', async () => {
+    if (device.getPlatform() !== 'android') {
+      return;
+    }
+
+    await expect(element(by.id('tab-bar-hidden-switch'))).toHaveLabel(
+      'tabBarHidden: true',
+    );
+    await expect(element(by.id('tab-bar-hidden-press-count'))).toHaveText(
+      'Bottom presses: 0',
+    );
+
+    // The Pressable is 120dp tall and anchored to the bottom of the screen, so
+    // it covers both the strip the tab bar freed and the system navigation bar
+    // below it. 40dp below its top edge is inside the strip - the bar is at
+    // least 80dp tall plus the bottom system inset - and clear of the system
+    // navigation bar, on which taps never reach the app.
+    await element(by.id('tab-bar-hidden-bottom-pressable')).tap({
+      x: 100,
+      y: 40,
+    });
+
+    await expect(element(by.id('tab-bar-hidden-press-count'))).toHaveText(
+      'Bottom presses: 1',
+    );
+  });
+
   it('tab bar should reappear after changing tabBarHidden value to false', async () => {
     await expect(element(by.id('tab-bar-hidden-switch'))).toHaveLabel(
       'tabBarHidden: true',

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/CustomBottomNavigationView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/CustomBottomNavigationView.kt
@@ -2,14 +2,34 @@ package com.swmansion.rnscreens.tabs.container
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.core.view.isVisible
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactPointerEventsView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 @SuppressLint("ViewConstructor") // Should not be restored & should only be constructed by us.
 class CustomBottomNavigationView(
     context: Context,
     val container: TabsContainer,
-) : BottomNavigationView(context) {
+) : BottomNavigationView(context),
+    ReactPointerEventsView {
     private var actionOrigin: TabsActionOrigin? = null
+
+    /**
+     * The tab bar is hidden by setting its visibility to `GONE`. A `GONE` view is skipped by its
+     * parent's layout pass, so it keeps the bounds it was last laid out with, and Android's own
+     * touch dispatch ignores it (`ViewGroup.canViewReceivePointerEvents` requires `VISIBLE`).
+     *
+     * React Native does not go through Android's dispatch to pick a touch target - it runs its own
+     * hit-test over the native view tree in `TouchTargetHelper`, which only checks bounds. The
+     * retained bounds of the hidden bar therefore keep capturing every touch aimed at the content
+     * laid out underneath it. Declaring [PointerEvents.NONE] while hidden is how a native view opts
+     * out of that hit-test, which brings it back in line with Android's dispatch.
+     *
+     * See https://github.com/software-mansion/react-native-screens/issues/4132.
+     */
+    override val pointerEvents: PointerEvents
+        get() = if (isVisible) PointerEvents.AUTO else PointerEvents.NONE
 
     internal fun setSelectedItemIdWithActionOrigin(
         itemId: Int,

--- a/apps/src/tests/issue-tests/Test4132.tsx
+++ b/apps/src/tests/issue-tests/Test4132.tsx
@@ -1,0 +1,330 @@
+import React, { useLayoutEffect } from 'react';
+import { View, Text, Pressable, StyleSheet, ScrollView } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  type NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
+
+// Repro for https://github.com/software-mansion/react-native-screens/issues/4132
+//
+// Adapted from the maintainer's snippet in the issue thread. Differences:
+//   * `Alert.alert` replaced with `console.log`, so taps driven by raw
+//     `adb shell input tap` can be read back from logcat without a dialog
+//     blocking the next probe,
+//   * the single bottom-anchored `Pressable` is replaced with a ladder of 12
+//     stacked 30dp-tall `Pressable`s, so a tap sweep maps where the dead band
+//     starts instead of only proving that "somewhere down there is dead",
+//   * the ladder occupies the left half only and the `ScrollView` runs to the
+//     bottom of the screen, so both reported paths - a static bottom-anchored
+//     `Pressable` and a row scrolled into the strip - can be exercised on one
+//     screen without either occluding the other,
+//   * a third route mounts the tab host with the bar already hidden, covering
+//     the initial-mount case next to the runtime-toggle one.
+
+const PROBE_COUNT = 12;
+const PROBE_HEIGHT = 30;
+const PROBE_STACK_HEIGHT = PROBE_COUNT * PROBE_HEIGHT;
+
+const RootStack = createNativeStackNavigator();
+const HomeStack = createNativeStackNavigator();
+const Tab = createNativeBottomTabNavigator();
+
+function log(message: string) {
+  console.log(`[RNS4132] ${message}`);
+}
+
+type ScreenProps = {
+  navigation: NativeStackNavigationProp<Record<string, undefined>>;
+};
+
+type DeadZoneReproProps = ScreenProps & {
+  label: string;
+  badgeColor: string;
+};
+
+function DeadZoneRepro({ label, badgeColor, navigation }: DeadZoneReproProps) {
+  return (
+    <View style={styles.reproContainer}>
+      <Text
+        style={[styles.badge, { backgroundColor: badgeColor }]}
+        testID="repro-badge">
+        {label}
+      </Text>
+
+      <Pressable
+        onPress={() => log('TOP tapped')}
+        style={[styles.btn, styles.topBtn]}
+        testID="top-pressable">
+        <Text style={styles.btnText}>TOP Pressable</Text>
+      </Pressable>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        testID="repro-scrollview">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <Pressable
+            key={i}
+            onPress={() => log(`Row ${i} tapped`)}
+            style={styles.rowBtn}
+            testID={`repro-row-${i}`}>
+            <Text style={styles.btnText}>Scrollable Row {i}</Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+
+      <View style={styles.probeStack} testID="probe-stack">
+        {Array.from({ length: PROBE_COUNT }).map((_, i) => (
+          <Pressable
+            key={i}
+            onPress={() => log(`PROBE ${i} tapped`)}
+            style={[
+              styles.probeRow,
+              { backgroundColor: i % 2 === 0 ? '#c62828' : '#ad1457' },
+            ]}
+            testID={`probe-${i}`}>
+            <Text style={styles.probeText}>probe {i}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Pressable
+        onPress={() => navigation.goBack()}
+        style={styles.backBtn}
+        testID="repro-back">
+        <Text style={styles.backBtnText}>← Go Back</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function ControlScreen({ navigation }: ScreenProps) {
+  return (
+    <DeadZoneRepro
+      label="CONTROL (root route, outside tabs)"
+      badgeColor="green"
+      navigation={navigation}
+    />
+  );
+}
+
+function DetailScreen({ navigation }: ScreenProps) {
+  useLayoutEffect(() => {
+    navigation.getParent()?.setOptions({
+      tabBarHidden: true,
+      tabBarStyle: { display: 'none' },
+    });
+    return () => {
+      navigation.getParent()?.setOptions({
+        tabBarHidden: false,
+        tabBarStyle: { display: 'flex' },
+      });
+    };
+  }, [navigation]);
+
+  return (
+    <DeadZoneRepro
+      label="DETAIL (inside tabs, tab bar hidden=true)"
+      badgeColor="orange"
+      navigation={navigation}
+    />
+  );
+}
+
+function HomeIndexScreen({ navigation }: ScreenProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Home tab (NativeTabs visible)</Text>
+
+      <Pressable
+        style={styles.link}
+        onPress={() => navigation.navigate('Detail')}
+        testID="open-detail">
+        <Text style={styles.linkText}>Open /detail (pushes inside tabs)</Text>
+        <Text style={styles.linkSubText}>Bug reproduces here</Text>
+      </Pressable>
+
+      <Pressable
+        style={styles.link}
+        onPress={() => navigation.getParent()?.navigate('Control')}
+        testID="open-control">
+        <Text style={styles.linkText}>Open /control (pushes outside tabs)</Text>
+        <Text style={styles.linkSubText}>Works perfectly here</Text>
+      </Pressable>
+
+      <Pressable
+        style={styles.link}
+        onPress={() => navigation.getParent()?.navigate('StaticHidden')}
+        testID="open-static-hidden">
+        <Text style={styles.linkText}>Open /static-hidden</Text>
+        <Text style={styles.linkSubText}>
+          Tab host mounted with the bar already hidden
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * Initial-mount variant: this tab host is mounted with the bar already hidden,
+ * rather than hiding it from a `useLayoutEffect` after the screen mounts.
+ */
+function StaticHiddenScreen() {
+  return (
+    <Tab.Navigator screenOptions={{ tabBarStyle: { display: 'none' } }}>
+      <Tab.Screen
+        name="StaticHiddenTab"
+        component={StaticHiddenTabContent}
+        options={{ title: 'Home' }}
+      />
+      <Tab.Screen
+        name="StaticHiddenOtherTab"
+        component={OtherTabScreen}
+        options={{ title: 'Other' }}
+      />
+    </Tab.Navigator>
+  );
+}
+
+function StaticHiddenTabContent({ navigation }: ScreenProps) {
+  return (
+    <DeadZoneRepro
+      label="STATIC (tab host mounted with the bar already hidden)"
+      badgeColor="purple"
+      navigation={navigation}
+    />
+  );
+}
+
+/**
+ * Control for the opposite direction: same content, but reached with the tab bar
+ * still visible. Everything the bar covers must stay untappable, and the bar
+ * itself must keep taking its own touches.
+ */
+function OtherTabScreen({ navigation }: ScreenProps) {
+  return (
+    <DeadZoneRepro
+      label="OTHER TAB (tab bar visible)"
+      badgeColor="#00695c"
+      navigation={navigation}
+    />
+  );
+}
+
+function HomeStackNavigator() {
+  return (
+    <HomeStack.Navigator screenOptions={{ headerShown: false }}>
+      <HomeStack.Screen name="HomeIndex" component={HomeIndexScreen} />
+      <HomeStack.Screen name="Detail" component={DetailScreen} />
+    </HomeStack.Navigator>
+  );
+}
+
+function TabsNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen
+        name="HomeTab"
+        component={HomeStackNavigator}
+        options={{ title: 'Home' }}
+      />
+      <Tab.Screen
+        name="OtherTab"
+        component={OtherTabScreen}
+        options={{ title: 'Other' }}
+      />
+    </Tab.Navigator>
+  );
+}
+
+export default function Test4132() {
+  return (
+    <NavigationContainer>
+      <RootStack.Navigator screenOptions={{ headerShown: false }}>
+        <RootStack.Screen name="Tabs" component={TabsNavigator} />
+        <RootStack.Screen name="Control" component={ControlScreen} />
+        <RootStack.Screen name="StaticHidden" component={StaticHiddenScreen} />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    justifyContent: 'center',
+    backgroundColor: '#f0f0f0',
+  },
+  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 20 },
+  link: {
+    padding: 16,
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+    marginVertical: 8,
+  },
+  linkText: { color: 'white', fontWeight: 'bold', fontSize: 16 },
+  linkSubText: { color: 'rgba(255,255,255,0.7)', fontSize: 12, marginTop: 4 },
+
+  reproContainer: { flex: 1, paddingTop: 80, backgroundColor: '#fff' },
+  badge: {
+    padding: 8,
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 16,
+    marginHorizontal: 16,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+
+  btn: {
+    padding: 16,
+    borderRadius: 8,
+    marginHorizontal: 16,
+    alignItems: 'center',
+  },
+  btnText: { color: 'white', fontWeight: 'bold' },
+  topBtn: { backgroundColor: '#333', marginBottom: 16 },
+
+  scroll: {
+    flex: 1,
+    backgroundColor: '#fafafa',
+    marginHorizontal: 16,
+    borderRadius: 8,
+  },
+  scrollContent: { padding: 16, paddingBottom: 40 },
+  rowBtn: {
+    padding: 16,
+    backgroundColor: '#888',
+    marginVertical: 4,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+
+  probeStack: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    width: '50%',
+    height: PROBE_STACK_HEIGHT,
+  },
+  probeRow: {
+    height: PROBE_HEIGHT,
+    justifyContent: 'center',
+    paddingLeft: 12,
+  },
+  probeText: { color: 'white', fontSize: 12, fontWeight: 'bold' },
+
+  backBtn: {
+    position: 'absolute',
+    top: 40,
+    left: 16,
+    padding: 8,
+    backgroundColor: '#ddd',
+    borderRadius: 8,
+  },
+  backBtnText: { fontWeight: 'bold' },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -196,6 +196,7 @@ export { default as Test4027 } from './Test4027';
 export { default as Test4064 } from './Test4064';
 export { default as Test4090 } from './Test4090';
 export { default as Test4107 } from './Test4107';
+export { default as Test4132 } from './Test4132';
 export { default as Test4155 } from './Test4155';
 export { default as Test4161 } from './Test4161';
 export { default as Test4220 } from './Test4220';

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
@@ -1,6 +1,6 @@
 import { SettingsSwitch } from '@apps/shared/SettingsSwitch';
 import React from 'react';
-import { ScrollView, Text } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
@@ -9,25 +9,66 @@ import {
   useTabsHostConfig,
   DEFAULT_TAB_ROUTE_OPTIONS,
 } from '@apps/shared/containers/tabs';
+import { Colors } from '@apps/shared/styling';
 
 function ConfigScreen() {
   const { hostConfig, updateHostConfig } = useTabsHostConfig();
+  const [bottomPressCount, setBottomPressCount] = React.useState(0);
 
   return (
-    <ScrollView style={{ padding: 40 }} testID="tab-bar-hidden-scrollview">
-      <Text style={{ textAlign: 'center' }}>
-        Change flag value by clicking on button.
-      </Text>
-      <SettingsSwitch
-        style={{ marginTop: 20, marginBottom: 15 }}
-        label="tabBarHidden"
-        value={hostConfig.tabBarHidden ?? false}
-        onValueChange={value => updateHostConfig({ tabBarHidden: value })}
-        testID="tab-bar-hidden-switch"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScrollView style={styles.scrollView} testID="tab-bar-hidden-scrollview">
+        <Text style={styles.hint}>
+          Change flag value by clicking on button.
+        </Text>
+        <SettingsSwitch
+          style={styles.settingsSwitch}
+          label="tabBarHidden"
+          value={hostConfig.tabBarHidden ?? false}
+          onValueChange={value => updateHostConfig({ tabBarHidden: value })}
+          testID="tab-bar-hidden-switch"
+        />
+        <Text style={styles.hint} testID="tab-bar-hidden-press-count">
+          {`Bottom presses: ${bottomPressCount}`}
+        </Text>
+      </ScrollView>
+      {/* Anchored to the bottom of the screen so that it sits in the strip the
+          tab bar frees up when hidden. See issue #4132. */}
+      <Pressable
+        style={styles.bottomPressable}
+        testID="tab-bar-hidden-bottom-pressable"
+        onPress={() => setBottomPressCount(count => count + 1)}>
+        <Text>Bottom Pressable</Text>
+      </Pressable>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    padding: 40,
+  },
+  hint: {
+    textAlign: 'center',
+  },
+  settingsSwitch: {
+    marginTop: 20,
+    marginBottom: 15,
+  },
+  bottomPressable: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 120,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.GreenLight60,
+  },
+});
 
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
@@ -38,6 +79,10 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
       tabBarItemTestID: 'tab-bar-item-1-id',
       tabBarItemAccessibilityLabel: 'First Tab Item',
       title: 'Tab1',
+      // Opt out of the SafeAreaView wrapper Android tab screens get by default,
+      // so that the content runs edge to edge and the bottom Pressable really
+      // sits in the strip the tab bar occupies, whatever the inset resolves to.
+      safeAreaConfiguration: { edges: { bottom: false } },
     },
   },
 ];

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
@@ -2,13 +2,15 @@
 
 ## Details
 
-**Description:** This test scenario focuses on the visibility management of the tab bar. It validates the tabBarHidden property, ensuring that the UI responds dynamically to state changes without layout shifts or persistence errors.
+**Description:** This test scenario focuses on the visibility management of the tab bar. It validates the tabBarHidden property, ensuring that the UI responds dynamically to state changes without layout shifts or persistence errors. It also covers the strip the tab bar frees up when hidden, which must accept touches on Android (#4132).
 
 **OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
 
 ## E2E test
 
 Full: Covers all manual scenario steps.
+
+Step 3 is Android-only: on iOS the tab bar is not hidden by collapsing a native view, so the defect it guards against does not apply there.
 
 ## Prerequisites
 
@@ -20,11 +22,16 @@ Full: Covers all manual scenario steps.
 1. Launch the app and navigate to the screen Tab Bar Hidden.
 
 - [ ] Screen with one Tab in tab bar should be displayed.
+- [ ] A green "Bottom Pressable" should be anchored to the bottom of the screen, behind the tab bar.
 
 2. Toggle `tabBarHidden` to `true`.
 
 - [ ] Tab bar should disappear immediately.
 
-3. Toggle back to `false`.
+3. Tap the green "Bottom Pressable", just above the system navigation bar.
+
+- [ ] `Bottom presses` should increment. (Android: before #4132 was fixed, the hidden tab bar kept its last bounds and swallowed this touch.)
+
+4. Toggle back to `false`.
 
 - [ ] Tab bar should reappear.


### PR DESCRIPTION
## Description

With `tabBarHidden` on, a strip across the bottom of an Android tab screen renders content but does not accept touches. The strip is exactly as tall as the tab bar was.

`TabsAppearanceApplicator` hides the bar with `bottomNavigationView.isVisible = !isTabBarHidden`, i.e. `View.GONE`. Android skips `GONE` children when laying out, so the bar keeps the bounds it was last laid out with, and Android's own touch dispatch never reaches it (`ViewGroup.canViewReceivePointerEvents` requires `VISIBLE`).

React Native does not pick its touch target through Android's dispatch. `JSTouchDispatcher` calls `TouchTargetHelper.findTargetTagAndCoordinatesForTouch`, which runs a separate hit-test over the native view tree. That walk checks bounds, transforms and `pointerEvents`, and **never looks at visibility** — `findTouchTargetView` iterates `viewGroup.getChildAt(i)` from the top of the z-order down and only asks `isTouchPointInView`. `TabsContainer` is a `FrameLayout` whose last child is the bar, so the hidden bar is the first candidate tested for every touch, and its retained bounds capture everything aimed at the content laid out underneath. The tag that comes back is resolved from the Material item views inside the bar, which are not part of the shadow tree, so the touch is dispatched to a tag no component owns and is silently dropped.

Declaring `PointerEvents.NONE` while the bar is not `VISIBLE` is how a native view opts out of that hit-test, and brings React Native's walk back in line with Android's dispatch. The repo already uses this mechanism for the same purpose in `DimmingViewPointerEventsImpl`.

Closes #4132.

### Measurements

Emulator: `AOSP_API_35` AVD, Android 15 (API 35), 1080x2400 @ 420dpi (2.625x), 3-button navigation (system navigation bar at `y=[2274,2400]`). React Native 0.87.0-rc.3, Fabric, `FabricExample` debug build at `edaabbb61`. It does reproduce on an emulator, contrary to the issue body — no physical device was needed.

`adb shell dumpsys activity top` on the failing screen, using the snippet from the first comment (`Test4132` in this PR), trimmed to the spine:

```
com.facebook.react.runtime.ReactSurfaceView{c3c7c27 V.E...... 0,0-1080,2400 #1}
  com.th3rdwave.safeareacontext.SafeAreaProvider{beeed4 V.E...... 0,0-1080,2400 #3a}
    com.swmansion.rnscreens.legacy.ScreenStack{27024ff V.E...... 0,0-1080,2400 #38}
      com.swmansion.rnscreens.legacy.Screen{881ed16 V.E...... 0,0-1080,2400 #36}
        com.swmansion.rnscreens.legacy.ScreenContentWrapper{7ff9372 V.E...... 0,0-1080,2400 #32}
          com.swmansion.rnscreens.tabs.host.TabsHost{2eab3c3 V.E...... 0,0-1080,2400 #2e}
            com.swmansion.rnscreens.tabs.container.TabsContainer{c862440 V.E...... 0,0-1080,2400 #3}
              android.widget.FrameLayout{afadc3d V.E...... 0,0-1080,2400 #5}
                com.swmansion.rnscreens.tabs.screen.TabsScreen{da91f79 V.E...... 0,0-1080,2400 #2a}
                  com.swmansion.rnscreens.legacy.ScreenStack{c2ccf3a V.E...... 0,0-1080,2400 #22}
                    com.swmansion.rnscreens.legacy.Screen{6e06d55 V.E...... 0,0-1080,2400 #18a}
                      com.swmansion.rnscreens.legacy.ScreenContentWrapper{c9446c V.E...... 0,0-1080,2400 #186}
                        com.facebook.react.views.scroll.ReactScrollView{4ca44b1 VFED.V... 42,522-1038,2400 #11a}
              com.swmansion.rnscreens.tabs.container.CustomBottomNavigationView{69a2b73 G.E...... 0,2063-1080,2400}
                com.google.android.material.bottomnavigation.BottomNavigationMenuView{6d3ba30 V.E...... 98,0-982,211}
```

Three things fall out of that dump:

- The bar is `G.E......` — correctly `GONE`.
- It has kept `0,2063-1080,2400`, a 337px (128dp) rect: an 80dp Material bar plus the 48dp bottom system inset.
- Every ancestor from `ReactSurfaceView` down to `ScreenContentWrapper` is `0,0-1080,2400`. Nothing above the content has stale or short bounds.

Probing the boundary one pixel at a time with raw `adb shell input tap` (a ladder of 30dp `Pressable`s, each logging its own index): the last coordinate that fires is **y=2062**, the first dead one is **y=2063**. The dead band starts at the hidden bar's `top`, to the pixel.

> [!NOTE]
> This is where the evidence parts company with the initial investigation in the thread. The bar *is* the eater, so the instinct in [#4132 (comment)](https://github.com/software-mansion/react-native-screens/issues/4132#issuecomment-4648294329) was pointing at the right view — but it is not "still intercepting touch events" in the Android sense. A `GONE` view cannot; `dispatchTouchEvent` skips it. It is React Native's own hit-test that still finds it.
>
> Credit to @Linden-786, whose [`dumpsys`](https://github.com/software-mansion/react-native-screens/issues/4132#issuecomment-5018024937) established both of the load-bearing facts here — that the bar is properly `GONE`, and that the dead band's top edge sits at exactly `screen_height - bottomNavigationView.height`. Their reading of *why* differs from what this reproduction shows: the strip is the bar's own retained rect rather than an inset applied to a `SafeAreaView` ancestor. In the harness above there is no `com.swmansion.rnscreens.safearea.SafeAreaView` in the tree at all — `@react-navigation/bottom-tabs/unstable` wraps in `react-native-safe-area-context`'s provider, not the RNS one — and the strip is dead anyway. Both readings predict the same boundary, because that inset *is* the bar's height; only the dump distinguishes them. `disableAutomaticContentInsets` fixing it also fits: dropping the wrapper moves the content out of the strip rather than making the strip live.

## Changes

- `CustomBottomNavigationView` implements `ReactPointerEventsView` and reports `PointerEvents.NONE` whenever it is not `VISIBLE`, so React Native's hit-test skips it and its subtree.
- `apps/src/tests/issue-tests/Test4132.tsx` — the issue's repro, adapted from the maintainer's snippet: it swaps the alerts for `console.log` so taps injected with `adb shell input tap` can be read back from logcat, replaces the single bottom button with a ladder of 30dp `Pressable`s so a tap sweep locates the boundary, and adds a route that mounts the tab host with the bar already hidden.
- `test-tabs-tab-bar-hidden` grows a bottom-anchored `Pressable` with a press counter, and opts out of the default Android `SafeAreaView` wrapper so its content runs edge to edge and that `Pressable` really sits in the strip the bar occupies.
- Its e2e spec gains an Android-only case asserting the counter increments on a tap inside that strip.

## Before & after - visual documentation

No visual change — the bar hides and shows exactly as before. What changes is where touches land. Raw `adb shell input tap` at fixed coordinates on the repro screen, reading `onPress` back from logcat:

| tap | y | before | after |
| --- | --- | --- | --- |
| static bottom-anchored `Pressable` | 1967 | fires | fires |
| static bottom-anchored `Pressable` | 2045 | fires | fires |
| static bottom-anchored `Pressable` | **2124** | **dead** | **fires** |
| static bottom-anchored `Pressable` | **2203** | **dead** | **fires** |
| row scrolled into the strip | 1890 | fires | fires |
| row scrolled into the strip | 2046 | fires | fires |
| row scrolled into the strip | **2202** | **dead** | **fires** |

With the bar visible, before and after are identical: taps above `y=2063` reach the content, taps below it reach the bar and select a tab.

## Test plan

Repro added as `Test4132`. From the Home tab:

1. **Open /detail** pushes a screen inside the tabs that sets `tabBarHidden` from a `useLayoutEffect` — the runtime-toggle path from the issue. Tap the lower probe rows and the scrolled rows that sit in the bottom ~128dp.
2. **Open /static-hidden** mounts a second tab host with `tabBarStyle: { display: 'none' }` from the first render — the initial-mount path. Same taps.
3. **Other** tab renders the same content with the bar visible — the regression control.
4. **Open /control** pushes the same content outside the tabs, where it always worked.

Both paths have the same cause; only the size of the strip differs. On the runtime-toggle path the bar had been laid out with the system inset applied and retained 337px; mounted already hidden it retained 210px (80dp, no inset yet), and the dead band started at `y=2190` instead of `y=2063`. Both are gone after the fix.

Also checked, on the same emulator:

- Bringing the bar back: it returns `V.E......` at `0,2063-1080,2400` and selects tabs both 250ms after the unhide and after settling — no window where it is visible but not yet hit-testable.
- With the bar visible, content under it stays untappable and the bar takes those touches, before and after the change.

Automated:

- `test-tabs-tab-bar-hidden.e2e.ts` — the new case fails on `main` (`Bottom presses: 0`) and passes with the fix.
- Full Android tabs suite: `yarn test-e2e-android e2e/single-feature-tests/tabs` — 9 passed, 5 skipped (iOS-only), 58 tests, 0 failures.
- `yarn check-types` and `./android/gradlew -p android spotlessCheck` clean.

## Notes

Not fixed here, but noticed while reading the surrounding code and worth its own change: `TabsContainer.getInterfaceInsets()` returns `bottomNavigationView.height` with no `tabBarHidden` check, while its sibling `updateInterfaceInsets()` does honour it. `getInterfaceInsets()` is what `SafeAreaView.onAttachedToWindow` reads, and the dump above shows a `GONE` bar keeping a 337px height — so a `SafeAreaView` that attaches while the bar is hidden is handed a full-height bottom inset for a bar nobody can see. That is a layout defect rather than a touch one, and it is not what makes the strip dead: the strip is dead in a tree with no RNS `SafeAreaView` in it at all. Happy to send it separately.

## Checklist

- [x] Included code example that can be used to test this change. *(`Test4132`)*
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. *(no visual change; tap measurements above)*
- [x] For API changes, updated relevant public types. *(no public API changes)*
- [ ] Ensured that CI passes
