### PR TITLE
fix(Android, Stack v4): Fix crash when a Screen is reordered inside ScreenStack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackViewManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.rnscreens.legacy
 
 import android.view.View
+import android.view.ViewGroup
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
@@ -45,7 +46,11 @@ class ScreenStackViewManager :
     }
 
     private fun prepareOutTransition(screen: Screen?) {
-        screen?.startRemovalTransition()
+        if (screen?.isBeingRemoved == true) {
+            screen.startRemovalTransition()
+        } else {
+            (screen?.parent as? ViewGroup)?.removeView(screen)
+        }
     }
 
     override fun invalidate() {

--- a/apps/src/tests/issue-tests/TestXXXX.tsx
+++ b/apps/src/tests/issue-tests/TestXXXX.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Screen, ScreenStack } from 'react-native-screens';
+
+export default function App() {
+  const [flip, setFlip] = useState(false);
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setFlip((f) => !f);
+      setCycle((c) => c + 1);
+    }, 1500);
+    return () => clearInterval(interval);
+  }, []);
+
+  const boxes = (prefix: string) => {
+    const arr = Array.from({ length: 20 }, (_, i) => i);
+    if (flip) {
+      arr.reverse();
+    }
+    return arr.map((i) => (
+      <View
+        key={`${prefix}-${i}`}
+        style={[styles.box, i % 2 === 0 ? styles.even : styles.odd]}>
+        <Text>
+          {prefix} {i}
+        </Text>
+      </View>
+    ));
+  };
+
+  const screenA = (
+    <Screen key="a" style={StyleSheet.absoluteFill} activityState={2}>
+      <Text style={styles.title}>
+        Screen A — cycle {cycle}, flip {String(flip)}
+      </Text>
+      {boxes('a')}
+    </Screen>
+  );
+  const screenB = (
+    <Screen key="b" style={StyleSheet.absoluteFill} activityState={2}>
+      <Text style={styles.title}>
+        Screen B — cycle {cycle}, flip {String(flip)}
+      </Text>
+      {boxes('b')}
+    </Screen>
+  );
+
+  return (
+    <ScreenStack style={styles.container}>
+      {flip ? [screenB, screenA] : [screenA, screenB]}
+    </ScreenStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  title: {
+    padding: 12,
+    fontWeight: 'bold',
+  },
+  box: {
+    height: 20,
+    marginVertical: 2,
+    marginHorizontal: 12,
+  },
+  even: {
+    backgroundColor: 'skyblue',
+  },
+  odd: {
+    backgroundColor: 'lightgreen',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as TestXXXX } from './TestXXXX';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/cpp/legacy/RNSScreenRemovalListener.cpp
+++ b/cpp/legacy/RNSScreenRemovalListener.cpp
@@ -1,18 +1,36 @@
 #include "RNSScreenRemovalListener.h"
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <unordered_set>
 using namespace facebook::react;
+
+namespace {
+
+bool isRNSScreen(const ShadowView &shadowView) {
+  return shadowView.componentName != nullptr &&
+      std::strcmp(shadowView.componentName, "RNSScreen") == 0;
+}
+
+} // namespace
 
 std::optional<MountingTransaction> RNSScreenRemovalListener::pullTransaction(
     SurfaceId surfaceId,
     MountingTransaction::Number transactionNumber,
     const TransactionTelemetry &telemetry,
     ShadowViewMutationList mutations) const {
+  std::unordered_set<Tag> insertedScreenTags;
+  for (const ShadowViewMutation &mutation : mutations) {
+    if (mutation.type == ShadowViewMutation::Type::Insert &&
+        isRNSScreen(mutation.newChildShadowView)) {
+      insertedScreenTags.insert(mutation.newChildShadowView.tag);
+    }
+  }
+
   for (const ShadowViewMutation &mutation : mutations) {
     // When using RNSModalScreen on Android it should be added here.
     if (mutation.type == ShadowViewMutation::Type::Remove &&
-        mutation.oldChildShadowView.componentName != nullptr &&
-        std::strcmp(mutation.oldChildShadowView.componentName, "RNSScreen") ==
-            0) {
+        isRNSScreen(mutation.oldChildShadowView) &&
+        insertedScreenTags.find(mutation.oldChildShadowView.tag) ==
+            insertedScreenTags.end()) {
       // We call the listener function even if this screen has not been owned
       // by RNSScreenStack as since RN 0.78 we do not have enough information
       // here. This final filter is applied later in NativeProxy.


### PR DESCRIPTION
## Description

Fabric treats a screen move as a pair of `Remove` and `Insert` mutations in a single transaction. Our removal-detection paths could not detect a move to another parent and starts removal transition unconditionally, marking the whole subtree of a screen that stays alive with `startViewTransition`. `ViewGroup` does not clear `mParent` for views in `mTransitioningViews`, so when the same commit also reorders children inside the moved screen, their Remove leaves `mParent` set and then `Insert` of the same view instance throws.

Proposing a simple mechanism for detecting when the Screen moves to another parent, and in that case, removing it immediately from the current parent.

## Changes

- detected Remove+Insert of the same tag is a move, which shouldn't notify the removal path

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/9fc84582-62c7-4ae3-a5cb-e711fc44f9c8" /> | <video src="https://github.com/user-attachments/assets/6bc490f7-4ece-4331-8188-081c1f554af4" /> |

## Test plan

Added dedicated test

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
