### PR TITLE
chore(test): e2e test for test-stack-lift-on-scroll-android

### DIFF
--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -75,6 +75,10 @@ export const CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW =
   'androidx.appcompat.widget.MenuPopupWindow$MenuDropDownListView';
 export const CLASS_NAME_ANDROID_MATERIAL_TOOLBAR =
   'com.google.android.material.appbar.MaterialToolbar';
+// Detox resolves `by.type` with `isAssignableFrom`, so this also matches the
+// library's internal `StackHeaderAppBarLayout` subclasses.
+export const CLASS_NAME_ANDROID_APP_BAR_LAYOUT =
+  'com.google.android.material.appbar.AppBarLayout';
 export const CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW =
   'androidx.appcompat.view.menu.ActionMenuItemView';
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -260,6 +260,8 @@ async function expectLiftFollowsScroll() {
   await expectAppBarFlat();
   await scrollAwayFromTop();
   await expectAppBarLifted();
+  await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
+  await expectAppBarLifted();
   // Has to be the edge jump: unlifting needs offset zero exactly. That makes
   // this usable only with an opaque header — every caller has one.
   await scrollToTopEdge();
@@ -304,24 +306,14 @@ describeIfAndroid('Stack v5: header lift on scroll (Android)', () => {
       await expectLiftFollowsScroll();
     });
 
-    // The lift cycle above only nudges the content off zero. This runs the whole
-    // content past the header instead, which is what "stays lifted" needs, and
-    // pins down that the only thing the scroll changes is the app bar's depth —
-    // its rectangle has to come back byte-identical.
-    it('should stay lifted and keep the small header pinned across a full scroll', async () => {
-      // Pins the starting state rather than inheriting it from the test above:
-      // a leftover scroll offset would keep the app bar lifted even though the
-      // top heading is already visible, so land on offset zero explicitly.
+    it('should keep the small header pinned across a full scroll', async () => {
       await scrollToTopEdge();
-      await expectAppBarFlat();
       const { frame: frameAtTop } = await appBarAttributes();
 
       await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
-      await expectAppBarLifted();
       jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
 
       await scrollToTopEdge();
-      await expectAppBarFlat();
       jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
     });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -1,0 +1,397 @@
+import { expect as jestExpect } from '@jest/globals';
+import { device, expect, element, by, waitFor } from 'detox';
+import type { AndroidElementAttributes } from 'detox/detox';
+import {
+  countMatches,
+  describeIfAndroid,
+  getElementAttributes,
+  getMatches,
+  scrollUntilVisible,
+  selectSingleFeatureTestsScreen,
+  waitUntil,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_ANDROID_APP_BAR_LAYOUT,
+  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
+} from '../../native-class-names';
+import type { TriState } from '@apps/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android';
+
+/**
+ * Covers the assertable half of `scenario.md`: that the app bar is attached and
+ * detached as `hidden` / `headerConfig enabled` are toggled, that the `small`
+ * header stays pinned while the content scrolls, that a transparent header
+ * overlays the content, and that the app bar's *lifted state* follows the scroll
+ * position.
+ *
+ * The lifted state is read through the app bar's `elevation`, which Material's
+ * app bar state list animator drives off `state_lifted` — the same state that
+ * paints the tonal `liftOnScrollColor`. So this asserts *that* the app bar lifts
+ * and unlifts, never how it looks: the tonal/color shift itself, and any
+ * flicker or header rebuild flash while it animates, stay manual-only (see
+ * `scenario.md`).
+ */
+
+const SCROLL_VIEW = 'lift-on-scroll-scrollview';
+const BOTTOM_MARKER = 'lift-on-scroll-bottom-marker';
+const TOP_HEADING = 'Header config';
+const HEADER_TITLE = 'Lift on scroll';
+const LIFT_PICKER = 'liftonscroll-picker';
+
+// Espresso's idle sync does not cover the app bar's elevation animation, so the
+// lifted state has to be polled rather than read once.
+const LIFT_TIMEOUT_MS = 3000;
+
+// The legacy headers of the outer navigator build `CustomToolbar`, which extends
+// `Toolbar` but not `MaterialToolbar`, so this stays scoped to the Stack v5
+// header under test.
+const toolbar = by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
+
+// Every screen the outer navigator has stacked keeps its own `AppBarLayout` in
+// the hierarchy, so the bare class matches several. Only the Stack v5 header
+// wraps a `MaterialToolbar`.
+const appBar = by
+  .type(CLASS_NAME_ANDROID_APP_BAR_LAYOUT)
+  .withDescendant(toolbar);
+
+async function appBarAttributes(): Promise<AndroidElementAttributes> {
+  const matches = await getMatches(appBar);
+
+  // Guards against reading a sibling screen's app bar if the scoping above ever
+  // stops being unique.
+  jestExpect(matches).toHaveLength(1);
+
+  return matches[0] as AndroidElementAttributes;
+}
+
+async function contentFrame() {
+  const attributes = (await getElementAttributes({
+    by: 'id',
+    value: SCROLL_VIEW,
+  })) as AndroidElementAttributes;
+
+  return attributes.frame;
+}
+
+async function appBarElevation(): Promise<number> {
+  return (await appBarAttributes()).elevation;
+}
+
+async function waitForAppBarElevation(
+  predicate: (elevation: number) => boolean,
+  expectation: string,
+) {
+  let observed = Number.NaN;
+
+  await waitUntil(
+    async () => {
+      observed = await appBarElevation();
+      return predicate(observed);
+    },
+    {
+      timeout: LIFT_TIMEOUT_MS,
+      message: () => `${expectation}, last observed elevation: ${observed}`,
+    },
+  );
+}
+
+const expectAppBarLifted = () =>
+  waitForAppBarElevation(
+    elevation => elevation > 0,
+    'expected the app bar to be lifted (elevation > 0)',
+  );
+
+const expectAppBarFlat = () =>
+  waitForAppBarElevation(
+    elevation => elevation === 0,
+    'expected the app bar to be flat (elevation === 0)',
+  );
+
+const expectAtTop = () =>
+  waitFor(element(by.text(TOP_HEADING)))
+    .toBeVisible()
+    .withTimeout(3000);
+
+/**
+ * Detox starts an upward scroll at the scroll view's *top edge*. A transparent
+ * header sits on top of the content there and swallows the touch, so the gesture
+ * moves nothing and `scrollTo('top')` hangs waiting for an edge it never reaches.
+ * Both helpers below anchor the gesture clear of the header instead, which keeps
+ * them working in every header mode.
+ */
+const ANCHOR_FOR_UPWARD_SCROLL = 0.35;
+const ANCHOR_FOR_DOWNWARD_SCROLL = 0.85;
+
+/**
+ * Enough to take the scroll position off zero, which is all the lifted state
+ * depends on — it does not care how far the content travelled.
+ */
+const STEP_DP = 500;
+
+/**
+ * Deliberately more than the content is long. `scrollBackToTop` has to land on
+ * the top edge *exactly*: the app bar unlifts only at offset zero, so stepping
+ * back by `STEP_DP` would leave it lifted whenever the gesture undershoots, even
+ * though the heading is already back on screen. Detox splits the amount into
+ * swipes and swallows the error once it runs out of content, so overshooting
+ * costs nothing and guarantees offset zero.
+ */
+const OVERSHOOT_DP = 20000;
+
+async function scrollAwayFromTop() {
+  await element(by.id(SCROLL_VIEW)).scroll(
+    STEP_DP,
+    'down',
+    Number.NaN,
+    ANCHOR_FOR_DOWNWARD_SCROLL,
+  );
+  await waitFor(element(by.text(TOP_HEADING)))
+    .not.toBeVisible()
+    .withTimeout(3000);
+}
+
+/** Returns to offset zero from anywhere; a no-op when already at the top. */
+async function scrollBackToTop() {
+  await element(by.id(SCROLL_VIEW)).scroll(
+    OVERSHOOT_DP,
+    'up',
+    Number.NaN,
+    ANCHOR_FOR_UPWARD_SCROLL,
+  );
+  await expectAtTop();
+}
+
+/** Rewinds the content, asserting nothing about what is on screen. */
+const rewind = scrollBackToTop;
+
+/**
+ * Scrolls to the very end of the content and back, proving all of it stays
+ * reachable. Heavier than a bounded step, so it is reserved for the cases that
+ * are about scrollability itself rather than about the lifted state.
+ */
+async function scrollThroughAllContentAndBack() {
+  await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
+  await scrollBackToTop();
+}
+
+// `SettingsSwitch` puts its testID on the touchable and renders
+// `<label>: <value>` in a child `Text`, so its state is only observable through
+// that text.
+type Switch = { testID: string; label: string };
+
+const ENABLED: Switch = {
+  testID: 'header-config-enabled-switch',
+  label: 'headerConfig enabled (attach/detach)',
+};
+const TRANSPARENT: Switch = {
+  testID: 'transparent-switch',
+  label: 'transparent',
+};
+const HIDDEN: Switch = { testID: 'hidden-switch', label: 'hidden' };
+
+// Controls live inside the scrolled content, so rewind before reaching for one.
+// The label assertion doubles as the wait for the re-render to land.
+async function toggleSwitch({ testID, label }: Switch, expected: boolean) {
+  await rewind();
+  await element(by.id(testID)).tap();
+  await waitFor(element(by.text(`${label}: ${expected}`)))
+    .toBeVisible()
+    .withTimeout(3000);
+}
+
+// Option ids are `SettingsPicker`'s own `<label>-<item>`, lowercased. The second
+// tap on the picker closes it again, so its options do not push the switches
+// below it off-screen.
+async function selectLiftOnScroll(value: TriState) {
+  await rewind();
+  await element(by.id(LIFT_PICKER)).tap();
+  await element(by.id(`liftonscroll-${value}`)).tap();
+  await element(by.id(LIFT_PICKER)).tap();
+  await expect(element(by.id(LIFT_PICKER))).toHaveText(
+    `liftOnScroll: ${value}`,
+  );
+}
+
+async function expectHeaderAttached() {
+  await waitFor(element(toolbar)).toBeVisible().withTimeout(3000);
+  await expect(element(by.text(HEADER_TITLE))).toBeVisible();
+  jestExpect(await countMatches(appBar)).toBe(1);
+}
+
+// A hidden or detached header is removed from the hierarchy, so its absence is
+// "does not exist". The content is asserted first, otherwise a screen that never
+// rendered would pass too.
+async function expectHeaderDetached() {
+  await waitFor(element(by.id(SCROLL_VIEW)))
+    .toBeVisible()
+    .withTimeout(3000);
+  await expect(element(appBar)).not.toExist();
+  await expect(element(toolbar)).not.toExist();
+  // Implied by the toolbar being gone — the title is one of its children — but
+  // asserted anyway: it is the part a reader of `scenario.md` actually checks
+  // ("there is no header"), and it keeps holding if the title ever stops being
+  // parented by the toolbar. Safe against the outer navigator's own header,
+  // whose title is the scenario name, and `by.text` matches exactly.
+  await expect(element(by.text(HEADER_TITLE))).not.toExist();
+}
+
+/**
+ * Whether the content starts above the app bar's bottom edge — i.e. whether the
+ * header overlays it. This is what `transparent` flips: it drops the app bar's
+ * scrolling content behavior, so the content is no longer offset below it.
+ */
+async function isContentUnderHeader(): Promise<boolean> {
+  const { frame } = await appBarAttributes();
+  return (await contentFrame()).y < frame.y + frame.height;
+}
+
+/**
+ * Asserts the full lift cycle for a configuration where lift is expected:
+ * flat at the top, lifted once scrolled away, flat again on return.
+ */
+async function expectLiftFollowsScroll() {
+  await expectAppBarFlat();
+  await scrollAwayFromTop();
+  await expectAppBarLifted();
+  await scrollBackToTop();
+  await expectAppBarFlat();
+}
+
+/**
+ * Asserts the lifted state is scroll-independent. Note this cannot assert a
+ * *value*: an app bar that is not liftable at all rests at the animator's
+ * "enabled" elevation, not at zero — only its invariance under scrolling is the
+ * claim being made.
+ */
+async function expectLiftUnaffectedByScroll() {
+  const elevationAtTop = await appBarElevation();
+
+  await scrollAwayFromTop();
+  jestExpect(await appBarElevation()).toBe(elevationAtTop);
+
+  await scrollBackToTop();
+  jestExpect(await appBarElevation()).toBe(elevationAtTop);
+}
+
+describeIfAndroid('Stack v5: header lift on scroll (Android)', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Stackv5',
+      'test-stack-lift-on-scroll-android',
+    );
+    await waitFor(element(by.id(SCROLL_VIEW)))
+      .toBeVisible()
+      .withTimeout(5000);
+  });
+
+  describe('baseline — liftOnScroll defaults to true', () => {
+    it('should render an attached small header, flat at rest', async () => {
+      await expectHeaderAttached();
+      await expectAppBarFlat();
+    });
+
+    it('should lift the header while scrolled and unlift it back at the top', async () => {
+      await expectLiftFollowsScroll();
+    });
+
+    // The lift cycle above only nudges the content off zero. This runs the whole
+    // content past the header instead, which is what "stays lifted" needs, and
+    // pins down that the only thing the scroll changes is the app bar's depth —
+    // its rectangle has to come back byte-identical.
+    it('should stay lifted and keep the small header pinned across a full scroll', async () => {
+      const { frame: frameAtTop } = await appBarAttributes();
+
+      await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
+      await expectAppBarLifted();
+      jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
+
+      await scrollBackToTop();
+      await expectAppBarFlat();
+      jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
+    });
+
+    it('should lay the content out below the header', async () => {
+      jestExpect(await isContentUnderHeader()).toBe(false);
+    });
+  });
+
+  describe('liftOnScroll = false', () => {
+    beforeAll(async () => {
+      await selectLiftOnScroll('false');
+    });
+
+    it('should keep the header attached', async () => {
+      await expectHeaderAttached();
+    });
+
+    it('should not lift or unlift the header while the content scrolls', async () => {
+      await expectLiftUnaffectedByScroll();
+    });
+  });
+
+  describe('liftOnScroll set back to a lifting value', () => {
+    it('should restore lift for the explicit true value', async () => {
+      await selectLiftOnScroll('true');
+
+      await expectHeaderAttached();
+      await expectLiftFollowsScroll();
+    });
+
+    it('should restore lift for the undefined (default) value', async () => {
+      await selectLiftOnScroll('undefined');
+
+      await expectHeaderAttached();
+      await expectLiftFollowsScroll();
+    });
+  });
+
+  describe('transparent header', () => {
+    it('should overlay the content and suppress lift while transparent', async () => {
+      await toggleSwitch(TRANSPARENT, true);
+
+      await expectHeaderAttached();
+      jestExpect(await isContentUnderHeader()).toBe(true);
+      await expectLiftUnaffectedByScroll();
+    });
+
+    it('should restore the content offset and lift once transparent is off', async () => {
+      await toggleSwitch(TRANSPARENT, false);
+
+      await expectHeaderAttached();
+      jestExpect(await isContentUnderHeader()).toBe(false);
+      await expectLiftFollowsScroll();
+    });
+  });
+
+  describe('hidden header', () => {
+    it('should detach the header while hidden, leaving the content scrollable', async () => {
+      await toggleSwitch(HIDDEN, true);
+
+      await expectHeaderDetached();
+      await scrollThroughAllContentAndBack();
+    });
+
+    it('should re-resolve the lift target once the header is shown again', async () => {
+      await toggleSwitch(HIDDEN, false);
+
+      await expectHeaderAttached();
+      await expectLiftFollowsScroll();
+    });
+  });
+
+  describe('headerConfig attach / detach', () => {
+    it('should remove the whole header when headerConfig is detached', async () => {
+      await toggleSwitch(ENABLED, false);
+
+      await expectHeaderDetached();
+      await scrollThroughAllContentAndBack();
+    });
+
+    it('should re-resolve the lift target once headerConfig is re-attached', async () => {
+      await toggleSwitch(ENABLED, true);
+
+      await expectHeaderAttached();
+      await expectLiftFollowsScroll();
+    });
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -308,6 +308,9 @@ describeIfAndroid('Stack v5: header lift on scroll (Android)', () => {
     // pins down that the only thing the scroll changes is the app bar's depth —
     // its rectangle has to come back byte-identical.
     it('should stay lifted and keep the small header pinned across a full scroll', async () => {
+      // Pins the starting state rather than inheriting it from the test above,
+      // so the lift assertions below still mean something when this runs alone.
+      await expectAppBarFlat();
       const { frame: frameAtTop } = await appBarAttributes();
 
       await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -260,8 +260,6 @@ async function expectLiftFollowsScroll() {
   await expectAppBarFlat();
   await scrollAwayFromTop();
   await expectAppBarLifted();
-  await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
-  await expectAppBarLifted();
   // Has to be the edge jump: unlifting needs offset zero exactly. That makes
   // this usable only with an opaque header — every caller has one.
   await scrollToTopEdge();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -127,15 +127,8 @@ const ANCHOR_FOR_DOWNWARD_SCROLL = 0.85;
  */
 const STEP_DP = 500;
 
-/**
- * Deliberately more than the content is long. `scrollBackToTop` has to land on
- * the top edge *exactly*: the app bar unlifts only at offset zero, so stepping
- * back by `STEP_DP` would leave it lifted whenever the gesture undershoots, even
- * though the heading is already back on screen. Detox splits the amount into
- * swipes and swallows the error once it runs out of content, so overshooting
- * costs nothing and guarantees offset zero.
- */
-const OVERSHOOT_DP = 20000;
+/** More than the content is long, so one call covers any distance travelled. */
+const LONG_WAY_DP = 20000;
 
 async function scrollAwayFromTop() {
   await element(by.id(SCROLL_VIEW)).scroll(
@@ -149,10 +142,16 @@ async function scrollAwayFromTop() {
     .withTimeout(3000);
 }
 
-/** Returns to offset zero from anywhere; a no-op when already at the top. */
+/**
+ * Scrolls back up until the top of the content is on screen. Works in every
+ * header mode, but makes no promise about the final offset: Detox's edge probe
+ * can end the gesture early, and the heading comes back into view well before
+ * offset zero. Anything that goes on to assert the app bar is *flat* must use
+ * `scrollToTopEdge` instead — unlifting happens at offset zero exactly.
+ */
 async function scrollBackToTop() {
   await element(by.id(SCROLL_VIEW)).scroll(
-    OVERSHOOT_DP,
+    LONG_WAY_DP,
     'up',
     Number.NaN,
     ANCHOR_FOR_UPWARD_SCROLL,
@@ -160,8 +159,16 @@ async function scrollBackToTop() {
   await expectAtTop();
 }
 
-/** Rewinds the content, asserting nothing about what is on screen. */
-const rewind = scrollBackToTop;
+/**
+ * Lands on offset zero, deterministically: Detox repeats the scroll until the
+ * view reports it cannot move further. Unusable while the header is transparent,
+ * which is exactly the hang described above — so this is for opaque or absent
+ * headers only.
+ */
+async function scrollToTopEdge() {
+  await element(by.id(SCROLL_VIEW)).scrollTo('top');
+  await expectAtTop();
+}
 
 /**
  * Scrolls to the very end of the content and back, proving all of it stays
@@ -170,7 +177,7 @@ const rewind = scrollBackToTop;
  */
 async function scrollThroughAllContentAndBack() {
   await scrollUntilVisible(BOTTOM_MARKER, SCROLL_VIEW);
-  await scrollBackToTop();
+  await scrollToTopEdge();
 }
 
 // `SettingsSwitch` puts its testID on the touchable and renders
@@ -188,10 +195,10 @@ const TRANSPARENT: Switch = {
 };
 const HIDDEN: Switch = { testID: 'hidden-switch', label: 'hidden' };
 
-// Controls live inside the scrolled content, so rewind before reaching for one.
-// The label assertion doubles as the wait for the re-render to land.
+// Controls live inside the scrolled content, so scroll back up before reaching
+// for one. The label assertion doubles as the wait for the re-render to land.
 async function toggleSwitch({ testID, label }: Switch, expected: boolean) {
-  await rewind();
+  await scrollBackToTop();
   await element(by.id(testID)).tap();
   await waitFor(element(by.text(`${label}: ${expected}`)))
     .toBeVisible()
@@ -202,7 +209,7 @@ async function toggleSwitch({ testID, label }: Switch, expected: boolean) {
 // tap on the picker closes it again, so its options do not push the switches
 // below it off-screen.
 async function selectLiftOnScroll(value: TriState) {
-  await rewind();
+  await scrollBackToTop();
   await element(by.id(LIFT_PICKER)).tap();
   await element(by.id(`liftonscroll-${value}`)).tap();
   await element(by.id(LIFT_PICKER)).tap();
@@ -252,7 +259,9 @@ async function expectLiftFollowsScroll() {
   await expectAppBarFlat();
   await scrollAwayFromTop();
   await expectAppBarLifted();
-  await scrollBackToTop();
+  // Has to be the edge jump: unlifting needs offset zero exactly. That makes
+  // this usable only with an opaque header — every caller has one.
+  await scrollToTopEdge();
   await expectAppBarFlat();
 }
 
@@ -305,7 +314,7 @@ describeIfAndroid('Stack v5: header lift on scroll (Android)', () => {
       await expectAppBarLifted();
       jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
 
-      await scrollBackToTop();
+      await scrollToTopEdge();
       await expectAppBarFlat();
       jestExpect((await appBarAttributes()).frame).toEqual(frameAtTop);
     });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -256,6 +256,7 @@ async function isContentUnderHeader(): Promise<boolean> {
  * flat at the top, lifted once scrolled away, flat again on return.
  */
 async function expectLiftFollowsScroll() {
+  await scrollToTopEdge();
   await expectAppBarFlat();
   await scrollAwayFromTop();
   await expectAppBarLifted();
@@ -308,8 +309,10 @@ describeIfAndroid('Stack v5: header lift on scroll (Android)', () => {
     // pins down that the only thing the scroll changes is the app bar's depth —
     // its rectangle has to come back byte-identical.
     it('should stay lifted and keep the small header pinned across a full scroll', async () => {
-      // Pins the starting state rather than inheriting it from the test above,
-      // so the lift assertions below still mean something when this runs alone.
+      // Pins the starting state rather than inheriting it from the test above:
+      // a leftover scroll offset would keep the app bar lifted even though the
+      // top heading is already visible, so land on offset zero explicitly.
+      await scrollToTopEdge();
       await expectAppBarFlat();
       const { frame: frameAtTop } = await appBarAttributes();
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native-screens';
 import LongText from '@apps/shared/LongText';
 
-type TriState = 'undefined' | 'true' | 'false';
+export type TriState = 'undefined' | 'true' | 'false';
 
 const TRI_STATE_VALUES: TriState[] = ['undefined', 'true', 'false'];
 
@@ -80,27 +80,37 @@ function ConfigScreen() {
   return (
     <ScrollViewMarker style={styles.scrollViewMarker}>
       <ScrollView
+        testID="lift-on-scroll-scrollview"
         nestedScrollEnabled
         style={styles.scroll}
-        contentContainerStyle={styles.content}>
+        contentContainerStyle={[
+          styles.content,
+          // A transparent header overlays the content, which would otherwise
+          // bury the controls that toggle it back off.
+          config.transparent && styles.contentUnderTransparentHeader,
+        ]}>
         <Text style={styles.heading}>Header config</Text>
         <SettingsSwitch
+          testID="header-config-enabled-switch"
           label="headerConfig enabled (attach/detach)"
           value={config.enabled}
           onValueChange={v => updateConfig('enabled', v)}
         />
         <SettingsPicker<TriState>
+          testID="liftonscroll-picker"
           label="liftOnScroll"
           value={config.liftOnScroll}
           onValueChange={v => updateConfig('liftOnScroll', v)}
           items={TRI_STATE_VALUES}
         />
         <SettingsSwitch
+          testID="transparent-switch"
           label="transparent"
           value={config.transparent}
           onValueChange={v => updateConfig('transparent', v)}
         />
         <SettingsSwitch
+          testID="hidden-switch"
           label="hidden"
           value={config.hidden}
           onValueChange={v => updateConfig('hidden', v)}
@@ -108,6 +118,9 @@ function ConfigScreen() {
 
         <Text style={styles.heading}>Scroll to observe lift</Text>
         <LongText size="xl" />
+        {/* Bottom sentinel: lets e2e assert the content actually scrolled
+            rather than inferring it from the scroll action not throwing. */}
+        <Text testID="lift-on-scroll-bottom-marker">End of content</Text>
       </ScrollView>
     </ScrollViewMarker>
   );
@@ -123,6 +136,10 @@ const styles = StyleSheet.create({
   content: {
     padding: 16,
     gap: 6,
+  },
+  // Clears a status bar plus a `small` app bar (56dp).
+  contentUnderTransparentHeader: {
+    paddingTop: 120,
   },
   heading: {
     fontSize: 20,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/scenario.md
@@ -3,7 +3,7 @@
 ## Details
 
 **Description:** Exercises the Android Material 3 header **lift-on-scroll**
-effect — the app bar's tonal/elevation shift applied when scrollable content
+effect - the app bar's tonal/elevation shift applied when scrollable content
 moves beneath the pinned `small` header.
 
 `liftOnScroll` only applies to the `small` header, so this scenario fixes the
@@ -17,7 +17,20 @@ so `liftOnScroll` has no effect there; that path is out of scope for this test.
 
 ## E2E test
 
-Incomplete - we can't detect the elevation/color flash with Detox.
+Incomplete: covers the lifted/unlifted transitions of steps 1–7, plus the app
+bar being attached, detached and pinned. Lift is read from the app bar's
+`elevation`, which Material drives off the same `state_lifted` that paints the
+tonal colour.
+
+Not automated:
+
+- The lift's *appearance* - the tonal/colour shift in steps 1–2. Detox reads no
+  colours.
+- Flicker while the elevation animates (step 1) and the "no visible header
+  rebuild/flash" of step 3. Detox samples state, not animation frames.
+- Step 2 asserts that the lifted state ignores scrolling, not that elevation is
+  zero: without `liftOnScroll` the app bar is not liftable, so it rests at a
+  non-zero elevation.
 
 ## Prerequisites
 
@@ -44,7 +57,7 @@ Incomplete - we can't detect the elevation/color flash with Detox.
 
 2. Set `liftOnScroll` = `false`, then scroll.
 
-- [ ] The header does not lift — it stays flat regardless of scroll position.
+- [ ] The header does not lift - it stays flat regardless of scroll position.
 
 3. Set `liftOnScroll` = `true` (or `undefined`) again, then scroll.
 


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1733

Adds Detox e2e coverage for the Android **lift-on-scroll** header behaviour, covering the assertable half of the existing `test-stack-lift-on-scroll-android` scenario.

The app bar's lifted state is read through its `elevation`, which Material's app bar state list animator drives off the same `state_lifted` that paints the tonal `liftOnScrollColor`. That makes the *transition* assertable even though the colour itself is not: the test asserts **that** the app bar lifts and unlifts, never how it looks.

## Changes

- New e2e spec `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts`, covering:
  - app bar attach / detach as `hidden` and `headerConfig enabled` are toggled,
  - the `small` header staying pinned while content scrolls,
  - a transparent header overlaying the content,
  - the lifted state following scroll position for `liftOnScroll` = `true` / `false` / `undefined`.
- `FabricExample/e2e/native-class-names.ts`: added `CLASS_NAME_ANDROID_APP_BAR_LAYOUT`. Detox resolves `by.type` with `isAssignableFrom`, so it also matches the library's internal `StackHeaderAppBarLayout` subclasses.
- Test screen (`apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx`):
  - added `testID`s to the scroll view and the config controls,
  - added a bottom sentinel so the test can assert the content actually scrolled instead of inferring it from the scroll action not throwing,
  - added top padding when `transparent` is on, so the overlaying header no longer buries the controls that toggle it back off,
  - exported `TriState` for reuse in the spec.
- `scenario.md`: replaced the "Incomplete - we can't detect the elevation/color flash with Detox" note with the actual coverage split, and listed what stays manual-only.

