### PR TITLE
refactor(FabricExample): migrate from component to element

### DIFF
--- a/apps/src/shared/containers/shared/use-elements-by-name.ts
+++ b/apps/src/shared/containers/shared/use-elements-by-name.ts
@@ -2,14 +2,14 @@ import React, { useMemo } from 'react';
 import type { StackRouteConfig } from '../stack';
 import type { TabRouteConfig } from '../tabs';
 
-export const useComponentsByName = (
+export const useElementsByName = (
   routeConfigs: StackRouteConfig[] | TabRouteConfig[],
 ) => {
   return useMemo(() => {
-    const map = new Map<string, React.ComponentType>();
+    const map = new Map<string, React.ReactElement>();
 
     for (const config of routeConfigs) {
-      map.set(config.name, config.Component);
+      map.set(config.name, config.element);
     }
 
     return map;

--- a/apps/src/shared/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/containers/stack/StackContainer.tsx
@@ -21,12 +21,12 @@ import {
   useRenderDebugInfo,
 } from 'react-native-screens/private';
 import { useParentNavigationEffect } from './hooks/useParentNavigationEffect';
-import { useComponentsByName } from '../shared/use-components-by-name';
+import { useElementsByName } from '../shared/use-elements-by-name';
 
 export function StackContainer({ routeConfigs }: StackContainerProps) {
   useSanitizeRouteConfigs(routeConfigs);
 
-  const componentsByName = useComponentsByName(routeConfigs);
+  const elementsByName = useElementsByName(routeConfigs);
 
   const [stackNavState, navActionDispatch]: [
     StackNavigationState,
@@ -81,8 +81,8 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
             setRouteOptions: navMethods.setRouteOptions,
           };
 
-          const Component = componentsByName.get(name);
-          if (!Component) {
+          const element = elementsByName.get(name);
+          if (!element) {
             throw new Error(
               `[Stack] No config matches the "${name}" route name`,
             );
@@ -97,7 +97,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
               onDismiss={onScreenDismissed}
               onNativeDismiss={onScreenNativelyDismissed}>
               <StackNavigationContext.Provider value={stackNavigationContext}>
-                <Component />
+                {element}
                 {headerConfig !== undefined && (
                   <Stack.HeaderConfig ref={headerConfigRef} {...headerConfig} />
                 )}

--- a/apps/src/shared/containers/stack/StackContainer.types.ts
+++ b/apps/src/shared/containers/stack/StackContainer.types.ts
@@ -20,11 +20,11 @@ export type StackRouteOptions = Omit<
  */
 export type StackRouteConfig = {
   name: string;
-  Component: React.ComponentType;
+  element: React.ReactElement;
   options?: StackRouteOptions;
 };
 
-export type StackRoute = Omit<StackRouteConfig, 'Component'> & {
+export type StackRoute = Omit<StackRouteConfig, 'element'> & {
   activityMode: StackScreenProps['activityMode'];
   routeKey: StackScreenProps['screenKey'];
   isMarkedForDismissal: boolean; // whether this route is during or after dismissal process

--- a/apps/src/shared/containers/stack/reducer.tsx
+++ b/apps/src/shared/containers/stack/reducer.tsx
@@ -277,7 +277,7 @@ function createRouteFromConfig(
   activityMode: StackScreenActivityMode = 'detached',
 ): StackRoute {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { Component, ...rest } = config;
+  const { element, ...rest } = config;
   return {
     ...rest,
     activityMode,

--- a/apps/src/shared/containers/tabs/TabsContainer.tsx
+++ b/apps/src/shared/containers/tabs/TabsContainer.tsx
@@ -21,7 +21,7 @@ import {
 } from './reducer';
 import { RNSLog } from 'react-native-screens/private';
 import { TabsContainerItem } from './TabsContainerItem';
-import { useComponentsByName } from '../shared/use-components-by-name';
+import { useElementsByName } from '../shared/use-elements-by-name';
 
 export function TabsContainer(props: TabsContainerProps) {
   RNSLog.info('TabsContainer render');
@@ -30,7 +30,7 @@ export function TabsContainer(props: TabsContainerProps) {
 
   useSanitizeRouteConfigs(routeConfigs);
 
-  const componentsByName = useComponentsByName(routeConfigs);
+  const elementsByName = useElementsByName(routeConfigs);
 
   const [tabsNavState, dispatch]: [
     TabsContainerState,
@@ -82,8 +82,8 @@ export function TabsContainer(props: TabsContainerProps) {
         const pendingForUpdate =
           route.routeKey === tabsNavState.suggestedState.selectedRouteKey;
 
-        const Component = componentsByName.get(route.name);
-        if (!Component) {
+        const element = elementsByName.get(route.name);
+        if (!element) {
           throw new Error(
             `[Tabs] No route config matches the "${route.name}" route name`,
           );
@@ -96,7 +96,7 @@ export function TabsContainer(props: TabsContainerProps) {
             navMethods={navMethods}
             isSelected={isSelected}
             pendingForUpdate={pendingForUpdate}
-            Component={Component}
+            element={element}
           />
         );
       })}

--- a/apps/src/shared/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/containers/tabs/TabsContainer.types.tsx
@@ -20,14 +20,14 @@ export type TabRouteOptions = Omit<
  */
 export type TabRouteConfig = {
   name: string;
-  Component: React.ComponentType;
+  element: React.ReactElement;
   options?: TabRouteOptions;
 };
 
 /**
  * Runtime instance of a tab route. Created from a TabRouteConfig blueprint.
  */
-export type TabRoute = Omit<TabRouteConfig, 'Component'> & {
+export type TabRoute = Omit<TabRouteConfig, 'element'> & {
   routeKey: string;
 };
 

--- a/apps/src/shared/containers/tabs/TabsContainerItem.tsx
+++ b/apps/src/shared/containers/tabs/TabsContainerItem.tsx
@@ -43,14 +43,14 @@ function TabsContainerItemImpl(props: TabsContainerItemProps) {
   return (
     <Tabs.Screen key={screenKey} {...nativeOptions} screenKey={screenKey}>
       <TabsNavigationContext value={tabsNavigationContext}>
-        {getContent(props.Component, safeAreaConfiguration)}
+        {getContent(props.element, safeAreaConfiguration)}
       </TabsNavigationContext>
     </Tabs.Screen>
   );
 }
 
 function getContent(
-  Component: TabRouteConfig['Component'],
+  element: TabRouteConfig['element'],
   safeAreaConfiguration: SafeAreaViewProps | undefined,
 ) {
   const safeAreaConfigurationWithDefault = getSafeAreaViewEdges(
@@ -62,14 +62,10 @@ function getContent(
   );
 
   if (anySAVEdgeSet) {
-    return (
-      <SafeAreaView {...safeAreaConfiguration}>
-        <Component />
-      </SafeAreaView>
-    );
+    return <SafeAreaView {...safeAreaConfiguration}>{element}</SafeAreaView>;
   }
 
-  return <Component />;
+  return element;
 }
 
 function getSafeAreaViewEdges(

--- a/apps/src/shared/containers/tabs/TabsContainerItem.types.ts
+++ b/apps/src/shared/containers/tabs/TabsContainerItem.types.ts
@@ -6,5 +6,5 @@ export type TabsContainerItemProps = {
   navMethods: TabsNavigationMethods;
   isSelected: boolean;
   pendingForUpdate: boolean;
-  Component: React.ComponentType;
+  element: React.ReactElement;
 };

--- a/apps/src/shared/containers/tabs/reducer.tsx
+++ b/apps/src/shared/containers/tabs/reducer.tsx
@@ -139,7 +139,7 @@ function tabsActionSetOptionsHandler(
 
 function createTabRouteFromConfig(config: TabRouteConfig): TabRoute {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { Component, ...rest } = config;
+  const { element, ...rest } = config;
   return {
     ...rest,
     // Tab names are required to be unique (enforced by useSanitizeRouteConfigs),

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/index.tsx
@@ -37,11 +37,11 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
         },
         {
           name: 'A',
-          Component: AScreen,
+          element: <AScreen />,
           options: {
             headerConfig: { title: 'A' },
           },

--- a/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-stack-in-tabs/index.tsx
@@ -57,7 +57,7 @@ function ConfigScreen() {
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Screen1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
   },
 ];
 
@@ -68,7 +68,7 @@ function StackScreen() {
 const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: StackScreen,
+    element: <StackScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -76,7 +76,7 @@ const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: DummyScreen,
+    element: <DummyScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',

--- a/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
+++ b/apps/src/tests/component-integration-tests/orientation/orientation-tabs-in-stack/index.tsx
@@ -57,7 +57,7 @@ function ConfigScreen() {
 const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -65,7 +65,7 @@ const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: DummyScreen,
+    element: <DummyScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',
@@ -80,7 +80,7 @@ function TabsScreen() {
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Screen1',
-    Component: TabsScreen,
+    element: <TabsScreen />,
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-lift-on-scroll/index.tsx
@@ -19,7 +19,7 @@ export function TestStackSvmLiftOnScroll() {
 const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'LiftOnScroll',
-    Component: ContentScreen,
+    element: <ContentScreen />,
     options: {
       headerConfig: {
         title: 'Lift on scroll',

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-stack-svm-tabs-special-effects/index.tsx
@@ -24,7 +24,7 @@ export function TestStackSvmTabsSpecialEffects() {
 const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Home',
-    Component: TabContents,
+    element: <TabContents />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -34,7 +34,7 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Stack',
-    Component: StackTabScreen,
+    element: <StackTabScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Stack',
@@ -47,11 +47,11 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'First',
-    Component: StackContents,
+    element: <StackContents />,
   },
   {
     name: 'Second',
-    Component: StackContents,
+    element: <StackContents />,
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/scroll-view-marker/test-svm-tabs-scroll-edge-effects/index.tsx
+++ b/apps/src/tests/component-integration-tests/scroll-view-marker/test-svm-tabs-scroll-edge-effects/index.tsx
@@ -20,7 +20,7 @@ export function TestSvmTabsScrollEdgeEffects() {
 const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Home',
-    Component: TabContents,
+    element: <TabContents />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -28,7 +28,7 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Second',
-    Component: TabContents,
+    element: <TabContents />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Second',

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-stack-in-tabs-base-navigation/index.tsx
@@ -20,7 +20,7 @@ import { Colors } from '@apps/shared/styling';
 const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
-    Component: FirstTabScreen,
+    element: <FirstTabScreen />,
     options: {
       title: 'First',
       ...DEFAULT_TAB_ROUTE_OPTIONS,
@@ -28,7 +28,7 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Second',
-    Component: SecondTabScreen,
+    element: <SecondTabScreen />,
     options: {
       title: 'Second',
       ...DEFAULT_TAB_ROUTE_OPTIONS,
@@ -36,7 +36,7 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Stack',
-    Component: StackTabScreen,
+    element: <StackTabScreen />,
     options: {
       title: 'Stack',
       ...DEFAULT_TAB_ROUTE_OPTIONS,
@@ -47,15 +47,15 @@ const TABS_ROUTE_CONFIGS: TabRouteConfig[] = [
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'First',
-    Component: FirstStackScreen,
+    element: <FirstStackScreen />,
   },
   {
     name: 'Second',
-    Component: SecondStackScreen,
+    element: <SecondStackScreen />,
   },
   {
     name: 'Third',
-    Component: ThirdStackScreen,
+    element: <ThirdStackScreen />,
   },
 ];
 

--- a/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-tabs-in-stack-stable-enter-transition/index.tsx
+++ b/apps/src/tests/component-integration-tests/tabs-stack-v5/test-stack-tabs-tabs-in-stack-stable-enter-transition/index.tsx
@@ -47,7 +47,7 @@ function SettingsTab() {
 const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'HomeTab',
-    Component: HomeTab,
+    element: <HomeTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -60,7 +60,7 @@ const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'SettingsTab',
-    Component: SettingsTab,
+    element: <SettingsTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Settings',
@@ -80,14 +80,14 @@ function NestedTabsScreen() {
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'First',
-    Component: FirstScreen,
+    element: <FirstScreen />,
     options: {
       headerConfig: { title: 'First' },
     },
   },
   {
     name: 'NestedTabs',
-    Component: NestedTabsScreen,
+    element: <NestedTabsScreen />,
     options: {
       headerConfig: { title: 'Nested Tabs' },
     },

--- a/apps/src/tests/issue-tests/Test3168.tsx
+++ b/apps/src/tests/issue-tests/Test3168.tsx
@@ -199,7 +199,7 @@ function TabsStackComponent() {
   const TAB_CONFIGS: TabRouteConfig[] = [
     {
       name: 'main',
-      Component: () => Menu({ tabsMode: true }),
+      element: <Menu tabsMode={true} />,
       options: {
         title: 'Main',
         ios: {
@@ -212,7 +212,7 @@ function TabsStackComponent() {
     },
     {
       name: 'another',
-      Component: AnotherTab,
+      element: <AnotherTab />,
       options: {
         title: 'Another',
         ios: {
@@ -225,7 +225,7 @@ function TabsStackComponent() {
     },
     {
       name: 'examples',
-      Component: () => ExamplesStackComponent({ showMenu: false }),
+      element: <ExamplesStackComponent showMenu={false} />,
       options: {
         title: 'Search',
         ios: {

--- a/apps/src/tests/issue-tests/Test3212/StackInTabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/StackInTabsScenario.tsx
@@ -36,12 +36,12 @@ export function StackInTabsScenario() {
           routeConfigs={[
             {
               name: 'config',
-              Component: ConfigComponent,
+              element: <ConfigComponent />,
               options: { title: 'Config' },
             },
             {
               name: 'stack',
-              Component: StackScenario,
+              element: <StackScenario />,
               options: {
                 title: 'Stack',
               },

--- a/apps/src/tests/issue-tests/Test3212/TabsScenario.tsx
+++ b/apps/src/tests/issue-tests/Test3212/TabsScenario.tsx
@@ -35,12 +35,12 @@ export function TabsScenario() {
             routeConfigs={[
               {
                 name: 'config',
-                Component: ConfigComponent,
+                element: <ConfigComponent />,
                 options: { title: 'Config' },
               },
               {
                 name: 'stack',
-                Component: ScrollViewTemplate,
+                element: <ScrollViewTemplate />,
                 options: {
                   title: 'Scroll',
                 },

--- a/apps/src/tests/issue-tests/Test3236.tsx
+++ b/apps/src/tests/issue-tests/Test3236.tsx
@@ -18,29 +18,27 @@ function makeTab(
   controllerMode: TabBarControllerMode,
   setControllerMode: (mode: TabBarControllerMode) => void,
 ) {
-  return function Tab() {
-    return (
-      <CenteredLayoutView>
-        <Text>{title}</Text>
-        <Button
-          title={`Change mode (currently ${controllerMode})`}
-          onPress={() => {
-            switch (controllerMode) {
-              case 'automatic':
-                setControllerMode('tabBar');
-                break;
-              case 'tabBar':
-                setControllerMode('tabSidebar');
-                break;
-              default:
-                setControllerMode('automatic');
-                break;
-            }
-          }}
-        />
-      </CenteredLayoutView>
-    );
-  };
+  return (
+    <CenteredLayoutView>
+      <Text>{title}</Text>
+      <Button
+        title={`Change mode (currently ${controllerMode})`}
+        onPress={() => {
+          switch (controllerMode) {
+            case 'automatic':
+              setControllerMode('tabBar');
+              break;
+            case 'tabBar':
+              setControllerMode('tabSidebar');
+              break;
+            default:
+              setControllerMode('automatic');
+              break;
+          }
+        }}
+      />
+    </CenteredLayoutView>
+  );
 }
 
 function App() {
@@ -54,7 +52,7 @@ function App() {
   const TAB_CONFIGS: TabRouteConfig[] = [
     {
       name: 'Tab1',
-      Component: makeTab('Tab 1', controllerMode, setControllerMode),
+      element: makeTab('Tab 1', controllerMode, setControllerMode),
       options: {
         title: 'Tab 1',
         ios: {
@@ -73,7 +71,7 @@ function App() {
     },
     {
       name: 'Tab2',
-      Component: makeTab('Tab 2', controllerMode, setControllerMode),
+      element: makeTab('Tab 2', controllerMode, setControllerMode),
       options: {
         title: 'Tab 2',
         ios: {

--- a/apps/src/tests/issue-tests/Test3288.tsx
+++ b/apps/src/tests/issue-tests/Test3288.tsx
@@ -136,7 +136,7 @@ function TestScreen() {
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: Config,
+    element: <Config />,
     options: {
       title: 'Config',
       ios: {
@@ -149,7 +149,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: TestScreen,
+    element: <TestScreen />,
     options: {
       title: 'Test',
       ios: {

--- a/apps/src/tests/issue-tests/Test3342.tsx
+++ b/apps/src/tests/issue-tests/Test3342.tsx
@@ -66,7 +66,7 @@ function Screen2(stackNavProp: StackNavigationProp) {
   const TAB_CONFIGS: TabRouteConfig[] = [
     {
       name: 'Tab1',
-      Component: () => TabScreen(stackNavProp),
+      element: <TabScreen {...stackNavProp} />,
       options: {
         title: 'Tab 1',
         ios: {
@@ -80,7 +80,7 @@ function Screen2(stackNavProp: StackNavigationProp) {
     },
     {
       name: 'Tab2',
-      Component: () => TabScreen(stackNavProp),
+      element: <TabScreen {...stackNavProp} />,
       options: {
         title: 'Tab 2',
         ios: {

--- a/apps/src/tests/issue-tests/Test3443.tsx
+++ b/apps/src/tests/issue-tests/Test3443.tsx
@@ -8,7 +8,7 @@ import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
 import { Text } from 'react-native';
 
 function makeTab(title: string, description: string) {
-  return () => (
+  return (
     <CenteredLayoutView>
       <Text style={{ fontWeight: 'bold' }}>{title}</Text>
       <Text style={{ textAlign: 'center' }}>{description}</Text>
@@ -19,7 +19,7 @@ function makeTab(title: string, description: string) {
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: makeTab(
+    element: makeTab(
       'Tab 1',
       'Tab icon is from Xcassets.\nOnly icon prop is defined.',
     ),
@@ -35,7 +35,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: makeTab(
+    element: makeTab(
       'Tab 2',
       'Tab icon is from Xcassets.\nBoth icon and selectedIcon props are defined.',
     ),

--- a/apps/src/tests/issue-tests/Test3492.tsx
+++ b/apps/src/tests/issue-tests/Test3492.tsx
@@ -489,7 +489,7 @@ function ScreenTab4() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       title: 'Config',
       ios: {
@@ -503,7 +503,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: ScreenTab2,
+    element: <ScreenTab2 />,
     options: {
       title: 'Tab 2',
       ios: {
@@ -517,7 +517,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: ScreenTab3,
+    element: <ScreenTab3 />,
     options: {
       title: 'Tab 3',
       ios: { icon: { type: 'sfSymbol', name: 'triangle' } },
@@ -526,7 +526,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab4',
-    Component: ScreenTab4,
+    element: <ScreenTab4 />,
     options: {
       title: 'Tab 4',
       ios: {

--- a/apps/src/tests/issue-tests/Test3576.tsx
+++ b/apps/src/tests/issue-tests/Test3576.tsx
@@ -175,11 +175,11 @@ const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 const routeConfigs: StackRouteConfig[] = [
   {
     name: 'Menu',
-    Component: MenuScreen,
+    element: <MenuScreen />,
   },
   ...ALPHABET.map(name => ({
     name,
-    Component: TemplateScreen,
+    element: <TemplateScreen />,
   })),
 ];
 

--- a/apps/src/tests/issue-tests/Test3596.tsx
+++ b/apps/src/tests/issue-tests/Test3596.tsx
@@ -18,19 +18,17 @@ enableFreeze(true);
 const ICON = require('@assets/variableIcons/globe_oversized.png');
 
 function makeTab(title: string) {
-  return function Tab() {
-    return (
-      <CenteredLayoutView style={{ backgroundColor: Colors.PurpleLight60 }}>
-        <Text>{title}</Text>
-      </CenteredLayoutView>
-    );
-  };
+  return (
+    <CenteredLayoutView style={{ backgroundColor: Colors.PurpleLight60 }}>
+      <Text>{title}</Text>
+    </CenteredLayoutView>
+  );
 }
 
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: makeTab('Tab 1'),
+    element: makeTab('Tab 1'),
     options: {
       title: 'Tab 1',
       ios: {
@@ -49,7 +47,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: makeTab('Tab 2'),
+    element: makeTab('Tab 2'),
     options: {
       title: 'Tab 2',
       ios: {
@@ -68,7 +66,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: makeTab('Tab 3'),
+    element: makeTab('Tab 3'),
     options: {
       title: 'Tab 3',
       ios: {

--- a/apps/src/tests/issue-tests/Test4027.tsx
+++ b/apps/src/tests/issue-tests/Test4027.tsx
@@ -38,7 +38,7 @@ function Screen1({ navigation }: StackNavigationProp) {
       routeConfigs={[
         {
           name: 'Tab1',
-          Component: () => TabsScreen({ navigation }),
+          element: <TabsScreen navigation={navigation} />,
           options: {
             ...DEFAULT_TAB_ROUTE_OPTIONS,
             title: 'Tab1',
@@ -46,7 +46,7 @@ function Screen1({ navigation }: StackNavigationProp) {
         },
         {
           name: 'Tab2',
-          Component: () => TabsScreen({ navigation }),
+          element: <TabsScreen navigation={navigation} />,
           options: {
             ...DEFAULT_TAB_ROUTE_OPTIONS,
             title: 'Tab2',
@@ -54,7 +54,7 @@ function Screen1({ navigation }: StackNavigationProp) {
         },
         {
           name: 'Tab3',
-          Component: () => TabsScreen({ navigation }),
+          element: <TabsScreen navigation={navigation} />,
           options: {
             ...DEFAULT_TAB_ROUTE_OPTIONS,
             title: 'Tab3',

--- a/apps/src/tests/issue-tests/Test4155.tsx
+++ b/apps/src/tests/issue-tests/Test4155.tsx
@@ -48,7 +48,7 @@ export function ExploreTab() {
 const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Home',
-    Component: HomeTab,
+    element: <HomeTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -56,7 +56,7 @@ const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Explore',
-    Component: ExploreTab,
+    element: <ExploreTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Explore',
@@ -83,11 +83,11 @@ export function TestScreen() {
 const STACK_ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'Tabs',
-    Component: TabsScreen,
+    element: <TabsScreen />,
   },
   {
     name: 'Test',
-    Component: TestScreen,
+    element: <TestScreen />,
     options: {
       headerConfig: {
         title: 'Test',

--- a/apps/src/tests/issue-tests/Test4161.tsx
+++ b/apps/src/tests/issue-tests/Test4161.tsx
@@ -62,7 +62,7 @@ function SettingsTab() {
 const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'HomeTab',
-    Component: HomeTab,
+    element: <HomeTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -75,7 +75,7 @@ const TAB_ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'SettingsTab',
-    Component: SettingsTab,
+    element: <SettingsTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Settings',

--- a/apps/src/tests/issue-tests/Test4240.tsx
+++ b/apps/src/tests/issue-tests/Test4240.tsx
@@ -74,7 +74,7 @@ function TabContentWrapper() {
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'HomeTab',
-    Component: TabContentWrapper,
+    element: <TabContentWrapper />,
     options: {
       title: 'Tab',
     },

--- a/apps/src/tests/issue-tests/Test4258.tsx
+++ b/apps/src/tests/issue-tests/Test4258.tsx
@@ -116,14 +116,14 @@ function SecondTab() {
   );
 }
 
-function TabsScreen({ homeTab }: { homeTab: TabRouteConfig['Component'] }) {
+function TabsScreen({ homeTab }: { homeTab: TabRouteConfig['element'] }) {
   const { dark, generation } = React.useContext(AppStateContext);
   const bg = dark ? DarkColors.background : Colors.background;
 
   const routeConfigs: TabRouteConfig[] = [
     {
       name: 'Home',
-      Component: homeTab,
+      element: homeTab,
       options: {
         ...DEFAULT_TAB_ROUTE_OPTIONS,
         title: 'Home',
@@ -143,7 +143,7 @@ function TabsScreen({ homeTab }: { homeTab: TabRouteConfig['Component'] }) {
     },
     {
       name: 'Second',
-      Component: SecondTab,
+      element: <SecondTab />,
       options: {
         ...DEFAULT_TAB_ROUTE_OPTIONS,
         title: 'Second',
@@ -197,7 +197,7 @@ function CoverScreen() {
 }
 
 function MainScreen({ navigation }: StackNavigationProp) {
-  const homeTab = () => <HomeTab navigation={navigation} />;
+  const homeTab = <HomeTab navigation={navigation} />;
   return <TabsScreen homeTab={homeTab} />;
 }
 

--- a/apps/src/tests/issue-tests/Test4265.tsx
+++ b/apps/src/tests/issue-tests/Test4265.tsx
@@ -73,7 +73,7 @@ function ProfileTab() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Home',
-    Component: HomeTab,
+    element: <HomeTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Home',
@@ -95,7 +95,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Search',
-    Component: SearchTab,
+    element: <SearchTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Search',
@@ -116,7 +116,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Profile',
-    Component: ProfileTab,
+    element: <ProfileTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Profile',

--- a/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabs/index.tsx
@@ -47,7 +47,7 @@ const DEFAULT_APPEARANCE_ANDROID: TabsScreenAppearanceAndroid = {
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: Tab1,
+    element: <Tab1 />,
     options: {
       android: {
         standardAppearance: DEFAULT_APPEARANCE_ANDROID,
@@ -92,7 +92,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: Tab2,
+    element: <Tab2 />,
     options: {
       badgeValue: 'NEW',
       testID: 'tab-screen-2-id',
@@ -176,7 +176,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: Tab3,
+    element: <Tab3 />,
     options: {
       badgeValue: '2137',
       testID: 'tab-screen-3-id',
@@ -224,7 +224,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab4',
-    Component: Tab4,
+    element: <Tab4 />,
     options: {
       testID: 'tab-screen-4-id',
       accessibilityLabel: 'Fourth Tab Screen',

--- a/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
+++ b/apps/src/tests/issue-tests/TestBottomTabsOrientation.tsx
@@ -76,9 +76,11 @@ function makeTabConfigs(
   return [
     {
       name: 'Auto',
-      Component: tabsOrientations.home.stackScreen
-        ? () => <TabElement orientation={tabsOrientations.home.stackScreen} />
-        : TabElement,
+      element: tabsOrientations.home.stackScreen ? (
+        <TabElement orientation={tabsOrientations.home.stackScreen} />
+      ) : (
+        <TabElement />
+      ),
       options: {
         title: 'Auto',
         orientation: tabsOrientations.home.tabScreen,
@@ -106,7 +108,7 @@ function makeTabConfigs(
     },
     {
       name: 'Portrait',
-      Component: () => (
+      element: (
         <TabElement orientation={tabsOrientations.portrait.stackScreen} />
       ),
       options: {
@@ -136,7 +138,7 @@ function makeTabConfigs(
     },
     {
       name: 'Landscape',
-      Component: () => (
+      element: (
         <TabElement orientation={tabsOrientations.landscape.stackScreen} />
       ),
       options: {

--- a/apps/src/tests/issue-tests/TestHeaderHeight.tsx
+++ b/apps/src/tests/issue-tests/TestHeaderHeight.tsx
@@ -464,7 +464,7 @@ function HeaderHeightTabsWrapper() {
   const TAB_CONFIGS: TabRouteConfig[] = [
     {
       name: 'Tab1',
-      Component: HeaderHeightTest,
+      element: <HeaderHeightTest />,
       options: {
         title: 'Tab 1',
         ios: {
@@ -483,7 +483,7 @@ function HeaderHeightTabsWrapper() {
     },
     {
       name: 'Tab2',
-      Component: HeaderHeightTest,
+      element: <HeaderHeightTest />,
       options: {
         title: 'Tab 2',
         ios: {

--- a/apps/src/tests/issue-tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
+++ b/apps/src/tests/issue-tests/TestSafeAreaViewIOS/split-view/ConfigColumn.tsx
@@ -17,7 +17,12 @@ export default function ConfigColumn({
     .map(index => {
       const configuration: TabRouteConfig = {
         name: 'column' + index,
-        Component: () => ConfigColumnTab({ index, configColumnIndex }),
+        element: (
+          <ConfigColumnTab
+            index={index}
+            configColumnIndex={configColumnIndex}
+          />
+        ),
         options: {
           title: 'Column ' + index,
           ios: {

--- a/apps/src/tests/issue-tests/TestSafeAreaViewIOS/tabs/TabsComponent.tsx
+++ b/apps/src/tests/issue-tests/TestSafeAreaViewIOS/tabs/TabsComponent.tsx
@@ -15,7 +15,7 @@ export default function TabsComponent() {
   const TAB_CONFIGS: TabRouteConfig[] = [
     {
       name: 'config',
-      Component: ConfigTab,
+      element: <ConfigTab />,
       options: {
         title: 'Config',
         ios: {
@@ -28,7 +28,7 @@ export default function TabsComponent() {
     },
     {
       name: 'test',
-      Component: TestTab,
+      element: <TestTab />,
       options: {
         title: 'Test',
         ios: {

--- a/apps/src/tests/issue-tests/TestScreenStack/index.tsx
+++ b/apps/src/tests/issue-tests/TestScreenStack/index.tsx
@@ -26,11 +26,11 @@ function TemplateScreen() {
 const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'A',
-    Component: TemplateScreen,
+    element: <TemplateScreen />,
   },
   {
     name: 'B',
-    Component: TemplateScreen,
+    element: <TemplateScreen />,
   },
 ];
 

--- a/apps/src/tests/issue-tests/TestStackNesting.tsx
+++ b/apps/src/tests/issue-tests/TestStackNesting.tsx
@@ -75,7 +75,7 @@ function NestedStackScreen() {
 const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'A',
-    Component: TemplateScreen,
+    element: <TemplateScreen />,
     options: {
       onWillAppear: () => console.log('A onWillAppear'),
       onWillDisappear: () => console.log('A onWillDisappear'),
@@ -85,7 +85,7 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
   },
   {
     name: 'B',
-    Component: TemplateScreen,
+    element: <TemplateScreen />,
     options: {
       onWillAppear: () => console.log('B onWillAppear'),
       onWillDisappear: () => console.log('B onWillDisappear'),
@@ -95,7 +95,7 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
   },
   {
     name: 'NestedStack',
-    Component: NestedStackScreen,
+    element: <NestedStackScreen />,
     options: {
       onWillAppear: () => console.log('NestedStack onWillAppear'),
       onWillDisappear: () => console.log('NestedStack onWillDisappear'),
@@ -108,11 +108,11 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
 const ROUTE_CONFIGS_NESTED_STACK: StackRouteConfig[] = [
   {
     name: 'NestedA',
-    Component: NestedTemplateScreen,
+    element: <NestedTemplateScreen />,
   },
   {
     name: 'NestedB',
-    Component: NestedTemplateScreen,
+    element: <NestedTemplateScreen />,
   },
 ];
 

--- a/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-to-top-guard/test-scroll-to-top-guard-header-subviews-ios/index.tsx
@@ -151,7 +151,7 @@ function TestScrollToTopGuardHeaderSubviewsIOS() {
       routeConfigs={[
         {
           name: 'Screen1',
-          Component: Screen1,
+          element: <Screen1 />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
+++ b/apps/src/tests/single-feature-tests/scroll-view-marker/test-svm-configures-scroll-view/index.tsx
@@ -14,7 +14,7 @@ function TestSvmConfiguresScrollView() {
       routeConfigs={[
         {
           name: 'Content',
-          Component: ContentScreen,
+          element: <ContentScreen />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/index.tsx
@@ -16,19 +16,19 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
         },
         {
           name: 'Blue',
-          Component: BlueScreen,
+          element: <BlueScreen />,
         },
         {
           name: 'Red',
-          Component: RedScreen,
+          element: <RedScreen />,
         },
         {
           name: 'NestedHost',
-          Component: NestedHostScreen,
+          element: <NestedHostScreen />,
         },
       ]}
     />
@@ -74,15 +74,15 @@ function NestedHostScreen() {
       routeConfigs={[
         {
           name: 'NestedHome',
-          Component: NestedHomeScreen,
+          element: <NestedHomeScreen />,
         },
         {
           name: 'NestedBlue',
-          Component: NestedBlueScreen,
+          element: <NestedBlueScreen />,
         },
         {
           name: 'NestedRed',
-          Component: NestedRedScreen,
+          element: <NestedRedScreen />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-android/index.tsx
@@ -117,11 +117,11 @@ function TestStackBackButton() {
         routeConfigs={[
           {
             name: 'Root',
-            Component: RootScreen,
+            element: <RootScreen />,
           },
           {
             name: 'Pushed',
-            Component: PushedScreen,
+            element: <PushedScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-icon-ios/index.tsx
@@ -223,7 +223,7 @@ function TestStackHeaderIconIOS() {
         routeConfigs={[
           {
             name: 'Home',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -91,7 +91,7 @@ function TestStackHeaderMenuIOS() {
         routeConfigs={[
           {
             name: 'Home',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-options-ios/index.tsx
@@ -15,7 +15,7 @@ function TestStackHeaderMenuOptionsIOS() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: ConfigScreen,
+          element: <ConfigScreen />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios/index.tsx
@@ -140,7 +140,7 @@ export function TestStackHeaderSelectiveUpdatesIOS() {
         routeConfigs={[
           {
             name: 'Home',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios/index.tsx
@@ -20,7 +20,7 @@ export function TestStackHeaderSubviewsOnpressIOS() {
         routeConfigs={[
           {
             name: 'Home',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lifecycle-events/index.tsx
@@ -57,7 +57,7 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
           options: {
             ...makeCallbacks('Home'),
             headerConfig: {
@@ -67,7 +67,7 @@ function StackSetup() {
         },
         {
           name: 'A',
-          Component: AScreen,
+          element: <AScreen />,
           options: {
             ...makeCallbacks('A'),
             headerConfig: {
@@ -77,7 +77,7 @@ function StackSetup() {
         },
         {
           name: 'NestedStack',
-          Component: NestedStackScreen,
+          element: <NestedStackScreen />,
           options: {
             ...makeCallbacks('NestedStack'),
             headerConfig: {
@@ -121,7 +121,7 @@ function NestedStackScreen() {
       routeConfigs={[
         {
           name: 'NestedHome',
-          Component: NestedHomeScreen,
+          element: <NestedHomeScreen />,
           options: {
             ...makeCallbacks('NestedHome'),
             headerConfig: {
@@ -131,7 +131,7 @@ function NestedStackScreen() {
         },
         {
           name: 'NestedA',
-          Component: NestedAScreen,
+          element: <NestedAScreen />,
           options: {
             ...makeCallbacks('NestedA'),
             headerConfig: {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android/index.tsx
@@ -55,7 +55,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
 function TestStackLiftOnScrollAndroid() {
   return (
     <StackContainer
-      routeConfigs={[{ name: 'Home', Component: ConfigScreen }]}
+      routeConfigs={[{ name: 'Home', element: <ConfigScreen /> }]}
     />
   );
 }

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/index.tsx
@@ -28,11 +28,11 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
         },
         {
           name: 'A',
-          Component: AScreen,
+          element: <AScreen />,
           options: {
             headerConfig: {
               title: 'A',
@@ -41,7 +41,7 @@ function StackSetup() {
         },
         {
           name: 'B',
-          Component: BScreen,
+          element: <BScreen />,
           options: {
             preventNativeDismiss: true,
             onNativeDismissPrevented: () => {
@@ -58,7 +58,7 @@ function StackSetup() {
         },
         {
           name: 'NestedStack',
-          Component: NestedStackScreen,
+          element: <NestedStackScreen />,
           options: {
             // This one is interesting. It will prevent nested stack from being popped.
             preventNativeDismiss: false,
@@ -116,7 +116,7 @@ function NestedStackScreen() {
       routeConfigs={[
         {
           name: 'NestedHome',
-          Component: NestedHomeScreen,
+          element: <NestedHomeScreen />,
           options: {
             // This one will also prevent!
             preventNativeDismiss: true,
@@ -131,7 +131,7 @@ function NestedStackScreen() {
         },
         {
           name: 'NestedA',
-          Component: NestedAScreen,
+          element: <NestedAScreen />,
           options: {
             headerConfig: {
               title: 'NestedA',
@@ -140,7 +140,7 @@ function NestedStackScreen() {
         },
         {
           name: 'NestedB',
-          Component: NestedBScreen,
+          element: <NestedBScreen />,
           options: {
             preventNativeDismiss: true,
             onNativeDismissPrevented: () => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/index.tsx
@@ -28,11 +28,11 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
         },
         {
           name: 'A',
-          Component: AScreen,
+          element: <AScreen />,
           options: {
             headerConfig: {
               title: 'A',
@@ -41,7 +41,7 @@ function StackSetup() {
         },
         {
           name: 'B',
-          Component: BScreen,
+          element: <BScreen />,
           options: {
             preventNativeDismiss: true,
             onNativeDismissPrevented: () => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-simple-nav/index.tsx
@@ -17,7 +17,7 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: HomeScreen,
+          element: <HomeScreen />,
           // Rendering a header (via headerConfig) makes the native back
           // button appear on non-root screens, including on Android. The
           // root screen (Home) always hides the back button.
@@ -29,7 +29,7 @@ function StackSetup() {
         },
         {
           name: 'A',
-          Component: AScreen,
+          element: <AScreen />,
           options: {
             headerConfig: {
               title: 'A',
@@ -38,7 +38,7 @@ function StackSetup() {
         },
         {
           name: 'B',
-          Component: BScreen,
+          element: <BScreen />,
           options: {
             headerConfig: {
               title: 'B',

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -194,7 +194,7 @@ function StackSetup() {
       routeConfigs={[
         {
           name: 'Home',
-          Component: ConfigScreen,
+          element: <ConfigScreen />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -150,11 +150,11 @@ function StackSetup() {
         routeConfigs={[
           {
             name: 'Home',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
           {
             name: 'Second',
-            Component: ConfigScreen,
+            element: <ConfigScreen />,
           },
         ]}
       />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android/index.tsx
@@ -79,7 +79,7 @@ function TestStackToolbarMenuA11y() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -81,7 +81,7 @@ function TestStackToolbarMenuBatchCommands() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android/index.tsx
@@ -97,7 +97,7 @@ function TestStackToolbarMenuCommands() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android/index.tsx
@@ -138,7 +138,7 @@ function TestStackToolbarMenuDisabled() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android/index.tsx
@@ -180,7 +180,7 @@ function TestStackToolbarMenuGroups() {
         routeConfigs={[
           {
             name: 'Main',
-            Component: MainScreen,
+            element: <MainScreen />,
             options: {
               headerConfig: {
                 title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/index.tsx
@@ -162,7 +162,7 @@ function TestStackToolbarMenuIcon() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android/index.tsx
@@ -119,7 +119,7 @@ function TestStackToolbarMenuShowAsAction() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android/index.tsx
@@ -167,7 +167,7 @@ function TestStackToolbarMenuTitle() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android/index.tsx
@@ -180,7 +180,7 @@ function TestStackToolbarNestedMenu() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
           options: {
             headerConfig: {
               title: HEADER_TITLE,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/index.tsx
@@ -161,7 +161,7 @@ function TestTabsAppearanceDefinedBySelectedTab() {
       routeConfigs={[
         {
           name: 'Tab1',
-          Component: TabScreen,
+          element: <TabScreen />,
           options: {
             title: 'Tab1',
             ios: {
@@ -191,7 +191,7 @@ function TestTabsAppearanceDefinedBySelectedTab() {
         },
         {
           name: 'Tab2',
-          Component: TabScreen,
+          element: <TabScreen />,
           options: {
             title: 'Tab2',
             ios: {
@@ -235,7 +235,7 @@ function TestTabsAppearanceDefinedBySelectedTab() {
         },
         {
           name: 'Tab3',
-          Component: TabScreen,
+          element: <TabScreen />,
           options: {
             title: 'Tab3',
             badgeValue: '123',
@@ -262,7 +262,7 @@ function TestTabsAppearanceDefinedBySelectedTab() {
         },
         {
           name: 'Tab4',
-          Component: TabScreen,
+          element: <TabScreen />,
           options: {
             title: 'Tab4',
             badgeValue: 'Platform',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios/index.tsx
@@ -180,7 +180,7 @@ function ScrollUpTab() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Config',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Config',
@@ -190,7 +190,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'ScrollDown',
-    Component: ScrollDownTab,
+    element: <ScrollDownTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'ScrollDown',
@@ -200,7 +200,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'ScrollUp',
-    Component: ScrollUpTab,
+    element: <ScrollUpTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'ScrollUp',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
@@ -50,7 +50,7 @@ function ConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Config',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Config',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-android/index.tsx
@@ -113,7 +113,7 @@ function IndicatorTab() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Default',
-    Component: DefaultTab,
+    element: <DefaultTab />,
     options: {
       title: 'Default',
       tabBarItemTestID: 'general-appearance-android-tab-default',
@@ -124,7 +124,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Label',
-    Component: LabelTab,
+    element: <LabelTab />,
     options: {
       title: 'Label',
       tabBarItemTestID: 'general-appearance-android-tab-label',
@@ -138,7 +138,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Ripple',
-    Component: RippleTab,
+    element: <RippleTab />,
     options: {
       title: 'Ripple',
       tabBarItemTestID: 'general-appearance-android-tab-ripple',
@@ -156,7 +156,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Indicator',
-    Component: IndicatorTab,
+    element: <IndicatorTab />,
     options: {
       title: 'Indicator',
       tabBarItemTestID: 'general-appearance-android-tab-indicator',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/index.tsx
@@ -266,7 +266,7 @@ function Tab3Screen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: Tab1Screen,
+    element: <Tab1Screen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -277,7 +277,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: Tab2Screen,
+    element: <Tab2Screen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',
@@ -290,7 +290,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: Tab3Screen,
+    element: <Tab3Screen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab3',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-ime-insets-android/index.tsx
@@ -68,7 +68,7 @@ function ConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Config',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Config',
@@ -82,7 +82,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: DummyScreen,
+    element: <DummyScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/index.tsx
@@ -185,7 +185,7 @@ function Tab4Screen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: Tab1Screen,
+    element: <Tab1Screen />,
     options: {
       title: 'Tab1',
       badgeValue: Platform.OS === 'ios' ? '1' : '',
@@ -203,7 +203,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: Tab2Screen,
+    element: <Tab2Screen />,
     options: {
       title: 'Tab2',
       badgeValue: '1234567890',
@@ -233,7 +233,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: Tab3Screen,
+    element: <Tab3Screen />,
     options: {
       title: 'Tab3',
       badgeValue: 'NEW!',
@@ -259,7 +259,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab4',
-    Component: Tab4Screen,
+    element: <Tab4Screen />,
     options: {
       title: 'Tab4',
       badgeValue: '⚠️',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/index.tsx
@@ -156,7 +156,7 @@ function ImageTab() {
 const IOS_ROUTES: TabRouteConfig[] = [
   {
     name: 'Tint',
-    Component: TintTab,
+    element: <TintTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tint',
@@ -174,7 +174,7 @@ const IOS_ROUTES: TabRouteConfig[] = [
   },
   {
     name: 'Override',
-    Component: OverrideTab,
+    element: <OverrideTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Override',
@@ -199,7 +199,7 @@ const IOS_ROUTES: TabRouteConfig[] = [
   },
   {
     name: 'XcassetIcon',
-    Component: XcassetDrawableResourceTab,
+    element: <XcassetDrawableResourceTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Xcasset',
@@ -213,7 +213,7 @@ const IOS_ROUTES: TabRouteConfig[] = [
   },
   {
     name: 'Image',
-    Component: ImageTab,
+    element: <ImageTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Image',
@@ -241,7 +241,7 @@ const IOS_ROUTES: TabRouteConfig[] = [
 const ANDROID_ROUTES: TabRouteConfig[] = [
   {
     name: 'DrawableResource',
-    Component: XcassetDrawableResourceTab,
+    element: <XcassetDrawableResourceTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'DrawableResource',
@@ -259,7 +259,7 @@ const ANDROID_ROUTES: TabRouteConfig[] = [
   },
   {
     name: 'Image',
-    Component: ImageTab,
+    element: <ImageTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Image',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-title/index.tsx
@@ -130,7 +130,7 @@ function LongTitleTab() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'LongTitle',
-    Component: LongTitleTab,
+    element: <LongTitleTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'A Very Long Tab Title That Should Truncate',
@@ -138,7 +138,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Color',
-    Component: ColorTab,
+    element: <ColorTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Color',
@@ -176,7 +176,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'FontConfig',
-    Component: FontTab,
+    element: <FontTab />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Font',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-layout-appearances-ios/index.tsx
@@ -124,8 +124,6 @@ function TabScreen({ name }: { name: string }) {
   );
 }
 
-const createTabScreen = (name: string) => () => <TabScreen name={name} />;
-
 const SHARED_IOS_OPTIONS = {
   ...DEFAULT_TAB_ROUTE_OPTIONS.ios,
   standardAppearance: APPEARANCE,
@@ -135,7 +133,7 @@ const SHARED_IOS_OPTIONS = {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Info',
-    Component: InfoScreen,
+    element: <InfoScreen />,
     options: {
       title: 'Info',
       ios: {
@@ -148,7 +146,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab1',
-    Component: createTabScreen('Tab 1'),
+    element: <TabScreen name="Tab 1" />,
     options: {
       title: 'Tab1',
       tabBarItemTestID: 'tab-item-title-style-tab1',
@@ -160,7 +158,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: createTabScreen('Tab 2'),
+    element: <TabScreen name="Tab 2" />,
     options: {
       title: 'Tab2',
       tabBarItemTestID: 'tab-item-title-style-tab2',
@@ -172,7 +170,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: createTabScreen('Tab 3'),
+    element: <TabScreen name="Tab 3" />,
     options: {
       title: 'Tab3',
       tabBarItemTestID: 'tab-item-title-style-tab3',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-lifecycle-events/index.tsx
@@ -60,7 +60,7 @@ function AppContents() {
     () => [
       {
         name: 'TabA',
-        Component: TabScreen,
+        element: <TabScreen />,
         options: {
           ...DEFAULT_TAB_ROUTE_OPTIONS,
           tabBarItemTestID: 'tab-a-item',
@@ -71,7 +71,7 @@ function AppContents() {
       },
       {
         name: 'TabB',
-        Component: TabScreen,
+        element: <TabScreen />,
         options: {
           ...DEFAULT_TAB_ROUTE_OPTIONS,
           tabBarItemTestID: 'tab-b-item',
@@ -82,7 +82,7 @@ function AppContents() {
       },
       {
         name: 'TabC',
-        Component: TabScreen,
+        element: <TabScreen />,
         options: {
           ...DEFAULT_TAB_ROUTE_OPTIONS,
           tabBarItemTestID: 'tab-c-item',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-more-navigation-controller-ios/index.tsx
@@ -46,32 +46,32 @@ function TabsNavigationButtons() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'First' },
   },
   {
     name: 'Second',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Second' },
   },
   {
     name: 'Third',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Third' },
   },
   {
     name: 'Fourth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fourth' },
   },
   {
     name: 'Fifth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Fifth' },
   },
   {
     name: 'Sixth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Sixth' },
   },
 ];

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-native-container-style/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-native-container-style/index.tsx
@@ -103,7 +103,7 @@ function TabScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Config',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Config',
@@ -127,7 +127,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Transparent',
-    Component: TabScreen,
+    element: <TabScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Transparent',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios/index.tsx
@@ -52,7 +52,7 @@ function TestTabsOverrideScrollViewContentInset() {
           routeConfigs={[
             {
               name: 'False',
-              Component: FalseTab,
+              element: <FalseTab />,
               options: {
                 title: 'False',
                 tabBarItemAccessibilityLabel: 'override-inset-tab-false',
@@ -64,7 +64,7 @@ function TestTabsOverrideScrollViewContentInset() {
             },
             {
               name: 'True',
-              Component: TrueTab,
+              element: <TrueTab />,
               options: {
                 title: 'True',
                 tabBarItemAccessibilityLabel: 'override-inset-tab-true',
@@ -76,7 +76,7 @@ function TestTabsOverrideScrollViewContentInset() {
             },
             {
               name: 'Default',
-              Component: DefaultTab,
+              element: <DefaultTab />,
               options: {
                 title: 'Default',
                 tabBarItemAccessibilityLabel: 'override-inset-tab-default',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-prevent-native-selection/index.tsx
@@ -98,32 +98,32 @@ const ROUTE_OPTIONS: TabRouteOptions = {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'First', tabBarItemTestID: 'First' },
   },
   {
     name: 'Second',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'Second', tabBarItemTestID: 'Second' },
   },
   {
     name: 'Third',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'Third', tabBarItemTestID: 'Third' },
   },
   {
     name: 'Fourth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'Fourth', tabBarItemTestID: 'Fourth' },
   },
   {
     name: 'Fifth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'Fifth', tabBarItemTestID: 'Fifth' },
   },
   {
     name: 'Sixth',
-    Component: ContentView,
+    element: <ContentView />,
     options: { ...ROUTE_OPTIONS, title: 'Sixth', tabBarItemTestID: 'Sixth' },
   },
 ];

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-screen-orientation/index.tsx
@@ -34,7 +34,7 @@ function ConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -42,7 +42,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: DummyScreen,
+    element: <DummyScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-simple-nav/index.tsx
@@ -51,7 +51,7 @@ function TabsNavigationButtons() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'First',
@@ -61,7 +61,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Second',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Second',
@@ -70,7 +70,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Third',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Third',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-special-effects-scroll-to-top/index.tsx
@@ -37,7 +37,7 @@ function ScrollScreen({ tabName }: ScrollScreenProps) {
 const TAB_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: () => <ScrollScreen tabName="tab1" />,
+    element: <ScrollScreen tabName="tab1" />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -52,7 +52,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: () => <ScrollScreen tabName="tab2" />,
+    element: <ScrollScreen tabName="tab2" />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',
@@ -67,7 +67,7 @@ const TAB_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab3',
-    Component: () => <ScrollScreen tabName="tab3" />,
+    element: <ScrollScreen tabName="tab3" />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab3',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-stale-update-rejection/index.tsx
@@ -91,7 +91,7 @@ function TabsNavigationButtons() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'First',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'First',
@@ -101,7 +101,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Second',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Second',
@@ -111,7 +111,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Third',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Third',
@@ -121,7 +121,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Fourth',
-    Component: ContentView,
+    element: <ContentView />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Fourth',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-system-item-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-system-item-ios/index.tsx
@@ -189,7 +189,7 @@ function RuntimeConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'StaticSystemItem',
-    Component: StaticSystemItemScreen,
+    element: <StaticSystemItemScreen />,
     options: {
       tabBarItemTestID: 'bookmark-tab-item',
       ios: {
@@ -199,7 +199,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'RuntimeConfig',
-    Component: RuntimeConfigScreen,
+    element: <RuntimeConfigScreen />,
     options: {
       tabBarItemTestID: 'custom-tab-item',
       ios: {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
@@ -82,7 +82,7 @@ function TestScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Config',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Config',
@@ -95,7 +95,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Keyboard',
-    Component: TestScreen,
+    element: <TestScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Keyboard',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios/index.tsx
@@ -53,7 +53,7 @@ function TestScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -61,7 +61,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: TestScreen,
+    element: <TestScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/ThemeScreen.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/ThemeScreen.tsx
@@ -87,7 +87,7 @@ export function InterfaceStyleScreen({ style }: { style: InterfaceStyle }) {
 
   const routeConfigs: TabRouteConfig[] = icons.map((icon, i) => ({
     name: `Tab${i + 1}`,
-    Component: () => <ThemedTabContent style={style} />,
+    element: <ThemedTabContent style={style} />,
     options: {
       title: `Tab${i + 1}`,
       ios: {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/index.tsx
@@ -40,11 +40,11 @@ function LightRootScreenContent() {
 }
 
 const ROUTE_CONFIGS: StackRouteConfig[] = [
-  { name: 'home', Component: HomeScreen },
-  { name: 'darkRoot', Component: DarkRootScreenContent },
-  { name: 'darkPushed', Component: DarkInterfaceStyleScreen },
-  { name: 'lightRoot', Component: LightRootScreenContent },
-  { name: 'lightPushed', Component: LightInterfaceStyleScreen },
+  { name: 'home', element: <HomeScreen /> },
+  { name: 'darkRoot', element: <DarkRootScreenContent /> },
+  { name: 'darkPushed', element: <DarkInterfaceStyleScreen /> },
+  { name: 'lightRoot', element: <LightRootScreenContent /> },
+  { name: 'lightPushed', element: <LightInterfaceStyleScreen /> },
 ];
 
 function TestTabsTabBarExperimentalUserInterfaceStyle() {

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
@@ -32,7 +32,7 @@ function ConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       tabBarItemTestID: 'tab-bar-item-1-id',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction/index.tsx
@@ -122,7 +122,7 @@ function ConfigScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -136,7 +136,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: DummyScreen,
+    element: <DummyScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-minimize-behavior-ios/index.tsx
@@ -51,7 +51,7 @@ function TestScreen() {
 const ROUTE_CONFIGS: TabRouteConfig[] = [
   {
     name: 'Tab1',
-    Component: ConfigScreen,
+    element: <ConfigScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab1',
@@ -59,7 +59,7 @@ const ROUTE_CONFIGS: TabRouteConfig[] = [
   },
   {
     name: 'Tab2',
-    Component: TestScreen,
+    element: <TestScreen />,
     options: {
       ...DEFAULT_TAB_ROUTE_OPTIONS,
       title: 'Tab2',


### PR DESCRIPTION
## Description

This PR implements [RFC 1671](https://github.com/software-mansion/react-native-screens-labs/blob/main-issue-tracker/rfcs/1671-migration-from-component-to-element.md). 

It migrates `TabsContainer` and `StackContainer` route configs from`React.ComponentType` to `React.ReactElement`. 

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1730

## Changes

Update the route config types, look up elements by name, and render `{element}` instead of `<Component />`.

Rename and update:
- `apps/src/shared/containers/shared/use-components-by-name.ts` to `apps/src/shared/containers/shared/use-elements-by-name.ts`

Update: 
- `apps/src/shared/containers/stack/reducer.tsx`
- `apps/src/shared/containers/stack/StackContainer.tsx`
- `apps/src/shared/containers/stack/StackContainer.types.ts`
- `apps/src/shared/containers/tabs/reducer.tsx`
- `apps/src/shared/containers/tabs/TabsContainer.tsx`
- `apps/src/shared/containers/tabs/TabsContainer.types.tsx`
- `apps/src/shared/containers/tabs/TabsContainerItem.tsx`
- `apps/src/shared/containers/tabs/TabsContainerItem.types.ts`
- all tests that use these containers

## Test plan
Verify all `component-integration-tests` and `issue-tests`.
From `single-feature-tests`, check:
- `test-stack-lifecycle-events` — appear/disappear events fire without remount
- `test-tabs-lifecycle-events` — tab-switch lifecycle events fire without remount
- `test-stack-simple-nav` — basic push and pop still work
- `test-stack-prevent-native-dismiss-nested-stack` — nested stack intercepts native back
- `test-stack-header-selective-updates-ios` — header updates rebuild only the changed item
- `test-stack-animation-android` — push/pop animations across multiple routes
- `test-tabs-stale-update-rejection` — native rejects superseded tab state updates
- `test-tabs-appearance-defined-by-selected-tab` — tab bar style follows the selected tab
- `test-tabs-special-effects-scroll-to-top` — re-tapping a tab preserves scroll position
- `test-tabs-tab-bar-experimental-user-interface-style-ios` — forced light/dark chrome without remounting tabs

The remaining `single-feature-tests` only differ in route options, not in how screens are mounted, so they are covered by the same `element` rendering path.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
