### PR TITLE
fix(Android, Tabs): expose tab item testID as viewIdResourceName

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/tabs/host/TabsHostA11yCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/host/TabsHostA11yCoordinator.kt
@@ -3,6 +3,9 @@ package com.swmansion.rnscreens.tabs.host
 import android.os.Build
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.children
 import androidx.core.view.get
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -23,8 +26,26 @@ class TabsHostA11yCoordinator(
             menuItem.contentDescription = tabsScreen.tabBarItemAccessibilityLabel
         }
 
-        // when matching view by id, espresso driver seems to look for tag property
-        findTabItemView(menuItem.itemId)?.tag = tabsScreen.tabBarItemTestID
+        findTabItemView(menuItem.itemId)?.let { tabItemView ->
+            // when matching view by id, espresso driver seems to look for tag property
+            tabItemView.tag = tabsScreen.tabBarItemTestID
+
+            // UiAutomator-based drivers (Maestro, Appium) read the node's viewIdResourceName instead,
+            // so expose the testID there as well — this is what React Native's ReactAccessibilityDelegate
+            // does for every other view. Read through to the screen so a prop update is reflected.
+            ViewCompat.setAccessibilityDelegate(
+                tabItemView,
+                object : AccessibilityDelegateCompat() {
+                    override fun onInitializeAccessibilityNodeInfo(
+                        host: View,
+                        info: AccessibilityNodeInfoCompat,
+                    ) {
+                        super.onInitializeAccessibilityNodeInfo(host, info)
+                        info.viewIdResourceName = tabsScreen.tabBarItemTestID
+                    }
+                },
+            )
+        }
     }
 
     // Third-party SDKs can freely assign their own ids to id-less views in CustomBottomNavigationView's subtree and there is no way to


### PR DESCRIPTION
## Description

Closes #4496.

A bottom tab item's `testID` is written to the view's `tag` property only:

```kotlin
// when matching view by id, espresso driver seems to look for tag property
findTabItemView(menuItem.itemId)?.tag = tabsScreen.tabBarItemTestID
```

As the comment says, that works for Espresso. But UiAutomator-based drivers — Maestro and Appium — match on `AccessibilityNodeInfo.getViewIdResourceName()` (exposed as `resource-id`) and never read the view tag. For them the id is invisible, and a selector silently matches nothing rather than failing loudly, which reads as a flaky tap.

This is inconsistent with the rest of React Native. `ReactAccessibilityDelegate` does `info.viewIdResourceName = testId` for every ordinary view, which is why `id` selectors work everywhere else in an RN app on Android but stop working on native tab items specifically.

Worth noting the intent behind the prop: the JS-side counterpart, expo/expo#47472, added `testID` to `NativeTabs.Trigger` explicitly "so native tabs can be matched in end-to-end tests". On Android that currently only holds for Espresso.

## Changes

- `TabsHostA11yCoordinator.setA11yPropertiesToTabItem` now also sets `viewIdResourceName` on the tab item's accessibility node, via a `AccessibilityDelegateCompat`.
- The existing `tag` assignment is kept, so Espresso is unaffected.
- `super.onInitializeAccessibilityNodeInfo` is called first, so Material's own node population — including the `contentDescription` and the "tab, N of M" announcement — is preserved.
- The delegate reads `tabsScreen.tabBarItemTestID` at node-init time rather than capturing it, so a prop update is reflected without reinstalling the delegate.

No public API change, and no visual change, so the visual documentation section is omitted.

## Test plan

Verified on a Pixel 8 emulator (API 34) against `react-native-screens` 4.26.2 applied as a patch, with `expo-router` 57.0.11 `unstable-native-tabs` and Maestro 2.6.0. The same change against `main`'s shape is what this PR contains; `ktlint 1.3.0` (matching `android/spotless.gradle`) reports clean on the modified file.

Minimal example:

```tsx
import { NativeTabs } from 'expo-router/unstable-native-tabs';

export default function Layout() {
  return (
    <NativeTabs>
      <NativeTabs.Trigger name="index" testID="tab-home">
        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
        <NativeTabs.Trigger.Icon md="home" />
      </NativeTabs.Trigger>
      <NativeTabs.Trigger name="search" testID="tab-search">
        <NativeTabs.Trigger.Label>Search</NativeTabs.Trigger.Label>
        <NativeTabs.Trigger.Icon md="search" />
      </NativeTabs.Trigger>
    </NativeTabs>
  );
}
```

Inspect the accessibility tree, no test framework required:

```
adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml | tr '>' '>\n' | grep navigation_bar_item
```

| | tab item nodes |
| --- | --- |
| before | no `resource-id` |
| after | `resource-id="tab-home"` / `resource-id="tab-search"` |

In both cases `content-desc` still holds the label and `selected` still tracks the active tab, so the screen-reader behaviour is unchanged. Equivalently, a Maestro step `- tapOn: { id: "tab-search" }` matches nothing before the change and taps the tab after it; in a real suite all four tabs of an app shell flow now tap by id.

I have not been able to run the repo's own Android e2e suite locally, so I would appreciate CI confirming that. Happy to add a `Test*.tsx` example under `apps/src/tests` if you would like one for this.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. *(no visual change)*
- [x] For API changes, updated relevant public types. *(no API change)*
- [ ] Ensured that CI passes *(cannot run the Android e2e suite locally; relying on CI)*