### PR TITLE
fix(Android): don't run header update for a screen detached from its stack

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt
@@ -231,7 +231,13 @@ class ScreenStackHeaderConfig(
 
     fun onUpdate() {
         val stack = screenStack
-        val isTop = stack == null || stack.topScreen == parent
+        // A screen that is not in a stack has nothing to configure a header for, and
+        // `canNavigateBack()` below asserts on exactly this condition. Treating a null
+        // stack as "is top" let a detached screen reach that assertion and throw.
+        if (stack == null) {
+            return
+        }
+        val isTop = stack.topScreen == parent
 
         if (!isAttachedToWindow || !isTop || isDestroyed) {
             return


### PR DESCRIPTION
## Description

`ScreenStackHeaderConfig.onUpdate()` and `ScreenStackFragment.canNavigateBack()` disagree about the same condition, so a screen detached from its stack while its header config is still attached crashes the app.

`onUpdate()` computes:

```kotlin
val stack = screenStack                                   // screen?.container as? ScreenStack
val isTop = stack == null || stack.topScreen == parent
if (!isAttachedToWindow || !isTop || isDestroyed) return
```

A null `screenStack` is treated as "is top", so execution continues. Further down it reaches:

```kotlin
newActionBar.setDisplayHomeAsUpEnabled(
    screenFragment?.canNavigateBack() == true && !isBackButtonHidden,
)
```

and `canNavigateBack()` asserts on exactly the state the first guard let through:

```kotlin
val container: ScreenContainer? = screen.container
check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
```

Both read the same `Screen.container` field. If it is not a `ScreenStack`, the permissive check passes and the strict one throws.

This is what users hit in #4429: an intermittent `IllegalStateException` on Android/Fabric during ordinary navigation, when a props update or an attach reaches a header config after its screen has left the stack.

Closes #4429.

## Changes

- `legacy/ScreenStackHeaderConfig.onUpdate()` returns early when `screenStack` is null, instead of treating it as "is top".

Scoped to the legacy implementation deliberately: the newer `stack/` code passes `canNavigateBack` to `StackScreenFragment` as a constructor value and has no equivalent assertion, so it is unaffected.

## Test plan

The crash is a race and does not reproduce on demand, so I made the transient state permanent for one screen and did an A/B.

In `onUpdate()`, before the guard, I detached one screen from its stack. That is the same field both accessors read, so it reproduces the real end state:

```kotlin
if (title == "Security") {
    screen?.container = null
}
```

Built a debug app (RN 0.86, Expo 57, Fabric, `react-native-screens` 4.25.2, Android 16 emulator) and navigated to that screen.

**1. Without this change**: crashes every time.

```
java.lang.IllegalStateException: ScreenStackFragment added into a non-stack container
    at com.swmansion.rnscreens.ScreenStackFragment.canNavigateBack(ScreenStackFragment.kt:499)
    at com.swmansion.rnscreens.ScreenStackHeaderConfig.onUpdate(ScreenStackHeaderConfig.kt:268)
    at com.swmansion.rnscreens.ScreenStackHeaderConfig.onAttachedToWindow(ScreenStackHeaderConfig.kt:183)
    at android.view.View.dispatchAttachedToWindow(View.java:23105)
```

This matches the trace in #4429, which arrives via `onAfterUpdateTransaction` instead of `onAttachedToWindow`. Both call `onUpdate()`, so the guard covers both entry points.

**2. With this change, detach still forced**: no crash, screen renders. Its header is skipped, which is correct, since a screen with no stack has no stack header to configure.

**3. With this change, detach removed**: normal behaviour, title and back button render as before.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. (No visual change: this removes a crash.)
- [ ] For API changes, updated relevant public types. (No API change.)
- [ ] Ensured that CI passes
