### PR TITLE
Fix light border around iOS 26 modal corners

### DIFF
--- a/ios/legacy/RNSScreen.mm
+++ b/ios/legacy/RNSScreen.mm
@@ -1561,6 +1561,42 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   if (isDisplayedWithinUINavController || isTabScreen || self.screenView.isPresentedAsNativeModal) {
     [self.screenView updateBounds];
   }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    if (self.screenView.isPresentedAsNativeModal &&
+        self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+      UIView *clippingView = self.view.superview;
+      UIView *shadowView = clippingView.superview;
+      UIView *transitionView = shadowView.superview;
+      if (transitionView != nil) {
+        CGRect shadowFrame = [transitionView convertRect:shadowView.bounds fromView:shadowView];
+        CGFloat displayScale = self.view.window.screen.scale;
+        CGFloat pixelTolerance = displayScale > 0.0 ? 1.0 / displayScale : 0.0;
+        BOOL isAlignedWithScreenEdges = displayScale > 0.0 &&
+            ABS(CGRectGetMinX(shadowFrame) - CGRectGetMinX(transitionView.bounds)) <= pixelTolerance &&
+            ABS(CGRectGetMaxX(shadowFrame) - CGRectGetMaxX(transitionView.bounds)) <= pixelTolerance &&
+            ABS(CGRectGetMaxY(shadowFrame) - CGRectGetMaxY(transitionView.bounds)) <= pixelTolerance;
+
+        if (isAlignedWithScreenEdges) {
+          // The physical display already clips a modal aligned with its bottom corners. Applying
+          // UIKit's software corner mask as well exposes the opaque sheet background along the
+          // antialiased edge, which appears as a light seam on dark content.
+          CGFloat topLeftRadius = [shadowView effectiveRadiusForCorner:UIRectCornerTopLeft];
+          CGFloat topRightRadius = [shadowView effectiveRadiusForCorner:UIRectCornerTopRight];
+          UICornerRadius *zeroRadius = [UICornerRadius fixedRadius:0.0];
+          clippingView.cornerConfiguration =
+              [UICornerConfiguration configurationWithTopLeftRadius:[UICornerRadius fixedRadius:topLeftRadius]
+                                                     topRightRadius:[UICornerRadius fixedRadius:topRightRadius]
+                                                   bottomLeftRadius:zeroRadius
+                                                  bottomRightRadius:zeroRadius];
+        } else {
+          clippingView.cornerConfiguration = shadowView.cornerConfiguration;
+        }
+      }
+    }
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 }
 
 - (BOOL)isModalWithHeader

--- a/ios/legacy/RNSScreen.mm
+++ b/ios/legacy/RNSScreen.mm
@@ -1579,6 +1579,11 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
             ABS(CGRectGetMaxY(shadowFrame) - CGRectGetMaxY(transitionView.bounds)) <= pixelTolerance;
 
         if (isAlignedWithScreenEdges) {
+          UIView *contentView = self.view.subviews.firstObject;
+          if (contentView.backgroundColor != nil) {
+            shadowView.backgroundColor = contentView.backgroundColor;
+          }
+
           // The physical display already clips a modal aligned with its bottom corners. Applying
           // UIKit's software corner mask as well exposes the opaque sheet background along the
           // antialiased edge, which appears as a light seam on dark content.


### PR DESCRIPTION
## Summary

- Dark native modals could show a thin light border around their bottom corners on iOS 26.
- This change removes that border without changing the modal presentation or swipe-to-dismiss behavior.

## Description

While testing a dark modal on an iPhone running iOS 26 or newer, I noticed a thin light line following the rounded bottom corners. The line remains visible after the presentation animation has finished.

The bottom line is caused by redundant software clipping where the modal already follows the physical display corners. A top line can also appear because UIKit's native backing view can retain the system background color, which contrasts with the modal content along the antialiased edge.

Changing the React Native view background, `contentStyle`, and navigation theme did not help. The line comes from UIKit's modal container instead.

On iOS 26, UIKit gives large modals an opaque system background. It also rounds the bottom of the modal in software, even when the modal already reaches the bottom and sides of the physical display. The antialiased edge of that second rounding exposes a small amount of the light system background.

This change detects that specific layout, matches the native backing view to the modal content, and removes only the redundant bottom corner radii. The native top corners are kept as they are. Smaller or differently positioned modals continue to use UIKit's original corner configuration.

The behavior is limited to iPhones running iOS 26 or newer.

Apple has confirmed that large sheets becoming opaque is intentional on iOS 26:

https://developer.apple.com/forums/thread/795880

Possibly related to #3559, although that issue describes a temporary shimmer during `formSheet` animations. This issue is a permanent line on a stationary `modal`.

## Before & after - visual documentation

### Before
<img width="780" height="450" alt="before" src="https://github.com/user-attachments/assets/3686b11f-6595-413e-8fe9-cfbffe6e43a2" />

 ### After
<img width="780" height="450" alt="after" src="https://github.com/user-attachments/assets/3581f391-2107-44a1-9010-321cfa85e52b" />

## Test plan

- [x] Present a dark native modal on an iPhone running iOS 26 or newer — verify the light line is gone.
- [x] Verify the top modal corners still use UIKit's original radius.
- [x] Swipe down on the modal — verify interactive dismissal still works.
- [x] Build the FabricExample with Xcode 27 and the iOS Simulator SDK 27.

## Checklist
- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes