### PR TITLE
fix(android): respect gestureEnabled for form sheets

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
@@ -234,7 +234,7 @@ class ScreenModalFragment :
 
         behavior.apply {
             isHideable = true
-            isDraggable = true
+            isDraggable = screen.isGestureEnabled
         }
 
         when (screen.sheetDetents.count) {

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/bottomsheet/SheetDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/bottomsheet/SheetDelegate.kt
@@ -188,7 +188,7 @@ class SheetDelegate(
 
         behavior.apply {
             isHideable = true
-            isDraggable = true
+            isDraggable = screen.isGestureEnabled
         }
 
         // There is a guard internally that does not allow the callback to be duplicated.


### PR DESCRIPTION
## Summary

Android `formSheet` presentations currently remain draggable even when `gestureEnabled: false` is set.

This change makes the Material bottom-sheet behavior use the existing `screen.isGestureEnabled` value in both Android form-sheet implementations:

- `SheetDelegate`
- `ScreenModalFragment`

With this change, `gestureEnabled: false` prevents swipe-to-dismiss while preserving the existing default behavior when the option is enabled or omitted.

## Root cause

The Android form-sheet setup hardcodes `isDraggable = true`, even though the screen's `gestureEnabled` prop is already propagated to native code.

## Validation

- `./android/gradlew -p android spotlessCheck -q`
- `git diff --check`
- The same patch compiled successfully in an Expo Android host app.
- A standalone `assembleDebug` from this clean checkout was attempted but was blocked by the environment's React Native Maven metadata lookup (`SAXNotRecognizedException`), before compiling the changed source.
