### PR TITLE
chore(docs): add privacy policy link to footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -30,7 +30,7 @@ const config = {
           innerHTML: topbarBannerReservationScript(
             firstZone.zoneId,
             firstZone.contentId,
-            TOPBAR_BANNER.hiddenPaths
+            TOPBAR_BANNER.hiddenPaths,
           ),
         },
       ]
@@ -104,7 +104,7 @@ const config = {
         style: 'light',
         links: [],
         copyright:
-          'All trademarks and copyrights belong to their respective owners. Read about our ',
+          'All trademarks and copyrights belong to their respective owners.',
       },
     }),
 };

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -104,7 +104,7 @@ const config = {
         style: 'light',
         links: [],
         copyright:
-          'All trademarks and copyrights belong to their respective owners.',
+          'All trademarks and copyrights belong to their respective owners. Read about our ',
       },
     }),
 };

--- a/docs/src/components/FooterBackground/styles.module.css
+++ b/docs/src/components/FooterBackground/styles.module.css
@@ -22,37 +22,46 @@
 
 .container {
   position: relative;
-  margin-top: 107px;
+  margin-top: 122px;
 }
 
 footer {
-  margin-top: -107px;
+  margin-top: -108px;
 }
 
 @media (max-width: 996px) {
   .container {
-    margin-top: 122px;
+    margin-top: 138px;
   }
   footer {
-    margin-top: -122px;
+    margin-top: -138px;
   }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 916px) {
   .container {
-    margin-top: 147px;
+    margin-top: 164px;
   }
   footer {
-    margin-top: -147px;
+    margin-top: -164px;
   }
 }
 
-@media (max-width: 375px) {
+@media (max-width: 505px) {
   .container {
-    margin-top: 173px;
+    margin-top: 189px;
   }
   footer {
-    margin-top: -173px;
+    margin-top: -189px;
+  }
+}
+
+@media (max-width: 344px) {
+  .container {
+    margin-top: 215px;
+  }
+  footer {
+    margin-top: -215px;
   }
 }
 

--- a/docs/src/css/overrides.css
+++ b/docs/src/css/overrides.css
@@ -46,6 +46,50 @@ table thead tr {
   border: transparent 2px solid;
 }
 
+footer.footer {
+  --ifm-footer-padding-vertical: 30px;
+}
+
+@media (max-width: 996px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 30px;
+  }
+}
+
+footer .footer__copyright p a[data-privacy-policy] {
+  text-decoration: none;
+}
+
+footer .footer__bottom [class*='footer__copyright'] {
+  justify-content: center;
+  padding-bottom: var(--swm-footer-copyright-padding-bottom);
+}
+
+footer .footer__bottom [class*='footer__copyright'] p {
+  text-align: center;
+}
+
+footer .footer__bottom [class*='footer__copyright'] p a[data-privacy-policy] {
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+footer
+  .footer__bottom
+  [class*='footer__copyright']
+  p
+  a[data-privacy-policy]:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (max-width: 996px) {
+  footer .footer__bottom [class*='footer__copyright'] {
+    align-items: center;
+  }
+}
+
 .header-github {
   margin-left: 1.5em;
 }

--- a/docs/src/theme/Footer/index.js
+++ b/docs/src/theme/Footer/index.js
@@ -1,3 +1,24 @@
-import { Footer } from '@swmansion/t-rex-ui';
+import React, { useEffect } from 'react';
+import { Footer as TRexFooter } from '@swmansion/t-rex-ui';
 
-export default Footer;
+const PRIVACY_POLICY_URL = 'https://swmansion.com/privacy/policy/';
+
+export default function Footer(props) {
+  useEffect(() => {
+    const paragraph = document.querySelector('footer .footer__copyright p');
+    if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
+      return;
+    }
+
+    const link = document.createElement('a');
+    link.href = PRIVACY_POLICY_URL;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.dataset.privacyPolicy = '';
+    link.textContent = 'Privacy Policy';
+    paragraph.appendChild(link);
+    paragraph.appendChild(document.createTextNode('.'));
+  }, []);
+
+  return <TRexFooter {...props} />;
+}

--- a/docs/src/theme/Footer/index.js
+++ b/docs/src/theme/Footer/index.js
@@ -9,7 +9,7 @@ export default function Footer(props) {
     if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
       return;
     }
-
+    paragraph.appendChild(document.createTextNode(' Read about our '));
     const link = document.createElement('a');
     link.href = PRIVACY_POLICY_URL;
     link.target = '_blank';

--- a/docs/src/theme/Footer/index.js
+++ b/docs/src/theme/Footer/index.js
@@ -13,7 +13,7 @@ export default function Footer(props) {
     const link = document.createElement('a');
     link.href = PRIVACY_POLICY_URL;
     link.target = '_blank';
-    link.rel = 'noopener noreferrer';
+    link.rel = 'noopener';
     link.dataset.privacyPolicy = '';
     link.textContent = 'Privacy Policy';
     paragraph.appendChild(link);


### PR DESCRIPTION
## Summary

* Adds a Privacy Policy link in the docs site footer
* Centers footer copyright content
* Fixes footer bottom padding and landing footer spacing across breakpoints

## Test Plan

- [ ] Confirm the footer shows the Privacy Policy link and opens `https://swmansion.com/privacy/policy/` in a new tab
- [ ] Check copyright text is centered on desktop and mobile
- [ ] Verify footer padding looks correct at common widths (desktop, tablet, phone)
- [ ] On the landing page, confirm footer/background spacing still lines up after the layout tweaks
<img width="1169" height="816" alt="image" src="https://github.com/user-attachments/assets/b1d293bc-cd10-4cdb-9f4e-ae0ec76bcc85" />
