### PR TITLE
fix(Android, Stack v5): change order of toolbar menu item prop application to ensure correct overflow behavior

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/toolbar/StackHeaderToolbarMenuApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/toolbar/StackHeaderToolbarMenuApplicator.kt
@@ -291,7 +291,6 @@ internal object StackHeaderToolbarMenuApplicator {
         }
         options.hidden?.let { menuItem.isVisible = !it }
         options.disabled?.let { menuItem.isEnabled = !it }
-        options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
 
         // checked is intentionally not handled here. The coordinator layout manages it in
         // applyGroupItemStateChange because toggling checked state requires group metadata
@@ -321,6 +320,9 @@ internal object StackHeaderToolbarMenuApplicator {
                 Log.w(TAG, "[RNScreens] menuTitle ignored: target is not a submenu.")
             }
         }
+
+        // Apply showAsAction property after icon is set to ensure correct overflow behavior.
+        options.showAsAction?.let { menuItem.setShowAsAction(it.toNativeShowAsAction()) }
     }
 
     private fun StackHeaderToolbarMenuItemConfig.toOptions() =


### PR DESCRIPTION
## Description

Moves applying `showAsAction` prop **AFTER** setting an icon to ensure that correct overflow behavior is applied. Prior to this PR, in some configurations the icon would not appear in the toolbar menu. Instead, overflow icon would be visible but it wouldn't open the overflow menu, making the menu item not available.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1714.

## Changes

- move applying `showAsAction` to the bottom of `StackHeaderToolbarMenuApplicator.applyMenuElementOptions`

## Before & after - visual documentation

| Before           | After            |
| ---------------- | ---------------- |
| <video src="https://github.com/user-attachments/assets/c18f3ba9-ba83-44f2-acdb-de0b4843cdfc" /> | <video src="https://github.com/user-attachments/assets/de62c583-9652-4220-be29-200562f2a9a0" /> |

## Test plan

Run `test-stack-toolbar-menu-show-as-action` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
