### PR TITLE
chore(iOS): silence release build warnings for v5 components

### DIFF
--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -10,9 +10,13 @@
 #import "RNSSplitScreenComponentView.h"
 #import "RNSSplitScreenController.h"
 
+#ifndef NS_BLOCK_ASSERTIONS
+
 static const NSInteger minNumberOfColumns = 2;
 static const NSInteger maxNumberOfColumns = 3;
 static const NSInteger maxNumberOfInspectors = 1;
+
+#endif // !NS_BLOCK_ASSERTIONS
 
 @interface RNSSplitHostController () <UISplitViewControllerDelegate,
                                       RNSSplitNavigationControllerFrameOriginChangeDelegate>

--- a/ios/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/stack/header/RNSStackHeaderMenuMapper.mm
@@ -88,18 +88,22 @@ static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
 
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
+#ifndef NS_BLOCK_ASSERTIONS
   for (NSString *key in dict) {
     RCTAssert([kRNSAllowedMenuKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu", key);
   }
+#endif // !NS_BLOCK_ASSERTIONS
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
+#ifndef NS_BLOCK_ASSERTIONS
   for (NSString *key in dict) {
     RCTAssert([kRNSAllowedMenuItemKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu item", key);
   }
+#endif // !NS_BLOCK_ASSERTIONS
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 

--- a/ios/stack/host/RNSStackNavigationController.mm
+++ b/ios/stack/host/RNSStackNavigationController.mm
@@ -102,10 +102,10 @@
     return;
   }
 
-  for (RNSPopOperation *op in _pendingPopOperations) {
-    UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
+  for ([[maybe_unused]] RNSPopOperation *op in _pendingPopOperations) {
     RCTAssert([self.viewControllers count] > 1, @"[RNScreens] Attempt to pop last screen from the stack");
-    RCTAssert(self.topViewController == controller, @"[RNScreens] Attempt to pop non-top screen");
+    RCTAssert(self.topViewController == static_cast<UIViewController *>(op.stackScreen.controller),
+              @"[RNScreens] Attempt to pop non-top screen");
     [self popViewControllerAnimated:YES];
   }
 
@@ -126,10 +126,12 @@
 
 - (void)dumpStackModel
 {
+#ifdef RNS_DEBUG_LOGGING
   RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
   for (UIViewController *viewController in self.viewControllers) {
     RNSLog(@"[RNScreens] %@", static_cast<RNSStackScreenComponentView *>(viewController.view).screenKey);
   }
+#endif // RNS_DEBUG_LOGGING
 }
 
 @end

--- a/ios/stack/host/RNSStackOperation.h
+++ b/ios/stack/host/RNSStackOperation.h
@@ -18,8 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSPopOperation : RNSStackOperation
 
-@property (nonatomic, strong, readonly) RNSStackScreenComponentView *stackScreen;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Silence Release build warnings.
Closes  https://github.com/software-mansion/react-native-screens-labs/issues/1732

## Changes
- Guard static integers with `#ifndef NS_BLOCK_ASSERTIONS` in `ios/split/RNSSplitHostController.mm`
- Guard assert loops with `#ifndef NS_BLOCK_ASSERTIONS` in `ios/stack/header/RNSStackHeaderMenuMapper.mm`
- Use `[[maybe_unused]]`, and use the value inline in the assert instead of creating a variable, in `ios/stack/host/RNSStackNavigationController.mm`
- Guard the `dumpStackModel` body with `#ifdef RNS_DEBUG_LOGGING` in `ios/stack/host/RNSStackNavigationController.mm`
- Remove the duplicated property in `ios/stack/host/RNSStackOperation.h`
## Test plan

- Confirm these 4 warnings no longer appear
- Build and run the app in both debug and release

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
