### PR TITLE
chore(test): e2e test for test-stack-toolbar-menu-batch-commands-android

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -5,6 +5,12 @@ import {
   NativeMatcher,
 } from 'detox/detox';
 import isVersionEqualOrHigherThan from './helpers/isVersionEqualOrHigherThan';
+import {
+  CLASS_NAME_ANDROID_CHECK_BOX,
+  CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
+  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
+  CLASS_NAME_ANDROID_RADIO_BUTTON,
+} from './native-class-names';
 
 const { getIOSVersionNumber } = require('../../scripts/e2e/ios-devices.js');
 
@@ -159,6 +165,15 @@ export function pickerOptionId(pickerLabel: string, option: string): string {
 
 export type SettingsControlOptions = ScrollOptions & { scrollViewId: string };
 
+/** Rewinds, scrolls `id` into view and taps it. */
+export async function scrollToAndTap(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+) {
+  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
+  await element(by.id(id)).tap();
+}
+
 type PickerSelection = {
   pickerId: string;
   /** The picker's `label` prop — option `testID`s are derived from it. */
@@ -186,14 +201,10 @@ export async function selectPickerOption(
     return;
   }
 
-  const scrollToAndTap = async (id: string) => {
-    await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
-    await element(by.id(id)).tap();
-  };
-
-  await scrollToAndTap(pickerId);
-  await scrollToAndTap(pickerOptionId(label, option));
-  await scrollToAndTap(pickerId);
+  const control = { scrollViewId, ...scroll };
+  await scrollToAndTap(pickerId, control);
+  await scrollToAndTap(pickerOptionId(label, option), control);
+  await scrollToAndTap(pickerId, control);
 
   await expect(element(by.id(pickerId))).toHaveText(expected);
 }
@@ -392,4 +403,178 @@ export async function waitUntil(
       typeof message === 'function' ? message() : message
     }`,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Android toolbar overflow menu (Stack v5 header)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detox's idle sync does not cover popup window animations, so waits that
+ * straddle the overflow menu opening or dismissing must be explicit.
+ */
+export const MENU_ANIMATION_TIMEOUT_MS = 5000;
+
+/** Probes an already-settled popup: by now it is either up or was never opened. */
+export const MENU_PRESENCE_TIMEOUT_MS = 250;
+
+/** The accessibility label AppCompat gives the overflow button. */
+const OVERFLOW_MENU_LABEL = 'More options';
+
+export const overflowMenu = () =>
+  element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW));
+
+/**
+ * A multi-toggle group renders check boxes and a single-selection one radio
+ * buttons, so the class asserts the group type.
+ */
+export type ToggleWidget =
+  | typeof CLASS_NAME_ANDROID_CHECK_BOX
+  | typeof CLASS_NAME_ANDROID_RADIO_BUTTON;
+
+export function menuItemRow(title: string): NativeMatcher {
+  return by
+    .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
+    .withDescendant(by.text(title));
+}
+
+export function menuItemToggle(
+  title: string,
+  widget: ToggleWidget,
+): NativeMatcher {
+  return by.type(widget).withAncestor(menuItemRow(title));
+}
+
+/**
+ * Asserts `title`'s row hosts a check box (a multi-toggle group) — the sibling
+ * widget is asserted absent so a mismatched group type fails loudly instead of
+ * matching nothing.
+ */
+export async function expectCheckBox(title: string, checked: boolean) {
+  await expect(
+    element(menuItemToggle(title, CLASS_NAME_ANDROID_RADIO_BUTTON)),
+  ).not.toExist();
+  await expect(
+    element(menuItemToggle(title, CLASS_NAME_ANDROID_CHECK_BOX)),
+  ).toHaveToggleValue(checked);
+}
+
+/** Asserts `title`'s row hosts a radio button (a single-selection group). */
+export async function expectRadioButton(title: string, checked: boolean) {
+  await expect(
+    element(menuItemToggle(title, CLASS_NAME_ANDROID_CHECK_BOX)),
+  ).not.toExist();
+  await expect(
+    element(menuItemToggle(title, CLASS_NAME_ANDROID_RADIO_BUTTON)),
+  ).toHaveToggleValue(checked);
+}
+
+/** Resolves instead of throwing, so it can be used as a condition. */
+export async function isMenuOpen(): Promise<boolean> {
+  return waitFor(overflowMenu())
+    .toExist()
+    .withTimeout(MENU_PRESENCE_TIMEOUT_MS)
+    .then(
+      () => true,
+      () => false,
+    );
+}
+
+/** Waits for the popup itself, so a menu that never opened fails here rather
+ * than on a row assertion racing the open animation. */
+export async function openOverflowMenu() {
+  await element(by.label(OVERFLOW_MENU_LABEL)).tap();
+  await waitFor(overflowMenu())
+    .toBeVisible()
+    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
+}
+
+export type OverflowMenuControl = {
+  /** The screen's scroll view — the anchor proving the popup is gone. */
+  scrollViewId: string;
+  /**
+   * Upper bound of Back presses while a popup is still up: one per popup of
+   * the deepest expected path. The default covers an overflow menu with one
+   * submenu level, plus margin to notice an unexpected extra popup.
+   */
+  maxMenuDepth?: number;
+};
+
+/**
+ * The helpers that depend on the screen behind the popup, bound to one spec's
+ * scroll view.
+ */
+export function createOverflowMenuHelpers({
+  scrollViewId,
+  maxMenuDepth = 3,
+}: OverflowMenuControl) {
+  /**
+   * Detox searches one window: while a popup holds focus nothing behind it is
+   * in the hierarchy, so the popup going away is not enough — the screen
+   * itself has to become addressable again.
+   */
+  const waitForScreen = async () => {
+    await waitFor(element(by.id(scrollViewId)))
+      .toBeVisible()
+      .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
+  };
+
+  /**
+   * Back only ever goes to an open popup: with no menu up the activity takes
+   * it and pops the test screen, failing every later case in a stateful
+   * suite. Submenus stack a popup per level, hence the loop.
+   */
+  const closeMenuIfOpen = async () => {
+    let pressCount = 0;
+
+    while (await isMenuOpen()) {
+      if (pressCount === maxMenuDepth) {
+        throw new Error(
+          `The overflow menu was still open after ${maxMenuDepth} Back presses.`,
+        );
+      }
+      await device.pressBack();
+      pressCount++;
+    }
+
+    if (pressCount > 0) {
+      await waitForScreen();
+    }
+  };
+
+  /**
+   * Closes the menu even on failure: a leaked popup is never a local problem —
+   * every later matcher would resolve against the popup window instead of the
+   * activity, failing the rest of the suite on views that are plainly there.
+   */
+  const closingMenuAfter = async (assertions: () => Promise<void>) => {
+    let assertionFailed = false;
+
+    try {
+      await assertions();
+    } catch (error) {
+      assertionFailed = true;
+      throw error;
+    } finally {
+      try {
+        await closeMenuIfOpen();
+      } catch (cleanupError) {
+        // A throw from `finally` would replace the error that actually failed.
+        if (!assertionFailed) {
+          throw cleanupError;
+        }
+      }
+    }
+  };
+
+  /**
+   * While the menu is open, Espresso resolves matchers against its window, so
+   * `assertions` can only address rows inside it.
+   */
+  const withOverflowMenu = async (assertions: () => Promise<void>) => {
+    await openOverflowMenu();
+    await closingMenuAfter(assertions);
+  };
+
+  return { waitForScreen, closeMenuIfOpen, closingMenuAfter, withOverflowMenu };
 }

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -1,7 +1,7 @@
 // Detox cannot read the bytes of a remotely loaded image, so every
-// image-load case below asserts only whether Apple's toolbar icon view
-// exists — that *a* photo (or none, for a failed/cleared load) was
-// applied — never that the downloaded content is the correct photo, and
+// image-load case below asserts only whether Apple's toolbar button is in
+// its icon-only form — that *a* photo (or none, for a failed/cleared load)
+// was applied — never that the downloaded content is the correct photo, and
 // never that the icon and its coalesced event land at the exact same
 // instant. See scenario.md's "Not automated" note.
 import { expect as jestExpect } from '@jest/globals';
@@ -18,10 +18,7 @@ import {
   scrollToAndTap,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
-} from '../../native-class-names';
+import { CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW } from '../../native-class-names';
 
 // Runs the whole scenario.md walkthrough as one continuous, stateful script:
 // "Reset log clears only the counter and log, not the menu" — so every case
@@ -32,36 +29,47 @@ const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 
 // The image cases download a large, uncached image over the network (or hit
 // an always-failing host), so the async load is visibly slow — see
-// scenario.md's Prerequisites and Note.
-const IMAGE_LOAD_TIMEOUT_MS = 30000;
+// scenario.md's Prerequisites and Note. Generous on purpose: a slow network
+// must not read as a failed batch. Stays under jest's per-test timeout.
+const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
-// Matched by accessibility label, not visible text: once an icon is applied
-// the row may show only the icon, but the label still carries the title.
+// Per scenario.md's Note, Android's overflow menu does not render item icons
+// and an action button does not show its checked state, so Apple's icon is
+// only observable while it sits in the toolbar and its check only inside the
+// overflow menu (`expectCheckBox`) — the steps move it between the two.
+//
+// The toolbar button itself is a text view that draws its icon as a compound
+// drawable, so there is no icon child to match. What is observable is
+// AppCompat's own switch: an icon-only action button renders no text and
+// exposes its title as the content description, while a text button renders
+// the title as text — never both (see the sibling toolbar-menu-title spec).
+//
+// Detox's Android `by.label` matches the content description *or* the text, so
+// it finds the button in either form; the form is then told apart by whether
+// the title is rendered as text.
 const appleToolbarButton: NativeMatcher = by
   .label('Apple')
   .and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
-
-const appleToolbarIcon: NativeMatcher = by
-  .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
-  .withAncestor(appleToolbarButton);
-
-async function expectAppleInToolbar() {
-  await expect(element(appleToolbarButton)).toBeVisible();
-}
 
 async function expectAppleNotInToolbar() {
   await expect(element(appleToolbarButton)).not.toExist();
 }
 
-// Existence-only, per the file header note: proves an icon view was (or
-// wasn't) mounted, not that its pixels are the correct photo.
-async function expectAppleToolbarIcon(present: boolean) {
-  if (present) {
-    await expect(element(appleToolbarIcon)).toBeVisible();
-  } else {
-    await expectAppleInToolbar();
-    await expect(element(appleToolbarIcon)).not.toExist();
-  }
+// Existence-only, per the file header note: proves the button is (or isn't) in
+// its icon-only form, not that the icon's pixels are the correct photo.
+//
+// Both forms are asserted positively: on Android, Detox evaluates a negated
+// matcher (`not.toHaveText`, `not.toExist`) against `null` when the view is
+// missing, so a negation alone would pass for a button that is not there.
+async function expectAppleInToolbarWithIcon() {
+  await expect(element(appleToolbarButton)).toBeVisible();
+  // An icon-only action button clears its text (`setText(null)`).
+  await expect(element(appleToolbarButton)).toHaveText('');
+}
+
+async function expectAppleInToolbarWithoutIcon() {
+  await expect(element(appleToolbarButton)).toBeVisible();
+  await expect(element(appleToolbarButton)).toHaveText('Apple');
 }
 
 // The small step keeps short rows from being scrolled past.
@@ -110,6 +118,9 @@ async function waitForEventCount(n: number, timeoutMs: number) {
 // coupled to the outcome of the one before it.
 async function expectEventCountUnchanged(action: () => Promise<void>) {
   const before = await readText('events-count-text');
+  // Guards the read itself: an empty or unexpected value must not become a
+  // baseline that the closing assertion then trivially confirms.
+  jestExpect(before).toMatch(/^Events received: \d+$/);
   await action();
   await scrollIntoView('events-count-text');
   await expect(element(by.id('events-count-text'))).toHaveText(before);
@@ -240,9 +251,11 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
         await tapById('toggle-apple-button');
       });
 
-      await expectAppleInToolbar();
-      await expectAppleToolbarIcon(false);
+      await expectAppleInToolbarWithoutIcon();
       await withOverflowMenu(async () => {
+        // A row that must still be there proves the menu's rows are
+        // addressable, so Apple's absence is a finding, not a no-op.
+        await expect(element(menuItemRow('Banana'))).toBeVisible();
         await expect(element(menuItemRow('Apple'))).not.toExist();
       });
     });
@@ -257,7 +270,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
       await tapById('batch-image-check-button');
       await waitForEventCount(7, IMAGE_LOAD_TIMEOUT_MS);
       await expectNewestEntry('fruits', ['apple', 'cherry']);
-      await expectAppleToolbarIcon(true);
+      await expectAppleInToolbarWithIcon();
     });
 
     it('moves Apple back to the overflow menu, checked, with no new event', async () => {
@@ -304,8 +317,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
         await tapById('toggle-apple-button');
       });
 
-      await expectAppleInToolbar();
-      await expectAppleToolbarIcon(false);
+      await expectAppleInToolbarWithoutIcon();
     });
 
     it('keeps Apple checked in the overflow menu, with no new event', async () => {
@@ -332,8 +344,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
         await tapById('toggle-apple-button');
       });
 
-      await expectAppleInToolbar();
-      await expectAppleToolbarIcon(false);
+      await expectAppleInToolbarWithoutIcon();
     });
 
     it('keeps the check from the first duplicate update and applies the second update’s icon', async () => {
@@ -341,7 +352,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
       await waitForEventCount(15, IMAGE_LOAD_TIMEOUT_MS);
       await expectPreviousEntry('fruits', ['apple']);
       await expectNewestEntry('fruits', ['apple', 'cherry']);
-      await expectAppleToolbarIcon(true);
+      await expectAppleInToolbarWithIcon();
     });
 
     it('keeps Apple checked in the overflow menu, with no new event', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -1,0 +1,358 @@
+// Detox cannot read the bytes of a remotely loaded image, so every
+// image-load case below asserts only whether Apple's toolbar icon view
+// exists — that *a* photo (or none, for a failed/cleared load) was
+// applied — never that the downloaded content is the correct photo, and
+// never that the icon and its coalesced event land at the exact same
+// instant. See scenario.md's "Not automated" note.
+import { expect as jestExpect } from '@jest/globals';
+import { device, expect, element, by, waitFor } from 'detox';
+import type { AndroidElementAttributes, NativeMatcher } from 'detox/detox';
+import {
+  createOverflowMenuHelpers,
+  describeIfAndroid,
+  expectCheckBox,
+  expectRadioButton,
+  getElementAttributes,
+  menuItemRow,
+  rewindAndScrollUntilVisible,
+  scrollToAndTap,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
+} from '../../native-class-names';
+
+// Runs the whole scenario.md walkthrough as one continuous, stateful script:
+// "Reset log clears only the counter and log, not the menu" — so every case
+// below starts from the checked/toolbar state the previous one left.
+
+const SCROLLVIEW_ID = 'toolbar-menu-batch-commands-scrollview';
+const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
+
+// The image cases download a large, uncached image over the network (or hit
+// an always-failing host), so the async load is visibly slow — see
+// scenario.md's Prerequisites and Note.
+const IMAGE_LOAD_TIMEOUT_MS = 30000;
+
+// Matched by accessibility label, not visible text: once an icon is applied
+// the row may show only the icon, but the label still carries the title.
+const appleToolbarButton: NativeMatcher = by
+  .label('Apple')
+  .and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
+
+const appleToolbarIcon: NativeMatcher = by
+  .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
+  .withAncestor(appleToolbarButton);
+
+async function expectAppleInToolbar() {
+  await expect(element(appleToolbarButton)).toBeVisible();
+}
+
+async function expectAppleNotInToolbar() {
+  await expect(element(appleToolbarButton)).not.toExist();
+}
+
+// Existence-only, per the file header note: proves an icon view was (or
+// wasn't) mounted, not that its pixels are the correct photo.
+async function expectAppleToolbarIcon(present: boolean) {
+  if (present) {
+    await expect(element(appleToolbarIcon)).toBeVisible();
+  } else {
+    await expectAppleInToolbar();
+    await expect(element(appleToolbarIcon)).not.toExist();
+  }
+}
+
+// The small step keeps short rows from being scrolled past.
+const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, pixels: 300 };
+
+// Rewinds to the top first, so a target above the current offset is still
+// reachable — `whileElement` only scrolls one way.
+async function scrollIntoView(id: string) {
+  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SETTINGS_CONTROL);
+}
+
+async function tapById(id: string) {
+  await scrollToAndTap(id, SETTINGS_CONTROL);
+}
+
+const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
+  scrollViewId: SCROLLVIEW_ID,
+});
+
+async function readText(id: string): Promise<string> {
+  await scrollIntoView(id);
+  const attrs = (await getElementAttributes({
+    by: 'id',
+    value: id,
+  })) as AndroidElementAttributes;
+  return attrs.text ?? '';
+}
+
+async function expectEventCount(n: number) {
+  await scrollIntoView('events-count-text');
+  await expect(element(by.id('events-count-text'))).toHaveText(
+    `Events received: ${n}`,
+  );
+}
+
+// For the image-load cases: the count settles only once the async command
+// queue drains, which can take a while over the network.
+async function waitForEventCount(n: number, timeoutMs: number) {
+  await scrollIntoView('events-count-text');
+  await waitFor(element(by.id('events-count-text')))
+    .toHaveText(`Events received: ${n}`)
+    .withTimeout(timeoutMs);
+}
+
+// The baseline is read rather than written into the test, so an `it` is not
+// coupled to the outcome of the one before it.
+async function expectEventCountUnchanged(action: () => Promise<void>) {
+  const before = await readText('events-count-text');
+  await action();
+  await scrollIntoView('events-count-text');
+  await expect(element(by.id('events-count-text'))).toHaveText(before);
+}
+
+// Payload order is a native implementation detail — compare ids as a set, the
+// same way the sibling toolbar-menu-disabled spec's `expectLastSelection` does.
+function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
+  const text = raw.replace(/^(▶ | {2})/, '');
+  const separator = text.indexOf(': ');
+  if (separator === -1) {
+    throw new Error(`Unrecognized event log entry: "${raw}"`);
+  }
+  const groupId = text.slice(0, separator);
+  const parsed: unknown = JSON.parse(text.slice(separator + 2));
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected a JSON array of ids in: "${raw}"`);
+  }
+  return { groupId, ids: parsed as string[] };
+}
+
+async function expectLogEntry(index: number, groupId: string, ids: string[]) {
+  const raw = await readText(`event-log-entry-${index}`);
+  const entry = parseLogEntry(raw);
+  jestExpect(entry.groupId).toBe(groupId);
+  jestExpect([...entry.ids].sort()).toEqual([...ids].sort());
+}
+
+async function expectNewestEntry(groupId: string, ids: string[]) {
+  await expectLogEntry(0, groupId, ids);
+}
+
+// Only meaningful right after a two-event batch — index 1 is one entry older
+// than "newest", i.e. the first of the two events the batch produced.
+async function expectPreviousEntry(groupId: string, ids: string[]) {
+  await expectLogEntry(1, groupId, ids);
+}
+
+describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Stackv5',
+      'test-stack-toolbar-menu-batch-commands-android',
+    );
+  });
+
+  // Covers taps made outside a `withOverflowMenu` block: a case that fails
+  // mid-menu must not leave the popup up and take every later case down too.
+  afterEach(closeMenuIfOpen);
+
+  describe('baseline — initial render', () => {
+    it('renders the header title, initial group states, and a zero event count', async () => {
+      await expect(element(by.text(HEADER_TITLE))).toBeVisible();
+      await expectEventCount(0);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', true);
+        await expectCheckBox('Banana', false);
+        await expectCheckBox('Cherry', false);
+        await expectCheckBox('Date', false);
+
+        await expectRadioButton('List', true);
+        await expectRadioButton('Grid', false);
+      });
+    });
+  });
+
+  describe('coalescing — one event per batch', () => {
+    it('emits one event for a four-item Select All batch', async () => {
+      await tapById('select-all-button');
+      await expectEventCount(1);
+      await expectNewestEntry('fruits', ['apple', 'banana', 'cherry', 'date']);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', true);
+        await expectCheckBox('Banana', true);
+        await expectCheckBox('Cherry', true);
+        await expectCheckBox('Date', true);
+      });
+    });
+
+    it('emits one event for a four-item Deselect All batch', async () => {
+      await tapById('deselect-all-button');
+      await expectEventCount(2);
+      await expectNewestEntry('fruits', []);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', false);
+        await expectCheckBox('Banana', false);
+        await expectCheckBox('Cherry', false);
+        await expectCheckBox('Date', false);
+      });
+    });
+  });
+
+  describe('coalescing — one event per affected group', () => {
+    it('emits two events, one per affected group, in update order', async () => {
+      await tapById('batch-across-groups-button');
+      await expectEventCount(4);
+      await expectPreviousEntry('fruits', ['cherry']);
+      await expectNewestEntry('view', ['grid']);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Cherry', true);
+        await expectRadioButton('Grid', true);
+        await expectRadioButton('List', false);
+      });
+    });
+  });
+
+  describe('single-object (non-array) argument', () => {
+    it('treats a single object argument as a one-element batch', async () => {
+      await tapById('single-object-update-button');
+      await expectEventCount(5);
+      await expectNewestEntry('fruits', ['banana', 'cherry']);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Banana', true);
+        await expectCheckBox('Cherry', true);
+      });
+    });
+  });
+
+  describe('atomic image load with showAsAction', () => {
+    it('moves Apple to the toolbar as a plain text button with no icon and no event', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleInToolbar();
+      await expectAppleToolbarIcon(false);
+      await withOverflowMenu(async () => {
+        await expect(element(menuItemRow('Apple'))).not.toExist();
+      });
+    });
+
+    it('emits one event for Deselect All while Apple sits in the toolbar', async () => {
+      await tapById('deselect-all-button');
+      await expectEventCount(6);
+      await expectNewestEntry('fruits', []);
+    });
+
+    it('applies the icon and the check together only once the image has loaded', async () => {
+      await tapById('batch-image-check-button');
+      await waitForEventCount(7, IMAGE_LOAD_TIMEOUT_MS);
+      await expectNewestEntry('fruits', ['apple', 'cherry']);
+      await expectAppleToolbarIcon(true);
+    });
+
+    it('moves Apple back to the overflow menu, checked, with no new event', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleNotInToolbar();
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', true);
+      });
+    });
+  });
+
+  describe('FIFO ordering — a late image must not override a newer command', () => {
+    it('emits one event for Deselect All', async () => {
+      await tapById('deselect-all-button');
+      await expectEventCount(8);
+      await expectNewestEntry('fruits', []);
+    });
+
+    it('applies the second (synchronous) command last, even though the first image resolves later', async () => {
+      await tapById('ordering-race-button');
+      await waitForEventCount(10, IMAGE_LOAD_TIMEOUT_MS);
+      await expectPreviousEntry('fruits', ['apple']);
+      await expectNewestEntry('fruits', []);
+
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', false);
+      });
+    });
+  });
+
+  describe('robustness — a failing image still completes the batch', () => {
+    it('applies both commands even though the first image fails to load', async () => {
+      await tapById('failing-image-button');
+      await waitForEventCount(12, IMAGE_LOAD_TIMEOUT_MS);
+      await expectPreviousEntry('fruits', ['apple']);
+      await expectNewestEntry('fruits', ['apple', 'banana']);
+    });
+
+    it('shows Apple in the toolbar with its icon cleared by the failed load', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleInToolbar();
+      await expectAppleToolbarIcon(false);
+    });
+
+    it('keeps Apple checked in the overflow menu, with no new event', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleNotInToolbar();
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', true);
+      });
+    });
+  });
+
+  describe('robustness — a repeated id in one batch (last icon wins)', () => {
+    it('emits one event for Deselect All', async () => {
+      await tapById('deselect-all-button');
+      await expectEventCount(13);
+      await expectNewestEntry('fruits', []);
+    });
+
+    it('moves Apple to the toolbar with no icon and no event', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleInToolbar();
+      await expectAppleToolbarIcon(false);
+    });
+
+    it('keeps the check from the first duplicate update and applies the second update’s icon', async () => {
+      await tapById('duplicate-id-button');
+      await waitForEventCount(15, IMAGE_LOAD_TIMEOUT_MS);
+      await expectPreviousEntry('fruits', ['apple']);
+      await expectNewestEntry('fruits', ['apple', 'cherry']);
+      await expectAppleToolbarIcon(true);
+    });
+
+    it('keeps Apple checked in the overflow menu, with no new event', async () => {
+      await expectEventCountUnchanged(async () => {
+        await tapById('toggle-apple-button');
+      });
+
+      await expectAppleNotInToolbar();
+      await withOverflowMenu(async () => {
+        await expectCheckBox('Apple', true);
+      });
+    });
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -81,7 +81,7 @@ async function expectEventCountUnchanged(action: () => Promise<void>) {
   await expect(element(by.id('events-count-text'))).toHaveText(before);
 }
 
-// Ids are compared as a set — payload order is an implementation detail.
+// Parses an event-log entry into group id + ids.
 function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
   const text = raw.replace(/^(▶ | {2})/, '');
   const separator = text.indexOf(': ');
@@ -99,6 +99,7 @@ function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
   return { groupId, ids: parsed };
 }
 
+// Compares ids sorted — order-insensitive, duplicates still fail.
 async function expectLogEntry(index: number, groupId: string, ids: string[]) {
   const raw = await readText(`event-log-entry-${index}`);
   const entry = parseLogEntry(raw);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -1,12 +1,6 @@
-// Detox cannot read the bytes of a remotely loaded image, so every
-// image-load case below asserts only whether Apple's toolbar button is in
-// its icon-only form — that *a* photo (or none, for a failed/cleared load)
-// was applied — never that the downloaded content is the correct photo, and
-// never that the icon and its coalesced event land at the exact same
-// instant. See scenario.md's "Not automated" note.
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
-import type { AndroidElementAttributes, NativeMatcher } from 'detox/detox';
+import type { NativeMatcher } from 'detox/detox';
 import {
   createOverflowMenuHelpers,
   describeIfAndroid,
@@ -20,33 +14,21 @@ import {
 } from '../../e2e-utils';
 import { CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW } from '../../native-class-names';
 
-// Runs the whole scenario.md walkthrough as one continuous, stateful script:
-// "Reset log clears only the counter and log, not the menu" — so every case
-// below starts from the checked/toolbar state the previous one left.
+// Stateful walkthrough of scenario.md: the menu's checked state is cumulative
+// and the screen has no full reset, so each case starts where the previous one
+// left off and event counts are absolute. See scenario.md's "Not automated"
+// section for what is not covered.
 
 const SCROLLVIEW_ID = 'toolbar-menu-batch-commands-scrollview';
 const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
+const SCROLL_STEP = { pixels: 300 };
 
-// The image cases download a large, uncached image over the network (or hit
-// an always-failing host), so the async load is visibly slow — see
-// scenario.md's Prerequisites and Note. Generous on purpose: a slow network
-// must not read as a failed batch. Stays under jest's per-test timeout.
+const EVENT_TIMEOUT_MS = 3000;
+// Generous on purpose: a slow image download must not read as a failed batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
-// Per scenario.md's Note, Android's overflow menu does not render item icons
-// and an action button does not show its checked state, so Apple's icon is
-// only observable while it sits in the toolbar and its check only inside the
-// overflow menu (`expectCheckBox`) — the steps move it between the two.
-//
-// The toolbar button itself is a text view that draws its icon as a compound
-// drawable, so there is no icon child to match. What is observable is
-// AppCompat's own switch: an icon-only action button renders no text and
-// exposes its title as the content description, while a text button renders
-// the title as text — never both (see the sibling toolbar-menu-title spec).
-//
-// Detox's Android `by.label` matches the content description *or* the text, so
-// it finds the button in either form; the form is then told apart by whether
-// the title is rendered as text.
+// `by.label` matches the button in both its icon-only (title as content
+// description) and text form; the form is told apart by the rendered text.
 const appleToolbarButton: NativeMatcher = by
   .label('Apple')
   .and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
@@ -55,15 +37,10 @@ async function expectAppleNotInToolbar() {
   await expect(element(appleToolbarButton)).not.toExist();
 }
 
-// Existence-only, per the file header note: proves the button is (or isn't) in
-// its icon-only form, not that the icon's pixels are the correct photo.
-//
-// Both forms are asserted positively: on Android, Detox evaluates a negated
-// matcher (`not.toHaveText`, `not.toExist`) against `null` when the view is
-// missing, so a negation alone would pass for a button that is not there.
+// Asserted positively: on Android a negated matcher passes on a missing view.
 async function expectAppleInToolbarWithIcon() {
   await expect(element(appleToolbarButton)).toBeVisible();
-  // An icon-only action button clears its text (`setText(null)`).
+  // AppCompat clears an icon-only action button's text (`setText(null)`).
   await expect(element(appleToolbarButton)).toHaveText('');
 }
 
@@ -72,17 +49,12 @@ async function expectAppleInToolbarWithoutIcon() {
   await expect(element(appleToolbarButton)).toHaveText('Apple');
 }
 
-// The small step keeps short rows from being scrolled past.
-const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, pixels: 300 };
-
-// Rewinds to the top first, so a target above the current offset is still
-// reachable — `whileElement` only scrolls one way.
 async function scrollIntoView(id: string) {
-  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SETTINGS_CONTROL);
+  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SCROLL_STEP);
 }
 
 async function tapById(id: string) {
-  await scrollToAndTap(id, SETTINGS_CONTROL);
+  await scrollToAndTap(id, { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP });
 }
 
 const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
@@ -91,43 +63,25 @@ const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
 
 async function readText(id: string): Promise<string> {
   await scrollIntoView(id);
-  const attrs = (await getElementAttributes({
-    by: 'id',
-    value: id,
-  })) as AndroidElementAttributes;
-  return attrs.text ?? '';
+  return (await getElementAttributes({ by: 'id', value: id })).text ?? '';
 }
 
-async function expectEventCount(n: number) {
-  await scrollIntoView('events-count-text');
-  await expect(element(by.id('events-count-text'))).toHaveText(
-    `Events received: ${n}`,
-  );
-}
-
-// For the image-load cases: the count settles only once the async command
-// queue drains, which can take a while over the network.
-async function waitForEventCount(n: number, timeoutMs: number) {
+async function expectEventCount(n: number, timeoutMs = EVENT_TIMEOUT_MS) {
   await scrollIntoView('events-count-text');
   await waitFor(element(by.id('events-count-text')))
     .toHaveText(`Events received: ${n}`)
     .withTimeout(timeoutMs);
 }
 
-// The baseline is read rather than written into the test, so an `it` is not
-// coupled to the outcome of the one before it.
 async function expectEventCountUnchanged(action: () => Promise<void>) {
   const before = await readText('events-count-text');
-  // Guards the read itself: an empty or unexpected value must not become a
-  // baseline that the closing assertion then trivially confirms.
   jestExpect(before).toMatch(/^Events received: \d+$/);
   await action();
   await scrollIntoView('events-count-text');
   await expect(element(by.id('events-count-text'))).toHaveText(before);
 }
 
-// Payload order is a native implementation detail — compare ids as a set, the
-// same way the sibling toolbar-menu-disabled spec's `expectLastSelection` does.
+// Ids are compared as a set — payload order is an implementation detail.
 function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
   const text = raw.replace(/^(▶ | {2})/, '');
   const separator = text.indexOf(': ');
@@ -136,10 +90,13 @@ function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
   }
   const groupId = text.slice(0, separator);
   const parsed: unknown = JSON.parse(text.slice(separator + 2));
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Expected a JSON array of ids in: "${raw}"`);
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((id): id is string => typeof id === 'string')
+  ) {
+    throw new Error(`Expected a JSON array of string ids in: "${raw}"`);
   }
-  return { groupId, ids: parsed as string[] };
+  return { groupId, ids: parsed };
 }
 
 async function expectLogEntry(index: number, groupId: string, ids: string[]) {
@@ -153,9 +110,7 @@ async function expectNewestEntry(groupId: string, ids: string[]) {
   await expectLogEntry(0, groupId, ids);
 }
 
-// Only meaningful right after a two-event batch — index 1 is one entry older
-// than "newest", i.e. the first of the two events the batch produced.
-async function expectPreviousEntry(groupId: string, ids: string[]) {
+async function expectSecondNewestEntry(groupId: string, ids: string[]) {
   await expectLogEntry(1, groupId, ids);
 }
 
@@ -168,8 +123,6 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
     );
   });
 
-  // Covers taps made outside a `withOverflowMenu` block: a case that fails
-  // mid-menu must not leave the popup up and take every later case down too.
   afterEach(closeMenuIfOpen);
 
   describe('baseline — initial render', () => {
@@ -221,7 +174,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
     it('emits two events, one per affected group, in update order', async () => {
       await tapById('batch-across-groups-button');
       await expectEventCount(4);
-      await expectPreviousEntry('fruits', ['cherry']);
+      await expectSecondNewestEntry('fruits', ['cherry']);
       await expectNewestEntry('view', ['grid']);
 
       await withOverflowMenu(async () => {
@@ -253,8 +206,6 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
 
       await expectAppleInToolbarWithoutIcon();
       await withOverflowMenu(async () => {
-        // A row that must still be there proves the menu's rows are
-        // addressable, so Apple's absence is a finding, not a no-op.
         await expect(element(menuItemRow('Banana'))).toBeVisible();
         await expect(element(menuItemRow('Apple'))).not.toExist();
       });
@@ -268,7 +219,7 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
 
     it('applies the icon and the check together only once the image has loaded', async () => {
       await tapById('batch-image-check-button');
-      await waitForEventCount(7, IMAGE_LOAD_TIMEOUT_MS);
+      await expectEventCount(7, IMAGE_LOAD_TIMEOUT_MS);
       await expectNewestEntry('fruits', ['apple', 'cherry']);
       await expectAppleInToolbarWithIcon();
     });
@@ -294,8 +245,8 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
 
     it('applies the second (synchronous) command last, even though the first image resolves later', async () => {
       await tapById('ordering-race-button');
-      await waitForEventCount(10, IMAGE_LOAD_TIMEOUT_MS);
-      await expectPreviousEntry('fruits', ['apple']);
+      await expectEventCount(10, IMAGE_LOAD_TIMEOUT_MS);
+      await expectSecondNewestEntry('fruits', ['apple']);
       await expectNewestEntry('fruits', []);
 
       await withOverflowMenu(async () => {
@@ -307,8 +258,8 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
   describe('robustness — a failing image still completes the batch', () => {
     it('applies both commands even though the first image fails to load', async () => {
       await tapById('failing-image-button');
-      await waitForEventCount(12, IMAGE_LOAD_TIMEOUT_MS);
-      await expectPreviousEntry('fruits', ['apple']);
+      await expectEventCount(12, IMAGE_LOAD_TIMEOUT_MS);
+      await expectSecondNewestEntry('fruits', ['apple']);
       await expectNewestEntry('fruits', ['apple', 'banana']);
     });
 
@@ -349,8 +300,8 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
 
     it('keeps the check from the first duplicate update and applies the second update’s icon', async () => {
       await tapById('duplicate-id-button');
-      await waitForEventCount(15, IMAGE_LOAD_TIMEOUT_MS);
-      await expectPreviousEntry('fruits', ['apple']);
+      await expectEventCount(15, IMAGE_LOAD_TIMEOUT_MS);
+      await expectSecondNewestEntry('fruits', ['apple']);
       await expectNewestEntry('fruits', ['apple', 'cherry']);
       await expectAppleInToolbarWithIcon();
     });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -104,9 +104,10 @@ async function setSlotInclude(slot: number, include: boolean) {
   ).toBeVisible();
 }
 
-const { waitForScreen, withOverflowMenu } = createOverflowMenuHelpers({
-  scrollViewId: SCROLLVIEW_ID,
-});
+const { waitForScreen, closeMenuIfOpen, withOverflowMenu } =
+  createOverflowMenuHelpers({
+    scrollViewId: SCROLLVIEW_ID,
+  });
 
 async function waitForMenuItem(title: MenuTitle) {
   await waitFor(
@@ -220,6 +221,11 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
       'test-stack-toolbar-menu-commands-android',
     );
   });
+
+  // The direct `openOverflowMenu()` cases below close the menu via
+  // `tapMenuItem`; if a step fails in between, the popup would otherwise leak
+  // into every later case of this stateful suite.
+  afterEach(closeMenuIfOpen);
 
   describe('baseline — initial render from props', () => {
     it('renders the header title and the three prop-configured menu items in order', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -1,7 +1,9 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
 import {
+  createOverflowMenuHelpers,
   describeIfAndroid,
+  openOverflowMenu,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import { CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW } from '../../native-class-names';
@@ -12,10 +14,6 @@ const HEADER_TITLE = 'Toolbar Menu Commands Test';
 // Detox's idle sync does not cover popup window animations, so every wait that
 // straddles the overflow menu opening or dismissing has to be explicit.
 const MENU_ANIMATION_TIMEOUT = 2000;
-
-// Probes an already-settled popup rather than an animation — by the time it is
-// used the menu is either up or was never opened.
-const MENU_PRESENCE_TIMEOUT = 250;
 
 // Every title this scenario can put into the menu. Assertions check the full
 // set — expected titles visible, all others absent — so a leaked entry fails.
@@ -106,9 +104,9 @@ async function setSlotInclude(slot: number, include: boolean) {
   ).toBeVisible();
 }
 
-async function openMenu() {
-  await element(by.label('More options')).tap();
-}
+const { waitForScreen, withOverflowMenu } = createOverflowMenuHelpers({
+  scrollViewId: SCROLLVIEW_ID,
+});
 
 async function waitForMenuItem(title: MenuTitle) {
   await waitFor(
@@ -118,15 +116,6 @@ async function waitForMenuItem(title: MenuTitle) {
         .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
     ),
   )
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-}
-
-// Detox resolves matchers against a single window: while the popup holds focus
-// nothing behind it is in the searched hierarchy, so the entry going away is
-// not enough — the screen itself has to become addressable again.
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLLVIEW_ID)))
     .toBeVisible()
     .withTimeout(MENU_ANIMATION_TIMEOUT);
 }
@@ -147,27 +136,6 @@ async function tapMenuItem(title: MenuTitle) {
   )
     .not.toExist()
     .withTimeout(MENU_ANIMATION_TIMEOUT);
-  await waitForScreen();
-}
-
-// Presses Back only when the popup is actually up: a menu that never opened
-// would otherwise take the Back press itself and pop the test screen.
-async function closeMenuIfOpen() {
-  const isOpen = await waitFor(
-    element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-  )
-    .toExist()
-    .withTimeout(MENU_PRESENCE_TIMEOUT)
-    .then(
-      () => true,
-      () => false,
-    );
-
-  if (!isOpen) {
-    return;
-  }
-
-  await device.pressBack();
   await waitForScreen();
 }
 
@@ -202,11 +170,7 @@ async function expectMenuItems(
   expectedVisible: [MenuTitle, ...MenuTitle[]],
   { checkOrder = false }: { checkOrder?: boolean } = {},
 ): Promise<void> {
-  await openMenu();
-
-  let assertionFailed = false;
-
-  try {
+  await withOverflowMenu(async () => {
     // Populated in a single layout pass, so once the first expected entry is up
     // the `not.toExist()` checks below cannot pass prematurely.
     await waitForMenuItem(expectedVisible[0]);
@@ -238,21 +202,7 @@ async function expectMenuItems(
         ).not.toExist();
       }
     }
-  } catch (error) {
-    assertionFailed = true;
-    throw error;
-  } finally {
-    // Closed here so a failed assertion does not leave the popup covering the
-    // screen — this suite is stateful and every later step would then fail.
-    try {
-      await closeMenuIfOpen();
-    } catch (cleanupError) {
-      // A throw from `finally` would replace the error that actually failed.
-      if (!assertionFailed) {
-        throw cleanupError;
-      }
-    }
-  }
+  });
 }
 
 async function expectLastClicked(id: string) {
@@ -280,7 +230,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
     });
 
     it('closes the menu and reports item-1 when tapping "Title A"', async () => {
-      await openMenu();
+      await openOverflowMenu();
       await tapMenuItem('Title A');
 
       await expect(element(by.text('Title B'))).not.toExist();
@@ -289,7 +239,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
     });
 
     it('reports item-3 when tapping "Title C"', async () => {
-      await openMenu();
+      await openOverflowMenu();
       await tapMenuItem('Title C');
 
       await expect(element(by.text('Title A'))).not.toExist();
@@ -322,7 +272,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
     });
 
     it('keeps the id stable across a title change — "Changed" still reports item-2', async () => {
-      await openMenu();
+      await openOverflowMenu();
       await tapMenuItem('Changed');
 
       await expect(element(by.text('Title A'))).not.toExist();

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -252,18 +252,31 @@ function MainScreen() {
 
   return (
     <ScrollViewMarker style={styles.scrollViewMarker}>
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        testID="toolbar-menu-batch-commands-scrollview">
         <Text style={styles.heading}>Batch Commands</Text>
         <View style={styles.buttons}>
-          <Button title="Select All (1 event)" onPress={selectAll} />
-          <Button title="Deselect All (1 event)" onPress={deselectAll} />
+          <Button
+            title="Select All (1 event)"
+            onPress={selectAll}
+            testID="select-all-button"
+          />
+          <Button
+            title="Deselect All (1 event)"
+            onPress={deselectAll}
+            testID="deselect-all-button"
+          />
           <Button
             title="Batch across groups (2 events)"
             onPress={batchAcrossGroups}
+            testID="batch-across-groups-button"
           />
           <Button
             title="Single object update (1 event)"
             onPress={singleObjectUpdate}
+            testID="single-object-update-button"
           />
           <Button
             title={
@@ -272,24 +285,33 @@ function MainScreen() {
                 : 'Move Apple to toolbar'
             }
             onPress={toggleAppleShowAsAction}
+            testID="toggle-apple-button"
           />
           <Button
             title="Batch: image + check (atomic)"
             onPress={batchWithImageLoad}
+            testID="batch-image-check-button"
           />
           <Button
             title="Ordering race (last: Apple absent)"
             onPress={runOrderingRace}
+            testID="ordering-race-button"
           />
           <Button
             title="Failing image + follow-up"
             onPress={runFailingImageRepro}
+            testID="failing-image-button"
           />
           <Button
             title="Duplicate id: merge + last icon"
             onPress={runDuplicateIdRepro}
+            testID="duplicate-id-button"
           />
-          <Button title="Reset log (menu state kept)" onPress={resetLog} />
+          <Button
+            title="Reset log (menu state kept)"
+            onPress={resetLog}
+            testID="reset-log-button"
+          />
         </View>
 
         <Text style={styles.hint}>
@@ -300,13 +322,18 @@ function MainScreen() {
           log.
         </Text>
 
-        <Text style={styles.heading}>Events received: {eventCount}</Text>
+        <Text testID="events-count-text" style={styles.heading}>
+          Events received: {eventCount}
+        </Text>
         <Text style={styles.subheading}>Newest first</Text>
         {eventLog.length === 0 ? (
           <Text style={styles.result}>—</Text>
         ) : (
           eventLog.map((entry, i) => (
-            <Text key={`${i}-${entry}`} style={styles.result}>
+            <Text
+              key={`${i}-${entry}`}
+              testID={`event-log-entry-${i}`}
+              style={styles.result}>
               {i === 0 ? '▶ ' : '  '}
               {entry}
             </Text>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario-description.ts
@@ -6,6 +6,6 @@ export const scenarioDescription: ScenarioDescription = {
   details:
     'Tests batched updates via the updateToolbarMenuElements view command.',
   platforms: ['android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -16,7 +16,21 @@ one batch is applied in order, with the last icon winning.
 
 ## E2E test
 
-TBD — automation is possible and planned but not yet implemented.
+Incomplete: covers steps 1–18.
+
+Not automated:
+
+- The visual correctness of a downloaded photo icon. Detox cannot read image
+  bytes, so a "photo applied" step is verified only through the presence (or
+  absence, for a cleared/failed load) of the icon's `ImageView`, never that
+  the pixels are actually the expected seeded photo. Verify the icon's
+  appearance visually.
+- Strict same-instant atomicity of an image-and-check batch. Detox has no way
+  to prove the icon and its coalesced event land with zero gap between them;
+  the automated steps wait for the batch's converged final state (event count
+  together with the icon) rather than proving no earlier, partially-applied
+  state was ever observable. Verify visually that the icon and the check
+  really do appear together.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -20,19 +20,10 @@ Incomplete: covers steps 1–18.
 
 Not automated:
 
-- The visual correctness of a downloaded photo icon. Detox cannot read image
-  bytes, and an Android action button draws its icon as part of the text view
-  rather than as a separate image view, so a "photo applied" step is verified
-  only through the button being in its icon-only form (no rendered text, title
-  exposed as content description) versus its text-button form ("APPLE"
-  rendered as text) — for a cleared/failed load — never that the pixels are
-  actually the expected seeded photo. Verify the icon's appearance visually.
-- Strict same-instant atomicity of an image-and-check batch. Detox has no way
-  to prove the icon and its coalesced event land with zero gap between them;
-  the automated steps wait for the batch's converged final state (event count
-  together with the icon) rather than proving no earlier, partially-applied
-  state was ever observable. Verify visually that the icon and the check
-  really do appear together.
+- The appearance of a downloaded photo icon — Detox cannot read image bytes,
+  so an icon is only asserted present or absent. Verify visually.
+- Same-instant atomicity of an image-and-check batch — only the final state is
+  asserted. Verify visually that the icon and the check appear together.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -21,10 +21,12 @@ Incomplete: covers steps 1–18.
 Not automated:
 
 - The visual correctness of a downloaded photo icon. Detox cannot read image
-  bytes, so a "photo applied" step is verified only through the presence (or
-  absence, for a cleared/failed load) of the icon's `ImageView`, never that
-  the pixels are actually the expected seeded photo. Verify the icon's
-  appearance visually.
+  bytes, and an Android action button draws its icon as part of the text view
+  rather than as a separate image view, so a "photo applied" step is verified
+  only through the button being in its icon-only form (no rendered text, title
+  exposed as content description) versus its text-button form ("APPLE"
+  rendered as text) — for a cleared/failed load — never that the pixels are
+  actually the expected seeded photo. Verify the icon's appearance visually.
 - Strict same-instant atomicity of an image-and-check batch. Detox has no way
   to prove the icon and its coalesced event land with zero gap between them;
   the automated steps wait for the batch's converged final state (event count


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1728

Adds Detox e2e coverage for the `test-stack-toolbar-menu-batch-commands-android`
scenario — the batched `updateToolbarMenuElements` view command on the Stack v5
Android header. The scenario screen already existed with `e2eCoverage: 'tbd'`;
this PR covers steps 1–18 and flips the coverage to `incomplete`.

The spec runs the scenario as one stateful walkthrough (the menu's checked
state is cumulative and the screen has no full reset) and covers:

- coalescing — one `onToolbarMenuGroupSelectionChange` per batch and per
  affected group, in update order,
- the single-object (non-array) argument form,
- atomic application of a batch mixing an async image load with plain updates,
- FIFO ordering of back-to-back commands — a late image load does not override
  a newer command,
- robustness — a failing image load still completes the batch and clears the
  icon; a repeated id in one batch is merged with the last icon winning.

Coverage is `incomplete` because Detox cannot read image
bytes: an icon is only asserted present or absent (via the action button's
icon-only vs text form), and only the final state of an image-and-check batch
is asserted. Both are left to manual verification, as noted in `scenario.md`.

## Changes

- Added `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts`
- `e2e-utils.ts`: extracted the Android overflow-menu helpers that the sibling
  toolbar-menu specs were duplicating (`createOverflowMenuHelpers`,
  `openOverflowMenu`, `isMenuOpen`, `menuItemRow`, `expectCheckBox`,
  `expectRadioButton`, …) and exported `scrollToAndTap`.
- `test-stack-toolbar-menu-commands-android.e2e.ts`: switched to the shared
  overflow-menu helpers, no behaviour change.
- Test screen: added `testID`s (scroll view, all command buttons, event
  counter, log entries).
- `scenario.md` / `scenario-description.ts`: documented what is and is not
  automated, and set `e2eCoverage: 'incomplete'`.
