### PR TITLE
Retracted: FullWindowOverlay recycled-order experiment

### DIFF
--- a/apps/src/tests/issue-tests/Test4511.tsx
+++ b/apps/src/tests/issue-tests/Test4511.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { FullWindowOverlay } from 'react-native-screens';
+
+export default function App() {
+  const [parentOpen, setParentOpen] = useState(false);
+  const [childOpen, setChildOpen] = useState(false);
+  const [cycles, setCycles] = useState(0);
+
+  const closeParent = () => {
+    setChildOpen(false);
+    setParentOpen(false);
+    setCycles(current => current + 1);
+  };
+
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>FullWindowOverlay recycling test</Text>
+      <Text>Completed cycles: {cycles}</Text>
+      <Pressable
+        onPress={() => setParentOpen(true)}
+        style={styles.primaryButton}>
+        <Text style={styles.primaryButtonText}>Open parent overlay</Text>
+      </Pressable>
+
+      {parentOpen && (
+        <FullWindowOverlay>
+          <View style={styles.parentBackdrop}>
+            <View style={styles.parentCard}>
+              <Text style={styles.title}>Parent overlay</Text>
+              <Pressable
+                onPress={() => setChildOpen(true)}
+                style={styles.button}>
+                <Text>Open child overlay</Text>
+              </Pressable>
+              <Pressable onPress={closeParent} style={styles.button}>
+                <Text>Close parent overlay</Text>
+              </Pressable>
+            </View>
+          </View>
+        </FullWindowOverlay>
+      )}
+
+      {childOpen && (
+        <FullWindowOverlay>
+          <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+            <View style={styles.childCard}>
+              <Text style={styles.childTitle}>Child overlay</Text>
+              <Pressable
+                onPress={() => setChildOpen(false)}
+                style={styles.button}>
+                <Text>Close child overlay</Text>
+              </Pressable>
+            </View>
+          </View>
+        </FullWindowOverlay>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    alignItems: 'center',
+    flex: 1,
+    gap: 16,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 12,
+    padding: 16,
+  },
+  primaryButtonText: {
+    color: 'white',
+    fontWeight: '600',
+  },
+  parentBackdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  parentCard: {
+    backgroundColor: 'white',
+    borderRadius: 20,
+    gap: 12,
+    padding: 24,
+    width: '100%',
+  },
+  button: {
+    backgroundColor: 'white',
+    borderColor: '#d4d4d4',
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 14,
+  },
+  childCard: {
+    alignSelf: 'center',
+    backgroundColor: '#f97316',
+    borderRadius: 20,
+    gap: 12,
+    marginTop: 540,
+    padding: 20,
+    width: 260,
+  },
+  childTitle: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as Test4511 } from './Test4511';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold

--- a/ios/legacy/RNSFullWindowOverlay.mm
+++ b/ios/legacy/RNSFullWindowOverlay.mm
@@ -157,7 +157,9 @@
     window = RCTKeyWindow();
   }
 
-  if (![[window subviews] containsObject:_container]) {
+  if (_container.superview == window) {
+    [window bringSubviewToFront:_container];
+  } else {
     [window addSubview:_container];
   }
 }
@@ -182,6 +184,10 @@
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [self addSubview:childComponentView];
+
+  if (self.superview != nil) {
+    [self maybeShow];
+  }
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index


### PR DESCRIPTION
## Verification correction — do not merge

I am retracting and closing this PR. A fresh stock audit invalidated the reproduction on which the change was based.

The originally published “before” and “after” screenshots both showed a healthy, visible Select menu. An older nearly blank raw capture was a transient Simulator framebuffer frame, not evidence of incorrect `UIWindow` sibling order.

Fresh results on Expo 57.0.14 / React Native 0.86.2 / Hermes / Fabric / iOS 26.5:

- Stock `react-native-screens` 4.27.0 passed 20 raw sibling-overlay lifecycle runs.
- Stock 4.27.0 passed 10 HeroUI Native 1.0.8 Dialog/Select cycles.
- Stock 4.25.2 passed 10 selection-close Dialog/Select cycles.
- Stock 4.25.2 passed another 10 Select-backdrop-dismiss cycles.
- Both native builds explicitly recompiled the stock `RNSFullWindowOverlay.mm` file.

Consequently, the assertions that stock fails on cycle four, that HeroUI stock fails on cycle three, and that the raw harness establishes the RNS package boundary are not supported.

The Objective-C++ change is plausible as an experiment, but without a verified failing stock case it could alter overlay ordering semantics unnecessarily. The added issue-test screen also does not fail on stock in the fresh audit, so it is not a regression test.

The corrected investigation record is at https://github.com/eliotgevers/react-native-screens-full-window-overlay-repro. I apologize for opening the PR before validating the screenshots and stock failure rigorously enough.
