### PR TITLE
feat(Android, Stack v5): expose `contentInsetStart`, `contentInsetEnd` for toolbar

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -35,6 +35,7 @@ import com.swmansion.rnscreens.stack.header.subview.StackHeaderSubview
 import com.swmansion.rnscreens.utils.dpToPx
 import com.swmansion.rnscreens.utils.resolveDrawableAttr
 import com.swmansion.rnscreens.utils.spToPx
+import kotlin.math.roundToInt
 
 /**
  * Builds and applies the Material app bar — type, subviews, title, back button,
@@ -334,8 +335,8 @@ internal class StackHeaderApplicator(
         val toolbar = appBar.toolbar
 
         toolbar.setContentInsetsRelative(
-            config.contentInsetStart?.let { toolbar.dpToPx(it).toInt() } ?: appBar.defaultContentInsetStart,
-            config.contentInsetEnd?.let { toolbar.dpToPx(it).toInt() } ?: appBar.defaultContentInsetEnd,
+            config.contentInsetStart?.let { toolbar.dpToPx(it).roundToInt() } ?: appBar.defaultContentInsetStart,
+            config.contentInsetEnd?.let { toolbar.dpToPx(it).roundToInt() } ?: appBar.defaultContentInsetEnd,
         )
 
         toolbar.requestLayout()

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -32,6 +32,7 @@ import com.swmansion.rnscreens.stack.header.appbar.StackHeaderAppBarLayout
 import com.swmansion.rnscreens.stack.header.config.StackHeaderConfigurationProviding
 import com.swmansion.rnscreens.stack.header.config.StackHeaderType
 import com.swmansion.rnscreens.stack.header.subview.StackHeaderSubview
+import com.swmansion.rnscreens.utils.dpToPx
 import com.swmansion.rnscreens.utils.resolveDrawableAttr
 import com.swmansion.rnscreens.utils.spToPx
 
@@ -324,6 +325,20 @@ internal class StackHeaderApplicator(
         setColor(appearance.color ?: defaults.color)
         setTypeface(appearance.resolveTypeface(defaults.typeface))
         setTextSizePx(appearance.fontSize?.let { view.spToPx(it) } ?: defaults.textSizePx)
+    }
+
+    internal fun applyContentInsets(
+        appBar: StackHeaderAppBarLayout,
+        config: StackHeaderConfigurationProviding,
+    ) {
+        val toolbar = appBar.toolbar
+
+        toolbar.setContentInsetsRelative(
+            config.contentInsetStart?.let { toolbar.dpToPx(it).toInt() } ?: appBar.defaultContentInsetStart,
+            config.contentInsetEnd?.let { toolbar.dpToPx(it).toInt() } ?: appBar.defaultContentInsetEnd,
+        )
+
+        toolbar.requestLayout()
     }
 
     internal fun applyBackButton(

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -211,6 +211,11 @@ internal class StackHeaderCoordinatorLayout(
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE_POSITIONING)
             }
 
+            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.CONTENT_INSETS)) {
+                applicator.applyContentInsets(appBar, provider)
+                provider.clearInvalidationFlags(StackHeaderInvalidationFlags.CONTENT_INSETS)
+            }
+
             if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.BACK_BUTTON)) {
                 applicator.applyBackButton(appBar.toolbar, provider, canNavigateBack, onNavigationIconClick)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.BACK_BUTTON)

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -20,6 +20,11 @@ internal sealed class StackHeaderAppBarLayout(
 ) : AppBarLayout(context) {
     abstract val toolbar: MaterialToolbar
 
+    // Material's default insets, read before we ever write one.
+    // Lazy because [toolbar] is initialized by the subclasses.
+    internal val defaultContentInsetStart: Int by lazy { toolbar.contentInsetStart }
+    internal val defaultContentInsetEnd: Int by lazy { toolbar.contentInsetEnd }
+
     init {
         layoutParams =
             CoordinatorLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -20,10 +20,8 @@ internal sealed class StackHeaderAppBarLayout(
 ) : AppBarLayout(context) {
     abstract val toolbar: MaterialToolbar
 
-    // Material's default insets, read before we ever write one.
-    // Lazy because [toolbar] is initialized by the subclasses.
-    internal val defaultContentInsetStart: Int by lazy { toolbar.contentInsetStart }
-    internal val defaultContentInsetEnd: Int by lazy { toolbar.contentInsetEnd }
+    internal abstract val defaultContentInsetStart: Int
+    internal abstract val defaultContentInsetEnd: Int
 
     init {
         layoutParams =
@@ -44,6 +42,9 @@ internal sealed class StackHeaderAppBarLayout(
                 elevation = 0f
                 layoutParams = LayoutParams(MATCH_PARENT, WRAP_CONTENT)
             }
+
+        override val defaultContentInsetStart: Int = toolbar.contentInsetStart
+        override val defaultContentInsetEnd: Int = toolbar.contentInsetEnd
 
         // Setting text size and typeface separately (Toolbar exposes only a whole text appearance)
         // needs the title/subtitle TextViews, and Toolbar has no getter for them. Material locates
@@ -93,6 +94,9 @@ internal sealed class StackHeaderAppBarLayout(
                             collapseMode = CollapsingToolbarLayout.LayoutParams.COLLAPSE_MODE_PIN
                         }
             }
+
+        override val defaultContentInsetStart: Int = toolbar.contentInsetStart
+        override val defaultContentInsetEnd: Int = toolbar.contentInsetEnd
 
         // collapsedTitleGravityMode is a construction-time-only attr (no public setter), so both
         // gravity modes are inflated from XML — differing only in that attribute — to stay 1:1.

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -169,6 +169,14 @@ internal class StackHeaderConfig(
         by invalidatingProperty(StackHeaderCollapsedTitleGravityMode.AVAILABLE_SPACE, StackHeaderInvalidationFlags.STRUCTURE)
         internal set
 
+    override var contentInsetStart: Float?
+        by invalidatingProperty(null, StackHeaderInvalidationFlags.CONTENT_INSETS)
+        internal set
+
+    override var contentInsetEnd: Float?
+        by invalidatingProperty(null, StackHeaderInvalidationFlags.CONTENT_INSETS)
+        internal set
+
     override val titleAppearance = ReactTextAppearance(reactContext.assets, ::invalidateTextAppearance)
     override val subtitleAppearance = ReactTextAppearance(reactContext.assets, ::invalidateTextAppearance)
     override val expandedTitleAppearance = ReactTextAppearance(reactContext.assets, ::invalidateTextAppearance)

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
@@ -199,6 +199,25 @@ internal open class StackHeaderConfigViewManager :
             }
     }
 
+    // region Header spacing
+    // Spacing arrives as a float defaulting to -1 (unset); 0 is a valid, applied value.
+
+    override fun setContentInsetStart(
+        view: StackHeaderConfig,
+        value: Float,
+    ) {
+        view.contentInsetStart = value.takeIf { it >= 0f }
+    }
+
+    override fun setContentInsetEnd(
+        view: StackHeaderConfig,
+        value: Float,
+    ) {
+        view.contentInsetEnd = value.takeIf { it >= 0f }
+    }
+
+    // endregion
+
     // region Text appearance
     // Font size arrives as a float defaulting to -1 (unset); non-positive means "use default".
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -42,6 +42,9 @@ internal interface StackHeaderConfigurationProviding {
     val collapsedTitleVerticalGravity: Int
     val collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityMode
 
+    val contentInsetStart: Float?
+    val contentInsetEnd: Float?
+
     val titleAppearance: TextAppearance
     val subtitleAppearance: TextAppearance
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderInvalidationFlags.kt
@@ -16,7 +16,9 @@ internal value class StackHeaderInvalidationFlags(
         val OVERFLOW_ICON = StackHeaderInvalidationFlags(1 shl 7)
         val TITLE_POSITIONING = StackHeaderInvalidationFlags(1 shl 8)
         val TITLE_APPEARANCE = StackHeaderInvalidationFlags(1 shl 9)
-        val APPEARANCE = TITLE or BACK_BUTTON or OVERFLOW_ICON or TITLE_POSITIONING or TITLE_APPEARANCE
+        val CONTENT_INSETS = StackHeaderInvalidationFlags(1 shl 10)
+        val APPEARANCE =
+            TITLE or BACK_BUTTON or OVERFLOW_ICON or TITLE_POSITIONING or TITLE_APPEARANCE or CONTENT_INSETS
         val ALL = STRUCTURE or SUBVIEWS or APPEARANCE or SCROLL_FLAGS or TOOLBAR_MENU or LIFT_ON_SCROLL
     }
 

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -28,6 +28,7 @@ import TestStackHeaderSelectiveUpdates from './test-stack-header-selective-updat
 import TestStackHeaderMenuOptionsIOS from './test-stack-header-menu-options-ios';
 import TestStackHeaderItemIdentifierIOS from './test-stack-header-item-identifier-ios';
 import TestStackHeaderTitleAppearance from './test-stack-header-title-appearance-android';
+import TestStackHeaderContentInsets from './test-stack-header-content-insets-android';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
@@ -57,6 +58,7 @@ export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nest
 export { default as TestStackToolbarMenuBatchCommands } from './test-stack-toolbar-menu-batch-commands-android';
 export { default as TestStackToolbarMenuA11y } from './test-stack-toolbar-menu-a11y-android';
 export { default as TestStackHeaderTitleAppearance } from './test-stack-header-title-appearance-android';
+export { default as TestStackHeaderContentInsets } from './test-stack-header-content-insets-android';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,
@@ -85,6 +87,7 @@ const scenarios = {
   TestStackToolbarMenuBatchCommands,
   TestStackToolbarMenuA11y,
   TestStackHeaderTitleAppearance,
+  TestStackHeaderContentInsets,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/index.tsx
@@ -1,0 +1,445 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  Button,
+  I18nManager,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import LongText from '@apps/shared/LongText';
+import { Colors } from '@apps/shared/styling';
+import {
+  type StackHeaderConfigProps,
+  type StackHeaderTypeAndroid,
+  type StackHeaderTitleHorizontalGravityAndroid,
+  type StackHeaderCollapsedTitleGravityModeAndroid,
+  type StackHeaderToolbarMenuElementAndroid,
+  ScrollViewMarker,
+} from 'react-native-screens';
+
+const HEADER_TITLE = I18nManager.isRTL ? 'الحواف' : 'Insets';
+
+// Probes are rulers: a fixed dp width, printed on them, to judge offsets
+// against. Note the toolbar lays the title out before start-gravity children,
+// so on `small` the leading probe follows the title rather than the inset.
+const RULER_PROBE_WIDTH = 40;
+const WIDE_PROBE_WIDTH = 160;
+const PROBE_HEIGHT = 32;
+
+const LEADING_PROBE_ID = 'content-insets-leading-probe';
+const CENTER_PROBE_ID = 'content-insets-center-probe';
+const TRAILING_PROBE_ID = 'content-insets-trailing-probe';
+
+// Each picker's options are the single source of truth; the option union type is
+// derived from the array so the two can never drift apart.
+const options = <const T extends string>(...values: T[]): T[] => values;
+
+const DP_VALUES = options('default', '0', '16', '32', '64', '96');
+const PROBE_SIZES = options('none', 'ruler', 'wide');
+const CENTER_PROBE_SIZES = options('none', 'ruler');
+const MENU_ITEMS_VALUES = options('0', '1', '2');
+const HEADER_TYPES: StackHeaderTypeAndroid[] = ['small', 'medium', 'large'];
+const HORIZONTAL_GRAVITY_OPTIONS: StackHeaderTitleHorizontalGravityAndroid[] = [
+  'start',
+  'center',
+  'end',
+];
+const GRAVITY_MODES: StackHeaderCollapsedTitleGravityModeAndroid[] = [
+  'entireSpace',
+  'availableSpace',
+];
+
+export type DpValue = (typeof DP_VALUES)[number];
+export type ProbeSize = (typeof PROBE_SIZES)[number];
+export type CenterProbeSize = (typeof CENTER_PROBE_SIZES)[number];
+export type MenuItemsValue = (typeof MENU_ITEMS_VALUES)[number];
+
+interface Config {
+  contentInsetStart: DpValue;
+  contentInsetEnd: DpValue;
+  type: StackHeaderTypeAndroid;
+  titleCentered: boolean;
+  collapsedTitleHorizontalGravity: StackHeaderTitleHorizontalGravityAndroid;
+  collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityModeAndroid;
+  backButtonHidden: boolean;
+  menuItems: MenuItemsValue;
+  leadingSubview: ProbeSize;
+  centerSubview: CenterProbeSize;
+  trailingSubview: ProbeSize;
+}
+
+const DEFAULT_CONFIG: Config = {
+  contentInsetStart: 'default',
+  contentInsetEnd: 'default',
+  type: 'small',
+  titleCentered: false,
+  collapsedTitleHorizontalGravity: 'start',
+  collapsedTitleGravityMode: 'availableSpace',
+  backButtonHidden: false,
+  menuItems: '0',
+  leadingSubview: 'ruler',
+  centerSubview: 'none',
+  trailingSubview: 'ruler',
+};
+
+// The reason the props exist: with `availableSpace` the collapsed title is
+// centered within the inset-shrunk content area, so it reads as off-center
+// until the insets are zeroed. Subviews stay off so the title is alone.
+const OFF_CENTER_PRESET: Config = {
+  ...DEFAULT_CONFIG,
+  type: 'large',
+  collapsedTitleHorizontalGravity: 'center',
+  collapsedTitleGravityMode: 'availableSpace',
+  leadingSubview: 'none',
+  trailingSubview: 'none',
+};
+
+const FIXED_PRESET: Config = {
+  ...OFF_CENTER_PRESET,
+  contentInsetStart: '0',
+  contentInsetEnd: '0',
+};
+
+const ConfigContext = React.createContext<{
+  config: Config;
+  updateConfig: <K extends keyof Config>(key: K, value: Config[K]) => void;
+  setConfig: (config: Config) => void;
+}>({
+  config: DEFAULT_CONFIG,
+  updateConfig: () => {},
+  setConfig: () => {},
+});
+
+function resolveDp(value: DpValue): number | undefined {
+  return value === 'default' ? undefined : Number(value);
+}
+
+function probeWidth(size: Exclude<ProbeSize, 'none'>): number {
+  return size === 'wide' ? WIDE_PROBE_WIDTH : RULER_PROBE_WIDTH;
+}
+
+function makeProbe(size: ProbeSize, label: string, testID: string) {
+  if (size === 'none') {
+    return undefined;
+  }
+
+  const width = probeWidth(size);
+
+  return {
+    render: () => (
+      <View testID={testID} style={[styles.probe, { width }]}>
+        <Text style={styles.probeLabel}>{`${label}·${width}`}</Text>
+      </View>
+    ),
+  };
+}
+
+function buildMenuItems(
+  count: MenuItemsValue,
+): StackHeaderToolbarMenuElementAndroid[] {
+  return Array.from({ length: Number(count) }, (_, i) => ({
+    type: 'menuItem',
+    id: `menu-item-${i}`,
+    title: `M${i}`,
+    showAsAction: 'always',
+  }));
+}
+
+function buildHeaderConfig(config: Config): StackHeaderConfigProps {
+  return {
+    title: HEADER_TITLE,
+    backButtonHidden: config.backButtonHidden,
+    android: {
+      type: config.type,
+      contentInsetStart: resolveDp(config.contentInsetStart),
+      contentInsetEnd: resolveDp(config.contentInsetEnd),
+      titleCentered: config.titleCentered,
+      collapsedTitleHorizontalGravity: config.collapsedTitleHorizontalGravity,
+      collapsedTitleGravityMode: config.collapsedTitleGravityMode,
+      leadingSubview: makeProbe(config.leadingSubview, 'L', LEADING_PROBE_ID),
+      // Center subviews are supported only by the small header.
+      centerSubview:
+        config.type === 'small'
+          ? makeProbe(config.centerSubview, 'C', CENTER_PROBE_ID)
+          : undefined,
+      trailingSubview: makeProbe(
+        config.trailingSubview,
+        'T',
+        TRAILING_PROBE_ID,
+      ),
+      toolbarMenu:
+        config.menuItems === '0'
+          ? undefined
+          : { children: buildMenuItems(config.menuItems) },
+      // Keeps the collapsed state of medium/large reachable from any offset.
+      scrollFlagEnterAlways: config.type === 'small' ? undefined : true,
+    },
+  };
+}
+
+function TestStackHeaderContentInsets() {
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+
+  const updateConfig = useCallback(
+    <K extends keyof Config>(key: K, value: Config[K]) => {
+      setConfig(prev => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  return (
+    <ConfigContext.Provider value={{ config, updateConfig, setConfig }}>
+      <StackContainer
+        routeConfigs={[
+          { name: 'Root', element: <RootScreen /> },
+          { name: 'Pushed', element: <PushedScreen /> },
+        ]}
+      />
+    </ConfigContext.Provider>
+  );
+}
+
+function Presets() {
+  const { setConfig } = useContext(ConfigContext);
+
+  return (
+    <View style={styles.presets}>
+      <Button
+        title="Reset"
+        testID="content-insets-preset-reset"
+        onPress={() => setConfig(DEFAULT_CONFIG)}
+      />
+      <Button
+        title="Off-center collapsed title"
+        testID="content-insets-preset-off-center"
+        onPress={() => setConfig(OFF_CENTER_PRESET)}
+      />
+      <Button
+        title="Fixed with insets"
+        testID="content-insets-preset-fixed"
+        onPress={() => setConfig(FIXED_PRESET)}
+      />
+    </View>
+  );
+}
+
+function RtlControls() {
+  const [forceRtl, setForceRtl] = useState(I18nManager.isRTL);
+
+  useEffect(() => {
+    I18nManager.forceRTL(forceRtl);
+  }, [forceRtl]);
+
+  return (
+    <>
+      <Text style={styles.heading}>Layout direction</Text>
+      <Text style={styles.note}>
+        contentInsetStart/End are relative, so they swap under RTL. Restart or
+        reload the app after toggling.
+      </Text>
+      <Text style={styles.note} testID="content-insets-is-rtl">
+        {`I18nManager.isRTL == ${I18nManager.isRTL}`}
+      </Text>
+      <SettingsSwitch
+        testID="content-insets-force-rtl-switch"
+        label="forceRTL"
+        value={forceRtl}
+        onValueChange={setForceRtl}
+      />
+    </>
+  );
+}
+
+function ConfigControls() {
+  const { config, updateConfig } = useContext(ConfigContext);
+
+  return (
+    <>
+      <Text style={styles.heading}>Presets</Text>
+      <Presets />
+
+      <Text style={styles.heading}>Content insets</Text>
+      <SettingsPicker<DpValue>
+        testID="content-inset-start-picker"
+        label="contentInsetStart"
+        value={config.contentInsetStart}
+        onValueChange={v => updateConfig('contentInsetStart', v)}
+        items={DP_VALUES}
+      />
+      <SettingsPicker<DpValue>
+        testID="content-inset-end-picker"
+        label="contentInsetEnd"
+        value={config.contentInsetEnd}
+        onValueChange={v => updateConfig('contentInsetEnd', v)}
+        items={DP_VALUES}
+      />
+
+      <Text style={styles.heading}>Header</Text>
+      <SettingsPicker<StackHeaderTypeAndroid>
+        testID="header-type-picker"
+        label="type"
+        value={config.type}
+        onValueChange={v => updateConfig('type', v)}
+        items={HEADER_TYPES}
+      />
+      <SettingsSwitch
+        testID="title-centered-switch"
+        label="titleCentered"
+        value={config.titleCentered}
+        onValueChange={v => updateConfig('titleCentered', v)}
+      />
+      <SettingsPicker<StackHeaderTitleHorizontalGravityAndroid>
+        testID="collapsed-title-gravity-picker"
+        label="collapsedTitleHorizontalGravity"
+        value={config.collapsedTitleHorizontalGravity}
+        onValueChange={v => updateConfig('collapsedTitleHorizontalGravity', v)}
+        items={HORIZONTAL_GRAVITY_OPTIONS}
+      />
+      <SettingsPicker<StackHeaderCollapsedTitleGravityModeAndroid>
+        testID="collapsed-title-gravity-mode-picker"
+        label="collapsedTitleGravityMode"
+        value={config.collapsedTitleGravityMode}
+        onValueChange={v => updateConfig('collapsedTitleGravityMode', v)}
+        items={GRAVITY_MODES}
+      />
+      <SettingsSwitch
+        testID="back-button-hidden-switch"
+        label="backButtonHidden"
+        value={config.backButtonHidden}
+        onValueChange={v => updateConfig('backButtonHidden', v)}
+      />
+      <SettingsPicker<MenuItemsValue>
+        testID="menu-items-picker"
+        label="menuItems"
+        value={config.menuItems}
+        onValueChange={v => updateConfig('menuItems', v)}
+        items={MENU_ITEMS_VALUES}
+      />
+
+      <Text style={styles.heading}>Probe subviews</Text>
+      <Text style={styles.note}>
+        {`Fixed-width rulers (${RULER_PROBE_WIDTH}dp / ${WIDE_PROBE_WIDTH}dp). The trailing gap is the end inset. On small the title is laid out first, so the title marks the start inset and the leading probe follows it.`}
+      </Text>
+      <SettingsPicker<ProbeSize>
+        testID="leading-subview-picker"
+        label="leadingSubview"
+        value={config.leadingSubview}
+        onValueChange={v => updateConfig('leadingSubview', v)}
+        items={PROBE_SIZES}
+      />
+      <SettingsPicker<CenterProbeSize>
+        testID="center-subview-picker"
+        label="centerSubview"
+        value={config.centerSubview}
+        onValueChange={v => updateConfig('centerSubview', v)}
+        items={CENTER_PROBE_SIZES}
+      />
+      <SettingsPicker<ProbeSize>
+        testID="trailing-subview-picker"
+        label="trailingSubview"
+        value={config.trailingSubview}
+        onValueChange={v => updateConfig('trailingSubview', v)}
+        items={PROBE_SIZES}
+      />
+
+      <RtlControls />
+    </>
+  );
+}
+
+function useApplyHeaderConfig() {
+  const { config } = useContext(ConfigContext);
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+  const headerConfig = useMemo(() => buildHeaderConfig(config), [config]);
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+}
+
+function ConfigScreen({ pushTitle }: { pushTitle: string }) {
+  const { push } = useStackNavigationContext();
+  useApplyHeaderConfig();
+
+  return (
+    <ScrollViewMarker style={styles.scrollViewMarker}>
+      <ScrollView
+        nestedScrollEnabled={true}
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        testID="content-insets-scrollview">
+        <ConfigControls />
+        <Text style={styles.heading}>Navigation</Text>
+        <Button title={pushTitle} onPress={() => push('Pushed')} />
+        <LongText size="lg" />
+        {/* Bottom sentinel: lets e2e assert the content actually scrolled. */}
+        <Text testID="content-insets-bottom-marker">End of content</Text>
+      </ScrollView>
+    </ScrollViewMarker>
+  );
+}
+
+function RootScreen() {
+  return <ConfigScreen pushTitle="Push screen (adds a back button)" />;
+}
+
+function PushedScreen() {
+  return <ConfigScreen pushTitle="Push another" />;
+}
+
+const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  note: {
+    fontSize: 13,
+    marginBottom: 4,
+  },
+  presets: {
+    gap: 4,
+  },
+  probe: {
+    height: PROBE_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: Colors.cardBorder,
+    backgroundColor: Colors.PurpleLight60,
+  },
+  probeLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});
+
+export default createScenario(
+  TestStackHeaderContentInsets,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Header content insets (Android)',
+  key: 'test-stack-header-content-insets-android',
+  details: 'Verify contentInsetStart/contentInsetEnd on the Android header.',
+  platforms: ['android'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-content-insets-android/scenario.md
@@ -1,0 +1,207 @@
+# Test Scenario: contentInsetStart / contentInsetEnd (Android)
+
+## Details
+
+**Description:** Verifies `contentInsetStart` and `contentInsetEnd` on the
+Stack v5 Android header config. Both map to
+`Toolbar.setContentInsetsRelative`, which bounds the toolbar's _content area_
+— the region the title, the collapsed title and the leading/center/trailing
+subviews are laid out in.
+
+The props exist because `collapsedTitleGravityMode: 'entireSpace'` is
+unusable, so `'availableSpace'` is the practical choice — and under
+`availableSpace` Material computes the collapsed title's gravity over the
+content area, which the platform's default start inset shrinks. A `center`
+collapsed title then reads as off-center even with no subviews present.
+Zeroing the insets is the escape hatch.
+
+The scenario covers two things: that the dp value is applied on both sides,
+across header types, and that leaving a prop unset restores Material's
+default; and that the centered collapsed title lines up once the insets are
+zeroed.
+
+**OS test creation version:** API 37
+
+## E2E test
+
+TBD
+
+Automation is possible for most of the scenario but is not implemented yet.
+
+## Prerequisites
+
+Android emulator or physical device.
+
+## Note
+
+- Material's defaults are **not symmetric**: the start inset is 16dp, the end
+  inset is 0.
+- **Layout order differs by header type.** The toolbar lays out its title
+  block before its start-gravity custom children, so on `small` the order is
+  `[start inset][title][L probe]` — the leading probe is _not_ a direct
+  measure of the start inset there, it only moves with the title. On
+  `medium` / `large` the toolbar has no title view (the collapsing layout
+  draws the collapsed title itself), so the order is
+  `[start inset][L probe][collapsed title]` and the probe does measure the
+  inset. The end side is `[T probe][menu][end inset]` on every type.
+- The inset is a **minimum**, not an offset. The navigation icon and the
+  toolbar menu are laid out first and are not bounded by it, so
+  `contentInsetStart` is inert while a back button is visible until it
+  exceeds the nav icon's width (`64` / `96` in the picker are above it,
+  `0`–`32` are below). `contentInsetEnd` behaves the same way against menu
+  items.
+- On `medium` / `large` the props affect the **collapsed** title only.
+- Toggling `forceRTL` requires an app restart or reload before it takes
+  effect.
+
+## Steps
+
+### Baseline
+
+1. Navigate to Single feature tests → Stack v5 →
+   `test-stack-header-content-insets-android`.
+
+- [ ] A `small` header titled "Insets" is visible. The title sits at the
+      start of the content area, the `L·40` probe immediately after it, and the
+      `T·40` probe at the trailing edge.
+- [ ] The title's leading edge is inset by roughly 16dp — visibly less than
+      half the `L·40` probe's width. The trailing probe sits flush against the
+      trailing edge, because Material's end default is 0.
+
+### Start inset — small
+
+The title is the measure here; the probe follows it.
+
+2. Set `contentInsetStart` to `0`.
+
+- [ ] The title moves to the very leading edge of the toolbar, and the
+      `L·40` probe moves with it by the same amount.
+- [ ] The trailing probe does not move.
+
+3. Step `contentInsetStart` through `16`, `32`, `64`, `96`.
+
+- [ ] The title's leading edge moves further from the leading edge at each
+      step, by the amount the value grew, and the probe keeps the same distance
+      behind it.
+- [ ] At `96` the title starts roughly two and a half `L·40` widths in.
+
+4. Set `contentInsetStart` back to `default`.
+
+- [ ] The title and the probe return to exactly the positions they had in
+      step 1.
+
+5. Set `contentInsetStart` to `16`.
+
+- [ ] Nothing moves — Material's start default is the same 16dp.
+
+6. Set `leadingSubview` to `none`, then step `contentInsetStart` between `0`
+   and `96` again.
+
+- [ ] The title behaves exactly as it did with the probe present; the probe
+      was never affecting the measurement.
+
+### End inset
+
+7. Tap `Reset`, then step `contentInsetEnd` through `32`, `64`, `96`.
+
+- [ ] The `T·40` probe moves away from the trailing edge at each step, by the
+      amount the value grew.
+- [ ] Neither the title nor the leading probe moves.
+
+8. Set `contentInsetEnd` to `0`, then to `default`.
+
+- [ ] The trailing probe returns flush against the trailing edge for both
+      values, and does not shift between them — Material's end default is 0.
+
+### Back button — start-side inertness
+
+9. Reset, then tap "Push screen (adds a back button)".
+
+- [ ] The pushed header shows a back button, and the title now starts after
+      it — further in than it did on `Root`. The `L·40` probe follows.
+
+10. On the pushed screen, set `contentInsetStart` to `0`, then `16`, then
+    `32`.
+
+- [ ] Nothing moves — all three values are below the nav icon's width, so the
+      inset is inert.
+
+11. Set `contentInsetStart` to `96`.
+
+- [ ] The title finally moves further in, past the back button, and the probe
+      follows.
+
+12. Turn `backButtonHidden` on and set `contentInsetStart` to `0`.
+
+- [ ] The back button disappears and the title jumps to the toolbar's leading
+      edge.
+
+### Toolbar menu — end-side inertness
+
+13. Turn `backButtonHidden` off, go back to `Root`, tap `Reset`, set
+    `menuItems` to `1`.
+
+- [ ] One action item `M0` appears at the trailing edge, and the `T·40` probe
+      sits before it.
+
+14. Step `contentInsetEnd` through `0`, `16`, `32`.
+
+- [ ] `M0` stays pinned where it is — it is laid out before the inset
+      applies.
+- [ ] The trailing probe does not move either, for the same reason the back
+      button pins the start side: the menu already reaches further in than these
+      values.
+
+15. Set `contentInsetEnd` to `96`.
+
+- [ ] `M0` still does not move.
+- [ ] The trailing probe is pushed further in, past the menu item — the inset
+      now exceeds the menu's width and takes effect again.
+
+### Collapsing headers — the motivating case
+
+16. Tap the `Off-center collapsed title` preset, then scroll the content up
+    until the `large` header is fully collapsed.
+
+- [ ] The collapsed title is horizontally **off-center** — shifted towards
+      the trailing edge, because it is centered inside a content area that the
+      default start inset shrank.
+- [ ] The expanded title (scroll back down) is unaffected.
+
+17. Tap the `Fixed with insets` preset and collapse the header again.
+
+- [ ] The collapsed title is centered in the header.
+
+### Collapsing headers — start inset without a title view
+
+18. Set `type` to `medium`, `collapsedTitleHorizontalGravity` to `start`,
+    `leadingSubview` to `none`, `contentInsetStart` to `96`. Collapse the
+    header.
+
+- [ ] The collapsed title starts 96dp from the leading edge.
+
+19. Set `leadingSubview` to `ruler`.
+
+- [ ] The `L·40` probe takes the 96dp position — here it _is_ the start-inset
+      measure, because the toolbar has no title view of its own.
+- [ ] The collapsed title is pushed a further 40dp in, to the probe's
+      trailing side. This is the opposite order from the `small` header.
+
+### RTL
+
+20. Reset. Turn `forceRTL` on and reload the app, then navigate back to this
+    scenario.
+
+- [ ] `I18nManager.isRTL == true` is displayed.
+- [ ] The header lays out right-to-left: the title and the `L·40` probe are
+      on the right, `T·40` on the left.
+
+21. Set `contentInsetStart` to `96`.
+
+- [ ] The title moves further from the **right** edge — the props are
+      relative, so start follows the layout direction.
+- [ ] The trailing probe on the left does not move.
+
+22. Turn `forceRTL` off and reload.
+
+- [ ] Layout returns to left-to-right and the insets follow it back.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/index.tsx
@@ -25,6 +25,7 @@ import {
   type StackHeaderTitleVerticalGravityAndroid,
   type StackHeaderCollapsedTitleGravityModeAndroid,
   type StackHeaderBackgroundSubviewCollapseModeAndroid,
+  type StackHeaderToolbarMenuElementAndroid,
   ScrollViewMarker,
 } from 'react-native-screens';
 
@@ -44,6 +45,8 @@ type PressRetentionValue = '0' | '20' | '50';
 type TextOption = 'undefined' | 'short' | 'long';
 type ScrollFlagValue = 'undefined' | 'true' | 'false';
 type MaxLinesValue = '1' | '2' | '3';
+type MenuItemsValue = '0' | '1' | '2';
+type DpValue = 'default' | '0' | '8' | '16' | '32';
 
 interface Config {
   enabled: boolean;
@@ -60,6 +63,9 @@ interface Config {
   collapsedTitleHorizontalGravity: StackHeaderTitleHorizontalGravityAndroid;
   collapsedTitleVerticalGravity: StackHeaderTitleVerticalGravityAndroid;
   collapsedTitleGravityMode: StackHeaderCollapsedTitleGravityModeAndroid;
+  contentInsetStart: DpValue;
+  contentInsetEnd: DpValue;
+  menuItems: MenuItemsValue;
   leadingSize: SubviewSize;
   centerSize: SubviewSize;
   trailingSize: SubviewSize;
@@ -89,6 +95,9 @@ const DEFAULT_CONFIG: Config = {
   collapsedTitleHorizontalGravity: 'start',
   collapsedTitleVerticalGravity: 'center',
   collapsedTitleGravityMode: 'availableSpace',
+  contentInsetStart: 'default',
+  contentInsetEnd: 'default',
+  menuItems: '0',
   leadingSize: 'none',
   centerSize: 'none',
   trailingSize: 'none',
@@ -128,6 +137,8 @@ const GRAVITY_MODE_OPTIONS: StackHeaderCollapsedTitleGravityModeAndroid[] = [
   'availableSpace',
   'entireSpace',
 ];
+const MENU_ITEMS_OPTIONS: MenuItemsValue[] = ['0', '1', '2'];
+const DP_OPTIONS: DpValue[] = ['default', '0', '8', '16', '32'];
 
 function resolveScrollFlag(value: ScrollFlagValue): boolean | undefined {
   switch (value) {
@@ -138,6 +149,21 @@ function resolveScrollFlag(value: ScrollFlagValue): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+function resolveDp(value: DpValue): number | undefined {
+  return value === 'default' ? undefined : Number(value);
+}
+
+function buildMenuItems(
+  count: MenuItemsValue,
+): StackHeaderToolbarMenuElementAndroid[] {
+  return Array.from({ length: Number(count) }, (_, i) => ({
+    type: 'menuItem',
+    id: `menu-item-${i}`,
+    title: `M${i}`,
+    showAsAction: 'always',
+  }));
 }
 
 function resolveText(
@@ -239,6 +265,12 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
       collapsedTitleVerticalGravity: config.collapsedTitleVerticalGravity,
       collapsedTitleGravityMode: config.collapsedTitleGravityMode,
       maxLines: Number(config.maxLines),
+      toolbarMenu:
+        config.menuItems === '0'
+          ? undefined
+          : { children: buildMenuItems(config.menuItems) },
+      contentInsetStart: resolveDp(config.contentInsetStart),
+      contentInsetEnd: resolveDp(config.contentInsetEnd),
       scrollFlagScroll: resolveScrollFlag(config.scrollFlagScroll),
       scrollFlagEnterAlways: resolveScrollFlag(config.scrollFlagEnterAlways),
       scrollFlagEnterAlwaysCollapsed: resolveScrollFlag(
@@ -403,6 +435,31 @@ function ConfigScreen() {
             />
           </>
         )}
+        <Text style={styles.heading}>Content Insets</Text>
+        <View style={styles.row}>
+          <View style={styles.rowItem}>
+            <SettingsPicker<DpValue>
+              label="inset start"
+              value={config.contentInsetStart}
+              onValueChange={v => updateConfig('contentInsetStart', v)}
+              items={DP_OPTIONS}
+            />
+          </View>
+          <View style={styles.rowItem}>
+            <SettingsPicker<DpValue>
+              label="inset end"
+              value={config.contentInsetEnd}
+              onValueChange={v => updateConfig('contentInsetEnd', v)}
+              items={DP_OPTIONS}
+            />
+          </View>
+        </View>
+        <SettingsPicker<MenuItemsValue>
+          label="menu items"
+          value={config.menuItems}
+          onValueChange={v => updateConfig('menuItems', v)}
+          items={MENU_ITEMS_OPTIONS}
+        />
         <Text style={styles.heading}>Toolbar Subviews</Text>
         <SettingsPicker<SubviewSize>
           label="leading"

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** This test focuses on handling custom subviews in the header on Android. As subview layout and synchronization in Shadow Tree is sensitive to any changes to other props, nearly full configuration of the header is provided. It also drives `contentInsetStart` / `contentInsetEnd` under the "Content Insets" section, since those bound the same content area the subviews are laid out in.
+**Description:** This test focuses on handling custom subviews in the header on Android. As subview layout and synchronization in Shadow Tree is sensitive to any changes to other props, nearly full configuration of the header is provided.
 
 **OS test creation version:** API 36
 
@@ -23,12 +23,6 @@ This feature is still WIP.
 - entire hierarchy is rebuild when number of subviews is changed in runtime
 - hierarchy rebuild causes a flash and resets scroll position
 - text ellipsize in RTL does not work with subviews
-- the content insets move the small title and the medium/large collapsed title,
-  never the medium/large expanded one
-- both insets are minimums, not offsets: the navigation icon and the menu are
-  laid out before they apply, so `contentInsetStart` is inert once a back button
-  is shown (push a screen) and `contentInsetEnd` is inert once the "menu items"
-  picker adds an item
 
 ## Steps
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-android/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** This test focuses on handling custom subviews in the header on Android. As subview layout and synchronization in Shadow Tree is sensitive to any changes to other props, nearly full configuration of the header is provided.
+**Description:** This test focuses on handling custom subviews in the header on Android. As subview layout and synchronization in Shadow Tree is sensitive to any changes to other props, nearly full configuration of the header is provided. It also drives `contentInsetStart` / `contentInsetEnd` under the "Content Insets" section, since those bound the same content area the subviews are laid out in.
 
 **OS test creation version:** API 36
 
@@ -23,6 +23,12 @@ This feature is still WIP.
 - entire hierarchy is rebuild when number of subviews is changed in runtime
 - hierarchy rebuild causes a flash and resets scroll position
 - text ellipsize in RTL does not work with subviews
+- the content insets move the small title and the medium/large collapsed title,
+  never the medium/large expanded one
+- both insets are minimums, not offsets: the navigation icon and the menu are
+  laid out before they apply, so `contentInsetStart` is inert once a back button
+  is shown (push a screen) and `contentInsetEnd` is inert once the "menu items"
+  picker adds an item
 
 ## Steps
 

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -913,6 +913,42 @@ export interface StackHeaderConfigPropsAndroid {
    */
   maxLines?: number | undefined;
   /**
+   * @summary Start inset of the toolbar.
+   *
+   * @description
+   * The inset is a minimum: the navigation icon is positioned before it is
+   * applied and is not bounded by it, so the content area starts at whichever
+   * reaches further from the edge — the navigation icon's trailing edge or this
+   * inset. A back button usually wins, which makes this prop inert while one is
+   * visible.
+   *
+   * @remarks
+   * Applies to all header types. On `medium` / `large` it affects the collapsed
+   * title only.
+   *
+   * By default, native platform applies non-zero inset which makes centered
+   * collapsed title look off-center when `collapsedTitleGravityMode:
+   * 'availableSpace'` is used.
+   *
+   * If value is not provided, falls back to Material's default.
+   *
+   * @platform android
+   */
+  contentInsetStart?: number | undefined;
+  /**
+   * @summary End inset of the toolbar content area.
+   *
+   * @remarks
+   * The end-side counterpart of `contentInsetStart`. Applies to all header
+   * types. Like its start-side counterpart it is a minimum, so it is inert
+   * while the toolbar menu shows items that already reach further in.
+   *
+   * If value is not provided, falls back to Material's default.
+   *
+   * @platform android
+   */
+  contentInsetEnd?: number | undefined;
+  /**
    * @summary Color of the title text. Applies to `small` header only.
    *
    * @remarks

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -125,6 +125,9 @@ export interface NativeProps extends ViewProps {
     'availableSpace'
   >;
 
+  contentInsetStart?: CT.WithDefault<CT.Float, -1.0>;
+  contentInsetEnd?: CT.WithDefault<CT.Float, -1.0>;
+
   titleColor?: ColorValue | undefined;
   titleFontFamily?: string | undefined;
   titleFontSize?: CT.WithDefault<CT.Float, -1.0>;


### PR DESCRIPTION
## Description

Exposes `contentInsetStart`, `contentInsetEnd` props to control the content inset. It can be used as a workaround for broken `entireSpace` gravity mode. More info in https://github.com/software-mansion/react-native-screens/pull/4387.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1742.

## Changes

- expose the prop in JS and native side
- capture default values for insets in `StackHeaderAppBarLayout` and use them when no value is provided
- add content inset and menu items configurations to subviews SFT

## Before & after - visual documentation

https://github.com/user-attachments/assets/58ab509b-2419-4d90-b613-34f07684ed4a

## Test plan

Run `test-stack-header-content-insets-android`, `test-stack-subviews-android`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>