### PR TITLE
fix(iOS, Stack v5): Opt out of largeTitleDisplayMode by default when headerConfig is not present

### DIFF
--- a/ios/stack/screen/RNSStackScreenController.mm
+++ b/ios/stack/screen/RNSStackScreenController.mm
@@ -19,6 +19,13 @@
     _screenView = componentView;
     _headerCoordinator = [[RNSStackScreenHeaderCoordinator alloc] initWithScreenController:self];
     _containerItemSupport = [RNSContainerItemSupport new];
+
+#if !TARGET_OS_TV
+    // NavigationBar is configured to always prefer large title and the actual configuration is
+    // handled by headerConfig updating the display mode on navigationItem.
+    // In case the headerConfig is not provided, we opt out of large title by default.
+    self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+#endif // !TARGET_OS_TV
   }
   return self;
 }


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1699

## Description

This PR fixes the issue with wrong header mode (large instead of regular) when headerConfig is not present in the screen.

## Changes

- opted out of large header when initializing the current screen, before headerConfig is attached

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <img width="393" height="257" alt="image" src="https://github.com/user-attachments/assets/849fa5af-7af6-435e-8c4a-f650693b3665" /> | <img width="389" height="222" alt="image" src="https://github.com/user-attachments/assets/af140fba-bcdf-48bb-b8b7-3bdf0c117926" /> |

## Test plan

You can use `test-stack-prevent-native-dismiss-nested-stack` which already has a nested stack inside. Observe that it works correctly when headerConfig is commented out.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
