### PR TITLE
fix(android) transparent header backgroundColor dropped by Props 2.0

### DIFF
--- a/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnscreens/RNSScreenShadowNode.cpp
@@ -122,7 +122,7 @@ void RNSScreenShadowNode::appendChild(
           ? 0.f
           : findHeaderHeight(
                 headerProps.titleFontSize,
-                headerProps.title.empty(),
+                !headerProps.title.has_value() || headerProps.title->empty(),
                 applyTopInset)
                 .value_or(0.f);
 

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -15,6 +15,7 @@
 #import <react/renderer/components/rnscreens/RCTComponentViewHelpers.h>
 #import <react/utils/ManagedObjectWrapper.h>
 #import <rnscreens/RNSScreenStackHeaderConfigComponentDescriptor.h>
+#import <optional>
 #import "RCTImageComponentView+RNSScreenStackHeaderConfig.h"
 #import "RNSBackBarButtonItem.h"
 #import "RNSBarButtonItem.h"
@@ -28,6 +29,16 @@ namespace react = facebook::react;
 
 static const NSNumber *const DEFAULT_TITLE_FONT_SIZE = @17;
 static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
+
+static NSString *_Nullable RNSNSStringFromOptionalStdString(const std::optional<std::string> &value)
+{
+  return value.has_value() ? RCTNSStringFromStringNilIfEmpty(value.value()) : nil;
+}
+
+static UIColor *_Nullable RNSUIColorFromOptionalSharedColor(const std::optional<react::SharedColor> &color)
+{
+  return color.has_value() ? RCTUIColorFromSharedColor(color.value()) : nil;
+}
 
 @interface RCTImageLoader (Private)
 - (id<RCTImageCache>)imageCache;
@@ -1022,26 +1033,26 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
     [self setBackButtonInCustomView:newScreenProps.backButtonInCustomView];
   }
 
-  _title = RCTNSStringFromStringNilIfEmpty(newScreenProps.title);
+  _title = RNSNSStringFromOptionalStdString(newScreenProps.title);
   if (newScreenProps.titleFontFamily != oldScreenProps.titleFontFamily) {
-    _titleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.titleFontFamily);
+    _titleFontFamily = RNSNSStringFromOptionalStdString(newScreenProps.titleFontFamily);
   }
-  _titleFontWeight = RCTNSStringFromStringNilIfEmpty(newScreenProps.titleFontWeight);
+  _titleFontWeight = RNSNSStringFromOptionalStdString(newScreenProps.titleFontWeight);
   _titleFontSize = [self getFontSizePropValue:newScreenProps.titleFontSize];
   _hideShadow = newScreenProps.hideShadow;
 
   _largeTitle = newScreenProps.largeTitle;
   if (newScreenProps.largeTitleFontFamily != oldScreenProps.largeTitleFontFamily) {
-    _largeTitleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.largeTitleFontFamily);
+    _largeTitleFontFamily = RNSNSStringFromOptionalStdString(newScreenProps.largeTitleFontFamily);
   }
-  _largeTitleFontWeight = RCTNSStringFromStringNilIfEmpty(newScreenProps.largeTitleFontWeight);
+  _largeTitleFontWeight = RNSNSStringFromOptionalStdString(newScreenProps.largeTitleFontWeight);
   _largeTitleFontSize = [self getFontSizePropValue:newScreenProps.largeTitleFontSize];
   _largeTitleHideShadow = newScreenProps.largeTitleHideShadow;
-  _largeTitleBackgroundColor = RCTUIColorFromSharedColor(newScreenProps.largeTitleBackgroundColor);
+  _largeTitleBackgroundColor = RNSUIColorFromOptionalSharedColor(newScreenProps.largeTitleBackgroundColor);
 
-  _backTitle = RCTNSStringFromStringNilIfEmpty(newScreenProps.backTitle);
+  _backTitle = RNSNSStringFromOptionalStdString(newScreenProps.backTitle);
   if (newScreenProps.backTitleFontFamily != oldScreenProps.backTitleFontFamily) {
-    _backTitleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.backTitleFontFamily);
+    _backTitleFontFamily = RNSNSStringFromOptionalStdString(newScreenProps.backTitleFontFamily);
   }
   _backTitleFontSize = [self getFontSizePropValue:newScreenProps.backTitleFontSize];
   _hideBackButton = newScreenProps.hideBackButton;
@@ -1061,37 +1072,45 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 
   // We cannot compare SharedColor because it is shared value.
   // We could compare color value, but it is more performant to just assign new value
-  _titleColor = RCTUIColorFromSharedColor(newScreenProps.titleColor);
-  _largeTitleColor = RCTUIColorFromSharedColor(newScreenProps.largeTitleColor);
-  _color = RCTUIColorFromSharedColor(newScreenProps.color);
-  _backgroundColor = RCTUIColorFromSharedColor(newScreenProps.backgroundColor);
+  _titleColor = RNSUIColorFromOptionalSharedColor(newScreenProps.titleColor);
+  _largeTitleColor = RNSUIColorFromOptionalSharedColor(newScreenProps.largeTitleColor);
+  _color = RNSUIColorFromOptionalSharedColor(newScreenProps.color);
+  _backgroundColor = RNSUIColorFromOptionalSharedColor(newScreenProps.backgroundColor);
 
   if (newScreenProps.blurEffect != oldScreenProps.blurEffect) {
     _blurEffect = [RNSConvert RNSBlurEffectStyleFromCppEquivalent:newScreenProps.blurEffect];
   }
 
   if (newScreenProps.headerLeftBarButtonItems != oldScreenProps.headerLeftBarButtonItems) {
-    const auto &vec = newScreenProps.headerLeftBarButtonItems;
-    NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
-    for (const auto &item : vec) {
-      NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
-      if ([dict isKindOfClass:[NSDictionary class]]) {
-        [array addObject:dict];
+    if (newScreenProps.headerLeftBarButtonItems.has_value()) {
+      const auto &vec = newScreenProps.headerLeftBarButtonItems.value();
+      NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
+      for (const auto &item : vec) {
+        NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
+        if ([dict isKindOfClass:[NSDictionary class]]) {
+          [array addObject:dict];
+        }
       }
+      _headerLeftBarButtonItems = array;
+    } else {
+      _headerLeftBarButtonItems = nil;
     }
-    _headerLeftBarButtonItems = array;
   }
 
   if (newScreenProps.headerRightBarButtonItems != oldScreenProps.headerRightBarButtonItems) {
-    const auto &vec = newScreenProps.headerRightBarButtonItems;
-    NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
-    for (const auto &item : vec) {
-      NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
-      if ([dict isKindOfClass:[NSDictionary class]]) {
-        [array addObject:dict];
+    if (newScreenProps.headerRightBarButtonItems.has_value()) {
+      const auto &vec = newScreenProps.headerRightBarButtonItems.value();
+      NSMutableArray<NSDictionary<NSString *, id> *> *array = [NSMutableArray arrayWithCapacity:vec.size()];
+      for (const auto &item : vec) {
+        NSDictionary *dict = [RNSConvert idFromFollyDynamic:item];
+        if ([dict isKindOfClass:[NSDictionary class]]) {
+          [array addObject:dict];
+        }
       }
+      _headerRightBarButtonItems = array;
+    } else {
+      _headerRightBarButtonItems = nil;
     }
-    _headerRightBarButtonItems = array;
   }
 
   [self updateViewControllerIfNeeded];

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -100,5 +100,10 @@ export default codegenNativeComponent<NativeProps>(
   'RNSScreenStackHeaderConfig',
   {
     interfaceOnly: true,
+    // Distinguishes omitted colors from transparent (0) under Android Props 2.0
+    // getDiffProps. HostPlatformColor::UndefinedColor and processColor("transparent")
+    // are both 0, so a default SharedColor{} would drop the key on CREATE.
+    // @ts-expect-error RN public Options type does not include this codegen flag yet.
+    generateOptionalProperties: true,
   },
 ) as HostComponent<NativeProps>;


### PR DESCRIPTION
## Description

On Android Fabric with Props 2.0 (`enablePropsUpdateReconciliationAndroid`), `ScreenStackHeaderConfig` `backgroundColor="transparent"` never reaches native. JS still has the color (`processColor` is `0`). Native never calls `setBackgroundColor`, so the toolbar keeps Material `colorPrimary`.

iOS is unaffected (it does not use the `getDiffProps` path).

Android `HostPlatformColor::UndefinedColor` is `0`, and so is `processColor('transparent')` / `'#00000000'` / `'rgba(0,0,0,0)'`. Without `generateOptionalProperties`, codegen emits `SharedColor backgroundColor{}` whose default is also `0`. On CREATE, Props 2.0 diffs against that default, omits the key, and Kotlin never paints.

This is a CREATE-path bug. A red → transparent UPDATE diffs against the previous color and can hide it.

**Minimal repro:** https://github.com/delekta/screens-transparent-header-bug-repro  
RN `0.87.0`, screens `4.27.0`, screens-only (no React Navigation required).

Do **not** disable Props 2.0 as the library fix.

## Changes

- Set `generateOptionalProperties: true` on `RNSScreenStackHeaderConfig` so omitted is `nullopt` and transparent is `optional(0)`. The diff then emits `0` and native `setBackgroundColor(0)` runs.
- The flag is component-wide (optional strings, colors, mixed arrays), so native readers are updated:
  - Android C++: `title.empty()` → `!title.has_value() || title->empty()` in `RNSScreenShadowNode.cpp`
  - iOS Fabric `updateProps`: unwrap `std::optional` for `RCTNSStringFromStringNilIfEmpty`, `RCTUIColorFromSharedColor`, and header bar-button vectors
- Kotlin ViewManagers are unchanged (`Int?` already). Unset color still skips the setter (theme bar). Transparent now applies `0`.

Please also cherry-pick onto `main` (5.0 / `src/fabric/legacy/…`) if that spec is still used there.

## Before & after - visual documentation

Chip **2. transparent** on the repro (CREATE / remount). Expected: lime page shows through the header. Fail: leftover Material bar.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bf95f40b-49e7-4016-81b1-418823cb434d" />  | <video src="https://github.com/user-attachments/assets/10f0a3cd-6a60-4316-9432-d4320d9a6c60" />  |









Opaque red (chip 1) should stay red in both.

## Test plan

Repro: https://github.com/delekta/screens-transparent-header-bug-repro

```sh
npm install
npm start
npm run android
```

Keep `ENABLE_PROPS_2_0 = true` in `MainApplication.kt`. Each chip remounts the stack so 2–4 are CREATE.

- Chip **1. Red** — header and page both red (control).
- Chip **2. transparent** — lime page; header must look lime (see-through). Fail = leftover Material bar.
- Chips **3 / 4** — `#00000000` and `rgba(0,0,0,0)` same as transparent.
- Chip **5** — `#FFFFFF00` still works (alpha 0, RGB ≠ 0).
- Chip **6** — dark, then UPDATE to transparent still works.
- Control: set `ENABLE_PROPS_2_0 = false`, rebuild; chip 2 already correct without this PR.
- iOS: header title, colors, and bar button items unchanged.

Same bug via native-stack: in the repro `index.js` import `./App.native-stack` instead of `./App`.

No new example files in this repo; the repro app is the test.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
```