### PR TITLE
chore(test): mark stack overflow icon e2e coverage as not automated

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/index.tsx
@@ -98,7 +98,7 @@ function TestStackOverflowIcon() {
       routeConfigs={[
         {
           name: 'Main',
-          Component: MainScreen,
+          element: <MainScreen />,
         },
       ]}
     />

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/scenario-description.ts
@@ -6,6 +6,6 @@ export const scenarioDescription: ScenarioDescription = {
   details:
     'Tests overflow menu icon customization: custom icon and tint colors.',
   platforms: ['android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-overflow-icon-android/scenario.md
@@ -12,7 +12,11 @@ the overflow popup. It allows customization via a custom icon and tint color
 
 ## E2E test
 
-TBD: Automation is planned in limited scope but not yet implemented.
+Incomplete: Not automated. The checkpoints verify the overflow button's
+rendered icon and tint colors, which Detox cannot assert (no color/drawable
+data in `getAttributes()`, no screenshot comparison). The pressed and focused
+tints additionally require mid-press observation and hardware-keyboard focus.
+This scenario is manual only.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

This PR documents that the `test-stack-overflow-icon-android` scenario cannot be automated with Detox. The scenario's checkpoints verify the overflow button's rendered icon and tint colors, which Detox cannot assert: `getAttributes()` exposes no color/drawable data and the e2e suite does no screenshot comparison. Additionally, the pressed and focused tints would require mid-press observation and hardware-keyboard focus, neither of which Detox can drive. The scenario is marked as manual-only.

The test screen is also migrated from the `Component:` route config to the `element:` form, following #4495.

## Changes

- **scenario.md**: Replace the "TBD" e2e section with "Incomplete: Not automated." plus an explanation of the Detox limitations
- **scenario-description.ts**: Set `e2eCoverage` from `'tbd'` to `'incomplete'`
- **index.tsx**: Migrate `StackContainer` route config from `Component: MainScreen` to `element: <MainScreen />`
