### PR TITLE
fix(Android, Tabs): prevent native view state restoration in TabsScreen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
@@ -2,6 +2,8 @@ package com.swmansion.rnscreens.tabs.screen
 
 import android.content.res.Configuration
 import android.graphics.drawable.Drawable
+import android.os.Parcelable
+import android.util.SparseArray
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.facebook.react.uimanager.ThemedReactContext
@@ -126,6 +128,17 @@ class TabsScreen(
         r: Int,
         b: Int,
     ) = Unit
+
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>) {
+        // Do nothing. React Native owns this view hierarchy and keeps it alive, so there is no
+        // need to serialize/deserialize native view state. View ids in this subtree are react
+        // tags, which are not stable identities - restoring state by id can apply state saved
+        // by one view type to a different one, crashing e.g. in CompoundButton (see #4523).
+    }
+
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>) {
+        // Ignore restoring instance state too, as we are not saving anything anyways.
+    }
 
     internal fun setTabsScreenDelegate(delegate: TabsScreenDelegate?) {
         tabsScreenDelegate = WeakReference(delegate)


### PR DESCRIPTION
## Description

On Android with Fabric and native bottom tabs, `TabsScreen` is the view returned from `TabsScreenFragment.onCreateView`, so `FragmentManager` saves and restores the native hierarchy state (`View#saveHierarchyState` / `View#restoreHierarchyState`) of the entire react-owned subtree beneath it.

View ids in that subtree are react tags, which are not stable identities across remounts. Restored state can therefore be applied to a different view type that now has the same id, crashing in widgets that cast the saved state unchecked, e.g.:

```text
java.lang.ClassCastException:
android.view.AbsSavedState$1 cannot be cast to
android.widget.CompoundButton$SavedState
```

React Native owns this view hierarchy and keeps it alive, so native save/restore of descendant state is both unnecessary and unsound here. Legacy `Screen` has suppressed it since #313 — this PR applies the same treatment to `TabsScreen`.

Note: `StackScreenFragment`'s view root has the same gap; a follow-up PR will address Stack v5 separately.

Closes #4523.

## Changes

- Override `dispatchSaveInstanceState` / `dispatchRestoreInstanceState` as no-ops in `TabsScreen`, mirroring `Screen` (legacy) behavior.

## Test plan

- Reporter's deterministic reproduction: https://github.com/anirudhsama/react-native-screens-tabs-state-repro — contains a one-tap Expo app and a Robolectric test that fails with the exact `ClassCastException` on the unpatched library and passes with these overrides (this repository currently has no Android unit test infrastructure, so the test is not ported here).
- Manual reproduction from the issue:

```kotlin
val childId = 42
val tabsScreen = TabsScreen(themedReactContext).apply {
    addView(CheckBox(activity).apply { id = childId })
}

val staleHierarchyState = SparseArray<Parcelable>()

View(activity)
    .apply { id = childId }
    .saveHierarchyState(staleHierarchyState)

tabsScreen.restoreHierarchyState(staleHierarchyState)
```

Before this change the final call crashes in `CompoundButton.onRestoreInstanceState`; after it, the stale native state is ignored.

- Verified locally: `yarn lint-android` passes, `:react-native-screens:compileDebugKotlin` builds clean.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)