### PR TITLE
fix(Android, Stack v5): prevent native view state restoration in stack screens

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -2,7 +2,9 @@ package com.swmansion.rnscreens.stack.header
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Parcelable
 import android.util.Log
+import android.util.SparseArray
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.activity.OnBackPressedDispatcherOwner
@@ -307,6 +309,22 @@ internal class StackHeaderCoordinatorLayout(
             stackScreen.onContentYOriginChanged(0)
             stackScreenWrapper.requestLayout()
         }
+    }
+
+    // endregion
+
+    // region Instance state
+
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>) {
+        // Do nothing. This view is the root of a fragment-managed, react-owned hierarchy that
+        // React Native keeps alive, so there is no need to serialize/deserialize native view
+        // state. View ids in this subtree are react tags, which are not stable identities -
+        // restoring state by id can apply state saved by one view type to a different one,
+        // crashing e.g. in CompoundButton (see #4523).
+    }
+
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>) {
+        // Ignore restoring instance state too, as we are not saving anything anyways.
     }
 
     // endregion


### PR DESCRIPTION
## Description

Follow-up to #4526 (Tabs), covering the same defect in Stack v5, as flagged in the discussion of #4523.

`StackHeaderCoordinatorLayout` is the view returned from `StackScreenFragment.onCreateView`, so `FragmentManager` saves and restores the native hierarchy state (`View#saveHierarchyState` / `View#restoreHierarchyState`) of the entire react-owned subtree beneath it — the `StackScreen` content as well as any react-owned header views hosted in the app bar.

View ids in that subtree are react tags, which are not stable identities across remounts. Restored state can therefore be applied to a different view type that now has the same id, crashing in widgets that cast the saved state unchecked, e.g.:

```text
java.lang.ClassCastException:
android.view.AbsSavedState$1 cannot be cast to
android.widget.CompoundButton$SavedState
```

React Native owns this view hierarchy and keeps it alive, so native save/restore of descendant state is both unnecessary and unsound here. Legacy `Screen` has suppressed it since #313; #4526 applied the same treatment to `TabsScreen`.

References #4523 (the issue itself is closed by the Tabs fix in #4526).

## Changes

- Override `dispatchSaveInstanceState` / `dispatchRestoreInstanceState` as no-ops in `StackHeaderCoordinatorLayout` — the fragment view root, so the override severs native state save/restore for the whole subtree, including react-owned header views that a `StackScreen`-level override would miss.

## Test plan

- Same failure mechanism as #4523; the reporter's deterministic reproduction for Tabs is https://github.com/anirudhsama/react-native-screens-tabs-state-repro — the Stack v5 equivalent substitutes the fragment view root:

```kotlin
val childId = 42
val stackScreen = StackScreen(themedReactContext)
val fragmentRoot = StackHeaderCoordinatorLayout(activity, stackScreen, canNavigateBack = false)
stackScreen.addView(CheckBox(activity).apply { id = childId })

val staleHierarchyState = SparseArray<Parcelable>()

View(activity)
    .apply { id = childId }
    .saveHierarchyState(staleHierarchyState)

fragmentRoot.restoreHierarchyState(staleHierarchyState)
```

Before this change the final call crashes in `CompoundButton.onRestoreInstanceState`; after it, the stale native state is ignored. (This repository currently has no Android unit test infrastructure, so the test is not ported here.)

- Verified locally: `yarn lint-android` passes, `:react-native-screens:compileDebugKotlin` builds clean.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)