### PR TITLE
chore(test): document non-automatable Stack v5 e2e scenarios

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario-description.ts
@@ -5,6 +5,6 @@ export const scenarioDescription: ScenarioDescription = {
   key: 'test-stack-subviews-ios',
   details: 'Tests header config and subview customization.',
   platforms: ['ios'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
@@ -11,7 +11,9 @@ removed and resized.
 
 ## E2E test
 
-TBD
+Incomplete. Not automated. Every step is verified visually against the
+Dev Tools element-inspector overlay, which Detox cannot access, so the checks
+stay manual.
 
 ## Prerequisites
 
@@ -20,6 +22,9 @@ TBD
 ## Note
 
 - "Position of items on device matches element tree" means that the DevTools overlay the item highlight with correct position and size. Alternatively, this could be checked by pressing and moving the cursor over the button to see if the whole visible area works, not triggering onPressOut immediately
+
+### Known Issues/Important Observations
+
 - on iOS 26, view may move to overflow menu if there is no space for them, iOS 18 tries to render all of them (including the header)
 - spacers on iOS 26 work only to split the glass "bubble" around the item, setting width only works on iOS < 26
 - the difference between `flexible` sizing (applied to trailing items) and `fixed` sizing (applied to leading items) is only visible on iOS **below 26.0**
@@ -34,38 +39,68 @@ TBD
 ## Steps on iPhone
 
 1. Open Dev Console
+
 2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
+
 3. Verify first layout.
+
   - [ ] Position of items on device matches element tree.
+
 4. Click "Toggle leading/trailing items count" to add items. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 5. Set title to `view`. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 6. Set subtitle to `view`. Verify layout.
+
   - [ ] on iOS 26, position of items on device matches element tree.
+
 7. Click on header items to resize and force other items to move. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 8. Rotate the screen to landscape. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 9. Rotate the screen back to portrait. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 10. Click "Toggle leading items count" to remove all leading items. Verify layout.
+
   - [ ] Position of items on device matches element tree.
+
 11. Click "large header enabled" to show large header. You may need to scroll down.
+
   - [ ] Regular title is removed whenever large title shows and item positions match element tree. You may need to remove some items to give space for the regular title.
-12. Set title to `long` and `largeTitle` to short. Scroll to reveal large title.
+
+12. Set title to `long` and `largeTitle` to `short`. Scroll to reveal large title.
+
   - [ ] on iOS 18, largeTitle should be long
   - [ ] on iOS 26, largeTitle should be short
-13. Set largeTitle to `none`.
+
+13. Set `largeTitle` to `none`.
+
   - [ ] on iOS 26, largeTitle should be long
 
 ## Steps on iPad
 
 1. Open Dev Console
+
 2. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
+
 3. Verify first layout.
+
   - [ ] Position of items on device matches element tree.
-5. Set title to `view`. Verify layout.
+
+4. Set title to `view`. Verify layout.
+
   - [ ] Position of items on device matches element tree.
-4. Resize the application. Verify layout.
+
+5. Resize the application. Verify layout.
+
   - [ ] Position of items on device matches element tree.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario-description.ts
@@ -6,6 +6,6 @@ export const scenarioDescription: ScenarioDescription = {
   details:
     'Tests the icon and state-aware tint props on toolbar menu items, both via props and via the updateToolbarMenuElements view command.',
   platforms: ['android'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-icon-android/scenario.md
@@ -15,7 +15,11 @@ props); changes to one item never touch others.
 
 ## E2E test
 
-TBD: E2E coverage has not been determined yet.
+Incomplete. Not automated. Almost every check verifies which drawable is shown
+and its tint color per interaction state (normal / pressed / focused /
+disabled) — pixel-level visual assertions Detox cannot express. The pressed
+and focused states additionally require observing rendering mid-gesture and
+hardware keyboard focus, neither of which Detox supports.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

This PR documents why two Stack v5 test scenarios cannot be reliably automated with Detox and updates their e2e coverage status from 'tbd' to 'incomplete'. Both scenarios involve visual assertions and interaction state observation beyond Detox's capabilities, so they remain manual tests.

Changes include updates to `scenario-description.ts` and `scenario.md` files, replacing placeholder "TBD" text with explicit explanations of what cannot be automated and why. The test-stack-subviews-ios scenario also receives formatting improvements for better readability.

## Changes

- **test-stack-subviews-ios**: Documented that visual verification against Dev Tools element-inspector overlay cannot be accessed by Detox, keeping all checks manual; reformatted scenario steps with improved spacing and added "Known Issues/Important Observations" subsection
- **test-stack-toolbar-menu-icon-android**: Documented that drawable and tint color assertions per interaction state (normal/pressed/focused/disabled) are pixel-level visual checks Detox cannot express; pressed/focused states additionally require mid-gesture observation and hardware keyboard focus support