### PR TITLE
feat(Android, Stack v5): expose `statusBarScrimColor` for the header

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.stack.header
 
 import android.annotation.SuppressLint
 import android.content.res.ColorStateList
+import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.Log
@@ -508,7 +509,53 @@ internal class StackHeaderApplicator(
                 appBar.collapsingToolbarLayout.setContentScrimColor(scrolledBackgroundColor)
             }
         }
+
+        applyStatusBarScrim(appBar, config, backgroundColor, scrolledBackgroundColor)
     }
+
+    private fun applyStatusBarScrim(
+        appBar: StackHeaderAppBarLayout,
+        config: StackHeaderConfigurationProviding,
+        backgroundColor: Int,
+        scrolledBackgroundColor: Int,
+    ) {
+        when (appBar) {
+            is StackHeaderAppBarLayout.Small -> {
+                val scrimColor = resolveStatusBarScrimColor(config, drivingColor = backgroundColor)
+                val autoFollow = scrimColor != null && config.statusBarScrimColor == null
+                appBar.setStatusBarScrimSyncEnabled(autoFollow)
+                appBar.statusBarForeground?.setTint(
+                    when {
+                        scrimColor == null -> Color.TRANSPARENT
+                        // Same lifted jump as the background fill in applyBackgroundColors.
+                        autoFollow && appBar.isLifted ->
+                            MaterialColors.layer(backgroundColor, scrolledBackgroundColor)
+                        else -> scrimColor
+                    },
+                )
+            }
+
+            is StackHeaderAppBarLayout.Collapsing -> {
+                // Defaulting to the content scrim color masks toolbar content passing
+                // through the status-bar area (scroll-only flags) and is a visual
+                // no-op in the opaque exitUntilCollapsed case.
+                val scrimColor =
+                    resolveStatusBarScrimColor(config, drivingColor = scrolledBackgroundColor)
+                if (scrimColor != null) {
+                    appBar.collapsingToolbarLayout.setStatusBarScrimColor(scrimColor)
+                } else {
+                    appBar.collapsingToolbarLayout.statusBarScrim = null
+                }
+            }
+        }
+    }
+
+    // The default scrim exists only for an opaque driving color — a translucent
+    // scrim would double-composite over the layer it covers.
+    private fun resolveStatusBarScrimColor(
+        config: StackHeaderConfigurationProviding,
+        drivingColor: Int,
+    ): Int? = config.statusBarScrimColor ?: drivingColor.takeIf { Color.alpha(it) == 0xFF }
 
     // endregion
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -32,6 +32,7 @@ import com.swmansion.rnscreens.common.text.TextAppearance
 import com.swmansion.rnscreens.common.text.TextAppearanceDefaults
 import com.swmansion.rnscreens.ext.detachFromCurrentParent
 import com.swmansion.rnscreens.stack.header.appbar.StackHeaderAppBarLayout
+import com.swmansion.rnscreens.stack.header.appbar.StackHeaderContentScrimDrawable
 import com.swmansion.rnscreens.stack.header.config.StackHeaderConfigurationProviding
 import com.swmansion.rnscreens.stack.header.config.StackHeaderType
 import com.swmansion.rnscreens.stack.header.subview.StackHeaderSubview
@@ -506,7 +507,8 @@ internal class StackHeaderApplicator(
                 // transparent/translucent content scrim.
                 appBar.setLiftOnScrollColor(null)
                 appBar.background = background
-                appBar.collapsingToolbarLayout.setContentScrimColor(scrolledBackgroundColor)
+                appBar.collapsingToolbarLayout.contentScrim =
+                    StackHeaderContentScrimDrawable(scrolledBackgroundColor)
             }
         }
 
@@ -538,14 +540,18 @@ internal class StackHeaderApplicator(
             is StackHeaderAppBarLayout.Collapsing -> {
                 // Defaulting to the content scrim color masks toolbar content passing
                 // through the status-bar area (scroll-only flags) and is a visual
-                // no-op in the opaque exitUntilCollapsed case.
+                // no-op in the opaque exitUntilCollapsed case. An invisible scrim is
+                // normalized to null so the content scrim exclusion can key on scrim
+                // presence alone.
                 val scrimColor =
                     resolveStatusBarScrimColor(config, drivingColor = scrolledBackgroundColor)
+                        ?.takeIf { Color.alpha(it) > 0 }
                 if (scrimColor != null) {
                     appBar.collapsingToolbarLayout.setStatusBarScrimColor(scrimColor)
                 } else {
                     appBar.collapsingToolbarLayout.statusBarScrim = null
                 }
+                appBar.updateContentScrimExclusion()
             }
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -2,6 +2,8 @@ package com.swmansion.rnscreens.stack.header.appbar
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.PaintDrawable
 import android.view.LayoutInflater
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
@@ -56,8 +58,28 @@ internal sealed class StackHeaderAppBarLayout(
         internal val titleTextView: TextView
         internal val subtitleTextView: TextView
 
+        // Keeps the status bar strip in sync with the bar's effective color through
+        // the lift animation (same per-frame mixed color Material applies to the
+        // background). Detached when an explicit statusBarScrimColor is set.
+        private var statusBarScrimSyncEnabled = false
+        private val statusBarScrimSync =
+            object : LiftOnScrollProgressListener() {
+                override fun onUpdate(
+                    elevation: Float,
+                    backgroundColor: Int,
+                    progress: Float,
+                ) {
+                    statusBarForeground?.setTint(backgroundColor)
+                }
+            }
+
         init {
             addView(toolbar)
+
+            // PaintDrawable is not color-extractable, so AppBarLayout's built-in
+            // colorSurface-keyed strip tint sync can never activate and fight the
+            // listener above (or an explicit scrim color) — regardless of theme.
+            statusBarForeground = PaintDrawable().apply { setTint(Color.TRANSPARENT) }
 
             toolbar.title = TITLE_PLACEHOLDER
             toolbar.subtitle = SUBTITLE_PLACEHOLDER
@@ -65,6 +87,16 @@ internal sealed class StackHeaderAppBarLayout(
             subtitleTextView = toolbar.findTextViewWithText(SUBTITLE_PLACEHOLDER)
             toolbar.title = ""
             toolbar.subtitle = ""
+        }
+
+        internal fun setStatusBarScrimSyncEnabled(enabled: Boolean) {
+            if (statusBarScrimSyncEnabled == enabled) return
+            statusBarScrimSyncEnabled = enabled
+            if (enabled) {
+                addLiftOnScrollProgressListener(statusBarScrimSync)
+            } else {
+                removeLiftOnScrollProgressListener(statusBarScrimSync)
+            }
         }
 
         private fun MaterialToolbar.findTextViewWithText(text: String): TextView =

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderAppBarLayout.kt
@@ -7,8 +7,10 @@ import android.graphics.drawable.PaintDrawable
 import android.view.LayoutInflater
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.view.WindowInsets
 import android.widget.TextView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
@@ -140,6 +142,9 @@ internal sealed class StackHeaderAppBarLayout(
                     as CollapsingToolbarLayout
             ).apply { addView(toolbar) }
 
+        private var trackedTopInset = 0
+        private var currentVerticalOffset = 0
+
         init {
             require(
                 type == StackHeaderType.MEDIUM ||
@@ -148,6 +153,51 @@ internal sealed class StackHeaderAppBarLayout(
                 "[RNScreens] Collapsing StackHeaderAppBarLayout must be MEDIUM or LARGE type."
             }
             addView(collapsingToolbarLayout)
+
+            addOnOffsetChangedListener { _, verticalOffset ->
+                currentVerticalOffset = verticalOffset
+                updateContentScrimExclusion()
+            }
+        }
+
+        // Observed here because both AppBarLayout and CollapsingToolbarLayout
+        // install their own OnApplyWindowInsetsListener in their constructors —
+        // setting ours would silently replace Material's. Reads the same inset
+        // CTL uses for its status bar scrim bounds.
+        override fun dispatchApplyWindowInsets(insets: WindowInsets): WindowInsets {
+            @Suppress("DEPRECATION")
+            trackedTopInset =
+                if (fitsSystemWindows) {
+                    WindowInsetsCompat.toWindowInsetsCompat(insets, this).systemWindowInsetTop
+                } else {
+                    0
+                }
+            updateContentScrimExclusion()
+            return super.dispatchApplyWindowInsets(insets)
+        }
+
+        /**
+         * While a status bar scrim is installed, the content scrim skips the
+         * status-bar strip that the status bar scrim paints alone. Otherwise,
+         * the two scrims stack there while fading (they share the same partial
+         * alpha), showing a darker band during the transition. The strip spans
+         * `[-verticalOffset, -verticalOffset + topInset]` in CTL coordinates,
+         * matching the status bar scrim bounds set in
+         * `CollapsingToolbarLayout.draw`.
+         */
+        internal fun updateContentScrimExclusion() {
+            val contentScrim =
+                collapsingToolbarLayout.contentScrim
+            check(contentScrim is StackHeaderContentScrimDrawable) {
+                "[RNScreens] Unexpected contentScrim class."
+            }
+
+            contentScrim.exclusionBottom =
+                if (collapsingToolbarLayout.statusBarScrim != null && trackedTopInset > 0) {
+                    trackedTopInset - currentVerticalOffset
+                } else {
+                    0
+                }
         }
 
         private companion object {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderContentScrimDrawable.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/appbar/StackHeaderContentScrimDrawable.kt
@@ -1,0 +1,36 @@
+package com.swmansion.rnscreens.stack.header.appbar
+
+import android.graphics.Canvas
+import android.graphics.drawable.ColorDrawable
+import androidx.core.graphics.withClip
+
+/**
+ * Content scrim that can skip the status-bar strip painted by the
+ * CollapsingToolbarLayout status bar scrim. Both scrims share the same alpha
+ * while fading, so wherever they overlap the strip composites darker than the
+ * rest of the scrim during the transition.
+ */
+internal class StackHeaderContentScrimDrawable(
+    color: Int,
+) : ColorDrawable(color) {
+    // Bottom of the skipped band in CollapsingToolbarLayout coordinates; the
+    // visible top edge of the scrim always aligns with the strip top. Values
+    // <= bounds.top disable the exclusion.
+    internal var exclusionBottom: Int = 0
+        set(value) {
+            if (field != value) {
+                field = value
+                invalidateSelf()
+            }
+        }
+
+    override fun draw(canvas: Canvas) {
+        if (exclusionBottom <= bounds.top) {
+            super.draw(canvas)
+            return
+        }
+        canvas.withClip(bounds.left, exclusionBottom, bounds.right, bounds.bottom) {
+            super.draw(canvas)
+        }
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfig.kt
@@ -143,6 +143,9 @@ internal class StackHeaderConfig(
     override var scrolledBackgroundColor: Int? by invalidatingProperty(null, StackHeaderInvalidationFlags.BACKGROUND_COLORS)
         internal set
 
+    override var statusBarScrimColor: Int? by invalidatingProperty(null, StackHeaderInvalidationFlags.BACKGROUND_COLORS)
+        internal set
+
     override var toolbarMenu: StackHeaderToolbarMenuConfig
         by invalidatingProperty(StackHeaderToolbarMenuConfig(emptyList(), emptyList()), StackHeaderInvalidationFlags.TOOLBAR_MENU)
         internal set

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigViewManager.kt
@@ -580,6 +580,13 @@ internal open class StackHeaderConfigViewManager :
         view.scrolledBackgroundColor = value
     }
 
+    override fun setStatusBarScrimColor(
+        view: StackHeaderConfig,
+        value: Int?,
+    ) {
+        view.statusBarScrimColor = value
+    }
+
     override fun setToolbarMenuGroupDividerEnabled(
         view: StackHeaderConfig,
         value: Boolean,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/config/StackHeaderConfigurationProviding.kt
@@ -29,6 +29,7 @@ internal interface StackHeaderConfigurationProviding {
     val liftOnScroll: Boolean
     val backgroundColor: Int?
     val scrolledBackgroundColor: Int?
+    val statusBarScrimColor: Int?
     val leadingSubview: StackHeaderSubviewProviding?
     val centerSubview: StackHeaderSubviewProviding?
     val trailingSubview: StackHeaderSubviewProviding?

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -30,6 +30,7 @@ import TestStackHeaderItemIdentifierIOS from './test-stack-header-item-identifie
 import TestStackHeaderTitleAppearance from './test-stack-header-title-appearance-android';
 import TestStackHeaderContentInsets from './test-stack-header-content-insets-android';
 import TestStackHeaderBackground from './test-stack-header-background-android';
+import TestStackHeaderStatusBarScrim from './test-stack-header-status-bar-scrim-android';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
@@ -61,6 +62,7 @@ export { default as TestStackToolbarMenuA11y } from './test-stack-toolbar-menu-a
 export { default as TestStackHeaderTitleAppearance } from './test-stack-header-title-appearance-android';
 export { default as TestStackHeaderContentInsets } from './test-stack-header-content-insets-android';
 export { default as TestStackHeaderBackground } from './test-stack-header-background-android';
+export { default as TestStackHeaderStatusBarScrim } from './test-stack-header-status-bar-scrim-android';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,
@@ -91,6 +93,7 @@ const scenarios = {
   TestStackHeaderTitleAppearance,
   TestStackHeaderContentInsets,
   TestStackHeaderBackground,
+  TestStackHeaderStatusBarScrim,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/index.tsx
@@ -1,0 +1,227 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  PlatformColor,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type ColorValue,
+} from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import LongText from '@apps/shared/LongText';
+import {
+  type StackHeaderConfigProps,
+  type StackHeaderTypeAndroid,
+  ScrollViewMarker,
+} from 'react-native-screens';
+
+const PLATFORM_COLOR_LIGHT = PlatformColor('@android:color/holo_green_light');
+const PLATFORM_COLOR_DARK = PlatformColor('@android:color/holo_green_dark');
+
+const options = <const T extends string>(...values: T[]): T[] => values;
+
+const HEADER_TYPES: StackHeaderTypeAndroid[] = ['small', 'medium', 'large'];
+const COLOR_OPTIONS = options(
+  'default',
+  'red',
+  'green',
+  'blue',
+  'translucent',
+  'transparent',
+  'platform',
+);
+
+type ColorOption = (typeof COLOR_OPTIONS)[number];
+
+interface Config {
+  type: StackHeaderTypeAndroid;
+  backgroundColor: ColorOption;
+  scrolledBackgroundColor: ColorOption;
+  statusBarScrimColor: ColorOption;
+  exitUntilCollapsed: boolean;
+}
+
+const DEFAULT_CONFIG: Config = {
+  type: 'small',
+  backgroundColor: 'default',
+  scrolledBackgroundColor: 'default',
+  statusBarScrimColor: 'default',
+  exitUntilCollapsed: false,
+};
+
+function resolveBackgroundColor(value: ColorOption): ColorValue | undefined {
+  switch (value) {
+    case 'red':
+      return Colors.RedLight60;
+    case 'green':
+      return Colors.GreenLight60;
+    case 'blue':
+      return Colors.BlueLight60;
+    case 'translucent':
+      return Colors.NavyLightTransparent;
+    case 'transparent':
+      return 'transparent';
+    case 'platform':
+      return PLATFORM_COLOR_LIGHT;
+    default:
+      return undefined;
+  }
+}
+
+function resolveStrongColor(value: ColorOption): ColorValue | undefined {
+  switch (value) {
+    case 'red':
+      return Colors.RedLight100;
+    case 'green':
+      return Colors.GreenLight100;
+    case 'blue':
+      return Colors.BlueLight100;
+    case 'translucent':
+      return Colors.NavyLightTransparent;
+    case 'transparent':
+      return 'transparent';
+    case 'platform':
+      return PLATFORM_COLOR_DARK;
+    default:
+      return undefined;
+  }
+}
+
+function buildHeaderConfig(config: Config): StackHeaderConfigProps {
+  return {
+    title: 'Status bar scrim',
+    android: {
+      type: config.type,
+
+      // Header content must be able to pass under the status bar to exercise
+      // the scrim: the small toolbar scrolls fully off, and medium/large exit
+      // fully unless exitUntilCollapsed pins the toolbar below the inset.
+      scrollFlagScroll: true,
+      scrollFlagEnterAlways: true,
+      scrollFlagExitUntilCollapsed:
+        config.type === 'small' ? undefined : config.exitUntilCollapsed,
+
+      backgroundColor: resolveBackgroundColor(config.backgroundColor),
+      scrolledBackgroundColor: resolveStrongColor(
+        config.scrolledBackgroundColor,
+      ),
+      statusBarScrimColor: resolveStrongColor(config.statusBarScrimColor),
+    },
+  };
+}
+
+function TestStackHeaderStatusBarScrimAndroid() {
+  return (
+    <View style={styles.backdrop}>
+      <StackContainer
+        routeConfigs={[{ name: 'Home', element: <ConfigScreen /> }]}
+      />
+    </View>
+  );
+}
+
+function ConfigScreen() {
+  const { setRouteOptions, routeKey } = useStackNavigationContext();
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+
+  const updateConfig = useCallback(
+    <K extends keyof Config>(key: K, value: Config[K]) => {
+      setConfig(prev => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const headerConfig = useMemo(() => buildHeaderConfig(config), [config]);
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollViewMarker style={styles.scrollViewMarker}>
+      <ScrollView
+        testID="header-status-bar-scrim-scrollview"
+        nestedScrollEnabled
+        style={styles.scroll}
+        contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Header config</Text>
+        <SettingsPicker<StackHeaderTypeAndroid>
+          testID="header-type-picker"
+          label="type"
+          value={config.type}
+          onValueChange={v => updateConfig('type', v)}
+          items={HEADER_TYPES}
+        />
+        <SettingsPicker<ColorOption>
+          testID="status-bar-scrim-color-picker"
+          label="statusBarScrimColor"
+          value={config.statusBarScrimColor}
+          onValueChange={v => updateConfig('statusBarScrimColor', v)}
+          items={COLOR_OPTIONS}
+        />
+        <SettingsPicker<ColorOption>
+          testID="background-color-picker"
+          label="backgroundColor"
+          value={config.backgroundColor}
+          onValueChange={v => updateConfig('backgroundColor', v)}
+          items={COLOR_OPTIONS}
+        />
+        <SettingsPicker<ColorOption>
+          testID="scrolled-background-color-picker"
+          label="scrolledBackgroundColor"
+          value={config.scrolledBackgroundColor}
+          onValueChange={v => updateConfig('scrolledBackgroundColor', v)}
+          items={COLOR_OPTIONS}
+        />
+        <SettingsSwitch
+          testID="exit-until-collapsed-switch"
+          label="scrollFlagExitUntilCollapsed (medium/large)"
+          value={config.exitUntilCollapsed}
+          onValueChange={v => updateConfig('exitUntilCollapsed', v)}
+        />
+
+        <Text style={styles.heading}>Scroll to move content under the bar</Text>
+        <LongText size="xl" />
+        <Text testID="header-status-bar-scrim-bottom-marker">
+          End of content
+        </Text>
+      </ScrollView>
+    </ScrollViewMarker>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Shows through the header when header is transparent.
+  backdrop: {
+    flex: 1,
+    backgroundColor: Colors.PurpleLight80,
+  },
+  scrollViewMarker: {
+    flex: 1,
+  },
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+});
+
+export default createScenario(
+  TestStackHeaderStatusBarScrimAndroid,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Header status bar scrim (Android)',
+  key: 'test-stack-header-status-bar-scrim-android',
+  details:
+    'Verify header statusBarScrimColor customization and default scrims.',
+  platforms: ['android'],
+  e2eCoverage: 'incomplete',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario.md
@@ -1,0 +1,130 @@
+# Test Scenario: Header status bar scrim (Android)
+
+## Details
+
+**Description:** Exercises the Android Material 3 header status bar scrim
+(`statusBarScrimColor`) — the strip masking header content that passes under
+the status bar in edge-to-edge apps. For the `small` header the scrim is a
+constant strip pinned to the top of the window that by default follows the
+bar's effective background color through the lift-on-scroll transition. For
+`medium`/`large` headers it fades in and out together with the content scrim
+and by default matches its color. Verifies the auto-following defaults, the
+opt-out for translucent backgrounds, explicit and `'transparent'` values, and
+the masking of toolbar content scrolling under the status bar.
+
+**OS test creation version:** API 37
+
+## E2E test
+
+Incomplete: not automated. Every assertion in this scenario is about rendered
+colors and animated transitions, neither of which Detox can read.
+
+## Prerequisites
+
+- Android emulator or device, app drawn edge-to-edge (the default; without a
+  top window inset reaching the header no scrim is drawn at all).
+
+## Note
+
+- The `small` strip is constant (always covers the status-bar area) while the
+  `medium`/`large` scrim shows only while the header is collapsed — this
+  asymmetry mirrors the native Material widgets and is expected.
+- The `scrollFlagExitUntilCollapsed` switch only takes effect for
+  `medium`/`large` headers. When OFF, the collapsing header exits fully and
+  its pinned toolbar passes under the status bar — the main masking case.
+- The whole stack is wrapped in a purple backdrop; it is visible through the
+  header when it is transparent.
+
+## Steps
+
+### Small header
+
+1. Navigate to **Stack v5 → Header status bar scrim (Android)**. Leave
+   defaults and observe the header at rest.
+
+- [ ] The status-bar area matches the header background exactly — no visible
+      seam or band.
+
+2. Scroll up so the toolbar scrolls off the screen.
+
+- [ ] The title and buttons passing under the status bar are masked by a
+      solid strip; the status bar icons sit on that strip, not on the list
+      content.
+- [ ] The strip color matches the scrolled (lifted) header color.
+
+3. Set `backgroundColor` = `red` and `scrolledBackgroundColor` = `blue`, then
+   scroll slowly up and down.
+
+- [ ] The strip animates between light red (at rest) and blue (scrolled) in
+      sync with the header's own color transition — it is never frozen at a
+      stale color.
+
+4. While scrolled (strip in the scrolled color), set `backgroundColor` =
+   `green`.
+
+- [ ] The strip immediately shows the scrolled color without animating from
+      the resting color; scrolling to the top reveals the light green strip.
+
+5. Set `statusBarScrimColor` = `red`.
+
+- [ ] A constant strong-red strip covers the status-bar area at rest and
+      while scrolled, regardless of the background colors.
+
+6. Set `statusBarScrimColor` = `transparent`, then scroll the toolbar off.
+
+- [ ] No strip: toolbar content is visible through the status-bar area.
+
+7. Set `statusBarScrimColor` back to `default` and `backgroundColor` =
+   `translucent`.
+
+- [ ] No default strip appears: the translucent header shows a uniform tint
+      with no darker double-composited band in the status-bar area.
+
+8. Keep `backgroundColor` = `translucent` and set `statusBarScrimColor` =
+   `blue`.
+
+- [ ] The explicit blue strip is applied over the translucent background.
+
+### Medium / large header
+
+9. Set `type` = `medium` (later repeat with `large`), all colors `default`,
+   `scrollFlagExitUntilCollapsed` ON. Collapse the header.
+
+- [ ] The scrim fades in with the collapse; with the default color it is
+      seamless — the status-bar area matches the collapsed toolbar color.
+
+10. Turn `scrollFlagExitUntilCollapsed` OFF and scroll the header fully away.
+
+- [ ] While the toolbar and title pass under the status bar they are masked
+      by the scrim; the mask fades out again when the header re-expands.
+
+11. Set `scrolledBackgroundColor` = `green` and collapse.
+
+- [ ] The status-bar area matches the strong green content scrim while
+      collapsed; both fade out together when expanding.
+
+12. Set `statusBarScrimColor` = `red` and collapse.
+
+- [ ] A red scrim fades in over the status-bar area together with the green
+      content scrim below it; no red is visible while expanded.
+
+13. Set `statusBarScrimColor` = `transparent`, `scrollFlagExitUntilCollapsed`
+    OFF, and scroll the header away.
+
+- [ ] Toolbar content is visible through the status-bar area (no mask).
+
+14. Set `statusBarScrimColor` back to `default` and `scrolledBackgroundColor`
+    = `translucent`, then collapse.
+
+- [ ] No default status-bar scrim: the translucent content scrim shows
+      without an extra darker band in the status-bar area.
+
+### Type changes keep settings
+
+15. Set `backgroundColor` = `red`, `scrolledBackgroundColor` = `blue`,
+    `statusBarScrimColor` = `green`, then switch `type` across `small` →
+    `medium` → `large` → `small`.
+
+- [ ] After every switch the scrim behavior matches the current type with the
+      same colors: constant green strip on `small`, green scrim fading with
+      collapse on `medium`/`large`.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-status-bar-scrim-android/scenario.md
@@ -21,8 +21,7 @@ colors and animated transitions, neither of which Detox can read.
 
 ## Prerequisites
 
-- Android emulator or device, app drawn edge-to-edge (the default; without a
-  top window inset reaching the header no scrim is drawn at all).
+- Android emulator or device
 
 ## Note
 
@@ -107,6 +106,8 @@ colors and animated transitions, neither of which Detox can read.
 
 - [ ] A red scrim fades in over the status-bar area together with the green
       content scrim below it; no red is visible while expanded.
+- [ ] Mid-fade the status-bar area is not darker than the fading scrims — the
+      status bar scrim never stacks on top of the content scrim.
 
 13. Set `statusBarScrimColor` = `transparent`, `scrollFlagExitUntilCollapsed`
     OFF, and scroll the header away.

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -800,7 +800,7 @@ export interface StackHeaderConfigPropsAndroid {
    * @description
    * For the `small` header, the scrim is a constant strip pinned to the top of
    * the window, drawn above the toolbar content. When not provided, the strip
-   * follows the bar's effective background color: {@link backgroundColor} at
+   * follows the header's effective background color: {@link backgroundColor} at
    * rest, animating together with the lift-on-scroll transition towards
    * {@link scrolledBackgroundColor}. An explicit color is applied statically,
    * without tracking.

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -814,8 +814,10 @@ export interface StackHeaderConfigPropsAndroid {
    * @remarks
    * The default scrim is installed only when the color it follows resolves to
    * a fully opaque color; translucent headers stay see-through. An explicit
-   * translucent color is honored, but composites over the header background
-   * (small) or the content scrim (`medium` / `large`) in the status-bar area.
+   * translucent color is honored and composites over the header background in
+   * the status-bar area (for `medium` / `large` headers the content scrim is
+   * excluded from that area while a scrim is installed, so the two scrims
+   * never stack).
    *
    * @platform android
    */

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -794,6 +794,33 @@ export interface StackHeaderConfigPropsAndroid {
    */
   scrolledBackgroundColor?: ColorValue | undefined;
   /**
+   * @summary Color of the scrim drawn in the status-bar area, masking header
+   * content that scrolls under the status bar in edge-to-edge apps.
+   *
+   * @description
+   * For the `small` header, the scrim is a constant strip pinned to the top of
+   * the window, drawn above the toolbar content. When not provided, the strip
+   * follows the bar's effective background color: {@link backgroundColor} at
+   * rest, animating together with the lift-on-scroll transition towards
+   * {@link scrolledBackgroundColor}. An explicit color is applied statically,
+   * without tracking.
+   *
+   * For `medium` / `large` headers, the scrim fades in and out together with
+   * the content scrim as the header collapses. When not provided, it matches
+   * the content scrim color ({@link scrolledBackgroundColor}).
+   *
+   * Set to `'transparent'` to disable the scrim entirely.
+   *
+   * @remarks
+   * The default scrim is installed only when the color it follows resolves to
+   * a fully opaque color; translucent headers stay see-through. An explicit
+   * translucent color is honored, but composites over the header background
+   * (small) or the content scrim (`medium` / `large`) in the status-bar area.
+   *
+   * @platform android
+   */
+  statusBarScrimColor?: ColorValue | undefined;
+  /**
    * @summary Toolbar menu configuration.
    *
    * @description

--- a/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigAndroidNativeComponent.ts
@@ -181,6 +181,7 @@ export interface NativeProps extends ViewProps {
 
   backgroundColor?: ColorValue | undefined;
   scrolledBackgroundColor?: ColorValue | undefined;
+  statusBarScrimColor?: ColorValue | undefined;
 
   toolbarMenu?: UnsafeMixed<StackHeaderToolbarMenuBaseAndroid> | undefined;
   toolbarMenuGroupDividerEnabled?: CT.WithDefault<boolean, false>;


### PR DESCRIPTION
## Description

In edge-to-edge apps the stack header draws under the status bar. Whenever
scroll flags let header content leave the screen, the title and buttons pass
straight through the status-bar area with nothing masking them. This PR exposes
`statusBarScrimColor` prop and enables a sensible scrim by default, so status
bar is always displayed on a solid background instead of obstructing the
toolbar.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/905.

### Details

Material provides two independent status-bar scrim mechanisms, depending on
header type.

#### Small header — `AppBarLayout.statusBarForeground`

The small header is an `AppBarLayout` (ABL) hosting a `MaterialToolbar`. ABL can
draw a `statusBarForeground` drawable _after_ (above) all of its children, sized
to the full width × the top window inset and translated against the scroll
offset — so the strip stays glued to the top of the window while the toolbar
scrolls away underneath it.

We want the default strip to always match the bar's _effective_ background
color, including mid-flight during the lift-on-scroll animation (the background
animates between `backgroundColor` and its blend with
`scrolledBackgroundColor`). Material has a built-in sync for this, but it is
narrowly keyed: when a drawable is set as `statusBarForeground`, ABL captures
its color (possible only for `ColorDrawable`, `MaterialShapeDrawable` and
`ColorStateListDrawable`) and re-tints the strip on each animation frame _only
if the captured color equals the theme's `colorSurface`_. Any custom background
color breaks the sync (the strip freezes while the bar animates).

So instead we install a `PaintDrawable` as the strip — it is not
color-extractable, the captured color is `null`, and the built-in sync is
permanently inert regardless of theme — and drive the tint ourselves from the
public `AppBarLayout.LiftOnScrollProgressListener`. That listener is invoked
from the same `ValueAnimator` frame with the same per-frame mixed color the
built-in sync would apply, so the result is pixel-identical to the native effect
while working for arbitrary colors. The lift animation only runs on lifted-state
_changes_, so when color props change while the bar is already lifted, the
applicator jumps the strip straight to the blended end color (same pattern as
the existing background jump).

#### Medium / large headers — `CollapsingToolbarLayout.statusBarScrim`

Collapsing headers pair the ABL with a `CollapsingToolbarLayout` (CTL), which
has its own mechanism: `statusBarScrim`. It shares the alpha animation of the
content scrim (fades in when the header collapses, out when it expands) and is
drawn _after_ all children and after the collapsing title — unlike the content
scrim, which is drawn _below_ the toolbar child and therefore cannot mask
toolbar content.

The default matters here: with scroll-only flags (no `exitUntilCollapsed`) the
CTL exits the screen but leaves the toolbar behind the status-bar area.
`statusBarScrim` property can be used to mask it. We default it to the content
scrim color (`scrolledBackgroundColor`), which makes the masking seamless and is
a visual no-op in the common opaque `exitUntilCollapsed` configuration.

One artifact needed a workaround: both CTL scrims share the same `scrimAlpha`
and overlap in the status-bar strip, so mid-fade the strip composites two layers
at partial alpha — visibly darker than either scrim duration of the fade. The
fix removes the overlap: our content scrim (the bottom layer) is a small
`ColorDrawable` subclass that skips the strip band whenever a status bar scrim
is installed. The band is exactly `[-offset, -offset + topInset]` in CTL
coordinates — the same rect CTL assigns to the status bar scrim — and the
content scrim's visible top edge always aligns with the strip top, so the
exclusion is a single clip. The offset is tracked with an
`OnOffsetChangedListener` and the inset by observing `dispatchApplyWindowInsets`
(both ABL and CTL install their own `OnApplyWindowInsetsListener`, so setting
ours would silently replace Material's).

#### Defaults and policy

| Header             | `statusBarScrimColor` unset                                                              | Explicit color             |
| ------------------ | ---------------------------------------------------------------------------------------- | -------------------------- |
| `small`            | constant strip following the bar's effective background color through the lift animation | static strip of that color |
| `medium` / `large` | scrim in the content scrim color, fading with the collapse                               | that color, same fade      |

- The default scrim is installed only when the color it follows resolves to a
  fully opaque color — translucent headers stay see-through instead of
  getting a double-composited band. An explicit color is always honored.
- `'transparent'` disables the scrim entirely.
- The `small` strip is constant while the `medium`/`large` scrim shows only
  when collapsed — this asymmetry mirrors the native Material widgets.

## Changes

- Added the `statusBarScrimColor` prop (fabric spec, public Android types,
  config plumbing, view manager) reusing the `BACKGROUND_COLORS`
  invalidation flag.
- `StackHeaderAppBarLayout.Small`: installed a `PaintDrawable` status bar
  strip and a `LiftOnScrollProgressListener` keeping it in sync with the
  bar's effective color; the listener is detached when an explicit color is
  set.
- `StackHeaderApplicator`: new `applyStatusBarScrim` step dispatching per
  header type, with the opacity policy in a single
  `resolveStatusBarScrimColor` helper; invisible collapsing scrims are
  normalized to `null`.
- `StackHeaderContentScrimDrawable` + exclusion plumbing in
  `StackHeaderAppBarLayout.Collapsing`: the content scrim skips the
  status-bar strip while a status bar scrim is installed, so the two fading
  scrims never stack.
- Added the `test-stack-header-status-bar-scrim-android` SFT.

## Visual documentation

https://github.com/user-attachments/assets/1f3d8a01-fc6a-4398-81db-659bd10064ab

## Test plan

Run `test-stack-header-status-bar-scrim-android`,
`test-stack-header-background-android`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>