### PR TITLE
chore(test): e2e test for test-tabs-bottom-accessory-visibility-ios

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -39,7 +39,7 @@ export function isIOSVersionAtLeast(version: string): boolean {
 }
 
 /**
- * Suites for iOS 26+-only features (e.g. `bottomAccessory`, the header overflow
+ * Suites for iOS 26+ only features (e.g. `bottomAccessory`, the header overflow
  * button). `isIOSVersionAtLeast` is false on Android, so these stay iOS-only
  * and additionally self-skip on iOS 18 and older.
  */

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -47,7 +47,7 @@ export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
   ? describe
   : describe.skip;
 
-export const describeIfiPadIOS26 =
+export const describeIfiPadOS26 =
   isIPadTarget && isIOSVersionAtLeast('26.0') ? describe : describe.skip;
 
 export type ScrollOptions = {

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -38,6 +38,18 @@ export function isIOSVersionAtLeast(version: string): boolean {
   );
 }
 
+/**
+ * Suites for iOS 26+-only features (e.g. `bottomAccessory`, the header overflow
+ * button). `isIOSVersionAtLeast` is false on Android, so these stay iOS-only
+ * and additionally self-skip on iOS 18 and older.
+ */
+export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
+  ? describe
+  : describe.skip;
+
+export const describeIfiPadIOS26 =
+  isIPadTarget && isIOSVersionAtLeast('26.0') ? describe : describe.skip;
+
 export type ScrollOptions = {
   /** Pixels per step. Smaller steps avoid overshooting a short row. */
   pixels?: number;

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -1,10 +1,10 @@
 import { device, expect, element, by } from 'detox';
 import { expect as jestExpect } from '@jest/globals';
 import {
-  describeIfiOS,
+  describeIfiOS26,
+  describeIfiPadIOS26,
   selectSingleFeatureTestsScreen,
   forceTapByLabeliOS,
-  describeIfiPad,
   getElementAttributes,
 } from '../../e2e-utils';
 import { IosElementAttributes } from 'detox/detox';
@@ -161,7 +161,7 @@ async function verifyConfigTabInitialContent() {
   ).toBeVisible();
 }
 
-describeIfiOS('Tabs bottomAccessory (iOS)', () => {
+describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(
@@ -311,7 +311,7 @@ describeIfiOS('Tabs bottomAccessory (iOS)', () => {
   });
 });
 
-describeIfiPad('@ipad Tabs bottomAccessory (iPad)', () => {
+describeIfiPadIOS26('@ipad Tabs bottomAccessory (iPad, iOS 26+)', () => {
   // The Config scroll view spans the full window height and is the same across
   // every test in this block, so read its frame + safe-area insets once and
   // reuse it as the window/safe-area reference for the bottom-anchor assertion.

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -2,7 +2,7 @@ import { device, expect, element, by } from 'detox';
 import { expect as jestExpect } from '@jest/globals';
 import {
   describeIfiOS26,
-  describeIfiPadIOS26,
+  describeIfiPadOS26,
   selectSingleFeatureTestsScreen,
   forceTapByLabeliOS,
   getElementAttributes,
@@ -311,7 +311,7 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
   });
 });
 
-describeIfiPadIOS26('@ipad Tabs bottomAccessory (iPad, iOS 26+)', () => {
+describeIfiPadOS26('@ipad Tabs bottomAccessory (iPadOS 26+)', () => {
   // The Config scroll view spans the full window height and is the same across
   // every test in this block, so read its frame + safe-area insets once and
   // reuse it as the window/safe-area reference for the bottom-anchor assertion.

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -2,7 +2,7 @@ import { device, expect, element, by, waitFor } from 'detox';
 import { expect as jestExpect } from '@jest/globals';
 import type { IosElementAttributes } from 'detox/detox';
 import {
-  describeIfiOS,
+  describeIfiOS26,
   getElementAttributes,
   getMatches,
   selectSingleFeatureTestsScreen,
@@ -15,21 +15,11 @@ import {
 } from '../../native-class-names';
 
 /**
- * Covers the end state of every `scenario.md` step: after each `hidden` /
- * `rendered` toggle (and their combinations) the bottom accessory is either
- * present with its content and laid out above the tab bar, or gone.
- *
- * Both toggles remove the accessory from the native view hierarchy -
- * `bottomAccessoryHidden` through `setBottomAccessory:nil`, `rendered` by
- * unmounting it - so presence is read the same way for both, and cross-checked
- * against the tab bar: the `UITabBar` itself stays full-width, but on iOS 26
- * the tab item pill (`_UITabButton`) is laid out to the accessory's width while
- * one is attached and shrinks back to its intrinsic width once it is gone. The
- * screen has a single tab, so that pill *is* the visible tab bar.
- *
- * What stays manual is the *animation* `hidden` drives: that the accessory
- * slides out/in smoothly with its content visible throughout and no blank
- * frame. Detox samples the settled hierarchy, not animation frames.
+ * Covers the end state of each `scenario.md` step: after every `hidden` /
+ * `rendered` toggle the accessory is either shown with its content above the
+ * tab bar, or gone. Presence is cross-checked against the tab item pill
+ * (`_UITabButton`), which spans the accessory's width while one is attached.
+ * Animation quality stays manual.
  */
 
 const SCROLL_VIEW = 'bottom-accessory-visibility-scrollview';
@@ -38,25 +28,17 @@ const HIDDEN_SWITCH = 'hidden-switch';
 const ACCESSORY_TEXT = 'bottom-accessory-text';
 const ACCESSORY_CONTENT = 'Bottom Accessory';
 
-// Detox syncs with UIKit animations, but the accessory is attached/detached by
-// `setBottomAccessory:animated:`, so give the transition a bounded grace period
-// rather than asserting the hierarchy on the very next sample.
+// Grace period for the animated `setBottomAccessory:` attach / detach.
 const TRANSITION_TIMEOUT_MS = 3000;
 
 const SETTINGS_CONTROL = { scrollViewId: SCROLL_VIEW };
 
 const bottomAccessory = by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY);
 
-/**
- * Width of the tab item pill while the accessory is attached, read once on the
- * baseline step. Every later step compares against it: narrower means the
- * accessory is gone, back to this width means it is attached again. A relative
- * check, so no system layout constant is hardcoded.
- */
+/** Pill width with the accessory attached, read on the baseline step. */
 let tabButtonWidthWithAccessory: number;
 
-// The single tab button resolves twice (same frame) even under `atIndex`, so
-// read the match set and take the first entry.
+// The tab button resolves twice (same frame), so read the match set.
 async function getTabButtonWidth(): Promise<number> {
   const [tabButton] = (await getMatches(
     by.type(CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26),
@@ -64,8 +46,7 @@ async function getTabButtonWidth(): Promise<number> {
   return tabButton.frame.width;
 }
 
-// RN mounts the text twice under the same `testID` (the paragraph view and its
-// accessibility proxy); `atIndex(0)` pins the matcher to one of them.
+// The text resolves twice under the same `testID`.
 const bottomAccessoryText = () =>
   element(by.id(ACCESSORY_TEXT).withAncestor(bottomAccessory)).atIndex(0);
 
@@ -89,7 +70,7 @@ async function expectSwitchState(
   await expect(element(by.id(switchId))).toHaveLabel(`${label}: ${value}`);
 }
 
-/** The accessory is in the hierarchy, shows its content, and sits above the tab bar. */
+/** Accessory present with its content, above the tab bar, pill stretched. */
 async function expectBottomAccessoryShown() {
   await waitFor(element(bottomAccessory))
     .toExist()
@@ -112,18 +93,13 @@ async function expectBottomAccessoryShown() {
     accessory.frame.y + accessory.frame.height,
   );
 
-  // Frames are integral points here; `toBeCloseTo(…, 0)` only tolerates
-  // sub-pixel drift, not a narrower pill.
   jestExpect(await getTabButtonWidth()).toBeCloseTo(
     tabButtonWidthWithAccessory,
     0,
   );
 }
 
-/**
- * Neither the accessory view nor its content is left in the hierarchy, and the
- * tab item pill has shrunk back from the accessory's width.
- */
+/** Accessory and its content gone from the hierarchy, pill shrunk back. */
 async function expectBottomAccessoryAbsent() {
   await waitFor(element(bottomAccessory))
     .not.toExist()
@@ -135,14 +111,14 @@ async function expectBottomAccessoryAbsent() {
   );
 }
 
-/** The screen is still interactive - its controls are on screen and readable. */
+/** The screen is still interactive. */
 async function expectConfigScreenResponsive() {
   await expect(element(by.id(SCROLL_VIEW))).toBeVisible();
   await expect(element(by.id(RENDERED_SWITCH))).toBeVisible();
   await expect(element(by.id(HIDDEN_SWITCH))).toBeVisible();
 }
 
-describeIfiOS('Tabs: bottomAccessoryHidden (iOS)', () => {
+describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
     await selectSingleFeatureTestsScreen(

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -70,7 +70,6 @@ async function expectSwitchState(
   await expect(element(by.id(switchId))).toHaveLabel(`${label}: ${value}`);
 }
 
-/** Accessory present with its content, above the tab bar, pill stretched. */
 async function expectBottomAccessoryShown() {
   await waitFor(element(bottomAccessory))
     .toExist()
@@ -99,7 +98,6 @@ async function expectBottomAccessoryShown() {
   );
 }
 
-/** Accessory and its content gone from the hierarchy, pill shrunk back. */
 async function expectBottomAccessoryAbsent() {
   await waitFor(element(bottomAccessory))
     .not.toExist()
@@ -111,7 +109,6 @@ async function expectBottomAccessoryAbsent() {
   );
 }
 
-/** The screen is still interactive. */
 async function expectConfigScreenResponsive() {
   await expect(element(by.id(SCROLL_VIEW))).toBeVisible();
   await expect(element(by.id(RENDERED_SWITCH))).toBeVisible();
@@ -127,10 +124,6 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
     );
   });
 
-  // ---------------------------------------------------------------------------
-  // Baseline
-  // ---------------------------------------------------------------------------
-
   it('should show the bottom accessory above the tab bar on load', async () => {
     await expectConfigScreenResponsive();
     await expectSwitchState(RENDERED_SWITCH, 'rendered', true);
@@ -144,10 +137,6 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
     await expectBottomAccessoryShown();
   });
 
-  // ---------------------------------------------------------------------------
-  // Hidden prop
-  // ---------------------------------------------------------------------------
-
   it('should remove the bottom accessory when hidden is toggled on', async () => {
     await setHidden(true);
 
@@ -160,10 +149,6 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
     await expectBottomAccessoryShown();
   });
 
-  // ---------------------------------------------------------------------------
-  // Rendered prop
-  // ---------------------------------------------------------------------------
-
   it('should remove the bottom accessory when rendered is toggled off', async () => {
     await setRendered(false);
 
@@ -175,10 +160,6 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
 
     await expectBottomAccessoryShown();
   });
-
-  // ---------------------------------------------------------------------------
-  // Combined
-  // ---------------------------------------------------------------------------
 
   it('should keep the bottom accessory absent when hidden is toggled on and then rendered off', async () => {
     await setHidden(true);

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -1,0 +1,230 @@
+import { device, expect, element, by, waitFor } from 'detox';
+import { expect as jestExpect } from '@jest/globals';
+import type { IosElementAttributes } from 'detox/detox';
+import {
+  describeIfiOS,
+  getElementAttributes,
+  getMatches,
+  selectSingleFeatureTestsScreen,
+  toggleSettingsSwitch,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
+  CLASS_NAME_UI_TAB_BAR,
+  CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26,
+} from '../../native-class-names';
+
+/**
+ * Covers the end state of every `scenario.md` step: after each `hidden` /
+ * `rendered` toggle (and their combinations) the bottom accessory is either
+ * present with its content and laid out above the tab bar, or gone.
+ *
+ * Both toggles remove the accessory from the native view hierarchy -
+ * `bottomAccessoryHidden` through `setBottomAccessory:nil`, `rendered` by
+ * unmounting it - so presence is read the same way for both, and cross-checked
+ * against the tab bar: the `UITabBar` itself stays full-width, but on iOS 26
+ * the tab item pill (`_UITabButton`) is laid out to the accessory's width while
+ * one is attached and shrinks back to its intrinsic width once it is gone. The
+ * screen has a single tab, so that pill *is* the visible tab bar.
+ *
+ * What stays manual is the *animation* `hidden` drives: that the accessory
+ * slides out/in smoothly with its content visible throughout and no blank
+ * frame. Detox samples the settled hierarchy, not animation frames.
+ */
+
+const SCROLL_VIEW = 'bottom-accessory-visibility-scrollview';
+const RENDERED_SWITCH = 'rendered-switch';
+const HIDDEN_SWITCH = 'hidden-switch';
+const ACCESSORY_TEXT = 'bottom-accessory-text';
+const ACCESSORY_CONTENT = 'Bottom Accessory';
+
+// Detox syncs with UIKit animations, but the accessory is attached/detached by
+// `setBottomAccessory:animated:`, so give the transition a bounded grace period
+// rather than asserting the hierarchy on the very next sample.
+const TRANSITION_TIMEOUT_MS = 3000;
+
+const SETTINGS_CONTROL = { scrollViewId: SCROLL_VIEW };
+
+const bottomAccessory = by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY);
+
+/**
+ * Width of the tab item pill while the accessory is attached, read once on the
+ * baseline step. Every later step compares against it: narrower means the
+ * accessory is gone, back to this width means it is attached again. A relative
+ * check, so no system layout constant is hardcoded.
+ */
+let tabButtonWidthWithAccessory: number;
+
+// The single tab button resolves twice (same frame) even under `atIndex`, so
+// read the match set and take the first entry.
+async function getTabButtonWidth(): Promise<number> {
+  const [tabButton] = (await getMatches(
+    by.type(CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26),
+  )) as IosElementAttributes[];
+  return tabButton.frame.width;
+}
+
+// RN mounts the text twice under the same `testID` (the paragraph view and its
+// accessibility proxy); `atIndex(0)` pins the matcher to one of them.
+const bottomAccessoryText = () =>
+  element(by.id(ACCESSORY_TEXT).withAncestor(bottomAccessory)).atIndex(0);
+
+const setHidden = (to: boolean) =>
+  toggleSettingsSwitch(
+    { switchId: HIDDEN_SWITCH, label: 'hidden', to },
+    SETTINGS_CONTROL,
+  );
+
+const setRendered = (to: boolean) =>
+  toggleSettingsSwitch(
+    { switchId: RENDERED_SWITCH, label: 'rendered', to },
+    SETTINGS_CONTROL,
+  );
+
+async function expectSwitchState(
+  switchId: string,
+  label: string,
+  value: boolean,
+) {
+  await expect(element(by.id(switchId))).toHaveLabel(`${label}: ${value}`);
+}
+
+/** The accessory is in the hierarchy, shows its content, and sits above the tab bar. */
+async function expectBottomAccessoryShown() {
+  await waitFor(element(bottomAccessory))
+    .toExist()
+    .withTimeout(TRANSITION_TIMEOUT_MS);
+  await expect(element(bottomAccessory)).toBeVisible();
+  await expect(bottomAccessoryText()).toExist();
+  await expect(bottomAccessoryText()).toHaveText(ACCESSORY_CONTENT);
+
+  const accessory = (await getElementAttributes({
+    by: 'type',
+    value: CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
+  })) as IosElementAttributes;
+  const tabBar = (await getElementAttributes({
+    by: 'type',
+    value: CLASS_NAME_UI_TAB_BAR,
+    index: 0,
+  })) as IosElementAttributes;
+
+  jestExpect(tabBar.frame.y).toBeGreaterThan(
+    accessory.frame.y + accessory.frame.height,
+  );
+
+  // Frames are integral points here; `toBeCloseTo(…, 0)` only tolerates
+  // sub-pixel drift, not a narrower pill.
+  jestExpect(await getTabButtonWidth()).toBeCloseTo(
+    tabButtonWidthWithAccessory,
+    0,
+  );
+}
+
+/**
+ * Neither the accessory view nor its content is left in the hierarchy, and the
+ * tab item pill has shrunk back from the accessory's width.
+ */
+async function expectBottomAccessoryAbsent() {
+  await waitFor(element(bottomAccessory))
+    .not.toExist()
+    .withTimeout(TRANSITION_TIMEOUT_MS);
+  await expect(element(by.id(ACCESSORY_TEXT))).not.toExist();
+
+  jestExpect(await getTabButtonWidth()).toBeLessThan(
+    tabButtonWidthWithAccessory,
+  );
+}
+
+/** The screen is still interactive - its controls are on screen and readable. */
+async function expectConfigScreenResponsive() {
+  await expect(element(by.id(SCROLL_VIEW))).toBeVisible();
+  await expect(element(by.id(RENDERED_SWITCH))).toBeVisible();
+  await expect(element(by.id(HIDDEN_SWITCH))).toBeVisible();
+}
+
+describeIfiOS('Tabs: bottomAccessoryHidden (iOS)', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Tabs',
+      'test-tabs-bottom-accessory-visibility-ios',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Baseline
+  // ---------------------------------------------------------------------------
+
+  it('should show the bottom accessory above the tab bar on load', async () => {
+    await expectConfigScreenResponsive();
+    await expectSwitchState(RENDERED_SWITCH, 'rendered', true);
+    await expectSwitchState(HIDDEN_SWITCH, 'hidden', false);
+
+    await waitFor(element(bottomAccessory))
+      .toExist()
+      .withTimeout(TRANSITION_TIMEOUT_MS);
+    tabButtonWidthWithAccessory = await getTabButtonWidth();
+
+    await expectBottomAccessoryShown();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hidden prop
+  // ---------------------------------------------------------------------------
+
+  it('should remove the bottom accessory when hidden is toggled on', async () => {
+    await setHidden(true);
+
+    await expectBottomAccessoryAbsent();
+  });
+
+  it('should bring the bottom accessory back with its content when hidden is toggled off', async () => {
+    await setHidden(false);
+
+    await expectBottomAccessoryShown();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rendered prop
+  // ---------------------------------------------------------------------------
+
+  it('should remove the bottom accessory when rendered is toggled off', async () => {
+    await setRendered(false);
+
+    await expectBottomAccessoryAbsent();
+  });
+
+  it('should bring the bottom accessory back with its content when rendered is toggled on', async () => {
+    await setRendered(true);
+
+    await expectBottomAccessoryShown();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Combined
+  // ---------------------------------------------------------------------------
+
+  it('should keep the bottom accessory absent when hidden is toggled on and then rendered off', async () => {
+    await setHidden(true);
+    await expectBottomAccessoryAbsent();
+
+    await setRendered(false);
+
+    await expectConfigScreenResponsive();
+    await expectBottomAccessoryAbsent();
+  });
+
+  it('should keep the bottom accessory absent when rendered is toggled on while still hidden', async () => {
+    await expectSwitchState(HIDDEN_SWITCH, 'hidden', true);
+    await setRendered(true);
+
+    await expectBottomAccessoryAbsent();
+  });
+
+  it('should show the bottom accessory with its content when hidden is toggled off', async () => {
+    await expectSwitchState(RENDERED_SWITCH, 'rendered', true);
+    await setHidden(false);
+
+    await expectBottomAccessoryShown();
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -4,22 +4,18 @@ import type { IosElementAttributes } from 'detox/detox';
 import {
   describeIfiOS26,
   getElementAttributes,
-  getMatches,
   selectSingleFeatureTestsScreen,
   toggleSettingsSwitch,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
   CLASS_NAME_UI_TAB_BAR,
-  CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26,
 } from '../../native-class-names';
 
 /**
  * Covers the end state of each `scenario.md` step: after every `hidden` /
  * `rendered` toggle the accessory is either shown with its content above the
- * tab bar, or gone. Presence is cross-checked against the tab item pill
- * (`_UITabButton`), which spans the accessory's width while one is attached.
- * Animation quality stays manual.
+ * tab bar, or gone. Animation quality stays manual.
  */
 
 const SCROLL_VIEW = 'bottom-accessory-visibility-scrollview';
@@ -34,17 +30,6 @@ const TRANSITION_TIMEOUT_MS = 3000;
 const SETTINGS_CONTROL = { scrollViewId: SCROLL_VIEW };
 
 const bottomAccessory = by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY);
-
-/** Pill width with the accessory attached, read on the baseline step. */
-let tabButtonWidthWithAccessory: number;
-
-// The tab button resolves twice (same frame), so read the match set.
-async function getTabButtonWidth(): Promise<number> {
-  const [tabButton] = (await getMatches(
-    by.type(CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26),
-  )) as IosElementAttributes[];
-  return tabButton.frame.width;
-}
 
 // The text resolves twice under the same `testID`.
 const bottomAccessoryText = () =>
@@ -91,11 +76,6 @@ async function expectBottomAccessoryShown() {
   jestExpect(tabBar.frame.y).toBeGreaterThan(
     accessory.frame.y + accessory.frame.height,
   );
-
-  jestExpect(await getTabButtonWidth()).toBeCloseTo(
-    tabButtonWidthWithAccessory,
-    0,
-  );
 }
 
 async function expectBottomAccessoryAbsent() {
@@ -103,16 +83,6 @@ async function expectBottomAccessoryAbsent() {
     .not.toExist()
     .withTimeout(TRANSITION_TIMEOUT_MS);
   await expect(element(by.id(ACCESSORY_TEXT))).not.toExist();
-
-  jestExpect(await getTabButtonWidth()).toBeLessThan(
-    tabButtonWidthWithAccessory,
-  );
-}
-
-async function expectConfigScreenResponsive() {
-  await expect(element(by.id(SCROLL_VIEW))).toBeVisible();
-  await expect(element(by.id(RENDERED_SWITCH))).toBeVisible();
-  await expect(element(by.id(HIDDEN_SWITCH))).toBeVisible();
 }
 
 describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
@@ -125,14 +95,8 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
   });
 
   it('should show the bottom accessory above the tab bar on load', async () => {
-    await expectConfigScreenResponsive();
     await expectSwitchState(RENDERED_SWITCH, 'rendered', true);
     await expectSwitchState(HIDDEN_SWITCH, 'hidden', false);
-
-    await waitFor(element(bottomAccessory))
-      .toExist()
-      .withTimeout(TRANSITION_TIMEOUT_MS);
-    tabButtonWidthWithAccessory = await getTabButtonWidth();
 
     await expectBottomAccessoryShown();
   });
@@ -167,7 +131,6 @@ describeIfiOS26('Tabs: bottomAccessoryHidden (iOS 26+)', () => {
 
     await setRendered(false);
 
-    await expectConfigScreenResponsive();
     await expectBottomAccessoryAbsent();
   });
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/index.tsx
@@ -14,7 +14,9 @@ import { Colors } from '@apps/shared/styling';
 function BottomAccessoryContent() {
   return (
     <View style={styles.accessory}>
-      <Text style={styles.accessoryText}>Bottom Accessory</Text>
+      <Text testID="bottom-accessory-text" style={styles.accessoryText}>
+        Bottom Accessory
+      </Text>
     </View>
   );
 }
@@ -36,13 +38,21 @@ function ConfigScreen() {
   }, [rendered, hidden, updateHostConfig]);
 
   return (
-    <ScrollView style={styles.container}>
+    <ScrollView
+      testID="bottom-accessory-visibility-scrollview"
+      style={styles.container}>
       <SettingsSwitch
+        testID="rendered-switch"
         label="rendered"
         value={rendered}
         onValueChange={setRendered}
       />
-      <SettingsSwitch label="hidden" value={hidden} onValueChange={setHidden} />
+      <SettingsSwitch
+        testID="hidden-switch"
+        label="hidden"
+        value={hidden}
+        onValueChange={setHidden}
+      />
     </ScrollView>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario-description.ts
@@ -7,6 +7,6 @@ export const scenarioDescription: ScenarioDescription = {
     'Test bottom accessory visibility toggling via bottomAccessory ' +
     'and bottomAccessoryHidden props.',
   platforms: ['ios'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios/scenario.md
@@ -15,7 +15,12 @@ produces a smooth animation with visible content, while toggling
 
 ## E2E test
 
-TBD: Automation is possible and planned but not yet implemented.
+Incomplete: covers the end state of steps 1-8 on iPhone - the accessory is
+present with its content (and the tab bar laid out below it) or absent after
+each `hidden` / `rendered` toggle.
+
+Not automated: animation quality - smooth slide out/in with content visible
+and no blank frame (steps 2-4, 8).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1745

Adds Detox e2e coverage for the iOS `bottomAccessoryHidden` prop on `TabsHost`, covering the end state of each step of the `test-tabs-bottom-accessory-visibility-ios` scenario on iPhone.

Both `hidden` (`bottomAccessoryHidden`) and `rendered` (`bottomAccessory` set / `undefined`) remove the accessory from the native hierarchy, so presence is asserted the same way for both: the RNS accessory view exists and is visible with its content, and its frame sits fully above the tab bar's top edge.

`bottomAccessory` only exists on iOS 26+, so both bottom-accessory suites now run only there: a shared `describeIfiOS26` / `describeIfiPadOS26` in `e2e-utils` (`isIOSVersionAtLeast('26.0')`) skips them on older iOS and on Android.

Animation quality (smooth slide out/in, no blank frame) stays manual - Detox samples settled state, not animation frames.

## Changes

- New spec `FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts` - one `it` per scenario step: baseline, `hidden` on/off, `rendered` off/on, and the combined `hidden` + `rendered` sequence.
- `FabricExample/e2e/e2e-utils.ts`: added `describeIfiOS26` and `describeIfiPadOS26`.
- `test-tabs-bottom-accessory-layout-ios.e2e.ts`: iPhone and `@ipad` suites switched to the iOS 26+ gates.
- Test screen `index.tsx`: added `testID`s only (`bottom-accessory-visibility-scrollview`, `rendered-switch`, `hidden-switch`, `bottom-accessory-text`).
- `scenario.md`: `## E2E test` section states the coverage split; `scenario-description.ts`: `e2eCoverage` → `'incomplete'`.
