### PR TITLE
fix(iOS, Stack v5): Refactor header coordination to hide header when no headerConfig is provided

### DIFF
--- a/ios/stack/header/RNSStackHeaderConfigComponentView.h
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.h
@@ -5,6 +5,7 @@
 #import "RNSStackHeaderConfigDataProviding.h"
 #import "RNSStackHeaderEventsDelegate.h"
 #import "RNSStackHeaderItemInvalidationDelegate.h"
+#import "RNSStackScreenHeaderCoordinator.h"
 #import "RNSViewFrameChangeDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -23,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL largeTitleEnabled;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *titleMenu;
 @property (nonatomic, readonly) NSArray<id> *children;
+
+@property (nonatomic, weak, nullable) RNSStackScreenHeaderCoordinator *headerCoordinator;
 
 - (void)resetProps;
 

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -12,7 +12,6 @@
 #import "RNSStackNavigationController.h"
 #import "RNSStackScreenComponentView.h"
 #import "RNSStackScreenController.h"
-#import "RNSStackScreenHeaderCoordinator.h"
 
 #import <React/RCTConversions.h>
 #import <React/RCTConvert.h>
@@ -123,18 +122,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 {
   if (self.window != nil) {
     [[self requireNavigationController] setNavigationBarFrameChangeDelegate:self];
-    RNSStackScreenHeaderCoordinator *coordinator = [self headerCoordinator];
-    coordinator.configDataProvider = self;
-    coordinator.frameChangeDelegate = self;
-    coordinator.eventsDelegate = self;
-    coordinator.imageLoader = self;
-    [coordinator rebuild];
-  } else {
-    RNSStackScreenHeaderCoordinator *coordinator = [self headerCoordinator];
-    coordinator.configDataProvider = nil;
-    coordinator.frameChangeDelegate = nil;
-    coordinator.eventsDelegate = nil;
-    coordinator.imageLoader = nil;
+    [self.headerCoordinator rebuild];
   }
   [super didMoveToWindow];
 }
@@ -155,7 +143,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     ((RNSStackHeaderItemSpacerComponentView *)childComponentView).invalidationDelegate = self;
   }
 
-  [[self headerCoordinator] rebuild];
+  [self.headerCoordinator rebuild];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
@@ -169,7 +157,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   }
 
   [_children removeObjectAtIndex:index];
-  [[self headerCoordinator] rebuild];
+  [self.headerCoordinator rebuild];
 }
 
 #pragma mark - RNSStackHeaderItemInvalidationDelegate
@@ -178,22 +166,21 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 {
   if (itemId == nil) {
     RCTLogWarn(@"[RNScreens] headerItemDidInvalidateWithId called with nil id, will run full header rebuild");
-    [[self headerCoordinator] rebuild];
+    [self.headerCoordinator rebuild];
     return;
   }
-  [[self headerCoordinator] rebuildItemWithId:itemId];
+  [self.headerCoordinator rebuildItemWithId:itemId];
 }
 
 - (void)headerItemMenuDidChangeWithId:(NSString *)itemId
 {
   if (itemId == nil) {
     RCTLogWarn(@"[RNScreens] headerItemMenuDidChangeWithId called with nil id, will run full header rebuild");
-    [[self headerCoordinator] rebuild];
+    [self.headerCoordinator rebuild];
     return;
   }
-  RNSStackScreenHeaderCoordinator *coordinator = [self headerCoordinator];
-  [coordinator resetTrackerForItemWithId:itemId];
-  [coordinator reapplyMenuForItemWithId:itemId];
+  [self.headerCoordinator resetTrackerForItemWithId:itemId];
+  [self.headerCoordinator reapplyMenuForItemWithId:itemId];
 }
 
 /**
@@ -204,15 +191,15 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   if (itemId == nil) {
     RCTLogWarn(
         @"[RNScreens] headerItemMenuDidUpdateFromCommandWithId called with nil id, will run full header rebuild");
-    [[self headerCoordinator] rebuild];
+    [self.headerCoordinator rebuild];
     return;
   }
-  [[self headerCoordinator] reapplyMenuForItemWithId:itemId];
+  [self.headerCoordinator reapplyMenuForItemWithId:itemId];
 }
 
 - (void)headerItemSpacerDidInvalidate
 {
-  [[self headerCoordinator] rebuild];
+  [self.headerCoordinator rebuild];
 }
 
 #pragma mark - RNSStackHeaderEventsDelegate
@@ -295,11 +282,11 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
         (oldItemData.itemType == RNSMenuItemTypeAutomatic &&
          [RNSStackHeaderMenuFinder singleSelectionRootForElementWithId:menuItemId inMenu:locator.rootMenu] != nil);
     if (isToggle) {
-      [[self headerCoordinator] setToggleState:updateOptions.toggleState
-                              forMenuElementId:menuItemId
-                                 trackerItemId:locator.trackerItemId
-                                      rootMenu:locator.rootMenu
-                                    parentMenu:locator.searchResult.parentMenu];
+      [self.headerCoordinator setToggleState:updateOptions.toggleState
+                            forMenuElementId:menuItemId
+                               trackerItemId:locator.trackerItemId
+                                    rootMenu:locator.rootMenu
+                                  parentMenu:locator.searchResult.parentMenu];
     }
   }
 
@@ -318,7 +305,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
                                     replacingChildWithId:menuItemId
                                              withElement:newItemData];
       }
-      [[self headerCoordinator] reapplyTitleMenu];
+      [self.headerCoordinator reapplyTitleMenu];
       break;
     case RNSMenuElementPositionOverflow:
       // TODO: handle overflow menu
@@ -366,7 +353,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
                                     replacingChildWithId:menuElementId
                                              withElement:newMenuItem];
       }
-      [[self headerCoordinator] reapplyTitleMenu];
+      [self.headerCoordinator reapplyTitleMenu];
       break;
     case RNSMenuElementPositionOverflow:
       // TODO: handle overflow menu
@@ -452,14 +439,14 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
   [super updateProps:props oldProps:oldProps];
 
-  [[self headerCoordinator] applyConfigProperties];
+  [self.headerCoordinator applyConfigProperties];
 
   if (titleMenuDidChange) {
     // title menu is a prop on the navigation item, not on one of the bar button items
     // thus it is not configured with matching RNSStackHeaderItemComponentView
     // but here directly
-    [[self headerCoordinator] resetTitleMenuTracker];
-    [[self headerCoordinator] reapplyTitleMenu];
+    [self.headerCoordinator resetTitleMenuTracker];
+    [self.headerCoordinator reapplyTitleMenu];
   }
 }
 
@@ -481,17 +468,6 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 }
 
 #pragma mark - Private
-
-- (nullable RNSStackScreenHeaderCoordinator *)headerCoordinator
-{
-  if (self.superview == nil) {
-    return nil;
-  }
-  RCTAssert([self.superview isKindOfClass:RNSStackScreenComponentView.class],
-            @"[RNScreens] Header Config should be a direct child of RNSStackScreenComponentView");
-  RNSStackScreenComponentView *screen = (RNSStackScreenComponentView *)self.superview;
-  return screen.controller.headerCoordinator;
-}
 
 - (RNSStackNavigationController *)requireNavigationController
 {

--- a/ios/stack/screen/RNSStackScreenComponentView.mm
+++ b/ios/stack/screen/RNSStackScreenComponentView.mm
@@ -132,6 +132,11 @@ namespace react = facebook::react;
 {
   if ([childComponentView isKindOfClass:RNSStackHeaderConfigComponentView.class]) {
     _headerConfig = (RNSStackHeaderConfigComponentView *)childComponentView;
+    _headerConfig.headerCoordinator = _controller.headerCoordinator;
+    _controller.headerCoordinator.configDataProvider = _headerConfig;
+    _controller.headerCoordinator.frameChangeDelegate = _headerConfig;
+    _controller.headerCoordinator.eventsDelegate = _headerConfig;
+    _controller.headerCoordinator.imageLoader = _headerConfig;
   }
   [super mountChildComponentView:childComponentView index:index];
 }
@@ -140,6 +145,7 @@ namespace react = facebook::react;
 {
   if ([childComponentView isKindOfClass:RNSStackHeaderConfigComponentView.class]) {
     [_controller.headerCoordinator clearHeaderConfiguration];
+    _headerConfig.headerCoordinator = nil;
     _headerConfig = nil;
   }
   [super unmountChildComponentView:childComponentView index:index];

--- a/ios/stack/screen/RNSStackScreenController.mm
+++ b/ios/stack/screen/RNSStackScreenController.mm
@@ -56,6 +56,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+  [self.headerCoordinator updateNavigationBarVisibilityAnimated:animated];
   [[self reactEventEmitter] emitOnWillAppear];
 }
 

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.h
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearHeaderConfiguration;
 
+- (void)updateNavigationBarVisibilityAnimated:(BOOL)animated;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -36,6 +36,17 @@
 
 #pragma mark - Public
 
+- (void)updateNavigationBarVisibilityAnimated:(BOOL)animated
+{
+  RNSStackNavigationController *navController = [self getNavigationController];
+  if (navController == nil || navController.topViewController != _screenController) {
+    return;
+  }
+
+  BOOL hidden = _configDataProvider == nil || _configDataProvider.hidden;
+  [navController.navigationBarCoordinator setHidden:hidden forNavigationController:navController animated:animated];
+}
+
 - (void)rebuild
 {
   if (_configDataProvider == nil) {
@@ -104,7 +115,7 @@
                   forController:controller];
 
   [self applyTitleMenuForController:controller];
-  [self applyNavigationBarProperties];
+  [self updateNavigationBarVisibilityAnimated:YES];
 }
 
 - (void)applyConfigProperties
@@ -114,7 +125,7 @@
   }
 
   [self applyConfigPropertiesForController:[self requireScreenController]];
-  [self applyNavigationBarProperties];
+  [self updateNavigationBarVisibilityAnimated:YES];
 }
 
 /**
@@ -266,6 +277,7 @@
   _configDataProvider = nil;
   _frameChangeDelegate = nil;
   _eventsDelegate = nil;
+  _imageLoader = nil;
 
   [_leadingBarButtonItems removeAllObjects];
   [_trailingBarButtonItems removeAllObjects];
@@ -300,10 +312,7 @@
   navItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 #endif // !TARGET_OS_TV
 
-  RNSStackNavigationController *navController = [self getNavigationController];
-  if (navController != nil) {
-    [navController.navigationBarCoordinator setHidden:NO forNavigationController:navController animated:YES];
-  }
+  [self updateNavigationBarVisibilityAnimated:YES];
 }
 
 /**
@@ -375,16 +384,6 @@
   RCTAssert([navController isKindOfClass:RNSStackNavigationController.class],
             @"[RNScreens] NavigationController should be instance of RNSStackNavigationController");
   return (RNSStackNavigationController *)navController;
-}
-
-- (void)applyNavigationBarProperties
-{
-  RNSStackNavigationController *navController = [self getNavigationController];
-  if (navController != nil) {
-    [navController.navigationBarCoordinator setHidden:_configDataProvider.hidden
-                              forNavigationController:navController
-                                             animated:YES];
-  }
 }
 
 - (void)applyConfigPropertiesForController:(RNSStackScreenController *)controller


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1699

## Description

Currently on v5 when no headerConfig is provided native header is rendered empty, with back button present. Additionally, the header is set to large variant by default, and that looks bad. This PR hides the header entirely when no config is provided, matching the behavior in v4.

> [!important]
> Without visible back button, screen dismiss gestures are disabled and swiping results in dismissing from outer stack. This is native behavior but indesirable in our case. We prevented this in v4 with a custom gesture recognizer, which is not implemented yet for v5, but will be in the future (https://github.com/software-mansion/react-native-screens-labs/issues/824). 

## Changes

- moved the header coordinator wiring header config earlier so we can catch the fact when screen `viewWillAppear` fires
- added method for setting header visibility
- added `screen.viewWillAppear` that hides the header if no config provider is present

## Before & after - visual documentation

n/a

## Test plan

Use simple navigation SFT, hide the header on one screen and navigate; use test-stack-header-subviews-ios, hide / show the header via prop updates. Verify that it hides.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
