### PR TITLE
feat(Android): add neutral screen nested-scroll delegate seam

### DIFF
--- a/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/MainApplication.kt
@@ -9,6 +9,8 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
+import com.fabricexample.nestedscroll.NestedScrollInteropTestPackage
+import com.fabricexample.nestedscroll.NestedScrollInteropTestProbe
 
 class MainApplication : Application(), ReactApplication {
 
@@ -17,14 +19,14 @@ class MainApplication : Application(), ReactApplication {
       context = applicationContext,
       packageList =
         PackageList(this).packages.apply {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
+          add(NestedScrollInteropTestPackage())
         },
     )
   }
 
   override fun onCreate() {
     super.onCreate()
+    NestedScrollInteropTestProbe.install()
     loadReactNative(this)
   }
 }

--- a/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestModule.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestModule.kt
@@ -1,0 +1,200 @@
+package com.fabricexample.nestedscroll
+
+import android.view.View
+import android.view.ViewParent
+import androidx.core.view.ViewCompat
+import androidx.core.view.ViewParentCompat
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.uimanager.UIManagerHelper
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollInterop
+
+class NestedScrollInteropTestModule(
+    reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+    private data class ParentTransaction(
+        val parent: ViewParent,
+        val type: Int,
+    )
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun configure(
+        enabled: Boolean,
+        consumeRemaining: Boolean,
+        promise: Promise,
+    ) {
+        NestedScrollInteropTestProbe.configure(enabled, consumeRemaining)
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun setFactoryInstalled(
+        installed: Boolean,
+        promise: Promise,
+    ) {
+        if (installed) {
+            NestedScrollInteropTestProbe.install()
+        } else {
+            ScreenNestedScrollInterop.removeFactory(NestedScrollInteropTestProbe)
+        }
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun dispatchInterleavedLifecycle(
+        reactTag: Double,
+        promise: Promise,
+    ) {
+        reactApplicationContext.runOnUiQueueThread {
+            val tag = reactTag.toInt()
+            val target =
+                try {
+                    UIManagerHelper
+                        .getUIManagerForReactTag(reactApplicationContext, tag)
+                        ?.resolveView(tag)
+                } catch (_: Throwable) {
+                    null
+                }
+
+            if (target == null) {
+                promise.reject(
+                    "E_NESTED_SCROLL_TARGET",
+                    "Could not resolve nested-scroll target for reactTag=$reactTag",
+                )
+                return@runOnUiQueueThread
+            }
+
+            var touchTransaction: ParentTransaction? = null
+            var nonTouchTransaction: ParentTransaction? = null
+            try {
+                touchTransaction =
+                    checkNotNull(startParentTransaction(target, ViewCompat.TYPE_TOUCH)) {
+                        "Initial TYPE_TOUCH transaction was not accepted"
+                    }
+                stopParentTransaction(target, touchTransaction)
+                touchTransaction = null
+
+                nonTouchTransaction =
+                    checkNotNull(startParentTransaction(target, ViewCompat.TYPE_NON_TOUCH)) {
+                        "TYPE_NON_TOUCH transaction was not accepted by the parent chain"
+                    }
+
+                // Keep NON_TOUCH open while a second TOUCH transaction starts. This exercises
+                // the production coordinator's per-type state without depending on whether the
+                // stock ReactScrollView itself implements NestedScrollingChild2/3.
+                touchTransaction =
+                    checkNotNull(startParentTransaction(target, ViewCompat.TYPE_TOUCH)) {
+                        "Second TYPE_TOUCH transaction was not accepted"
+                    }
+
+                stopParentTransaction(target, touchTransaction)
+                touchTransaction = null
+                stopParentTransaction(target, nonTouchTransaction)
+                nonTouchTransaction = null
+
+                promise.resolve(null)
+            } catch (error: Throwable) {
+                touchTransaction?.let { stopParentTransaction(target, it) }
+                nonTouchTransaction?.let { stopParentTransaction(target, it) }
+                promise.reject("E_NESTED_SCROLL_LIFECYCLE", error)
+            }
+        }
+    }
+
+    @ReactMethod
+    fun reset(promise: Promise) {
+        NestedScrollInteropTestProbe.reset()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun snapshot(promise: Promise) {
+        val snapshot = NestedScrollInteropTestProbe.snapshot()
+        val lifecycleTrace = Arguments.createArray().apply {
+            snapshot.lifecycleTrace.forEach(::pushString)
+        }
+        val map = Arguments.createMap().apply {
+            putDouble("sequence", snapshot.sequence.toDouble())
+            putInt("delegatesCreated", snapshot.delegatesCreated)
+            putInt("attached", snapshot.attached)
+            putInt("detached", snapshot.detached)
+            putInt("layouts", snapshot.layouts)
+            putInt("touchStarts", snapshot.touchStarts)
+            putInt("nonTouchStarts", snapshot.nonTouchStarts)
+            putInt("touchStops", snapshot.touchStops)
+            putInt("nonTouchStops", snapshot.nonTouchStops)
+            putInt("touchPre", snapshot.touchPre)
+            putInt("nonTouchPre", snapshot.nonTouchPre)
+            putInt("touchPost", snapshot.touchPost)
+            putInt("nonTouchPost", snapshot.nonTouchPost)
+            putInt("preFlings", snapshot.preFlings)
+            putInt("flings", snapshot.flings)
+            putDouble("delegateConsumedPreY", snapshot.delegateConsumedPreY.toDouble())
+            putDouble("delegateConsumedPostY", snapshot.delegateConsumedPostY.toDouble())
+            putString("lastScreenClass", snapshot.lastScreenClass)
+            putInt("lastScreenId", snapshot.lastScreenId)
+            putString("lastTargetClass", snapshot.lastTargetClass)
+            putInt("lastTargetId", snapshot.lastTargetId)
+            putInt("lastTargetScrollY", snapshot.lastTargetScrollY)
+            putArray("lifecycleTrace", lifecycleTrace)
+        }
+        promise.resolve(map)
+    }
+
+    private fun startParentTransaction(
+        target: View,
+        type: Int,
+    ): ParentTransaction? {
+        var child = target
+        var parent = target.parent
+
+        while (parent != null) {
+            if (
+                ViewParentCompat.onStartNestedScroll(
+                    parent,
+                    child,
+                    target,
+                    ViewCompat.SCROLL_AXIS_VERTICAL,
+                    type,
+                )
+            ) {
+                ViewParentCompat.onNestedScrollAccepted(
+                    parent,
+                    child,
+                    target,
+                    ViewCompat.SCROLL_AXIS_VERTICAL,
+                    type,
+                )
+                return ParentTransaction(parent, type)
+            }
+
+            if (parent !is View) {
+                return null
+            }
+            child = parent
+            parent = parent.parent
+        }
+
+        return null
+    }
+
+    private fun stopParentTransaction(
+        target: View,
+        transaction: ParentTransaction,
+    ) {
+        ViewParentCompat.onStopNestedScroll(
+            transaction.parent,
+            target,
+            transaction.type,
+        )
+    }
+
+    companion object {
+        const val NAME = "NestedScrollInteropTest"
+    }
+}

--- a/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestPackage.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestPackage.kt
@@ -1,0 +1,13 @@
+package com.fabricexample.nestedscroll
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class NestedScrollInteropTestPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+        listOf(NestedScrollInteropTestModule(reactContext))
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
+}

--- a/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestProbe.kt
+++ b/FabricExample/android/app/src/main/java/com/fabricexample/nestedscroll/NestedScrollInteropTestProbe.kt
@@ -1,0 +1,395 @@
+package com.fabricexample.nestedscroll
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollDelegate
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollDelegateFactory
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollInterop
+
+/** Test-only external consumer used by FabricExample to validate the public nested-scroll seam. */
+object NestedScrollInteropTestProbe : ScreenNestedScrollDelegateFactory {
+    data class Snapshot(
+        val sequence: Long,
+        val delegatesCreated: Int,
+        val attached: Int,
+        val detached: Int,
+        val layouts: Int,
+        val touchStarts: Int,
+        val nonTouchStarts: Int,
+        val touchStops: Int,
+        val nonTouchStops: Int,
+        val touchPre: Int,
+        val nonTouchPre: Int,
+        val touchPost: Int,
+        val nonTouchPost: Int,
+        val preFlings: Int,
+        val flings: Int,
+        val delegateConsumedPreY: Long,
+        val delegateConsumedPostY: Long,
+        val lastScreenClass: String,
+        val lastScreenId: Int,
+        val lastTargetClass: String,
+        val lastTargetId: Int,
+        val lastTargetScrollY: Int,
+        val lifecycleTrace: List<String>,
+    )
+
+    private val lock = Any()
+
+    @Volatile
+    private var enabled = false
+
+    @Volatile
+    private var consumeRemaining = false
+
+    private var snapshotSequence = 0L
+    private var delegatesCreated = 0
+    private var attached = 0
+    private var detached = 0
+    private var layouts = 0
+    private var touchStarts = 0
+    private var nonTouchStarts = 0
+    private var touchStops = 0
+    private var nonTouchStops = 0
+    private var touchPre = 0
+    private var nonTouchPre = 0
+    private var touchPost = 0
+    private var nonTouchPost = 0
+    private var preFlings = 0
+    private var flings = 0
+    private var delegateConsumedPreY = 0L
+    private var delegateConsumedPostY = 0L
+    private var lastScreenClass = "none"
+    private var lastScreenId = View.NO_ID
+    private var lastTargetClass = "none"
+    private var lastTargetId = View.NO_ID
+    private var lastTargetScrollY = 0
+    private val lifecycleTrace = ArrayDeque<String>()
+
+    fun install() = ScreenNestedScrollInterop.installFactory(this)
+
+    fun configure(
+        enabled: Boolean,
+        consumeRemaining: Boolean,
+    ) {
+        this.enabled = enabled
+        this.consumeRemaining = consumeRemaining
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            delegatesCreated = 0
+            attached = 0
+            detached = 0
+            layouts = 0
+            touchStarts = 0
+            nonTouchStarts = 0
+            touchStops = 0
+            nonTouchStops = 0
+            touchPre = 0
+            nonTouchPre = 0
+            touchPost = 0
+            nonTouchPost = 0
+            preFlings = 0
+            flings = 0
+            delegateConsumedPreY = 0L
+            delegateConsumedPostY = 0L
+            lastScreenClass = "none"
+            lastScreenId = View.NO_ID
+            lastTargetClass = "none"
+            lastTargetId = View.NO_ID
+            lastTargetScrollY = 0
+            lifecycleTrace.clear()
+        }
+    }
+
+    fun snapshot(): Snapshot =
+        synchronized(lock) {
+            snapshotSequence += 1
+            Snapshot(
+                sequence = snapshotSequence,
+                delegatesCreated = delegatesCreated,
+                attached = attached,
+                detached = detached,
+                layouts = layouts,
+                touchStarts = touchStarts,
+                nonTouchStarts = nonTouchStarts,
+                touchStops = touchStops,
+                nonTouchStops = nonTouchStops,
+                touchPre = touchPre,
+                nonTouchPre = nonTouchPre,
+                touchPost = touchPost,
+                nonTouchPost = nonTouchPost,
+                preFlings = preFlings,
+                flings = flings,
+                delegateConsumedPreY = delegateConsumedPreY,
+                delegateConsumedPostY = delegateConsumedPostY,
+                lastScreenClass = lastScreenClass,
+                lastScreenId = lastScreenId,
+                lastTargetClass = lastTargetClass,
+                lastTargetId = lastTargetId,
+                lastTargetScrollY = lastTargetScrollY,
+                lifecycleTrace = lifecycleTrace.toList(),
+            )
+        }
+
+    override fun create(screen: ViewGroup): ScreenNestedScrollDelegate {
+        synchronized(lock) {
+            delegatesCreated += 1
+        }
+        return ProbeDelegate(screen)
+    }
+
+    private fun rememberScreen(screen: ViewGroup) {
+        lastScreenClass = screen.javaClass.name
+        lastScreenId = System.identityHashCode(screen)
+    }
+
+    private fun rememberTarget(target: View) {
+        lastTargetClass = target.javaClass.name
+        lastTargetId = System.identityHashCode(target)
+        lastTargetScrollY = target.scrollY
+    }
+
+    private fun recordLifecycle(event: String) {
+        if (lifecycleTrace.size == MAX_TRACE_EVENTS) {
+            lifecycleTrace.removeFirst()
+        }
+        lifecycleTrace.addLast(event)
+    }
+
+    private fun typeName(type: Int): String =
+        when (type) {
+            ViewCompat.TYPE_TOUCH -> "touch"
+            ViewCompat.TYPE_NON_TOUCH -> "nonTouch"
+            else -> "type-$type"
+        }
+
+    private fun incrementByType(
+        type: Int,
+        touch: () -> Unit,
+        nonTouch: () -> Unit,
+    ) {
+        when (type) {
+            ViewCompat.TYPE_TOUCH -> touch()
+            ViewCompat.TYPE_NON_TOUCH -> nonTouch()
+        }
+    }
+
+    private class ProbeDelegate(
+        private val screen: ViewGroup,
+    ) : ScreenNestedScrollDelegate {
+        private val acceptedTypes = mutableSetOf<Int>()
+        private val throwawayConsumed = IntArray(2)
+
+        override fun onStartNestedScroll(
+            child: View,
+            target: View,
+            axes: Int,
+        ): Boolean = onStartNestedScroll(child, target, axes, ViewCompat.TYPE_TOUCH)
+
+        override fun onNestedScrollAccepted(
+            child: View,
+            target: View,
+            axes: Int,
+        ) = onNestedScrollAccepted(child, target, axes, ViewCompat.TYPE_TOUCH)
+
+        override fun onStopNestedScroll(target: View) = onStopNestedScroll(target, ViewCompat.TYPE_TOUCH)
+
+        override fun onNestedScroll(
+            target: View,
+            dxConsumed: Int,
+            dyConsumed: Int,
+            dxUnconsumed: Int,
+            dyUnconsumed: Int,
+        ) {
+            throwawayConsumed.fill(0)
+            onNestedScroll(
+                target,
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                ViewCompat.TYPE_TOUCH,
+                throwawayConsumed,
+            )
+        }
+
+        override fun onNestedPreScroll(
+            target: View,
+            dx: Int,
+            dy: Int,
+            consumed: IntArray,
+        ) = onNestedPreScroll(target, dx, dy, consumed, ViewCompat.TYPE_TOUCH)
+
+        override fun onNestedFling(
+            target: View,
+            velocityX: Float,
+            velocityY: Float,
+            consumed: Boolean,
+        ): Boolean {
+            synchronized(lock) {
+                flings += 1
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+            return false
+        }
+
+        override fun onNestedPreFling(
+            target: View,
+            velocityX: Float,
+            velocityY: Float,
+        ): Boolean {
+            synchronized(lock) {
+                preFlings += 1
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+            return false
+        }
+
+        override fun getNestedScrollAxes(): Int =
+            if (acceptedTypes.isEmpty()) ViewCompat.SCROLL_AXIS_NONE else ViewCompat.SCROLL_AXIS_VERTICAL
+
+        override fun onStartNestedScroll(
+            child: View,
+            target: View,
+            axes: Int,
+            type: Int,
+        ): Boolean {
+            if (!enabled || axes and ViewCompat.SCROLL_AXIS_VERTICAL == 0) {
+                acceptedTypes.remove(type)
+                return false
+            }
+
+            acceptedTypes.add(type)
+            synchronized(lock) {
+                incrementByType(
+                    type,
+                    touch = { touchStarts += 1 },
+                    nonTouch = { nonTouchStarts += 1 },
+                )
+                recordLifecycle("start:${typeName(type)}")
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+            return true
+        }
+
+        override fun onNestedScrollAccepted(
+            child: View,
+            target: View,
+            axes: Int,
+            type: Int,
+        ) = Unit
+
+        override fun onStopNestedScroll(
+            target: View,
+            type: Int,
+        ) {
+            if (type !in acceptedTypes) return
+            synchronized(lock) {
+                incrementByType(
+                    type,
+                    touch = { touchStops += 1 },
+                    nonTouch = { nonTouchStops += 1 },
+                )
+                recordLifecycle("stop:${typeName(type)}")
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+            acceptedTypes.remove(type)
+        }
+
+        override fun onNestedPreScroll(
+            target: View,
+            dx: Int,
+            dy: Int,
+            consumed: IntArray,
+            type: Int,
+        ) {
+            if (type !in acceptedTypes) return
+
+            val consumedY = if (consumeRemaining) dy else 0
+            consumed[1] += consumedY
+            synchronized(lock) {
+                incrementByType(
+                    type,
+                    touch = { touchPre += 1 },
+                    nonTouch = { nonTouchPre += 1 },
+                )
+                delegateConsumedPreY += consumedY.toLong()
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+        }
+
+        override fun onNestedScroll(
+            target: View,
+            dxConsumed: Int,
+            dyConsumed: Int,
+            dxUnconsumed: Int,
+            dyUnconsumed: Int,
+            type: Int,
+        ) {
+            throwawayConsumed.fill(0)
+            onNestedScroll(
+                target,
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                type,
+                throwawayConsumed,
+            )
+        }
+
+        override fun onNestedScroll(
+            target: View,
+            dxConsumed: Int,
+            dyConsumed: Int,
+            dxUnconsumed: Int,
+            dyUnconsumed: Int,
+            type: Int,
+            consumed: IntArray,
+        ) {
+            if (type !in acceptedTypes) return
+
+            val consumedY = if (consumeRemaining) dyUnconsumed else 0
+            consumed[1] += consumedY
+            synchronized(lock) {
+                incrementByType(
+                    type,
+                    touch = { touchPost += 1 },
+                    nonTouch = { nonTouchPost += 1 },
+                )
+                delegateConsumedPostY += consumedY.toLong()
+                rememberScreen(screen)
+                rememberTarget(target)
+            }
+        }
+
+        override fun onScreenAttached(screen: ViewGroup) {
+            synchronized(lock) {
+                attached += 1
+            }
+        }
+
+        override fun onScreenDetached(screen: ViewGroup) {
+            synchronized(lock) {
+                detached += 1
+            }
+            acceptedTypes.clear()
+        }
+
+        override fun onScreenLayout(screen: ViewGroup) {
+            synchronized(lock) {
+                layouts += 1
+            }
+        }
+    }
+
+    private const val MAX_TRACE_EVENTS = 32
+}

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android.e2e.ts
@@ -1,0 +1,394 @@
+import { expect as jestExpect } from '@jest/globals';
+import { by, device, element, waitFor } from 'detox';
+import type { AndroidElementAttributes } from 'detox/detox';
+import type { ProbeSnapshot } from '@apps/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android';
+import {
+  describeIfAndroid,
+  getElementAttributes,
+  getMatches,
+  getTopmostMatch,
+  selectSingleFeatureTestsScreen,
+  waitUntil,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_ANDROID_APP_BAR_LAYOUT,
+  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
+} from '../../native-class-names';
+
+type ProbeScreen = 'home' | 'details' | 'nested';
+
+const toolbar = by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
+const appBar = by.type(CLASS_NAME_ANDROID_APP_BAR_LAYOUT).withDescendant(toolbar);
+
+const SCROLL_STEP_DP = 500;
+const SCROLL_ANCHOR_Y = 0.85;
+const SWIPE_OFFSET = 0.55;
+const SWIPE_START_X = 0.5;
+const SWIPE_UP_START_Y = 0.85;
+const SWIPE_DOWN_START_Y = 0.2;
+const REVERSE_SWIPE_OFFSET = 0.35;
+
+let lastSnapshotSequence = 0;
+
+function probeId(screen: ProbeScreen, suffix: string) {
+  return `nested-scroll-probe-${screen}-${suffix}`;
+}
+
+async function appBarAttributes(): Promise<AndroidElementAttributes> {
+  const matches = await getMatches(appBar);
+  jestExpect(matches).toHaveLength(1);
+  return matches[0] as AndroidElementAttributes;
+}
+
+async function topmostAppBarAttributes(): Promise<AndroidElementAttributes> {
+  return (await getTopmostMatch(appBar)) as AndroidElementAttributes;
+}
+
+async function readSnapshot(screen: ProbeScreen): Promise<ProbeSnapshot> {
+  await element(by.id(probeId(screen, 'snapshot-button'))).tap();
+
+  let snapshot: ProbeSnapshot | null = null;
+  await waitUntil(
+    async () => {
+      const attributes = (await getElementAttributes({
+        by: 'id',
+        value: probeId(screen, 'snapshot'),
+      })) as AndroidElementAttributes;
+      const text = attributes.text;
+      if (text == null || text === 'none') return false;
+
+      const parsed = JSON.parse(text) as ProbeSnapshot;
+      if (parsed.sequence <= lastSnapshotSequence) return false;
+
+      snapshot = parsed;
+      return true;
+    },
+    {
+      timeout: 3000,
+      message: () =>
+        `expected a probe snapshot newer than sequence ${lastSnapshotSequence}`,
+    },
+  );
+
+  jestExpect(snapshot).not.toBeNull();
+  lastSnapshotSequence = snapshot!.sequence;
+  return snapshot!;
+}
+
+async function setMode(
+  screen: ProbeScreen,
+  mode: 'observe' | 'consume' | 'disabled',
+) {
+  const suffix = mode === 'disabled' ? 'disable' : mode;
+  await element(by.id(probeId(screen, suffix))).tap();
+  await waitFor(element(by.id(probeId(screen, 'mode'))))
+    .toHaveText(mode)
+    .withTimeout(3000);
+}
+
+async function resetProbe(screen: ProbeScreen) {
+  await element(by.id(probeId(screen, 'reset'))).tap();
+  await waitFor(element(by.id(probeId(screen, 'snapshot'))))
+    .toHaveText('none')
+    .withTimeout(3000);
+}
+
+async function waitForScreen(screen: ProbeScreen, label: string) {
+  await waitFor(element(by.id(probeId(screen, 'route'))))
+    .toHaveText(label)
+    .withTimeout(5000);
+}
+
+async function scrollToTop(screen: ProbeScreen) {
+  await element(by.id(probeId(screen, 'scrollview'))).scrollTo('top');
+  await waitFor(element(by.id(probeId(screen, 'top'))))
+    .toBeVisible()
+    .withTimeout(3000);
+}
+
+async function scrollAwayFromTop(screen: ProbeScreen) {
+  await element(by.id(probeId(screen, 'scrollview'))).scroll(
+    SCROLL_STEP_DP,
+    'down',
+    Number.NaN,
+    SCROLL_ANCHOR_Y,
+  );
+}
+
+async function swipeUpFromSafeAnchor(
+  screen: ProbeScreen,
+  speed: 'fast' | 'slow',
+  offset = SWIPE_OFFSET,
+) {
+  await element(by.id(probeId(screen, 'scrollview'))).swipe(
+    'up',
+    speed,
+    offset,
+    SWIPE_START_X,
+    SWIPE_UP_START_Y,
+  );
+}
+
+async function swipeDownFromSafeAnchor(
+  screen: ProbeScreen,
+  speed: 'fast' | 'slow',
+  offset = REVERSE_SWIPE_OFFSET,
+) {
+  await element(by.id(probeId(screen, 'scrollview'))).swipe(
+    'down',
+    speed,
+    offset,
+    SWIPE_START_X,
+    SWIPE_DOWN_START_Y,
+  );
+}
+
+async function waitForAdditionalAppBar(previousCount: number) {
+  await waitUntil(
+    async () => {
+      const matches = await getMatches(appBar, { orEmpty: true });
+      return matches.length > previousCount;
+    },
+    {
+      timeout: 5000,
+      message: () =>
+        'expected the pushed Stack v5 screen to attach its AppBarLayout',
+    },
+  );
+}
+
+function totalConsumedY(snapshot: ProbeSnapshot) {
+  return snapshot.delegateConsumedPreY + snapshot.delegateConsumedPostY;
+}
+
+describeIfAndroid('Stack v5: nested-scroll interop seam (Android)', () => {
+  beforeEach(async () => {
+    lastSnapshotSequence = 0;
+    await device.reloadReactNative();
+    await selectSingleFeatureTestsScreen(
+      'Stackv5',
+      'test-stack-nested-scroll-interop-android',
+    );
+    await waitForScreen('home', 'Home');
+    await waitFor(element(by.id(probeId('home', 'scrollview'))))
+      .toBeVisible()
+      .withTimeout(5000);
+    await waitFor(element(toolbar)).toBeVisible().withTimeout(5000);
+  });
+
+  it('forwards the real Stack v5 touch transaction without consuming it', async () => {
+    await setMode('home', 'observe');
+    await scrollToTop('home');
+
+    // Collapse enough native chrome to make the ScrollView a valid Detox swipe target,
+    // then isolate the transaction we actually want to inspect.
+    await scrollAwayFromTop('home');
+    await resetProbe('home');
+    await swipeUpFromSafeAnchor('home', 'fast');
+
+    const snapshot = await readSnapshot('home');
+    jestExpect(snapshot.lastScreenClass).toBe(
+      'com.swmansion.rnscreens.stack.screen.StackScreen',
+    );
+    jestExpect(snapshot.lastTargetClass).toContain('ReactScrollView');
+    jestExpect(snapshot.touchStarts).toBeGreaterThan(0);
+    jestExpect(snapshot.touchPre + snapshot.touchPost).toBeGreaterThan(0);
+    jestExpect(snapshot.delegateConsumedPreY).toBe(0);
+    jestExpect(snapshot.delegateConsumedPostY).toBe(0);
+    jestExpect(snapshot.lastTargetScrollY).toBeGreaterThan(0);
+  });
+
+  it('keeps Stack v5 first and lets the delegate consume only the remaining distance', async () => {
+    await scrollToTop('home');
+    const expandedFrame = (await appBarAttributes()).frame;
+
+    await setMode('home', 'consume');
+    await scrollAwayFromTop('home');
+
+    const snapshot = await readSnapshot('home');
+    const collapsedFrame = (await appBarAttributes()).frame;
+    jestExpect(Math.abs(totalConsumedY(snapshot))).toBeGreaterThan(0);
+    jestExpect(snapshot.lastTargetScrollY).toBe(0);
+    jestExpect(collapsedFrame.y).toBeLessThan(expandedFrame.y);
+  });
+
+  it('switches to the pushed screen source and restores the original source on pop', async () => {
+    await setMode('home', 'observe');
+    await scrollToTop('home');
+    await scrollAwayFromTop('home');
+    const home = await readSnapshot('home');
+
+    await element(by.id(probeId('home', 'push'))).tap();
+    await waitForScreen('details', 'Details');
+    await scrollAwayFromTop('details');
+    const details = await readSnapshot('details');
+
+    jestExpect(details.lastScreenId).not.toBe(home.lastScreenId);
+    jestExpect(details.lastTargetId).not.toBe(home.lastTargetId);
+
+    await element(by.id(probeId('details', 'pop'))).tap();
+    await waitForScreen('home', 'Home');
+    await scrollAwayFromTop('home');
+    const restoredHome = await readSnapshot('home');
+
+    jestExpect(restoredHome.lastScreenId).toBe(home.lastScreenId);
+    jestExpect(restoredHome.lastTargetId).toBe(home.lastTargetId);
+  });
+
+  it('preserves an outer Stack v5 header when the delegate accepts an inner stack source', async () => {
+    await setMode('home', 'observe');
+    await scrollToTop('home');
+    const appBarCountBeforePush = (
+      await getMatches(appBar, { orEmpty: true })
+    ).length;
+
+    await element(by.id(probeId('home', 'push-nested'))).tap();
+    await waitForScreen('nested', 'Nested');
+    await waitForAdditionalAppBar(appBarCountBeforePush);
+
+    await scrollToTop('nested');
+    const expandedFrame = (await topmostAppBarAttributes()).frame;
+    await scrollAwayFromTop('nested');
+
+    const snapshot = await readSnapshot('nested');
+    const collapsedFrame = (await topmostAppBarAttributes()).frame;
+    jestExpect(snapshot.lastScreenClass).toBe(
+      'com.swmansion.rnscreens.stack.screen.StackScreen',
+    );
+    jestExpect(snapshot.lastTargetClass).toContain('ReactScrollView');
+    jestExpect(snapshot.touchStarts).toBeGreaterThan(0);
+    jestExpect(totalConsumedY(snapshot)).toBe(0);
+    jestExpect(snapshot.lastTargetScrollY).toBeGreaterThan(0);
+    jestExpect(collapsedFrame.y).toBeLessThan(expandedFrame.y);
+  });
+
+  it('keeps the outer ancestor first before an inner delegate consumes the remainder', async () => {
+    await scrollToTop('home');
+    const appBarCountBeforePush = (
+      await getMatches(appBar, { orEmpty: true })
+    ).length;
+
+    await element(by.id(probeId('home', 'push-nested'))).tap();
+    await waitForScreen('nested', 'Nested');
+    await waitForAdditionalAppBar(appBarCountBeforePush);
+    await setMode('nested', 'consume');
+    await scrollToTop('nested');
+
+    const expandedFrame = (await topmostAppBarAttributes()).frame;
+    await scrollAwayFromTop('nested');
+
+    const snapshot = await readSnapshot('nested');
+    const collapsedFrame = (await topmostAppBarAttributes()).frame;
+    jestExpect(totalConsumedY(snapshot)).toBeGreaterThan(0);
+    jestExpect(snapshot.lastTargetScrollY).toBe(0);
+    jestExpect(collapsedFrame.y).toBeLessThan(expandedFrame.y);
+  });
+
+  it('clamps signed delegate consumption correctly when scroll direction reverses', async () => {
+    await setMode('home', 'consume');
+    await scrollToTop('home');
+
+    // Warm up with Detox scroll() only to expose the target, then use real swipes for the
+    // forward/reverse transactions whose signed consumption we assert.
+    await scrollAwayFromTop('home');
+    await resetProbe('home');
+    await swipeUpFromSafeAnchor('home', 'slow');
+
+    const forward = await readSnapshot('home');
+    const collapsedFrame = (await appBarAttributes()).frame;
+    jestExpect(totalConsumedY(forward)).toBeGreaterThan(0);
+
+    await resetProbe('home');
+    await swipeDownFromSafeAnchor('home', 'slow');
+
+    const reverse = await readSnapshot('home');
+    const expandedFrame = (await appBarAttributes()).frame;
+    jestExpect(totalConsumedY(reverse)).toBeLessThan(0);
+    jestExpect(reverse.lastTargetScrollY).toBe(forward.lastTargetScrollY);
+    jestExpect(expandedFrame.y).toBeGreaterThan(collapsedFrame.y);
+  });
+
+  it('keeps TOUCH and NON_TOUCH lifecycle independent when a new TOUCH starts during NON_TOUCH', async () => {
+    await setMode('home', 'observe');
+    await resetProbe('home');
+
+    await element(by.id(probeId('home', 'interleave'))).tap();
+
+    let interleaveStatus = 'idle';
+    await waitUntil(
+      async () => {
+        const attributes = (await getElementAttributes({
+          by: 'id',
+          value: probeId('home', 'interleave-status'),
+        })) as AndroidElementAttributes;
+        interleaveStatus = attributes.text ?? 'missing-status';
+        return interleaveStatus !== 'idle';
+      },
+      {
+        timeout: 3000,
+        message: () =>
+          `expected interleaved lifecycle dispatch to finish; last status: ${interleaveStatus}`,
+      },
+    );
+    jestExpect(interleaveStatus).toBe('done');
+
+    const snapshot = await readSnapshot('home');
+    jestExpect(snapshot.lastTargetClass).toContain('ReactScrollView');
+    jestExpect(snapshot.touchStarts).toBe(2);
+    jestExpect(snapshot.touchStops).toBe(2);
+    jestExpect(snapshot.nonTouchStarts).toBe(1);
+    jestExpect(snapshot.nonTouchStops).toBe(1);
+    jestExpect(snapshot.lifecycleTrace).toEqual([
+      'start:touch',
+      'stop:touch',
+      'start:nonTouch',
+      'start:touch',
+      'stop:touch',
+      'stop:nonTouch',
+    ]);
+  });
+
+  it('is behaviorally inert when the external delegate declines nested scroll', async () => {
+    await scrollToTop('home');
+    const expandedFrame = (await appBarAttributes()).frame;
+    await setMode('home', 'disabled');
+
+    await scrollAwayFromTop('home');
+    await scrollAwayFromTop('home');
+
+    const snapshot = await readSnapshot('home');
+    const collapsedFrame = (await appBarAttributes()).frame;
+    jestExpect(snapshot.touchStarts).toBe(0);
+    jestExpect(snapshot.nonTouchStarts).toBe(0);
+    jestExpect(snapshot.touchPre).toBe(0);
+    jestExpect(snapshot.nonTouchPre).toBe(0);
+    jestExpect(snapshot.touchPost).toBe(0);
+    jestExpect(snapshot.nonTouchPost).toBe(0);
+    jestExpect(totalConsumedY(snapshot)).toBe(0);
+    jestExpect(collapsedFrame.y).toBeLessThan(expandedFrame.y);
+  });
+
+  it('preserves stock Stack v5 behavior when no delegate factory is installed', async () => {
+    await setMode('home', 'observe');
+    await scrollToTop('home');
+    await element(by.id(probeId('home', 'remove-factory'))).tap();
+    await waitFor(element(by.id(probeId('home', 'factory'))))
+      .toHaveText('absent')
+      .withTimeout(3000);
+
+    await element(by.id(probeId('home', 'push'))).tap();
+    await waitForScreen('details', 'Details');
+    await scrollToTop('details');
+    const expandedFrame = (await topmostAppBarAttributes()).frame;
+
+    await scrollAwayFromTop('details');
+    await scrollAwayFromTop('details');
+
+    const snapshot = await readSnapshot('details');
+    const collapsedFrame = (await topmostAppBarAttributes()).frame;
+    jestExpect(snapshot.delegatesCreated).toBe(0);
+    jestExpect(snapshot.touchStarts).toBe(0);
+    jestExpect(snapshot.nonTouchStarts).toBe(0);
+    jestExpect(collapsedFrame.y).toBeLessThan(expandedFrame.y);
+  });
+});

--- a/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
@@ -1,0 +1,374 @@
+package com.swmansion.rnscreens.common.nestedscroll
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.ViewParentCompat
+
+/**
+ * CoordinatorLayout that preserves its normal child-behavior dispatch and optionally forwards
+ * the remaining nested-scroll transaction to an external screen delegate.
+ */
+internal abstract class ScreenNestedScrollCoordinatorLayout(
+    context: Context,
+    private val screen: ViewGroup,
+) : CoordinatorLayout(context) {
+    private data class AncestorBridge(
+        val parent: ViewParent,
+        val target: View,
+    )
+
+    private var nestedScrollDelegate: ScreenNestedScrollDelegate? = null
+    private val superAcceptedTypes = mutableSetOf<Int>()
+    private val delegateAcceptedTypes = mutableSetOf<Int>()
+    private val ancestorBridges = mutableMapOf<Int, AncestorBridge>()
+    private val delegateConsumed = IntArray(2)
+    private val ancestorConsumed = IntArray(2)
+
+    override fun getNestedScrollAxes(): Int = super.getNestedScrollAxes() or (nestedScrollDelegate?.getNestedScrollAxes() ?: 0)
+
+    override fun onStartNestedScroll(
+        child: View,
+        target: View,
+        axes: Int,
+        type: Int,
+    ): Boolean {
+        stopAncestorBridge(type)
+
+        val superAccepted = super.onStartNestedScroll(child, target, axes, type)
+        val delegateAccepted =
+            isNearestInteropCoordinatorFor(target) &&
+                nestedScrollDelegate?.onStartNestedScroll(child, target, axes, type) == true
+
+        if (superAccepted) superAcceptedTypes.add(type) else superAcceptedTypes.remove(type)
+        if (delegateAccepted) delegateAcceptedTypes.add(type) else delegateAcceptedTypes.remove(type)
+
+        // If the delegate is the only reason this inner coordinator accepts the source, Android
+        // would otherwise stop searching the parent chain here. Preserve the natural parent
+        // priority by bridging the original target to the first ancestor that would have accepted
+        // it, then let the external delegate see only what remains.
+        if (!superAccepted && delegateAccepted) {
+            startAncestorBridge(target, axes, type)
+        }
+
+        return superAccepted || delegateAccepted
+    }
+
+    override fun onNestedScrollAccepted(
+        child: View,
+        target: View,
+        axes: Int,
+        type: Int,
+    ) {
+        if (type in superAcceptedTypes) {
+            super.onNestedScrollAccepted(child, target, axes, type)
+        }
+        if (type in delegateAcceptedTypes) {
+            nestedScrollDelegate?.onNestedScrollAccepted(child, target, axes, type)
+        }
+    }
+
+    override fun onStopNestedScroll(
+        target: View,
+        type: Int,
+    ) {
+        if (type in superAcceptedTypes) {
+            super.onStopNestedScroll(target, type)
+        }
+        stopAncestorBridge(type)
+        if (type in delegateAcceptedTypes) {
+            nestedScrollDelegate?.onStopNestedScroll(target, type)
+        }
+        superAcceptedTypes.remove(type)
+        delegateAcceptedTypes.remove(type)
+    }
+
+    override fun onNestedPreScroll(
+        target: View,
+        dx: Int,
+        dy: Int,
+        consumed: IntArray,
+        type: Int,
+    ) {
+        val consumedBeforeX = consumed[0]
+        val consumedBeforeY = consumed[1]
+
+        if (type in superAcceptedTypes) {
+            super.onNestedPreScroll(target, dx, dy, consumed, type)
+        } else {
+            dispatchAncestorPreScroll(dx, dy, consumed, type)
+        }
+
+        if (type in delegateAcceptedTypes) {
+            val consumedByScreensX = consumed[0] - consumedBeforeX
+            val consumedByScreensY = consumed[1] - consumedBeforeY
+            val remainingX = dx - consumedByScreensX
+            val remainingY = dy - consumedByScreensY
+            delegateConsumed.fill(0)
+
+            nestedScrollDelegate?.onNestedPreScroll(
+                target,
+                remainingX,
+                remainingY,
+                delegateConsumed,
+                type,
+            )
+
+            consumed[0] += clampSignedConsumption(remainingX, delegateConsumed[0])
+            consumed[1] += clampSignedConsumption(remainingY, delegateConsumed[1])
+        }
+    }
+
+    override fun onNestedScroll(
+        target: View,
+        dxConsumed: Int,
+        dyConsumed: Int,
+        dxUnconsumed: Int,
+        dyUnconsumed: Int,
+        type: Int,
+        consumed: IntArray,
+    ) {
+        val consumedBeforeX = consumed[0]
+        val consumedBeforeY = consumed[1]
+
+        if (type in superAcceptedTypes) {
+            super.onNestedScroll(
+                target,
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                type,
+                consumed,
+            )
+        } else {
+            dispatchAncestorPostScroll(
+                target,
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                consumed,
+                type,
+            )
+        }
+
+        if (type in delegateAcceptedTypes) {
+            val consumedByScreensX = consumed[0] - consumedBeforeX
+            val consumedByScreensY = consumed[1] - consumedBeforeY
+            val remainingX = dxUnconsumed - consumedByScreensX
+            val remainingY = dyUnconsumed - consumedByScreensY
+            delegateConsumed.fill(0)
+
+            nestedScrollDelegate?.onNestedScroll(
+                target,
+                dxConsumed,
+                dyConsumed,
+                remainingX,
+                remainingY,
+                type,
+                delegateConsumed,
+            )
+
+            consumed[0] += clampSignedConsumption(remainingX, delegateConsumed[0])
+            consumed[1] += clampSignedConsumption(remainingY, delegateConsumed[1])
+        }
+    }
+
+    override fun onNestedPreFling(
+        target: View,
+        velocityX: Float,
+        velocityY: Float,
+    ): Boolean {
+        val superConsumed =
+            ViewCompat.TYPE_TOUCH in superAcceptedTypes &&
+                super.onNestedPreFling(target, velocityX, velocityY)
+
+        if (superConsumed) {
+            return true
+        }
+
+        val ancestorConsumed =
+            ancestorBridges[ViewCompat.TYPE_TOUCH]?.let { bridge ->
+                ViewParentCompat.onNestedPreFling(
+                    bridge.parent,
+                    bridge.target,
+                    velocityX,
+                    velocityY,
+                )
+            } == true
+
+        if (ancestorConsumed) {
+            return true
+        }
+
+        return ViewCompat.TYPE_TOUCH in delegateAcceptedTypes &&
+            nestedScrollDelegate?.onNestedPreFling(target, velocityX, velocityY) == true
+    }
+
+    override fun onNestedFling(
+        target: View,
+        velocityX: Float,
+        velocityY: Float,
+        consumed: Boolean,
+    ): Boolean {
+        val handledBySuper =
+            ViewCompat.TYPE_TOUCH in superAcceptedTypes &&
+                super.onNestedFling(target, velocityX, velocityY, consumed)
+
+        if (handledBySuper) {
+            return true
+        }
+
+        val handledByAncestor =
+            ancestorBridges[ViewCompat.TYPE_TOUCH]?.let { bridge ->
+                ViewParentCompat.onNestedFling(
+                    bridge.parent,
+                    bridge.target,
+                    velocityX,
+                    velocityY,
+                    consumed,
+                )
+            } == true
+
+        if (handledByAncestor) {
+            return true
+        }
+
+        return ViewCompat.TYPE_TOUCH in delegateAcceptedTypes &&
+            nestedScrollDelegate?.onNestedFling(target, velocityX, velocityY, consumed) == true
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        nestedScrollDelegate = ScreenNestedScrollInterop.createDelegate(screen)
+        nestedScrollDelegate?.onScreenAttached(screen)
+    }
+
+    override fun onDetachedFromWindow() {
+        ancestorBridges.keys.toList().forEach(::stopAncestorBridge)
+        nestedScrollDelegate?.onScreenDetached(screen)
+        nestedScrollDelegate = null
+        superAcceptedTypes.clear()
+        delegateAcceptedTypes.clear()
+        super.onDetachedFromWindow()
+    }
+
+    override fun onLayout(
+        changed: Boolean,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+    ) {
+        super.onLayout(changed, left, top, right, bottom)
+        nestedScrollDelegate?.onScreenLayout(screen)
+    }
+
+    /**
+     * Nested navigation can place more than one screen CoordinatorLayout above the same source.
+     * Only the closest one may expose the transaction externally, otherwise the same external
+     * participant could receive the same source movement more than once. Screens-owned ancestor
+     * behavior is preserved separately through [startAncestorBridge].
+     */
+    private fun isNearestInteropCoordinatorFor(target: View): Boolean {
+        var current: View? = target
+        while (current != null) {
+            if (current is ScreenNestedScrollCoordinatorLayout) {
+                return current === this
+            }
+            current = current.parent as? View
+        }
+        return false
+    }
+
+    /**
+     * Replays Android's normal parent search from this coordinator upward while keeping the
+     * original nested-scroll target. This path is used only when the external delegate caused an
+     * otherwise non-participating inner screen to accept the source.
+     */
+    private fun startAncestorBridge(
+        target: View,
+        axes: Int,
+        type: Int,
+    ) {
+        var directChild: View = this
+        var candidate = parent
+
+        while (candidate != null) {
+            if (ViewParentCompat.onStartNestedScroll(candidate, directChild, target, axes, type)) {
+                ancestorBridges[type] = AncestorBridge(candidate, target)
+                ViewParentCompat.onNestedScrollAccepted(candidate, directChild, target, axes, type)
+                return
+            }
+
+            if (candidate is View) {
+                directChild = candidate
+            }
+            candidate = candidate.parent
+        }
+    }
+
+    private fun stopAncestorBridge(type: Int) {
+        val bridge = ancestorBridges.remove(type) ?: return
+        ViewParentCompat.onStopNestedScroll(bridge.parent, bridge.target, type)
+    }
+
+    private fun dispatchAncestorPreScroll(
+        dx: Int,
+        dy: Int,
+        consumed: IntArray,
+        type: Int,
+    ) {
+        val bridge = ancestorBridges[type] ?: return
+        ancestorConsumed.fill(0)
+        ViewParentCompat.onNestedPreScroll(
+            bridge.parent,
+            bridge.target,
+            dx,
+            dy,
+            ancestorConsumed,
+            type,
+        )
+        consumed[0] += clampSignedConsumption(dx, ancestorConsumed[0])
+        consumed[1] += clampSignedConsumption(dy, ancestorConsumed[1])
+    }
+
+    private fun dispatchAncestorPostScroll(
+        target: View,
+        dxConsumed: Int,
+        dyConsumed: Int,
+        dxUnconsumed: Int,
+        dyUnconsumed: Int,
+        consumed: IntArray,
+        type: Int,
+    ) {
+        val bridge = ancestorBridges[type] ?: return
+        ancestorConsumed.fill(0)
+        ViewParentCompat.onNestedScroll(
+            bridge.parent,
+            target,
+            dxConsumed,
+            dyConsumed,
+            dxUnconsumed,
+            dyUnconsumed,
+            type,
+            ancestorConsumed,
+        )
+        consumed[0] += clampSignedConsumption(dxUnconsumed, ancestorConsumed[0])
+        consumed[1] += clampSignedConsumption(dyUnconsumed, ancestorConsumed[1])
+    }
+
+    private fun clampSignedConsumption(
+        available: Int,
+        consumed: Int,
+    ): Int =
+        when {
+            available > 0 -> consumed.coerceIn(0, available)
+            available < 0 -> consumed.coerceIn(available, 0)
+            else -> 0
+        }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
@@ -24,6 +24,7 @@ internal abstract class ScreenNestedScrollCoordinatorLayout(
     private var nestedScrollDelegate: ScreenNestedScrollDelegate? = null
     private val superAcceptedTypes = mutableSetOf<Int>()
     private val delegateAcceptedTypes = mutableSetOf<Int>()
+    private val delegateTargets = mutableMapOf<Int, View>()
     private val ancestorBridges = mutableMapOf<Int, AncestorBridge>()
     private val delegateConsumed = IntArray(2)
     private val ancestorConsumed = IntArray(2)
@@ -67,6 +68,7 @@ internal abstract class ScreenNestedScrollCoordinatorLayout(
             super.onNestedScrollAccepted(child, target, axes, type)
         }
         if (type in delegateAcceptedTypes) {
+            delegateTargets[type] = target
             nestedScrollDelegate?.onNestedScrollAccepted(child, target, axes, type)
         }
     }
@@ -80,7 +82,9 @@ internal abstract class ScreenNestedScrollCoordinatorLayout(
         }
         stopAncestorBridge(type)
         if (type in delegateAcceptedTypes) {
-            nestedScrollDelegate?.onStopNestedScroll(target, type)
+            nestedScrollDelegate?.onStopNestedScroll(delegateTargets.remove(type) ?: target, type)
+        } else {
+            delegateTargets.remove(type)
         }
         superAcceptedTypes.remove(type)
         delegateAcceptedTypes.remove(type)
@@ -250,7 +254,12 @@ internal abstract class ScreenNestedScrollCoordinatorLayout(
 
     override fun onDetachedFromWindow() {
         ancestorBridges.keys.toList().forEach(::stopAncestorBridge)
-        nestedScrollDelegate?.onScreenDetached(screen)
+        val delegate = nestedScrollDelegate
+        delegateTargets.toList().forEach { (type, target) ->
+            delegate?.onStopNestedScroll(target, type)
+        }
+        delegateTargets.clear()
+        delegate?.onScreenDetached(screen)
         nestedScrollDelegate = null
         superAcceptedTypes.clear()
         delegateAcceptedTypes.clear()

--- a/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollCoordinatorLayout.kt
@@ -261,9 +261,9 @@ internal abstract class ScreenNestedScrollCoordinatorLayout(
         delegateTargets.clear()
         delegate?.onScreenDetached(screen)
         nestedScrollDelegate = null
+        super.onDetachedFromWindow()
         superAcceptedTypes.clear()
         delegateAcceptedTypes.clear()
-        super.onDetachedFromWindow()
     }
 
     override fun onLayout(

--- a/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollInterop.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/nestedscroll/ScreenNestedScrollInterop.kt
@@ -1,0 +1,58 @@
+package com.swmansion.rnscreens.common.nestedscroll
+
+import android.view.ViewGroup
+import androidx.core.view.NestedScrollingParent3
+
+/**
+ * Optional Android nested-scroll participant owned outside react-native-screens.
+ *
+ * Implementations receive the same AndroidX nested-scroll transaction as the screen container,
+ * without react-native-screens depending on the implementation. This is intentionally separate
+ * from the Container / ContainerItem hierarchy: that hierarchy resolves content through nested
+ * navigation containers, while this contract only forwards a transaction already received by the
+ * owning CoordinatorLayout.
+ */
+interface ScreenNestedScrollDelegate : NestedScrollingParent3 {
+    fun onScreenAttached(screen: ViewGroup) = Unit
+
+    fun onScreenDetached(screen: ViewGroup) = Unit
+
+    fun onScreenLayout(screen: ViewGroup) = Unit
+}
+
+fun interface ScreenNestedScrollDelegateFactory {
+    fun create(screen: ViewGroup): ScreenNestedScrollDelegate?
+}
+
+/**
+ * Process-wide extension point for optional screen nested-scroll delegates.
+ *
+ * The default is no delegate, preserving existing react-native-screens behavior. A single
+ * external owner may install a factory before screens are created. The screen's own CoordinatorLayout
+ * behaviors always run first; the delegate can consume only the signed distance left afterwards.
+ */
+object ScreenNestedScrollInterop {
+    @Volatile
+    private var factory: ScreenNestedScrollDelegateFactory? = null
+
+    @JvmStatic
+    fun installFactory(factory: ScreenNestedScrollDelegateFactory) {
+        synchronized(this) {
+            check(this.factory == null || this.factory === factory) {
+                "[RNScreens] A different ScreenNestedScrollDelegateFactory is already installed."
+            }
+            this.factory = factory
+        }
+    }
+
+    @JvmStatic
+    fun removeFactory(factory: ScreenNestedScrollDelegateFactory) {
+        synchronized(this) {
+            if (this.factory === factory) {
+                this.factory = null
+            }
+        }
+    }
+
+    internal fun createDelegate(screen: ViewGroup): ScreenNestedScrollDelegate? = factory?.create(screen)
+}

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/stack/views/ScreensCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/stack/views/ScreensCoordinatorLayout.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.view.WindowInsets
 import android.view.animation.Animation
 import android.view.animation.AnimationSet
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.facebook.react.uimanager.ReactPointerEventsView
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollCoordinatorLayout
 import com.swmansion.rnscreens.legacy.PointerEventsBoxNoneImpl
 import com.swmansion.rnscreens.legacy.ScreenStackFragment
 import com.swmansion.rnscreens.legacy.bottomsheet.usesFormSheetPresentation
@@ -15,7 +15,7 @@ internal class ScreensCoordinatorLayout(
     context: Context,
     internal val fragment: ScreenStackFragment,
     private val pointerEventsImpl: ReactPointerEventsView,
-) : CoordinatorLayout(context),
+) : ScreenNestedScrollCoordinatorLayout(context, fragment.screen),
     ReactPointerEventsView by pointerEventsImpl {
     constructor(context: Context, fragment: ScreenStackFragment) : this(
         context,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -9,11 +9,11 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.facebook.react.bridge.ReactContext
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
+import com.swmansion.rnscreens.common.nestedscroll.ScreenNestedScrollCoordinatorLayout
 import com.swmansion.rnscreens.stack.header.appbar.StackHeaderAppBarLayout
 import com.swmansion.rnscreens.stack.header.appbar.StackHeaderScrollingViewBehavior
 import com.swmansion.rnscreens.stack.header.config.OnHeaderConfigurationAttachListener
@@ -36,7 +36,7 @@ internal class StackHeaderCoordinatorLayout(
     context: Context,
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
-) : CoordinatorLayout(context) {
+) : ScreenNestedScrollCoordinatorLayout(context, stackScreen) {
     // region Config attach / detach
 
     private var currentProvider: StackHeaderConfigurationProviding? = null

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -9,6 +9,7 @@ import TestStackAnimationAndroid from './test-stack-animation-android';
 import TestStackSimpleNav from './test-stack-simple-nav';
 import TestStackSubviewsAndroid from './test-stack-subviews-android';
 import TestStackLiftOnScrollAndroid from './test-stack-lift-on-scroll-android';
+import TestStackNestedScrollInteropAndroid from './test-stack-nested-scroll-interop-android';
 import TestStackSubviewsIOS from './test-stack-subviews-ios';
 import TestStackHeaderMenuIOS from './test-stack-header-menu-ios';
 import TestStackHeaderIconIOS from './test-stack-header-icon-ios';
@@ -38,6 +39,7 @@ export { default as TestStackAnimationAndroid } from './test-stack-animation-and
 export { default as TestStackSimpleNav } from './test-stack-simple-nav';
 export { default as TestStackSubviewsAndroid } from './test-stack-subviews-android';
 export { default as TestStackLiftOnScrollAndroid } from './test-stack-lift-on-scroll-android';
+export { default as TestStackNestedScrollInteropAndroid } from './test-stack-nested-scroll-interop-android';
 export { default as TestStackSubviewsIOS } from './test-stack-subviews-ios';
 export { default as TestStackHeaderIconIOS } from './test-stack-header-icon-ios';
 export { default as TestStackHeaderItemIdentifierIOS } from './test-stack-header-item-identifier-ios';
@@ -66,6 +68,7 @@ const scenarios = {
   TestStackSimpleNav,
   TestStackSubviewsAndroid,
   TestStackLiftOnScrollAndroid,
+  TestStackNestedScrollInteropAndroid,
   TestStackSubviewsIOS,
   TestStackHeaderMenuIOS,
   TestStackHeaderIconIOS,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/index.tsx
@@ -1,0 +1,353 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Button,
+  findNodeHandle,
+  NativeModules,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  ScrollViewMarker,
+  type StackHeaderConfigProps,
+} from 'react-native-screens';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import LongText from '@apps/shared/LongText';
+import { Colors } from '@apps/shared/styling';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { scenarioDescription } from './scenario-description';
+
+export type ProbeSnapshot = {
+  sequence: number;
+  delegatesCreated: number;
+  attached: number;
+  detached: number;
+  layouts: number;
+  touchStarts: number;
+  nonTouchStarts: number;
+  touchStops: number;
+  nonTouchStops: number;
+  touchPre: number;
+  nonTouchPre: number;
+  touchPost: number;
+  nonTouchPost: number;
+  preFlings: number;
+  flings: number;
+  delegateConsumedPreY: number;
+  delegateConsumedPostY: number;
+  lastScreenClass: string;
+  lastScreenId: number;
+  lastTargetClass: string;
+  lastTargetId: number;
+  lastTargetScrollY: number;
+  lifecycleTrace: string[];
+};
+
+type ProbeModule = {
+  configure(enabled: boolean, consumeRemaining: boolean): Promise<void>;
+  setFactoryInstalled(installed: boolean): Promise<void>;
+  dispatchInterleavedLifecycle(reactTag: number): Promise<void>;
+  reset(): Promise<void>;
+  snapshot(): Promise<ProbeSnapshot>;
+};
+
+type ProbeMode = 'disabled' | 'observe' | 'consume';
+type ProbeScreenLabel = 'Home' | 'Details' | 'Nested';
+
+const probe = NativeModules.NestedScrollInteropTest as ProbeModule;
+
+const HEADER_CONFIG: StackHeaderConfigProps = {
+  title: 'Nested scroll interop',
+  android: {
+    type: 'large',
+    scrollFlagScroll: true,
+    scrollFlagExitUntilCollapsed: true,
+    scrollFlagEnterAlways: true,
+  },
+};
+
+const OUTER_NESTED_HEADER_CONFIG: StackHeaderConfigProps = {
+  ...HEADER_CONFIG,
+  title: 'Outer nested header',
+};
+
+function TestStackNestedScrollInteropAndroid() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const prepare = async () => {
+      await probe.setFactoryInstalled(true);
+      await probe.configure(true, false);
+      await probe.reset();
+      if (mounted) {
+        setReady(true);
+      }
+    };
+
+    void prepare();
+
+    return () => {
+      mounted = false;
+      void probe.configure(false, false);
+      void probe.setFactoryInstalled(true);
+    };
+  }, []);
+
+  if (!ready) {
+    return <Text testID="nested-scroll-probe-boot">Preparing probe</Text>;
+  }
+
+  return (
+    <StackContainer
+      routeConfigs={[
+        { name: 'Home', element: <ProbeScreen label="Home" /> },
+        { name: 'Details', element: <ProbeScreen label="Details" /> },
+        { name: 'Nested', element: <NestedProbeStack /> },
+      ]}
+    />
+  );
+}
+
+function NestedProbeStack() {
+  const { routeKey, setRouteOptions } = useStackNavigationContext();
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig: OUTER_NESTED_HEADER_CONFIG });
+  }, [routeKey, setRouteOptions]);
+
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Inner',
+          element: <ProbeScreen label="Nested" headerEnabled={false} />,
+        },
+      ]}
+    />
+  );
+}
+
+function ProbeScreen({
+  label,
+  headerEnabled = true,
+}: {
+  label: ProbeScreenLabel;
+  headerEnabled?: boolean;
+}) {
+  const { routeKey, setRouteOptions, push, pop } = useStackNavigationContext();
+  const scrollRef = useRef<ScrollView>(null);
+  const [snapshot, setSnapshot] = useState<ProbeSnapshot | null>(null);
+  const [mode, setMode] = useState<ProbeMode>('observe');
+  const [factoryInstalled, setFactoryInstalled] = useState(true);
+  const [interleaveStatus, setInterleaveStatus] = useState('idle');
+  const prefix = `nested-scroll-probe-${label.toLowerCase()}`;
+
+  useEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: headerEnabled ? HEADER_CONFIG : undefined,
+    });
+  }, [headerEnabled, routeKey, setRouteOptions]);
+
+  const configure = useCallback(async (nextMode: ProbeMode) => {
+    const enabled = nextMode !== 'disabled';
+    await probe.configure(enabled, nextMode === 'consume');
+    await probe.reset();
+    setMode(nextMode);
+    setSnapshot(null);
+    setInterleaveStatus('idle');
+  }, []);
+
+  const configureFactory = useCallback(async (installed: boolean) => {
+    await probe.setFactoryInstalled(installed);
+    await probe.reset();
+    setFactoryInstalled(installed);
+    setSnapshot(null);
+    setInterleaveStatus('idle');
+  }, []);
+
+  const reset = useCallback(async () => {
+    await probe.reset();
+    setSnapshot(null);
+    setInterleaveStatus('idle');
+  }, []);
+
+  const refreshSnapshot = useCallback(async () => {
+    setSnapshot(null);
+    setSnapshot(await probe.snapshot());
+  }, []);
+
+  const dispatchInterleavedLifecycle = useCallback(async () => {
+    const reactTag = findNodeHandle(scrollRef.current);
+    if (reactTag == null) {
+      setInterleaveStatus('missing-target');
+      return;
+    }
+
+    try {
+      await probe.dispatchInterleavedLifecycle(reactTag);
+      setInterleaveStatus('done');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setInterleaveStatus(`error:${message}`);
+    }
+  }, []);
+
+  const snapshotText = useMemo(
+    () => (snapshot == null ? 'none' : JSON.stringify(snapshot)),
+    [snapshot],
+  );
+
+  return (
+    <View testID={`${prefix}-screen`} style={styles.screen}>
+      <View style={styles.probePanel}>
+        <Text testID={`${prefix}-route`}>{label}</Text>
+        <Text testID={`${prefix}-mode`}>{mode}</Text>
+        <Text testID={`${prefix}-factory`}>
+          {factoryInstalled ? 'installed' : 'absent'}
+        </Text>
+        <Text testID={`${prefix}-interleave-status`}>{interleaveStatus}</Text>
+        <View style={styles.buttonRow}>
+          <Button
+            testID={`${prefix}-observe`}
+            title="Observe"
+            onPress={() => void configure('observe')}
+          />
+          <Button
+            testID={`${prefix}-consume`}
+            title="Consume remaining"
+            onPress={() => void configure('consume')}
+          />
+          <Button
+            testID={`${prefix}-disable`}
+            title="Disable"
+            onPress={() => void configure('disabled')}
+          />
+          <Button
+            testID={`${prefix}-reset`}
+            title="Reset"
+            onPress={() => void reset()}
+          />
+          <Button
+            testID={`${prefix}-snapshot-button`}
+            title="Snapshot"
+            onPress={() => void refreshSnapshot()}
+          />
+        </View>
+        {label === 'Home' ? (
+          <>
+            <View style={styles.buttonRow}>
+              <Button
+                testID={`${prefix}-remove-factory`}
+                title="Remove factory"
+                onPress={() => void configureFactory(false)}
+              />
+              <Button
+                testID={`${prefix}-install-factory`}
+                title="Install factory"
+                onPress={() => void configureFactory(true)}
+              />
+              <Button
+                testID={`${prefix}-interleave`}
+                title="Interleave types"
+                onPress={() => void dispatchInterleavedLifecycle()}
+              />
+            </View>
+            <View style={styles.buttonRow}>
+              <Button
+                testID={`${prefix}-push`}
+                title="Push details"
+                onPress={() => push('Details')}
+              />
+              <Button
+                testID={`${prefix}-push-nested`}
+                title="Push nested stack"
+                onPress={() => push('Nested')}
+              />
+            </View>
+          </>
+        ) : null}
+        {label === 'Details' ? (
+          <View style={styles.buttonRow}>
+            <Button
+              testID={`${prefix}-pop`}
+              title="Pop details"
+              onPress={() => pop(routeKey)}
+            />
+          </View>
+        ) : null}
+        <Text
+          testID={`${prefix}-snapshot`}
+          numberOfLines={1}
+          style={styles.snapshot}>
+          {snapshotText}
+        </Text>
+      </View>
+
+      <ScrollViewMarker style={styles.scrollViewMarker}>
+        <ScrollView
+          ref={scrollRef}
+          testID={`${prefix}-scrollview`}
+          nestedScrollEnabled
+          style={styles.scroll}
+          contentContainerStyle={styles.content}>
+          <Text testID={`${prefix}-top`} style={styles.heading}>
+            {label} content top
+          </Text>
+          <LongText size="xl" />
+          <Text testID={`${prefix}-bottom`}>{label} content bottom</Text>
+        </ScrollView>
+      </ScrollViewMarker>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  probePanel: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    gap: 4,
+    backgroundColor: Colors.cardBackground,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+  },
+  snapshot: {
+    fontSize: 10,
+  },
+  scrollViewMarker: {
+    flex: 1,
+  },
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 8,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default createScenario(
+  TestStackNestedScrollInteropAndroid,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario-description.ts
@@ -6,6 +6,6 @@ export const scenarioDescription: ScenarioDescription = {
   details:
     'Verify Stack v5 can forward its remaining Android nested-scroll transaction to an external delegate.',
   platforms: ['android'],
-  e2eCoverage: 'complete',
+  e2eCoverage: 'full',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Nested scroll interop (Android)',
+  key: 'test-stack-nested-scroll-interop-android',
+  details:
+    'Verify Stack v5 can forward its remaining Android nested-scroll transaction to an external delegate.',
+  platforms: ['android'],
+  e2eCoverage: 'complete',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-nested-scroll-interop-android/scenario.md
@@ -1,0 +1,34 @@
+# Nested scroll interop (Android)
+
+Validates the optional Android nested-scroll delegate seam on Stack v5 without depending on any external package.
+
+The FabricExample app installs a test-only delegate. The delegate can either observe the transaction without consuming distance or consume every pixel left after `react-native-screens` has run its own CoordinatorLayout behaviors. The scenario can also remove the factory entirely to exercise the production-default no-delegate path.
+
+## Expected behavior
+
+1. In **Observe** mode, a React Native `ScrollView` remains the source owner. Touch scroll and fling reach the external delegate, including `TYPE_NON_TOUCH` momentum callbacks, while the Stack v5 large header and content continue to move normally.
+2. In **Consume remaining** mode, Stack v5 keeps first priority. Its large header can collapse, then the test delegate consumes the remaining distance before the child content moves.
+3. Pushing `Details` creates a different screen/source pair. Popping back to `Home` restores the original pair.
+4. With Stack v5 nested inside another Stack v5 screen, an inner delegate does not bypass the outer screen's native scroll behavior: the original target is bridged to the first accepting ancestor before the delegate sees the remainder.
+5. The nested ancestor keeps first priority even when the inner delegate consumes the remainder.
+6. Signed remaining distance is preserved in both directions, including reverse scroll used to expand a collapsed header.
+7. A new touch transaction after momentum does not corrupt the independently tracked `TYPE_TOUCH` / `TYPE_NON_TOUCH` lifecycle.
+8. When the delegate declines nested scroll, the seam is behaviorally inert.
+9. With the factory removed entirely, newly created screens use the stock Stack v5 path without creating a delegate.
+10. The test delegate never owns source fling physics; fling handlers return `false`.
+
+## E2E coverage
+
+The Android e2e test asserts:
+
+- the delegate is attached to `StackScreen`, not the legacy screen implementation;
+- touch and non-touch nested-scroll callbacks are delivered;
+- observe mode consumes zero distance and the React Native scroll view moves;
+- consume mode receives only the remaining distance after Stack v5 and prevents the child from moving while the native header is allowed to react first;
+- push/back switches to a new screen/source and restores the original source on return;
+- a large outer Stack v5 header still collapses when the source belongs to a nested Stack v5 whose external delegate accepts the transaction;
+- with that nested source in consume mode, the outer ancestor collapses first and only the residual distance is consumed by the delegate;
+- reverse scroll produces signed negative delegate consumption and expands the native header without moving the child;
+- a fast momentum transaction followed by a new touch produces coherent touch/non-touch start/stop accounting and lifecycle ordering;
+- disabling the delegate leaves the existing Stack v5 scroll behavior unchanged;
+- removing the factory entirely before creating a new screen produces zero delegates and preserves stock scrolling behavior.


### PR DESCRIPTION
## Description

`react-native-screens` already owns the Android `CoordinatorLayout` ancestors that participate in nested scroll for both the current native-stack path and Stack v5.

Native integrations that need to observe or consume the same AndroidX nested-scroll transaction currently have no neutral extension point, so they must either patch screens or introduce another scroll owner.

This PR adds an optional Android-only nested-scroll delegate seam at those existing screen-owned coordinators.

The ordering is intentionally conservative:

```text
React Native nested-scroll source
        ↓
react-native-screens / existing CoordinatorLayout behavior
        ↓ signed remainder only
optional external delegate
```

`react-native-screens` always keeps first priority.

If no delegate factory is installed, the existing path is unchanged.

The seam has no dependency on Material3, Expo, React Navigation, or any external package, and it does not add a JS API.

## Changes

- add public native Android `ScreenNestedScrollDelegate`, `ScreenNestedScrollDelegateFactory`, and `ScreenNestedScrollInterop` contracts;
- add an internal `ScreenNestedScrollCoordinatorLayout` shared by:
  - legacy/current native-stack `ScreensCoordinatorLayout`;
  - Stack v5 `StackHeaderCoordinatorLayout`;
- preserve `TYPE_TOUCH` and `TYPE_NON_TOUCH` independently;
- run existing screens behavior first and forward only signed remaining distance to the delegate;
- clamp delegate consumption to the available signed remainder;
- expose only the nearest screen coordinator for a source so nested screens cannot deliver the same transaction twice;
- when the delegate is the only reason an inner screen accepts nested scroll, preserve normal outer-ancestor priority by bridging the original target to the first accepting ancestor before forwarding the remainder;
- preserve fling priority as screens -> bridged ancestor -> delegate;
- forward screen attach, layout, and detach lifecycle to the delegate;
- add a FabricExample test-only delegate/probe and a dedicated Stack v5 E2E scenario.

The test implementation lives outside the production package so it exercises the public seam in the same way an external native consumer would.

The public factory is process-wide and allows a single external owner. Installing a different factory while one is already installed fails closed.

## Test plan

New dedicated scenario:

`test-stack-nested-scroll-interop-android`

Post-rebase validation on Android API 34 arm64-v8a against current upstream `main` (`8fe8b874ee1d5a68d6d0ce48b4ac350787176e78`):

- nested-scroll interop E2E: **9/9 PASS**
- existing `test-stack-lift-on-scroll-android`: **14/14 PASS**

The new E2E coverage verifies:

1. real Stack v5 touch observation with zero delegate consumption;
2. screens behavior first, delegate receives only the remainder;
3. push creates a new screen/source and pop restores the original pair;
4. nested Stack v5 keeps outer ancestor behavior ahead of the inner delegate;
5. outer ancestor still wins when the delegate consumes the remainder;
6. signed reverse consumption expands the native header correctly;
7. independently tracked TOUCH/NON_TOUCH interleaving through the real RN target and Android parent chain;
8. a declining delegate is inert;
9. removing the factory entirely preserves the stock path and creates no delegate.

The lifecycle interleaving test deliberately drives `TYPE_TOUCH` / `TYPE_NON_TOUCH` through `ViewParentCompat` using a real React Native scroll target.

It validates this seam's per-type state; it does **not** claim that every stock React Native version emits `TYPE_NON_TOUCH` from the child itself.

Broader Fabric E2E validation before the final rebase completed with 33 passing suites, 25 skipped suites, and one `events.e2e.ts` suite that failed in `beforeAll` at `device.launchApp()` / Detox `isReady`, before any Events test body ran.

`events.e2e.ts` then passed **9/9 twice consecutively** in isolated reruns.

This is reported separately rather than calling the full run green.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For API changes, updated relevant public types. (Native Android API only; no JS API change.)
- [ ] Ensured that CI passes