### PR TITLE
fix(Android, Tabs): resolve bottom bar height eagerly to avoid attach-after-content flash

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
@@ -178,6 +178,11 @@ class TabsContainer internal constructor(
 
         bottomNavigationView.setOnItemSelectedListener(this::onMenuItemSelected)
         invalidationFlags.invalidateAll()
+
+        bottomNavigationView.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+        )
     }
 
     // region Public API (third-party stable)
@@ -386,7 +391,10 @@ class TabsContainer internal constructor(
         }
     }
 
-    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
+    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, resolveBottomNavigationViewHeight().toFloat())
+
+    private fun resolveBottomNavigationViewHeight(): Int =
+        bottomNavigationView.height.takeIf { it > 0 } ?: bottomNavigationView.measuredHeight
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
@@ -745,7 +753,7 @@ class TabsContainer internal constructor(
         }
 
     private fun updateInterfaceInsets(newHeight: Int? = null) {
-        val height = if (tabBarHidden) 0 else (newHeight ?: bottomNavigationView.height)
+        val height = if (tabBarHidden) 0 else (newHeight ?: resolveBottomNavigationViewHeight())
 
         interfaceInsetsChangeListener?.apply {
             this.onInterfaceInsetsChange(EdgeInsets(0.0f, 0.0f, 0.0f, height.toFloat()))


### PR DESCRIPTION
## Description

On Android, the experimental `Tabs.Host`/`Tabs.Screen` bottom tab bar can attach and populate visibly *after* the tab's screen content is already presented, instead of appearing together with it. This is very noticeable on a cold-start navigation into a tabs screen (e.g. `index.tsx` redirecting into a `(tabs)` route on mount): the content briefly renders full-bleed with no space reserved for the bar, then the bar attaches with its labels and the content jumps down to make room.

This was reported downstream as [expo/expo#47610](https://github.com/expo/expo/issues/47610) ("Android NativeTabs: tab bar attaches/populates after screen content is presented on SDK 57"), using Expo Router's `NativeTabs` (which is a thin wrapper around `Tabs.Host`/`Tabs.Screen`). I traced the underlying issue to `TabsContainer.kt`.

### Root cause

`BottomNavigationView`'s `height` is only populated once Android performs a real layout pass on it. `TabsContainer.getInterfaceInsets()` reads `bottomNavigationView.height` synchronously — and `SafeAreaView` calls this getter immediately in `onAttachedToWindow()`, via `newProvider.getInterfaceInsets()`, right when it registers itself as a listener. If a `SafeAreaView` wrapping the tab content attaches to the window before `bottomNavigationView`'s first layout pass has happened, it reads a height of `0` and renders assuming no bottom inset. The correct height only propagates later, once Android's layout pass fires `onLayoutChange` on `bottomNavigationView`, which calls `updateInterfaceInsets(newHeight)` — producing the visible jump.

## Changes

- In `TabsContainer`'s `init` block, eagerly `measure()` `bottomNavigationView` with unconstrained specs right after adding it to the hierarchy. `BottomNavigationView`'s height is a fixed Material theme dimension independent of its final on-screen width, so this doesn't need a full layout pass to be accurate.
- Added `resolveBottomNavigationViewHeight()`, which returns the laid-out `height` when available, falling back to the eagerly-measured `measuredHeight` otherwise.
- Used this helper in both `getInterfaceInsets()` and `updateInterfaceInsets()`, so the very first inset read (before any real layout pass) already reflects the bar's real height instead of `0`.

## Before & after - visual documentation

Repro: [iamvinny/tabs-sdk-57](https://github.com/iamvinny/tabs-sdk-57) (linked from the downstream issue) — `index.tsx` redirects into a `(tabs)` screen with `NativeTabs` on mount. Frames below are consecutive screenshots captured a few dozen ms apart during that cold-start transition.

**Before (unpatched):** mid-transition frame shows the screen content filling the entire screen edge-to-edge, no space reserved for the bar. The bar and its labels only appear ~100-200ms later, and the content visibly jumps up to make room.

**After (patched):** the same mid-transition frame already shows the bar attached with its labels, and the content already sized to leave room for it — no jump.

*(Screenshots available — happy to attach directly to this PR description if useful; captured via `adb exec-out screencap` in rapid succession around the transition.)*

## Test plan

- Reproduced with the linked minimal repro app (`iamvinny/tabs-sdk-57`, Expo SDK 57, `expo-router` `NativeTabs`, this library at `4.25.2` initially, patch verified against `main`).
- Built a debug APK against this library's source (both the published `4.25.2` tree and this repo's current `main`, patched equivalently) and ran it on an Android 35 emulator (API 35, Pixel 6 AVD).
- Captured rapid sequential screenshots (`adb exec-out screencap -p`) around the cold-start `index.tsx` → `(tabs)` transition, before and after the patch, confirming the tab bar and content are presented together after the fix, instead of the bar attaching after content as before.
- Ran `yarn format-android` (spotless/ktlint) and `./android/gradlew -p android spotlessCheck` — both pass.

I did not modify or add an automated instrumentation test for this, since the bug is a native measurement/layout timing race that's awkward to assert deterministically in a unit test; let me know if there's a preferred pattern in this codebase for that and I'm happy to add one.

## Checklist

- [x] Included code example that can be used to test this change (linked repro app).
- [x] For visual changes, included before/after description (screenshots available on request).
- [ ] For API changes, updated relevant public types. *(N/A — no public API surface changed.)*
- [ ] Ensured that CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom navigation sizing during initialization.
  * Fixed interface inset calculations when navigation elements are hidden or not yet laid out.
  * Prevented layout inconsistencies by using measured dimensions as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->