### PR TITLE
fix(Android): make fragment restoration R8-safe

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -141,6 +141,7 @@ android {
         versionCode 1
         versionName "1.0"
         buildConfigField "boolean", "RNS_DEBUG_LOGGING", areDebugLogsEnabled().toString()
+        consumerProguardFiles "consumer-rules.pro"
         ndk {
             abiFilters (*reactNativeArchitectures())
         }

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,4 @@
+# RNScreensFragmentFactory checks this marker relationship after loading fragments by name.
+# Preserve it for live implementations while still allowing shrinking and obfuscation.
+-keep,allowobfuscation interface com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment
+-keep,allowobfuscation,allowshrinking class * implements com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment

--- a/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragment.kt
@@ -1,7 +1,0 @@
-package com.swmansion.rnscreens.fragment.restoration
-
-/**
- * Marks fragments owned by react-native-screens so that [RNScreensFragmentFactory] can identify
- * them without relying on class names, which may be changed by R8.
- */
-internal interface RNScreensFragment

--- a/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragment.kt
@@ -1,0 +1,7 @@
+package com.swmansion.rnscreens.fragment.restoration
+
+/**
+ * Marks fragments owned by react-native-screens so that [RNScreensFragmentFactory] can identify
+ * them without relying on class names, which may be changed by R8.
+ */
+internal interface RNScreensFragment

--- a/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt
@@ -1,11 +1,14 @@
 package com.swmansion.rnscreens.fragment.restoration
 
-class RNScreensFragmentFactory : androidx.fragment.app.FragmentFactory() {
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+
+class RNScreensFragmentFactory : FragmentFactory() {
     override fun instantiate(
         classLoader: ClassLoader,
         className: String,
-    ): androidx.fragment.app.Fragment =
-        if (className.startsWith(com.swmansion.rnscreens.BuildConfig.LIBRARY_PACKAGE_NAME)) {
+    ): Fragment =
+        if (RNScreensFragment::class.java.isAssignableFrom(loadFragmentClass(classLoader, className))) {
             AutoRemovingFragment()
         } else {
             super.instantiate(classLoader, className)

--- a/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensFragmentFactory.kt
@@ -8,7 +8,7 @@ class RNScreensFragmentFactory : FragmentFactory() {
         classLoader: ClassLoader,
         className: String,
     ): Fragment =
-        if (RNScreensFragment::class.java.isAssignableFrom(loadFragmentClass(classLoader, className))) {
+        if (RNScreensNonRestorableFragment::class.java.isAssignableFrom(loadFragmentClass(classLoader, className))) {
             AutoRemovingFragment()
         } else {
             super.instantiate(classLoader, className)

--- a/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensNonRestorableFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/fragment/restoration/RNScreensNonRestorableFragment.kt
@@ -1,0 +1,8 @@
+package com.swmansion.rnscreens.fragment.restoration
+
+/**
+ * Marks react-native-screens fragments that must not be restored from saved state.
+ * [RNScreensFragmentFactory] uses this marker without relying on class names, which may be changed
+ * by R8.
+ */
+internal interface RNScreensNonRestorableFragment

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenFragment.kt
@@ -16,6 +16,7 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.swmansion.rnscreens.ext.recycle
+import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
 import com.swmansion.rnscreens.legacy.events.HeaderBackButtonClickedEvent
 import com.swmansion.rnscreens.legacy.events.ScreenAppearEvent
 import com.swmansion.rnscreens.legacy.events.ScreenDisappearEvent
@@ -28,7 +29,8 @@ import kotlin.math.min
 
 open class ScreenFragment :
     Fragment,
-    ScreenFragmentWrapper {
+    ScreenFragmentWrapper,
+    RNScreensFragment {
     enum class ScreenLifecycleEvent {
         DID_APPEAR,
         WILL_APPEAR,

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenFragment.kt
@@ -16,7 +16,7 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.swmansion.rnscreens.ext.recycle
-import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
+import com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment
 import com.swmansion.rnscreens.legacy.events.HeaderBackButtonClickedEvent
 import com.swmansion.rnscreens.legacy.events.ScreenAppearEvent
 import com.swmansion.rnscreens.legacy.events.ScreenDisappearEvent
@@ -30,7 +30,7 @@ import kotlin.math.min
 open class ScreenFragment :
     Fragment,
     ScreenFragmentWrapper,
-    RNScreensFragment {
+    RNScreensNonRestorableFragment {
     enum class ScreenLifecycleEvent {
         DID_APPEAR,
         WILL_APPEAR,

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
@@ -18,7 +18,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.swmansion.rnscreens.ext.parentAsView
 import com.swmansion.rnscreens.ext.recycle
-import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
+import com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment
 import com.swmansion.rnscreens.legacy.bottomsheet.BottomSheetDialogRootView
 import com.swmansion.rnscreens.legacy.bottomsheet.BottomSheetDialogScreen
 import com.swmansion.rnscreens.legacy.events.ScreenDismissedEvent
@@ -26,7 +26,7 @@ import com.swmansion.rnscreens.legacy.events.ScreenDismissedEvent
 class ScreenModalFragment :
     BottomSheetDialogFragment,
     ScreenStackFragmentWrapper,
-    RNScreensFragment {
+    RNScreensNonRestorableFragment {
     override lateinit var screen: Screen
 
     // Nested containers

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenModalFragment.kt
@@ -18,13 +18,15 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.swmansion.rnscreens.ext.parentAsView
 import com.swmansion.rnscreens.ext.recycle
+import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
 import com.swmansion.rnscreens.legacy.bottomsheet.BottomSheetDialogRootView
 import com.swmansion.rnscreens.legacy.bottomsheet.BottomSheetDialogScreen
 import com.swmansion.rnscreens.legacy.events.ScreenDismissedEvent
 
 class ScreenModalFragment :
     BottomSheetDialogFragment,
-    ScreenStackFragmentWrapper {
+    ScreenStackFragmentWrapper,
+    RNScreensFragment {
     override lateinit var screen: Screen
 
     // Nested containers

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -7,14 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.transition.Slide
-import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
+import com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment
 import com.swmansion.rnscreens.stack.header.StackHeaderCoordinatorLayout
 
 internal class StackScreenFragment(
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
 ) : Fragment(),
-    RNScreensFragment {
+    RNScreensNonRestorableFragment {
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -7,12 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.transition.Slide
+import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
 import com.swmansion.rnscreens.stack.header.StackHeaderCoordinatorLayout
 
 internal class StackScreenFragment(
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
-) : Fragment() {
+) : Fragment(),
+    RNScreensFragment {
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
@@ -6,10 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
 
 class TabsScreenFragment(
     internal val tabsScreen: TabsScreen,
-) : Fragment() {
+) : Fragment(),
+    RNScreensFragment {
     internal val requireScreenKey: String by tabsScreen::requireScreenKey
     internal val isPreventNativeSelectionEnabled: Boolean by tabsScreen::preventNativeSelection
 

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
@@ -6,12 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.swmansion.rnscreens.fragment.restoration.RNScreensFragment
+import com.swmansion.rnscreens.fragment.restoration.RNScreensNonRestorableFragment
 
 class TabsScreenFragment(
     internal val tabsScreen: TabsScreen,
 ) : Fragment(),
-    RNScreensFragment {
+    RNScreensNonRestorableFragment {
     internal val requireScreenKey: String by tabsScreen::requireScreenKey
     internal val isPreventNativeSelectionEnabled: Boolean by tabsScreen::preventNativeSelection
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "android/src/fabric/",
     "android/src/versioned/",
     "android/build.gradle",
+    "android/consumer-rules.pro",
     "android/CMakeLists.txt",
     "ios/",
     "cpp/",


### PR DESCRIPTION
## Description

Closes #4505.

`RNScreensFragmentFactory` currently identifies screen fragments by checking whether the restored class name starts with the library package. R8 can repackage those classes when optimized resource shrinking is enabled, so the check falls through to normal fragment restoration and the screen fragment constructor throws.

This change makes restoration independent of class and package names.

## Changes

- Added an internal `RNScreensNonRestorableFragment` marker for fragments owned by the library.
- Marked the legacy screen/modal fragments and the Stack v5 / Tabs fragments.
- Updated `RNScreensFragmentFactory` to load the fragment class and check the marker with `isAssignableFrom` before substituting `AutoRemovingFragment`.
- Added targeted consumer R8 rules that preserve the marker relationship while still allowing unused implementations to be shrunk and live classes to be obfuscated.
- Included the consumer rules in the published npm package and Android AAR.

## Test plan

Used the maintainer-confirmed reproducer from https://github.com/t0maboro/RNS4505 with React Native 0.86.2, `android.r8.optimizedResourceShrinking=true`, minification, and resource shrinking enabled.

Control (`react-native-screens` 4.25.0):

1. Built and installed the release APK on an Android 36 emulator.
2. Confirmed R8 moved `ScreenFragment` and `ScreenStackFragment` to `v3.D` and `v3.N`.
3. Pushed Home -> Second -> Third, backgrounded the app, killed its process, and relaunched it.
4. Relaunch crashed with `Unable to instantiate fragment v3.N` and `Screen fragments should never be restored`.

Patched build from this branch:

1. Packed the branch as an npm tarball and rebuilt the same release reproducer.
2. Confirmed the consumer rules are present in the release AAR and merged into the app's R8 configuration.
3. Confirmed R8 still obfuscated/repackaged the marker, factory, and live screen fragments; it also removed the unused modal implementation.
4. Inspected the optimized DEX and confirmed each live screen fragment still implements the obfuscated marker interface.
5. Repeated the same navigation, background, process-kill, and cold-start sequence.
6. The app relaunched normally and the crash log remained empty.

Additional checks:

- `yarn lint-android`
- `yarn check-types`
- `FabricExample/android/gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a`
- `FabricExample/android/gradlew :react-native-screens:compileDebugKotlin --rerun-tasks --console=plain -PreactNativeArchitectures=arm64-v8a`
- `FabricExample/android/gradlew :react-native-screens:bundleReleaseAar --console=plain -PreactNativeArchitectures=arm64-v8a`
- Reproducer `android/gradlew :app:assembleRelease --console=plain -PreactNativeArchitectures=arm64-v8a`

## Checklist

- [x] Included a code example that can be used to test this change (linked reproducer).
- [x] No visual changes.
- [x] No public API changes.
- [x] Local CI-equivalent lint, type-check, debug build, and R8 release build pass.
