### PR TITLE
fix(Example): SAV import and `defaultRouteName` type in TabsContainer

### DIFF
--- a/apps/src/shared/containers/tabs/TabsContainer.types.tsx
+++ b/apps/src/shared/containers/tabs/TabsContainer.types.tsx
@@ -4,7 +4,7 @@ import type {
   TabsHostProps,
   TabsScreenProps,
 } from 'react-native-screens';
-import type { SafeAreaViewProps } from '../../../../../../src/components/safe-area/SafeAreaView.types';
+import type { SafeAreaViewProps } from 'react-native-screens/experimental';
 
 /// Route definition
 
@@ -92,7 +92,7 @@ export type TabsContainerProps = Omit<
    * Name of the tab that should be selected initially.
    * Defaults to the first tab if not provided.
    */
-  defaultRouteName?: string;
+  defaultRouteName?: string | undefined;
 };
 
 export type SetTabOptionsMethod = (


### PR DESCRIPTION
## Description

Fixes 2 minor TS errors I stumbled upon while working on the library.

## Changes

- import SAV props from `react-native-screens/experimental` instead of invalid direct path
- add `| undefined` to tye type of optional `defaultRouteName` prop (see https://github.com/software-mansion/react-native-screens/pull/3719)

## Before & after - visual documentation

N/A

## Test plan

No errors in `TabsContainer.types.tsx` file.

## Checklist

- [x] Ensured that CI passes
