### PR TITLE
chore(test): e2e test for test-stack-header-item-identifier-ios

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -53,9 +53,6 @@ export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
   ? describe
   : describe.skip;
 
-export const describeIfiPadIOS26 =
-  isIPadTarget && isIOSVersionAtLeast('26.0') ? describe : describe.skip;
-
 export type ScrollOptions = {
   /** Pixels per step. Smaller steps avoid overshooting a short row. */
   pixels?: number;

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -218,12 +218,16 @@ export async function selectPickerOption(
   await expect(element(by.id(pickerId))).toHaveText(expected);
 }
 
-/** `to` is the state expected afterwards — a swallowed tap fails here. */
+/** `to` is the state expected afterwards — a swallowed tap fails here. Omit
+ * `control` on screens whose switches sit outside any scroll view. */
 export async function toggleSettingsSwitch(
   { switchId, label, to }: { switchId: string; label: string; to: boolean },
-  { scrollViewId, ...scroll }: SettingsControlOptions,
+  control?: SettingsControlOptions,
 ) {
-  await rewindAndScrollUntilVisible(switchId, scrollViewId, scroll);
+  if (control) {
+    const { scrollViewId, ...scroll } = control;
+    await rewindAndScrollUntilVisible(switchId, scrollViewId, scroll);
+  }
   await element(by.id(switchId)).tap();
 
   await expect(element(by.text(`${label}: ${to}`))).toBeVisible();

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -44,6 +44,18 @@ export function isIOSVersionAtLeast(version: string): boolean {
   );
 }
 
+/**
+ * Suites for iOS 26+ only features (e.g. `bottomAccessory`, the header overflow
+ * button). `isIOSVersionAtLeast` is false on Android, so these stay iOS-only
+ * and additionally self-skip on iOS 18 and older.
+ */
+export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
+  ? describe
+  : describe.skip;
+
+export const describeIfiPadIOS26 =
+  isIPadTarget && isIOSVersionAtLeast('26.0') ? describe : describe.skip;
+
 export type ScrollOptions = {
   /** Pixels per step. Smaller steps avoid overshooting a short row. */
   pixels?: number;

--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -46,6 +46,10 @@ export const CLASS_NAME_UI_BUTTON_BAR_BUTTON = '_UIButtonBarButton';
 export const CLASS_NAME_UI_MODERN_BAR_BUTTON = '_UIModernBarButton';
 export const CLASS_NAME_UI_NAVIGATION_BAR_LARGE_TITLE_VIEW =
   '_UINavigationBarLargeTitleView';
+// The liquid-glass "bubble" hosting bar button items on iOS 26. Items sharing
+// a background share one platter; separator-delimited items get one each.
+export const CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW =
+  '_UINavigationBarPlatterView';
 
 // --- UIKit: context menu ---
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -21,6 +21,31 @@ function barButtonIcon(sfSymbolName: string) {
   );
 }
 
+// Every SF Symbol the test screen cycles through (SYMBOL_CYCLES in the test
+// screen's index.tsx).
+const ALL_SYMBOLS = [
+  '1.circle.fill',
+  '2.circle.fill',
+  '3.circle.fill',
+  'fish.fill',
+  'carrot.fill',
+  'birthday.cake.fill',
+];
+
+// Asserts the bar shows exactly the `expected` symbols: each expected symbol
+// is visible and every other known symbol is absent, so a stale item left
+// over from the previous screen fails the test. A duplicated symbol also
+// fails, since `toBeVisible` rejects multiple matches.
+async function expectExactBarButtonSymbols(expected: string[]) {
+  for (const name of ALL_SYMBOLS) {
+    if (expected.includes(name)) {
+      await expect(barButtonIcon(name)).toBeVisible();
+    } else {
+      await expect(barButtonIcon(name)).not.toExist();
+    }
+  }
+}
+
 async function waitForScreen(routeName: 'One' | 'Two' | 'Three') {
   await waitFor(element(by.type(CLASS_NAME_UI_LABEL).and(by.text(routeName))))
     .toExist()
@@ -105,9 +130,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
     });
 
     it('should show three trailing items on screen One — 1.circle.fill, fish.fill, carrot.fill — ordered left to right', async () => {
-      await expect(barButtonIcon('1.circle.fill')).toBeVisible();
-      await expect(barButtonIcon('fish.fill')).toBeVisible();
-      await expect(barButtonIcon('carrot.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '1.circle.fill',
+        'fish.fill',
+        'carrot.fill',
+      ]);
 
       await expectOrderedLeftToRight([
         barButtonIcon('1.circle.fill'),
@@ -120,10 +147,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await pushNext();
       await waitForScreen('Two');
 
-      await expect(barButtonIcon('1.circle.fill')).not.toExist();
-      await expect(barButtonIcon('2.circle.fill')).toBeVisible();
-      await expect(barButtonIcon('birthday.cake.fill')).toBeVisible();
-      await expect(barButtonIcon('fish.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '2.circle.fill',
+        'birthday.cake.fill',
+        'fish.fill',
+      ]);
 
       await expectOrderedLeftToRight([
         barButtonIcon('birthday.cake.fill'),
@@ -136,10 +164,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await pushNext();
       await waitForScreen('Three');
 
-      await expect(barButtonIcon('2.circle.fill')).not.toExist();
-      await expect(barButtonIcon('3.circle.fill')).toBeVisible();
-      await expect(barButtonIcon('carrot.fill')).toBeVisible();
-      await expect(barButtonIcon('birthday.cake.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '3.circle.fill',
+        'carrot.fill',
+        'birthday.cake.fill',
+      ]);
 
       await expectOrderedLeftToRight([
         barButtonIcon('carrot.fill'),
@@ -174,9 +203,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
     });
 
     it('should give each of the three trailing items its own platter on screen One, ordered left to right', async () => {
-      await expect(barButtonIcon('1.circle.fill')).toBeVisible();
-      await expect(barButtonIcon('fish.fill')).toBeVisible();
-      await expect(barButtonIcon('carrot.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '1.circle.fill',
+        'fish.fill',
+        'carrot.fill',
+      ]);
 
       await expectItemsInOwnPlatters([
         '1.circle.fill',
@@ -189,7 +220,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await pushNext();
       await waitForScreen('Two');
 
-      await expect(barButtonIcon('2.circle.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '2.circle.fill',
+        'birthday.cake.fill',
+        'fish.fill',
+      ]);
       await expectItemsInOwnPlatters([
         'birthday.cake.fill',
         '2.circle.fill',
@@ -201,7 +236,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await pushNext();
       await waitForScreen('Three');
 
-      await expect(barButtonIcon('3.circle.fill')).toBeVisible();
+      await expectExactBarButtonSymbols([
+        '3.circle.fill',
+        'carrot.fill',
+        'birthday.cake.fill',
+      ]);
       await expectItemsInOwnPlatters([
         'carrot.fill',
         'birthday.cake.fill',

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -37,11 +37,29 @@ async function pushNext() {
   await element(by.text('Next')).tap();
 }
 
+// Waits on the popped screen's title disappearing first: waiting only for the
+// destination's title would pass early, since the back button already shows
+// it. Once the popped title is gone, the destination title is unambiguous and
+// is asserted to confirm where the pop landed.
+async function popBackFrom(routeName: 'Two' | 'Three') {
+  await element(by.text('Go back')).tap();
+  await waitFor(element(by.type(CLASS_NAME_UI_LABEL).and(by.text(routeName))))
+    .not.toExist()
+    .withTimeout(3000);
+  await waitForScreen(routeName === 'Three' ? 'Two' : 'One');
+}
+
 async function frameX(matcher: {
   getAttributes: () => Promise<unknown>;
 }): Promise<number> {
   const attrs = (await matcher.getAttributes()) as IosElementAttributes;
   return attrs.frame.x;
+}
+
+function expectAscending(xs: number[]) {
+  for (let i = 1; i < xs.length; i++) {
+    jestExpect(xs[i]).toBeGreaterThan(xs[i - 1]);
+  }
 }
 
 // Asserts `matchers` sit left-to-right in the given order, by comparing their
@@ -53,23 +71,29 @@ async function expectOrderedLeftToRight(
   for (const matcher of matchers) {
     xs.push(await frameX(matcher));
   }
-  for (let i = 1; i < xs.length; i++) {
-    jestExpect(xs[i]).toBeGreaterThan(xs[i - 1]);
-  }
+  expectAscending(xs);
 }
 
 // Asserts each symbol sits in its own liquid-glass platter, in the given
 // left-to-right order.
 async function expectItemsInOwnPlatters(sfSymbolNames: string[]) {
-  const platters = sfSymbolNames.map(name =>
-    by
-      .type(CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW)
-      .withDescendant(by.id(name)),
-  );
-  for (const platter of platters) {
-    jestExpect((await getMatches(platter)).length).toBe(1);
+  const frames: IosElementAttributes['frame'][] = [];
+  for (const name of sfSymbolNames) {
+    const matches = (await getMatches(
+      by
+        .type(CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW)
+        .withDescendant(by.id(name)),
+    )) as IosElementAttributes[];
+    jestExpect(matches.length).toBe(1);
+    frames.push(matches[0].frame);
   }
-  await expectOrderedLeftToRight(platters.map(platter => element(platter)));
+  // Each symbol's platter must be a different view: with separators off every
+  // symbol resolves to the single shared platter, so its frame repeats here.
+  const distinctFrames = new Set(
+    frames.map(({ x, y, width, height }) => `${x},${y},${width},${height}`),
+  );
+  jestExpect(distinctFrames.size).toBe(sfSymbolNames.length);
+  expectAscending(frames.map(frame => frame.x));
 }
 
 async function toggleSwitch(testID: string, label: string, to: boolean) {
@@ -144,10 +168,20 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
         'test-stack-header-item-identifier-ios',
       );
       await waitForScreen('One');
+      // Scenario step 4: push through the stack with sfSymbol items first and
+      // pop back to One, so the toggle swaps the item type on a header whose
+      // native items are already materialized — not on a pristine screen.
+      await pushNext();
+      await waitForScreen('Two');
+      await pushNext();
+      await waitForScreen('Three');
+      await popBackFrom('Three');
+      await popBackFrom('Two');
       await toggleSwitch('toggle-custom-views', 'Custom views', true);
     });
 
-    it('should show three custom-render trailing items on screen One, ordered alpha, bravo, charlie left to right', async () => {
+    it('should replace the sfSymbol items with three custom-render items on screen One, ordered alpha, bravo, charlie left to right', async () => {
+      await expect(barButtonIcon('1.circle.fill')).not.toExist();
       await expect(customItem('alpha')).toBeVisible();
       await expect(customItem('bravo')).toBeVisible();
       await expect(customItem('charlie')).toBeVisible();
@@ -198,6 +232,15 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
         'test-stack-header-item-identifier-ios',
       );
       await waitForScreen('One');
+      // Scenario step 6: push through the stack and pop back to One, so the
+      // toggle splits already-materialized items into per-item platters — not
+      // items configured with separators from birth.
+      await pushNext();
+      await waitForScreen('Two');
+      await pushNext();
+      await waitForScreen('Three');
+      await popBackFrom('Three');
+      await popBackFrom('Two');
       await toggleSwitch('toggle-separators', 'Separators', true);
     });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -12,7 +12,6 @@ import {
   CLASS_NAME_UI_MODERN_BAR_BUTTON,
   CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW,
 } from '../../native-class-names';
-import type { ItemId } from '@apps/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios';
 
 // The icon of the header bar button item, addressed by its icon id (SF Symbol
 // name or asset path).
@@ -20,12 +19,6 @@ function barButtonIcon(sfSymbolName: string) {
   return element(
     by.id(sfSymbolName).withAncestor(by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON)),
   );
-}
-
-// A custom-rendered trailing header item, addressed by the `testID` added to
-// its render output (`custom-item-<id>`).
-function customItem(id: ItemId) {
-  return element(by.id(`custom-item-${id}`));
 }
 
 async function waitForScreen(routeName: 'One' | 'Two' | 'Three') {
@@ -152,74 +145,6 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
         barButtonIcon('carrot.fill'),
         barButtonIcon('birthday.cake.fill'),
         barButtonIcon('3.circle.fill'),
-      ]);
-    });
-  });
-
-  describe('custom views with identifiers', () => {
-    beforeAll(async () => {
-      await device.reloadReactNative();
-      await selectSingleFeatureTestsScreen(
-        'Stackv5',
-        'test-stack-header-item-identifier-ios',
-      );
-      await waitForScreen('One');
-      // Scenario step 4: push through the stack with sfSymbol items first and
-      // pop back to One, so the toggle swaps the item type on a header whose
-      // native items are already materialized — not on a pristine screen.
-      await pushNext();
-      await waitForScreen('Two');
-      await pushNext();
-      await waitForScreen('Three');
-      await popBackFrom('Three');
-      await popBackFrom('Two');
-      await toggleSettingsSwitch({
-        switchId: 'toggle-custom-views',
-        label: 'Custom views',
-        to: true,
-      });
-    });
-
-    it('should replace the sfSymbol items with three custom-render items on screen One, ordered alpha, bravo, charlie left to right', async () => {
-      await expect(barButtonIcon('1.circle.fill')).not.toExist();
-      await expect(customItem('alpha')).toBeVisible();
-      await expect(customItem('bravo')).toBeVisible();
-      await expect(customItem('charlie')).toBeVisible();
-
-      await expectOrderedLeftToRight([
-        customItem('alpha'),
-        customItem('bravo'),
-        customItem('charlie'),
-      ]);
-    });
-
-    it('should reposition the alpha item to the center on screen Two, without dropping any item', async () => {
-      await pushNext();
-      await waitForScreen('Two');
-
-      await expect(customItem('alpha')).toBeVisible();
-      await expect(customItem('bravo')).toBeVisible();
-      await expect(customItem('charlie')).toBeVisible();
-
-      await expectOrderedLeftToRight([
-        customItem('bravo'),
-        customItem('alpha'),
-        customItem('charlie'),
-      ]);
-    });
-
-    it('should reposition the alpha item to the right edge on screen Three, without dropping any item', async () => {
-      await pushNext();
-      await waitForScreen('Three');
-
-      await expect(customItem('alpha')).toBeVisible();
-      await expect(customItem('bravo')).toBeVisible();
-      await expect(customItem('charlie')).toBeVisible();
-
-      await expectOrderedLeftToRight([
-        customItem('bravo'),
-        customItem('charlie'),
-        customItem('alpha'),
       ]);
     });
   });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -1,0 +1,240 @@
+import { expect as jestExpect } from '@jest/globals';
+import { device, expect, element, by, waitFor } from 'detox';
+import { IosElementAttributes } from 'detox/detox';
+import {
+  describeIfiOS26,
+  getMatches,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
+import {
+  CLASS_NAME_UI_LABEL,
+  CLASS_NAME_UI_MODERN_BAR_BUTTON,
+  CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW,
+} from '../../native-class-names';
+import type { ItemId } from '@apps/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios';
+
+// The icon of the header bar button item, addressed by its icon id (SF Symbol
+// name or asset path).
+function barButtonIcon(sfSymbolName: string) {
+  return element(
+    by.id(sfSymbolName).withAncestor(by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON)),
+  );
+}
+
+// A custom-rendered trailing header item, addressed by the `testID` added to
+// its render output (`custom-item-<id>`).
+function customItem(id: ItemId) {
+  return element(by.id(`custom-item-${id}`));
+}
+
+async function waitForScreen(routeName: 'One' | 'Two' | 'Three') {
+  await waitFor(element(by.type(CLASS_NAME_UI_LABEL).and(by.text(routeName))))
+    .toExist()
+    .withTimeout(3000);
+}
+
+async function pushNext() {
+  await element(by.text('Next')).tap();
+}
+
+async function frameX(matcher: {
+  getAttributes: () => Promise<unknown>;
+}): Promise<number> {
+  const attrs = (await matcher.getAttributes()) as IosElementAttributes;
+  return attrs.frame.x;
+}
+
+// Asserts `matchers` sit left-to-right in the given order, by comparing their
+// horizontal position.
+async function expectOrderedLeftToRight(
+  matchers: { getAttributes: () => Promise<unknown> }[],
+) {
+  const xs: number[] = [];
+  for (const matcher of matchers) {
+    xs.push(await frameX(matcher));
+  }
+  for (let i = 1; i < xs.length; i++) {
+    jestExpect(xs[i]).toBeGreaterThan(xs[i - 1]);
+  }
+}
+
+// Asserts each symbol sits in its own liquid-glass platter, in the given
+// left-to-right order.
+async function expectItemsInOwnPlatters(sfSymbolNames: string[]) {
+  const platters = sfSymbolNames.map(name =>
+    by
+      .type(CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW)
+      .withDescendant(by.id(name)),
+  );
+  for (const platter of platters) {
+    jestExpect((await getMatches(platter)).length).toBe(1);
+  }
+  await expectOrderedLeftToRight(platters.map(platter => element(platter)));
+}
+
+async function toggleSwitch(testID: string, label: string, to: boolean) {
+  await element(by.id(testID)).tap();
+  await expect(element(by.id(testID))).toHaveLabel(`${label}: ${to}`);
+}
+
+// The identifier-driven item-matching behavior under test only exists on
+// iOS 26+ (see scenario.md, "OS test creation version").
+describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
+  describe('sfSymbols with identifiers (default)', () => {
+    beforeAll(async () => {
+      await device.reloadReactNative();
+      await selectSingleFeatureTestsScreen(
+        'Stackv5',
+        'test-stack-header-item-identifier-ios',
+      );
+
+      await waitForScreen('One');
+    });
+
+    it('should show three trailing items on screen One — 1.circle.fill, fish.fill, carrot.fill — ordered left to right', async () => {
+      await expect(barButtonIcon('1.circle.fill')).toBeVisible();
+      await expect(barButtonIcon('fish.fill')).toBeVisible();
+      await expect(barButtonIcon('carrot.fill')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        barButtonIcon('1.circle.fill'),
+        barButtonIcon('fish.fill'),
+        barButtonIcon('carrot.fill'),
+      ]);
+    });
+
+    it('should show the numbered item as 2.circle.fill in the center on screen Two, with the food items swapping symbols', async () => {
+      await pushNext();
+      await waitForScreen('Two');
+
+      await expect(barButtonIcon('1.circle.fill')).not.toExist();
+      await expect(barButtonIcon('2.circle.fill')).toBeVisible();
+      await expect(barButtonIcon('birthday.cake.fill')).toBeVisible();
+      await expect(barButtonIcon('fish.fill')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        barButtonIcon('birthday.cake.fill'),
+        barButtonIcon('2.circle.fill'),
+        barButtonIcon('fish.fill'),
+      ]);
+    });
+
+    it('should show the numbered item as 3.circle.fill at the right edge on screen Three, with the food items swapping symbols again', async () => {
+      await pushNext();
+      await waitForScreen('Three');
+
+      await expect(barButtonIcon('2.circle.fill')).not.toExist();
+      await expect(barButtonIcon('3.circle.fill')).toBeVisible();
+      await expect(barButtonIcon('carrot.fill')).toBeVisible();
+      await expect(barButtonIcon('birthday.cake.fill')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        barButtonIcon('carrot.fill'),
+        barButtonIcon('birthday.cake.fill'),
+        barButtonIcon('3.circle.fill'),
+      ]);
+    });
+  });
+
+  describe('custom views with identifiers', () => {
+    beforeAll(async () => {
+      await device.reloadReactNative();
+      await selectSingleFeatureTestsScreen(
+        'Stackv5',
+        'test-stack-header-item-identifier-ios',
+      );
+      await waitForScreen('One');
+      await toggleSwitch('toggle-custom-views', 'Custom views', true);
+    });
+
+    it('should show three custom-render trailing items on screen One, ordered alpha, bravo, charlie left to right', async () => {
+      await expect(customItem('alpha')).toBeVisible();
+      await expect(customItem('bravo')).toBeVisible();
+      await expect(customItem('charlie')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        customItem('alpha'),
+        customItem('bravo'),
+        customItem('charlie'),
+      ]);
+    });
+
+    it('should reposition the alpha item to the center on screen Two, without dropping any item', async () => {
+      await pushNext();
+      await waitForScreen('Two');
+
+      await expect(customItem('alpha')).toBeVisible();
+      await expect(customItem('bravo')).toBeVisible();
+      await expect(customItem('charlie')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        customItem('bravo'),
+        customItem('alpha'),
+        customItem('charlie'),
+      ]);
+    });
+
+    it('should reposition the alpha item to the right edge on screen Three, without dropping any item', async () => {
+      await pushNext();
+      await waitForScreen('Three');
+
+      await expect(customItem('alpha')).toBeVisible();
+      await expect(customItem('bravo')).toBeVisible();
+      await expect(customItem('charlie')).toBeVisible();
+
+      await expectOrderedLeftToRight([
+        customItem('bravo'),
+        customItem('charlie'),
+        customItem('alpha'),
+      ]);
+    });
+  });
+
+  describe('separators enabled', () => {
+    beforeAll(async () => {
+      await device.reloadReactNative();
+      await selectSingleFeatureTestsScreen(
+        'Stackv5',
+        'test-stack-header-item-identifier-ios',
+      );
+      await waitForScreen('One');
+      await toggleSwitch('toggle-separators', 'Separators', true);
+    });
+
+    it('should give each of the three trailing items its own platter on screen One, ordered left to right', async () => {
+      await expect(barButtonIcon('1.circle.fill')).toBeVisible();
+      await expect(barButtonIcon('fish.fill')).toBeVisible();
+      await expect(barButtonIcon('carrot.fill')).toBeVisible();
+
+      await expectItemsInOwnPlatters([
+        '1.circle.fill',
+        'fish.fill',
+        'carrot.fill',
+      ]);
+    });
+
+    it('should keep one platter per item on screen Two, with the numbered item in the center one', async () => {
+      await pushNext();
+      await waitForScreen('Two');
+
+      await expect(barButtonIcon('2.circle.fill')).toBeVisible();
+      await expectItemsInOwnPlatters([
+        'birthday.cake.fill',
+        '2.circle.fill',
+        'fish.fill',
+      ]);
+    });
+
+    it('should keep one platter per item on screen Three, with the numbered item in the rightmost one', async () => {
+      await pushNext();
+      await waitForScreen('Three');
+
+      await expect(barButtonIcon('3.circle.fill')).toBeVisible();
+      await expectItemsInOwnPlatters([
+        'carrot.fill',
+        'birthday.cake.fill',
+        '3.circle.fill',
+      ]);
+    });
+  });
+});

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -5,6 +5,7 @@ import {
   describeIfiOS26,
   getMatches,
   selectSingleFeatureTestsScreen,
+  toggleSettingsSwitch,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_UI_LABEL,
@@ -96,11 +97,6 @@ async function expectItemsInOwnPlatters(sfSymbolNames: string[]) {
   expectAscending(frames.map(frame => frame.x));
 }
 
-async function toggleSwitch(testID: string, label: string, to: boolean) {
-  await element(by.id(testID)).tap();
-  await expect(element(by.id(testID))).toHaveLabel(`${label}: ${to}`);
-}
-
 // The identifier-driven item-matching behavior under test only exists on
 // iOS 26+ (see scenario.md, "OS test creation version").
 describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
@@ -177,7 +173,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await waitForScreen('Three');
       await popBackFrom('Three');
       await popBackFrom('Two');
-      await toggleSwitch('toggle-custom-views', 'Custom views', true);
+      await toggleSettingsSwitch({
+        switchId: 'toggle-custom-views',
+        label: 'Custom views',
+        to: true,
+      });
     });
 
     it('should replace the sfSymbol items with three custom-render items on screen One, ordered alpha, bravo, charlie left to right', async () => {
@@ -241,7 +241,11 @@ describeIfiOS26('Stack Header Item Identifier (iOS)', () => {
       await waitForScreen('Three');
       await popBackFrom('Three');
       await popBackFrom('Two');
-      await toggleSwitch('toggle-separators', 'Separators', true);
+      await toggleSettingsSwitch({
+        switchId: 'toggle-separators',
+        label: 'Separators',
+        to: true,
+      });
     });
 
     it('should give each of the three trailing items its own platter on screen One, ordered left to right', async () => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -22,7 +22,7 @@ import type {
 } from 'react-native-screens/components/stack/header';
 import type { PlatformIconIOS } from 'react-native-screens';
 
-type ItemId = 'alpha' | 'bravo' | 'charlie';
+export type ItemId = 'alpha' | 'bravo' | 'charlie';
 
 const SYMBOL_CYCLES: Record<ItemId, string[]> = {
   alpha: ['1.circle.fill', '2.circle.fill', '3.circle.fill'],
@@ -87,7 +87,10 @@ function makeItem(
       type: 'item',
       id,
       render: () => (
-        <View style={[styles.customItem, { backgroundColor: color }]} />
+        <View
+          testID={`custom-item-${id}`}
+          style={[styles.customItem, { backgroundColor: color }]}
+        />
       ),
       ...identifierProp,
     };
@@ -149,7 +152,13 @@ function Screen(props: { routeName: string }) {
         ),
       },
     }),
-    [routeName, identifiersEnabled, separatorsEnabled, customViewsEnabled, screenIndex],
+    [
+      routeName,
+      identifiersEnabled,
+      separatorsEnabled,
+      customViewsEnabled,
+      screenIndex,
+    ],
   );
 
   useLayoutEffect(() => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -22,7 +22,7 @@ import type {
 } from 'react-native-screens/components/stack/header';
 import type { PlatformIconIOS } from 'react-native-screens';
 
-export type ItemId = 'alpha' | 'bravo' | 'charlie';
+type ItemId = 'alpha' | 'bravo' | 'charlie';
 
 const SYMBOL_CYCLES: Record<ItemId, string[]> = {
   alpha: ['1.circle.fill', '2.circle.fill', '3.circle.fill'],
@@ -87,10 +87,7 @@ function makeItem(
       type: 'item',
       id,
       render: () => (
-        <View
-          testID={`custom-item-${id}`}
-          style={[styles.customItem, { backgroundColor: color }]}
-        />
+        <View style={[styles.customItem, { backgroundColor: color }]} />
       ),
       ...identifierProp,
     };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario-description.ts
@@ -8,6 +8,6 @@ export const scenarioDescription: ScenarioDescription = {
     'ordered differently and with different icons across screens. On iOS 26+ matched items animate ' +
     'between positions instead of cross-fading. Not supported on iOS 18 and below.',
   platforms: ['ios'],
-  e2eCoverage: 'tbd',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -13,19 +13,19 @@ stay put, only changing their appearance.
 
 ## E2E test
 
-Incomplete: covers the end state after each push for steps 1–4 and 6–7 — which
+Incomplete: covers the end state after each push for steps 1–3 and 6–7 — which
 item shows at which trailing position (asserted via horizontal frame order) for
-the sfSymbols, custom-views, and separators configurations, and that with
-separators each item sits in its own platter view.
+the sfSymbols and separators configurations, and that with separators each
+item sits in its own platter view.
 
 Not automated:
 
 - Transition quality (steps 2–4, 7): flashing / blur / crossfade — Detox
   samples settled state, not animation frames.
+- Step 4 (custom views): intentionally left manual-only — it exercises the
+  test screen's rendering more than the identifier matching itself.
 - Step 5 (identifiers off): end state is identical, only the transition
   differs — Detox can't assert it.
-- Custom-view colors (step 4): Detox reads no colors; only presence and
-  position are asserted.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -22,8 +22,8 @@ Not automated:
 
 - Transition quality (steps 2–4, 7): flashing / blur / crossfade — Detox
   samples settled state, not animation frames.
-- Step 4 (custom views): intentionally left manual-only — it exercises the
-  test screen's rendering more than the identifier matching itself.
+- Step 4 (custom views): automating it would only check that the custom views
+  render, not the real identifier-matching functionality.
 - Step 5 (identifiers off): end state is identical, only the transition
   differs — Detox can't assert it.
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -13,18 +13,19 @@ stay put, only changing their appearance.
 
 ## E2E test
 
-Incomplete: covers the end state after each push for steps 1–4 and 6–7 -
-which item shows at which trailing position (asserted via horizontal frame
-order) for the sfSymbols, custom-views, and separators configurations, and
-that with separators each item sits in its own platter view.
+Incomplete: covers the end state after each push for steps 1–4 and 6–7 — which
+item shows at which trailing position (asserted via horizontal frame order) for
+the sfSymbols, custom-views, and separators configurations, and that with
+separators each item sits in its own platter view.
 
 Not automated:
 
-- Transition quality: items "not flashing" while changing symbols (steps
-  2–4) and the blur/crossfade of separated transitions (step 7). Detox
+- Transition quality (steps 2–4, 7): flashing / blur / crossfade — Detox
   samples settled state, not animation frames.
-- Step 5 (identifiers off): its end state is identical to the identifier
-  case — only the transition differs, so there is nothing to assert.
+- Step 5 (identifiers off): end state is identical, only the transition
+  differs — Detox can't assert it.
+- Custom-view colors (step 4): Detox reads no colors; only presence and
+  position are asserted.
 
 ## Prerequisites
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/scenario.md
@@ -13,7 +13,18 @@ stay put, only changing their appearance.
 
 ## E2E test
 
-TBD.
+Incomplete: covers the end state after each push for steps 1–4 and 6–7 -
+which item shows at which trailing position (asserted via horizontal frame
+order) for the sfSymbols, custom-views, and separators configurations, and
+that with separators each item sits in its own platter view.
+
+Not automated:
+
+- Transition quality: items "not flashing" while changing symbols (steps
+  2–4) and the blur/crossfade of separated transitions (step 7). Detox
+  samples settled state, not animation frames.
+- Step 5 (identifiers off): its end state is identical to the identifier
+  case — only the transition differs, so there is nothing to assert.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1750

Adds a Detox e2e test for the `test-stack-header-item-identifier-ios` scenario (Stack v5, iOS 26). The suite asserts the settled end state of identifier-driven header item matching: which SF Symbol item sits at which trailing position after each push (via horizontal frame order), and — with separators enabled — that each item sits in its own `_UINavigationBarPlatterView`, with an explicit distinct-platter check so a shared-platter regression fails at the platter assertion rather than as an ordering error.

The separators suite follows the scenario's step 6 path: it pushes through the stack first and pops back to screen One before flipping the toggle, so the reconfiguration of already-materialized native items is exercised, not just items configured from birth. The custom-views step (scenario step 4) is left manual-only per review feedback — automating it would only check that the custom views render, not the real identifier-matching functionality. Transition-quality checks (flashing, blur/crossfade) and the identifiers-off step (identical end state) also remain manual-only, as documented in the scenario.

## Changes

- Added `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts` gated with `describeIfiOS26`.
- `FabricExample/e2e/e2e-utils.ts` - added the shared `describeIfiOS26`.
- `FabricExample/e2e/native-class-names.ts` - registered `_UINavigationBarPlatterView` (the iOS 26 liquid-glass bar-item bubble).
- `scenario.md` — filled in the E2E coverage section (automated vs manual-only); `scenario-description.ts` — `e2eCoverage: 'tbd'` → `'incomplete'`.
