### PR TITLE
fix(Example): update TestStackHeaderTitleAppearanceAndroid's route configs to new API

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-android/index.tsx
@@ -328,7 +328,7 @@ function TestStackHeaderTitleAppearanceAndroid() {
 function StackSetup() {
   return (
     <StackContainer
-      routeConfigs={[{ name: 'Home', Component: ConfigScreen, options: {} }]}
+      routeConfigs={[{ name: 'Home', element: <ConfigScreen />, options: {} }]}
     />
   );
 }


### PR DESCRIPTION
## Description

Changes route definition in `TestStackHeaderTitleAppearanceAndroid` SFT to new `StackContainer` API (`Component` -> `element`). I must've missed this during one of the rebases.

## Changes

- use `element: <ConfigScreen />` instead of `Component: ConfigScreen` in `TestStackHeaderTitleAppearanceAndroid` SFT

## Before & after - visual documentation

N/A

## Test plan

Run `TestStackHeaderTitleAppearanceAndroid`. No error message should appear when the screen loads.

## Checklist

- [x] Ensured that CI passes
