### PR TITLE
fix(iOS): restore back chevron after RTL changes

### DIFF
--- a/ios/legacy/RNSScreenStack.h
+++ b/ios/legacy/RNSScreenStack.h
@@ -10,8 +10,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_INLINE BOOL RNSNavigationControllerIsRTL(UINavigationController *navigationController)
+/**
+ * Returns whether the navigation controller currently uses right-to-left layout.
+ */
+NS_INLINE BOOL RNSNavigationControllerIsRTL(UINavigationController *_Nullable navigationController)
 {
+  if (navigationController == nil) {
+    return NO;
+  }
+
   UISemanticContentAttribute semanticContentAttribute = navigationController.view.semanticContentAttribute;
   if (semanticContentAttribute == UISemanticContentAttributeForceRightToLeft) {
     return YES;

--- a/ios/legacy/RNSScreenStack.h
+++ b/ios/legacy/RNSScreenStack.h
@@ -10,6 +10,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_INLINE BOOL RNSNavigationControllerIsRTL(UINavigationController *navigationController)
+{
+  UISemanticContentAttribute semanticContentAttribute = navigationController.view.semanticContentAttribute;
+  if (semanticContentAttribute == UISemanticContentAttributeForceRightToLeft) {
+    return YES;
+  }
+  if (semanticContentAttribute == UISemanticContentAttributeForceLeftToRight) {
+    return NO;
+  }
+  return navigationController.traitCollection.layoutDirection == UITraitEnvironmentLayoutDirectionRightToLeft;
+}
+
 @interface RNSNavigationController : UINavigationController <RNSViewControllerDelegate,
                                                              RNSTabsSpecialEffectsSupporting
 #if !TARGET_OS_TV

--- a/ios/legacy/RNSScreenStack.mm
+++ b/ios/legacy/RNSScreenStack.mm
@@ -823,10 +823,9 @@ RNS_IGNORE_SUPER_CALL_END
   if (customAnimationOnSwipePropSetAndSelectedAnimationIsCustom) {
     if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
       UIRectEdge edges = ((RNSScreenEdgeGestureRecognizer *)gestureRecognizer).edges;
-      BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
+      BOOL isRTL = RNSNavigationControllerIsRTL(_controller);
       BOOL isSlideFromLeft = topScreen.stackAnimation == RNSScreenStackAnimationSlideFromLeft;
-      // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
-      // of `UISemanticContentAttributeForceLeftToRight`, so we just check if it is RTL or not
+      // If no explicit semantic fallback is set, the navigation controller's trait collection determines direction.
       BOOL isCorrectEdge = (isRTL && edges == UIRectEdgeRight) ||
           (!isRTL && isSlideFromLeft && edges == UIRectEdgeRight) ||
           (isRTL && isSlideFromLeft && edges == UIRectEdgeLeft) || (!isRTL && edges == UIRectEdgeLeft);
@@ -897,7 +896,7 @@ RNS_IGNORE_SUPER_CALL_END
     translation = [gestureRecognizer translationInView:gestureRecognizer.view].x;
     velocity = [gestureRecognizer velocityInView:gestureRecognizer.view].x;
     distance = gestureRecognizer.view.bounds.size.width;
-    BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
+    BOOL isRTL = RNSNavigationControllerIsRTL(_controller);
     if (isRTL) {
       translation = -translation;
       velocity = -velocity;
@@ -1018,7 +1017,7 @@ RNS_IGNORE_SUPER_CALL_END
   NSDictionary *gestureResponseDistanceValues = topScreen.gestureResponseDistance;
   float x = [gestureRecognizer locationInView:gestureRecognizer.view].x;
   float y = [gestureRecognizer locationInView:gestureRecognizer.view].y;
-  BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
+  BOOL isRTL = RNSNavigationControllerIsRTL(_controller);
   if (isRTL) {
     x = _controller.view.frame.size.width - x;
   }

--- a/ios/legacy/RNSScreenStackAnimator.mm
+++ b/ios/legacy/RNSScreenStackAnimator.mm
@@ -132,8 +132,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   CGAffineTransform rightTransform = CGAffineTransformMakeTranslation(containerWidth, 0);
   CGAffineTransform leftTransform = CGAffineTransformMakeTranslation(-belowViewWidth, 0);
 
-  if (toViewController.navigationController.view.semanticContentAttribute ==
-      UISemanticContentAttributeForceRightToLeft) {
+  if (RNSNavigationControllerIsRTL(toViewController.navigationController)) {
     rightTransform = CGAffineTransformMakeTranslation(-containerWidth, 0);
     leftTransform = CGAffineTransformMakeTranslation(belowViewWidth, 0);
   }
@@ -232,8 +231,7 @@ static constexpr float RNSShadowViewMaxAlpha = 0.1;
   CGAffineTransform rightTransform = CGAffineTransformMakeTranslation(-containerWidth, 0);
   CGAffineTransform leftTransform = CGAffineTransformMakeTranslation(belowViewWidth, 0);
 
-  if (toViewController.navigationController.view.semanticContentAttribute ==
-      UISemanticContentAttributeForceRightToLeft) {
+  if (RNSNavigationControllerIsRTL(toViewController.navigationController)) {
     rightTransform = CGAffineTransformMakeTranslation(containerWidth, 0);
     leftTransform = CGAffineTransformMakeTranslation(-belowViewWidth, 0);
   }

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -797,12 +797,10 @@ RNS_IGNORE_SUPER_CALL_END
     [parentViewController
         setOverrideTraitCollection:[UITraitCollection traitCollectionWithLayoutDirection:layoutDirection]
             forChildViewController:navCtrl];
-    return;
   }
 
-  // A detached navigation controller has no parent that can override its traits yet.
-  // Preserve the legacy fallback until the next configuration pass after attachment.
-  if (parentViewController == nil && navCtrl.view.semanticContentAttribute != self.direction) {
+  // Keep the explicit legacy value synchronized because stack gestures and animations inspect it before traits.
+  if (navCtrl.view.semanticContentAttribute != self.direction) {
     navCtrl.view.semanticContentAttribute = self.direction;
     navCtrl.navigationBar.semanticContentAttribute = self.direction;
     [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -603,6 +603,7 @@ RNS_IGNORE_SUPER_CALL_END
 #if !TARGET_OS_TV
           RNSSearchBar *searchBar = subview.subviews[0];
           searchBarPresent = true;
+          searchBar.controller.searchBar.semanticContentAttribute = config.direction;
           navitem.searchController = searchBar.controller;
           navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
@@ -778,7 +779,9 @@ RNS_IGNORE_SUPER_CALL_END
     if (navCtrl.traitCollection.layoutDirection != layoutDirection) {
       navCtrl.traitOverrides.layoutDirection = layoutDirection;
     }
-  } else {
+  } else
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+  {
     UIViewController *parentViewController = navCtrl.parentViewController;
     if (parentViewController != nil && navCtrl.traitCollection.layoutDirection != layoutDirection) {
       [parentViewController
@@ -786,18 +789,12 @@ RNS_IGNORE_SUPER_CALL_END
               forChildViewController:navCtrl];
     }
   }
-#else
-  UIViewController *parentViewController = navCtrl.parentViewController;
-  if (parentViewController != nil && navCtrl.traitCollection.layoutDirection != layoutDirection) {
-    [parentViewController
-        setOverrideTraitCollection:[UITraitCollection traitCollectionWithLayoutDirection:layoutDirection]
-            forChildViewController:navCtrl];
-  }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
 
   // Keep the explicit legacy value synchronized because stack gestures and animations inspect it directly.
   if (navCtrl.view.semanticContentAttribute != self.direction) {
     navCtrl.view.semanticContentAttribute = self.direction;
+  }
+  if (navCtrl.navigationBar.semanticContentAttribute != self.direction) {
     navCtrl.navigationBar.semanticContentAttribute = self.direction;
   }
 }

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -604,6 +604,16 @@ RNS_IGNORE_SUPER_CALL_END
           RNSSearchBar *searchBar = subview.subviews[0];
           searchBarPresent = true;
           navitem.searchController = searchBar.controller;
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+          if (@available(iOS 17.0, *)) {
+            if (config.direction == UISemanticContentAttributeForceRightToLeft) {
+              // Overriding the navigation controller's layout direction makes UIKit drop the default search icon.
+              // Keep the search field's existing left-to-right content layout while the navigation bar is mirrored.
+              searchBar.controller.searchBar.searchTextField.semanticContentAttribute =
+                  UISemanticContentAttributeForceLeftToRight;
+            }
+          }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
           navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
           if (@available(iOS 16.0, *)) {
@@ -769,27 +779,31 @@ RNS_IGNORE_SUPER_CALL_END
     return;
   }
 
+  UITraitEnvironmentLayoutDirection layoutDirection = self.direction == UISemanticContentAttributeForceRightToLeft
+      ? UITraitEnvironmentLayoutDirectionRightToLeft
+      : UITraitEnvironmentLayoutDirectionLeftToRight;
+
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
   if (@available(iOS 17.0, *)) {
-    navCtrl.traitOverrides.layoutDirection = self.direction == UISemanticContentAttributeForceRightToLeft
-        ? UITraitEnvironmentLayoutDirectionRightToLeft
-        : UITraitEnvironmentLayoutDirectionLeftToRight;
-
-    // RNSScreenStack and its animator inspect this explicit value when
-    // resolving swipe and transition direction.
-    if (navCtrl.view.semanticContentAttribute != self.direction) {
-      navCtrl.view.semanticContentAttribute = self.direction;
+    if (navCtrl.traitCollection.layoutDirection != layoutDirection) {
+      navCtrl.traitOverrides.layoutDirection = layoutDirection;
     }
     return;
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
 
-  // iOS 12 cancels swipe gesture when direction is changed. See #1091
-  if (navCtrl.view.semanticContentAttribute != self.direction) {
-    // This is needed for swipe back gesture direction
-    navCtrl.view.semanticContentAttribute = self.direction;
+  UIViewController *parentViewController = navCtrl.parentViewController;
+  if (parentViewController != nil && navCtrl.traitCollection.layoutDirection != layoutDirection) {
+    [parentViewController
+        setOverrideTraitCollection:[UITraitCollection traitCollectionWithLayoutDirection:layoutDirection]
+            forChildViewController:navCtrl];
+    return;
+  }
 
-    // This is responsible for the direction of the navigationBar and its contents
+  // A detached navigation controller has no parent that can override its traits yet.
+  // Preserve the legacy fallback until the next configuration pass after attachment.
+  if (parentViewController == nil && navCtrl.view.semanticContentAttribute != self.direction) {
+    navCtrl.view.semanticContentAttribute = self.direction;
     navCtrl.navigationBar.semanticContentAttribute = self.direction;
     [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
         setSemanticContentAttribute:self.direction];

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -803,12 +803,6 @@ RNS_IGNORE_SUPER_CALL_END
   if (navCtrl.view.semanticContentAttribute != self.direction) {
     navCtrl.view.semanticContentAttribute = self.direction;
     navCtrl.navigationBar.semanticContentAttribute = self.direction;
-    [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
-        setSemanticContentAttribute:self.direction];
-    [[UIView appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
-        setSemanticContentAttribute:self.direction];
-    [[UISearchBar appearanceWhenContainedInInstancesOfClasses:@[ navCtrl.navigationBar.class ]]
-        setSemanticContentAttribute:self.direction];
   }
 }
 

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -764,10 +764,28 @@ RNS_IGNORE_SUPER_CALL_END
 
 - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *)navCtrl
 {
-  if ((self.direction == UISemanticContentAttributeForceLeftToRight ||
-       self.direction == UISemanticContentAttributeForceRightToLeft) &&
-      // iOS 12 cancels swipe gesture when direction is changed. See #1091
-      navCtrl.view.semanticContentAttribute != self.direction) {
+  if (self.direction != UISemanticContentAttributeForceLeftToRight &&
+      self.direction != UISemanticContentAttributeForceRightToLeft) {
+    return;
+  }
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+  if (@available(iOS 17.0, *)) {
+    navCtrl.traitOverrides.layoutDirection = self.direction == UISemanticContentAttributeForceRightToLeft
+        ? UITraitEnvironmentLayoutDirectionRightToLeft
+        : UITraitEnvironmentLayoutDirectionLeftToRight;
+
+    // RNSScreenStack and its animator inspect this explicit value when
+    // resolving swipe and transition direction.
+    if (navCtrl.view.semanticContentAttribute != self.direction) {
+      navCtrl.view.semanticContentAttribute = self.direction;
+    }
+    return;
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
+
+  // iOS 12 cancels swipe gesture when direction is changed. See #1091
+  if (navCtrl.view.semanticContentAttribute != self.direction) {
     // This is needed for swipe back gesture direction
     navCtrl.view.semanticContentAttribute = self.direction;
 

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -604,16 +604,6 @@ RNS_IGNORE_SUPER_CALL_END
           RNSSearchBar *searchBar = subview.subviews[0];
           searchBarPresent = true;
           navitem.searchController = searchBar.controller;
-#if RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
-          if (@available(iOS 17.0, *)) {
-            if (config.direction == UISemanticContentAttributeForceRightToLeft) {
-              // Overriding the navigation controller's layout direction makes UIKit drop the default search icon.
-              // Keep the search field's existing left-to-right content layout while the navigation bar is mirrored.
-              searchBar.controller.searchBar.searchTextField.semanticContentAttribute =
-                  UISemanticContentAttributeForceLeftToRight;
-            }
-          }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
           navitem.hidesSearchBarWhenScrolling = searchBar.hideWhenScrolling;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
           if (@available(iOS 16.0, *)) {
@@ -788,18 +778,24 @@ RNS_IGNORE_SUPER_CALL_END
     if (navCtrl.traitCollection.layoutDirection != layoutDirection) {
       navCtrl.traitOverrides.layoutDirection = layoutDirection;
     }
-    return;
+  } else {
+    UIViewController *parentViewController = navCtrl.parentViewController;
+    if (parentViewController != nil && navCtrl.traitCollection.layoutDirection != layoutDirection) {
+      [parentViewController
+          setOverrideTraitCollection:[UITraitCollection traitCollectionWithLayoutDirection:layoutDirection]
+              forChildViewController:navCtrl];
+    }
   }
-#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
-
+#else
   UIViewController *parentViewController = navCtrl.parentViewController;
   if (parentViewController != nil && navCtrl.traitCollection.layoutDirection != layoutDirection) {
     [parentViewController
         setOverrideTraitCollection:[UITraitCollection traitCollectionWithLayoutDirection:layoutDirection]
             forChildViewController:navCtrl];
   }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(17_0)
 
-  // Keep the explicit legacy value synchronized because stack gestures and animations inspect it before traits.
+  // Keep the explicit legacy value synchronized because stack gestures and animations inspect it directly.
   if (navCtrl.view.semanticContentAttribute != self.direction) {
     navCtrl.view.semanticContentAttribute = self.direction;
     navCtrl.navigationBar.semanticContentAttribute = self.direction;


### PR DESCRIPTION
## Description

Closes #4395.

After switching from forced RTL back to LTR, UIKit can restore the navigation-item placement while retaining the mirrored back-indicator image. The legacy stack previously relied on `semanticContentAttribute` and scoped `UIAppearance`, which do not reliably refresh the native back indicator after a runtime direction change.

The stack now updates layout direction through UIKit traits:

- iOS 17+: `UINavigationController.traitOverrides.layoutDirection`
- iOS < 17: the parent view controller's `setOverrideTraitCollection:forChildViewController:`, matching the native Tabs implementation

The explicit navigation-controller semantic value remains synchronized on every iOS version because legacy stack gestures and custom transitions consume it directly. Search bars inherit the navigation controller's native RTL behavior without a field-level direction override.

## Changes

- Refresh stack layout direction through UIKit traits.
- Keep the legacy semantic direction synchronized after applying traits so back gestures retain their native RTL direction.
- Let UIKit render the complete search bar in RTL rather than forcing only its text field to LTR.
- Keep semantic updates scoped to the current navigation controller instead of registering global `UIAppearance` rules.

## Reproduction in FabricExample

The existing `Test654` demonstrates the issue:

1. Build and launch `FabricExample` on iOS.
2. Enable **Right to left** on the main screen.
3. Open **Issue Tests**, search for `Test654`, and open it.
4. Tap **Tap me for second screen**; verify the RTL back item and edge gesture match native UIKit behavior.
5. Restart at the main screen, disable **Right to left**, and repeat.
6. Verify the first LTR visit shows a left-side, left-pointing back chevron.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| ![LTR back chevron incorrectly points right](https://raw.githubusercontent.com/huytdps13400/react-native-screens/fix/4395-visual-evidence/pr-assets/4395-before.png) | ![LTR back chevron correctly points left](https://raw.githubusercontent.com/huytdps13400/react-native-screens/fix/4395-visual-evidence/pr-assets/4395-after.png) |

## Verification

- `corepack yarn check-types` on the repository-pinned Node 23.11.0
- `corepack yarn prepare`
- Prior branch verification: full `FabricExample` Release build and manual LTR → RTL → LTR chevron flow on iOS 26.5
- Latest review correction is pushed for the repository iOS build and E2E workflows to validate

## Checklist

- [x] Included reproduction steps using the existing example app.
- [x] Included before/after screenshots.
- [x] No public API change.
- [ ] CI passes on the latest head.
