### PR TITLE
fix(Android, Stack v4+): transition RecyclerView as a unit on screen removal

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -221,6 +221,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.8.9'
     implementation 'androidx.transition:transition-ktx:1.7.0'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.14.0'
     implementation "androidx.core:core-ktx:1.17.0"

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/Screen.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PixelUtil
@@ -478,7 +479,8 @@ class Screen(
                 endTransitionRecursive(childView.toolbar)
             }
 
-            if (childView is ViewGroup) {
+            // Mirrors the skip in `startTransitionRecursive`.
+            if (childView is ViewGroup && childView !is RecyclerView) {
                 endTransitionRecursive(childView)
             }
         }
@@ -507,7 +509,10 @@ class Screen(
                     startTransitionRecursive(child.toolbar)
                 }
 
-                if (child is ViewGroup) {
+                // Transition a RecyclerView as one unit. It owns the attach/detach lifecycle
+                // of its children, and a child left in `mTransitioningViews` keeps its parent
+                // set after removal, which makes recycling it throw.
+                if (child is ViewGroup && child !is RecyclerView) {
                     startTransitionRecursive(child)
                 }
             }


### PR DESCRIPTION
**Note: this fix was discovered via https://github.com/callstack/react-native-pager-view/issues/1005#issuecomment-5095233311 and all credit goes to @mozzius**

## Description

When a screen is removed, `Screen.startTransitionRecursive` calls `startViewTransition` on every descendant so the outgoing screen keeps drawing through the exit animation. That works by delaying `ViewGroup`'s detachment contract and the transitioning view keeps its parent when it is removed:

```java
// ViewGroup.removeFromArray
if (!(mTransitioningViews != null && mTransitioningViews.contains(children[index]))) {
    children[index].mParent = null;      // skipped while transitioning
}
```

`RecyclerView` owns the attach/detach lifecycle of its children, and rejects any holder whose parent is still set:

```java
// RecyclerView.Recycler.recycleViewHolderInternal
if (holder.isScrap() || holder.itemView.getParent() != null) {
    throw new IllegalArgumentException("Scrapped or attached views may not be recycled. ...");
}
```

So once a screen removal has marked a `ViewPager2` page, the next recycle throws:

```
java.lang.IllegalArgumentException: Scrapped or attached views may not be recycled.
  isScrap:false isAttached:true androidx.viewpager2.widget.ViewPager2$RecyclerViewImpl{...},
  adapter:com.reactnativepagerview.ViewPagerAdapter@...

  at ...RecyclerView$Recycler.recycleViewHolderInternal(RecyclerView.java:7071)
  at ...RecyclerView$LayoutManager.removeAndRecycleViewAt(RecyclerView.java:9741)
  at ...LinearLayoutManager.recycleChildren(LinearLayoutManager.java:1464)
  at ...LinearLayoutManager.fill(LinearLayoutManager.java:1613)
  at ...RecyclerView.scrollStep(RecyclerView.java:2047)
  at ...RecyclerView$ViewFlinger.run(RecyclerView.java:5835)
```

## Repro Steps:

Setup: a RecyclerView inside of a native stack:

1. A native stack. ScreenStackViewManager.removeViewAt is the only caller of startRemovalTransition()
2. A RecyclerView anywhere in the popped screen's subtree. Depth is irrelevant and `<PagerView>` is the example in our app.
3. ≥3 pages, so a page actually leaves the retained window and recycleChildren runs.

Minimal test screen

```
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import React from 'react';
import { Button, Text, View } from 'react-native';
import PagerView from 'react-native-pager-view';

const Stack = createNativeStackNavigator();

function Home({ navigation }) {
  return <Button title="Open pager" onPress={() => navigation.navigate('Pager')} />;
}

function Pager() {
  return (
    <PagerView style={{ flex: 1 }} initialPage={0}>
      {Array.from({ length: 6 }, (_, i) => (
        <View key={i} style={{ flex: 1, backgroundColor: i % 2 ? '#cde' : '#edc' }}>
          <Text style={{ fontSize: 64, textAlign: 'center', marginTop: 240 }}>{i}</Text>
        </View>
      ))}
    </PagerView>
  );
}

export default function Test2461() {
  return (
    <NavigationContainer independent>
      <Stack.Navigator>
        <Stack.Screen name="Home" component={Home} />
        <Stack.Screen name="Pager" component={Pager} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

```

On Android: open the pager screen, drag horizontally and release mid-page, then immediately press Back while it's still gliding. Use a back button rather than back gesture. Repeat a couple times given the animation settle window is only a few hundred milliseconds.

### Notes

Fixes the crash reported in #2461 (closed without a fix).
Downstream: callstack/react-native-pager-view#1005.

## Changes

- `legacy/Screen.kt`: skip recursion into a `RecyclerView` in `startTransitionRecursive`, and mirror
  the skip in `endTransitionRecursive`.
- `android/build.gradle`: declare `androidx.recyclerview:recyclerview` explicitly. It was already on
  the compile classpath transitively via Material, but the new import should not rely on that. Pinned
  at `1.1.0`, which is what Material already resolves.