### PR TITLE
feat(Android, Stack v5): support for host-level color scheme configuration

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/common/text/TextAppearanceDefaults.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/text/TextAppearanceDefaults.kt
@@ -12,9 +12,6 @@ import com.swmansion.rnscreens.utils.resolveStyleResAttr
  *
  * Resolved from the style rather than read back from the widget: Material resolves a slot's
  * default typeface asynchronously, so until that lands the widget reports [Typeface.DEFAULT].
- *
- * Values depend on the current theme and display metrics — resolve at apply time through
- * the widget's own context.
  */
 internal class TextAppearanceDefaults(
     val color: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderApplicator.kt
@@ -218,6 +218,10 @@ internal class StackHeaderApplicator(
         appBar: StackHeaderAppBarLayout,
         config: StackHeaderConfigurationProviding,
     ) {
+        // Defaults are resolved from wrappedContext, not the widget's own context: MaterialToolbar
+        // wraps its context (materialThemeOverlay) in a ContextThemeWrapper whose theme is a
+        // one-time copy, so it never sees later setTheme calls on wrappedContext (color scheme
+        // changes).
         when (appBar) {
             is StackHeaderAppBarLayout.Small -> {
                 val toolbar = appBar.toolbar
@@ -229,7 +233,7 @@ internal class StackHeaderApplicator(
                     view = toolbar,
                     defaults =
                         TextAppearanceDefaults.resolve(
-                            toolbar.context,
+                            wrappedContext,
                             R.attr.textAppearanceTitleLarge,
                             R.attr.colorOnSurface,
                         ),
@@ -242,7 +246,7 @@ internal class StackHeaderApplicator(
                     view = toolbar,
                     defaults =
                         TextAppearanceDefaults.resolve(
-                            toolbar.context,
+                            wrappedContext,
                             R.attr.textAppearanceLabelMedium,
                             R.attr.colorOnSurfaceVariant,
                         ),
@@ -276,7 +280,7 @@ internal class StackHeaderApplicator(
                 applySlot(
                     view = ctl,
                     defaults =
-                        TextAppearanceDefaults.resolve(ctl.context, expandedTitleAttr, R.attr.colorOnSurface),
+                        TextAppearanceDefaults.resolve(wrappedContext, expandedTitleAttr, R.attr.colorOnSurface),
                     appearance = config.expandedTitleAppearance,
                     setColor = { ctl.setExpandedTitleTextColor(ColorStateList.valueOf(it)) },
                     setTypeface = { ctl.setExpandedTitleTypeface(it) },
@@ -285,7 +289,7 @@ internal class StackHeaderApplicator(
                 applySlot(
                     view = ctl,
                     defaults =
-                        TextAppearanceDefaults.resolve(ctl.context, R.attr.textAppearanceTitleLarge, R.attr.colorOnSurface),
+                        TextAppearanceDefaults.resolve(wrappedContext, R.attr.textAppearanceTitleLarge, R.attr.colorOnSurface),
                     appearance = config.collapsedTitleAppearance,
                     setColor = { ctl.setCollapsedTitleTextColor(it) },
                     setTypeface = { ctl.setCollapsedTitleTypeface(it) },
@@ -294,7 +298,7 @@ internal class StackHeaderApplicator(
                 applySlot(
                     view = ctl,
                     defaults =
-                        TextAppearanceDefaults.resolve(ctl.context, expandedSubtitleAttr, R.attr.colorOnSurfaceVariant),
+                        TextAppearanceDefaults.resolve(wrappedContext, expandedSubtitleAttr, R.attr.colorOnSurfaceVariant),
                     appearance = config.expandedSubtitleAppearance,
                     setColor = { ctl.setExpandedSubtitleTextColor(ColorStateList.valueOf(it)) },
                     setTypeface = { ctl.setExpandedSubtitleTypeface(it) },
@@ -303,7 +307,7 @@ internal class StackHeaderApplicator(
                 applySlot(
                     view = ctl,
                     defaults =
-                        TextAppearanceDefaults.resolve(ctl.context, R.attr.textAppearanceLabelMedium, R.attr.colorOnSurfaceVariant),
+                        TextAppearanceDefaults.resolve(wrappedContext, R.attr.textAppearanceLabelMedium, R.attr.colorOnSurfaceVariant),
                     appearance = config.collapsedSubtitleAppearance,
                     setColor = { ctl.setCollapsedSubtitleTextColor(it) },
                     setTypeface = { ctl.setCollapsedSubtitleTypeface(it) },
@@ -366,7 +370,7 @@ internal class StackHeaderApplicator(
         val baseDrawable =
             config.backButtonIcon
                 ?.let { getResizedDrawable(toolbar, it) }
-                ?: resolveDefaultBackButtonIcon()
+                ?: resolveDefaultBackButtonIcon(toolbar)
 
         val tintList =
             buildTintList(
@@ -394,7 +398,7 @@ internal class StackHeaderApplicator(
         val baseDrawable =
             config.overflowIcon
                 ?.let { getResizedDrawable(toolbar, it) }
-                ?: resolveDefaultOverflowIcon()
+                ?: resolveDefaultOverflowIcon(toolbar)
 
         val tintList =
             buildTintList(
@@ -591,13 +595,21 @@ internal class StackHeaderApplicator(
         }
     }
 
-    private fun resolveDefaultBackButtonIcon(): Drawable? = resolveDrawableAttr(wrappedContext, androidx.appcompat.R.attr.homeAsUpIndicator)
+    // Default icon drawables must load through the toolbar's snapshot context, not
+    // wrappedContext: on Android 14+ the framework's themed resource cache returns stale
+    // entries for a Theme mutated in place by setTheme (ThemeKey dedup + shallow clone),
+    // freezing the icon tint after a color scheme change. The toolbar wrapper's theme is
+    // created fresh on every rebuild, so its cache entries always match the current palette.
+    // Plain attribute resolution (e.g. text appearance defaults) doesn't hit that cache and
+    // stays on the live wrappedContext.
+    private fun resolveDefaultBackButtonIcon(toolbar: MaterialToolbar): Drawable? =
+        resolveDrawableAttr(toolbar.context, androidx.appcompat.R.attr.homeAsUpIndicator)
 
     // Mirrors how the toolbar's own overflow button obtains its icon: an AppCompatImageView built
     // with actionOverflowButtonStyle resolves the theme's srcCompat and applies AppCompat's
     // colorControlNormal auto-tint.
-    private fun resolveDefaultOverflowIcon(): Drawable? =
-        AppCompatImageView(wrappedContext, null, androidx.appcompat.R.attr.actionOverflowButtonStyle).drawable
+    private fun resolveDefaultOverflowIcon(toolbar: MaterialToolbar): Drawable? =
+        AppCompatImageView(toolbar.context, null, androidx.appcompat.R.attr.actionOverflowButtonStyle).drawable
 
     private fun maybeApplyRTLCollapsingToolbarLayoutWorkaround(
         coordinatorLayout: StackHeaderCoordinatorLayout,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -338,7 +338,11 @@ internal class StackHeaderCoordinatorLayout(
                 else -> R.style.Theme_Material3Expressive_DayNight_NoActionBar
             },
         )
-        if (uiNightMode == appliedUiNightMode) return
+
+        if (uiNightMode == appliedUiNightMode) {
+            return
+        }
+
         appliedUiNightMode = uiNightMode
         currentProvider?.let {
             // A rebuild is forced because MaterialToolbar snapshots its theme at construction:

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -317,6 +317,9 @@ internal class StackHeaderCoordinatorLayout(
 
     override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
 
+    // No onConfigurationChanged override is needed: this view never sets its own colorScheme,
+    // so resolution always delegates to the parent provider, which does handle system changes.
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         colorSchemeCoordinator.setup(this) { applyUiNightMode(it) }
@@ -455,6 +458,8 @@ internal class StackHeaderCoordinatorLayout(
     // region Teardown
 
     internal fun tearDown() {
+        colorSchemeCoordinator.teardown()
+
         removeHeader()
 
         stackScreenWrapper.removeView(stackScreen)

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens.stack.header
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Parcelable
 import android.util.Log
 import android.util.SparseArray
@@ -14,6 +15,9 @@ import com.facebook.react.bridge.ReactContext
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeCoordinator
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeListener
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeProviding
 import com.swmansion.rnscreens.stack.header.appbar.StackHeaderAppBarLayout
 import com.swmansion.rnscreens.stack.header.appbar.StackHeaderScrollingViewBehavior
 import com.swmansion.rnscreens.stack.header.config.OnHeaderConfigurationAttachListener
@@ -36,7 +40,8 @@ internal class StackHeaderCoordinatorLayout(
     context: Context,
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
-) : CoordinatorLayout(context) {
+) : CoordinatorLayout(context),
+    ColorSchemeProviding {
     // region Config attach / detach
 
     private var currentProvider: StackHeaderConfigurationProviding? = null
@@ -173,8 +178,12 @@ internal class StackHeaderCoordinatorLayout(
         activity?.onBackPressedDispatcher?.onBackPressed()
     }
 
-    private fun processUpdate(provider: StackHeaderConfigurationProviding) {
-        val needsRebuild = provider.invalidationFlags.needsRebuild
+    private fun processUpdate(
+        provider: StackHeaderConfigurationProviding,
+        forcedFlags: StackHeaderInvalidationFlags = StackHeaderInvalidationFlags.NONE,
+    ) {
+        val effectiveFlags = provider.invalidationFlags or forcedFlags
+        val needsRebuild = effectiveFlags.needsRebuild
         if (needsRebuild) {
             resetHeader()
             if (provider.hidden) {
@@ -196,42 +205,42 @@ internal class StackHeaderCoordinatorLayout(
 
         val appBar = appBarLayout
         if (appBar != null) {
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.TITLE)) {
                 applicator.applyTitleAndSubtitle(appBar, provider, isAppBarFullyCollapsed)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE_APPEARANCE)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.TITLE_APPEARANCE)) {
                 applicator.applyTitleAndSubtitleAppearance(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE_APPEARANCE)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TITLE_POSITIONING)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.TITLE_POSITIONING)) {
                 applicator.applyTitlePositioning(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TITLE_POSITIONING)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.CONTENT_INSETS)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.CONTENT_INSETS)) {
                 applicator.applyContentInsets(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.CONTENT_INSETS)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.BACK_BUTTON)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.BACK_BUTTON)) {
                 applicator.applyBackButton(appBar.toolbar, provider, canNavigateBack, onNavigationIconClick)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.BACK_BUTTON)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.SCROLL_FLAGS)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.SCROLL_FLAGS)) {
                 applicator.applyScrollFlags(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.SCROLL_FLAGS)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.BACKGROUND_COLORS)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.BACKGROUND_COLORS)) {
                 applicator.applyBackgroundColors(appBar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.BACKGROUND_COLORS)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)) {
                 // Lift-on-scroll is disabled in transparent mode: there is no content
                 // scrolling behavior installed and the app bar overlays the content.
                 applicator.applyLiftOnScroll(
@@ -242,7 +251,7 @@ internal class StackHeaderCoordinatorLayout(
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.LIFT_ON_SCROLL)
             }
 
-            if (provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.TOOLBAR_MENU)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.TOOLBAR_MENU)) {
                 val (forwardIdMap, reverseIdMap) =
                     StackHeaderToolbarMenuApplicator.generateToolbarMenuItemMappings(
                         provider.toolbarMenu,
@@ -281,13 +290,65 @@ internal class StackHeaderCoordinatorLayout(
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.TOOLBAR_MENU)
             }
 
-            if (needsRebuild || provider.invalidationFlags.containsAny(StackHeaderInvalidationFlags.OVERFLOW_ICON)) {
+            if (needsRebuild || effectiveFlags.containsAny(StackHeaderInvalidationFlags.OVERFLOW_ICON)) {
                 applicator.applyOverflowIcon(appBar.toolbar, provider)
                 provider.clearInvalidationFlags(StackHeaderInvalidationFlags.OVERFLOW_ICON)
             }
         }
 
         onMaybeHeaderLayoutChanged()
+    }
+
+    // endregion
+
+    // region Color scheme
+
+    private val colorSchemeCoordinator = ColorSchemeCoordinator()
+
+    // Night mode the header visuals were last applied against. Unlike the coordinator's
+    // internal dedupe (reset on every setup()), this survives detach/reattach, skipping
+    // redundant full re-applies e.g. on tab switches.
+    private var appliedUiNightMode: Int =
+        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+
+    override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
+
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        colorSchemeCoordinator.setup(this) { applyUiNightMode(it) }
+    }
+
+    override fun onDetachedFromWindow() {
+        colorSchemeCoordinator.teardown()
+        super.onDetachedFromWindow()
+    }
+
+    private fun applyUiNightMode(uiNightMode: Int) {
+        wrappedContext.setTheme(
+            when (uiNightMode) {
+                Configuration.UI_MODE_NIGHT_YES -> R.style.Theme_Material3Expressive_Dark_NoActionBar
+                Configuration.UI_MODE_NIGHT_NO -> R.style.Theme_Material3Expressive_Light_NoActionBar
+                else -> R.style.Theme_Material3Expressive_DayNight_NoActionBar
+            },
+        )
+        if (uiNightMode == appliedUiNightMode) return
+        appliedUiNightMode = uiNightMode
+        currentProvider?.let {
+            // A rebuild is forced because MaterialToolbar snapshots its theme at construction:
+            // ripples, the overflow popup and menu item views resolve from that frozen copy, so
+            // only view recreation refreshes them.
+            val wasFullyCollapsed = isAppBarFullyCollapsed
+            processUpdate(it, forcedFlags = StackHeaderInvalidationFlags.STRUCTURE)
+            // The rebuilt app bar starts expanded; restore the fully-collapsed resting state
+            // so a scrolled-down screen doesn't jump. Fractional offsets reset.
+            if (wasFullyCollapsed) {
+                appBarLayout?.setExpanded(false, false)
+            }
+        }
     }
 
     // endregion

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -2,11 +2,16 @@ package com.swmansion.rnscreens.stack.host
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
 import android.util.Log
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.swmansion.rnscreens.common.colorscheme.ColorScheme
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeCoordinator
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeListener
+import com.swmansion.rnscreens.common.colorscheme.ColorSchemeProviding
 import com.swmansion.rnscreens.common.container.Container
 import com.swmansion.rnscreens.common.container.ParentContainerItemRegistry
 import com.swmansion.rnscreens.ext.isMeasured
@@ -23,7 +28,8 @@ internal class StackContainer(
     private val delegate: WeakReference<StackContainerDelegate>,
 ) : FrameLayout(context),
     Container,
-    FragmentManager.OnBackStackChangedListener {
+    FragmentManager.OnBackStackChangedListener,
+    ColorSchemeProviding {
     private var fragmentManager: FragmentManager? = null
 
     private fun requireFragmentManager(): FragmentManager =
@@ -51,6 +57,20 @@ internal class StackContainer(
     private val fragmentOpExecutor: FragmentOperationExecutor = FragmentOperationExecutor()
     private val fragmentOps: MutableList<FragmentOperation> = arrayListOf()
 
+    // region Color Scheme
+
+    private val colorSchemeCoordinator = ColorSchemeCoordinator()
+
+    internal var colorScheme: ColorScheme by colorSchemeCoordinator::colorScheme
+
+    override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
+
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+
+    // endregion
+
     init {
         id = ViewIdGenerator.generateViewId()
     }
@@ -74,6 +94,10 @@ internal class StackContainer(
         // We run container update to handle any pending updates requested before container was
         // attached to window.
         performContainerUpdateIfNeeded()
+
+        // StackContainer only provides container-level color scheme configuration for its screens
+        // but doesn't actually use any color scheme-dependent views so we don't need the callback.
+        colorSchemeCoordinator.setup(this, null)
     }
 
     override fun onDetachedFromWindow() {
@@ -81,6 +105,12 @@ internal class StackContainer(
         requireFragmentManager().removeOnBackStackChangedListener(this)
         fragmentManager = null
         parentContainerRegistry.detach(this)
+        colorSchemeCoordinator.teardown()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        super.onConfigurationChanged(newConfig)
+        colorSchemeCoordinator.onConfigurationChanged(newConfig)
     }
 
     internal fun setupFragmentManger() {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -19,6 +19,7 @@ import com.swmansion.rnscreens.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.helpers.ViewIdGenerator
 import com.swmansion.rnscreens.stack.screen.StackScreen
 import com.swmansion.rnscreens.stack.screen.StackScreenFragment
+import com.swmansion.rnscreens.stack.screen.StackScreenFragmentDelegate
 import com.swmansion.rnscreens.utils.RNSLog
 import java.lang.ref.WeakReference
 
@@ -29,7 +30,8 @@ internal class StackContainer(
 ) : FrameLayout(context),
     Container,
     FragmentManager.OnBackStackChangedListener,
-    ColorSchemeProviding {
+    ColorSchemeProviding,
+    StackScreenFragmentDelegate {
     private var fragmentManager: FragmentManager? = null
 
     private fun requireFragmentManager(): FragmentManager =
@@ -112,6 +114,8 @@ internal class StackContainer(
         super.onConfigurationChanged(newConfig)
         colorSchemeCoordinator.onConfigurationChanged(newConfig)
     }
+
+    override fun onFragmentConfigurationChanged(config: Configuration) = onConfigurationChanged(config)
 
     internal fun setupFragmentManger() {
         fragmentManager =
@@ -235,7 +239,7 @@ internal class StackContainer(
         screen: StackScreen,
         canNavigateBack: Boolean,
     ): StackScreenFragment =
-        StackScreenFragment(screen, canNavigateBack).also {
+        StackScreenFragment(screen, canNavigateBack, WeakReference(this)).also {
             Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -84,6 +84,10 @@ internal class StackContainer(
         parentContainerRegistry.attach(this)
         setupFragmentManger()
 
+        // StackContainer only provides container-level color scheme configuration for its screens
+        // but doesn't use any color scheme-dependent views, so we don't need the callback.
+        colorSchemeCoordinator.setup(this, null)
+
         // Following line works with a couple of assumptions.
         // First, that this view is laid out by our parent view, which is a component view.
         // Component views on new architecture receive their first layout after the view hierarchy is
@@ -96,10 +100,6 @@ internal class StackContainer(
         // We run container update to handle any pending updates requested before container was
         // attached to window.
         performContainerUpdateIfNeeded()
-
-        // StackContainer only provides container-level color scheme configuration for its screens
-        // but doesn't actually use any color scheme-dependent views so we don't need the callback.
-        colorSchemeCoordinator.setup(this, null)
     }
 
     override fun onDetachedFromWindow() {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
+import com.swmansion.rnscreens.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.helpers.getFabricUIManagerNotNull
 import com.swmansion.rnscreens.stack.screen.StackScreen
 import com.swmansion.rnscreens.utils.RNSLog
@@ -25,6 +26,8 @@ class StackHost(
     private val container = StackContainer(reactContext, WeakReference(this))
     private val containerUpdateCoordinator = StackContainerUpdateCoordinator()
     private var isLayoutEnqueued = false
+
+    internal var colorScheme: ColorScheme by container::colorScheme
 
     init {
         addView(container)

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHostViewManager.kt
@@ -1,12 +1,14 @@
 package com.swmansion.rnscreens.stack.host
 
 import android.view.View
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHostManagerDelegate
 import com.facebook.react.viewmanagers.RNSStackHostManagerInterface
+import com.swmansion.rnscreens.common.colorscheme.ColorScheme
 import com.swmansion.rnscreens.stack.screen.StackScreen
 
 @ReactModule(name = StackHostViewManager.REACT_CLASS)
@@ -69,6 +71,18 @@ class StackHostViewManager :
      * native layout traversal will remeasure the view and apply correct layout.
      */
     override fun needsCustomLayoutForChildren() = true
+
+    override fun setColorScheme(
+        view: StackHost,
+        value: String?,
+    ) {
+        when (value) {
+            null, "inherit" -> view.colorScheme = ColorScheme.INHERIT
+            "light" -> view.colorScheme = ColorScheme.LIGHT
+            "dark" -> view.colorScheme = ColorScheme.DARK
+            else -> throw JSApplicationIllegalArgumentException("[RNScreens] Invalid color scheme: $value.")
+        }
+    }
 
     companion object {
         const val REACT_CLASS = "RNSStackHost"

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -1,5 +1,6 @@
 package com.swmansion.rnscreens.stack.screen
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -8,10 +9,12 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.transition.Slide
 import com.swmansion.rnscreens.stack.header.StackHeaderCoordinatorLayout
+import java.lang.ref.WeakReference
 
 internal class StackScreenFragment(
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
+    private val delegate: WeakReference<StackScreenFragmentDelegate>,
 ) : Fragment() {
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
@@ -69,6 +72,11 @@ internal class StackScreenFragment(
         super.onDestroy()
         stackScreen.onDismiss()
         teardownPreventNativeDismissCallback()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        delegate.get()?.onFragmentConfigurationChanged(newConfig)
     }
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragmentDelegate.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragmentDelegate.kt
@@ -1,0 +1,12 @@
+package com.swmansion.rnscreens.stack.screen
+
+import android.content.res.Configuration
+
+internal interface StackScreenFragmentDelegate {
+    /**
+     * Notifies the delegate that the fragment received a configuration update,
+     * e.g. theme change from JS via Appearance.setColorScheme. Fragments are
+     * the only place where such updates are delivered reliably.
+     */
+    fun onFragmentConfigurationChanged(config: Configuration)
+}

--- a/apps/src/shared/containers/stack/StackContainer.tsx
+++ b/apps/src/shared/containers/stack/StackContainer.tsx
@@ -23,7 +23,8 @@ import {
 import { useParentNavigationEffect } from './hooks/useParentNavigationEffect';
 import { useElementsByName } from '../shared/use-elements-by-name';
 
-export function StackContainer({ routeConfigs }: StackContainerProps) {
+export function StackContainer(props: StackContainerProps) {
+  const { routeConfigs, ...restProps } = props;
   useSanitizeRouteConfigs(routeConfigs);
 
   const elementsByName = useElementsByName(routeConfigs);
@@ -63,7 +64,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
   );
 
   return (
-    <Stack.Host ref={hostRef}>
+    <Stack.Host ref={hostRef} {...restProps}>
       {stackNavState.stack.map(
         ({
           options: { headerConfig, headerConfigRef, ...options } = {},

--- a/apps/src/shared/containers/stack/StackContainer.types.ts
+++ b/apps/src/shared/containers/stack/StackContainer.types.ts
@@ -3,6 +3,7 @@ import {
   StackScreenProps,
   StackHeaderConfigProps,
   StackHeaderConfigRef,
+  StackHostProps,
 } from 'react-native-screens';
 
 /// Route definition
@@ -32,7 +33,7 @@ export type StackRoute = Omit<StackRouteConfig, 'element'> & {
 
 /// StackContainer props
 
-export type StackContainerProps = {
+export type StackContainerProps = Omit<StackHostProps, 'children' | 'ref'> & {
   routeConfigs: StackRouteConfig[];
 };
 

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -32,6 +32,7 @@ import TestStackHeaderTitleAppearance from './test-stack-header-title-appearance
 import TestStackHeaderContentInsets from './test-stack-header-content-insets-android';
 import TestStackHeaderBackground from './test-stack-header-background-android';
 import TestStackHeaderStatusBarScrim from './test-stack-header-status-bar-scrim-android';
+import TestStackColorScheme from './test-stack-color-scheme';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
@@ -65,6 +66,7 @@ export { default as TestStackHeaderTitleAppearance } from './test-stack-header-t
 export { default as TestStackHeaderContentInsets } from './test-stack-header-content-insets-android';
 export { default as TestStackHeaderBackground } from './test-stack-header-background-android';
 export { default as TestStackHeaderStatusBarScrim } from './test-stack-header-status-bar-scrim-android';
+export { default as TestStackColorScheme } from './test-stack-color-scheme';
 
 const scenarios = {
   TestStackPreventNativeDismissSingleStack,
@@ -97,6 +99,7 @@ const scenarios = {
   TestStackHeaderContentInsets,
   TestStackHeaderBackground,
   TestStackHeaderStatusBarScrim,
+  TestStackColorScheme,
 };
 
 const StackScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
@@ -1,87 +1,61 @@
 import {
   Appearance,
-  Platform,
+  Button,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
   View,
-  Button,
 } from 'react-native';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import React, {
+  useCallback,
   useEffect,
-  useMemo,
+  useLayoutEffect,
+  useRef,
   useState,
   createContext,
   useContext,
 } from 'react';
 import { SettingsPicker } from '@apps/shared';
+import LongText from '@apps/shared/LongText';
 import {
   StackContainer,
   useStackNavigationContext,
   type StackRouteConfig,
 } from '@apps/shared/containers/stack';
 import type {
-  StackHeaderConfigProps,
+  StackHeaderConfigRef,
+  StackHeaderToolbarMenuBaseAndroid,
+  StackHeaderTypeAndroid,
   StackHostColorScheme,
 } from 'react-native-screens';
 import { Colors } from '@apps/shared/styling';
 
-const HostConfigContext = createContext<{
+const ColorSchemeContext = createContext<{
   hostColorScheme: StackHostColorScheme;
   setHostColorScheme: (val: StackHostColorScheme) => void;
+  reactColorScheme: Appearance.ColorSchemeOverride;
+  setReactColorScheme: (val: Appearance.ColorSchemeOverride) => void;
 }>({
   hostColorScheme: 'inherit',
   setHostColorScheme: () => {},
+  reactColorScheme: 'auto',
+  setReactColorScheme: () => {},
 });
 
-function ConfigScreen() {
-  const { push, setRouteOptions, routeKey } = useStackNavigationContext();
-  const { hostColorScheme, setHostColorScheme } = useContext(HostConfigContext);
-
-  const [reactColorScheme, setReactColorScheme] =
-    useState<Appearance.ColorSchemeOverride>('auto');
-  const [headerColorScheme, setHeaderColorScheme] =
-    useState<StackHostColorScheme>('inherit');
-
-  useEffect(() => {
-    Appearance.setColorScheme(reactColorScheme);
-  }, [reactColorScheme]);
-
-  const headerConfig = useMemo<StackHeaderConfigProps>(() => {
-    return {
-      title: 'Config',
-      android: {
-        // colorScheme:
-        //   headerColorScheme === 'inherit' ? undefined : headerColorScheme,
-      },
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- per-header colorScheme not implemented yet
-  }, [headerColorScheme]);
-
-  useEffect(() => {
-    setRouteOptions(routeKey, { headerConfig });
-  }, [headerConfig, setRouteOptions, routeKey]);
+// Rendered on every screen so the scheme can be changed without navigating back.
+function ColorSchemePickers() {
+  const {
+    hostColorScheme,
+    setHostColorScheme,
+    reactColorScheme,
+    setReactColorScheme,
+  } = useContext(ColorSchemeContext);
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <View style={styles.section}>
-        <Text style={styles.text}>
-          Sources of color scheme in ascending order of precedence: system,
-          React Native, StackHost prop, and (on Android) the headerConfig prop.
-        </Text>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.heading}>System color scheme</Text>
-        <Text style={styles.text}>
-          Switch system color scheme via quick settings in notification drawer
-          (Android/iOS) or Cmd+Shift+A (iOS simulator).
-        </Text>
-      </View>
-
+    <>
       <View style={styles.section}>
         <Text style={styles.heading}>React Native's color scheme</Text>
         <SettingsPicker<Appearance.ColorSchemeOverride>
@@ -101,33 +75,194 @@ function ConfigScreen() {
           items={['inherit', 'light', 'dark']}
         />
       </View>
+    </>
+  );
+}
 
-      {Platform.OS === 'android' && (
-        <View style={styles.section}>
-          <Text style={styles.heading}>
-            Header config override (NOT IMPLEMENTED YET)
-          </Text>
-          <SettingsPicker<StackHostColorScheme>
-            label={'headerConfig.android.colorScheme'}
-            value={headerColorScheme}
-            onValueChange={setHeaderColorScheme}
-            items={['inherit', 'light', 'dark']}
-          />
-        </View>
-      )}
+function buildToolbarMenu(
+  onGroupChange: (groupId: string, selectedIds: string[]) => void,
+): StackHeaderToolbarMenuBaseAndroid {
+  return {
+    groups: [
+      {
+        groupId: 'filters',
+        onSelectionChange: ids => onGroupChange('filters', ids),
+      },
+      {
+        groupId: 'sort',
+        singleSelection: true,
+        onSelectionChange: ids => onGroupChange('sort', ids),
+      },
+    ],
+    children: [
+      {
+        type: 'menuItem',
+        id: 'textAction',
+        title: 'Text',
+        showAsAction: 'always',
+        onPress: () => {},
+      },
+      {
+        type: 'menuItem',
+        id: 'iconAction',
+        title: 'Icon',
+        showAsAction: 'always',
+        icon: {
+          type: 'imageSource',
+          imageSource: require('@assets/trees.jpg'),
+        },
+        onPress: () => {},
+      },
+      {
+        type: 'menuItem',
+        id: 'filterA',
+        title: 'Filter A',
+        groupId: 'filters',
+        initialToggleState: true,
+      },
+      {
+        type: 'menuItem',
+        id: 'filterB',
+        title: 'Filter B',
+        groupId: 'filters',
+      },
+      {
+        type: 'menuItem',
+        id: 'sortAsc',
+        title: 'Sort ascending',
+        groupId: 'sort',
+        initialToggleState: true,
+      },
+      {
+        type: 'menuItem',
+        id: 'sortDesc',
+        title: 'Sort descending',
+        groupId: 'sort',
+      },
+    ],
+  };
+}
+
+function ConfigScreen() {
+  const { push, setRouteOptions, routeKey } = useStackNavigationContext();
+
+  const [headerType, setHeaderType] = useState<StackHeaderTypeAndroid>('small');
+  const [lastSelection, setLastSelection] = useState<string | null>(null);
+
+  const headerConfigRef = useRef<StackHeaderConfigRef>(null);
+  const iconSeedRef = useRef(0);
+
+  const handleGroupChange = useCallback(
+    (groupId: string, selectedIds: string[]) => {
+      setLastSelection(`${groupId}: ${JSON.stringify(selectedIds)}`);
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    setRouteOptions(routeKey, {
+      headerConfig: {
+        title: 'Config',
+        subtitle: 'Color scheme test',
+        android: {
+          type: headerType,
+          scrollFlagScroll: true,
+          scrollFlagExitUntilCollapsed: true,
+          toolbarMenu: buildToolbarMenu(handleGroupChange),
+        },
+      },
+      headerConfigRef,
+    });
+  }, [setRouteOptions, routeKey, headerType, handleGroupChange]);
+
+  const loadRemoteIcon = useCallback(() => {
+    iconSeedRef.current += 1;
+    headerConfigRef.current?.android?.updateToolbarMenuElements({
+      id: 'iconAction',
+      options: {
+        icon: {
+          type: 'imageSource',
+          imageSource: {
+            uri: `https://picsum.photos/seed/rns-color-scheme-${iconSeedRef.current}/128`,
+          },
+        },
+      },
+    });
+  }, []);
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      nestedScrollEnabled>
+      <View style={styles.section}>
+        <Text style={styles.text}>
+          Sources of color scheme in ascending order of precedence: system,
+          React Native, StackHost prop.
+        </Text>
+      </View>
 
       <View style={styles.section}>
-        <Button title="Push Keyboard Screen" onPress={() => push('Keyboard')} />
+        <Text style={styles.heading}>System color scheme</Text>
+        <Text style={styles.text}>
+          Switch system color scheme via quick settings in notification drawer
+          (Android/iOS) or Cmd+Shift+A (iOS simulator).
+        </Text>
       </View>
+
+      <ColorSchemePickers />
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>Header type (Android)</Text>
+        <SettingsPicker<StackHeaderTypeAndroid>
+          label={'type'}
+          value={headerType}
+          onValueChange={setHeaderType}
+          items={['small', 'medium', 'large']}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>Back button</Text>
+        <Button title="Push Details" onPress={() => push('Details')} />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>Toolbar menu (Android)</Text>
+        <Text style={styles.text}>
+          Change checkbox/radio selection in the overflow menu, load a remote
+          icon, then change the color scheme and observe what the toolbar menu
+          keeps.
+        </Text>
+        <Text style={styles.text}>
+          Last selection: {lastSelection ?? 'none yet'}
+        </Text>
+        <Button
+          title="Load remote icon (imperative)"
+          onPress={loadRemoteIcon}
+        />
+      </View>
+
+      <TextInput placeholder="Type something..." style={styles.input} />
+
+      <LongText size="xl" />
     </ScrollView>
   );
 }
 
-function TestScreen() {
+function DetailsScreen() {
   return (
-    <View style={styles.containerCenter}>
-      <TextInput placeholder="Type something..." style={styles.input} />
-    </View>
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <View style={styles.section}>
+        <Text style={styles.text}>
+          Change the color scheme here and watch the back arrow, then navigate
+          back — the Config header must already use the new palette when it
+          shows up.
+        </Text>
+      </View>
+
+      <ColorSchemePickers />
+    </ScrollView>
   );
 }
 
@@ -137,11 +272,12 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
     element: <ConfigScreen />,
   },
   {
-    name: 'Keyboard',
-    element: <TestScreen />,
+    name: 'Details',
+    element: <DetailsScreen />,
     options: {
       headerConfig: {
-        title: 'Keyboard',
+        title: 'Details',
+        subtitle: 'Back button',
       },
     },
   },
@@ -150,25 +286,32 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
 function TestStackColorScheme() {
   const [hostColorScheme, setHostColorScheme] =
     useState<StackHostColorScheme>('inherit');
+  const [reactColorScheme, setReactColorScheme] =
+    useState<Appearance.ColorSchemeOverride>('auto');
+
+  useEffect(() => {
+    Appearance.setColorScheme(reactColorScheme);
+  }, [reactColorScheme]);
 
   return (
-    <HostConfigContext.Provider value={{ hostColorScheme, setHostColorScheme }}>
+    <ColorSchemeContext.Provider
+      value={{
+        hostColorScheme,
+        setHostColorScheme,
+        reactColorScheme,
+        setReactColorScheme,
+      }}>
       <StackContainer
         routeConfigs={ROUTE_CONFIGS}
         colorScheme={hostColorScheme}
       />
-    </HostConfigContext.Provider>
+    </ColorSchemeContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  containerCenter: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
     backgroundColor: Colors.cardBackground,
   },
   content: {
@@ -178,7 +321,6 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
     marginBottom: 5,
-    color: 'rgb(0, 122, 255)',
   },
   section: {
     marginBottom: 20,
@@ -191,7 +333,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'gray',
     padding: 10,
-    width: '80%',
+    marginBottom: 20,
     borderRadius: 5,
   },
 });

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
@@ -1,0 +1,199 @@
+import {
+  Appearance,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Button,
+} from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+} from 'react';
+import { SettingsPicker } from '@apps/shared';
+import {
+  StackContainer,
+  useStackNavigationContext,
+  type StackRouteConfig,
+} from '@apps/shared/containers/stack';
+import type {
+  StackHeaderConfigProps,
+  StackHostColorScheme,
+} from 'react-native-screens';
+import { Colors } from '@apps/shared/styling';
+
+const HostConfigContext = createContext<{
+  hostColorScheme: StackHostColorScheme;
+  setHostColorScheme: (val: StackHostColorScheme) => void;
+}>({
+  hostColorScheme: 'inherit',
+  setHostColorScheme: () => {},
+});
+
+function ConfigScreen() {
+  const { push, setRouteOptions, routeKey } = useStackNavigationContext();
+  const { hostColorScheme, setHostColorScheme } = useContext(HostConfigContext);
+
+  const [reactColorScheme, setReactColorScheme] =
+    useState<Appearance.ColorSchemeOverride>('auto');
+  const [headerColorScheme, setHeaderColorScheme] =
+    useState<StackHostColorScheme>('inherit');
+
+  useEffect(() => {
+    Appearance.setColorScheme(reactColorScheme);
+  }, [reactColorScheme]);
+
+  const headerConfig = useMemo<StackHeaderConfigProps>(() => {
+    return {
+      title: 'Config',
+      android: {
+        // colorScheme:
+        //   headerColorScheme === 'inherit' ? undefined : headerColorScheme,
+      },
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- per-header colorScheme not implemented yet
+  }, [headerColorScheme]);
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <View style={styles.section}>
+        <Text style={styles.text}>
+          Sources of color scheme in ascending order of precedence: system,
+          React Native, StackHost prop, and (on Android) the headerConfig prop.
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>System color scheme</Text>
+        <Text style={styles.text}>
+          Switch system color scheme via quick settings in notification drawer
+          (Android/iOS) or Cmd+Shift+A (iOS simulator).
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>React Native's color scheme</Text>
+        <SettingsPicker<Appearance.ColorSchemeOverride>
+          label={'colorScheme'}
+          value={reactColorScheme}
+          onValueChange={setReactColorScheme}
+          items={['auto', 'light', 'dark']}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>StackHost color scheme</Text>
+        <SettingsPicker<StackHostColorScheme>
+          label={'colorScheme'}
+          value={hostColorScheme}
+          onValueChange={setHostColorScheme}
+          items={['inherit', 'light', 'dark']}
+        />
+      </View>
+
+      {Platform.OS === 'android' && (
+        <View style={styles.section}>
+          <Text style={styles.heading}>
+            Header config override (NOT IMPLEMENTED YET)
+          </Text>
+          <SettingsPicker<StackHostColorScheme>
+            label={'headerConfig.android.colorScheme'}
+            value={headerColorScheme}
+            onValueChange={setHeaderColorScheme}
+            items={['inherit', 'light', 'dark']}
+          />
+        </View>
+      )}
+
+      <View style={styles.section}>
+        <Button title="Push Keyboard Screen" onPress={() => push('Keyboard')} />
+      </View>
+    </ScrollView>
+  );
+}
+
+function TestScreen() {
+  return (
+    <View style={styles.containerCenter}>
+      <TextInput placeholder="Type something..." style={styles.input} />
+    </View>
+  );
+}
+
+const ROUTE_CONFIGS: StackRouteConfig[] = [
+  {
+    name: 'Config',
+    element: <ConfigScreen />,
+  },
+  {
+    name: 'Keyboard',
+    element: <TestScreen />,
+    options: {
+      headerConfig: {
+        title: 'Keyboard',
+      },
+    },
+  },
+];
+
+function TestStackColorScheme() {
+  const [hostColorScheme, setHostColorScheme] =
+    useState<StackHostColorScheme>('inherit');
+
+  return (
+    <HostConfigContext.Provider value={{ hostColorScheme, setHostColorScheme }}>
+      <StackContainer
+        routeConfigs={ROUTE_CONFIGS}
+        colorScheme={hostColorScheme}
+      />
+    </HostConfigContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  containerCenter: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 20,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 5,
+    color: 'rgb(0, 122, 255)',
+  },
+  section: {
+    marginBottom: 20,
+  },
+  text: {
+    color: 'gray',
+    marginBottom: 10,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: 'gray',
+    padding: 10,
+    width: '80%',
+    borderRadius: 5,
+  },
+});
+
+export default createScenario(TestStackColorScheme, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/index.tsx
@@ -291,6 +291,8 @@ function TestStackColorScheme() {
 
   useEffect(() => {
     Appearance.setColorScheme(reactColorScheme);
+
+    return () => Appearance.setColorScheme('auto');
   }, [reactColorScheme]);
 
   return (

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Color Scheme',
   key: 'test-stack-color-scheme',
   details:
-    'Tests how the stack handles system, React Native, StackHost, and header config color schemes.',
+    'Tests how the stack handles system, React Native, and StackHost color schemes.',
   platforms: ['android'], // TODO: add iOS
   e2eCoverage: 'incomplete',
   smokeTest: true,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Color Scheme',
+  key: 'test-stack-color-scheme',
+  details:
+    'Tests how the stack handles system, React Native, StackHost, and header config color schemes.',
+  platforms: ['android'], // TODO: add iOS
+  e2eCoverage: 'incomplete',
+  smokeTest: true,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
@@ -2,7 +2,12 @@
 
 ## Details
 
-**Description:** Verifies the `colorScheme` prop behavior on `StackHost` and `headerConfig`, ensuring the stack correctly inherits or overrides the system and React Native appearance settings. The test validates real-time UI updates across light, dark, and inherited modes on both iOS and Android, including the Android-specific header override capability.
+**Description:** Verifies the `colorScheme` prop behavior on `StackHost`:
+that it takes precedence over the system and React Native appearance
+settings, and that the whole header — background, title, subtitle, toolbar
+menu, default icons, ripples and the overflow popup — re-themes on every
+source path, without losing content scroll position or a fully collapsed
+header.
 
 **OS test creation version:** Android: API Level 37.
 
@@ -10,85 +15,167 @@
 
 ## E2E test
 
-Incomplete: Not automated. Detox does not have access to color attributes natively, making it impossible to reliably verify if the native header color has changed in response to a style update.
+Incomplete: Not automated. Detox does not have access to color attributes
+natively, making it impossible to reliably verify if the native header color
+has changed in response to a style update.
 
 ## Prerequisites
 
-<!--- iOS device/simulator (use Cmd+Shift+A to toggle appearance on simulator)-->
+<!--- iOS device/simulator (use Cmd+Shift+A to toggle appearance on the
+      simulator)-->
 
-- Android emulator (use CLI):
+- Android emulator or device, API Level 34 or newer (some icon staleness
+  regressions only reproduce on Android 14+).
+- System color scheme is switched either from quick settings or via CLI:
   - `adb shell "cmd uimode night yes"`
   - `adb shell "cmd uimode night no"`
 
 ## Note
 
 - Color Scheme isn't currently supported on iOS.
-- Each of the below steps must be executed twice: once with a system color scheme setting, and once with the color scheme forced via the React Native API.
-- For React Native settings, use the toggle displayed on the test screen.
-
-Assumption:
-
-- System and RN color scheme settings are working correctly.
-- Here only the `colorScheme` props on `StackHost` and `headerConfig` are tested, verified against different system/RN combinations.
+- There are three sources of the color scheme, in ascending order of
+  precedence: system, React Native `Appearance`, `StackHost` prop. The last
+  two are changed with the pickers rendered on every screen of this test.
+- An effective color scheme change rebuilds the header natively. The
+  following are expected results of that, not bugs:
+  - **KI-1 (menu state):** checkbox/radio selections and the results of
+    imperative `updateToolbarMenuElements` calls are discarded — the same
+    semantics as a `toolbarMenu` prop change. Icons declared in props,
+    including already resolved remote ones, survive.
+  - **KI-2 (collapse):** a fully collapsed header stays collapsed; any
+    other offset resets to expanded. Content scroll position is kept in
+    both cases.
+- The **trees** icon action item is a bundled photo and is deliberately
+  palette-independent — it must look the same in both schemes. It is there
+  to show which icons survive a rebuild (KI-1), not to test tinting.
+- Section **B** is executed three times, once per color scheme source. The
+  remaining sections are executed once, with any source.
 
 ## Steps
 
-### Baseline
+### A. Precedence
 
 1. Launch the app and navigate to the **Stack Color Scheme** screen.
 
-- [ ] Config screen is shown. Pickers default to `auto` / `inherit`.
+- [ ] Config screen is shown. Pickers default to `auto` / `inherit` /
+      `small`.
+- [ ] The header shows the title, subtitle, a **Text** action item, the
+      trees icon action item and the overflow button, in the current system
+      palette.
+
+2. With StackHost colorScheme = `inherit`, set the React Native picker to
+   `light`, then to `dark`.
+
+- [ ] The header follows React Native in both cases — StackHost defers to
+      it.
+
+3. Keep React Native = `dark` and set StackHost = `light`. Then set React
+   Native = `light` and StackHost = `dark`.
+
+- [ ] The header follows StackHost in both cases — the prop overrides React
+      Native and the system.
+
+4. Set StackHost = `inherit`, React Native = `auto`, then toggle the system
+   color scheme.
+
+- [ ] The header follows the system.
 
 ---
 
-### StackHost `inherit` — follows RN/system
+### B. Everything re-themes
 
-2. Set system/RN to **light**, StackHost colorScheme = `inherit`
+Executed with header type `small`. Execute steps 5–9 three times: once
+changing the scheme from the system, once with the React Native picker and
+once with the StackHost picker, leaving the other two sources at `auto` /
+`inherit`.
 
-- [ ] Header background appears in **light** mode styling.
+5. Cycle the scheme light → dark → light with the chosen source, checking
+   the header after **each** change.
 
-3. Set system/RN to **dark**, keep StackHost colorScheme = `inherit`
+- [ ] Header background, including the status bar area behind it, and the
+      title and subtitle adapt.
+- [ ] The **Text** action item label color adapts.
+- [ ] The overflow button icon adapts — the return to light is the case that
+      catches a stale icon.
+- [ ] The trees icon action item looks the same (see Note).
+- [ ] No crash, flicker or layout freeze on any change.
 
-- [ ] Header appears in **dark** mode styling — StackHost defers to RN/system.
+6. Press and hold the overflow button.
 
----
+- [ ] The ripple color matches the current scheme.
 
-### StackHost `light` / `dark` — overrides RN/system
+7. Open the overflow menu.
 
-4. Set system/RN to **dark**, set StackHost colorScheme = `light`
+- [ ] The popup background, item titles and checkbox marks match the current
+      scheme.
 
-- [ ] Header appears **light** — StackHost overrides dark from RN/system.
+8. Tap **Push Details**, then change the color scheme with the same source.
 
-5. Set system/RN to **light**, set StackHost colorScheme = `dark`
+- [ ] The back arrow icon, title, subtitle and background adapt.
+- [ ] Pressing and holding the back arrow shows a ripple matching the
+      current scheme.
 
-- [ ] Header appears **dark** — StackHost overrides light from RN/system.
+9. Navigate back to **Config**.
 
-6. Cycle StackHost through `inherit` → `dark` → `light` → `inherit`
-
-- [ ] Stack header color scheme updates immediately with each change, with no crashes or layout freezing.
-
----
-
-### HeaderConfig override (Android only)
-
-7. Set system/RN to **light** and StackHost to **light**.
-8. Set the Header config override to **dark**.
-
-- [ ] The stack header appears **dark**, overriding the StackHost and RN/system settings.
-
-9. Set StackHost to **dark**, and Header config override to **light**.
-
-- [ ] The stack header appears **light**.
-
-10. Set the Header config override back to **inherit**.
-
-- [ ] The stack header reverts to matching the StackHost setting (**dark**).
+- [ ] The Config header already uses the current palette when it shows up —
+      no flash of the previous one.
 
 ---
 
-### Keyboard screen — simple check
+### C. Collapsing header
 
-11. Tap **Push Keyboard Screen**, open the keyboard via the TextInput (or Cmd+K on iOS simulator)
+Executed once, with the React Native or StackHost picker — a pin-driven
+change is the stricter path. A collapsing header renders its title and
+subtitle in four separate slots (expanded and collapsed) and takes its
+scrolled color from the content scrim, none of which the `small` header
+exercises.
 
-- [ ] iOS: Keyboard appearance matches the currently active color scheme (verify for both light and dark RN/System values).
-- [ ] Android: Keyboard appearance matches the system color scheme.
+10. Set header type to `medium` and change the color scheme with the header
+    **expanded**.
+
+- [ ] The expanded title and subtitle adapt, together with the header
+      background.
+
+11. Scroll the content until the header is **fully** collapsed, then change
+    the color scheme.
+
+- [ ] The collapsed title and subtitle adapt, together with the scrolled
+      background and the status bar area behind it.
+- [ ] The header stays fully collapsed and the content scroll position is
+      unchanged.
+
+12. Set header type to `large` and repeat step 10.
+
+- [ ] Same result — only the title and subtitle sizes differ from `medium`.
+
+---
+
+### D. Toolbar menu state across a color scheme change
+
+13. In the overflow menu check **Filter B** and select **Sort descending**,
+    close the menu, then tap **Load remote icon (imperative)** and wait for
+    the trees icon to be replaced by the downloaded image.
+
+- [ ] The **Last selection** line reflects both groups and the icon action
+      item shows the remote image.
+
+14. Change the color scheme, then open the overflow menu.
+
+- [ ] Selections are back to the initial config — **Filter A**, **Sort
+      ascending** (KI-1).
+- [ ] The icon action item shows the bundled trees image again — the
+      imperative update is discarded while the prop icon survives (KI-1).
+
+---
+
+### E. Keyboard
+
+15. Open the keyboard via the TextInput on the Config screen.
+<!--- (or Cmd+K on iOS simulator) -->
+
+<!--- [ ] iOS: Keyboard appearance matches the currently active color scheme
+      (verify for both light and dark RN/System values).-->
+
+- [ ] Android: Keyboard appearance matches the system color scheme,
+      regardless of the React Native and StackHost values — the header's
+      color scheme does not affect it.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
@@ -156,8 +156,8 @@ exercises.
     close the menu, then tap **Load remote icon (imperative)** and wait for
     the trees icon to be replaced by the downloaded image.
 
-- [ ] The **Last selection** line reflects both groups and the icon action
-      item shows the remote image.
+- [ ] The **Last selection** line reflects last group selection change and the
+      icon action item shows the remote image.
 
 14. Change the color scheme, then open the overflow menu.
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-color-scheme/scenario.md
@@ -1,0 +1,94 @@
+# Test Scenario: colorScheme
+
+## Details
+
+**Description:** Verifies the `colorScheme` prop behavior on `StackHost` and `headerConfig`, ensuring the stack correctly inherits or overrides the system and React Native appearance settings. The test validates real-time UI updates across light, dark, and inherited modes on both iOS and Android, including the Android-specific header override capability.
+
+**OS test creation version:** Android: API Level 37.
+
+<!-- TODO: add iOS versions-->
+
+## E2E test
+
+Incomplete: Not automated. Detox does not have access to color attributes natively, making it impossible to reliably verify if the native header color has changed in response to a style update.
+
+## Prerequisites
+
+<!--- iOS device/simulator (use Cmd+Shift+A to toggle appearance on simulator)-->
+
+- Android emulator (use CLI):
+  - `adb shell "cmd uimode night yes"`
+  - `adb shell "cmd uimode night no"`
+
+## Note
+
+- Color Scheme isn't currently supported on iOS.
+- Each of the below steps must be executed twice: once with a system color scheme setting, and once with the color scheme forced via the React Native API.
+- For React Native settings, use the toggle displayed on the test screen.
+
+Assumption:
+
+- System and RN color scheme settings are working correctly.
+- Here only the `colorScheme` props on `StackHost` and `headerConfig` are tested, verified against different system/RN combinations.
+
+## Steps
+
+### Baseline
+
+1. Launch the app and navigate to the **Stack Color Scheme** screen.
+
+- [ ] Config screen is shown. Pickers default to `auto` / `inherit`.
+
+---
+
+### StackHost `inherit` — follows RN/system
+
+2. Set system/RN to **light**, StackHost colorScheme = `inherit`
+
+- [ ] Header background appears in **light** mode styling.
+
+3. Set system/RN to **dark**, keep StackHost colorScheme = `inherit`
+
+- [ ] Header appears in **dark** mode styling — StackHost defers to RN/system.
+
+---
+
+### StackHost `light` / `dark` — overrides RN/system
+
+4. Set system/RN to **dark**, set StackHost colorScheme = `light`
+
+- [ ] Header appears **light** — StackHost overrides dark from RN/system.
+
+5. Set system/RN to **light**, set StackHost colorScheme = `dark`
+
+- [ ] Header appears **dark** — StackHost overrides light from RN/system.
+
+6. Cycle StackHost through `inherit` → `dark` → `light` → `inherit`
+
+- [ ] Stack header color scheme updates immediately with each change, with no crashes or layout freezing.
+
+---
+
+### HeaderConfig override (Android only)
+
+7. Set system/RN to **light** and StackHost to **light**.
+8. Set the Header config override to **dark**.
+
+- [ ] The stack header appears **dark**, overriding the StackHost and RN/system settings.
+
+9. Set StackHost to **dark**, and Header config override to **light**.
+
+- [ ] The stack header appears **light**.
+
+10. Set the Header config override back to **inherit**.
+
+- [ ] The stack header reverts to matching the StackHost setting (**dark**).
+
+---
+
+### Keyboard screen — simple check
+
+11. Tap **Push Keyboard Screen**, open the keyboard via the TextInput (or Cmd+K on iOS simulator)
+
+- [ ] iOS: Keyboard appearance matches the currently active color scheme (verify for both light and dark RN/System values).
+- [ ] Android: Keyboard appearance matches the system color scheme.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/index.tsx
@@ -1,6 +1,5 @@
 import {
   Appearance,
-  ColorSchemeName,
   Platform,
   ScrollView,
   StyleSheet,
@@ -23,7 +22,7 @@ import {
 function ConfigScreen() {
   const { hostConfig, updateHostConfig } = useTabsHostConfig();
   const [reactColorScheme, setReactColorScheme] =
-    React.useState<ColorSchemeName>('unspecified');
+    React.useState<Appearance.ColorSchemeOverride>('auto');
 
   useEffect(() => {
     Appearance.setColorScheme(reactColorScheme);
@@ -48,13 +47,15 @@ function ConfigScreen() {
 
       <View style={styles.section}>
         <Text style={styles.heading}>React Native's color scheme</Text>
-        <SettingsPicker<ColorSchemeName>
+        <SettingsPicker<Appearance.ColorSchemeOverride>
           label={'colorScheme'}
           value={reactColorScheme}
-          onValueChange={function (value: ColorSchemeName): void {
+          onValueChange={function (
+            value: Appearance.ColorSchemeOverride,
+          ): void {
             setReactColorScheme(value);
           }}
-          items={['unspecified', 'light', 'dark']}
+          items={['auto', 'light', 'dark']}
         />
       </View>
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
@@ -33,7 +33,7 @@ Assumption:
 
 1. Launch the app and navigate to the **Tab Bar Color Scheme** screen.
 
-- [ ] Config tab is shown. Pickers default to `unspecified` / `inherit`
+- [ ] Config tab is shown. Pickers default to `auto` / `inherit`
 
 ---
 

--- a/src/components/stack/header/StackHeaderConfig.android.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.android.types.ts
@@ -481,9 +481,10 @@ export interface StackHeaderConfigCommandsAndroid {
    * @remarks
    * Updates are applied to the live toolbar: they take effect only while the
    * header is shown, and are discarded whenever the menu is rebuilt from the
-   * `toolbarMenu` prop — whether by a prop change or a structural change such
-   * as hiding and re-showing the header. They persist across unrelated
-   * re-renders. An update whose `id` is not in the current menu is ignored.
+   * `toolbarMenu` prop — whether by a prop change, a structural change such
+   * as hiding and re-showing the header, or an effective color scheme change.
+   * They persist across unrelated re-renders. An update whose `id` is not in
+   * the current menu is ignored.
    *
    * @param updates A single update object or an array of updates.
    */

--- a/src/components/stack/host/StackHost.tsx
+++ b/src/components/stack/host/StackHost.tsx
@@ -6,9 +6,11 @@ import type { StackHostProps } from './StackHost.types';
 /**
  * EXPERIMENTAL API, MIGHT CHANGE W/O ANY NOTICE
  */
-function StackHost({ children, ref }: StackHostProps) {
+function StackHost(props: StackHostProps) {
+  const { children, ref, ...restProps } = props;
+
   return (
-    <StackHostNativeComponent ref={ref} style={styles.container}>
+    <StackHostNativeComponent ref={ref} style={styles.container} {...restProps}>
       {children}
     </StackHostNativeComponent>
   );

--- a/src/components/stack/host/StackHost.types.ts
+++ b/src/components/stack/host/StackHost.types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { HostInstance, ViewProps } from 'react-native';
 import { type NativeProps } from '../../../fabric/stack/StackHostNativeComponent';
-import { ColorScheme } from '../../shared/types';
+import type { ColorScheme } from '../../shared/types';
 
 export type StackHostColorScheme = ColorScheme | 'inherit';
 
@@ -24,8 +24,10 @@ export type StackHostProps = {
    * @remarks
    * Color scheme isn't currently supported on iOS.
    *
-   * On Android, when the effective color scheme changes, the header is rebuilt
-   * which restores initial selection and changes applied via view commands.
+   * On Android, changing the effective color scheme rebuilds the header. The
+   * toolbar menu is rebuilt from the `toolbarMenu` prop, so its initial
+   * selection is restored and any changes applied via the
+   * `updateToolbarMenuElements` view command are discarded.
    *
    * @default inherit
    *

--- a/src/components/stack/host/StackHost.types.ts
+++ b/src/components/stack/host/StackHost.types.ts
@@ -24,6 +24,9 @@ export type StackHostProps = {
    * @remarks
    * Color scheme isn't currently supported on iOS.
    *
+   * On Android, when the effective color scheme changes, the header is rebuilt
+   * which restores initial selection and changes applied via view commands.
+   *
    * @default inherit
    *
    * @platform android

--- a/src/components/stack/host/StackHost.types.ts
+++ b/src/components/stack/host/StackHost.types.ts
@@ -1,11 +1,32 @@
 import React from 'react';
 import type { HostInstance, ViewProps } from 'react-native';
 import { type NativeProps } from '../../../fabric/stack/StackHostNativeComponent';
+import { ColorScheme } from '../../shared/types';
+
+export type StackHostColorScheme = ColorScheme | 'inherit';
 
 export type StackHostProps = {
+  // General
   children: NonNullable<ViewProps['children']>;
   // TODO: Work on these types
   ref?:
     | React.RefObject<(React.Component<NativeProps> & HostInstance) | null>
     | undefined;
+  /**
+   * @summary Specifies the color scheme used by the container and any child
+   * containers.
+   *
+   * The following values are currently supported:
+   * - `inherit` - the interface style from parent,
+   * - `light` - the light interface style,
+   * - `dark` - the dark interface style.
+   *
+   * @remarks
+   * Color scheme isn't currently supported on iOS.
+   *
+   * @default inherit
+   *
+   * @platform android
+   */
+  colorScheme?: StackHostColorScheme | undefined;
 };

--- a/src/components/stack/index.ts
+++ b/src/components/stack/index.ts
@@ -2,7 +2,7 @@ import { StackHost } from './host';
 import { StackScreen } from './screen';
 import { StackHeaderConfig } from './header';
 
-export type { StackHostProps } from './host';
+export type { StackHostProps, StackHostColorScheme } from './host';
 
 export type {
   OnDismissEventPayload,

--- a/src/fabric/stack/StackHostNativeComponent.ts
+++ b/src/fabric/stack/StackHostNativeComponent.ts
@@ -1,9 +1,18 @@
 'use client';
 
-import type { HostComponent, ViewProps } from 'react-native';
+import type {
+  HostComponent,
+  ViewProps,
+  CodegenTypes as CT,
+} from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
-export interface NativeProps extends ViewProps {}
+type StackHostColorScheme = 'inherit' | 'light' | 'dark';
+
+export interface NativeProps extends ViewProps {
+  // General
+  colorScheme?: CT.WithDefault<StackHostColorScheme, 'inherit'>;
+}
 
 export default codegenNativeComponent<NativeProps>(
   'RNSStackHost',


### PR DESCRIPTION
## Description

Adds support for configuring host-level color scheme of the Stack. Color scheme propagation works with Tabs as well.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1748.

### Details

#### Source of color scheme configuration

In Tabs, the tab bar is a part of the container on both platforms. That's why color scheme configuration is exposed only on the Host component. 

For Stack, it's different between the platforms. On iOS, `UINavigationBar` (and `UIToolbar`) are also part of the `UINavigationController` but on Android each screen has its own independent `AppBarLayout`. There are no views which are a part of the container that would require adaptation to color scheme.

We decided for now to expose the same configuration (host-level) for Android implementation, same as Tabs for API consistency. All screens inside the `StackContainer` will use the theme resolved by the container. In the future, we plan to expose per-screen/per-header-config configuration as well (https://github.com/software-mansion/react-native-screens-labs/issues/1749). 

Something that might be worth considering is whether iOS implementation of Tabs and Stack might also use screen-level configuration - it shouldn't impact shared views like navigation bar or tab bar but on iOS this might influence e.g. keyboard appearance.

#### `StackScreenFragment` <-> `StackContainer` communication

When appearance is modified by `react-native`'s `Appearance` module, only fragments are informed about configuration change; views don't receive it (more details: https://github.com/software-mansion/react-native-screens/pull/3167). That's why `StackScreenFragment`s need to inform `StackContainer` about a change (so that we're able to resolve correct system theme).

In Tabs, this information goes from `TabsScreenFragment` (native impl) to `TabsContainer` (native impl) via `TabsScreen` (React view). This isn't ideal because we're relying on React view to pass information that can belong fully on the native side.

<img width="5139" height="2508" alt="image" src="https://github.com/user-attachments/assets/43322dc9-178d-4eff-90d7-edc29f15653f" />

For Stack, we decided to keep it native-only by introducing `StackScreenFragmentDelegate` interface that will allow fragments to inform the delegate (`StackContainer`) about configuration change directly. Tabs implementation should be refactored in a similar way in the future.

#### `colorSchemeCoordinator` in `StackHeaderCoordinatorLayout`

Even though we currently don't expose per-screen/per-header-config configuration of the color scheme, I decided to re-use  `colorSchemeCoordinator` in `StackHeaderCoordinatorLayout`. By using it, we get color scheme propagation "for free" by making `StackHeaderCoordinatorLayout` `ColorSchemeProviding`. We modify the `wrappedContext`'s theme according to the coordinator. It will also make exposing screen-level config easier in the future. One minor detail: we don't need to receive `onConfigurationChange` calls from views not fragments because container-level coordinator will receive them and propagate the change to screens. System's color scheme is always resolved by top coordinator in the hierarchy so stale `systemUiNightMode` is not a problem.

#### Updating the color scheme of the header

Unfortunately, to fully adapt to new color scheme, we need to recreate the `MaterialToolbar` (which we can do by rebuilding the entire header). Otherwise, toolbar items and back button icon/overflow icon in the toolbar don't update their font and ripple color + the overflow menu remains in previous color scheme. This happens due to how `MaterialToolbar`'s internals copy the theme and don't fully react to theme change in the `wrappedContext`.

This however causes 2 problems:

1. Rebuilding the header expands the collapsing header. We already track if the header is fully collapsed (see https://github.com/software-mansion/react-native-screens/pull/4436) so we can use it to restore collapsed state. Currently, I added this only to the theme change. I think we can consider applying this fix on every rebuild but this requires some investigation - when scroll flags are changed, we want to reset the state and currently we do so by expanding the header unconditionally. Here's the internal ticket to track this: https://github.com/software-mansion/react-native-screens-labs/issues/1192.

2. Rebuilding the header clears the toolbar state which includes user's radio/checkbox selection and any updates applied via view commands. This is unacceptable but there doesn't seem to be a simple way to prevent this - we can't re-apply the menu from previous toolbar. This will require additional serialization/deserialization process - here's the internal ticket to track this: https://github.com/software-mansion/react-native-screens-labs/issues/1755.

#### Native-originating header update

In order to force header rebuild, for now I added `forcedFlags` which allow to bypass invalidation flags that live on the provider. But this isn't a clean solution - if in the future prop update causes a native color scheme update, we will apply the update twice - from color scheme coordinator's callback and then after React transaction - this is unnecessary. Also, while testing I found this related bug: https://github.com/software-mansion/react-native-screens-labs/issues/1756 - when Stack is nested in Tabs, if we change the tab and go back, header is not reconstructed. This happens because tab fragment is detached which results in view hierarchy being destroyed. When the view is recreated, invalidation flags on the provider remain empty which skips the entire header update. This should be handled in follow up PR. See the ticket for more details - I am considering refactoring the invalidation flags by moving them to the native implementation. I'm open for feedback here.

## Changes

- handle `colorScheme` prop on `StackHost`/`StackContainer` by adding `colorSchemeCoordinator` and implementing `ColorSchemeProviding`
- add `StackScreenFragmentDelegate` to inform `StackContainer` about configuration change in one of the fragments
- resolve text appearance from `wrappedContext` to handle correct color scheme
- resolve default icons from toolbar's context to work around cache bug
- add SFT

## Before & after - visual documentation

https://github.com/user-attachments/assets/0896a236-75ef-4035-9a86-19549929c7b6

## Test plan

Run `test-stack-color-scheme` SFT.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>