### PR TITLE
feat(Android, FormSheet v5): Support largestUndimmedDetentIndex

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/helpers/ContextExt.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/helpers/ContextExt.kt
@@ -1,0 +1,20 @@
+package com.swmansion.rnscreens.helpers
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import com.facebook.react.bridge.ReactContext
+
+internal fun Context.findHostActivity(): Activity? {
+    var current: Context? = this
+    while (current is ContextWrapper) {
+        if (current is Activity) {
+            return current
+        }
+        if (current is ReactContext) {
+            return current.currentActivity
+        }
+        current = current.baseContext
+    }
+    return null
+}

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
@@ -146,7 +146,7 @@ internal class FormSheetBehaviorController(
         peekHeight = detents.firstHeight(sheetAvailableSpace)
         maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
         if (applyInitialDetent) {
-            state = resolveStateFromIndex(initialDetentIndex, detents.count)
+            state = resolveStateFromIndex(detents, initialDetentIndex)
         }
     }
 
@@ -163,22 +163,21 @@ internal class FormSheetBehaviorController(
         expandedOffset = detents.expandedOffsetFromTop(sheetAvailableSpace)
         maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
         if (applyInitialDetent) {
-            state = resolveStateFromIndex(initialDetentIndex, detents.count)
+            state = resolveStateFromIndex(detents, initialDetentIndex)
         }
     }
 
     private fun resolveStateFromIndex(
-        index: Int,
-        detentsCount: Int,
+        detents: FormSheetDetents,
+        requestedIndex: Int,
     ): Int {
-        val resolvedIndex = if (index == FORM_SHEET_LAST_DETENT_INDEX) detentsCount - 1 else index
-        val safeIndex = resolvedIndex.coerceIn(0, detentsCount - 1)
+        val index = detents.resolveDetentIndex(requestedIndex)
 
-        return when (detentsCount) {
+        return when (detents.count) {
             1 -> BottomSheetBehavior.STATE_EXPANDED
-            2 -> if (safeIndex == 0) BottomSheetBehavior.STATE_COLLAPSED else BottomSheetBehavior.STATE_EXPANDED
+            2 -> if (index == 0) BottomSheetBehavior.STATE_COLLAPSED else BottomSheetBehavior.STATE_EXPANDED
             3 ->
-                when (safeIndex) {
+                when (index) {
                     0 -> BottomSheetBehavior.STATE_COLLAPSED
                     1 -> BottomSheetBehavior.STATE_HALF_EXPANDED
                     else -> BottomSheetBehavior.STATE_EXPANDED
@@ -208,6 +207,5 @@ internal class FormSheetBehaviorController(
 
     companion object {
         private const val FORM_SHEET_UNKNOWN_DETENT_INDEX = -1
-        private const val FORM_SHEET_LAST_DETENT_INDEX = -1
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
@@ -3,6 +3,8 @@ package com.swmansion.rnscreens.modals.formsheet.native.core
 import android.content.Context
 import android.view.ContextThemeWrapper
 import android.view.View
+import android.view.Window
+import com.swmansion.rnscreens.helpers.findHostActivity
 import com.swmansion.rnscreens.modals.formsheet.native.interfaces.FormSheetContentSizeChangeDelegate
 import com.swmansion.rnscreens.modals.formsheet.native.interfaces.FormSheetDialogEventEmitter
 import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetConfig
@@ -43,6 +45,10 @@ class FormSheetDialogManager(
             override fun onNativeDismissPrevented() {
                 eventEmitter?.emitOnNativeDismissPreventedEvent()
             }
+
+            override fun resolveWindowBelow(): Window? =
+                presentationManager.windowBelow()
+                    ?: context.findHostActivity()?.window
         }
 
     private val dimmingManager = FormSheetDimmingManager(context)

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
@@ -68,7 +68,7 @@ class FormSheetDialogManager(
         }
 
     private fun createPresentation(): FormSheetPresentation =
-        FormSheetPresentation(themedContext, container, presentationCallbacks).also {
+        FormSheetPresentation(themedContext, container, dimmingManager, presentationCallbacks).also {
             it.applyInitialConfig(formSheetConfig, lastContentHeight)
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetConfig.kt
@@ -5,6 +5,7 @@ internal data class FormSheetConfig(
     val detents: List<Double> = emptyList(),
     val prefersGrabberVisible: Boolean = false,
     val initialDetentIndex: Int = 0,
+    val largestUndimmedDetentIndex: Int = FormSheetDetents.ALWAYS_DIMMED_DETENT_INDEX,
     val preferredCornerRadius: Float = SYSTEM_DEFAULT_CORNER_RADIUS,
     val preventNativeDismiss: Boolean = false,
     val nativeContainerBackgroundColor: Int? = null,

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -1,5 +1,7 @@
 package com.swmansion.rnscreens.modals.formsheet.native.model
 
+import android.util.Log
+
 internal class FormSheetDetents(
     rawDetents: List<Double>,
 ) {
@@ -57,9 +59,31 @@ internal class FormSheetDetents(
         return (contentHeight + bottomInset).coerceAtMost(containerHeight)
     }
 
+    internal fun resolveDetentIndex(requestedIndex: Int): Int {
+        val resolvedIndex = if (requestedIndex == LAST_DETENT_INDEX) count - 1 else requestedIndex
+        return resolvedIndex.coerceIn(0, count - 1)
+    }
+
+    internal fun resolveLargestUndimmedDetentIndex(requestedIndex: Int): Int {
+        if (requestedIndex == ALWAYS_DIMMED_DETENT_INDEX) {
+            return ALWAYS_DIMMED_DETENT_INDEX
+        }
+
+        val resolvedIndex = if (requestedIndex == NEVER_DIMMED_DETENT_INDEX) count - 1 else requestedIndex
+        if (resolvedIndex !in 0 until count) {
+            Log.e(
+                TAG,
+                "[RNScreens] largestUndimmedDetentIndex ($requestedIndex) exceeds effective detents count ($count). " +
+                    "Falling back to the default behavior (always dimmed).",
+            )
+            return ALWAYS_DIMMED_DETENT_INDEX
+        }
+        return resolvedIndex
+    }
+
     internal fun halfExpandedRatio(): Float {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for halfExpandedRatio." }
-        return (heightFractionAt(1) / heightFractionAt(2)).toFloat()
+        return heightFractionAt(1).toFloat()
     }
 
     internal fun expandedOffsetFromTop(
@@ -100,7 +124,16 @@ internal class FormSheetDetents(
     }
 
     companion object {
+        const val TAG = "FormSheetDetents"
+
         const val MAX_DETENTS = 3
         const val FIT_TO_CONTENTS_DETENT_VALUE = -1.0
+
+        // Predefined values for `initialDetentIndex`. Keep in sync with the JS counterpart.
+        const val LAST_DETENT_INDEX = -1
+
+        // Predefined values for `largestUndimmedDetentIndex`. Keep in sync with the JS counterpart.
+        const val ALWAYS_DIMMED_DETENT_INDEX = -1
+        const val NEVER_DIMMED_DETENT_INDEX = -2
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
@@ -27,7 +27,7 @@ internal class FormSheetAnimatorFactory(
             }
 
         val alphaAnimator =
-            ValueAnimator.ofFloat(startAlpha, dimmingManager.maxAlpha).apply {
+            ValueAnimator.ofFloat(startAlpha, dimmingManager.presentationTargetAlpha).apply {
                 addUpdateListener { animation ->
                     dimmingManager.dimmingAlpha = animation.animatedValue as Float
                 }
@@ -45,7 +45,9 @@ internal class FormSheetAnimatorFactory(
         isInterrupting: Boolean = false,
     ): Animator {
         val startY = if (isInterrupting) view.translationY else 0f
-        val startAlpha = if (isInterrupting) dimmingManager.dimmingAlpha else dimmingManager.maxAlpha
+        // The dimming may rest at any value (e.g. 0 at an undimmed detent), so always fade out
+        // from the currently rendered one.
+        val startAlpha = dimmingManager.dimmingAlpha
 
         val slideAnimator =
             ValueAnimator.ofFloat(startY, view.height.toFloat()).apply {

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetBackdropTouchForwarder.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetBackdropTouchForwarder.kt
@@ -1,0 +1,103 @@
+package com.swmansion.rnscreens.modals.formsheet.native.presentation
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.View
+import android.view.Window
+
+/**
+ * Routes touches landing on the sheet's backdrop (Material's `touch_outside` view) to the window
+ * below while the backdrop is undimmed. A dimmed backdrop keeps Material's default handling, i.e.
+ * a tap cancels the Dialog.
+ *
+ * The routing is decided on ACTION_DOWN and kept for the whole gesture, so the window that
+ * received the DOWN also receives the matching MOVE / UP / CANCEL events.
+ */
+internal class FormSheetBackdropTouchForwarder(
+    private val backdropView: View,
+    private val isBackdropDimmed: () -> Boolean,
+    private val resolveWindowBelow: () -> Window?,
+) : View.OnTouchListener,
+    View.OnAttachStateChangeListener {
+    private var forwardingWindow: Window? = null
+    private var lastForwardedEvent: MotionEvent? = null
+
+    internal fun setup() {
+        backdropView.setOnTouchListener(this)
+        backdropView.addOnAttachStateChangeListener(this)
+    }
+
+    internal fun destroy() {
+        backdropView.setOnTouchListener(null)
+        backdropView.removeOnAttachStateChangeListener(this)
+        cancelForwardedGesture()
+    }
+
+    // Forwarded gestures intentionally bypass the backdrop's click handling.
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouch(
+        view: View,
+        event: MotionEvent,
+    ): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+            forwardingWindow = if (isBackdropDimmed()) null else resolveWindowBelow()
+        }
+        val window = forwardingWindow ?: return false
+
+        forwardTouch(event, window)
+
+        if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+            endForwardedGesture()
+        }
+        return true
+    }
+
+    override fun onViewAttachedToWindow(view: View) = Unit
+
+    // The dialog window is being torn down mid-gesture (e.g. the sheet got dismissed from JS);
+    // the target would otherwise never receive the end of the gesture.
+    override fun onViewDetachedFromWindow(view: View) = cancelForwardedGesture()
+
+    private fun forwardTouch(
+        event: MotionEvent,
+        window: Window,
+    ) {
+        val forwarded = MotionEvent.obtain(event)
+        // Both windows live in screen space; re-express the event relative to the target's decor.
+        val backdropOrigin = IntArray(2).also { backdropView.getLocationOnScreen(it) }
+        val targetOrigin = IntArray(2).also { window.decorView.getLocationOnScreen(it) }
+        forwarded.offsetLocation(
+            (backdropOrigin[0] - targetOrigin[0]).toFloat(),
+            (backdropOrigin[1] - targetOrigin[1]).toFloat(),
+        )
+        dispatch(forwarded, window)
+
+        lastForwardedEvent?.recycle()
+        lastForwardedEvent = forwarded
+    }
+
+    private fun cancelForwardedGesture() {
+        val window = forwardingWindow ?: return
+        lastForwardedEvent?.let { lastEvent ->
+            val cancelEvent = MotionEvent.obtain(lastEvent).apply { action = MotionEvent.ACTION_CANCEL }
+            dispatch(cancelEvent, window)
+            cancelEvent.recycle()
+        }
+        endForwardedGesture()
+    }
+
+    private fun endForwardedGesture() {
+        forwardingWindow = null
+        lastForwardedEvent?.recycle()
+        lastForwardedEvent = null
+    }
+
+    // Dispatching through the window callback (the Activity / Dialog) keeps their own hooks, e.g.
+    // Activity.onUserInteraction, in the loop. Falls back to the decor for callback-less windows.
+    private fun dispatch(
+        event: MotionEvent,
+        window: Window,
+    ) {
+        window.callback?.dispatchTouchEvent(event) ?: window.decorView.dispatchTouchEvent(event)
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetDimmingManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetDimmingManager.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.View
 import com.facebook.react.bridge.ReactContext
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 import kotlin.math.roundToInt
 
 internal class FormSheetDimmingManager(
@@ -19,6 +20,16 @@ internal class FormSheetDimmingManager(
 
     internal var isTransitionAnimationRunning: Boolean = false
 
+    private var sheetView: View? = null
+
+    private var detentsCount: Int = 1
+    private var largestUndimmedDetentIndex: Int = FormSheetDetents.ALWAYS_DIMMED_DETENT_INDEX
+    private var presentationDetentIndex: Int = 0
+
+    // The resting alpha of the detent the sheet is presented at. Used as the target of the enter transition.
+    internal val presentationTargetAlpha: Float
+        get() = if (presentationDetentIndex > largestUndimmedDetentIndex) maxAlpha else 0f
+
     // The drawable rendering this sheet's dimming, added to the overlay of dimmingHost which is
     // Material's `design_bottom_sheet` component or the DecorView of the main application content.
     private var dimmingDrawable: ColorDrawable? = null
@@ -27,6 +38,28 @@ internal class FormSheetDimmingManager(
     private val dimmingHostLayoutListener =
         View.OnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
             dimmingDrawable?.setBounds(0, 0, view.width, view.height)
+        }
+
+    private val bottomSheetCallback =
+        object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(
+                bottomSheet: View,
+                newState: Int,
+            ) = Unit
+
+            override fun onSlide(
+                bottomSheet: View,
+                slideOffset: Float,
+            ) {
+                // Prevent system updates from overriding alpha while running custom enter/exit animation.
+                // When initialDetentIndex is snapping to a high detent, BottomSheetBehavior fires onSlide
+                // events that conflict with our manual alpha animator, causing the backdrop to flash.
+                if (isTransitionAnimationRunning) {
+                    return
+                }
+
+                updateDimmingForSheetPosition()
+            }
         }
 
     internal var dimmingAlpha: Float = 0f
@@ -66,30 +99,83 @@ internal class FormSheetDimmingManager(
         dimmingDrawable = null
     }
 
-    internal fun attachToBehavior(behavior: BottomSheetBehavior<*>) {
-        behavior.addBottomSheetCallback(
-            object : BottomSheetBehavior.BottomSheetCallback() {
-                override fun onStateChanged(
-                    bottomSheet: View,
-                    newState: Int,
-                ) = Unit
+    internal fun attachToSheet(view: View) {
+        sheetView = view
+        BottomSheetBehavior.from(view).addBottomSheetCallback(bottomSheetCallback)
+    }
 
-                override fun onSlide(
-                    bottomSheet: View,
-                    slideOffset: Float,
-                ) {
-                    // Prevent system updates from overriding alpha while running custom enter/exit animation.
-                    // When initialDetentIndex is snapping to a high detent, BottomSheetBehavior fires onSlide
-                    // events that conflict with our manual alpha animator, causing the backdrop to flash.
-                    if (isTransitionAnimationRunning) {
-                        return
-                    }
+    internal fun detachFromSheet() {
+        sheetView?.let {
+            BottomSheetBehavior.from(it).removeBottomSheetCallback(bottomSheetCallback)
+        }
+        sheetView = null
+    }
 
-                    val fraction = if (slideOffset >= 0) 1f else 1f + slideOffset
-                    dimmingAlpha = fraction * maxAlpha
-                }
-            },
-        )
+    internal fun updateDimmingProfile(
+        detents: FormSheetDetents,
+        largestUndimmedDetentIndex: Int,
+        initialDetentIndex: Int,
+    ) {
+        detentsCount = detents.count
+        this.largestUndimmedDetentIndex = detents.resolveLargestUndimmedDetentIndex(largestUndimmedDetentIndex)
+        presentationDetentIndex = detents.resolveDetentIndex(initialDetentIndex)
+
+        if (isTransitionAnimationRunning) {
+            return
+        }
+
+        updateDimmingForSheetPosition()
+    }
+
+    // Renders the dimming matching the current position of the attached sheet.
+    private fun updateDimmingForSheetPosition() {
+        val sheetView = sheetView ?: return
+        if (!sheetView.isLaidOut) {
+            return
+        }
+
+        dimmingAlpha = dimmingProgress(sheetView) * maxAlpha
+    }
+
+    /**
+     * Dimming progress (0..1) for the laid-out [sheetView]. The dimming grows linearly between the resting
+     * position of the largest undimmed detent and the resting position of the next detent (the first dimmed).
+     */
+    private fun dimmingProgress(sheetView: View): Float {
+        if (largestUndimmedDetentIndex >= detentsCount - 1) {
+            return 0f
+        }
+
+        // Material positions the sheet relative to its parent (CoordinatorLayout)
+        // the same space the behavior is configured against in FormSheetBehaviorController.
+        val sheetAvailableSpace = (sheetView.parent as View).height
+        val undimmedTop = restingTopForDetentIndex(largestUndimmedDetentIndex, sheetView, sheetAvailableSpace)
+        val dimmedTop = restingTopForDetentIndex(largestUndimmedDetentIndex + 1, sheetView, sheetAvailableSpace)
+        if (undimmedTop <= dimmedTop) {
+            return if (sheetView.top <= dimmedTop) 1f else 0f
+        }
+
+        return ((undimmedTop - sheetView.top).toFloat() / (undimmedTop - dimmedTop)).coerceIn(0f, 1f)
+    }
+
+    private fun restingTopForDetentIndex(
+        index: Int,
+        sheetView: View,
+        sheetAvailableSpace: Int,
+    ): Int {
+        val sheetBehavior = BottomSheetBehavior.from(sheetView)
+        return when {
+            index < 0 -> sheetAvailableSpace
+            index >= detentsCount - 1 -> sheetBehavior.expandedOffset
+            index == 0 -> {
+                // Material extends the peek height by the bottom system inset it pads the sheet
+                // with (see BottomSheetBehavior.calculatePeekHeight), so the collapsed sheet keeps
+                // `peekHeight` of content above the inset.
+                val insetExtendedPeekHeight = sheetBehavior.peekHeight + sheetView.paddingBottom
+                maxOf(sheetAvailableSpace - insetExtendedPeekHeight, sheetBehavior.expandedOffset)
+            }
+            else -> (sheetAvailableSpace * (1 - sheetBehavior.halfExpandedRatio)).toInt()
+        }
     }
 
     private fun resolveActivityDecorView(): View? {

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetDimmingManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetDimmingManager.kt
@@ -1,14 +1,12 @@
 package com.swmansion.rnscreens.modals.formsheet.native.presentation
 
-import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.util.Log
 import android.view.View
-import com.facebook.react.bridge.ReactContext
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.swmansion.rnscreens.helpers.findHostActivity
 import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 import kotlin.math.roundToInt
 
@@ -61,6 +59,9 @@ internal class FormSheetDimmingManager(
                 updateDimmingForSheetPosition()
             }
         }
+
+    internal val isDimmed: Boolean
+        get() = dimmingAlpha > 0f
 
     internal var dimmingAlpha: Float = 0f
         set(value) {
@@ -178,19 +179,7 @@ internal class FormSheetDimmingManager(
         }
     }
 
-    private fun resolveActivityDecorView(): View? {
-        var current: Context? = context
-        while (current is ContextWrapper) {
-            if (current is Activity) {
-                return current.window?.decorView
-            }
-            if (current is ReactContext) {
-                return current.currentActivity?.window?.decorView
-            }
-            current = current.baseContext
-        }
-        return null
-    }
+    private fun resolveActivityDecorView(): View? = context.findHostActivity()?.window?.decorView
 
     companion object {
         const val TAG = "FormSheetDimmingManager"

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetAppearanceCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetBehaviorController
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetDimensionsCoordinator
@@ -17,6 +16,7 @@ import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 internal class FormSheetPresentation(
     themedContext: Context,
     private val container: FormSheetContainer,
+    private val dimmingManager: FormSheetDimmingManager,
     private val callbacks: Callbacks,
 ) {
     internal interface Callbacks {
@@ -37,9 +37,6 @@ internal class FormSheetPresentation(
         }
 
     internal val bottomSheetView: FrameLayout? = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet)
-
-    internal val sheetBehavior: BottomSheetBehavior<FrameLayout>?
-        get() = bottomSheetView?.let { BottomSheetBehavior.from(it) }
 
     private val behaviorController =
         bottomSheetView?.let {
@@ -83,10 +80,16 @@ internal class FormSheetPresentation(
         contentHeight: Int,
     ) {
         onContentHeightChanged(contentHeight)
+        val detents = resolveDetents(config.detents)
         dimensionsCoordinator.updateFormSheetDimensions(
-            resolveDetents(config.detents),
+            detents,
             config.initialDetentIndex,
             applyInitialDetent = true,
+        )
+        dimmingManager.updateDimmingProfile(
+            detents = detents,
+            largestUndimmedDetentIndex = config.largestUndimmedDetentIndex,
+            initialDetentIndex = config.initialDetentIndex,
         )
         container.setGrabberVisible(config.prefersGrabberVisible)
         appearanceCoordinator.updateCornerRadius(config.preferredCornerRadius)
@@ -98,10 +101,27 @@ internal class FormSheetPresentation(
         oldConfig: FormSheetConfig,
         newConfig: FormSheetConfig,
     ) {
-        if (oldConfig.detents != newConfig.detents) {
-            dimensionsCoordinator.updateFormSheetDimensions(
-                resolveDetents(newConfig.detents),
-                newConfig.initialDetentIndex,
+        val dimensionsChanged = oldConfig.detents != newConfig.detents
+        val largestUndimmedDetentIndexChanged =
+            oldConfig.largestUndimmedDetentIndex !=
+                newConfig.largestUndimmedDetentIndex
+
+        if (dimensionsChanged || largestUndimmedDetentIndexChanged) {
+            val detents = resolveDetents(newConfig.detents)
+
+            if (dimensionsChanged) {
+                dimensionsCoordinator.updateFormSheetDimensions(
+                    detents,
+                    newConfig.initialDetentIndex,
+                )
+            }
+
+            // The dimming profile depends on the detents geometry, so it's refreshed after the
+            // dimensions update.
+            dimmingManager.updateDimmingProfile(
+                detents = detents,
+                largestUndimmedDetentIndex = newConfig.largestUndimmedDetentIndex,
+                initialDetentIndex = newConfig.initialDetentIndex,
             )
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
@@ -2,7 +2,9 @@ package com.swmansion.rnscreens.modals.formsheet.native.presentation
 
 import android.content.Context
 import android.util.Log
+import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.FrameLayout
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetAppearanceCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetBehaviorController
@@ -25,6 +27,8 @@ internal class FormSheetPresentation(
         fun onNativeDismissAllowed()
 
         fun onNativeDismissPrevented()
+
+        fun resolveWindowBelow(): Window?
     }
 
     internal val dialog =
@@ -64,7 +68,19 @@ internal class FormSheetPresentation(
             onDismissPrevented = callbacks::onNativeDismissPrevented,
         )
 
+    // On an undimmed sheet, the backdrop tap should be forwarded to the window
+    // below.
+    private val backdropTouchForwarder =
+        dialog.findViewById<View>(com.google.android.material.R.id.touch_outside)?.let { backdropView ->
+            FormSheetBackdropTouchForwarder(
+                backdropView = backdropView,
+                isBackdropDimmed = { dimmingManager.isDimmed },
+                resolveWindowBelow = callbacks::resolveWindowBelow,
+            )
+        }
+
     init {
+        backdropTouchForwarder?.setup()
         nativeDismissCoordinator.setup()
         appearanceCoordinator.setup()
         dimensionsCoordinator.setup()
@@ -144,6 +160,7 @@ internal class FormSheetPresentation(
 
     internal fun destroy() {
         behaviorController?.destroy()
+        backdropTouchForwarder?.destroy()
         nativeDismissCoordinator.destroy()
         dimensionsCoordinator.destroy()
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -4,6 +4,7 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.util.Log
 import android.view.View
+import android.view.Window
 import androidx.core.view.doOnPreDraw
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.common.event.ViewAppearanceEventEmitter
@@ -21,6 +22,13 @@ internal class FormSheetPresentationManager(
 
     private val bottomSheetView: View?
         get() = currentPresentation?.bottomSheetView
+
+    internal fun windowBelow(): Window? =
+        FormSheetStackRegistry
+            .sheetBelow(this)
+            ?.currentPresentation
+            ?.dialog
+            ?.window
 
     private var state = FormSheetPresentationState.DISMISSED
     private var shouldBeOpen = false

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -23,12 +23,15 @@ internal class FormSheetPresentationManager(
     private val bottomSheetView: View?
         get() = currentPresentation?.bottomSheetView
 
+    private var dismissalWindowBelow: Window? = null
+
     internal fun windowBelow(): Window? =
-        FormSheetStackRegistry
-            .sheetBelow(this)
-            ?.currentPresentation
-            ?.dialog
-            ?.window
+        dismissalWindowBelow
+            ?: FormSheetStackRegistry
+                .sheetBelow(this)
+                ?.currentPresentation
+                ?.dialog
+                ?.window
 
     private var state = FormSheetPresentationState.DISMISSED
     private var shouldBeOpen = false
@@ -117,6 +120,12 @@ internal class FormSheetPresentationManager(
         }
 
         state = FormSheetPresentationState.DISMISSING
+        dismissalWindowBelow =
+            FormSheetStackRegistry
+                .sheetBelow(this)
+                ?.currentPresentation
+                ?.dialog
+                ?.window
         dismissSheetsAbove()
         // Leaving the stack immediately is deliberate, if another sheet is presented during this exit animation,
         // it must stack on a "stable" sheet - the one we don't intend to dismiss. This window is about to be
@@ -276,6 +285,7 @@ internal class FormSheetPresentationManager(
                     )
             }
             dismissalOrigin = FormSheetDismissalOrigin.UNSPECIFIED
+            dismissalWindowBelow = null
 
             // ensure state hasn't updated during dismissal
             resolvePresentationState()
@@ -284,6 +294,7 @@ internal class FormSheetPresentationManager(
 
     internal fun destroy() {
         FormSheetStackRegistry.unregister(this)
+        dismissalWindowBelow = null
         dimmingManager.detachDimming()
         dimmingManager.detachFromSheet()
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -85,7 +85,7 @@ internal class FormSheetPresentationManager(
 
         state = FormSheetPresentationState.PRESENTING
         val presentation = presentationFactory().also { currentPresentation = it }
-        presentation.sheetBehavior?.let(dimmingManager::attachToBehavior)
+        presentation.bottomSheetView?.let(dimmingManager::attachToSheet)
 
         FormSheetStackRegistry.register(this)
         appearanceEventEmitter?.emitOnWillAppear()
@@ -238,6 +238,7 @@ internal class FormSheetPresentationManager(
     private fun performDismiss() {
         shouldSkipExitAnimation = false
         dimmingManager.detachDimming()
+        dimmingManager.detachFromSheet()
         currentPresentation?.destroy()
         currentPresentation = null
         onDismissComplete()
@@ -276,6 +277,7 @@ internal class FormSheetPresentationManager(
     internal fun destroy() {
         FormSheetStackRegistry.unregister(this)
         dimmingManager.detachDimming()
+        dimmingManager.detachFromSheet()
 
         currentSheetAnimator?.cancel()
         currentSheetAnimator = null

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHost.kt
@@ -8,6 +8,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.swmansion.rnscreens.common.ShadowStateProxy
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetDialogManager
 import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetConfig
+import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 
 class FormSheetHost(
     val reactContext: ThemedReactContext,
@@ -32,6 +33,8 @@ class FormSheetHost(
     internal var detents: List<Double> = emptyList()
 
     internal var initialDetentIndex: Int = 0
+
+    internal var largestUndimmedDetentIndex: Int = FormSheetDetents.ALWAYS_DIMMED_DETENT_INDEX
 
     private val sheetContentView =
         FormSheetContentView(context) { width, height ->
@@ -97,6 +100,7 @@ class FormSheetHost(
                 detents = this.detents,
                 prefersGrabberVisible = this.prefersGrabberVisible,
                 initialDetentIndex = this.initialDetentIndex,
+                largestUndimmedDetentIndex = this.largestUndimmedDetentIndex,
                 preferredCornerRadius = this.preferredCornerRadius,
                 preventNativeDismiss = this.preventNativeDismiss,
                 nativeContainerBackgroundColor = this.nativeContainerBackgroundColor,

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHostViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHostViewManager.kt
@@ -102,7 +102,7 @@ class FormSheetHostViewManager :
         view: FormSheetHost,
         value: Int,
     ) {
-        // TODO: @t0maboro - implement later
+        view.largestUndimmedDetentIndex = value
     }
 
     override fun setInitialDetentIndex(

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -8,7 +8,7 @@ import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-
 import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
-import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
+import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index';
 import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
 import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
@@ -26,7 +26,7 @@ export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expa
 export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-contents';
 export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
 export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
-export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
+export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index';
 export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
 export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
 export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/index.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
   },
   sheetContent: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: Colors.NavyLight40,
     padding: 24,
     justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/scenario-description.ts
@@ -1,11 +1,11 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Largest Undimmed Detent Index (iOS)',
-  key: 'test-form-sheet-largest-undimmed-detent-index-ios',
+  name: 'Largest Undimmed Detent Index',
+  key: 'test-form-sheet-largest-undimmed-detent-index',
   details:
     'largestUndimmedDetentIndex: dimming per detent and interactivity of the screen underneath.',
-  platforms: ['ios'],
+  platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the `largestUndimmedDetentIndex` property of the `FormSheet` component with detents `[0.5, 0.65, 0.8]`. This test ensures that the dimming view behind the sheet is applied or removed depending on the current detent, that the screen underneath stays interactive while the sheet is undimmed, and that the value can be changed while the sheet is presented.
 
-**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5; Android: API Level 36.
 
 ## E2E test
 
@@ -14,6 +14,7 @@ TBD: Planned, but will be implemented separately.
 
 - iPhone: device or simulator.
 - iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: device or emulator.
 
 ## Note
 

--- a/src/components/modals/form-sheet/FormSheet.types.ts
+++ b/src/components/modals/form-sheet/FormSheet.types.ts
@@ -91,7 +91,7 @@ export interface FormSheetProps {
    * * `last` - there won't be a dimming view for any detent level.
    *
    * @default 'none'
-   * @platform ios
+   * @platform android, ios
    */
   largestUndimmedDetentIndex?: number | 'none' | 'last' | undefined;
 
@@ -103,7 +103,7 @@ export interface FormSheetProps {
    * This prop only applies when the sheet transitions from closed to open.
    *
    * @default 0
-   * @platform ios
+   * @platform android, ios
    */
   initialDetentIndex?: number | 'last' | undefined;
 


### PR DESCRIPTION
## Description

 This PR brings the `largestUndimmedDetentIndex` prop to Android, which has two parts:
- the backdrop is undimmed at/below the configured detent and dims as the sheet is dragged past it.
- while the backdrop is undimmed, touches fall through to whatever is behind the sheet (the window below in a stack, or the host activity)

On Android, there is no cross-window hit-testing, and `WindowManager.transferTouchGesture` was added for API level 35+, so the internal API doesn't apply in our case. Instead, we manually forward the touch from the sheet's backdrop to the window below.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1554

## Changes

- `FormSheetDimmingManager` drives dimming from the sheet position, `updateDimmingForSheetPosition` interpolates the backdrop alpha linearly between the resting top of the largest undimmed detent and the next detent (fully dimmed). The enter animator now targets the resting alpha of the initial detent instead of always `maxAlpha`.
- `FormSheetBackdropTouchForwarder` was introduced as an OnTouchListener on Material's `touch_outside`. An undimmed backdrop copies each event, re-calculates it in the target window's coordinates and dispatches it through the target `Window.Callback`, consuming the original, so no sheet dismissal is triggered.
- `Context.findHostActivity` was extracted to helpers as it's shared by the dimming manager and the touch forwarder.

Additional fixes:
- `halfExpandedRatio` returned d1/d2, but Material lays the half-expanded sheet out at parentHeight * (1 - ratio), relative to the parent, so the middle detent of e.g. `[0.3, 0.6, 0.8]` rested at `0.75` instead of `0.6`.

## Before & after - visual documentation

<video src="https://github.com/user-attachments/assets/e94d78e7-ebb6-4f4c-ab64-923e8579ac3e" /> .

## Test plan

Marked SFT as applicable on android. Tested with stacking sheets example as well.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
