### PR TITLE
fix(Android, Tabs): use ViewIdGenerator to identify MenuItems instead of sequential ids

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/tabs/appearance/TabsAppearanceCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/appearance/TabsAppearanceCoordinator.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.MenuItem
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.swmansion.rnscreens.tabs.container.TabsContainer
-import com.swmansion.rnscreens.tabs.container.menuItemIdForFragmentAtIndex
 import com.swmansion.rnscreens.tabs.screen.TabsScreen
 import com.swmansion.rnscreens.tabs.screen.TabsScreenFragment
 
@@ -28,13 +27,12 @@ internal class TabsAppearanceCoordinator(
         context: Context,
         tabsAppearance: TabsAppearance?,
     ) {
-        tabsScreenFragments.forEachIndexed { index, fragment ->
-            val menuItemId = menuItemIdForFragmentAtIndex(index)
+        tabsScreenFragments.forEach { fragment ->
+            val menuItemId = fragment.menuItemId
             val menuItem =
                 checkNotNull(bottomNavigationView.menu.findItem(menuItemId)) {
                     "[RNScreens] Missing MenuItem for id: $menuItemId"
                 }
-            check(menuItem.itemId == menuItemId) { "[RNScreens] Illegal state: menu items are shuffled" }
             updateMenuItemAppearance(context, menuItem, fragment.tabsScreen, tabsAppearance)
         }
     }

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
@@ -19,5 +19,3 @@ internal fun Menu.indexOfItem(item: MenuItem): Int {
     }
     return -1
 }
-
-

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
@@ -2,30 +2,22 @@ package com.swmansion.rnscreens.tabs.container
 
 import android.view.Menu
 import android.view.MenuItem
-import com.swmansion.rnscreens.tabs.screen.TabsScreen
+import com.swmansion.rnscreens.tabs.screen.TabsScreenFragment
 
-// MenuItem ids are offset by one, because 0 has special meaning in the BottomNavigationMenuView API.
+internal fun Menu.getOrCreateMenuItemForFragment(fragment: TabsScreenFragment): MenuItem =
+    this.findItem(fragment.menuItemId) ?: this.add(
+        Menu.NONE,
+        fragment.menuItemId,
+        Menu.NONE,
+        fragment.tabsScreen.tabTitle,
+    )
 
-/**
- * Compute MenuItem id for a fragment at given index in "tabsModel" of TabsContainer
- */
-internal fun menuItemIdForFragmentAtIndex(fragmentIndex: Int): Int = fragmentIndex + 1
-
-/**
- * Compute fragment index in "tabsModel" of TabsContainer for a MenuItem with given id.
- */
-internal fun fragmentIndexForMenuItemId(menuItemId: Int): Int {
-    check(menuItemId >= 1) { "[RNScreens] MenuItem id must not be less than 1" }
-    return menuItemId - 1
+internal fun Menu.indexOfItem(item: MenuItem): Int {
+    // We can iterate because we know that there are a few items at most
+    for (i in 0 until size()) {
+        if (getItem(i) === item) return i
+    }
+    return -1
 }
 
-internal fun Menu.getOrCreateMenuItemForFragmentAt(
-    index: Int,
-    tabsScreen: TabsScreen,
-): MenuItem =
-    this.findItem(menuItemIdForFragmentAtIndex(index)) ?: this.add(
-        Menu.NONE,
-        menuItemIdForFragmentAtIndex(index),
-        Menu.NONE,
-        tabsScreen.tabTitle,
-    )
+

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/MenuHelpers.kt
@@ -12,12 +12,5 @@ internal fun Menu.getOrCreateMenuItemForFragment(fragment: TabsScreenFragment): 
         fragment.tabsScreen.tabTitle,
     )
 
-internal fun Menu.indexOfItem(item: MenuItem): Int {
-    // We can iterate because we know that there are a few items at most
-    for (i in 0 until size()) {
-        if (getItem(i) === item) return i
-    }
-    return -1
-}
 
 

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
@@ -530,17 +530,19 @@ class TabsContainer internal constructor(
     }
 
     private fun updateNavigationMenuStructure() {
-        if (bottomNavigationView.menu.size != tabsModel.size) {
-            // Most likely first render or some tab has been removed. Let's nuke the menu (easiest option).
-            bottomNavigationView.menu.clear()
+        val menu = bottomNavigationView.menu
+        val isMenuInSync =
+            menu.size == tabsModel.size &&
+                tabsModel.withIndex().all { (index, fragment) ->
+                    menu.getItem(index).itemId == fragment.menuItemId
+                }
+
+        if (isMenuInSync) {
+            return
         }
-        tabsModel.forEachIndexed { index, fragment ->
-            val menuItem =
-                bottomNavigationView.menu.getOrCreateMenuItemForFragmentAt(
-                    index,
-                    fragment.tabsScreen,
-                )
-            check(fragmentIndexForMenuItemId(menuItem.itemId) == index) { "[RNScreens] Illegal state: menu items are shuffled" }
+        menu.clear()
+        tabsModel.forEach { fragment ->
+            menu.getOrCreateMenuItemForFragment(fragment)
         }
     }
 
@@ -717,12 +719,10 @@ class TabsContainer internal constructor(
         appearanceCoordinator.updateTabAppearance(themedContext, this)
     }
 
-    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? = tabsModel.getOrNull(fragmentIndexForMenuItemId(itemId))
+    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? = tabsModel.find { it.menuItemId == itemId }
 
     private fun getMenuItemIdForFragment(tabsScreenFragment: TabsScreenFragment): Int? =
-        tabsModel.indexOfFirst { it === tabsScreenFragment }.takeIf { it != -1 }?.let {
-            menuItemIdForFragmentAtIndex(it)
-        }
+        tabsScreenFragment.menuItemId.takeIf { tabsModel.any { it === tabsScreenFragment } }
 
     private fun getSelectedTabsScreenFragmentId(): Int? =
         tabsModel
@@ -731,10 +731,9 @@ class TabsContainer internal constructor(
 
     private fun getMenuItemForTabsScreen(tabsScreen: TabsScreen): MenuItem? =
         tabsModel
-            .indexOfFirst { it.tabsScreen === tabsScreen }
-            .takeIf { it != -1 }
-            ?.let { index ->
-                bottomNavigationView.menu.findItem(menuItemIdForFragmentAtIndex(index))
+            .find { it.tabsScreen === tabsScreen }
+            ?.let { fragment ->
+                bottomNavigationView.menu.findItem(fragment.menuItemId)
             }
 
     private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? = tabsModel.find { it.requireScreenKey == screenKey }

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreenFragment.kt
@@ -6,12 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.swmansion.rnscreens.helpers.ViewIdGenerator
 
 class TabsScreenFragment(
     internal val tabsScreen: TabsScreen,
 ) : Fragment() {
     internal val requireScreenKey: String by tabsScreen::requireScreenKey
     internal val isPreventNativeSelectionEnabled: Boolean by tabsScreen::preventNativeSelection
+
+    internal val menuItemId: Int = ViewIdGenerator.generateViewId()
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
## Description

On Android, tab `MenuItem`s were identified with sequential ids. Those ids can collide with view tags assigned by the React Native renderer. Tapping the 4th tab dispatch a tap to a RN view with tag `4`.

This PR assigns each tab a `MenuItem` id from `ViewIdGenerator`, which generates ids that do not collide with RN tags.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1108

## Changes

- Persist a `menuItemId` from `ViewIdGenerator` on each `TabsScreenFragment` and use that id when creating/looking up `MenuItem`s, instead of deriving the id from the fragment index.
- In `updateNavigationMenuStructure` (`TabsContainer.kt`), if the menu order no longer matches `tabsModel`, clear and rebuild the menu. With sequential ids, a shuffle was treated as an illegal state. With stable unique ids, tab reordering can desync the menu, so rebuilding is required.
- Update other functions which are using old ids 

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f3535e6b-ac94-4416-a7d7-08257d427bb9" controls="controls" width="100%"></video> | <video src="https://github.com/user-attachments/assets/dd77bc6c-fd7f-458f-9d6f-f72e5eae3821" controls="controls" width="100%"></video> |

## Test plan

- Check If this problem do not occur in [issue 1108](https://github.com/software-mansion/react-native-screens-labs/issues/1108)
- Check test `test-tabs-stale-update-rejection`
- Check test `test-tabs-simple-nav`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
