### PR TITLE
feat(iOS, Stack v5): Add (large) (sub)title appearance to header

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -29,6 +29,7 @@ import TestStackHeaderSelectiveUpdates from './test-stack-header-selective-updat
 import TestStackHeaderMenuOptionsIOS from './test-stack-header-menu-options-ios';
 import TestStackHeaderItemIdentifierIOS from './test-stack-header-item-identifier-ios';
 import TestStackHeaderTitleAppearance from './test-stack-header-title-appearance-android';
+import TestStackHeaderTitleAppearanceIOS from './test-stack-header-title-appearance-ios';
 import TestStackHeaderContentInsets from './test-stack-header-content-insets-android';
 import TestStackHeaderBackground from './test-stack-header-background-android';
 import TestStackHeaderStatusBarScrim from './test-stack-header-status-bar-scrim-android';
@@ -63,6 +64,7 @@ export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nest
 export { default as TestStackToolbarMenuBatchCommands } from './test-stack-toolbar-menu-batch-commands-android';
 export { default as TestStackToolbarMenuA11y } from './test-stack-toolbar-menu-a11y-android';
 export { default as TestStackHeaderTitleAppearance } from './test-stack-header-title-appearance-android';
+export { default as TestStackHeaderTitleAppearanceIOS } from './test-stack-header-title-appearance-ios';
 export { default as TestStackHeaderContentInsets } from './test-stack-header-content-insets-android';
 export { default as TestStackHeaderBackground } from './test-stack-header-background-android';
 export { default as TestStackHeaderStatusBarScrim } from './test-stack-header-status-bar-scrim-android';
@@ -96,6 +98,7 @@ const scenarios = {
   TestStackToolbarMenuBatchCommands,
   TestStackToolbarMenuA11y,
   TestStackHeaderTitleAppearance,
+  TestStackHeaderTitleAppearanceIOS,
   TestStackHeaderContentInsets,
   TestStackHeaderBackground,
   TestStackHeaderStatusBarScrim,

--- a/apps/src/tests/single-feature-tests/stack-v5/index.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/index.ts
@@ -28,7 +28,7 @@ import TestStackHeaderSubviewOnPress from './test-stack-header-subview-onpress-i
 import TestStackHeaderSelectiveUpdates from './test-stack-header-selective-updates-ios';
 import TestStackHeaderMenuOptionsIOS from './test-stack-header-menu-options-ios';
 import TestStackHeaderItemIdentifierIOS from './test-stack-header-item-identifier-ios';
-import TestStackHeaderTitleAppearance from './test-stack-header-title-appearance-android';
+import TestStackHeaderTitleAppearanceAndroid from './test-stack-header-title-appearance-android';
 import TestStackHeaderTitleAppearanceIOS from './test-stack-header-title-appearance-ios';
 import TestStackHeaderContentInsets from './test-stack-header-content-insets-android';
 import TestStackHeaderBackground from './test-stack-header-background-android';
@@ -63,7 +63,7 @@ export { default as TestStackToolbarMenuIcon } from './test-stack-toolbar-menu-i
 export { default as TestStackToolbarNestedMenu } from './test-stack-toolbar-nested-menu-android';
 export { default as TestStackToolbarMenuBatchCommands } from './test-stack-toolbar-menu-batch-commands-android';
 export { default as TestStackToolbarMenuA11y } from './test-stack-toolbar-menu-a11y-android';
-export { default as TestStackHeaderTitleAppearance } from './test-stack-header-title-appearance-android';
+export { default as TestStackHeaderTitleAppearanceAndroid } from './test-stack-header-title-appearance-android';
 export { default as TestStackHeaderTitleAppearanceIOS } from './test-stack-header-title-appearance-ios';
 export { default as TestStackHeaderContentInsets } from './test-stack-header-content-insets-android';
 export { default as TestStackHeaderBackground } from './test-stack-header-background-android';
@@ -97,7 +97,7 @@ const scenarios = {
   TestStackToolbarNestedMenu,
   TestStackToolbarMenuBatchCommands,
   TestStackToolbarMenuA11y,
-  TestStackHeaderTitleAppearance,
+  TestStackHeaderTitleAppearanceAndroid,
   TestStackHeaderTitleAppearanceIOS,
   TestStackHeaderContentInsets,
   TestStackHeaderBackground,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-android/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-android/scenario-description.ts
@@ -1,7 +1,7 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Stack Header Title Appearance',
+  name: 'Stack Header Title Appearance (Android)',
   key: 'test-stack-header-title-appearance-android',
   details: 'Tests title/subtitle appearance.',
   platforms: ['android'],

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/index.tsx
@@ -1,0 +1,382 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  PlatformColor,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+  type ColorValue,
+  type TextStyle,
+} from 'react-native';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import {
+  StackContainer,
+  useStackNavigationContext,
+} from '@apps/shared/containers/stack';
+import { SettingsPicker, SettingsSwitch } from '@apps/shared';
+import { Colors } from '@apps/shared/styling';
+import type {
+  StackHeaderAppearanceIOS,
+  StackHeaderConfigProps,
+} from 'react-native-screens';
+
+const TITLE_TEXT = 'Title';
+const SUBTITLE_TEXT = 'Subtitle';
+const LARGE_TITLE_TEXT = 'Large Title';
+const LARGE_SUBTITLE_TEXT = 'Large Subtitle';
+
+// A PlatformColor resolved by the OS — distinct from the literal red/blue below.
+const PLATFORM_COLOR = PlatformColor('systemGreenColor');
+
+// Each picker's options are the single source of truth; the option union type is
+// derived from the array so the two can never drift apart.
+const options = <const T extends string>(...values: T[]): T[] => values;
+
+const COLOR_OPTIONS = options('default', 'red', 'blue', 'platform');
+const SIZE_OPTIONS = options('default', '12', '30');
+const FAMILY_OPTIONS = options('default', 'Courier New', 'Times New Roman');
+const WEIGHT_OPTIONS = options('default', '400', '700', 'bold', '900');
+const STYLE_OPTIONS = options('default', 'normal', 'italic');
+
+type ColorOption = (typeof COLOR_OPTIONS)[number];
+type SizeOption = (typeof SIZE_OPTIONS)[number];
+type FamilyOption = (typeof FAMILY_OPTIONS)[number];
+type WeightOption = (typeof WEIGHT_OPTIONS)[number];
+type StyleOption = (typeof STYLE_OPTIONS)[number];
+
+interface SlotAppearance {
+  color: ColorOption;
+  fontSize: SizeOption;
+  fontFamily: FamilyOption;
+  fontWeight: WeightOption;
+  fontStyle: StyleOption;
+}
+
+// Subtitle appearance covers both regular and large subtitle — UIKit
+// derives the large subtitle appearance from subtitleTextAttributes.
+type SlotKey = 'title' | 'largeTitle' | 'subtitle';
+
+// One per appearance object — standard and scroll edge are configured
+// completely independently. When `enabled` is false, the corresponding
+// appearance prop is not passed at all.
+interface AppearanceConfig {
+  enabled: boolean;
+  slots: Record<SlotKey, SlotAppearance>;
+}
+
+type AppearanceKey = 'standard' | 'scrollEdge';
+
+interface Config {
+  largeTitleEnabled: boolean;
+  standard: AppearanceConfig;
+  scrollEdge: AppearanceConfig;
+}
+
+const SLOTS: SlotKey[] = ['title', 'largeTitle', 'subtitle'];
+
+const DEFAULT_SLOT: SlotAppearance = {
+  color: 'default',
+  fontSize: 'default',
+  fontFamily: 'default',
+  fontWeight: 'default',
+  fontStyle: 'default',
+};
+
+function makeDefaultSlots(): Record<SlotKey, SlotAppearance> {
+  return {
+    title: { ...DEFAULT_SLOT },
+    largeTitle: { ...DEFAULT_SLOT },
+    subtitle: { ...DEFAULT_SLOT },
+  };
+}
+
+function makeDefaultAppearanceConfig(): AppearanceConfig {
+  return { enabled: false, slots: makeDefaultSlots() };
+}
+
+const DEFAULT_CONFIG: Config = {
+  largeTitleEnabled: false,
+  standard: makeDefaultAppearanceConfig(),
+  scrollEdge: makeDefaultAppearanceConfig(),
+};
+
+function resolveColor(value: ColorOption): ColorValue | undefined {
+  switch (value) {
+    case 'red':
+      return 'red';
+    case 'blue':
+      return 'blue';
+    case 'platform':
+      return PLATFORM_COLOR;
+    default:
+      return undefined;
+  }
+}
+
+function resolveSize(value: SizeOption): number | undefined {
+  return value === 'default' ? undefined : Number(value);
+}
+
+function resolveFamily(value: FamilyOption): string | undefined {
+  return value === 'default' ? undefined : value;
+}
+
+function resolveWeight(value: WeightOption): TextStyle['fontWeight'] {
+  switch (value) {
+    case '400':
+      return 400;
+    case '700':
+      return 700;
+    case '900':
+      return 900;
+    case 'bold':
+      return 'bold';
+    default:
+      return undefined;
+  }
+}
+
+function resolveStyle(value: StyleOption): TextStyle['fontStyle'] {
+  return value === 'default' ? undefined : value;
+}
+
+function resolveSlot(slot: SlotAppearance) {
+  return {
+    color: resolveColor(slot.color),
+    fontSize: resolveSize(slot.fontSize),
+    fontFamily: resolveFamily(slot.fontFamily),
+    fontWeight: resolveWeight(slot.fontWeight),
+    fontStyle: resolveStyle(slot.fontStyle),
+  };
+}
+
+function buildAppearance(
+  appearanceConfig: AppearanceConfig,
+): StackHeaderAppearanceIOS | undefined {
+  if (!appearanceConfig.enabled) {
+    return undefined;
+  }
+
+  const title = resolveSlot(appearanceConfig.slots.title);
+  const largeTitle = resolveSlot(appearanceConfig.slots.largeTitle);
+  const subtitle = resolveSlot(appearanceConfig.slots.subtitle);
+
+  return {
+    titleFontColor: title.color,
+    titleFontSize: title.fontSize,
+    titleFontFamily: title.fontFamily,
+    titleFontWeight: title.fontWeight,
+    titleFontStyle: title.fontStyle,
+
+    largeTitleFontColor: largeTitle.color,
+    largeTitleFontSize: largeTitle.fontSize,
+    largeTitleFontFamily: largeTitle.fontFamily,
+    largeTitleFontWeight: largeTitle.fontWeight,
+    largeTitleFontStyle: largeTitle.fontStyle,
+
+    subtitleFontColor: subtitle.color,
+    subtitleFontSize: subtitle.fontSize,
+    subtitleFontFamily: subtitle.fontFamily,
+    subtitleFontWeight: subtitle.fontWeight,
+    subtitleFontStyle: subtitle.fontStyle,
+  };
+}
+
+function buildHeaderConfig(config: Config): StackHeaderConfigProps {
+  return {
+    title: TITLE_TEXT,
+    subtitle: SUBTITLE_TEXT,
+    ios: {
+      largeTitle: LARGE_TITLE_TEXT,
+      largeSubtitle: LARGE_SUBTITLE_TEXT,
+      largeTitleEnabled: config.largeTitleEnabled,
+      standardAppearance: buildAppearance(config.standard),
+      scrollEdgeAppearance: buildAppearance(config.scrollEdge),
+    },
+  };
+}
+
+function AppearanceControls({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: SlotAppearance;
+  onChange: (next: SlotAppearance) => void;
+}) {
+  return (
+    <>
+      <Text style={styles.subheading}>{label}</Text>
+      <SettingsPicker<ColorOption>
+        label={`${label} color`}
+        value={value.color}
+        onValueChange={v => onChange({ ...value, color: v })}
+        items={COLOR_OPTIONS}
+      />
+      <SettingsPicker<SizeOption>
+        label={`${label} fontSize`}
+        value={value.fontSize}
+        onValueChange={v => onChange({ ...value, fontSize: v })}
+        items={SIZE_OPTIONS}
+      />
+      <SettingsPicker<FamilyOption>
+        label={`${label} fontFamily`}
+        value={value.fontFamily}
+        onValueChange={v => onChange({ ...value, fontFamily: v })}
+        items={FAMILY_OPTIONS}
+      />
+      <SettingsPicker<WeightOption>
+        label={`${label} fontWeight`}
+        value={value.fontWeight}
+        onValueChange={v => onChange({ ...value, fontWeight: v })}
+        items={WEIGHT_OPTIONS}
+      />
+      <SettingsPicker<StyleOption>
+        label={`${label} fontStyle`}
+        value={value.fontStyle}
+        onValueChange={v => onChange({ ...value, fontStyle: v })}
+        items={STYLE_OPTIONS}
+      />
+    </>
+  );
+}
+
+function AppearanceSection({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: AppearanceConfig;
+  onChange: (next: AppearanceConfig) => void;
+}) {
+  return (
+    <>
+      <View style={styles.switchRow}>
+        <Text style={styles.heading}>{label}</Text>
+        <Switch
+          value={value.enabled}
+          onValueChange={enabled => onChange({ ...value, enabled })}
+        />
+      </View>
+      {value.enabled &&
+        SLOTS.map(slot => (
+          <AppearanceControls
+            key={slot}
+            label={slot}
+            value={value.slots[slot]}
+            onChange={next =>
+              onChange({ ...value, slots: { ...value.slots, [slot]: next } })
+            }
+          />
+        ))}
+    </>
+  );
+}
+
+function TestStackHeaderTitleAppearanceIOS() {
+  return <StackSetup />;
+}
+
+function StackSetup() {
+  return (
+    <StackContainer
+      routeConfigs={[{ name: 'Home', element: <ConfigScreen />, options: {} }]}
+    />
+  );
+}
+
+function ConfigScreen() {
+  const navigation = useStackNavigationContext();
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+
+  const updateAppearance = useCallback(
+    (appearance: AppearanceKey, next: AppearanceConfig) => {
+      setConfig(prev => ({ ...prev, [appearance]: next }));
+    },
+    [],
+  );
+
+  const { setRouteOptions, routeKey } = navigation;
+  const headerConfig = useMemo(() => buildHeaderConfig(config), [config]);
+
+  useEffect(() => {
+    setRouteOptions(routeKey, { headerConfig });
+  }, [headerConfig, setRouteOptions, routeKey]);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      contentInsetAdjustmentBehavior="automatic">
+      <Button
+        title="Reset appearance"
+        onPress={() =>
+          setConfig(prev => ({
+            ...prev,
+            standard: makeDefaultAppearanceConfig(),
+            scrollEdge: makeDefaultAppearanceConfig(),
+          }))
+        }
+      />
+
+      <SettingsSwitch
+        label="largeTitleEnabled"
+        value={config.largeTitleEnabled}
+        onValueChange={v =>
+          setConfig(prev => ({ ...prev, largeTitleEnabled: v }))
+        }
+      />
+
+      <AppearanceSection
+        label="standardAppearance"
+        value={config.standard}
+        onChange={next => updateAppearance('standard', next)}
+      />
+      <AppearanceSection
+        label="scrollEdgeAppearance"
+        value={config.scrollEdge}
+        onChange={next => updateAppearance('scrollEdge', next)}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollViewMarker: {
+    flex: 1,
+  },
+  scroll: {
+    backgroundColor: Colors.cardBackground,
+  },
+  content: {
+    padding: 16,
+    gap: 6,
+    paddingBottom: 400,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    marginTop: 8,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+});
+
+export default createScenario(
+  TestStackHeaderTitleAppearanceIOS,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Stack Header Title Appearance (iOS)',
+  key: 'test-stack-header-title-appearance-ios',
+  details:
+    'Tests title/large title/subtitle appearance via standardAppearance and scrollEdgeAppearance. Subtitle appearance applies to both regular and large subtitle as well.',
+  platforms: ['ios'],
+  e2eCoverage: 'incomplete',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
@@ -40,20 +40,34 @@ TBD.
 ## Steps
 
 1. Launch the app and navigate to the **Stack Header Title Appearance (iOS)** screen.
+
 2. Enable `standardAppearance`. Under title, select `red` for `color`.
-  - When fully scrolled to top, nothing changes
-  - When scrolled down, title is red, font family, size (!), weight, style remain default
+
+  - [ ] When fully scrolled to top, nothing changes
+  
+  - [ ] When scrolled down, title is red, font family, size (!), weight, style remain default
+  
 3. Under title select 30 for `fontSize`, Times New Roman for `fontFamily`, 900 for `fontWeight`,
    italic for `fontStyle`. Under subtitle select blue for `color`, 12 for `fontSize`,
    Courier New for `fontFamily`, 400 for `fontWeight`, normal for `fontStyle`.
-  - When fully scrolled to top, nothing changes
-  - When scrolled down, updated configuration is visible on both title and subtitle
+
+  - [ ] When fully scrolled to top, nothing changes
+  
+  - [ ] When scrolled down, updated configuration is visible on both title and subtitle
+  
 4. Set `largeTitleEnabled`.
-  - No configuration is applied to large title. Large subtitle has the same configuration as subtitle.
+
+  - [ ] No configuration is applied to large title. Large subtitle has the same configuration as subtitle.
+  
 5. Select the same options for `largeTitle` as for `subtitle`.
-  - Updated configuration for large title is visible and matches large subtitle.
+
+  - [ ] Updated configuration for large title is visible and matches large subtitle.
+  
 6. Unset `largeTitleEnabled`. Enable `scrollEdgeAppearance`. Select all the same options
    as in 3. but swap `title` and `subtitle` options. Scroll to top.
-  - Upon scrolling to the edge, configurations swap but are otherwise identical.
+
+  - [ ] Upon scrolling to the edge, configurations swap but are otherwise identical.
+  
 7. Set large title `color` to `platform`.
-  - Large title color is updated to a shade of green.
+
+  - [ ] Large title color is updated to a shade of green.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
@@ -1,0 +1,58 @@
+# Test Scenario: Header Title & Subtitle Appearance (iOS)
+
+## Details
+
+**Description:** Verifies customization of the title, large title and subtitle
+text appearance in the iOS stack v5 header — color, font size, font family,
+font weight and font style — configured through the `standardAppearance` and
+`scrollEdgeAppearance` objects of the header config. Subtitle appearance keys
+apply to both the regular and the large subtitle (UIKit derives the large
+subtitle appearance from `subtitleTextAttributes`).
+The two appearance objects are configured independently and can be toggled off 
+so they are not passed at all. The scenario checks that a default appearance
+renders identically to no appearance, `scrollEdgeAppearance` attributes deriving from
+`standardAppearance` if not defined, restoring props to their defaults at runtime,
+and `PlatformColor` resolution.
+
+**OS test creation version:** iOS 26
+
+## E2E test
+
+TBD.
+
+## Prerequisites
+
+- iOS simulator; subtitle and large subtitle (both the text and the subtitle
+  appearance keys) require iOS 26+. On older iOS versions the subtitle-related
+  options should have no effect while title/large title styling keeps working.
+
+## Note
+
+- `standardAppearance` applies when scrollable content is scrolled under the
+  header; `scrollEdgeAppearance` applies when content edge is aligned with the
+  header edge (and for large-title headers at rest). When only
+  `standardAppearance` is set, the system derives the scroll-edge appearance
+  from it.
+- `color` options: `red` / `blue` are literals; `platform` is
+  `PlatformColor('systemGreenColor')`.
+
+## Steps
+
+1. Launch the app and navigate to the **Stack Header Title Appearance (iOS)** screen.
+2. Enable `standardAppearance`. Under title, select `red` for `color`.
+  - Title is red, font family, size (!), weight, style remain default
+3. Under title select 30 for `fontSize`, Times New Roman for `fontFamily`, 900 for `fontWeight`,
+   italic for `fontStyle`. Under subtitle select blue for `color`, 12 for `fontSize`,
+   Courier New for `fontFamily`, 400 for `fontWeight`, normal for `fontStyle`.
+  - Updated configuration is visible on both title and subtitle
+4. Set `largeTitleEnabled`.
+  - No configuration is applied to large title. Large subtitle has the same configuration as subtitle.
+5. Select the same options for `largeTitle` as for `subtitle`.
+  - Updated configuration for large title is visible and matches large subtitle.
+6. Scroll the content all the way to the top.
+  - The text keeps the configuration from `standardAppearance`.
+7. Unset `largeTitleEnabled`. Enable `scrollEdgeAppearance`. Select all the same options
+   as in 3. but swap `title` and `subtitle` options. Scroll to top.
+  - Upon scrolling to the edge, configurations swap but are otherwise identical.
+8. Set large title `color` to `platform`.
+  - Large title color is updated to a shade of green.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-title-appearance-ios/scenario.md
@@ -10,9 +10,10 @@ apply to both the regular and the large subtitle (UIKit derives the large
 subtitle appearance from `subtitleTextAttributes`).
 The two appearance objects are configured independently and can be toggled off 
 so they are not passed at all. The scenario checks that a default appearance
-renders identically to no appearance, `scrollEdgeAppearance` attributes deriving from
-`standardAppearance` if not defined, restoring props to their defaults at runtime,
-and `PlatformColor` resolution.
+renders identically to no appearance, that with `scrollEdgeAppearance` unset
+UIKit natively derives the scroll-edge look from `standardAppearance` (a set
+`scrollEdgeAppearance` is standalone and does not inherit its attributes),
+restoring props to their defaults at runtime, and `PlatformColor` resolution.
 
 **OS test creation version:** iOS 26
 
@@ -40,19 +41,19 @@ TBD.
 
 1. Launch the app and navigate to the **Stack Header Title Appearance (iOS)** screen.
 2. Enable `standardAppearance`. Under title, select `red` for `color`.
-  - Title is red, font family, size (!), weight, style remain default
+  - When fully scrolled to top, nothing changes
+  - When scrolled down, title is red, font family, size (!), weight, style remain default
 3. Under title select 30 for `fontSize`, Times New Roman for `fontFamily`, 900 for `fontWeight`,
    italic for `fontStyle`. Under subtitle select blue for `color`, 12 for `fontSize`,
    Courier New for `fontFamily`, 400 for `fontWeight`, normal for `fontStyle`.
-  - Updated configuration is visible on both title and subtitle
+  - When fully scrolled to top, nothing changes
+  - When scrolled down, updated configuration is visible on both title and subtitle
 4. Set `largeTitleEnabled`.
   - No configuration is applied to large title. Large subtitle has the same configuration as subtitle.
 5. Select the same options for `largeTitle` as for `subtitle`.
   - Updated configuration for large title is visible and matches large subtitle.
-6. Scroll the content all the way to the top.
-  - The text keeps the configuration from `standardAppearance`.
-7. Unset `largeTitleEnabled`. Enable `scrollEdgeAppearance`. Select all the same options
+6. Unset `largeTitleEnabled`. Enable `scrollEdgeAppearance`. Select all the same options
    as in 3. but swap `title` and `subtitle` options. Scroll to top.
   - Upon scrolling to the edge, configurations swap but are otherwise identical.
-8. Set large title `color` to `platform`.
+7. Set large title `color` to `platform`.
   - Large title color is updated to a shade of green.

--- a/ios/stack/header/RNSStackHeaderAppearanceMapper.h
+++ b/ios/stack/header/RNSStackHeaderAppearanceMapper.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSStackHeaderAppearanceMapper : NSObject
+
+/**
+ * Maps appearance props to a UINavigationBarAppearance object.
+ *
+ * `appearanceDict` should be an NSDictionary with a flat structure, where entries correspond
+ * to UIKit attributes, e.g. `titleFontFamily`, `subtitleFontColor`.
+ */
++ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict;
+
+/**
+ * Maps appearance props to a UINavigationBarAppearance object derived from `baseAppearance`.
+ *
+ * The result inherits from `baseAppearance` and uses a transparent background, mirroring
+ * how UIKit resolves a nil scroll edge appearance from the standard one. Entries in
+ * `appearanceDict` override the inherited attributes.
+ */
++ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict
+                                                  inheritingFrom:(nullable UINavigationBarAppearance *)baseAppearance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/stack/header/RNSStackHeaderAppearanceMapper.h
+++ b/ios/stack/header/RNSStackHeaderAppearanceMapper.h
@@ -8,22 +8,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Maps appearance props to a UINavigationBarAppearance object.
- *
  * `appearanceDict` should be an NSDictionary with a flat structure, where entries correspond
- * to UIKit attributes, e.g. `titleFontFamily`, `subtitleFontColor`.
+ * to UIKit attributes, e.g. `titleFontFamily`, `subtitleFontColor`, or empty, for UIKit defaults.
  */
 + (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict;
 
 /**
- * Maps scroll edge appearance props to a standalone UINavigationBarAppearance object.
- *
- * Returns nil for an empty dictionary — the navigation item's scroll edge appearance
- * should then stay nil, so that UIKit's native resolution applies: the item's (or bar's)
- * standard appearance with a transparent background. When a dictionary is provided, the
- * result is built on the same transparent-background base with the given attributes on
- * top; it intentionally does NOT inherit attributes from the standard appearance,
- * mirroring how UIKit treats an explicitly assigned scroll edge appearance object as a
- * complete description.
+ * Maps scroll edge appearance props to a UINavigationBarAppearance object.
+ * `appearanceDict` should be an NSDictionary with a flat structure, where entries correspond
+ * to UIKit attributes, e.g. `titleFontFamily`, `subtitleFontColor`, or empty, for UIKit defaults.
+ * The appearance object is built with transparent background configured by default, matching UIKit.
  */
 + (nullable UINavigationBarAppearance *)scrollEdgeAppearanceFromDictionary:(nullable NSDictionary *)appearanceDict;
 

--- a/ios/stack/header/RNSStackHeaderAppearanceMapper.h
+++ b/ios/stack/header/RNSStackHeaderAppearanceMapper.h
@@ -15,14 +15,17 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict;
 
 /**
- * Maps appearance props to a UINavigationBarAppearance object derived from `baseAppearance`.
+ * Maps scroll edge appearance props to a standalone UINavigationBarAppearance object.
  *
- * The result inherits from `baseAppearance` and uses a transparent background, mirroring
- * how UIKit resolves a nil scroll edge appearance from the standard one. Entries in
- * `appearanceDict` override the inherited attributes.
+ * Returns nil for an empty dictionary — the navigation item's scroll edge appearance
+ * should then stay nil, so that UIKit's native resolution applies: the item's (or bar's)
+ * standard appearance with a transparent background. When a dictionary is provided, the
+ * result is built on the same transparent-background base with the given attributes on
+ * top; it intentionally does NOT inherit attributes from the standard appearance,
+ * mirroring how UIKit treats an explicitly assigned scroll edge appearance object as a
+ * complete description.
  */
-+ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict
-                                                  inheritingFrom:(nullable UINavigationBarAppearance *)baseAppearance;
++ (nullable UINavigationBarAppearance *)scrollEdgeAppearanceFromDictionary:(nullable NSDictionary *)appearanceDict;
 
 @end
 

--- a/ios/stack/header/RNSStackHeaderAppearanceMapper.mm
+++ b/ios/stack/header/RNSStackHeaderAppearanceMapper.mm
@@ -1,0 +1,90 @@
+#import "RNSStackHeaderAppearanceMapper.h"
+#import "RNSDefines.h"
+
+#import <React/RCTConvert.h>
+#import <React/RCTFont.h>
+
+@implementation RNSStackHeaderAppearanceMapper
+
++ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict
+{
+  if (appearanceDict.count == 0) {
+    return nil;
+  }
+
+  UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
+  [self applyTextAttributesFromDictionary:appearanceDict toAppearance:appearance];
+  return appearance;
+}
+
++ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict
+                                                  inheritingFrom:(nullable UINavigationBarAppearance *)baseAppearance
+{
+  if (appearanceDict.count == 0 && baseAppearance == nil) {
+    return nil;
+  }
+
+  UINavigationBarAppearance *appearance = baseAppearance != nil
+      ? [[UINavigationBarAppearance alloc] initWithBarAppearance:baseAppearance]
+      : [UINavigationBarAppearance new];
+
+  // UIKit resolves a nil scroll edge appearance to the standard one with a transparent
+  // background; configureWithTransparentBackground resets only the background & shadow
+  // properties, keeping the inherited text attributes.
+  [appearance configureWithTransparentBackground];
+
+  [self applyTextAttributesFromDictionary:appearanceDict toAppearance:appearance];
+  return appearance;
+}
+
++ (void)applyTextAttributesFromDictionary:(nullable NSDictionary *)appearanceDict
+                             toAppearance:(nonnull UINavigationBarAppearance *)appearance
+{
+  appearance.titleTextAttributes = [self textAttributes:appearance.titleTextAttributes
+                                  updatedWithDictionary:appearanceDict
+                                              keyPrefix:@"title"];
+  appearance.largeTitleTextAttributes = [self textAttributes:appearance.largeTitleTextAttributes
+                                       updatedWithDictionary:appearanceDict
+                                                   keyPrefix:@"largeTitle"];
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    // UIKit derives both the regular and the large subtitle appearance from
+    // subtitleTextAttributes; largeSubtitleTextAttributes is ignored.
+    appearance.subtitleTextAttributes = [self textAttributes:appearance.subtitleTextAttributes
+                                       updatedWithDictionary:appearanceDict
+                                                   keyPrefix:@"subtitle"];
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+}
+
++ (nonnull NSDictionary *)textAttributes:(nullable NSDictionary *)baseAttributes
+                   updatedWithDictionary:(nullable NSDictionary *)appearanceDict
+                               keyPrefix:(nonnull NSString *)keyPrefix
+{
+  id fontFamily = appearanceDict[[keyPrefix stringByAppendingString:@"FontFamily"]];
+  id fontSize = appearanceDict[[keyPrefix stringByAppendingString:@"FontSize"]];
+  id fontWeight = appearanceDict[[keyPrefix stringByAppendingString:@"FontWeight"]];
+  id fontStyle = appearanceDict[[keyPrefix stringByAppendingString:@"FontStyle"]];
+  id fontColor = appearanceDict[[keyPrefix stringByAppendingString:@"FontColor"]];
+
+  NSMutableDictionary *textAttributes = [baseAttributes mutableCopy] ?: [NSMutableDictionary new];
+
+  if (fontFamily != nil || fontSize != nil || fontWeight != nil || fontStyle != nil) {
+    textAttributes[NSFontAttributeName] = [RCTFont updateFont:baseAttributes[NSFontAttributeName]
+                                                   withFamily:fontFamily
+                                                         size:fontSize
+                                                       weight:fontWeight
+                                                        style:fontStyle
+                                                      variant:nil
+                                              scaleMultiplier:1.0];
+  }
+
+  if (fontColor != nil) {
+    textAttributes[NSForegroundColorAttributeName] = [RCTConvert UIColor:fontColor];
+  }
+
+  return textAttributes;
+}
+
+@end

--- a/ios/stack/header/RNSStackHeaderAppearanceMapper.mm
+++ b/ios/stack/header/RNSStackHeaderAppearanceMapper.mm
@@ -17,20 +17,18 @@
   return appearance;
 }
 
-+ (nullable UINavigationBarAppearance *)appearanceFromDictionary:(nullable NSDictionary *)appearanceDict
-                                                  inheritingFrom:(nullable UINavigationBarAppearance *)baseAppearance
++ (nullable UINavigationBarAppearance *)scrollEdgeAppearanceFromDictionary:(nullable NSDictionary *)appearanceDict
 {
-  if (appearanceDict.count == 0 && baseAppearance == nil) {
+  if (appearanceDict.count == 0) {
     return nil;
   }
 
-  UINavigationBarAppearance *appearance = baseAppearance != nil
-      ? [[UINavigationBarAppearance alloc] initWithBarAppearance:baseAppearance]
-      : [UINavigationBarAppearance new];
+  UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
 
-  // UIKit resolves a nil scroll edge appearance to the standard one with a transparent
-  // background; configureWithTransparentBackground resets only the background & shadow
-  // properties, keeping the inherited text attributes.
+  // A nil navigationItem.scrollEdgeAppearance natively resolves to the item's (or bar's)
+  // standard appearance with a transparent background. Start the explicit scroll edge
+  // appearance from the same transparent base so that a text-only appearance prop does
+  // not suddenly bring back the default bar background at the scroll edge.
   [appearance configureWithTransparentBackground];
 
   [self applyTextAttributesFromDictionary:appearanceDict toAppearance:appearance];

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.h
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic, readonly) BOOL backButtonMenuEnabled;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *titleMenu;
+@property (nonatomic, readonly, nullable) UINavigationBarAppearance *standardAppearance;
+@property (nonatomic, readonly, nullable) UINavigationBarAppearance *scrollEdgeAppearance;
 @property (nonatomic, readonly) NSArray<id> *children;
 
 @property (nonatomic, weak, nullable) RNSStackScreenHeaderCoordinator *headerCoordinator;

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -44,9 +44,6 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   RNSStackHeaderConfigEventEmitter *_Nonnull _reactEventEmitter;
   NSMutableArray<id> *_children;
   RCTImageLoader *_imageLoader;
-  // Scroll edge appearance inherits from the standard one, so the raw prop
-  // is kept around to rebuild the appearance when either prop changes.
-  NSDictionary *_Nullable _scrollEdgeAppearanceDict;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -77,7 +74,6 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   _titleMenu = nil;
   _standardAppearance = nil;
   _scrollEdgeAppearance = nil;
-  _scrollEdgeAppearanceDict = nil;
 }
 
 - (NSArray<id> *)children
@@ -459,23 +455,14 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     _backButtonMenuEnabled = newHeaderProps.backButtonMenuEnabled;
   }
 
-  BOOL standardAppearanceDidChange = oldHeaderProps.standardAppearance != newHeaderProps.standardAppearance;
-  BOOL scrollEdgeAppearanceDidChange = oldHeaderProps.scrollEdgeAppearance != newHeaderProps.scrollEdgeAppearance;
-
-  if (standardAppearanceDidChange) {
+  if (oldHeaderProps.standardAppearance != newHeaderProps.standardAppearance) {
     _standardAppearance = [RNSStackHeaderAppearanceMapper
         appearanceFromDictionary:[self dictionaryFromAppearanceProp:newHeaderProps.standardAppearance]];
   }
 
-  if (scrollEdgeAppearanceDidChange) {
-    _scrollEdgeAppearanceDict = [self dictionaryFromAppearanceProp:newHeaderProps.scrollEdgeAppearance];
-  }
-
-  if (standardAppearanceDidChange || scrollEdgeAppearanceDidChange) {
-    // Scroll edge appearance inherits from the standard one, so it must be
-    // rebuilt when either prop changes.
-    _scrollEdgeAppearance = [RNSStackHeaderAppearanceMapper appearanceFromDictionary:_scrollEdgeAppearanceDict
-                                                                      inheritingFrom:_standardAppearance];
+  if (oldHeaderProps.scrollEdgeAppearance != newHeaderProps.scrollEdgeAppearance) {
+    _scrollEdgeAppearance = [RNSStackHeaderAppearanceMapper
+        scrollEdgeAppearanceFromDictionary:[self dictionaryFromAppearanceProp:newHeaderProps.scrollEdgeAppearance]];
   }
 
   if (oldHeaderProps.titleMenu != newHeaderProps.titleMenu) {

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -1,6 +1,7 @@
 #import "RNSStackHeaderConfigComponentView.h"
 #import "RNSConversions.h"
 #import "RNSImageLoadingHelper.h"
+#import "RNSStackHeaderAppearanceMapper.h"
 #import "RNSStackHeaderConfigEventEmitter.h"
 #import "RNSStackHeaderConfigShadowStateProxy.h"
 #import "RNSStackHeaderItemComponentView.h"
@@ -43,6 +44,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   RNSStackHeaderConfigEventEmitter *_Nonnull _reactEventEmitter;
   NSMutableArray<id> *_children;
   RCTImageLoader *_imageLoader;
+  // Scroll edge appearance inherits from the standard one, so the raw prop
+  // is kept around to rebuild the appearance when either prop changes.
+  NSDictionary *_Nullable _scrollEdgeAppearanceDict;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -71,6 +75,9 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   _backButtonDisplayMode = UINavigationItemBackButtonDisplayModeDefault;
   _backButtonMenuEnabled = YES;
   _titleMenu = nil;
+  _standardAppearance = nil;
+  _scrollEdgeAppearance = nil;
+  _scrollEdgeAppearanceDict = nil;
 }
 
 - (NSArray<id> *)children
@@ -452,6 +459,25 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
     _backButtonMenuEnabled = newHeaderProps.backButtonMenuEnabled;
   }
 
+  BOOL standardAppearanceDidChange = oldHeaderProps.standardAppearance != newHeaderProps.standardAppearance;
+  BOOL scrollEdgeAppearanceDidChange = oldHeaderProps.scrollEdgeAppearance != newHeaderProps.scrollEdgeAppearance;
+
+  if (standardAppearanceDidChange) {
+    _standardAppearance = [RNSStackHeaderAppearanceMapper
+        appearanceFromDictionary:[self dictionaryFromAppearanceProp:newHeaderProps.standardAppearance]];
+  }
+
+  if (scrollEdgeAppearanceDidChange) {
+    _scrollEdgeAppearanceDict = [self dictionaryFromAppearanceProp:newHeaderProps.scrollEdgeAppearance];
+  }
+
+  if (standardAppearanceDidChange || scrollEdgeAppearanceDidChange) {
+    // Scroll edge appearance inherits from the standard one, so it must be
+    // rebuilt when either prop changes.
+    _scrollEdgeAppearance = [RNSStackHeaderAppearanceMapper appearanceFromDictionary:_scrollEdgeAppearanceDict
+                                                                      inheritingFrom:_standardAppearance];
+  }
+
   if (oldHeaderProps.titleMenu != newHeaderProps.titleMenu) {
     _titleMenu = [RNSStackHeaderMenuMapper
         menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newHeaderProps.titleMenu)];
@@ -489,6 +515,26 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 }
 
 #pragma mark - Private
+
+- (nullable NSDictionary *)dictionaryFromAppearanceProp:(const folly::dynamic &)appearanceProp
+{
+  if (appearanceProp.type() != folly::dynamic::OBJECT) {
+    return nil;
+  }
+
+  return rnscreens::conversion::RNSConvertFollyDynamicToId(appearanceProp);
+}
+
+- (nullable RNSStackScreenHeaderCoordinator *)headerCoordinator
+{
+  if (self.superview == nil) {
+    return nil;
+  }
+  RCTAssert([self.superview isKindOfClass:RNSStackScreenComponentView.class],
+            @"[RNScreens] Header Config should be a direct child of RNSStackScreenComponentView");
+  RNSStackScreenComponentView *screen = (RNSStackScreenComponentView *)self.superview;
+  return screen.controller.headerCoordinator;
+}
 
 - (RNSStackNavigationController *)requireNavigationController
 {

--- a/ios/stack/header/RNSStackHeaderConfigDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderConfigDataProviding.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic, readonly) BOOL backButtonMenuEnabled;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *titleMenu;
+@property (nonatomic, readonly, nullable) UINavigationBarAppearance *standardAppearance;
+@property (nonatomic, readonly, nullable) UINavigationBarAppearance *scrollEdgeAppearance;
 
 /**
  Children are expected to conform to either RNSStackHeaderItemDataProviding

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -315,6 +315,8 @@
 
   navItem.title = nil;
   navItem.titleView = nil;
+  navItem.standardAppearance = nil;
+  navItem.scrollEdgeAppearance = nil;
   [navItem setLeftBarButtonItems:@[] animated:YES];
   [navItem setRightBarButtonItems:@[] animated:YES];
 
@@ -423,6 +425,8 @@
   UINavigationItem *navItem = controller.navigationItem;
 
   navItem.title = _configDataProvider.title;
+  navItem.standardAppearance = _configDataProvider.standardAppearance;
+  navItem.scrollEdgeAppearance = _configDataProvider.scrollEdgeAppearance;
 
 #if !TARGET_OS_TV
   NSString *prompt = _configDataProvider.prompt;

--- a/src/components/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/stack/header/StackHeaderConfig.ios.tsx
@@ -14,6 +14,7 @@ import type {
 } from './StackHeaderConfig.types';
 import StackHeaderConfigIOSNativeComponent, {
   Commands as StackHeaderConfigIOSNativeCommands,
+  HeaderAppearance,
   MenuItemPressEvent,
   MenuSelectionChangeEvent,
   NativeMenuElementOptionsIOS,
@@ -22,8 +23,9 @@ import type { StackHeaderItemPlacement } from './ios/StackHeaderItem.ios.types';
 import { StackHeaderItemSpacerPlacement } from './ios/StackHeaderItemSpacer.ios.types';
 import StackHeaderItemSpacer from './ios/StackHeaderItemSpacer.ios';
 import StackHeaderItem from './ios/StackHeaderItem.ios';
-import { NativeSyntheticEvent, StyleSheet } from 'react-native';
+import { NativeSyntheticEvent, StyleSheet, processColor } from 'react-native';
 import type {
+  StackHeaderAppearanceIOS,
   StackHeaderInlineCustomItemIOS,
   StackHeaderInlineItemIOS,
   StackHeaderMenuItemOptionsIOS,
@@ -59,6 +61,8 @@ function StackHeaderConfig(
     backButtonTitle,
     backButtonDisplayMode,
     backButtonMenuEnabled,
+    standardAppearance,
+    scrollEdgeAppearance,
   } = ios ?? {};
 
   const nativeRef =
@@ -162,6 +166,8 @@ function StackHeaderConfig(
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
       prompt={prompt}
+      standardAppearance={mapAppearanceToNativeProp(standardAppearance)}
+      scrollEdgeAppearance={mapAppearanceToNativeProp(scrollEdgeAppearance)}
       titleMenu={resolvedTitleMenu}
       style={styles.config}
       onMenuItemPress={handleMenuItemPress}
@@ -174,6 +180,36 @@ function StackHeaderConfig(
       {trailingItems?.map(item => makeItemViewFromItem(item, 'trailing'))}
     </StackHeaderConfigIOSNativeComponent>
   );
+}
+
+function mapAppearanceToNativeProp(
+  appearance?: StackHeaderAppearanceIOS,
+): HeaderAppearance | undefined {
+  if (!appearance) return undefined;
+
+  const {
+    titleFontColor,
+    titleFontWeight,
+    largeTitleFontColor,
+    largeTitleFontWeight,
+    subtitleFontColor,
+    subtitleFontWeight,
+  } = appearance;
+
+  return {
+    ...appearance,
+    titleFontColor: processColor(titleFontColor),
+    titleFontWeight:
+      titleFontWeight !== undefined ? String(titleFontWeight) : undefined,
+    largeTitleFontColor: processColor(largeTitleFontColor),
+    largeTitleFontWeight:
+      largeTitleFontWeight !== undefined
+        ? String(largeTitleFontWeight)
+        : undefined,
+    subtitleFontColor: processColor(subtitleFontColor),
+    subtitleFontWeight:
+      subtitleFontWeight !== undefined ? String(subtitleFontWeight) : undefined,
+  };
 }
 
 function makeItemViewFromItem(

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -560,10 +560,9 @@ export interface StackHeaderConfigPropsIOS {
    * @summary Appearance of the header when the edge of scrollable content
    * is aligned with the edge of the header.
    *
-   * @description The scroll edge appearance is derived from `standardAppearance`,
-   * inheriting its text attributes over a transparent background - matching how UIKit
-   * resolves an unset scroll edge appearance. Attributes defined here override the
-   * inherited ones.
+   * @description If unset, derives the configuration from `standardAppearance`,
+   * otherwise becomes a standalone definition. In both cases it keeps transparent
+   * background by default (iOS <18).
    *
    * @platform ios
    */

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import type { TextStyle } from 'react-native';
 import type { PlatformIconIOS } from '../../shared/types';
 import type { StackHeaderMenuIOS } from './ios/StackHeaderMenu.ios.types';
 
@@ -290,6 +291,119 @@ export type StackHeaderBackButtonDisplayModeIOS =
   | 'generic'
   | 'minimal';
 
+export interface StackHeaderAppearanceIOS {
+  /**
+   * @summary Specifies the font family used for the title of the header.
+   *
+   * @platform ios
+   */
+  titleFontFamily?: TextStyle['fontFamily'] | undefined;
+  /**
+   * @summary Specifies the font size used for the title of the header.
+   *
+   * @platform ios
+   */
+  titleFontSize?: TextStyle['fontSize'] | undefined;
+  /**
+   * @summary Specifies the font weight used for the title of the header.
+   *
+   * @platform ios
+   */
+  titleFontWeight?: TextStyle['fontWeight'] | undefined;
+  /**
+   * @summary Specifies the font style used for the title of the header.
+   *
+   * @platform ios
+   */
+  titleFontStyle?: TextStyle['fontStyle'] | undefined;
+  /**
+   * @summary Specifies the font color used for the title of the header.
+   *
+   * @platform ios
+   */
+  titleFontColor?: TextStyle['color'] | undefined;
+  /**
+   * @summary Specifies the font family used for the large title of the header.
+   *
+   * @platform ios
+   */
+  largeTitleFontFamily?: TextStyle['fontFamily'] | undefined;
+  /**
+   * @summary Specifies the font size used for the large title of the header.
+   *
+   * @platform ios
+   */
+  largeTitleFontSize?: TextStyle['fontSize'] | undefined;
+  /**
+   * @summary Specifies the font weight used for the large title of the header.
+   *
+   * @platform ios
+   */
+  largeTitleFontWeight?: TextStyle['fontWeight'] | undefined;
+  /**
+   * @summary Specifies the font style used for the large title of the header.
+   *
+   * @platform ios
+   */
+  largeTitleFontStyle?: TextStyle['fontStyle'] | undefined;
+  /**
+   * @summary Specifies the font color used for the large title of the header.
+   *
+   * @platform ios
+   */
+  largeTitleFontColor?: TextStyle['color'] | undefined;
+  /**
+   * @summary Specifies the font family used for the subtitle of the header.
+   *
+   * @description Applies to both the regular and the large subtitle.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 and higher
+   */
+  subtitleFontFamily?: TextStyle['fontFamily'] | undefined;
+  /**
+   * @summary Specifies the font size used for the subtitle of the header.
+   *
+   * @description Applies to both the regular and the large subtitle.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 and higher
+   */
+  subtitleFontSize?: TextStyle['fontSize'] | undefined;
+  /**
+   * @summary Specifies the font weight used for the subtitle of the header.
+   *
+   * @description Applies to both the regular and the large subtitle.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 and higher
+   */
+  subtitleFontWeight?: TextStyle['fontWeight'] | undefined;
+  /**
+   * @summary Specifies the font style used for the subtitle of the header.
+   *
+   * @description Applies to both the regular and the large subtitle.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 and higher
+   */
+  subtitleFontStyle?: TextStyle['fontStyle'] | undefined;
+  /**
+   * @summary Specifies the font color used for the subtitle of the header.
+   *
+   * @description Applies to both the regular and the large subtitle.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 and higher
+   */
+  subtitleFontColor?: TextStyle['color'] | undefined;
+}
+
 export interface StackHeaderConfigPropsIOS {
   /**
    * @summary Title displayed next to the back button on this screen.
@@ -435,6 +549,25 @@ export interface StackHeaderConfigPropsIOS {
    * @platform iOS
    */
   prompt?: string | undefined;
+  /**
+   * @summary Appearance of the header when the edge of scrollable content
+   * is not aligned with the edge of the header.
+   *
+   * @platform ios
+   */
+  standardAppearance?: StackHeaderAppearanceIOS | undefined;
+  /**
+   * @summary Appearance of the header when the edge of scrollable content
+   * is aligned with the edge of the header.
+   *
+   * @description The scroll edge appearance is derived from `standardAppearance`,
+   * inheriting its text attributes over a transparent background - matching how UIKit
+   * resolves an unset scroll edge appearance. Attributes defined here override the
+   * inherited ones.
+   *
+   * @platform ios
+   */
+  scrollEdgeAppearance?: StackHeaderAppearanceIOS | undefined;
 }
 
 export interface StackHeaderConfigCommandsIOS {

--- a/src/components/stack/index.ts
+++ b/src/components/stack/index.ts
@@ -40,6 +40,7 @@ export type {
   // iOS
   StackHeaderBackButtonDisplayModeIOS,
   StackHeaderConfigPropsIOS,
+  StackHeaderAppearanceIOS,
   StackHeaderInlineItemIOS,
   StackHeaderInlineCustomItemIOS,
   StackHeaderTitleCustomItemIOS,

--- a/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -3,6 +3,7 @@
 import type {
   CodegenTypes as CT,
   HostComponent,
+  ProcessedColorValue,
   ViewProps,
 } from 'react-native';
 import { codegenNativeCommands, codegenNativeComponent } from 'react-native';
@@ -13,6 +14,26 @@ import type {
 import { UnsafeMixed } from '../codegenUtils';
 
 type BackButtonDisplayMode = 'default' | 'generic' | 'minimal';
+
+export type HeaderAppearance = {
+  titleFontFamily?: string | undefined;
+  titleFontSize?: CT.Float | undefined;
+  titleFontWeight?: string | undefined;
+  titleFontStyle?: string | undefined;
+  titleFontColor?: ProcessedColorValue | null | undefined;
+
+  largeTitleFontFamily?: string | undefined;
+  largeTitleFontSize?: CT.Float | undefined;
+  largeTitleFontWeight?: string | undefined;
+  largeTitleFontStyle?: string | undefined;
+  largeTitleFontColor?: ProcessedColorValue | null | undefined;
+
+  subtitleFontFamily?: string | undefined;
+  subtitleFontSize?: CT.Float | undefined;
+  subtitleFontWeight?: string | undefined;
+  subtitleFontStyle?: string | undefined;
+  subtitleFontColor?: ProcessedColorValue | null | undefined;
+};
 
 export type MenuItemPressEvent = Readonly<{ menuItemId: string }>;
 
@@ -40,6 +61,9 @@ export interface NativeProps extends ViewProps {
   prompt?: string | undefined;
 
   titleMenu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
+
+  standardAppearance?: UnsafeMixed<HeaderAppearance> | undefined;
+  scrollEdgeAppearance?: UnsafeMixed<HeaderAppearance> | undefined;
 
   onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;
   onMenuSelectionChange?:


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/857
Closes https://github.com/software-mansion/react-native-screens-labs/issues/859
Closes https://github.com/software-mansion/react-native-screens-labs/issues/858

## Description

This PR adds text style configuration for various titles in header. It defines a common flow for UINavigationBarAppearance that will be used for adding other props in following PRs.

UIKit resolve defaults in the following order:
- `navigationItem.standardAppearance` defaults to `navigationBar.standardAppearance` [source](https://developer.apple.com/documentation/uikit/uinavigationitem/standardappearance?language=objc)
- `navigationItem.scrollEdgeAppearance` defaults to `navigationBar.scrollEdgeApperance` which defaults to `navigationBar.standardAppearance` modified to use transparent background [source](https://developer.apple.com/documentation/uikit/uinavigationbar/scrolledgeappearance?language=objc)

For now we're not exposing global navigation bar settings. We're not changing UIKit behavior. `standardAppearance` is independent of `scrollEdgeAppearance`.

## Changes

- added props for `standardAppearance` and `scrollEdgeAppearance`: both are objects / UnsafeMixed with fields matching 1:1 UIKit's `UINavigationBarAppearance`
- added mapper class that creates an actual `UINavigationBarApperance` from above objects
- header coordinator applies the built objects to `navigationItem`

## Before & after - visual documentation


https://github.com/user-attachments/assets/10d9a975-7ee6-4b69-80fe-b0133ee40f06

> [!important]
> At the end there is a visual glitch visible. This is confirmed native.
> 

## Test plan

Use test-stack-header-title-appearance-ios SFT. Verify that the configuration works.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
