### PR TITLE
refactor(iOS): polish silence of warnings for v5 components

### DIFF
--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -10,13 +10,9 @@
 #import "RNSSplitScreenComponentView.h"
 #import "RNSSplitScreenController.h"
 
-#ifndef NS_BLOCK_ASSERTIONS
-
-static const NSInteger minNumberOfColumns = 2;
-static const NSInteger maxNumberOfColumns = 3;
-static const NSInteger maxNumberOfInspectors = 1;
-
-#endif // !NS_BLOCK_ASSERTIONS
+[[maybe_unused]] static const NSInteger minNumberOfColumns = 2;
+[[maybe_unused]] static const NSInteger maxNumberOfColumns = 3;
+[[maybe_unused]] static const NSInteger maxNumberOfInspectors = 1;
 
 @interface RNSSplitHostController () <UISplitViewControllerDelegate,
                                       RNSSplitNavigationControllerFrameOriginChangeDelegate>

--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -10,9 +10,13 @@
 #import "RNSSplitScreenComponentView.h"
 #import "RNSSplitScreenController.h"
 
+#ifndef NS_BLOCK_ASSERTIONS
+
 static const NSInteger minNumberOfColumns = 2;
 static const NSInteger maxNumberOfColumns = 3;
 static const NSInteger maxNumberOfInspectors = 1;
+
+#endif // !NS_BLOCK_ASSERTIONS
 
 @interface RNSSplitHostController () <UISplitViewControllerDelegate,
                                       RNSSplitNavigationControllerFrameOriginChangeDelegate>

--- a/ios/stack/header/RNSStackHeaderMenuMapper.mm
+++ b/ios/stack/header/RNSStackHeaderMenuMapper.mm
@@ -88,18 +88,22 @@ static NSSet<NSString *> *const kRNSAllowedMenuItemKeys = [NSSet
 
 + (void)validateMenuKeys:(NSDictionary *)dict
 {
+#ifndef NS_BLOCK_ASSERTIONS
   for (NSString *key in dict) {
     RCTAssert([kRNSAllowedMenuKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu", key);
   }
+#endif // !NS_BLOCK_ASSERTIONS
   RCTAssert(dict[@"children"], @"[RNScreens] missing key \"children\" in menu");
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 
 + (void)validateMenuItemKeys:(NSDictionary *)dict
 {
+#ifndef NS_BLOCK_ASSERTIONS
   for (NSString *key in dict) {
     RCTAssert([kRNSAllowedMenuItemKeys containsObject:key], @"[RNScreens] Invalid key \"%@\" found in menu item", key);
   }
+#endif // !NS_BLOCK_ASSERTIONS
   RCTAssert(dict[@"id"], @"[RNScreens] missing id on one of menu elements");
 }
 

--- a/ios/stack/host/RNSStackNavigationController.mm
+++ b/ios/stack/host/RNSStackNavigationController.mm
@@ -126,8 +126,8 @@
 
 - (void)dumpStackModel
 {
-#ifdef RNS_DEBUG_LOGGING
   RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
+#ifdef RNS_DEBUG_LOGGING
   for (UIViewController *viewController in self.viewControllers) {
     RNSLog(@"[RNScreens] %@", static_cast<RNSStackScreenComponentView *>(viewController.view).screenKey);
   }

--- a/ios/stack/host/RNSStackNavigationController.mm
+++ b/ios/stack/host/RNSStackNavigationController.mm
@@ -102,10 +102,10 @@
     return;
   }
 
-  for (RNSPopOperation *op in _pendingPopOperations) {
-    UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
+  for ([[maybe_unused]] RNSPopOperation *op in _pendingPopOperations) {
     RCTAssert([self.viewControllers count] > 1, @"[RNScreens] Attempt to pop last screen from the stack");
-    RCTAssert(self.topViewController == controller, @"[RNScreens] Attempt to pop non-top screen");
+    RCTAssert(self.topViewController == static_cast<UIViewController *>(op.stackScreen.controller),
+              @"[RNScreens] Attempt to pop non-top screen");
     [self popViewControllerAnimated:YES];
   }
 
@@ -126,10 +126,12 @@
 
 - (void)dumpStackModel
 {
+#ifdef RNS_DEBUG_LOGGING
   RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
   for (UIViewController *viewController in self.viewControllers) {
     RNSLog(@"[RNScreens] %@", static_cast<RNSStackScreenComponentView *>(viewController.view).screenKey);
   }
+#endif // RNS_DEBUG_LOGGING
 }
 
 @end

--- a/ios/stack/host/RNSStackOperation.h
+++ b/ios/stack/host/RNSStackOperation.h
@@ -18,8 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSPopOperation : RNSStackOperation
 
-@property (nonatomic, strong, readonly) RNSStackScreenComponentView *stackScreen;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

This PR is a follow-up to [PR 4508](https://github.com/software-mansion/react-native-screens/pull/4508/changes). It polish uncorrect silence of warnings.

## Changes

- Use `[[maybe_unused]]` for static integers in  `ios/split/RNSSplitHostController.mm`
- 

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
