### PR TITLE
refactor(iOS): polish silence of warnings for v5 components

### DIFF
--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -10,13 +10,9 @@
 #import "RNSSplitScreenComponentView.h"
 #import "RNSSplitScreenController.h"
 
-#ifndef NS_BLOCK_ASSERTIONS
-
-static const NSInteger minNumberOfColumns = 2;
-static const NSInteger maxNumberOfColumns = 3;
-static const NSInteger maxNumberOfInspectors = 1;
-
-#endif // !NS_BLOCK_ASSERTIONS
+[[maybe_unused]] static const NSInteger minNumberOfColumns = 2;
+[[maybe_unused]] static const NSInteger maxNumberOfColumns = 3;
+[[maybe_unused]] static const NSInteger maxNumberOfInspectors = 1;
 
 @interface RNSSplitHostController () <UISplitViewControllerDelegate,
                                       RNSSplitNavigationControllerFrameOriginChangeDelegate>

--- a/ios/stack/host/RNSStackNavigationController.mm
+++ b/ios/stack/host/RNSStackNavigationController.mm
@@ -126,8 +126,8 @@
 
 - (void)dumpStackModel
 {
-#ifdef RNS_DEBUG_LOGGING
   RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
+#ifdef RNS_DEBUG_LOGGING
   for (UIViewController *viewController in self.viewControllers) {
     RNSLog(@"[RNScreens] %@", static_cast<RNSStackScreenComponentView *>(viewController.view).screenKey);
   }

--- a/ios/stack/host/RNSStackNavigationController.mm
+++ b/ios/stack/host/RNSStackNavigationController.mm
@@ -126,8 +126,8 @@
 
 - (void)dumpStackModel
 {
-  RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
 #ifdef RNS_DEBUG_LOGGING
+  RNSLog(@"[RNScreens] StackContainer [%ld] MODEL BEGIN", self.view.tag);
   for (UIViewController *viewController in self.viewControllers) {
     RNSLog(@"[RNScreens] %@", static_cast<RNSStackScreenComponentView *>(viewController.view).screenKey);
   }


### PR DESCRIPTION
## Description

This PR is a follow-up to [PR 4508](https://github.com/software-mansion/react-native-screens/pull/4508). It polish uncorrect silence of warnings.

## Changes

- Use `[[maybe_unused]]` for static integers in  `ios/split/RNSSplitHostController.mm`
- In `ios/stack/host/RNSStackNavigationController.mm`, wrap only the `dumpStackModel` for-loop with `#ifdef RNS_DEBUG_LOGGING`

## Test plan

- Confirm these 4 warnings no longer appear
- Build and run the app in both debug and release

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
