### PR TITLE
fix(Android, FormSheet v5): Recreate the dialog on every presentation cycle

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
@@ -29,6 +29,16 @@ internal class FormSheetDimensionsCoordinator(
 
         bottomSheetView?.let { view ->
             disableMaterialInsetsAnimationCallback(view)
+            // The dialog is recreated every time it's shown, so its decor initially has no height.
+            // We need to rely on the first layout pass, because other paths (e.g. window insets)
+            // rarely change between presentations.
+            applyDimensionsAfterFirstLayout(view)
+        }
+    }
+
+    private fun applyDimensionsAfterFirstLayout(view: FrameLayout) {
+        view.doOnLayout {
+            updateNativeContainerHeight()
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
@@ -1,19 +1,13 @@
 package com.swmansion.rnscreens.modals.formsheet.native.core
 
 import android.content.Context
-import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.View
-import android.widget.FrameLayout
-import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetAppearanceCoordinator
-import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetBehaviorController
-import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetDimensionsCoordinator
-import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetNativeDismissCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.interfaces.FormSheetContentSizeChangeDelegate
 import com.swmansion.rnscreens.modals.formsheet.native.interfaces.FormSheetDialogEventEmitter
 import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetConfig
-import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 import com.swmansion.rnscreens.modals.formsheet.native.presentation.FormSheetDimmingManager
+import com.swmansion.rnscreens.modals.formsheet.native.presentation.FormSheetPresentation
 import com.swmansion.rnscreens.modals.formsheet.native.presentation.FormSheetPresentationManager
 import kotlin.properties.Delegates
 
@@ -32,134 +26,64 @@ class FormSheetDialogManager(
     // Eagerly create the container so it's always ready for the provided content view
     private val container = FormSheetContainer(themedContext, contentView)
 
-    // Eagerly create the dialog and attach the container
-    private val dialog =
-        FormSheetDialog(themedContext).apply {
-            setContentView(container)
-            // Backdrop taps are handled by Material's `touch_outside` view, which calls `cancel()`,
-            // intercepted by FormSheetDialog.cancelRequestInterceptor, that's responsible for
-            // preventNativeDismiss handling.
-            setCanceledOnTouchOutside(true)
-        }
+    // The React content only reports height changes, so a new presentation is seeded with the
+    // last known value.
+    private var lastContentHeight = 0
 
-    private val bottomSheetView = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+    private val presentationCallbacks =
+        object : FormSheetPresentation.Callbacks {
+            override fun onDetentChanged(index: Int) {
+                eventEmitter?.emitOnDetentChanged(index)
+            }
 
-    private val behaviorController =
-        bottomSheetView?.let {
-            FormSheetBehaviorController(it) { index -> eventEmitter?.emitOnDetentChanged(index) }
+            override fun onNativeDismissAllowed() {
+                presentationManager.handleNativeDismiss()
+            }
+
+            override fun onNativeDismissPrevented() {
+                eventEmitter?.emitOnNativeDismissPreventedEvent()
+            }
         }
 
     private val dimmingManager = FormSheetDimmingManager(context)
 
-    private val appearanceCoordinator =
-        FormSheetAppearanceCoordinator(
-            bottomSheetView = bottomSheetView,
-        )
-
-    private val dimensionsCoordinator =
-        FormSheetDimensionsCoordinator(
-            dialog = dialog,
-            container = container,
-            bottomSheetView = bottomSheetView,
-            behaviorController = behaviorController,
-        )
-
     private val presentationManager =
         FormSheetPresentationManager(
-            dialog = dialog,
-            bottomSheetView = bottomSheetView,
+            presentationFactory = ::createPresentation,
             dimmingManager = dimmingManager,
             onNativeDismiss = { eventEmitter?.emitOnNativeDismissEvent() },
             onDismiss = { eventEmitter?.emitOnDismissEvent() },
-        )
-
-    private val nativeDismissCoordinator =
-        FormSheetNativeDismissCoordinator(
-            dialog = dialog,
-            behaviorController = behaviorController,
-            onDismissAllowed = { presentationManager.handleNativeDismiss() },
-            onDismissPrevented = { eventEmitter?.emitOnNativeDismissPreventedEvent() },
         )
 
     internal var eventEmitter: FormSheetDialogEventEmitter? by Delegates.observable(null) { _, _, newValue ->
         presentationManager.appearanceEventEmitter = newValue
     }
 
-    internal val contentSizeChangeDelegate: FormSheetContentSizeChangeDelegate
-        get() = dimensionsCoordinator
+    internal val contentSizeChangeDelegate: FormSheetContentSizeChangeDelegate =
+        object : FormSheetContentSizeChangeDelegate {
+            override fun onContentHeightChanged(newHeight: Int) {
+                lastContentHeight = newHeight
+                presentationManager.presentation?.onContentHeightChanged(newHeight)
+            }
+        }
 
-    init {
-        presentationManager.setup()
-        nativeDismissCoordinator.setup()
-        appearanceCoordinator.setup()
-        dimensionsCoordinator.setup()
-        behaviorController?.setup()
-    }
+    private fun createPresentation(): FormSheetPresentation =
+        FormSheetPresentation(themedContext, container, presentationCallbacks).also {
+            it.applyInitialConfig(formSheetConfig, lastContentHeight)
+        }
 
     internal fun applyConfig(newConfig: FormSheetConfig) {
         val oldConfig = formSheetConfig
         formSheetConfig = newConfig
 
-        val reopened = !oldConfig.isOpen && newConfig.isOpen
-
-        // ALWAYS refresh dimensions when reopening to ensure that BottomSheet
-        // state and layout are synchronized with native behavior.
-        val dimensionsChanged = oldConfig.detents != newConfig.detents
-        if (dimensionsChanged || reopened) {
-            dimensionsCoordinator.updateFormSheetDimensions(
-                resolveDetents(newConfig.detents),
-                newConfig.initialDetentIndex,
-                reopened,
-            )
-        }
-
-        if (oldConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
-            container.setGrabberVisible(newConfig.prefersGrabberVisible)
-        }
-
-        if (oldConfig.preferredCornerRadius != newConfig.preferredCornerRadius) {
-            appearanceCoordinator.updateCornerRadius(newConfig.preferredCornerRadius)
-        }
-
-        if (oldConfig.nativeContainerBackgroundColor != newConfig.nativeContainerBackgroundColor) {
-            appearanceCoordinator.updateBackgroundColor(newConfig.nativeContainerBackgroundColor)
-        }
-
-        if (oldConfig.shouldPreventNativeDismiss != newConfig.shouldPreventNativeDismiss) {
-            nativeDismissCoordinator.shouldPreventDismiss = newConfig.shouldPreventNativeDismiss
-        }
+        presentationManager.presentation?.applyConfigUpdate(oldConfig, newConfig)
 
         if (oldConfig.isOpen != newConfig.isOpen) {
             presentationManager.requestProgrammaticStateUpdate(newConfig.isOpen)
         }
     }
 
-    private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
-        if (rawDetents.isEmpty()) {
-            return FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
-        }
-
-        return try {
-            FormSheetDetents(rawDetents)
-        } catch (e: IllegalArgumentException) {
-            Log.e(
-                "[RNScreens]",
-                "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
-                e,
-            )
-            FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
-        }
-    }
-
     internal fun destroy() {
-        behaviorController?.destroy()
-        nativeDismissCoordinator.destroy()
         presentationManager.destroy()
-        dimensionsCoordinator.destroy()
-        dialog.dismiss()
-    }
-
-    companion object {
-        private const val LARGE_DETENT_FRACTION = 1.0
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/core/FormSheetDialogManager.kt
@@ -63,7 +63,7 @@ class FormSheetDialogManager(
         object : FormSheetContentSizeChangeDelegate {
             override fun onContentHeightChanged(newHeight: Int) {
                 lastContentHeight = newHeight
-                presentationManager.presentation?.onContentHeightChanged(newHeight)
+                presentationManager.currentPresentation?.onContentHeightChanged(newHeight)
             }
         }
 
@@ -76,7 +76,7 @@ class FormSheetDialogManager(
         val oldConfig = formSheetConfig
         formSheetConfig = newConfig
 
-        presentationManager.presentation?.applyConfigUpdate(oldConfig, newConfig)
+        presentationManager.currentPresentation?.applyConfigUpdate(oldConfig, newConfig)
 
         if (oldConfig.isOpen != newConfig.isOpen) {
             presentationManager.requestProgrammaticStateUpdate(newConfig.isOpen)

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
@@ -1,0 +1,158 @@
+package com.swmansion.rnscreens.modals.formsheet.native.presentation
+
+import android.content.Context
+import android.util.Log
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetAppearanceCoordinator
+import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetBehaviorController
+import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetDimensionsCoordinator
+import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetNativeDismissCoordinator
+import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetContainer
+import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetDialog
+import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetConfig
+import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
+
+internal class FormSheetPresentation(
+    themedContext: Context,
+    private val container: FormSheetContainer,
+    private val callbacks: Callbacks,
+) {
+    internal interface Callbacks {
+        fun onDetentChanged(index: Int)
+
+        fun onNativeDismissAllowed()
+
+        fun onNativeDismissPrevented()
+    }
+
+    internal val dialog =
+        FormSheetDialog(themedContext).apply {
+            setContentView(container)
+            // Backdrop taps are handled by Material's `touch_outside` view, which calls `cancel()`,
+            // intercepted by FormSheetDialog.cancelRequestInterceptor, that's responsible for
+            // preventNativeDismiss handling.
+            setCanceledOnTouchOutside(true)
+        }
+
+    internal val bottomSheetView: FrameLayout? = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet)
+
+    internal val sheetBehavior: BottomSheetBehavior<FrameLayout>?
+        get() = bottomSheetView?.let { BottomSheetBehavior.from(it) }
+
+    private val behaviorController =
+        bottomSheetView?.let {
+            FormSheetBehaviorController(it) { index -> callbacks.onDetentChanged(index) }
+        }
+
+    private val appearanceCoordinator =
+        FormSheetAppearanceCoordinator(
+            bottomSheetView = bottomSheetView,
+        )
+
+    private val dimensionsCoordinator =
+        FormSheetDimensionsCoordinator(
+            dialog = dialog,
+            container = container,
+            bottomSheetView = bottomSheetView,
+            behaviorController = behaviorController,
+        )
+
+    private val nativeDismissCoordinator =
+        FormSheetNativeDismissCoordinator(
+            dialog = dialog,
+            behaviorController = behaviorController,
+            onDismissAllowed = callbacks::onNativeDismissAllowed,
+            onDismissPrevented = callbacks::onNativeDismissPrevented,
+        )
+
+    init {
+        nativeDismissCoordinator.setup()
+        appearanceCoordinator.setup()
+        dimensionsCoordinator.setup()
+        behaviorController?.setup()
+    }
+
+    internal fun onContentHeightChanged(height: Int) {
+        dimensionsCoordinator.onContentHeightChanged(height)
+    }
+
+    internal fun applyInitialConfig(
+        config: FormSheetConfig,
+        contentHeight: Int,
+    ) {
+        onContentHeightChanged(contentHeight)
+        dimensionsCoordinator.updateFormSheetDimensions(
+            resolveDetents(config.detents),
+            config.initialDetentIndex,
+            applyInitialDetent = true,
+        )
+        container.setGrabberVisible(config.prefersGrabberVisible)
+        appearanceCoordinator.updateCornerRadius(config.preferredCornerRadius)
+        appearanceCoordinator.updateBackgroundColor(config.nativeContainerBackgroundColor)
+        nativeDismissCoordinator.shouldPreventDismiss = config.shouldPreventNativeDismiss
+    }
+
+    internal fun applyConfigUpdate(
+        oldConfig: FormSheetConfig,
+        newConfig: FormSheetConfig,
+    ) {
+        if (oldConfig.detents != newConfig.detents) {
+            dimensionsCoordinator.updateFormSheetDimensions(
+                resolveDetents(newConfig.detents),
+                newConfig.initialDetentIndex,
+            )
+        }
+
+        if (oldConfig.prefersGrabberVisible != newConfig.prefersGrabberVisible) {
+            container.setGrabberVisible(newConfig.prefersGrabberVisible)
+        }
+
+        if (oldConfig.preferredCornerRadius != newConfig.preferredCornerRadius) {
+            appearanceCoordinator.updateCornerRadius(newConfig.preferredCornerRadius)
+        }
+
+        if (oldConfig.nativeContainerBackgroundColor != newConfig.nativeContainerBackgroundColor) {
+            appearanceCoordinator.updateBackgroundColor(newConfig.nativeContainerBackgroundColor)
+        }
+
+        if (oldConfig.shouldPreventNativeDismiss != newConfig.shouldPreventNativeDismiss) {
+            nativeDismissCoordinator.shouldPreventDismiss = newConfig.shouldPreventNativeDismiss
+        }
+    }
+
+    internal fun destroy() {
+        behaviorController?.destroy()
+        nativeDismissCoordinator.destroy()
+        dimensionsCoordinator.destroy()
+
+        dialog.setOnShowListener(null)
+        dialog.dismiss()
+
+        // The FormSheetContainer outlives the presentation - its lifecycle is managed by FormSheetDialogManager
+        // which is tied with the React's Host lifecycle.
+        (container.parent as? ViewGroup)?.removeView(container)
+    }
+
+    private fun resolveDetents(rawDetents: List<Double>): FormSheetDetents {
+        if (rawDetents.isEmpty()) {
+            return FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
+        }
+
+        return try {
+            FormSheetDetents(rawDetents)
+        } catch (e: IllegalArgumentException) {
+            Log.e(
+                "[RNScreens]",
+                "Invalid FormSheet detents: $rawDetents. Falling back to large detent.",
+                e,
+            )
+            FormSheetDetents(listOf(LARGE_DETENT_FRACTION))
+        }
+    }
+
+    companion object {
+        private const val LARGE_DETENT_FRACTION = 1.0
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -4,6 +4,7 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.util.Log
 import android.view.View
+import androidx.core.view.doOnPreDraw
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.common.event.ViewAppearanceEventEmitter
 
@@ -88,6 +89,7 @@ internal class FormSheetPresentationManager(
 
         FormSheetStackRegistry.register(this)
         appearanceEventEmitter?.emitOnWillAppear()
+        presentation.bottomSheetView?.let(::keepOffscreenUntilEnterAnimation)
         presentation.dialog.setOnShowListener {
             presentation.dialog.setOnShowListener(null)
 
@@ -155,6 +157,24 @@ internal class FormSheetPresentationManager(
         currentSheetAnimator = null
 
         performDismiss()
+    }
+
+    /**
+     * `Dialog.show()` **posts** the show message behind the sync barrier of the traversal scheduled while
+     * adding the decor to the window, so the Dialog always draws its first frame before `OnShowListener`
+     * (with our custom enter animation) runs. A freshly created sheet rests at `translationY = 0`, so that
+     * frame would show it at its final position and the enter animator would then snap it back
+     * off-screen.
+     *
+     * Applying the translation on the first pre-draw - after the layout, when the sheet height is
+     * already known, but before anything is drawn - keeps the sheet off-screen from the very first frame.
+     */
+    private fun keepOffscreenUntilEnterAnimation(view: View) {
+        view.doOnPreDraw {
+            if (currentSheetAnimator == null) {
+                view.translationY = view.height.toFloat()
+            }
+        }
     }
 
     private fun startEnterAnimation() {

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -16,11 +16,11 @@ internal class FormSheetPresentationManager(
 ) {
     internal var appearanceEventEmitter: ViewAppearanceEventEmitter? = null
 
-    internal var presentation: FormSheetPresentation? = null
+    internal var currentPresentation: FormSheetPresentation? = null
         private set
 
     private val bottomSheetView: View?
-        get() = presentation?.bottomSheetView
+        get() = currentPresentation?.bottomSheetView
 
     private var state = FormSheetPresentationState.DISMISSED
     private var shouldBeOpen = false
@@ -84,7 +84,7 @@ internal class FormSheetPresentationManager(
         }
 
         state = FormSheetPresentationState.PRESENTING
-        val presentation = presentationFactory().also { presentation = it }
+        val presentation = presentationFactory().also { currentPresentation = it }
         presentation.sheetBehavior?.let(dimmingManager::attachToBehavior)
 
         FormSheetStackRegistry.register(this)
@@ -238,8 +238,8 @@ internal class FormSheetPresentationManager(
     private fun performDismiss() {
         shouldSkipExitAnimation = false
         dimmingManager.detachDimming()
-        presentation?.destroy()
-        presentation = null
+        currentPresentation?.destroy()
+        currentPresentation = null
         onDismissComplete()
     }
 
@@ -280,8 +280,8 @@ internal class FormSheetPresentationManager(
         currentSheetAnimator?.cancel()
         currentSheetAnimator = null
 
-        presentation?.destroy()
-        presentation = null
+        currentPresentation?.destroy()
+        currentPresentation = null
 
         state = FormSheetPresentationState.DISMISSED
     }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -6,16 +6,20 @@ import android.util.Log
 import android.view.View
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.common.event.ViewAppearanceEventEmitter
-import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetDialog
 
 internal class FormSheetPresentationManager(
-    private val dialog: FormSheetDialog,
-    private val bottomSheetView: View?,
+    private val presentationFactory: () -> FormSheetPresentation,
     private val dimmingManager: FormSheetDimmingManager,
     private val onNativeDismiss: () -> Unit,
     private val onDismiss: () -> Unit,
 ) {
     internal var appearanceEventEmitter: ViewAppearanceEventEmitter? = null
+
+    internal var presentation: FormSheetPresentation? = null
+        private set
+
+    private val bottomSheetView: View?
+        get() = presentation?.bottomSheetView
 
     private var state = FormSheetPresentationState.DISMISSED
     private var shouldBeOpen = false
@@ -25,12 +29,6 @@ internal class FormSheetPresentationManager(
 
     private val animatorFactory = FormSheetAnimatorFactory(dimmingManager)
     private var currentSheetAnimator: Animator? = null
-
-    internal fun setup() {
-        bottomSheetView?.let { view ->
-            dimmingManager.attachToBehavior(BottomSheetBehavior.from(view))
-        }
-    }
 
     internal fun requestProgrammaticStateUpdate(shouldBeOpen: Boolean) {
         if (shouldBeOpen) {
@@ -85,10 +83,13 @@ internal class FormSheetPresentationManager(
         }
 
         state = FormSheetPresentationState.PRESENTING
+        val presentation = presentationFactory().also { presentation = it }
+        presentation.sheetBehavior?.let(dimmingManager::attachToBehavior)
+
         FormSheetStackRegistry.register(this)
         appearanceEventEmitter?.emitOnWillAppear()
-        dialog.setOnShowListener {
-            dialog.setOnShowListener(null)
+        presentation.dialog.setOnShowListener {
+            presentation.dialog.setOnShowListener(null)
 
             // Every sheet dims the surface inside the window below, attaching an overlay to the sheet
             // directly below in the stack, or to the DecorView when this sheet is the
@@ -97,7 +98,7 @@ internal class FormSheetPresentationManager(
 
             startEnterAnimation()
         }
-        dialog.show()
+        presentation.dialog.show()
     }
 
     private fun dismissIfNeeded() {
@@ -153,11 +154,11 @@ internal class FormSheetPresentationManager(
         currentSheetAnimator?.cancel()
         currentSheetAnimator = null
 
-        bottomSheetView?.let { syncBehaviorStateAfterExitAnimationComplete(it) }
         performDismiss()
     }
 
     private fun startEnterAnimation() {
+        val bottomSheetView = bottomSheetView
         if (bottomSheetView == null) {
             onPresentationComplete()
             return
@@ -186,6 +187,7 @@ internal class FormSheetPresentationManager(
     }
 
     private fun startExitAnimation() {
+        val bottomSheetView = bottomSheetView
         if (bottomSheetView == null) {
             performDismiss()
             return
@@ -205,7 +207,6 @@ internal class FormSheetPresentationManager(
                             dimmingManager.isTransitionAnimationRunning = false
 
                             if (currentSheetAnimator == this@apply) currentSheetAnimator = null
-                            syncBehaviorStateAfterExitAnimationComplete(bottomSheetView)
                             performDismiss()
                         }
                     },
@@ -217,7 +218,8 @@ internal class FormSheetPresentationManager(
     private fun performDismiss() {
         shouldSkipExitAnimation = false
         dimmingManager.detachDimming()
-        dialog.dismiss()
+        presentation?.destroy()
+        presentation = null
         onDismissComplete()
     }
 
@@ -251,27 +253,6 @@ internal class FormSheetPresentationManager(
         }
     }
 
-    /**
-     * Synchronizes the BottomSheetBehavior state with our custom exit animation.
-     *
-     * Since our custom ExitAnimator uses `translationY` for visual movement, the physical
-     * `top` of the view remains at the top of the screen. If we just call `state = STATE_HIDDEN`,
-     * Material will attempt to align the layout and enter `STATE_SETTLING`, leaving the state
-     * machine corrupted for the next open.
-     *
-     * To fix this, we manually push the physical `top` to the bottom of the screen.
-     * This makes the behavior skip the animation and synchronously switch to `STATE_HIDDEN`,
-     * properly cleaning up its internal state on dismissal.
-     */
-    private fun syncBehaviorStateAfterExitAnimationComplete(view: View) {
-        val behavior = BottomSheetBehavior.from(view)
-        val parent = view.parent as? View
-        val targetTop = parent?.height ?: view.height
-
-        view.offsetTopAndBottom(targetTop - view.top)
-        behavior.state = BottomSheetBehavior.STATE_HIDDEN
-    }
-
     internal fun destroy() {
         FormSheetStackRegistry.unregister(this)
         dimmingManager.detachDimming()
@@ -279,7 +260,8 @@ internal class FormSheetPresentationManager(
         currentSheetAnimator?.cancel()
         currentSheetAnimator = null
 
-        dialog.setOnShowListener(null)
+        presentation?.destroy()
+        presentation = null
 
         state = FormSheetPresentationState.DISMISSED
     }


### PR DESCRIPTION
## Description

On iOS, `RNSFormSheetContentController` is the only long-lived object of a FormSheet, while UIKit creates a fresh `UISheetPresentationController` for every present/dismiss cycle. On Android I kept a single `BottomSheetDialog`, `BottomSheetBehavior` and the sheet view alive for the whole lifetime of the host and reused it on every reopen. Material stores a lot of state on a sheet it has already laid out (the `ViewDragHelper` and the offsets it settles to, the padding derived from the system insets, the callbacks it installs), and `dismiss()` only detaches the decor, so all of it survived into the next presentation. Clearing and preparing that state for a subsequent presentation required some workarounds (`syncBehaviorStateAfterExitAnimationComplete`, etc.) that kept growing in amount. 

This PR aligns Android with iOS instead: the dialog, the sheet view and every coordinator bound to them now live exactly as long as a single presentation. Only `FormSheetContainer` - and with it the React content - outlives a presentation and is handed over from one dialog to the next, so React state is preserved across reopens.

Recreating the sheet view also exposed the enter-transition race. `Dialog.show()` posts the show message behind the sync barrier of the traversal scheduled while adding the decor to the window, so the first frame is always drawn before `OnShowListener` starts the enter animator. On `main` this was masked most of the time, because the reused view still had `translationY = height` left over from the previous exit animation. With a fresh view, every reopen drew the sheet at its final position for a frame before the animator snapped it off-screen. The sheet is now translated off-screen on its first pre-draw, so it is never drawn before the animation owns it.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1689

## Changes

- New `FormSheetPresentation` owns `FormSheetDialog` and its coordinators for a single presentation.
- `FormSheetPresentationManager` takes a `presentationFactory` instead of a dialog; it creates the Presentation object and manages its lifecycle.
- `FormSheetDialogManager` keeps only what lives as long as the host: the config, the container, the dimming manager.
- `FormSheetDimensionsCoordinator` resolves the dimensions after the first layout of the new dialog; a fresh decor has no height at insets dispatch time and nothing else is guaranteed to re-trigger the resolution.
- `FormSheetPresentationManager.keepOffscreenUntilEnterAnimation` registers a one-shot pre-draw listener before `dialog.show()` that sets `translationY = height`, unless the enter animator already owns the view.

## Before & after - visual documentation

N/A - mostly refactor

## Test plan

Went through all examples marked as applicable on Android and ensured that the initial translation is always applied before the animation starts.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
