### PR TITLE
refactor(iOS, FormSheet v5): Make `RNSFormSheetConfigurationApplicator` stateless

### DIFF
--- a/ios/modals/form-sheet/RNSFormSheetConfigurationApplicator.h
+++ b/ios/modals/form-sheet/RNSFormSheetConfigurationApplicator.h
@@ -10,12 +10,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNSFormSheetConfigurationApplicator : NSObject
 
-- (void)applyConfigurationIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
++ (void)applyConfigurationIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
                                         behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
                                               controller:(RNSFormSheetContentController *)controller
                                              coordinator:(RNSFormSheetUpdateCoordinator *)coordinator;
-
-- (void)resetInitialDetent;
 
 @end
 

--- a/ios/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
+++ b/ios/modals/form-sheet/RNSFormSheetConfigurationApplicator.mm
@@ -7,43 +7,33 @@
 #import "RNSFormSheetUpdateCoordinator.h"
 #import "RNSFormSheetUpdateFlags.h"
 
-@implementation RNSFormSheetConfigurationApplicator {
-  BOOL _initialDetentApplied;
-}
+@implementation RNSFormSheetConfigurationApplicator
 
-- (instancetype)init
-{
-  if (self = [super init]) {
-    _initialDetentApplied = NO;
-  }
-  return self;
-}
-
-- (void)resetInitialDetent
-{
-  _initialDetentApplied = NO;
-}
-
-- (void)applyConfigurationIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
++ (void)applyConfigurationIfNeededWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
                                         behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
                                               controller:(RNSFormSheetContentController *)controller
                                              coordinator:(RNSFormSheetUpdateCoordinator *)coordinator
 {
-  RNSFormSheetUpdateFlags configFlags = RNSFormSheetUpdateFlagsAppearance | RNSFormSheetUpdateFlagsBehavior;
+  RNSFormSheetUpdateFlags configFlags =
+      RNSFormSheetUpdateFlagsAppearance | RNSFormSheetUpdateFlagsBehavior | RNSFormSheetUpdateFlagsInitialDetent;
+
+  BOOL shouldSelectInitialDetent = [coordinator needsAny:RNSFormSheetUpdateFlagsInitialDetent];
 
   [coordinator updateIfAnyNeeded:configFlags
                performOperations:^{
                  [self applyConfigurationWithAppearanceProvider:appearanceProvider
                                                behaviorProvider:behaviorProvider
-                                                     controller:controller];
+                                                     controller:controller
+                                            selectInitialDetent:shouldSelectInitialDetent];
                }];
 }
 
 #pragma mark - Updaters
 
-- (void)applyConfigurationWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
++ (void)applyConfigurationWithAppearanceProvider:(id<RNSFormSheetAppearanceProvider>)appearanceProvider
                                 behaviorProvider:(id<RNSFormSheetBehaviorProvider>)behaviorProvider
                                       controller:(RNSFormSheetContentController *)controller
+                             selectInitialDetent:(BOOL)selectInitialDetent
 {
 #if !TARGET_OS_TV
   UISheetPresentationController *sheet = controller.sheetPresentationController;
@@ -57,11 +47,10 @@
       [RNSFormSheetDetentResolver buildSheetDetentsWithBehaviorProvider:behaviorProvider];
 
   UISheetPresentationControllerDetentIdentifier initialDetentIdentifier = nil;
-  if (!_initialDetentApplied) {
+  if (selectInitialDetent) {
     initialDetentIdentifier =
         [RNSFormSheetDetentResolver initialDetentIdentifierForDetents:nativeDetents
                                                      atRequestedIndex:behaviorProvider.initialDetentIndex];
-    _initialDetentApplied = YES;
   }
 
   BOOL prefersScrollingExpands = behaviorProvider.prefersScrollingExpandsWhenScrolledToEdge;

--- a/ios/modals/form-sheet/RNSFormSheetContentController.h
+++ b/ios/modals/form-sheet/RNSFormSheetContentController.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setNeedsPresentationUpdate;
 - (void)setNeedsBehaviorUpdate;
 - (void)setNeedsAppearanceUpdate;
-- (void)setNeedsInitialDetentReset;
+- (void)setNeedsInitialDetentUpdate;
 
 #pragma mark - Updates
 

--- a/ios/modals/form-sheet/RNSFormSheetContentController.mm
+++ b/ios/modals/form-sheet/RNSFormSheetContentController.mm
@@ -20,12 +20,9 @@
 
 @implementation RNSFormSheetContentController {
   RNSFormSheetUpdateCoordinator *_Nonnull _updateCoordinator;
-  RNSFormSheetConfigurationApplicator *_Nonnull _configurationApplicator;
   RNSFormSheetPresentationManager *_Nonnull _presentationManager;
 
   UITapGestureRecognizer *_Nullable _backdropTapGestureRecognizer;
-
-  BOOL _needsInitialDetentReset;
 }
 
 - (instancetype)init
@@ -34,10 +31,7 @@
     self.modalPresentationStyle = UIModalPresentationFormSheet;
 
     _updateCoordinator = [RNSFormSheetUpdateCoordinator new];
-    _configurationApplicator = [RNSFormSheetConfigurationApplicator new];
     _presentationManager = [RNSFormSheetPresentationManager new];
-
-    _needsInitialDetentReset = NO;
   }
   return self;
 }
@@ -142,7 +136,7 @@
   // We must force a full configuration update for this new instance.
   [self setNeedsAppearanceUpdate];
   [self setNeedsBehaviorUpdate];
-  [self setNeedsInitialDetentReset];
+  [self setNeedsInitialDetentUpdate];
   [self updateConfigurationIfNeeded];
 }
 
@@ -160,15 +154,10 @@
     return;
   }
 
-  if (_needsInitialDetentReset) {
-    _needsInitialDetentReset = NO;
-    [_configurationApplicator resetInitialDetent];
-  }
-
-  [_configurationApplicator applyConfigurationIfNeededWithAppearanceProvider:appearanceProvider
-                                                            behaviorProvider:behaviorProvider
-                                                                  controller:self
-                                                                 coordinator:_updateCoordinator];
+  [RNSFormSheetConfigurationApplicator applyConfigurationIfNeededWithAppearanceProvider:appearanceProvider
+                                                                       behaviorProvider:behaviorProvider
+                                                                             controller:self
+                                                                            coordinator:_updateCoordinator];
 }
 
 #pragma mark - Signals
@@ -188,9 +177,9 @@
   [_updateCoordinator setNeeds:RNSFormSheetUpdateFlagsBehavior];
 }
 
-- (void)setNeedsInitialDetentReset
+- (void)setNeedsInitialDetentUpdate
 {
-  _needsInitialDetentReset = YES;
+  [_updateCoordinator setNeeds:RNSFormSheetUpdateFlagsInitialDetent];
 }
 
 #pragma mark - Updates

--- a/ios/modals/form-sheet/RNSFormSheetHostComponentView.mm
+++ b/ios/modals/form-sheet/RNSFormSheetHostComponentView.mm
@@ -246,9 +246,9 @@ namespace react = facebook::react;
       // because UIKit destroys the presentationController after the modal is dismissed.
       [_controller setNeedsAppearanceUpdate];
       [_controller setNeedsBehaviorUpdate];
-      // Reset the initial-detent applied flag when reopening so the
-      // configured initialDetentIndex can be applied again.
-      [_controller setNeedsInitialDetentReset];
+      // Request the configured initialDetentIndex to be selected
+      // again on the fresh presentation controller.
+      [_controller setNeedsInitialDetentUpdate];
     }
   }
 

--- a/ios/modals/form-sheet/RNSFormSheetUpdateFlags.h
+++ b/ios/modals/form-sheet/RNSFormSheetUpdateFlags.h
@@ -10,4 +10,7 @@ typedef NS_OPTIONS(NSUInteger, RNSFormSheetUpdateFlags) {
   RNSFormSheetUpdateFlagsAppearance = 1 << 1,
   // The sheet's behavioral layout (detents, scrolling config) needs to be re-applied.
   RNSFormSheetUpdateFlagsBehavior = 1 << 2,
+  // The sheet's selected detent needs to be (re)set to the configured `initialDetentIndex`.
+  // Requested once per presentation cycle, since UIKit recreates the presentation controller on every present.
+  RNSFormSheetUpdateFlagsInitialDetent = 1 << 3,
 };


### PR DESCRIPTION
## Description

`RNSFormSheetConfigurationApplicator` should be a pure mapper from the providers onto `UISheetPresentationController`, but it had state guarding that `selectedDetentIdentifier` is set only once per presentation. This PR moves that state to be an invalidation flag.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1482

## Changes

- Added new entry in `RNSFormSheetUpdateFlags`.
- Removed state from the applicator

## Before & after - visual documentation

N/A refactor

## Test plan

Tested with already existing examples, especially "Sheet initial detent index"

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
