### PR TITLE
chore(FormSheet v5): Update testing scenarios and layout visibility in examples

### DIFF
--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
@@ -1,7 +1,7 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Stack v5 In FormSheet (iOS)',
+  name: 'Nested Stack v5 In FormSheet (iOS)',
   key: 'test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios',
   details:
     'Stack v5 nested in a sheet: layout across detents and navigation state kept across dismiss/reopen.',

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario-description.ts
@@ -1,9 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'FormSheet with Nested Stack v5',
+  name: 'Stack v5 In FormSheet (iOS)',
   key: 'test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios',
-  details: 'Test nesting Stack v5 inside a FormSheet',
+  details:
+    'Stack v5 nested in a sheet: layout across detents and navigation state kept across dismiss/reopen.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: FormSheet with Nested Stack v5
+# Test Scenario: Stack v5 In FormSheet (iOS)
 
 ## Details
 
@@ -23,7 +23,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **FormSheet with Nested Stack v5** screen.
+1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
 
 - [ ] Content with the button "Open FormSheet" is shown
 
@@ -68,7 +68,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **FormSheet with Nested Stack v5** screen.
+1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
 
 - [ ] Content with the button "Open FormSheet" is shown.
 

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - The nested stack fills the sheet with `flex: 1`; each screen paints its own background (Home – light blue, A – light yellow), so the covered area is what shows how the sheet sizes its content.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -64,47 +64,3 @@ TBD: Planned, but will be implemented separately.
 6. Tap the "Pop" button (or native header back button) to pop Screen A.
 
 - [ ] The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered, and the light blue background completely covers the FormSheet content area.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Nested Stack v5 In FormSheet (iOS)** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Initialization & Layout Verification
-
-2. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "Home Screen" text is visible and centered within the panel. The light blue background completely covers the FormSheet content area.
-
-3. Tap the "Push A" button to push Screen A.
-
-- [ ] The stack navigates to "Screen A". The "Screen A" text is centered within the floating panel. The light yellow background completely covers the FormSheet content area.
-
----
-
-### Detent Adaptation
-
-4. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
-
-- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The layout adapts dynamically - the light yellow background stretches to cover the new full height, and the "Screen A" text dynamically re-centers itself within the newly expanded panel.
-
----
-
-### State Persistence
-
-5. Swipe down on the FormSheet to dismiss it, then tap the "Open FormSheet" button again.
-
-- [ ] The FormSheet re-opens as a centered floating panel at the initial lower detent (0.6). The stack's navigation state has been kept - the panel immediately displays "Screen A" (with the yellow background and centered text) rather than resetting back to the Home Screen.
-
----
-
-### Pop Action
-
-6. Tap the "Pop" button (or native header back button) to pop Screen A.
-
-- [ ] The stack correctly navigates back to the "Home Screen". The "Home Screen" text is visible and centered within the panel, and the light blue background completely covers the FormSheet content area.

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the layout and state persistence of a `StackContainer` nested within a `FormSheet`. This test ensures that the Stack layout correctly fills the `FormSheet` container, that content remains properly centered, that the layout smoothly adapts when the FormSheet height changes, and that the Stack's navigation state is preserved when the sheet is dismissed and reopened.
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5.
 
 ## E2E test
 
@@ -12,12 +12,14 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone and iPad
-- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
 
 ## Note
 
-- On iPad: The FormSheet is presented as a **centered floating panel** with a fixed width, not as a full-width bottom sheet as on iPhone.
+- iOS only – the scenario covers the iOS layout of a nested Stack v5; the Android counterpart will be added separately.
+- The nested stack fills the sheet with `flex: 1`; each screen paints its own background (Home – light blue, A – light yellow), so the covered area is what shows how the sheet sizes its content.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
 
@@ -25,7 +27,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown
+- [ ] The host screen shows the "Open FormSheet" button.
 
 ---
 
@@ -34,7 +36,6 @@ TBD: Planned, but will be implemented separately.
 2. Tap the "Open FormSheet" button.
 
 - [ ] The FormSheet opens at the initial lower detent (0.6). The "Home Screen" text is visible and centered within the sheet. The light blue background completely covers the FormSheet content area.
-
 
 3. Tap the "Push A" button to push Screen A.
 
@@ -70,7 +71,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown.
+- [ ] The host screen shows the "Open FormSheet" button.
 
 ---
 

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Stack v5 In FormSheet (iOS)
+# Test Scenario: Nested Stack v5 In FormSheet (iOS)
 
 ## Details
 
@@ -25,7 +25,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
+1. Launch the app and navigate to the **Nested Stack v5 In FormSheet (iOS)** screen.
 
 - [ ] The host screen shows the "Open FormSheet" button.
 
@@ -69,7 +69,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Stack v5 In FormSheet (iOS)** screen.
+1. Launch the app and navigate to the **Nested Stack v5 In FormSheet (iOS)** screen.
 
 - [ ] The host screen shows the "Open FormSheet" button.
 

--- a/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
+++ b/apps/src/tests/component-integration-tests/form-sheet/test-form-sheet-stack-v5-nesting-stack-v5-in-form-sheet-ios/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - The nested stack fills the sheet with `flex: 1`; each screen paints its own background (Home – light blue, A – light yellow), so the covered area is what shows how the sheet sizes its content.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -53,7 +53,7 @@ const scenarios = {
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {
   name: 'FormSheet',
-  details: 'Single feature tests for the standalone FormSheet component',
+  details: 'Single feature tests for FormSheet',
   scenarios,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -3,51 +3,51 @@ import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 // Scenario objects (default exports) — carry metadata, used to build the
 // scenario group consumed by the selection menu.
 import TestFormSheetBase from './test-form-sheet-base';
-import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
-import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
-import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
-import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
-import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
-import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
-import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius';
-import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
-import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss';
-import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
 import TestFormSheetDismissEvents from './test-form-sheet-dismiss-events';
+import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
+import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
+import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
+import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
+import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
+import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
+import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
+import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
+import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius';
 import TestFormSheetPresentationState from './test-form-sheet-presentation-state';
+import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss';
 import TestFormSheetStacking from './test-form-sheet-stacking';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
 export { default as TestFormSheetBase } from './test-form-sheet-base';
-export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-contents';
-export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
-export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';
-export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
-export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expand-scroll-view-ios';
-export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
-export { default as TestFormSheetPreferredCornerRadius } from './test-form-sheet-preferred-corner-radius';
-export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
-export { default as TestFormSheetPreventNativeDismiss } from './test-form-sheet-prevent-native-dismiss';
-export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
 export { default as TestFormSheetDismissEvents } from './test-form-sheet-dismiss-events';
+export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expand-scroll-view-ios';
+export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-contents';
+export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
+export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
+export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
+export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
+export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
+export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';
+export { default as TestFormSheetPreferredCornerRadius } from './test-form-sheet-preferred-corner-radius';
 export { default as TestFormSheetPresentationState } from './test-form-sheet-presentation-state';
+export { default as TestFormSheetPreventNativeDismiss } from './test-form-sheet-prevent-native-dismiss';
 export { default as TestFormSheetStacking } from './test-form-sheet-stacking';
 
 const scenarios = {
   TestFormSheetBase,
-  TestFormSheetFitToContents,
-  TestFormSheetInitialDetentIndex,
-  TestFormSheetOnDetentChanged,
-  TestFormSheetLargestUndimmedDetentIndex,
-  TestFormSheetExpandScrollView,
-  TestFormSheetGrabberVisible,
-  TestFormSheetPreferredCornerRadius,
-  TestFormSheetNativeContainerStyle,
-  TestFormSheetPreventNativeDismiss,
-  TestFormSheetLifecycleEvents,
   TestFormSheetDismissEvents,
+  TestFormSheetExpandScrollView,
+  TestFormSheetFitToContents,
+  TestFormSheetGrabberVisible,
+  TestFormSheetInitialDetentIndex,
+  TestFormSheetLargestUndimmedDetentIndex,
+  TestFormSheetLifecycleEvents,
+  TestFormSheetNativeContainerStyle,
+  TestFormSheetOnDetentChanged,
+  TestFormSheetPreferredCornerRadius,
   TestFormSheetPresentationState,
+  TestFormSheetPreventNativeDismiss,
   TestFormSheetStacking,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -3,57 +3,57 @@ import type { ScenarioGroup } from '@apps/tests/shared/helpers';
 // Scenario objects (default exports) — carry metadata, used to build the
 // scenario group consumed by the selection menu.
 import TestFormSheetBase from './test-form-sheet-base';
-import TestFormSheetDismissEvents from './test-form-sheet-dismiss-events';
-import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
 import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
-import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
-import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
-import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
-import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
 import TestFormSheetOnDetentChanged from './test-form-sheet-on-detent-changed';
+import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
+import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
+import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetPreferredCornerRadius from './test-form-sheet-preferred-corner-radius';
-import TestFormSheetPresentationState from './test-form-sheet-presentation-state';
+import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
 import TestFormSheetPreventNativeDismiss from './test-form-sheet-prevent-native-dismiss';
+import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
+import TestFormSheetDismissEvents from './test-form-sheet-dismiss-events';
+import TestFormSheetPresentationState from './test-form-sheet-presentation-state';
 import TestFormSheetStacking from './test-form-sheet-stacking';
 
 // Scenario entry-point components — each scenario's default export re-exported
 // under a name for direct rendering (e.g. from App.tsx or e2e harnesses).
 export { default as TestFormSheetBase } from './test-form-sheet-base';
-export { default as TestFormSheetDismissEvents } from './test-form-sheet-dismiss-events';
-export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expand-scroll-view-ios';
 export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-contents';
-export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
 export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
-export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
-export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
-export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
 export { default as TestFormSheetOnDetentChanged } from './test-form-sheet-on-detent-changed';
+export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
+export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expand-scroll-view-ios';
+export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
 export { default as TestFormSheetPreferredCornerRadius } from './test-form-sheet-preferred-corner-radius';
-export { default as TestFormSheetPresentationState } from './test-form-sheet-presentation-state';
+export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
 export { default as TestFormSheetPreventNativeDismiss } from './test-form-sheet-prevent-native-dismiss';
+export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
+export { default as TestFormSheetDismissEvents } from './test-form-sheet-dismiss-events';
+export { default as TestFormSheetPresentationState } from './test-form-sheet-presentation-state';
 export { default as TestFormSheetStacking } from './test-form-sheet-stacking';
 
 const scenarios = {
   TestFormSheetBase,
-  TestFormSheetDismissEvents,
-  TestFormSheetExpandScrollView,
   TestFormSheetFitToContents,
-  TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
-  TestFormSheetLargestUndimmedDetentIndex,
-  TestFormSheetLifecycleEvents,
-  TestFormSheetNativeContainerStyle,
   TestFormSheetOnDetentChanged,
+  TestFormSheetLargestUndimmedDetentIndex,
+  TestFormSheetExpandScrollView,
+  TestFormSheetGrabberVisible,
   TestFormSheetPreferredCornerRadius,
-  TestFormSheetPresentationState,
+  TestFormSheetNativeContainerStyle,
   TestFormSheetPreventNativeDismiss,
+  TestFormSheetLifecycleEvents,
+  TestFormSheetDismissEvents,
+  TestFormSheetPresentationState,
   TestFormSheetStacking,
 };
 
 const FormSheetScenarioGroup: ScenarioGroup<keyof typeof scenarios> = {
   name: 'FormSheet',
-  details: 'Single feature tests for FormSheets',
+  details: 'Single feature tests for the standalone FormSheet component',
   scenarios,
 };
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario-description.ts
@@ -1,9 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Basic functionality',
+  name: 'Basic Functionality',
   key: 'test-form-sheet-base',
-  details: 'Allows to test the basic functionality of FormSheet component.',
+  details:
+    'Single sheet with two detents: open, drag between detents, check content layout, dismiss.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -70,7 +70,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Basic Functionality** screen.
 
-- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
+- [ ] The host screen shows the "FormSheet Test" title and the "Open FormSheet" button.
 
 ---
 
@@ -103,7 +103,7 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap "Open FormSheet", then swipe the panel down past the lower detent.
 
-- [ ] The panel dismisses natively. "Open FormSheet" is pressable again and opens the panel at 0.6 (the JS state was synced by `onNativeDismiss`).
+- [ ] The panel dismisses natively. "Open FormSheet" is pressable again and opens the panel at 0.6.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -69,9 +69,9 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
 
-## Steps - Android only
+---
 
-### System back
+### Android only - System back
 
 7. Tap "Open FormSheet", then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -23,7 +23,7 @@ TBD: Planned, but will be implemented separately.
   - **Android:** the content box is laid out once to the _largest_ detent (minus system bars). At lower detents the sheet reveals only the top part of that box, which is why the content is anchored to the top – it stays visible at every detent and moves together with the sheet.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -63,47 +63,6 @@ TBD: Planned, but will be implemented separately.
 6. Tap "Open FormSheet", then swipe the sheet down past the lower detent.
 
 - [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Basic Functionality** screen.
-
-- [ ] The host screen shows the "FormSheet Test" title and the "Open FormSheet" button.
-
----
-
-### Presentation & layout
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.6) and the host screen is dimmed. The panel has a fixed width and is horizontally centered.
-- [ ] "FormSheet content" and "Dismiss from JS" are centered both vertically and horizontally within the panel.
-
----
-
-### Detent adaptation
-
-3. Drag the panel up to the largest detent (1.0).
-
-- [ ] The panel grows vertically to the maximum available height (respecting the top inset) while its width stays fixed. The content re-centers within the taller panel.
-
-4. Drag the panel back down to the lower detent (0.6).
-
-- [ ] The panel settles at 0.6 and the content re-centers again. Nothing is clipped.
-
----
-
-### Dismissal
-
-5. Tap "Dismiss from JS".
-
-- [ ] The panel dismisses with an animation. The host screen is undimmed and "Open FormSheet" is pressable again.
-
-6. Tap "Open FormSheet", then swipe the panel down past the lower detent.
-
-- [ ] The panel dismisses natively. "Open FormSheet" is pressable again and opens the panel at 0.6.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify the core present / resize / dismiss flow of a standalone `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
+**Description:** Verify the core present / resize / dismiss flow of `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify the core present / resize / dismiss flow of a standalone `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box with `flex: 1` that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
+**Description:** Verify the core present / resize / dismiss flow of a standalone `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
@@ -29,7 +29,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Basic Functionality** screen.
 
-- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
+- [ ] The host screen shows the "FormSheet Test" title and the "Open FormSheet" button.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -1,8 +1,8 @@
-# Test Scenario: Basic functionality
+# Test Scenario: Basic Functionality
 
 ## Details
 
-**Description:** Verify the core functionality and layout stability of the `FormSheet` component. This test ensures that the FormSheet opens correctly, that its internal content is properly centered, and that the content dynamically maintains its centered alignment when the user manually adjusts the sheet's height between different detents.
+**Description:** Verify the core present / resize / dismiss flow of a standalone `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box with `flex: 1` that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
 
 **OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
 
@@ -12,74 +12,140 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone and iPad
-- Android emulator
-- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
 ## Note
 
-- On iPad: The FormSheet is presented as a **centered floating panel** with a fixed width, not as a full-width bottom sheet as on iPhone.
+- Content sizing differs between platforms and both behaviors are expected:
+  - **iOS:** the content box is laid out to the _current_ detent, so the centered content re-centers every time the sheet settles at a different detent.
+  - **Android:** the content box is laid out once to the _largest_ detent (minus system bars). At lower detents the sheet reveals only the top part of that box, which is why the content is anchored to the top – it stays visible at every detent and moves together with the sheet.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
 
 ### Baseline
 
-1. Launch the app and navigate to the **Basic functionality** screen.
+1. Launch the app and navigate to the **Basic Functionality** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown
-
----
-
-### Initialization & Layout Verification
-
-2. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens at the initial lower detent (0.6). The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered both vertically and horizontally within the sheet.
+- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
 
 ---
 
-### Detent Adaptation
+### Presentation & layout
 
-3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet expands to take up the maximum available height (respecting the top inset). The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remains perfectly centered within the newly expanded view area.
+- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed.
+- [ ] "FormSheet content" and "Dismiss from JS" are centered both vertically and horizontally within the sheet.
 
 ---
 
-### Dismissal Verification
+### Detent adaptation
 
-4. Tap the "Dismiss from JS" button (or swipe down completely).
+3. Drag the sheet up to the largest detent (1.0).
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.
+- [ ] The sheet expands to the maximum available height (respecting the top inset). The content re-centers within the taller sheet.
+
+4. Drag the sheet back down to the lower detent (0.6).
+
+- [ ] The sheet settles at 0.6 and the content re-centers again. Nothing is clipped.
+
+---
+
+### Dismissal
+
+5. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses with an animation. The host screen is undimmed and "Open FormSheet" is pressable again.
+
+6. Tap "Open FormSheet", then swipe the sheet down past the lower detent.
+
+- [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
 
 ## Steps - iPad
 
 ### Baseline
 
-1. Launch the app and navigate to the **Basic functionality** screen.
+1. Launch the app and navigate to the **Basic Functionality** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown.
-
----
-
-### Initialization & Layout Verification
-
-2. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens as a centered floating panel at the initial lower detent (0.6). The panel has a fixed width and is horizontally centered on screen. The "FormSheet content" text and the "Dismiss from JS" button are visible and perfectly centered within the panel.
+- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
 
 ---
 
-### Detent Adaptation
+### Presentation & layout
 
-3. Grab the top edge of the FormSheet and swipe up to expand it to the maximum detent (1.0).
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet panel expands vertically to take up the maximum available height (respecting the top inset), while the width remains fixed. The internal layout adapts dynamically, and the "FormSheet content" text along with the "Dismiss from JS" button remains perfectly centered within the newly expanded panel.
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.6) and the host screen is dimmed. The panel has a fixed width and is horizontally centered.
+- [ ] "FormSheet content" and "Dismiss from JS" are centered both vertically and horizontally within the panel.
 
 ---
 
-### Dismissal Verification
+### Detent adaptation
 
-4. Tap the "Dismiss from JS" button (or swipe down completely).
+3. Drag the panel up to the largest detent (1.0).
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. Pressables on the main screen are working.
+- [ ] The panel grows vertically to the maximum available height (respecting the top inset) while its width stays fixed. The content re-centers within the taller panel.
+
+4. Drag the panel back down to the lower detent (0.6).
+
+- [ ] The panel settles at 0.6 and the content re-centers again. Nothing is clipped.
+
+---
+
+### Dismissal
+
+5. Tap "Dismiss from JS".
+
+- [ ] The panel dismisses with an animation. The host screen is undimmed and "Open FormSheet" is pressable again.
+
+6. Tap "Open FormSheet", then swipe the panel down past the lower detent.
+
+- [ ] The panel dismisses natively. "Open FormSheet" is pressable again and opens the panel at 0.6 (the JS state was synced by `onNativeDismiss`).
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Basic Functionality** screen.
+
+- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
+
+---
+
+### Presentation & layout
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed.
+- [ ] "FormSheet content" and "Dismiss from JS" are horizontally centered and anchored to the top of the sheet. Both are fully visible and tappable.
+
+---
+
+### Detent adaptation
+
+3. Drag the sheet up to the largest detent (1.0).
+
+- [ ] The sheet expands to the maximum available height (below the status bar). The content stays anchored to the top of the sheet and moves together with it – no re-layout, flicker or jumps during the drag.
+
+4. Drag the sheet back down to the lower detent (0.6).
+
+- [ ] The sheet settles at 0.6 and the content moves down with it, still anchored to the top of the sheet.
+
+---
+
+### Dismissal
+
+5. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses with an animation. The host screen is undimmed and "Open FormSheet" is pressable again.
+
+6. Tap "Open FormSheet", then swipe the sheet down past the lower detent.
+
+- [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
+
+7. Tap "Open FormSheet", then use the system back gesture (or the back button).
+
+- [ ] The sheet dismisses natively, exactly like after the swipe.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -111,7 +111,7 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Basic Functionality** screen.
 
-- [ ] The host screen shows the "Basic Functionality" title and the "Open FormSheet" button.
+- [ ] The host screen shows the "FormSheet Test" title and the "Open FormSheet" button.
 
 ---
 
@@ -120,7 +120,7 @@ TBD: Planned, but will be implemented separately.
 2. Tap "Open FormSheet".
 
 - [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed.
-- [ ] "FormSheet content" and "Dismiss from JS" are horizontally centered and anchored to the top of the sheet. Both are fully visible and tappable.
+- [ ] "FormSheet content" and "Dismiss from JS" are horizontally centered and anchored to the top of the sheet.
 
 ---
 
@@ -144,7 +144,7 @@ TBD: Planned, but will be implemented separately.
 
 6. Tap "Open FormSheet", then swipe the sheet down past the lower detent.
 
-- [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
+- [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6.
 
 7. Tap "Open FormSheet", then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -23,7 +23,7 @@ TBD: Planned, but will be implemented separately.
   - **Android:** the content box is laid out once to the _largest_ detent (minus system bars). At lower detents the sheet reveals only the top part of that box, which is why the content is anchored to the top – it stays visible at every detent and moves together with the sheet.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -38,7 +38,8 @@ TBD: Planned, but will be implemented separately.
 2. Tap "Open FormSheet".
 
 - [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed.
-- [ ] "FormSheet content" and "Dismiss from JS" are centered both vertically and horizontally within the sheet.
+- [ ] iOS: "FormSheet content" and "Dismiss from JS" are centered both vertically and horizontally within the sheet.
+- [ ] Android: "FormSheet content" and "Dismiss from JS" are horizontally centered and anchored to the top of the sheet.
 
 ---
 
@@ -46,11 +47,15 @@ TBD: Planned, but will be implemented separately.
 
 3. Drag the sheet up to the largest detent (1.0).
 
-- [ ] The sheet expands to the maximum available height (respecting the top inset). The content re-centers within the taller sheet.
+- [ ] The sheet expands to the maximum available height (respecting the top inset).
+- [ ] iOS: the content re-centers within the taller sheet.
+- [ ] Android: the content stays anchored to the top of the sheet and moves together with it.
 
 4. Drag the sheet back down to the lower detent (0.6).
 
-- [ ] The sheet settles at 0.6 and the content re-centers again. Nothing is clipped.
+- [ ] The sheet settles at 0.6. Nothing is clipped.
+- [ ] iOS: the content re-centers again.
+- [ ] Android: the content moves down with the sheet, still anchored to its top.
 
 ---
 
@@ -64,46 +69,9 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6 (the JS state was synced by `onNativeDismiss`).
 
-## Steps - Android
+## Steps - Android only
 
-### Baseline
-
-1. Launch the app and navigate to the **Basic Functionality** screen.
-
-- [ ] The host screen shows the "FormSheet Test" title and the "Open FormSheet" button.
-
----
-
-### Presentation & layout
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed.
-- [ ] "FormSheet content" and "Dismiss from JS" are horizontally centered and anchored to the top of the sheet.
-
----
-
-### Detent adaptation
-
-3. Drag the sheet up to the largest detent (1.0).
-
-- [ ] The sheet expands to the maximum available height (below the status bar). The content stays anchored to the top of the sheet and moves together with it – no re-layout, flicker or jumps during the drag.
-
-4. Drag the sheet back down to the lower detent (0.6).
-
-- [ ] The sheet settles at 0.6 and the content moves down with it, still anchored to the top of the sheet.
-
----
-
-### Dismissal
-
-5. Tap "Dismiss from JS".
-
-- [ ] The sheet dismisses with an animation. The host screen is undimmed and "Open FormSheet" is pressable again.
-
-6. Tap "Open FormSheet", then swipe the sheet down past the lower detent.
-
-- [ ] The sheet dismisses natively. "Open FormSheet" is pressable again and opens the sheet at 0.6.
+### System back
 
 7. Tap "Open FormSheet", then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-base/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the core present / resize / dismiss flow of a standalone `FormSheet` with two detents (`[0.6, 1.0]`) and how its React content is laid out on each platform. The sheet content is a box with `flex: 1` that fills the sheet; on iOS its children are vertically centered (the box follows the current detent), on Android they are anchored to the top (the box is laid out to the largest detent).
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/index.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Button,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -121,7 +128,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Dismiss Events',
   key: 'test-form-sheet-dismiss-events',
   details:
-    'Allows to test the dismiss events (onDismiss, onNativeDismiss) of the FormSheet component.',
+    'onDismiss vs onNativeDismiss: which event fires for JS and native dismissal.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -60,9 +60,9 @@ TBD: Planned, but will be implemented separately.
 - [ ] The sheet dismisses.
 - [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
 
-## Steps - Android only
+---
 
-### Native dismissal – system back
+### Android only - system back native dismissal
 
 6. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - Wait for the dismissal animation to finish before reading the log.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -60,50 +60,11 @@ TBD: Planned, but will be implemented separately.
 - [ ] The sheet dismisses.
 - [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
 
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Dismiss Events** screen.
-
-- [ ] The host screen shows the "Open FormSheet" and "Clear Logs" buttons and an empty "Event Logs" panel ("No events recorded yet.").
-
----
-
-### Native dismissal – swipe
-
-2. Tap "Open FormSheet", wait for the sheet to present, then swipe it down past the lower detent.
-
-- [ ] The sheet dismisses and the host screen is undimmed.
-- [ ] The log shows exactly one new entry: `onNativeDismiss`.
-
----
-
-### Native dismissal – backdrop
-
-3. Tap "Open FormSheet", wait for the sheet to present, then tap the backdrop (the dimmed area above the sheet).
-
-- [ ] The sheet dismisses.
-- [ ] The log shows exactly one new entry: `onNativeDismiss`.
-
----
+## Steps - Android only
 
 ### Native dismissal – system back
 
-4. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button).
+6. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button).
 
 - [ ] The sheet dismisses.
 - [ ] The log shows exactly one new entry: `onNativeDismiss`.
-
----
-
-### Programmatic dismissal
-
-5. Tap "Clear Logs".
-
-- [ ] The log is empty again.
-
-6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet.
-
-- [ ] The sheet dismisses.
-- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify that the `FormSheet` component correctly emits dismiss events. The `onDismiss` event should be fired every time the sheet is dismissed programmatically. The `onNativeDismiss` event should be fired when the user dismisses the sheet via a native gesture (e.g., swiping down or tapping the backdrop).
+**Description:** Verify the dismiss events of the `FormSheet` component with detents `[0.6, 1.0]`. `onNativeDismiss` must fire when the user dismisses the sheet natively (swipe down, backdrop tap, and on Android the system back gesture); `onDismiss` must fire when the sheet is dismissed programmatically (`isOpen` set to `false`). The host screen keeps a timestamped event log.
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,36 +12,138 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
+
+- The scenario's `onNativeDismiss` handler also sets `isOpen` back to `false`; this JS-side sync must **not** produce an additional `onDismiss` entry.
+- Wait for the dismissal animation to finish before reading the log.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Dismiss Events** screen.
 
-- [ ] An example with "Open FormSheet" and "Clear Logs" buttons is shown, along with an empty event logs area.
+- [ ] The host screen shows the "Open FormSheet" and "Clear Logs" buttons and an empty "Event Logs" panel ("No events recorded yet.").
 
 ---
 
-### Native Dismissal (Swiping down)
+### Native dismissal – swipe
 
-2. Tap the "Open FormSheet" button.
-3. Wait for the sheet presentation animation to finish.
-4. Dismiss the FormSheet by swiping it down to the bottom of the screen.
+2. Tap "Open FormSheet", wait for the sheet to present, then swipe it down past the lower detent.
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
-- [ ] The logs list updates to show new `onNativeDismiss` event added.
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
 
 ---
 
-### Programmatic Dismissal (JS)
+### Native dismissal – backdrop
 
-5. Tap "Clear Logs" to reset the list.
-6. Tap the "Open FormSheet" button.
-7. Wait for the sheet presentation animation to finish.
-8. Tap the "Dismiss from JS" button inside the FormSheet.
+3. Tap "Open FormSheet", wait for the sheet to present, then tap the backdrop (the dimmed area above the sheet).
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
-- [ ] The logs list updates to show new `onDismiss` event added.
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Programmatic dismissal
+
+4. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+5. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet.
+
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Dismiss Events** screen.
+
+- [ ] The host screen shows the "Open FormSheet" and "Clear Logs" buttons and an empty "Event Logs" panel ("No events recorded yet.").
+
+---
+
+### Native dismissal – swipe
+
+2. Tap "Open FormSheet", wait for the panel to present, then swipe it down past the lower detent.
+
+- [ ] The panel dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Native dismissal – backdrop
+
+3. Tap "Open FormSheet", wait for the panel to present, then tap the backdrop (the dimmed area around the panel).
+
+- [ ] The panel dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Programmatic dismissal
+
+4. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+5. Tap "Open FormSheet", wait for the panel to present, then tap "Dismiss from JS" inside the panel.
+
+- [ ] The panel dismisses.
+- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Dismiss Events** screen.
+
+- [ ] The host screen shows the "Open FormSheet" and "Clear Logs" buttons and an empty "Event Logs" panel ("No events recorded yet.").
+
+---
+
+### Native dismissal – swipe
+
+2. Tap "Open FormSheet", wait for the sheet to present, then swipe it down past the lower detent.
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Native dismissal – backdrop
+
+3. Tap "Open FormSheet", wait for the sheet to present, then tap the backdrop (the dimmed area above the sheet).
+
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Native dismissal – system back
+
+4. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button).
+
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one new entry: `onNativeDismiss`.
+
+---
+
+### Programmatic dismissal
+
+5. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet.
+
+- [ ] The sheet dismisses.
+- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -106,4 +106,4 @@ TBD: Planned, but will be implemented separately.
 6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet.
 
 - [ ] The sheet dismisses.
-- [ ] The log shows exactly one entry: `onDismiss`.
+- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - Wait for the dismissal animation to finish before reading the log.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -42,7 +42,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Native dismissal – backdrop
 
-3. Tap "Open FormSheet", wait for the sheet to present, then tap the backdrop (the dimmed area above the sheet).
+3. Tap "Open FormSheet", wait for the sheet to present, then tap the backdrop (the dimmed area outside the sheet).
 
 - [ ] The sheet dismisses.
 - [ ] The log shows exactly one new entry: `onNativeDismiss`.
@@ -59,45 +59,6 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses.
 - [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Dismiss Events** screen.
-
-- [ ] The host screen shows the "Open FormSheet" and "Clear Logs" buttons and an empty "Event Logs" panel ("No events recorded yet.").
-
----
-
-### Native dismissal – swipe
-
-2. Tap "Open FormSheet", wait for the panel to present, then swipe it down past the lower detent.
-
-- [ ] The panel dismisses.
-- [ ] The log shows exactly one new entry: `onNativeDismiss`.
-
----
-
-### Native dismissal – backdrop
-
-3. Tap "Open FormSheet", wait for the panel to present, then tap the backdrop (the dimmed area around the panel).
-
-- [ ] The panel dismisses.
-- [ ] The log shows exactly one new entry: `onNativeDismiss`.
-
----
-
-### Programmatic dismissal
-
-4. Tap "Clear Logs".
-
-- [ ] The log is empty again.
-
-5. Tap "Open FormSheet", wait for the panel to present, then tap "Dismiss from JS" inside the panel.
-
-- [ ] The panel dismisses.
-- [ ] The log shows exactly one entry: `onDismiss`.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -145,4 +145,4 @@ TBD: Planned, but will be implemented separately.
 6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet.
 
 - [ ] The sheet dismisses.
-- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
+- [ ] The log shows exactly one entry: `onDismiss`.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify the dismiss events of the `FormSheet` component with detents `[0.6, 1.0]`. `onNativeDismiss` must fire when the user dismisses the sheet natively (swipe down, backdrop tap, and on Android the system back gesture); `onDismiss` must fire when the sheet is dismissed programmatically (`isOpen` set to `false`). The host screen keeps a timestamped event log.
+**Description:** Verify the dismiss events of the `FormSheet` component with detents `[0.6, 1.0]`. `onNativeDismiss` must fire when the user dismisses the sheet natively (swipe down, backdrop tap); `onDismiss` must fire when the sheet is dismissed programmatically (`isOpen` set to `false`). The host screen keeps a timestamped event log.
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
@@ -18,7 +18,6 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- The scenario's `onNativeDismiss` handler also sets `isOpen` back to `false`; this JS-side sync must **not** produce an additional `onDismiss` entry.
 - Wait for the dismissal animation to finish before reading the log.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-dismiss-events/scenario.md
@@ -97,7 +97,7 @@ TBD: Planned, but will be implemented separately.
 5. Tap "Open FormSheet", wait for the panel to present, then tap "Dismiss from JS" inside the panel.
 
 - [ ] The panel dismisses.
-- [ ] The log shows exactly one entry: `onDismiss` (and no `onNativeDismiss`).
+- [ ] The log shows exactly one entry: `onDismiss`.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/index.tsx
@@ -8,17 +8,9 @@ import {
   View,
 } from 'react-native';
 import { FormSheet } from 'react-native-screens';
-import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
-
-const scenarioDescription: ScenarioDescription = {
-  name: 'Expand when scrolled to edge',
-  key: 'test-form-sheet-expand-scroll-view-ios',
-  details:
-    'Allows testing the prefersScrollingExpandsWhenScrolledToEdge prop with nested ScrollView.',
-  platforms: ['ios'],
-};
 
 function TestFormSheetExpandScrollView() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Largest Undimmed Detent Index (iOS)',
-  key: 'test-form-sheet-largest-undimmed-detent-index-ios',
+  name: 'Expand On Scroll To Edge (iOS)',
+  key: 'test-form-sheet-expand-scroll-view-ios',
   details:
-    'largestUndimmedDetentIndex: dimming per detent and interactivity of the screen underneath.',
+    'prefersScrollingExpandsWhenScrolledToEdge with a nested ScrollView: does scrolling expand the sheet.',
   platforms: ['ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: prefersScrollingExpandsWhenScrolledToEdge
+# Test Scenario: Expand On Scroll To Edge (iOS)
 
 ## Details
 
@@ -24,9 +24,9 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Expand when scrolled to edge** screen.
+1. Launch the app and navigate to the **Expand On Scroll To Edge (iOS)** screen.
 
-- [ ] A status text indicating the current prop value ("Expands on edge scroll: ON"), a switch, and an "Open FormSheet" button are shown.
+- [ ] A status text indicating the current prop value ("Expands on scroll: ON"), a switch, and an "Open FormSheet" button are shown.
 
 ### Expansion enabled (Default)
 
@@ -42,7 +42,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Expansion disabled
 
-5. Tap the switch so the status reads "Expands on edge scroll: OFF".
+5. Tap the switch so the status reads "Expands on scroll: OFF".
 
 6. Tap the "Open FormSheet" button.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -17,7 +17,7 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- iOS only – Android ignores `prefersScrollingExpandsWhenScrolledToEdge` for now.
+- iOS only
 - The property only takes effect when scrolling starts exactly at the top edge of the `ScrollView` (content offset 0).
 - The list keeps its scroll position across dismiss/present – scroll back to the top before testing the edge behavior again.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - The list keeps its scroll position across dismiss/present – scroll back to the top before testing the edge behavior again.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -69,51 +69,3 @@ TBD: Planned, but will be implemented separately.
 9. Tap "Dismiss from JS" (or swipe down on the header).
 
 - [ ] The sheet dismisses and "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Expand On Scroll To Edge (iOS)** screen.
-
-- [ ] The host screen shows "Expands on scroll: ON", a switch (on) and the "Open FormSheet" button.
-
----
-
-### Expansion enabled (default)
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.5). The "Drag Here to Expand" header and the scrollable list ("List Item 1", "List Item 2", …) are visible.
-
-3. Swipe up on the list.
-
-- [ ] The panel grows to the largest detent (1.0) first (width unchanged); the list does not scroll until the panel has finished expanding.
-
-4. Swipe up on the list again.
-
-- [ ] The list scrolls normally and reveals further items; "Dismiss from JS" is reachable at the end of the list.
-
-5. Tap "Dismiss from JS" (or swipe down on the header).
-
-- [ ] The panel dismisses.
-
----
-
-### Expansion disabled
-
-6. Flip the switch so the host screen reads "Expands on scroll: OFF", then tap "Open FormSheet".
-
-- [ ] The panel presents at the lower detent (0.5).
-
-7. Make sure the list is scrolled to the very top, then swipe up on the list.
-
-- [ ] The list scrolls normally and reveals further items. The panel **does not** grow – it stays at 0.5.
-
-8. Drag the "Drag Here to Expand" header up.
-
-- [ ] The panel grows to the largest detent (1.0) – manual dragging outside the list still works.
-
-9. Tap "Dismiss from JS" (or swipe down on the header).
-
-- [ ] The panel dismisses and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - The list keeps its scroll position across dismiss/present – scroll back to the top before testing the edge behavior again.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-expand-scroll-view-ios/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `prefersScrollingExpandsWhenScrolledToEdge` property of the `FormSheet` component. This test ensures that when the property is set to `true`, scrolling a child `ScrollView` at a lower detent expands the sheet to a larger detent first. When set to `false`, the same scrolling action should not expand the sheet, and the scroll view should scroll normally. It also verifies that manual dragging still works when scroll expansion is disabled.
+**Description:** Verify the `prefersScrollingExpandsWhenScrolledToEdge` property of the `FormSheet` component with detents `[0.5, 1.0]` and a `ScrollView` inside the sheet. When the property is `true` (the UIKit default), scrolling the list up from its top edge at the lower detent expands the sheet first; when it is `false`, the list scrolls normally and the sheet stays at its detent. Manual dragging of the non-scrollable area expands the sheet in both cases.
 
-**OS test creation version:** iOS: 18.6 and 26.4
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5.
 
 ## E2E test
 
@@ -12,13 +12,15 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
 
 ## Note
 
-- The default value of `prefersScrollingExpandsWhenScrolledToEdge` in UIKit is `true`.
-- This property only takes effect when scrolling begins exactly from the top edge of the `ScrollView` (i.e., when the content offset is at 0).
-- The FormSheet will open with the list scrolled to the point where it was left during dismissal. You may need to scroll back to the top before testing edge behaviors.
+- iOS only – Android ignores `prefersScrollingExpandsWhenScrolledToEdge` for now.
+- The property only takes effect when scrolling starts exactly at the top edge of the `ScrollView` (content offset 0).
+- The list keeps its scroll position across dismiss/present – scroll back to the top before testing the edge behavior again.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
 
@@ -26,32 +28,92 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Expand On Scroll To Edge (iOS)** screen.
 
-- [ ] A status text indicating the current prop value ("Expands on scroll: ON"), a switch, and an "Open FormSheet" button are shown.
+- [ ] The host screen shows "Expands on scroll: ON", a switch (on) and the "Open FormSheet" button.
 
-### Expansion enabled (Default)
+---
 
-2. Ensure the toggle is set to `ON`. Tap the "Open FormSheet" button.
+### Expansion enabled (default)
 
-- [ ] The FormSheet opens at the initial lower detent (0.5). The "Drag Here to Expand" header and a scrollable list of items are visible.
+2. Tap "Open FormSheet".
 
-3. Swipe up on the scrollable list content.
+- [ ] The sheet presents at the lower detent (0.5). The "Drag Here to Expand" header and the scrollable list ("List Item 1", "List Item 2", …) are visible.
 
-- [ ] The FormSheet expands to the maximum detent (1.0). The list content does not scroll until the sheet has finished expanding to the maximum detent.
+3. Swipe up on the list.
 
-4. Dismiss the sheet by tapping "Dismiss from JS" or swiping down on the drag indicator.
+- [ ] The sheet expands to the largest detent (1.0) first; the list does not scroll until the sheet has finished expanding.
+
+4. Swipe up on the list again.
+
+- [ ] The list scrolls normally and reveals further items; "Dismiss from JS" is reachable at the end of the list.
+
+5. Tap "Dismiss from JS" (or swipe down on the header).
+
+- [ ] The sheet dismisses.
+
+---
 
 ### Expansion disabled
 
-5. Tap the switch so the status reads "Expands on scroll: OFF".
+6. Flip the switch so the host screen reads "Expands on scroll: OFF", then tap "Open FormSheet".
 
-6. Tap the "Open FormSheet" button.
+- [ ] The sheet presents at the lower detent (0.5).
 
-- [ ] The FormSheet opens at the initial lower detent (0.5).
+7. Make sure the list is scrolled to the very top, then swipe up on the list.
 
-7. Swipe up on the scrollable list content (ensure you are starting from the very top edge of the ScrollView).
+- [ ] The list scrolls normally and reveals further items. The sheet **does not** expand – it stays at 0.5.
 
-- [ ] The list scrolls normally to reveal lower items. The FormSheet **does not** expand to the maximum detent and remains at 0.5. 
+8. Drag the "Drag Here to Expand" header up.
 
-8. Grab the "Drag Here to Expand" header area above the list and drag it up.
+- [ ] The sheet expands to the largest detent (1.0) – manual dragging outside the list still works.
 
-- [ ] The FormSheet expands to the maximum detent (1.0), verifying that manual sheet expansion is still possible outside the ScrollView area.
+9. Tap "Dismiss from JS" (or swipe down on the header).
+
+- [ ] The sheet dismisses and "Open FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Expand On Scroll To Edge (iOS)** screen.
+
+- [ ] The host screen shows "Expands on scroll: ON", a switch (on) and the "Open FormSheet" button.
+
+---
+
+### Expansion enabled (default)
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.5). The "Drag Here to Expand" header and the scrollable list ("List Item 1", "List Item 2", …) are visible.
+
+3. Swipe up on the list.
+
+- [ ] The panel grows to the largest detent (1.0) first (width unchanged); the list does not scroll until the panel has finished expanding.
+
+4. Swipe up on the list again.
+
+- [ ] The list scrolls normally and reveals further items; "Dismiss from JS" is reachable at the end of the list.
+
+5. Tap "Dismiss from JS" (or swipe down on the header).
+
+- [ ] The panel dismisses.
+
+---
+
+### Expansion disabled
+
+6. Flip the switch so the host screen reads "Expands on scroll: OFF", then tap "Open FormSheet".
+
+- [ ] The panel presents at the lower detent (0.5).
+
+7. Make sure the list is scrolled to the very top, then swipe up on the list.
+
+- [ ] The list scrolls normally and reveals further items. The panel **does not** grow – it stays at 0.5.
+
+8. Drag the "Drag Here to Expand" header up.
+
+- [ ] The panel grows to the largest detent (1.0) – manual dragging outside the list still works.
+
+9. Tap "Dismiss from JS" (or swipe down on the header).
+
+- [ ] The panel dismisses and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Fit to contents',
+  name: 'Fit To Contents',
   key: 'test-form-sheet-fit-to-contents',
   details:
-    'Allows to test the fitToContents detent and dynamic height changes of the FormSheet component.',
+    'detents="fitToContents": the sheet wraps its content and follows dynamic content height changes.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify `detents="fitToContents"` of the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening and follows changes of the content height while presented. On iOS the height change is animated; on Android the sheet snaps to the new height immediately (no animation yet).
+**Description:** Verify `detents="fitToContents"` of the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening and follows changes of the content height while presented. On iOS the height change is animated; on Android the sheet snaps to the new height immediately.
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
@@ -18,9 +18,8 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- With `fitToContents` the React content box wraps its children on both platforms (there is no detent to lay the content out to), so the sheet height follows the content height.
 - **iOS:** the sheet has extra empty space at the bottom – the native bottom inset (home indicator area) is added below the content.
-- **Android:** when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes is planned separately.
+- **Android:** when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes should be investigated separately.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; `fitToContents` applies to the panel height.
 
 ## Steps - iPhone

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -72,7 +72,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents as a centered floating panel with a fixed width and a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). No visual jumps during the presentation animation.
+- [ ] The sheet presents as a centered floating panel with a fixed width and a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons).
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes should be investigated separately.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; `fitToContents` applies to the panel height.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -36,8 +36,10 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons) plus the empty bottom inset area. No visual jumps during the presentation animation.
-- [ ] iPad: the panel height matches the content exactly – there is no bottom inset area below it.
+- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). No visual jumps during the presentation animation.
+- [ ] iPhone: the empty bottom inset area is added below the content.
+- [ ] iPad: the sheet height matches the content exactly – there is no bottom inset area below it.
+- [ ] Android: the sheet surface extends behind the navigation bar while the content sits above it.
 
 ---
 
@@ -45,52 +47,20 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap "Expand Content" inside the sheet.
 
-- [ ] The extra text box appears and the sheet grows to fully accommodate it, with a smooth animation and no visual glitches. The button now reads "Collapse Content".
+- [ ] The extra text box appears and the sheet grows to fully accommodate it – the whole extra text box is visible. The button now reads "Collapse Content".
+- [ ] iOS: the height change is animated smoothly, with no visual glitches.
+- [ ] Android: the sheet snaps to the new height immediately (no animation).
 
 4. Tap "Collapse Content".
 
-- [ ] The extra text box disappears and the sheet shrinks back to its original height, with a smooth animation.
+- [ ] The extra text box disappears and the sheet shrinks back to its original height.
+- [ ] iOS: the shrink is animated.
+- [ ] Android: the sheet snaps back immediately (no animation).
 
 ---
 
 ### Dismissal
 
 5. Tap "Dismiss from JS" (or swipe the sheet down).
-
-- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
-
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Fit To Contents** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). The sheet surface extends behind the navigation bar while the content sits above it.
-
----
-
-### Dynamic height
-
-3. Tap "Expand Content" inside the sheet.
-
-- [ ] The extra text box appears and the sheet snaps to the new, taller height immediately (no animation). The whole extra text box is visible; the button now reads "Collapse Content".
-
-4. Tap "Collapse Content".
-
-- [ ] The extra text box disappears and the sheet snaps back to its original height immediately (no animation).
-
----
-
-### Dismissal
-
-5. Tap "Dismiss from JS" (or swipe the sheet down, or use the system back gesture).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes should be investigated separately.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; `fitToContents` applies to the panel height.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -37,6 +37,7 @@ TBD: Planned, but will be implemented separately.
 2. Tap "Open FormSheet".
 
 - [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons) plus the empty bottom inset area. No visual jumps during the presentation animation.
+- [ ] iPad: the panel height matches the content exactly – there is no bottom inset area below it.
 
 ---
 
@@ -57,42 +58,6 @@ TBD: Planned, but will be implemented separately.
 5. Tap "Dismiss from JS" (or swipe the sheet down).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Fit To Contents** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel with a fixed width and a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons).
-
----
-
-### Dynamic height
-
-3. Tap "Expand Content" inside the panel.
-
-- [ ] The extra text box appears and the panel grows vertically to fully accommodate it, with a smooth animation and no visual glitches; the width stays fixed. The button now reads "Collapse Content".
-
-4. Tap "Collapse Content".
-
-- [ ] The extra text box disappears and the panel shrinks back to its original height, with a smooth animation.
-
----
-
-### Dismissal
-
-5. Tap "Dismiss from JS" (or swipe the panel down).
-
-- [ ] The panel dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -108,7 +108,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). The sheet surface extends behind the navigation bar while the content sits above it. No visual jumps during the presentation animation.
+- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). The sheet surface extends behind the navigation bar while the content sits above it.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify `detents="fitToContents"` of the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening and follows changes of the content height while presented. On iOS the height change is animated; on Android the sheet snaps to the new height immediately (no animation yet).
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,55 +12,121 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone and iPad
-- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
 ## Note
 
-- On iPad: The FormSheet is presented as a **centered floating panel**. The `fitToContents` behavior still applies to the height of this panel seamlessly, while its width remains fixed. Therefore, explicit separate steps for iPad are omitted.
-- On Android: when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes is planned separately.
+- With `fitToContents` the React content box wraps its children on both platforms (there is no detent to lay the content out to), so the sheet height follows the content height.
+- **iOS:** the sheet has extra empty space at the bottom – the native bottom inset (home indicator area) is added below the content.
+- **Android:** when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes is planned separately.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; `fitToContents` applies to the panel height.
 
-## Steps
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Fit To Contents** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown.
+- [ ] The host screen shows the "Open FormSheet" button.
 
 ---
 
-### Initialization & `fitToContents` Verification
+### Presentation
 
-2. Tap the "Open FormSheet" button.
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet opens smoothly. Its height is matched to its internal content (on iPhone, it will have an extra empty space on the bottom which is originating from native inset application). There are no visual jumps during the initial presentation animation.
-
----
-
-### Dynamic Height Adaptation
-
-3. Tap the "Expand Content" button inside the FormSheet.
-
-- [ ] The extra text box appears and the sheet grows in height to fully accommodate the newly added content, without visual glitches.
-- [ ] iOS: the height change is animated smoothly.
-- [ ] Android: the sheet snaps to the new height immediately (no animation).
+- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons) plus the empty bottom inset area. No visual jumps during the presentation animation.
 
 ---
 
-### Dynamic Height Adaptation
+### Dynamic height
 
-4. Tap the "Collapse Content" button.
+3. Tap "Expand Content" inside the sheet.
 
-- [ ] The extra text box disappears and the sheet shrinks back to its original, smaller height.
-- [ ] iOS: the height change is animated smoothly.
-- [ ] Android: the sheet snaps to the smaller height immediately (no animation).
+- [ ] The extra text box appears and the sheet grows to fully accommodate it, with a smooth animation and no visual glitches. The button now reads "Collapse Content".
+
+4. Tap "Collapse Content".
+
+- [ ] The extra text box disappears and the sheet shrinks back to its original height, with a smooth animation.
 
 ---
 
-### Dismissal Verification
+### Dismissal
 
-5. Tap the "Dismiss from JS" button (or swipe down completely).
+5. Tap "Dismiss from JS" (or swipe the sheet down).
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Fit To Contents** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel with a fixed width and a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). No visual jumps during the presentation animation.
+
+---
+
+### Dynamic height
+
+3. Tap "Expand Content" inside the panel.
+
+- [ ] The extra text box appears and the panel grows vertically to fully accommodate it, with a smooth animation and no visual glitches; the width stays fixed. The button now reads "Collapse Content".
+
+4. Tap "Collapse Content".
+
+- [ ] The extra text box disappears and the panel shrinks back to its original height, with a smooth animation.
+
+---
+
+### Dismissal
+
+5. Tap "Dismiss from JS" (or swipe the panel down).
+
+- [ ] The panel dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Fit To Contents** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents with a height matching its content ("FormSheet content" title, description text, "Expand Content" and "Dismiss from JS" buttons). The sheet surface extends behind the navigation bar while the content sits above it. No visual jumps during the presentation animation.
+
+---
+
+### Dynamic height
+
+3. Tap "Expand Content" inside the sheet.
+
+- [ ] The extra text box appears and the sheet snaps to the new, taller height immediately (no animation). The whole extra text box is visible; the button now reads "Collapse Content".
+
+4. Tap "Collapse Content".
+
+- [ ] The extra text box disappears and the sheet snaps back to its original height immediately (no animation).
+
+---
+
+### Dismissal
+
+5. Tap "Dismiss from JS" (or swipe the sheet down, or use the system back gesture).
+
+- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fit-to-contents/scenario.md
@@ -1,8 +1,8 @@
-# Test Scenario: Fit to contents
+# Test Scenario: Fit To Contents
 
 ## Details
 
-**Description:** Verify the `fitToContents` for the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening, and dynamically animates to a new height when the internal content size changes.
+**Description:** Verify `detents="fitToContents"` of the `FormSheet` component. This test ensures that the FormSheet calculates its initial height to wrap its content upon opening and follows changes of the content height while presented. On iOS the height change is animated; on Android the sheet snaps to the new height immediately (no animation yet).
 
 **OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
 
@@ -19,13 +19,13 @@ TBD: Planned, but will be implemented separately.
 ## Note
 
 - On iPad: The FormSheet is presented as a **centered floating panel**. The `fitToContents` behavior still applies to the height of this panel seamlessly, while its width remains fixed. Therefore, explicit separate steps for iPad are omitted.
-- On Android: While mounting/unmounting the component immediately, the sheet updates it's position to a desired state. The animation for dynamic content size update will be considered separately in a follow-up PRs.
+- On Android: when content is mounted/unmounted, the sheet updates its height immediately, without animation. Animating dynamic content size changes is planned separately.
 
 ## Steps
 
 ### Baseline
 
-1. Launch the app and navigate to the **Fit to contents** screen.
+1. Launch the app and navigate to the **Fit To Contents** screen.
 
 - [ ] Content with the button "Open FormSheet" is shown.
 
@@ -43,7 +43,9 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Expand Content" button inside the FormSheet.
 
-- [ ] The extra text box appears. The native FormSheet smoothly animates and grows in height to fully accommodate the newly added content without any visual glitches.
+- [ ] The extra text box appears and the sheet grows in height to fully accommodate the newly added content, without visual glitches.
+- [ ] iOS: the height change is animated smoothly.
+- [ ] Android: the sheet snaps to the new height immediately (no animation).
 
 ---
 
@@ -51,7 +53,9 @@ TBD: Planned, but will be implemented separately.
 
 4. Tap the "Collapse Content" button.
 
-- [ ] The extra text box disappears. The native FormSheet smoothly animates and shrinks back to its original, smaller height.
+- [ ] The extra text box disappears and the sheet shrinks back to its original, smaller height.
+- [ ] iOS: the height change is animated smoothly.
+- [ ] Android: the sheet snaps to the smaller height immediately (no animation).
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Switch, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Switch, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Grabber visibility',
+  name: 'Grabber Visibility',
   key: 'test-form-sheet-grabber-visible',
   details:
-    'Allows to test the `prefersGrabberVisible` prop of the FormSheet component.',
+    'prefersGrabberVisible: toggled before presenting and while the sheet is presented.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
@@ -18,8 +18,7 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- Both switches (host screen and inside the sheet) drive the same state, so they always show the same value.
-- **iOS:** the grabber is the system indicator drawn by `UISheetPresentationController`; the system may still hide it in some presentation contexts.
+- **iOS:** the grabber is the system indicator the system may still hide it in some presentation contexts.
 - **Android:** the grabber is Material's drag handle, rendered above the React content; toggling it changes the content position by the handle height.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the grabber is drawn at the top edge of the panel.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the grabber is Material's drag handle, rendered above the React content; toggling it changes the content position by the handle height.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the grabber is drawn at the top edge of the panel.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -71,56 +71,6 @@ TBD: Planned, but will be implemented separately.
 9. Flip it to **on** once more and tap "Dismiss from JS".
 
 - [ ] The sheet dismisses. The switch on the host screen reflects the last value set inside the sheet (on).
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Grabber Visibility** screen.
-
-- [ ] The host screen shows the "prefersGrabberVisible" switch (off) and the "Open FormSheet" button.
-
----
-
-### Grabber hidden (default)
-
-2. Tap "Open FormSheet" without touching the switch.
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.6). No grabber indicator is shown at the top of the panel. The switch inside the panel is off.
-
-3. Swipe the panel down to dismiss it.
-
-- [ ] The panel dismisses; "Open FormSheet" is pressable again.
-
----
-
-### Toggling from the host screen
-
-4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
-
-- [ ] The panel presents at 0.6 with a grabber indicator at its top edge. The switch inside the panel is on.
-
-5. Swipe the panel down, flip the host switch back to **off**, then tap "Open FormSheet".
-
-- [ ] The panel presents with no grabber indicator.
-
-6. Swipe the panel down.
-
----
-
-### Toggling from inside the sheet
-
-7. Tap "Open FormSheet", then flip the switch inside the panel to **on**.
-
-- [ ] The grabber indicator appears at the top edge of the panel without the panel being dismissed or re-presented.
-
-8. Flip the switch inside the panel back to **off**.
-
-- [ ] The grabber indicator disappears, again without any re-presentation.
-
-9. Flip it to **on** once more and tap "Dismiss from JS".
-
-- [ ] The panel dismisses. The switch on the host screen reflects the last value set inside the panel (on).
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Sheet Grabber Visibility
+# Test Scenario: Grabber Visibility
 
 ## Details
 
@@ -19,7 +19,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Grabber visibility** screen.
+1. Launch the app and navigate to the **Grabber Visibility** screen.
 
 - [ ] Content with the "prefersGrabberVisible" toggle (switched off by default) and the "Open FormSheet" button is shown.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify that the `prefersGrabberVisible` prop of the `FormSheet` component correctly controls the visibility of the grabber indicator at the top of the sheet. This test covers toggling the prop both before the sheet is presented (from the underlying screen) and while the sheet is already presented (from inside the sheet).
+**Description:** Verify that the `prefersGrabberVisible` property of the `FormSheet` component controls the grabber indicator at the top of the sheet. This test covers toggling the property before the sheet is presented (from the host screen) and while the sheet is presented (from inside the sheet).
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,65 +12,163 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
+
+- Both switches (host screen and inside the sheet) drive the same state, so they always show the same value.
+- **iOS:** the grabber is the system indicator drawn by `UISheetPresentationController`; the system may still hide it in some presentation contexts.
+- **Android:** the grabber is Material's drag handle, rendered above the React content; toggling it changes the content position by the handle height.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; the grabber is drawn at the top edge of the panel.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Grabber Visibility** screen.
 
-- [ ] Content with the "prefersGrabberVisible" toggle (switched off by default) and the "Open FormSheet" button is shown.
+- [ ] The host screen shows the "prefersGrabberVisible" switch (off) and the "Open FormSheet" button.
 
 ---
 
-### Initial state - grabber hidden
+### Grabber hidden (default)
 
-2. Without flipping the toggle, tap the "Open FormSheet" button.
+2. Tap "Open FormSheet" without touching the switch.
 
-- [ ] The FormSheet opens at the initial lower detent (0.6). No grabber indicator is shown at the top of the sheet.
+- [ ] The sheet presents at the lower detent (0.6). No grabber indicator is shown at the top of the sheet. The switch inside the sheet is off.
 
-3. Dismiss the FormSheet by swiping it down.
+3. Swipe the sheet down to dismiss it.
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
-
----
-
-### Toggling visibility from outside the FormSheet
-
-4. Flip the "prefersGrabberVisible" toggle on the main screen to **on**.
-
-5. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens at the initial lower detent (0.6). A grabber indicator is visible at the top of the sheet.
-
-6. Dismiss the FormSheet by swiping it down.
-
-7. Flip the "prefersGrabberVisible" toggle on the main screen back to **off**.
-
-8. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens with no grabber indicator visible at the top of the sheet.
-
-9. Dismiss the FormSheet by swiping it down.
+- [ ] The sheet dismisses; "Open FormSheet" is pressable again.
 
 ---
 
-### Toggling visibility from inside the FormSheet
+### Toggling from the host screen
 
-10. Tap the "Open FormSheet" button.
+4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
 
-- [ ] The FormSheet opens with no grabber indicator visible at the top of the sheet. The "prefersGrabberVisible" toggle inside the sheet is switched off and reflects the same state as the toggle on the main screen.
+- [ ] The sheet presents at 0.6 with a grabber indicator at its top. The switch inside the sheet is on.
 
-11. Flip the "prefersGrabberVisible" toggle inside the FormSheet to **on**.
+5. Swipe the sheet down, flip the host switch back to **off**, then tap "Open FormSheet".
 
-- [ ] The grabber indicator appears at the top of the sheet without dismissing or re-presenting the sheet.
+- [ ] The sheet presents with no grabber indicator.
 
-12. Flip the "prefersGrabberVisible" toggle inside the FormSheet back to **off**.
+6. Swipe the sheet down.
 
-- [ ] The grabber indicator disappears from the top of the sheet without dismissing or re-presenting the sheet.
+---
 
-13. Tap the "Dismiss from JS" button.
+### Toggling from inside the sheet
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "prefersGrabberVisible" toggle on the main screen reflects the last value set inside the sheet (off).
+7. Tap "Open FormSheet", then flip the switch inside the sheet to **on**.
+
+- [ ] The grabber indicator appears at the top of the sheet without the sheet being dismissed or re-presented.
+
+8. Flip the switch inside the sheet back to **off**.
+
+- [ ] The grabber indicator disappears, again without any re-presentation.
+
+9. Flip it to **on** once more and tap "Dismiss from JS".
+
+- [ ] The sheet dismisses. The switch on the host screen reflects the last value set inside the sheet (on).
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Grabber Visibility** screen.
+
+- [ ] The host screen shows the "prefersGrabberVisible" switch (off) and the "Open FormSheet" button.
+
+---
+
+### Grabber hidden (default)
+
+2. Tap "Open FormSheet" without touching the switch.
+
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.6). No grabber indicator is shown at the top of the panel. The switch inside the panel is off.
+
+3. Swipe the panel down to dismiss it.
+
+- [ ] The panel dismisses; "Open FormSheet" is pressable again.
+
+---
+
+### Toggling from the host screen
+
+4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
+
+- [ ] The panel presents at 0.6 with a grabber indicator at its top edge. The switch inside the panel is on.
+
+5. Swipe the panel down, flip the host switch back to **off**, then tap "Open FormSheet".
+
+- [ ] The panel presents with no grabber indicator.
+
+6. Swipe the panel down.
+
+---
+
+### Toggling from inside the sheet
+
+7. Tap "Open FormSheet", then flip the switch inside the panel to **on**.
+
+- [ ] The grabber indicator appears at the top edge of the panel without the panel being dismissed or re-presented.
+
+8. Flip the switch inside the panel back to **off**.
+
+- [ ] The grabber indicator disappears, again without any re-presentation.
+
+9. Flip it to **on** once more and tap "Dismiss from JS".
+
+- [ ] The panel dismisses. The switch on the host screen reflects the last value set inside the panel (on).
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Grabber Visibility** screen.
+
+- [ ] The host screen shows the "prefersGrabberVisible" switch (off) and the "Open FormSheet" button.
+
+---
+
+### Grabber hidden (default)
+
+2. Tap "Open FormSheet" without touching the switch.
+
+- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed. No drag handle is shown at the top of the sheet; the "FormSheet content" title is anchored to the top of the sheet. The switch inside the sheet is off.
+
+3. Swipe the sheet down to dismiss it.
+
+- [ ] The sheet dismisses; "Open FormSheet" is pressable again.
+
+---
+
+### Toggling from the host screen
+
+4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
+
+- [ ] The sheet presents at 0.6 with a drag handle at its top; the content sits below the handle. The switch inside the sheet is on.
+
+5. Swipe the sheet down, flip the host switch back to **off**, then tap "Open FormSheet".
+
+- [ ] The sheet presents with no drag handle.
+
+6. Swipe the sheet down.
+
+---
+
+### Toggling from inside the sheet
+
+7. Tap "Open FormSheet", then flip the switch inside the sheet to **on**.
+
+- [ ] The drag handle appears at the top of the sheet without the sheet being dismissed or re-presented; the content shifts down by the handle height.
+
+8. Flip the switch inside the sheet back to **off**.
+
+- [ ] The drag handle disappears and the content shifts back up, again without any re-presentation.
+
+9. Flip it to **on** once more and tap "Dismiss from JS".
+
+- [ ] The sheet dismisses. The switch on the host screen reflects the last value set inside the sheet (on).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-grabber-visible/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the grabber is Material's drag handle, rendered above the React content; toggling it changes the content position by the handle height.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the grabber is drawn at the top edge of the panel.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -48,11 +48,12 @@ TBD: Planned, but will be implemented separately.
 
 4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
 
-- [ ] The sheet presents at 0.6 with a grabber indicator at its top. The switch inside the sheet is on.
+- [ ] The sheet presents at 0.6 with a grabber at its top. The switch inside the sheet is on.
+- [ ] Android: the content sits below the drag handle.
 
 5. Swipe the sheet down, flip the host switch back to **off**, then tap "Open FormSheet".
 
-- [ ] The sheet presents with no grabber indicator.
+- [ ] The sheet presents with no grabber.
 
 6. Swipe the sheet down.
 
@@ -62,61 +63,13 @@ TBD: Planned, but will be implemented separately.
 
 7. Tap "Open FormSheet", then flip the switch inside the sheet to **on**.
 
-- [ ] The grabber indicator appears at the top of the sheet without the sheet being dismissed or re-presented.
+- [ ] The grabber appears at the top of the sheet without the sheet being dismissed or re-presented.
+- [ ] Android: the content shifts down by the grabber height.
 
 8. Flip the switch inside the sheet back to **off**.
 
-- [ ] The grabber indicator disappears, again without any re-presentation.
-
-9. Flip it to **on** once more and tap "Dismiss from JS".
-
-- [ ] The sheet dismisses. The switch on the host screen reflects the last value set inside the sheet (on).
-
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Grabber Visibility** screen.
-
-- [ ] The host screen shows the "prefersGrabberVisible" switch (off) and the "Open FormSheet" button.
-
----
-
-### Grabber hidden (default)
-
-2. Tap "Open FormSheet" without touching the switch.
-
-- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed. No drag handle is shown at the top of the sheet; the "FormSheet content" title is anchored to the top of the sheet. The switch inside the sheet is off.
-
-3. Swipe the sheet down to dismiss it.
-
-- [ ] The sheet dismisses; "Open FormSheet" is pressable again.
-
----
-
-### Toggling from the host screen
-
-4. Flip the switch on the host screen to **on**, then tap "Open FormSheet".
-
-- [ ] The sheet presents at 0.6 with a drag handle at its top; the content sits below the handle. The switch inside the sheet is on.
-
-5. Swipe the sheet down, flip the host switch back to **off**, then tap "Open FormSheet".
-
-- [ ] The sheet presents with no drag handle.
-
-6. Swipe the sheet down.
-
----
-
-### Toggling from inside the sheet
-
-7. Tap "Open FormSheet", then flip the switch inside the sheet to **on**.
-
-- [ ] The drag handle appears at the top of the sheet without the sheet being dismissed or re-presented; the content shifts down by the handle height.
-
-8. Flip the switch inside the sheet back to **off**.
-
-- [ ] The drag handle disappears and the content shifts back up, again without any re-presentation.
+- [ ] The grabber disappears, again without any re-presentation.
+- [ ] Android: the content shifts back up.
 
 9. Flip it to **on** once more and tap "Dismiss from JS".
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -98,7 +98,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario-description.ts
@@ -1,9 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Sheet initial detent index',
+  name: 'Initial Detent Index',
   key: 'test-form-sheet-initial-detent-index',
-  details: 'Allows to test initialDetentIndex prop of FormSheet component.',
+  details:
+    "initialDetentIndex: opening detent for 0, 1 and 'last'; re-renders must not snap the sheet back.",
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the content box is laid out to the largest detent and anchored to the top, so the "Opened at Initial Index" title and the buttons stay at the top of the sheet at every detent.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline & default (index 0)
 
@@ -70,57 +70,6 @@ TBD: Planned, but will be implemented separately.
 - [ ] "Selected Initial Detent: last" is shown before opening. The sheet presents directly at the maximum height (1.0) and the title reads "Opened at Initial Index: last".
 
 9. Dismiss the sheet.
-
-- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline & default (index 0)
-
-1. Launch the app and navigate to the **Initial Detent Index** screen.
-
-- [ ] The host screen shows "Selected Initial Detent: 0", the three "Set Initial to …" buttons and the "Open FormSheet" button.
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel directly at the lowest detent (0.3). The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are centered and fully visible.
-
----
-
-### Re-render validation
-
-3. Drag the panel up to the middle detent (0.6).
-
-- [ ] The panel settles at 0.6; its width stays fixed.
-
-4. Tap "Force Re-render (0)" inside the panel.
-
-- [ ] The button's counter increments (a React render happened).
-- [ ] The panel stays at 0.6 – it does not snap back to the initial detent.
-
-5. Tap "Dismiss from JS" (or swipe the panel down).
-
-- [ ] The panel dismisses.
-
----
-
-### Middle detent (index 1)
-
-6. Tap "Set Initial to 1 (0.6)", then "Open FormSheet".
-
-- [ ] "Selected Initial Detent: 1" is shown before opening. The panel presents directly at the middle detent (0.6) and the title reads "Opened at Initial Index: 1".
-
-7. Dismiss the panel.
-
----
-
-### 'last' detent (index N-1)
-
-8. Tap "Set Initial to 'last' (1.0)", then "Open FormSheet".
-
-- [ ] "Selected Initial Detent: last" is shown before opening. The panel presents directly at the maximum height (1.0) and the title reads "Opened at Initial Index: last".
-
-9. Dismiss the panel.
 
 - [ ] The host screen is undimmed and "Open FormSheet" is pressable again.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the content box is laid out to the largest detent and anchored to the top, so the "Opened at Initial Index" title and the buttons stay at the top of the sheet at every detent.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline & default (index 0)
 
@@ -32,7 +32,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents directly at the lowest detent (0.3). The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are centered and fully visible.
+- [ ] The sheet presents directly at the lowest detent (0.3). The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are fully visible (centered on iOS, anchored to the top on Android).
 
 ---
 
@@ -69,57 +69,6 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] "Selected Initial Detent: last" is shown before opening. The sheet presents directly at the maximum height (1.0) and the title reads "Opened at Initial Index: last".
 
-9. Dismiss the sheet.
-
-- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.
-
-## Steps - Android
-
-### Baseline & default (index 0)
-
-1. Launch the app and navigate to the **Initial Detent Index** screen.
-
-- [ ] The host screen shows "Selected Initial Detent: 0", the three "Set Initial to …" buttons and the "Open FormSheet" button.
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents directly at the lowest detent (0.3) and the host screen is dimmed. The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are anchored to the top of the sheet and fully visible.
-
----
-
-### Re-render validation
-
-3. Drag the sheet up to the middle detent (0.6).
-
-- [ ] The sheet settles at 0.6; the content moves together with the sheet and stays at its top.
-
-4. Tap "Force Re-render (0)" inside the sheet.
-
-- [ ] The button's counter increments (a React render happened).
-- [ ] The sheet stays at 0.6 – it does not snap back to the initial detent.
-
-5. Tap "Dismiss from JS" (or swipe the sheet down).
-
-- [ ] The sheet dismisses.
-
----
-
-### Middle detent (index 1)
-
-6. Tap "Set Initial to 1 (0.6)", then "Open FormSheet".
-
-- [ ] "Selected Initial Detent: 1" is shown before opening. The sheet presents directly at the middle detent (0.6) and the title reads "Opened at Initial Index: 1".
-
-7. Dismiss the sheet.
-
----
-
-### 'last' detent (index N-1)
-
-8. Tap "Set Initial to 'last' (1.0)", then "Open FormSheet".
-
-- [ ] "Selected Initial Detent: last" is shown before opening. The sheet presents directly at the maximum height (1.0, below the status bar) and the title reads "Opened at Initial Index: last".
-
-9. Dismiss the sheet (tap "Dismiss from JS", swipe down, or use the system back gesture).
+9. Dismiss the sheet (tap "Dismiss from JS", swipe down).
 
 - [ ] The host screen is undimmed and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `initialDetentIndex` property of the `FormSheet` component. This test ensures that the FormSheet correctly respects the initial index when mounting and does not forcibly snap back to the initial index if the component re-renders while already presented.
+**Description:** Verify the `initialDetentIndex` property of the `FormSheet` component with detents `[0.3, 0.6, 1.0]`. This test ensures that the FormSheet opens at the requested detent (index `0`, `1` or `'last'`) and does not snap back to the initial detent when the component re-renders while already presented.
 
-**OS test creation version:** iOS: 18.6 and 26.4; Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,47 +12,165 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator (iPhone).
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
 
-### Baseline & Default (Index 0)
+- `initialDetentIndex` is applied only when the sheet transitions from closed to open; changing it while the sheet is presented has no effect until the next presentation.
+- **Android:** the index maps to the Material states (`0` → collapsed, `1` → half-expanded, `'last'` → expanded). The content box is laid out to the largest detent and anchored to the top, so the "Opened at Initial Index" title and the buttons stay at the top of the sheet at every detent.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
+
+## Steps - iPhone
+
+### Baseline & default (index 0)
 
 1. Launch the app and navigate to the **Initial Detent Index** screen.
-2. Ensure "Selected Initial Detent: 0" is displayed.
-3. Tap the "Open FormSheet" button.
 
-- [ ] The FormSheet opens and snaps immediately to the lowest detent (0.3 detent).
+- [ ] The host screen shows "Selected Initial Detent: 0", the three "Set Initial to …" buttons and the "Open FormSheet" button.
 
-### Re-render Validation
+2. Tap "Open FormSheet".
 
-4. While the sheet is open at the 0.3 detent, drag it up to the middle detent (0.6).
-5. Tap the "Force Re-render" button inside the sheet.
-
-- [ ] The button's counter updates (confirming a React render cycle occurred).
-- [ ] The sheet remains at the 0.6 detent.
-
-6. Dismiss the sheet by swiping down or tapping "Dismiss from JS".
+- [ ] The sheet presents directly at the lowest detent (0.3). The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are centered and fully visible.
 
 ---
 
-### Middle Detent (Index 1)
+### Re-render validation
 
-7. On the main screen, tap "Set Initial to 1 (0.6)".
-8. Tap the "Open FormSheet" button.
+3. Drag the sheet up to the middle detent (0.6).
 
-- [ ] The FormSheet opens directly at the middle detent (0.6 detent).
+- [ ] The sheet settles at 0.6.
+
+4. Tap "Force Re-render (0)" inside the sheet.
+
+- [ ] The button's counter increments (a React render happened).
+- [ ] The sheet stays at 0.6 – it does not snap back to the initial detent.
+
+5. Tap "Dismiss from JS" (or swipe the sheet down).
+
+- [ ] The sheet dismisses.
+
+---
+
+### Middle detent (index 1)
+
+6. Tap "Set Initial to 1 (0.6)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: 1" is shown before opening. The sheet presents directly at the middle detent (0.6) and the title reads "Opened at Initial Index: 1".
+
+7. Dismiss the sheet.
+
+---
+
+### 'last' detent (index N-1)
+
+8. Tap "Set Initial to 'last' (1.0)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: last" is shown before opening. The sheet presents directly at the maximum height (1.0) and the title reads "Opened at Initial Index: last".
 
 9. Dismiss the sheet.
 
+- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline & default (index 0)
+
+1. Launch the app and navigate to the **Initial Detent Index** screen.
+
+- [ ] The host screen shows "Selected Initial Detent: 0", the three "Set Initial to …" buttons and the "Open FormSheet" button.
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel directly at the lowest detent (0.3). The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are centered and fully visible.
+
 ---
 
-### 'last' Detent (Index N-1)
+### Re-render validation
 
-10. On the main screen, tap "Set Initial to 'last' (1.0)".
-11. Tap the "Open FormSheet" button.
+3. Drag the panel up to the middle detent (0.6).
 
-- [ ] The FormSheet opens and snaps directly to the maximum height (1.0 detent).
+- [ ] The panel settles at 0.6; its width stays fixed.
 
-12. Dismiss the sheet.
+4. Tap "Force Re-render (0)" inside the panel.
+
+- [ ] The button's counter increments (a React render happened).
+- [ ] The panel stays at 0.6 – it does not snap back to the initial detent.
+
+5. Tap "Dismiss from JS" (or swipe the panel down).
+
+- [ ] The panel dismisses.
+
+---
+
+### Middle detent (index 1)
+
+6. Tap "Set Initial to 1 (0.6)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: 1" is shown before opening. The panel presents directly at the middle detent (0.6) and the title reads "Opened at Initial Index: 1".
+
+7. Dismiss the panel.
+
+---
+
+### 'last' detent (index N-1)
+
+8. Tap "Set Initial to 'last' (1.0)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: last" is shown before opening. The panel presents directly at the maximum height (1.0) and the title reads "Opened at Initial Index: last".
+
+9. Dismiss the panel.
+
+- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline & default (index 0)
+
+1. Launch the app and navigate to the **Initial Detent Index** screen.
+
+- [ ] The host screen shows "Selected Initial Detent: 0", the three "Set Initial to …" buttons and the "Open FormSheet" button.
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents directly at the lowest detent (0.3) and the host screen is dimmed. The title inside reads "Opened at Initial Index: 0"; the "Force Re-render (0)" and "Dismiss from JS" buttons are anchored to the top of the sheet and fully visible.
+
+---
+
+### Re-render validation
+
+3. Drag the sheet up to the middle detent (0.6).
+
+- [ ] The sheet settles at 0.6; the content moves together with the sheet and stays at its top.
+
+4. Tap "Force Re-render (0)" inside the sheet.
+
+- [ ] The button's counter increments (a React render happened).
+- [ ] The sheet stays at 0.6 – it does not snap back to the initial detent.
+
+5. Tap "Dismiss from JS" (or swipe the sheet down).
+
+- [ ] The sheet dismisses.
+
+---
+
+### Middle detent (index 1)
+
+6. Tap "Set Initial to 1 (0.6)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: 1" is shown before opening. The sheet presents directly at the middle detent (0.6) and the title reads "Opened at Initial Index: 1".
+
+7. Dismiss the sheet.
+
+---
+
+### 'last' detent (index N-1)
+
+8. Tap "Set Initial to 'last' (1.0)", then "Open FormSheet".
+
+- [ ] "Selected Initial Detent: last" is shown before opening. The sheet presents directly at the maximum height (1.0, below the status bar) and the title reads "Opened at Initial Index: last".
+
+9. Dismiss the sheet (tap "Dismiss from JS", swipe down, or use the system back gesture).
+
+- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Sheet initial detent index
+# Test Scenario: Initial Detent Index
 
 ## Details
 
@@ -19,7 +19,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline & Default (Index 0)
 
-1. Launch the app and navigate to the **Sheet initial detent index** screen.
+1. Launch the app and navigate to the **Initial Detent Index** screen.
 2. Ensure "Selected Initial Detent: 0" is displayed.
 3. Tap the "Open FormSheet" button.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-initial-detent-index/scenario.md
@@ -19,7 +19,7 @@ TBD: Planned, but will be implemented separately.
 ## Note
 
 - `initialDetentIndex` is applied only when the sheet transitions from closed to open; changing it while the sheet is presented has no effect until the next presentation.
-- **Android:** the index maps to the Material states (`0` → collapsed, `1` → half-expanded, `'last'` → expanded). The content box is laid out to the largest detent and anchored to the top, so the "Opened at Initial Index" title and the buttons stay at the top of the sheet at every detent.
+- **Android:** the content box is laid out to the largest detent and anchored to the top, so the "Opened at Initial Index" title and the buttons stay at the top of the sheet at every detent.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
@@ -44,7 +44,7 @@ TBD: Planned, but will be implemented separately.
 
 4. Tap "Force Re-render (0)" inside the sheet.
 
-- [ ] The button's counter increments (a React render happened).
+- [ ] The button's counter increments.
 - [ ] The sheet stays at 0.6 – it does not snap back to the initial detent.
 
 5. Tap "Dismiss from JS" (or swipe the sheet down).

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -115,8 +115,10 @@ const styles = StyleSheet.create({
     color: Colors.text,
   },
   buttonGroup: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
     gap: 12,
-    alignItems: 'center',
   },
   spacing: {
     height: 32,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -39,7 +39,7 @@ function TestFormSheetLargestUndimmedDetentIndex() {
         isOpen={isOpen}
         onNativeDismiss={() => setIsOpen(false)}
         largestUndimmedDetentIndex={undimmedIndex}
-        detents={[0.3, 0.6, 0.8]}>
+        detents={[0.5, 0.65, 0.8]}>
         <View style={styles.sheetContent}>
           <Text style={styles.sheetTitle}>
             Undimmed Index: {String(undimmedIndex)}
@@ -51,11 +51,11 @@ function TestFormSheetLargestUndimmedDetentIndex() {
               onPress={() => setUndimmedIndex('none')}
             />
             <Button
-              title="Set 0 (0.3 height)"
+              title="Set 0 (0.5 height)"
               onPress={() => setUndimmedIndex(0)}
             />
             <Button
-              title="Set 1 (0.6 height)"
+              title="Set 1 (0.65 height)"
               onPress={() => setUndimmedIndex(1)}
             />
             <Button
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - With the default `'none'` every detent is dimmed; a tap on the dimmed area dismisses the sheet instead of reaching the button underneath.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the host screen stays visible around the panel.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - With the default `'none'` every detent is dimmed; a tap on the dimmed area dismisses the sheet instead of reaching the button underneath.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the host screen stays visible around the panel.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -89,71 +89,3 @@ TBD: Planned, but will be implemented separately.
 11. Tap "Dismiss from JS".
 
 - [ ] The sheet dismisses and "Increment Background Counter" works again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Largest Undimmed Detent Index (iOS)** screen, then tap "Increment Background Counter" a few times.
-
-- [ ] "Background clicks" increases with every tap.
-
----
-
-### Default `'none'`
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lowest detent (0.5) and the host screen around it is dimmed immediately. The title inside reads "Undimmed Index: none" and all five buttons are fully visible.
-
-3. Tap "Increment Background Counter".
-
-- [ ] The counter does **not** change – the tap is intercepted by the dimming view and dismisses the panel.
-
----
-
-### Index `0`
-
-4. Tap "Open FormSheet", then "Set 0 (0.5 height)" inside the panel.
-
-- [ ] The host screen becomes undimmed immediately; the title reads "Undimmed Index: 0".
-
-5. Tap "Increment Background Counter".
-
-- [ ] The counter increments while the panel stays open at 0.5.
-
-6. Drag the panel up to the middle detent (0.65).
-
-- [ ] As the panel settles at 0.65 the host screen is dimmed again and "Increment Background Counter" is no longer reachable.
-
----
-
-### `'last'`
-
-7. Tap "Set 'last'" inside the panel.
-
-- [ ] The host screen becomes undimmed at 0.65; the title reads "Undimmed Index: last".
-
-8. Drag the panel up to the largest detent (0.8), then tap "Increment Background Counter".
-
-- [ ] The host screen stays undimmed at 0.8 and the counter increments.
-
-9. Drag the panel down to 0.5 and tap "Increment Background Counter" again.
-
-- [ ] The counter increments – the host screen is undimmed at every detent.
-
----
-
-### Back to `'none'`
-
-10. Tap "Set 'none'" inside the panel.
-
-- [ ] The host screen is dimmed immediately and "Increment Background Counter" is blocked again.
-
----
-
-### Dismissal
-
-11. Tap "Dismiss from JS".
-
-- [ ] The panel dismisses and "Increment Background Counter" works again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Sheet largest undimmed detent index
+# Test Scenario: Largest Undimmed Detent Index (iOS)
 
 ## Details
 
@@ -18,7 +18,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Sheet largest undimmed detent index** screen.
+1. Launch the app and navigate to the **Largest Undimmed Detent Index (iOS)** screen.
 2. Tap the "Increment Background Counter" button at the top of the screen a few times.
 
 - [ ] The counter increases successfully.
@@ -29,21 +29,21 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap the "Open FormSheet" button.
 
-- [ ] The FormSheet opens at the first detent (0.3). The background behind the sheet immediately becomes dimmed. 
+- [ ] The FormSheet opens at the first detent (0.5). The background behind the sheet immediately becomes dimmed. 
 - [ ] Tapping the "Increment Background Counter" button does **not** work (the tap is intercepted by the dimming view and it dismisses the sheet).
 
 ---
 
 ### Dynamic Updates: Index 0 Validation
 
-4. Inside the sheet, tap the "Set 0 (0.3 height)" button.
+4. Inside the sheet, tap the "Set 0 (0.5 height)" button.
 
 - [ ] The background is undimmed immediately.
-- [ ] Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.3.
+- [ ] Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.5.
 
-5. Grab the top of the sheet and drag it up to the middle detent (0.6).
+5. Grab the top of the sheet and drag it up to the middle detent (0.65).
 
-- [ ] As the sheet transitions to index 1 (0.6), the background is dimmed again. The background counter button is no longer pressable.
+- [ ] As the sheet transitions to index 1 (0.65), the background is dimmed again. The background counter button is no longer pressable.
 
 ---
 
@@ -51,7 +51,7 @@ TBD: Planned, but will be implemented separately.
 
 6. Inside the sheet, tap the "Set 'last'" button.
 
-- [ ] The background is undimmed for lower detents (0.3 and 0.6).
+- [ ] The background is undimmed for lower detents (0.5 and 0.65).
 - [ ] Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
 - [ ] Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `largestUndimmedDetentIndex` property of the `FormSheet` component. This test ensures that the background dimming view is correctly applied or removed based on the current detent index, and that the underlying screen is interactive, when the sheet is undimmed. 
+**Description:** Verify the `largestUndimmedDetentIndex` property of the `FormSheet` component with detents `[0.5, 0.65, 0.8]`. This test ensures that the dimming view behind the sheet is applied or removed depending on the current detent, that the screen underneath stays interactive while the sheet is undimmed, and that the value can be changed while the sheet is presented.
 
-**OS test creation version:** iOS: 18.6 and 26.4
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5.
 
 ## E2E test
 
@@ -12,61 +12,148 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator (iPhone).
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
 
-## Steps
+## Note
+
+- iOS only – Android ignores `largestUndimmedDetentIndex` for now.
+- The "Increment Background Counter" button stays at the top of the host screen so it remains reachable above the sheet at every detent; the largest detent is 0.8 on purpose.
+- With the default `'none'` every detent is dimmed; a tap on the dimmed area dismisses the sheet instead of reaching the button underneath.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; the host screen stays visible around the panel.
+
+## Steps - iPhone
 
 ### Baseline
 
-1. Launch the app and navigate to the **Largest Undimmed Detent Index (iOS)** screen.
-2. Tap the "Increment Background Counter" button at the top of the screen a few times.
+1. Launch the app and navigate to the **Largest Undimmed Detent Index (iOS)** screen, then tap "Increment Background Counter" a few times.
 
-- [ ] The counter increases successfully.
-
----
-
-### Initialization & Default 'none' Behavior
-
-3. Tap the "Open FormSheet" button.
-
-- [ ] The FormSheet opens at the first detent (0.5). The background behind the sheet immediately becomes dimmed. 
-- [ ] Tapping the "Increment Background Counter" button does **not** work (the tap is intercepted by the dimming view and it dismisses the sheet).
+- [ ] "Background clicks" increases with every tap.
 
 ---
 
-### Dynamic Updates: Index 0 Validation
+### Default `'none'`
 
-4. Inside the sheet, tap the "Set 0 (0.5 height)" button.
+2. Tap "Open FormSheet".
 
-- [ ] The background is undimmed immediately.
-- [ ] Tapping the "Increment Background Counter" button successfully increases the counter while the sheet remains open at 0.5.
+- [ ] The sheet presents at the lowest detent (0.5) and the host screen is dimmed immediately. The title inside reads "Undimmed Index: none" and all five buttons are fully visible.
 
-5. Grab the top of the sheet and drag it up to the middle detent (0.65).
+3. Tap "Increment Background Counter".
 
-- [ ] As the sheet transitions to index 1 (0.65), the background is dimmed again. The background counter button is no longer pressable.
-
----
-
-### Dynamic Updates: 'last' Validation
-
-6. Inside the sheet, tap the "Set 'last'" button.
-
-- [ ] The background is undimmed for lower detents (0.5 and 0.65).
-- [ ] Dragging the sheet to its maximum height (0.8) keeps the background undimmed. 
-- [ ] Tapping the background counter button at the top of the screen successfully increments the count regardless of which detent the sheet is resting at.
+- [ ] The counter does **not** change – the tap is intercepted by the dimming view and dismisses the sheet.
 
 ---
 
-### Fallback to 'none'
+### Index `0`
 
-7. Inside the sheet, tap the "Set 'none'" button.
+4. Tap "Open FormSheet", then "Set 0 (0.5 height)" inside the sheet.
 
-- [ ] The background dims immediately. Interaction with the background counter is blocked.
+- [ ] The host screen becomes undimmed immediately; the title reads "Undimmed Index: 0".
+
+5. Tap "Increment Background Counter".
+
+- [ ] The counter increments while the sheet stays open at 0.5.
+
+6. Drag the sheet up to the middle detent (0.65).
+
+- [ ] As the sheet settles at 0.65 the host screen is dimmed again and "Increment Background Counter" is no longer reachable.
 
 ---
 
-### Dismissal Verification
+### `'last'`
 
-8. Tap the "Dismiss from JS" button (or swipe down completely).
+7. Tap "Set 'last'" inside the sheet.
 
-- [ ] The FormSheet dismisses smoothly. The background counter button becomes pressable again.
+- [ ] The host screen becomes undimmed at 0.65; the title reads "Undimmed Index: last".
+
+8. Drag the sheet up to the largest detent (0.8), then tap "Increment Background Counter".
+
+- [ ] The host screen stays undimmed at 0.8 and the counter increments.
+
+9. Drag the sheet down to 0.5 and tap "Increment Background Counter" again.
+
+- [ ] The counter increments – the host screen is undimmed at every detent.
+
+---
+
+### Back to `'none'`
+
+10. Tap "Set 'none'" inside the sheet.
+
+- [ ] The host screen is dimmed immediately and "Increment Background Counter" is blocked again.
+
+---
+
+### Dismissal
+
+11. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and "Increment Background Counter" works again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Largest Undimmed Detent Index (iOS)** screen, then tap "Increment Background Counter" a few times.
+
+- [ ] "Background clicks" increases with every tap.
+
+---
+
+### Default `'none'`
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel at the lowest detent (0.5) and the host screen around it is dimmed immediately. The title inside reads "Undimmed Index: none" and all five buttons are fully visible.
+
+3. Tap "Increment Background Counter".
+
+- [ ] The counter does **not** change – the tap is intercepted by the dimming view and dismisses the panel.
+
+---
+
+### Index `0`
+
+4. Tap "Open FormSheet", then "Set 0 (0.5 height)" inside the panel.
+
+- [ ] The host screen becomes undimmed immediately; the title reads "Undimmed Index: 0".
+
+5. Tap "Increment Background Counter".
+
+- [ ] The counter increments while the panel stays open at 0.5.
+
+6. Drag the panel up to the middle detent (0.65).
+
+- [ ] As the panel settles at 0.65 the host screen is dimmed again and "Increment Background Counter" is no longer reachable.
+
+---
+
+### `'last'`
+
+7. Tap "Set 'last'" inside the panel.
+
+- [ ] The host screen becomes undimmed at 0.65; the title reads "Undimmed Index: last".
+
+8. Drag the panel up to the largest detent (0.8), then tap "Increment Background Counter".
+
+- [ ] The host screen stays undimmed at 0.8 and the counter increments.
+
+9. Drag the panel down to 0.5 and tap "Increment Background Counter" again.
+
+- [ ] The counter increments – the host screen is undimmed at every detent.
+
+---
+
+### Back to `'none'`
+
+10. Tap "Set 'none'" inside the panel.
+
+- [ ] The host screen is dimmed immediately and "Increment Background Counter" is blocked again.
+
+---
+
+### Dismissal
+
+11. Tap "Dismiss from JS".
+
+- [ ] The panel dismisses and "Increment Background Counter" works again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-largest-undimmed-detent-index-ios/scenario.md
@@ -17,7 +17,7 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- iOS only – Android ignores `largestUndimmedDetentIndex` for now.
+- iOS only - Android implementation is planned separately.
 - The "Increment Background Counter" button stays at the top of the host screen so it remains reachable above the sheet at every detent; the largest detent is 0.8 on purpose.
 - With the default `'none'` every detent is dimmed; a tap on the dimmed area dismisses the sheet instead of reaching the button underneath.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the host screen stays visible around the panel.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/index.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Button,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -121,7 +128,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Lifecycle Events',
   key: 'test-form-sheet-lifecycle-events',
   details:
-    'Allows to test the lifecycle events (onWillAppear, onDidAppear, onWillDisappear, onDidDisappear) of the FormSheet component.',
+    'onWillAppear, onDidAppear, onWillDisappear, onDidDisappear: order on present and dismiss.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify that the `FormSheet` component correctly emits lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the exact order corresponding to the underlying native modal presentation transitions.
+**Description:** Verify that a standalone `FormSheet` emits its lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the order matching the native presentation transitions, for both programmatic and native dismissal. The host screen keeps a timestamped event log; the sheet has a single detent (`[0.4]`).
 
-**OS test creation version:** iOS: 18.6 and 26.4; Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
 
 ## E2E test
 
@@ -12,42 +12,129 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
+
+- `*WillAppear` / `*WillDisappear` are expected as soon as the transition starts, `*DidAppear` / `*DidDisappear` when it ends – wait for the animation to finish before reading the log.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet. The event flow is identical.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Lifecycle Events** screen.
 
-- [ ] A UI with "Open FormSheet" and "Clear Logs" buttons is shown, along with an empty event logs area.
+- [ ] The host screen shows the "Open FormSheet" button and a "Clear Logs" button and an empty "Event Logs" panel ("No events recorded yet.").
 
 ---
 
-### Presentation (Opening)
+### Presentation
 
-2. Tap the "Open FormSheet" button.
-3. Wait for the sheet presentation animation to finish.
+2. Tap "Open FormSheet" and wait for the presentation animation to finish.
 
-- [ ] The FormSheet opens smoothly.
-- [ ] The logs list updates to show exactly two new events in the following order: `onWillAppear`, `onDidAppear`
-
----
-
-### Native Dismissal (Swiping down)
-
-4. Dismiss the FormSheet by swiping it down.
-
-- [ ] The logs list updates to show exactly two new events: `onWillDisappear`, `onDidDisappear`
+- [ ] The sheet presents at the 0.4 detent.
+- [ ] The log shows exactly two new entries, in this order: `onWillAppear`, `onDidAppear`.
 
 ---
 
-### Programmatic Dismissal (JS)
+### Native dismissal
 
-5. Tap "Clear Logs" to reset the list.
-6. Tap "Open FormSheet" and wait for it to open.
-7. Tap the "Dismiss from JS" button inside the FormSheet.
+3. Swipe the sheet down to dismiss it and wait for the animation to finish.
 
-- [ ] The FormSheet closes smoothly.
-- [ ] The final logs list contains exactly four events in total, recorded in the following chronological order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
+- [ ] The log shows exactly two new entries, in this order: `onWillDisappear`, `onDidDisappear`.
+
+---
+
+### Programmatic dismissal
+
+4. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+5. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet and wait for the animation to finish.
+
+- [ ] The sheet dismisses.
+- [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Lifecycle Events** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button and a "Clear Logs" button and an empty "Event Logs" panel ("No events recorded yet.").
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet" and wait for the presentation animation to finish.
+
+- [ ] The sheet presents as a centered floating panel at the 0.4 detent.
+- [ ] The log shows exactly two new entries, in this order: `onWillAppear`, `onDidAppear`.
+
+---
+
+### Native dismissal
+
+3. Swipe the panel down to dismiss it and wait for the animation to finish.
+
+- [ ] The log shows exactly two new entries, in this order: `onWillDisappear`, `onDidDisappear`.
+
+---
+
+### Programmatic dismissal
+
+4. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+5. Tap "Open FormSheet", wait for the panel to present, then tap "Dismiss from JS" inside the panel and wait for the animation to finish.
+
+- [ ] The panel dismisses.
+- [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Lifecycle Events** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button and a "Clear Logs" button and an empty "Event Logs" panel ("No events recorded yet.").
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet" and wait for the presentation animation to finish.
+
+- [ ] The sheet presents at the 0.4 detent.
+- [ ] The log shows exactly two new entries, in this order: `onWillAppear`, `onDidAppear`.
+
+---
+
+### Native dismissal
+
+3. Swipe the sheet down to dismiss it and wait for the animation to finish.
+
+- [ ] The log shows exactly two new entries, in this order: `onWillDisappear`, `onDidDisappear`.
+
+4. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button) and wait for the animation to finish.
+
+- [ ] The sheet dismisses and the log again shows `onWillDisappear`, `onDidDisappear` as the last two entries.
+
+---
+
+### Programmatic dismissal
+
+5. Tap "Clear Logs".
+
+- [ ] The log is empty again.
+
+6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet and wait for the animation to finish.
+
+- [ ] The sheet dismisses.
+- [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify that a standalone `FormSheet` emits its lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the order matching the native presentation transitions, for both programmatic and native dismissal. The host screen keeps a timestamped event log; the sheet has a single detent (`[0.4]`).
+**Description:** Verify that `FormSheet` emits its lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the order matching the native presentation transitions, for both programmatic and native dismissal. The host screen keeps a timestamped event log; the sheet has a single detent (`[0.4]`).
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -59,9 +59,9 @@ TBD: Planned, but will be implemented separately.
 - [ ] The sheet dismisses.
 - [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
 
-## Steps - Android only
+---
 
-### Native dismissal – system back
+### Android only - system back native dismissal
 
 6. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button) and wait for the animation to finish.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - `*WillAppear` / `*WillDisappear` are expected as soon as the transition starts, `*DidAppear` / `*DidDisappear` when it ends – wait for the animation to finish before reading the log.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet. The event flow is identical.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -59,44 +59,10 @@ TBD: Planned, but will be implemented separately.
 - [ ] The sheet dismisses.
 - [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
 
-## Steps - Android
+## Steps - Android only
 
-### Baseline
+### Native dismissal – system back
 
-1. Launch the app and navigate to the **Lifecycle Events** screen.
+6. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button) and wait for the animation to finish.
 
-- [ ] The host screen shows the "Open FormSheet" button and a "Clear Logs" button and an empty "Event Logs" panel ("No events recorded yet.").
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet" and wait for the presentation animation to finish.
-
-- [ ] The sheet presents at the 0.4 detent.
-- [ ] The log shows exactly two new entries, in this order: `onWillAppear`, `onDidAppear`.
-
----
-
-### Native dismissal
-
-3. Swipe the sheet down to dismiss it and wait for the animation to finish.
-
-- [ ] The log shows exactly two new entries, in this order: `onWillDisappear`, `onDidDisappear`.
-
-4. Tap "Open FormSheet", wait for the sheet to present, then use the system back gesture (or the back button) and wait for the animation to finish.
-
-- [ ] The sheet dismisses and the log again shows `onWillDisappear`, `onDidDisappear` as the last two entries.
-
----
-
-### Programmatic dismissal
-
-5. Tap "Clear Logs".
-
-- [ ] The log is empty again.
-
-6. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet and wait for the animation to finish.
-
-- [ ] The sheet dismisses.
-- [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
+- [ ] The sheet dismisses and the log shows `onWillDisappear`, `onDidDisappear` as the last two entries.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify that a standalone `FormSheet` emits its lifecycle events (`onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`) in the order matching the native presentation transitions, for both programmatic and native dismissal. The host screen keeps a timestamped event log; the sheet has a single detent (`[0.4]`).
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-lifecycle-events/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - `*WillAppear` / `*WillDisappear` are expected as soon as the transition starts, `*DidAppear` / `*DidDisappear` when it ends – wait for the animation to finish before reading the log.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet. The event flow is identical.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -57,44 +57,6 @@ TBD: Planned, but will be implemented separately.
 5. Tap "Open FormSheet", wait for the sheet to present, then tap "Dismiss from JS" inside the sheet and wait for the animation to finish.
 
 - [ ] The sheet dismisses.
-- [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Lifecycle Events** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button and a "Clear Logs" button and an empty "Event Logs" panel ("No events recorded yet.").
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet" and wait for the presentation animation to finish.
-
-- [ ] The sheet presents as a centered floating panel at the 0.4 detent.
-- [ ] The log shows exactly two new entries, in this order: `onWillAppear`, `onDidAppear`.
-
----
-
-### Native dismissal
-
-3. Swipe the panel down to dismiss it and wait for the animation to finish.
-
-- [ ] The log shows exactly two new entries, in this order: `onWillDisappear`, `onDidDisappear`.
-
----
-
-### Programmatic dismissal
-
-4. Tap "Clear Logs".
-
-- [ ] The log is empty again.
-
-5. Tap "Open FormSheet", wait for the panel to present, then tap "Dismiss from JS" inside the panel and wait for the animation to finish.
-
-- [ ] The panel dismisses.
 - [ ] The log contains exactly four entries, in this order: `onWillAppear`, `onDidAppear`, `onWillDisappear`, `onDidDisappear`.
 
 ## Steps - Android

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Native container style',
+  name: 'Native Container Style',
   key: 'test-form-sheet-native-container-style',
   details:
-    'Allows to test the native container style properties (backgroundColor) of the FormSheet.',
+    'nativeContainerStyle.backgroundColor: native background fills the whole sheet, including safe areas.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; there is no bottom safe area to cover, so the color simply fills the panel.
 - **Android:** the sheet container is laid out behind the navigation bar, so the native color extends to the bottom edge of the screen while the React content stays above the bar. Content height changes are applied immediately, without animation.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -36,8 +36,10 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents with a height matching its content. The navy background fills the whole sheet, including the area under the home indicator – no default-colored gap in the bottom safe area.
-- [ ] iPad: the navy background fills the floating panel up to its rounded corners – there is no bottom safe-area strip to cover.
+- [ ] The sheet presents with a height matching its content. The navy background fills the whole sheet – no default-colored gap anywhere.
+- [ ] iPhone: the navy background also covers the area under the home indicator (the bottom safe area).
+- [ ] iPad: the navy background fills the sheet up to its rounded corners – there is no bottom safe-area strip to cover.
+- [ ] Android: the navy background extends behind the navigation bar to the bottom edge of the screen.
 
 ---
 
@@ -45,7 +47,9 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap "Expand Content" inside the sheet.
 
-- [ ] The sheet grows to accommodate the extra text box with a smooth animation. The navy background covers the new bounds throughout – no flashes or white gaps.
+- [ ] The sheet grows to accommodate the extra text box. The navy background covers the new bounds throughout – no flashes or white gaps.
+- [ ] iOS: the height change is animated smoothly.
+- [ ] Android: the sheet snaps to the taller height immediately (no animation).
 
 4. Tap "Dismiss from JS".
 
@@ -57,48 +61,8 @@ TBD: Planned, but will be implemented separately.
 
 5. Tap the "PURPLE" chip, then "Open FormSheet".
 
-- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet (on iPhone including the bottom safe area), exactly like navy did.
+- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet (including the bottom safe area on iPhone and the navigation bar area on Android), exactly like navy did.
 
 6. Swipe the sheet down.
-
-- [ ] The sheet dismisses and "Open FormSheet" is pressable again.
-
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Native Container Style** screen.
-
-- [ ] The host screen shows the "Select Native Background Color:" chips with "NAVY" selected, and the "Open FormSheet" button.
-
----
-
-### Default color
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents with a height matching its content and the host screen is dimmed. The navy background fills the whole sheet and extends behind the navigation bar to the bottom edge of the screen – no default-colored gap.
-
----
-
-### Layout stability
-
-3. Tap "Expand Content" inside the sheet.
-
-- [ ] The sheet snaps to the taller height immediately (no animation). The navy background covers the new bounds – no flashes or white gaps.
-
-4. Tap "Dismiss from JS".
-
-- [ ] The sheet dismisses.
-
----
-
-### Changing the color
-
-5. Tap the "PURPLE" chip, then "Open FormSheet".
-
-- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet down to the bottom edge of the screen, exactly like navy did.
-
-6. Swipe the sheet down (or use the system back gesture).
 
 - [ ] The sheet dismisses and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; there is no bottom safe area to cover, so the color simply fills the panel.
 - **Android:** the sheet container is laid out behind the navigation bar, so the native color extends to the bottom edge of the screen while the React content stays above the bar. Content height changes are applied immediately, without animation.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -37,6 +37,7 @@ TBD: Planned, but will be implemented separately.
 2. Tap "Open FormSheet".
 
 - [ ] The sheet presents with a height matching its content. The navy background fills the whole sheet, including the area under the home indicator – no default-colored gap in the bottom safe area.
+- [ ] iPad: the navy background fills the floating panel up to its rounded corners – there is no bottom safe-area strip to cover.
 
 ---
 
@@ -56,51 +57,11 @@ TBD: Planned, but will be implemented separately.
 
 5. Tap the "PURPLE" chip, then "Open FormSheet".
 
-- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet, including the bottom safe area, exactly like navy did.
+- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet (on iPhone including the bottom safe area), exactly like navy did.
 
 6. Swipe the sheet down.
 
 - [ ] The sheet dismisses and "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Native Container Style** screen.
-
-- [ ] The host screen shows the "Select Native Background Color:" chips with "NAVY" selected, and the "Open FormSheet" button.
-
----
-
-### Default color
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel with a height matching its content. The navy background fills the whole panel up to its rounded corners.
-
----
-
-### Layout stability
-
-3. Tap "Expand Content" inside the panel.
-
-- [ ] The panel grows vertically to accommodate the extra text box with a smooth animation; the width stays fixed. The navy background covers the new bounds throughout – no flashes or white gaps.
-
-4. Tap "Dismiss from JS".
-
-- [ ] The panel dismisses.
-
----
-
-### Changing the color
-
-5. Tap the "PURPLE" chip, then "Open FormSheet".
-
-- [ ] "PURPLE" is highlighted before opening. The panel presents with a purple background that fills the whole panel, exactly like navy did.
-
-6. Swipe the panel down.
-
-- [ ] The panel dismisses and "Open FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `nativeContainerStyle` functionality of the `FormSheet` component. This test ensures that styling properties applied to the native container (e.g. `backgroundColor`) correctly map to the underlying `UIView`, seamlessly filling the entire modal bounds including the bottom safe area.
+**Description:** Verify `nativeContainerStyle.backgroundColor` of the `FormSheet` component with `detents="fitToContents"`. This test ensures that the color is applied to the native container of the sheet – filling the whole sheet bounds, including the bottom safe area that React content does not cover – and that it can be changed between presentations.
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,51 +12,132 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone with a Home Indicator (e.g., iPhone 13/14/15) to properly verify the bottom safe area coverage.
-- Android emulator
+- iPhone: device or simulator **with a home indicator** (e.g. iPhone 13 or newer), to verify the bottom safe area coverage.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator with a visible navigation bar (gesture or 3-button).
 
-## Steps
+## Note
+
+- The React content of the sheet has no background of its own, so every visible sheet pixel comes from the native container color.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; there is no bottom safe area to cover, so the color simply fills the panel.
+- **Android:** the sheet container is laid out behind the navigation bar, so the native color extends to the bottom edge of the screen while the React content stays above the bar. Content height changes are applied immediately, without animation.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Native Container Style** screen.
 
-- [ ] Content with the button "Open FormSheet" and color selection controls is shown. The default selected color is "NAVY".
+- [ ] The host screen shows the "Select Native Background Color:" chips with "NAVY" selected, and the "Open FormSheet" button.
 
 ---
 
-### Applying Default Native Background Color
+### Default color
 
-2. Tap the "Open FormSheet" button.
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet opens smoothly.
-- [ ] The navy background extends completely to the bottom edge of the screen, rendering underneath the system Home Indicator without leaving any default-colored gaps in the safe area.
-
----
-
-### Layout Stability
-
-3. Tap the "Expand Content" button.
-
-- [ ] The FormSheet animates and expands in height to accommodate the new content. The native background seamlessly covers the new bounds without any visual flashes or white gaps during the transition.
-
-4. Tap the "Dismiss from JS" button.
-
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen.
+- [ ] The sheet presents with a height matching its content. The navy background fills the whole sheet, including the area under the home indicator – no default-colored gap in the bottom safe area.
 
 ---
 
-### Dynamic Native Background Color
+### Layout stability
 
-5. In the color selection controls, tap the **"PURPLE"** option.
+3. Tap "Expand Content" inside the sheet.
 
-- [ ] The PURPLE option becomes visually active.
+- [ ] The sheet grows to accommodate the extra text box with a smooth animation. The navy background covers the new bounds throughout – no flashes or white gaps.
 
-6. Tap the "Open FormSheet" button.
+4. Tap "Dismiss from JS".
 
-- [ ] The FormSheet opens smoothly.
-- [ ] The background color is now purple, extending to the bottom edge of the screen just as it did with the navy color.
+- [ ] The sheet dismisses.
 
-7. Swipe down to dismiss the FormSheet.
+---
 
-- [ ] The FormSheet dismisses smoothly.
+### Changing the color
+
+5. Tap the "PURPLE" chip, then "Open FormSheet".
+
+- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet, including the bottom safe area, exactly like navy did.
+
+6. Swipe the sheet down.
+
+- [ ] The sheet dismisses and "Open FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Native Container Style** screen.
+
+- [ ] The host screen shows the "Select Native Background Color:" chips with "NAVY" selected, and the "Open FormSheet" button.
+
+---
+
+### Default color
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel with a height matching its content. The navy background fills the whole panel up to its rounded corners.
+
+---
+
+### Layout stability
+
+3. Tap "Expand Content" inside the panel.
+
+- [ ] The panel grows vertically to accommodate the extra text box with a smooth animation; the width stays fixed. The navy background covers the new bounds throughout – no flashes or white gaps.
+
+4. Tap "Dismiss from JS".
+
+- [ ] The panel dismisses.
+
+---
+
+### Changing the color
+
+5. Tap the "PURPLE" chip, then "Open FormSheet".
+
+- [ ] "PURPLE" is highlighted before opening. The panel presents with a purple background that fills the whole panel, exactly like navy did.
+
+6. Swipe the panel down.
+
+- [ ] The panel dismisses and "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Native Container Style** screen.
+
+- [ ] The host screen shows the "Select Native Background Color:" chips with "NAVY" selected, and the "Open FormSheet" button.
+
+---
+
+### Default color
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents with a height matching its content and the host screen is dimmed. The navy background fills the whole sheet and extends behind the navigation bar to the bottom edge of the screen – no default-colored gap.
+
+---
+
+### Layout stability
+
+3. Tap "Expand Content" inside the sheet.
+
+- [ ] The sheet snaps to the taller height immediately (no animation). The navy background covers the new bounds – no flashes or white gaps.
+
+4. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses.
+
+---
+
+### Changing the color
+
+5. Tap the "PURPLE" chip, then "Open FormSheet".
+
+- [ ] "PURPLE" is highlighted before opening. The sheet presents with a purple background that fills the whole sheet down to the bottom edge of the screen, exactly like navy did.
+
+6. Swipe the sheet down (or use the system back gesture).
+
+- [ ] The sheet dismisses and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -12,13 +12,13 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iPhone: device or simulator **with a home indicator** (e.g. iPhone 13 or newer), to verify the bottom safe area coverage.
+- iPhone: device or simulator.
 - iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
-- Android: phone device or emulator with a visible navigation bar (gesture or 3-button).
+- Android: phone device or emulator.
 
 ## Note
 
-- The React content of the sheet has no background of its own, so every visible sheet pixel comes from the native container color.
+- The React content of the sheet has no background of its own, so the background is sampled from the native container background color.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; there is no bottom safe area to cover, so the color simply fills the panel.
 - **Android:** the sheet container is laid out behind the navigation bar, so the native color extends to the bottom edge of the screen while the React content stays above the bar. Content height changes are applied immediately, without animation.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-native-container-style/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Native container style
+# Test Scenario: Native Container Style
 
 ## Details
 
@@ -19,7 +19,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Native container style** screen.
+1. Launch the app and navigate to the **Native Container Style** screen.
 
 - [ ] Content with the button "Open FormSheet" and color selection controls is shown. The default selected color is "NAVY".
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
@@ -67,6 +67,7 @@ const styles = StyleSheet.create({
   },
   sheetContainer: {
     flex: 1,
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     backgroundColor: Colors.background,
     padding: 24,
     alignItems: 'center',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario-description.ts
@@ -1,10 +1,10 @@
-import { ScenarioDescription } from '@apps/tests/shared/helpers';
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'OnDetentChanged',
+  name: 'Detent Changed Event',
   key: 'test-form-sheet-on-detent-changed',
   details:
-    'Allows testing the onDetentChanged event, verifying that the correct detent index is reported when swiping.',
+    'onDetentChanged: reported index while dragging between three detents.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Detent Changed Event',
   key: 'test-form-sheet-on-detent-changed',
   details:
-    'onDetentChanged: reported index while dragging between three detents.',
+    'onDetentChanged: reported index after settling between three detents.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the event is emitted when the Material sheet settles in a state (collapsed → `0`, half-expanded → `1`, expanded → `2`), not while dragging. The content box is laid out to the largest detent and anchored to the top, so the card moves together with the sheet.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -63,49 +63,5 @@ TBD: Planned, but will be implemented separately.
 ### Dismissal
 
 8. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent).
-
-- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
-
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Detent Changed Event** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Track detent changes
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents at the lowest detent (0.4) and the host screen is dimmed. The "Active Index" card is anchored to the top of the sheet and shows `0`.
-
-3. Drag the sheet up until it settles at the middle detent (0.7).
-
-- [ ] The sheet settles at 0.7 and the card updates to `1` only after the sheet stops moving.
-
-4. Drag the sheet up to the maximum detent (1.0).
-
-- [ ] The sheet expands to the maximum available height (below the status bar) and the card updates to `2`.
-
-5. Drag the sheet down until it settles at the lowest detent (0.4).
-
-- [ ] The sheet settles at 0.4 and the card updates back to `0`.
-
-6. Drag the sheet up until it settles at the middle detent (0.7) again.
-
-- [ ] The sheet settles at 0.7 and the card updates to `1`.
-
-7. Drag the sheet a short way up towards the maximum detent (1.0) and release it before it passes the halfway point.
-
-- [ ] The sheet settles back at 0.7 and the card still shows `1` – an aborted drag that settles at the current detent does not produce a new index.
-
----
-
-### Dismissal
-
-8. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent, or use the system back gesture).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: onDetentChanged
+# Test Scenario: Detent Changed Event
 
 ## Details
 
@@ -18,9 +18,9 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **OnDetentChanged** screen.
+1. Launch the app and navigate to the **Detent Changed Event** screen.
 
-- [ ] A status text "Current Detent Index: 0" and an "Open FormSheet" button are shown.
+- [ ] An "Open FormSheet" button is shown.
 
 ### Track Detent Changes
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** the event is emitted when the Material sheet settles in a state (collapsed → `0`, half-expanded → `1`, expanded → `2`), not while dragging. The content box is laid out to the largest detent and anchored to the top, so the card moves together with the sheet.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -65,42 +65,6 @@ TBD: Planned, but will be implemented separately.
 8. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Detent Changed Event** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Track detent changes
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lowest detent (0.4). The "Active Index" card inside the panel shows `0`.
-
-3. Drag the panel up until it settles at the middle detent (0.7).
-
-- [ ] The panel settles at 0.7 (width unchanged) and the card updates to `1`.
-
-4. Drag the panel up to the maximum detent (1.0).
-
-- [ ] The panel grows to the maximum available height and the card updates to `2`.
-
-5. Drag the panel down until it settles at the lowest detent (0.4).
-
-- [ ] The panel settles at 0.4 and the card updates back to `0`.
-
----
-
-### Dismissal
-
-6. Tap "Dismiss from JS" (or swipe the panel down past the lowest detent).
-
-- [ ] The panel dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `onDetentChanged` event of the `FormSheet` component. This test ensures that when the user manually drags the sheet between multiple configured detents, the event is fired and accurately reports the array index of the newly settled detent.
+**Description:** Verify the `onDetentChanged` event of the `FormSheet` component with detents `[0.4, 0.7, 1.0]`. This test ensures that when the user drags the sheet between the configured detents, the event is fired once the sheet settles and reports the array index of the new detent, which the sheet displays in its "Active Index" card.
 
-**OS test creation version:** iOS: 18.6 and 26.4
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,34 +12,128 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator (iPhone)
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
+
+- The event reports the index within the `detents` array: `0` for 0.4, `1` for 0.7, `2` for 1.0. Opening the sheet resets the displayed value to `0`.
+- **Android:** the event is emitted when the Material sheet settles in a state (collapsed → `0`, half-expanded → `1`, expanded → `2`), not while dragging. The content box is laid out to the largest detent and anchored to the top, so the card moves together with the sheet.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Detent Changed Event** screen.
 
-- [ ] An "Open FormSheet" button is shown.
+- [ ] The host screen shows the "Open FormSheet" button.
 
-### Track Detent Changes
+---
 
-2. Tap the "Open FormSheet" button.
+### Track detent changes
 
-- [ ] The FormSheet opens at the smallest initial detent (0.4). The textbox inside the sheet displays `0`.
+2. Tap "Open FormSheet".
 
-3. Grab the drag indicator and swipe up until the sheet snaps to the middle detent (0.7).
+- [ ] The sheet presents at the lowest detent (0.4). The "Active Index" card inside the sheet shows `0`.
 
-- [ ] The sheet settles in the middle of the screen. The textbox inside the sheet updates to `1`.
+3. Drag the sheet up until it settles at the middle detent (0.7).
 
-4. Swipe up again to expand the sheet to the maximum detent (1.0).
+- [ ] The sheet settles at 0.7 and the card updates to `1`.
 
-- [ ] The sheet expands to fill the available screen height. The textbox inside the sheet updates to `2`.
+4. Drag the sheet up to the maximum detent (1.0).
 
-5. Swipe down to collapse the sheet back to the smallest detent (0.4).
+- [ ] The sheet fills the available height and the card updates to `2`.
 
-- [ ] The sheet shrinks back to the smallest size. The textbox inside the sheet updates back to `0`.
+5. Drag the sheet down until it settles at the lowest detent (0.4).
 
-6. Tap the "Dismiss from JS" button or swipe the sheet all the way down to dismiss it.
+- [ ] The sheet settles at 0.4 and the card updates back to `0`.
 
-- [ ] The FormSheet dismisses successfully.
+6. Drag the sheet up to 0.7, then release it without reaching 1.0.
+
+- [ ] The card shows `1` – an aborted drag that settles back at the same detent does not produce a different index.
+
+---
+
+### Dismissal
+
+7. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent).
+
+- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Detent Changed Event** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Track detent changes
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel at the lowest detent (0.4). The "Active Index" card inside the panel shows `0`.
+
+3. Drag the panel up until it settles at the middle detent (0.7).
+
+- [ ] The panel settles at 0.7 (width unchanged) and the card updates to `1`.
+
+4. Drag the panel up to the maximum detent (1.0).
+
+- [ ] The panel grows to the maximum available height and the card updates to `2`.
+
+5. Drag the panel down until it settles at the lowest detent (0.4).
+
+- [ ] The panel settles at 0.4 and the card updates back to `0`.
+
+---
+
+### Dismissal
+
+6. Tap "Dismiss from JS" (or swipe the panel down past the lowest detent).
+
+- [ ] The panel dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Detent Changed Event** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Track detent changes
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents at the lowest detent (0.4) and the host screen is dimmed. The "Active Index" card is anchored to the top of the sheet and shows `0`.
+
+3. Drag the sheet up until it settles at the middle detent (0.7).
+
+- [ ] The sheet settles at 0.7 and the card updates to `1` only after the sheet stops moving.
+
+4. Drag the sheet up to the maximum detent (1.0).
+
+- [ ] The sheet expands to the maximum available height (below the status bar) and the card updates to `2`.
+
+5. Drag the sheet down until it settles at the lowest detent (0.4).
+
+- [ ] The sheet settles at 0.4 and the card updates back to `0`.
+
+6. Drag the sheet up to 0.7, then release it without reaching 1.0.
+
+- [ ] The card shows `1` – an aborted drag that settles back at the same detent does not produce a different index.
+
+---
+
+### Dismissal
+
+7. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent, or use the system back gesture).
+
+- [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-on-detent-changed/scenario.md
@@ -50,15 +50,19 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet settles at 0.4 and the card updates back to `0`.
 
-6. Drag the sheet up to 0.7, then release it without reaching 1.0.
+6. Drag the sheet up until it settles at the middle detent (0.7) again.
 
-- [ ] The card shows `1` – an aborted drag that settles back at the same detent does not produce a different index.
+- [ ] The sheet settles at 0.7 and the card updates to `1`.
+
+7. Drag the sheet a short way up towards the maximum detent (1.0) and release it before it passes the halfway point.
+
+- [ ] The sheet settles back at 0.7 and the card still shows `1` – an aborted drag that settles at the current detent does not produce a new index.
 
 ---
 
 ### Dismissal
 
-7. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent).
+8. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.
 
@@ -126,14 +130,18 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet settles at 0.4 and the card updates back to `0`.
 
-6. Drag the sheet up to 0.7, then release it without reaching 1.0.
+6. Drag the sheet up until it settles at the middle detent (0.7) again.
 
-- [ ] The card shows `1` – an aborted drag that settles back at the same detent does not produce a different index.
+- [ ] The sheet settles at 0.7 and the card updates to `1`.
+
+7. Drag the sheet a short way up towards the maximum detent (1.0) and release it before it passes the halfway point.
+
+- [ ] The sheet settles back at 0.7 and the card still shows `1` – an aborted drag that settles at the current detent does not produce a new index.
 
 ---
 
 ### Dismissal
 
-7. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent, or use the system back gesture).
+8. Tap "Dismiss from JS" (or swipe the sheet down past the lowest detent, or use the system back gesture).
 
 - [ ] The sheet dismisses and the host screen is undimmed; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/index.tsx
@@ -83,9 +83,11 @@ const styles = StyleSheet.create({
   buttonGroup: {
     gap: 12,
     alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
   },
   spacing: {
-    height: 32,
+    height: 12,
   },
 });
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet, type FormSheetProps } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Sheet preferred corner radius',
+  name: 'Corner Radius',
   key: 'test-form-sheet-preferred-corner-radius',
   details:
-    'Allows to test the preferredCornerRadius property of the FormSheet component.',
+    'preferredCornerRadius: system default, sharp and custom radii, updated while presented.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Sheet corner radius
+# Test Scenario: Corner Radius
 
 ## Details
 
@@ -28,7 +28,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
+1. Launch the app and navigate to the **Corner Radius** screen.
 
 - [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 
@@ -68,7 +68,7 @@ TBD: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Sheet preferred corner radius** screen.
+1. Launch the app and navigate to the **Corner Radius** screen.
 
 - [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -20,7 +20,7 @@ TBD: Planned, but will be implemented separately.
 
 - **iOS 18:** the radius affects the **top** corners of the sheet. **iOS 26:** the radius affects **all** corners.
 - **iPad:** the sheet is presented as a floating panel, so the radius affects **all four** corners.
-- **Android:** rounded-corner clipping is applied only on API level 33+; the radius affects the **top** corners. Known limitation: updating the radius while the sheet is fully expanded to the top of the screen (1.0) makes the corners flat – Material enforces flat corners on the `EXPANDED` state transition and a JS prop update does not re-trigger the state. Change the radius at the 0.6 detent.
+- **Android:** rounded-corner clipping is applied only on API level 33+; the radius affects the **top** corners. Known limitation: updating the radius while the sheet is fully expanded to the top of the screen (1.0) makes the corners flat, change the radius at the 0.6 detent.
 
 ## Steps - iPhone
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **iPad:** the sheet is presented as a floating panel, so the radius affects **all four** corners.
 - **Android:** rounded-corner clipping is applied only on API level 33+; the radius affects the **top** corners. Known limitation: updating the radius while the sheet is fully expanded to the top of the screen (1.0) makes the corners flat, change the radius at the 0.6 detent.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -36,7 +36,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents at the lower detent (0.6). The top corners (iOS 18) or all corners (iOS 26) have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
+- [ ] The sheet presents at the lower detent (0.6). The top corners (iPhone on iOS 18) or all four corners (iPhone on iOS 26, iPad) have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
 
 ---
 
@@ -65,50 +65,6 @@ TBD: Planned, but will be implemented separately.
 7. Tap "Dismiss from JS" (or swipe the sheet down).
 
 - [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Corner Radius** screen.
-
-- [ ] The host screen shows "Current Radius: systemDefault" and the "Open FormSheet" button.
-
----
-
-### System default
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.6). All four corners have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
-
----
-
-### Dynamic updates
-
-3. Tap "Sharp (0)" inside the panel.
-
-- [ ] All four corners become sharp immediately, without re-presenting the panel. The title reads "Current Radius: 0".
-
-4. Tap "Small (10)".
-
-- [ ] All four corners get a slight rounding; the title reads "Current Radius: 10".
-
-5. Tap "Large (50)".
-
-- [ ] All four corners get a deep rounding; the title reads "Current Radius: 50".
-
-6. Tap "System default".
-
-- [ ] All four corners return to the system-default rounding; the title reads "Current Radius: systemDefault".
-
----
-
-### Dismissal
-
-7. Tap "Dismiss from JS" (or swipe the panel down).
-
-- [ ] The panel dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -22,7 +22,7 @@ TBD: Planned, but will be implemented separately.
 - **iPad:** the sheet is presented as a floating panel, so the radius affects **all four** corners.
 - **Android:** rounded-corner clipping is applied only on API level 33+; the radius affects the **top** corners. Known limitation: updating the radius while the sheet is fully expanded to the top of the screen (1.0) makes the corners flat, change the radius at the 0.6 detent.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -36,7 +36,7 @@ TBD: Planned, but will be implemented separately.
 
 2. Tap "Open FormSheet".
 
-- [ ] The sheet presents at the lower detent (0.6). The top corners (iPhone on iOS 18) or all four corners (iPhone on iOS 26, iPad) have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
+- [ ] The sheet presents at the lower detent (0.6). The affected corners (see Note: top corners on iOS 18 and Android, all corners on iOS 26 and iPad) have the platform-default rounding. The title inside reads "Current Radius: systemDefault".
 
 ---
 
@@ -66,54 +66,14 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
 
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Corner Radius** screen.
-
-- [ ] The host screen shows "Current Radius: systemDefault" and the "Open FormSheet" button.
-
----
-
-### System default
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed. The top corners have the Material default rounding. The title inside reads "Current Radius: systemDefault" and is anchored to the top of the sheet.
-
----
-
-### Dynamic updates (at 0.6)
-
-3. Tap "Sharp (0)" inside the sheet.
-
-- [ ] The top corners become sharp immediately, without re-presenting the sheet. The title reads "Current Radius: 0".
-
-4. Tap "Small (10)".
-
-- [ ] The top corners get a slight rounding; the title reads "Current Radius: 10".
-
-5. Tap "Large (50)".
-
-- [ ] The top corners get a deep rounding; the title reads "Current Radius: 50".
-
-6. Tap "System default".
-
-- [ ] The top corners return to the default rounding; the title reads "Current Radius: systemDefault".
-
----
+## Steps - Android only
 
 ### Known limitation at 1.0
 
-7. Drag the sheet up to the largest detent (1.0), then tap "Large (50)".
+8. Tap "Open FormSheet", drag the sheet up to the largest detent (1.0), then tap "Large (50)".
 
 - [ ] The corners become flat instead of rounded (see Note) – this is the documented Material limitation, not a regression.
 
----
+9. Tap "Dismiss from JS".
 
-### Dismissal
-
-8. Tap "Dismiss from JS" (or swipe the sheet down, or use the system back gesture).
-
-- [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
+- [ ] The sheet dismisses.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -66,9 +66,9 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
 
-## Steps - Android only
+---
 
-### Known limitation at 1.0
+### Android only - Known limitation at 1.0 detent
 
 8. Tap "Open FormSheet", drag the sheet up to the largest detent (1.0), then tap "Large (50)".
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-preferred-corner-radius/scenario.md
@@ -2,9 +2,9 @@
 
 ## Details
 
-**Description:** Verify the `preferredCornerRadius` property of the `FormSheet` component. This test ensures that negative values successfully map to the system's automatic dimension, specific positive values correctly alter the corner rounding, and the sheet dynamically updates its radius when the prop changes while presented.
+**Description:** Verify the `preferredCornerRadius` property of the `FormSheet` component with detents `[0.6, 1.0]`. This test ensures that `'systemDefault'` maps to the system's automatic corner radius, that explicit values (`0`, `10`, `50`) change the rounding, and that the radius updates while the sheet is presented.
 
-**OS test creation version:** iOS: 18.6 and 26.4, iPadOS 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
@@ -12,17 +12,15 @@ TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone and iPad
-- On iPad: Ensure the device is in full-screen mode, regular width, regular height size class
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator running API level 33 or higher.
 
 ## Note
 
-- On iOS 18, the corner radius primarily affects the **top** corners of the bottom sheet.
-- On iOS 26, the corner radius primarily affects **all** corners of the bottom sheet.
-- On iPad, because the FormSheet is presented as a floating panel, the corner radius will affect **all four** corners.
-- On Android, rounded-corner clipping is only applied on API level 33+.
-- On Android, dynamically updating the corner radius while the sheet is fully expanded to the top of the screen will cause the corners to revert to a flat shape. This is a known limitation of the underlying Material component, which enforces flat corners as a reaction to the EXPANDED state transition. Updating prop dynamically from JS doesn't trigger native behavior state update.
+- **iOS 18:** the radius affects the **top** corners of the sheet. **iOS 26:** the radius affects **all** corners.
+- **iPad:** the sheet is presented as a floating panel, so the radius affects **all four** corners.
+- **Android:** rounded-corner clipping is applied only on API level 33+; the radius affects the **top** corners. Known limitation: updating the radius while the sheet is fully expanded to the top of the screen (1.0) makes the corners flat – Material enforces flat corners on the `EXPANDED` state transition and a JS prop update does not re-trigger the state. Change the radius at the 0.6 detent.
 
 ## Steps - iPhone
 
@@ -30,39 +28,43 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Corner Radius** screen.
 
-- [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
+- [ ] The host screen shows "Current Radius: systemDefault" and the "Open FormSheet" button.
 
 ---
 
-### Initialization & Default Value Verification
+### System default
 
-2. Tap the "Open FormSheet" button.
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet opens. The top corners (iOS 18) or all corners (iOS 26) of the sheet display the standard, system-default rounded appearance.
-
----
-
-### Dynamic Updates Validation
-
-3. Tap the "Sharp (0)" button.
-
-- [ ] The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, becoming sharp.
-
-4. Tap the "Small (10)" button.
-
-- [ ] The top corners (iOS 18) or all corners (iOS 26) update to a slightly rounded curve.
-
-5. Tap the "Large (50)" button.
-
-- [ ] The top corners (iOS 18) or all corners (iOS 26) of the sheet update dynamically, displaying deeply rounded curve.
+- [ ] The sheet presents at the lower detent (0.6). The top corners (iOS 18) or all corners (iOS 26) have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
 
 ---
 
-### Dismissal Verification
+### Dynamic updates
 
-6. Tap the "Dismiss from JS" button (or swipe down completely).
+3. Tap "Sharp (0)" inside the sheet.
 
-- [ ] The FormSheet dismisses smoothly. Pressables on the main screen remain active.
+- [ ] The corners become sharp immediately, without re-presenting the sheet. The title reads "Current Radius: 0".
+
+4. Tap "Small (10)".
+
+- [ ] The corners get a slight rounding; the title reads "Current Radius: 10".
+
+5. Tap "Large (50)".
+
+- [ ] The corners get a deep rounding; the title reads "Current Radius: 50".
+
+6. Tap "System default".
+
+- [ ] The corners return to the system-default rounding; the title reads "Current Radius: systemDefault".
+
+---
+
+### Dismissal
+
+7. Tap "Dismiss from JS" (or swipe the sheet down).
+
+- [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
 
 ## Steps - iPad
 
@@ -70,36 +72,92 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Corner Radius** screen.
 
-- [ ] Content with the button "Open FormSheet" and current radius text ("systemDefault") is shown.
+- [ ] The host screen shows "Current Radius: systemDefault" and the "Open FormSheet" button.
 
 ---
 
-### Initialization & Default Value Verification
+### System default
 
-2. Tap the "Open FormSheet" button.
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet opens as a centered floating panel. All four corners of the panel display the standard, system-default rounded appearance.
-
----
-
-### Dynamic Updates Validation
-
-3. Tap the "Sharp (0)" button.
-
-- [ ] All four corners of the sheet update dynamically, becoming sharp.
-
-4. Tap the "Small (10)" button.
-
-- [ ] All four corners update to a slightly rounded curve.
-
-5. Tap the "Large (50)" button.
-
-- [ ] All four corners of the sheet update dynamically, displaying deeply rounded curve.
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.6). All four corners have the standard, system-default rounding. The title inside reads "Current Radius: systemDefault".
 
 ---
 
-### Dismissal Verification
+### Dynamic updates
 
-6. Tap the "Dismiss from JS" button (or swipe down completely).
+3. Tap "Sharp (0)" inside the panel.
 
-- [ ] The FormSheet dismisses smoothly. Pressables on the main screen remain active.
+- [ ] All four corners become sharp immediately, without re-presenting the panel. The title reads "Current Radius: 0".
+
+4. Tap "Small (10)".
+
+- [ ] All four corners get a slight rounding; the title reads "Current Radius: 10".
+
+5. Tap "Large (50)".
+
+- [ ] All four corners get a deep rounding; the title reads "Current Radius: 50".
+
+6. Tap "System default".
+
+- [ ] All four corners return to the system-default rounding; the title reads "Current Radius: systemDefault".
+
+---
+
+### Dismissal
+
+7. Tap "Dismiss from JS" (or swipe the panel down).
+
+- [ ] The panel dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Corner Radius** screen.
+
+- [ ] The host screen shows "Current Radius: systemDefault" and the "Open FormSheet" button.
+
+---
+
+### System default
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed. The top corners have the Material default rounding. The title inside reads "Current Radius: systemDefault" and is anchored to the top of the sheet.
+
+---
+
+### Dynamic updates (at 0.6)
+
+3. Tap "Sharp (0)" inside the sheet.
+
+- [ ] The top corners become sharp immediately, without re-presenting the sheet. The title reads "Current Radius: 0".
+
+4. Tap "Small (10)".
+
+- [ ] The top corners get a slight rounding; the title reads "Current Radius: 10".
+
+5. Tap "Large (50)".
+
+- [ ] The top corners get a deep rounding; the title reads "Current Radius: 50".
+
+6. Tap "System default".
+
+- [ ] The top corners return to the default rounding; the title reads "Current Radius: systemDefault".
+
+---
+
+### Known limitation at 1.0
+
+7. Drag the sheet up to the largest detent (1.0), then tap "Large (50)".
+
+- [ ] The corners become flat instead of rounded (see Note) – this is the documented Material limitation, not a regression.
+
+---
+
+### Dismissal
+
+8. Tap "Dismiss from JS" (or swipe the sheet down, or use the system back gesture).
+
+- [ ] The sheet dismisses and the host screen shows the last selected radius; "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     alignItems: 'center',
   },
   sheetTitle: {

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Presentation state',
+  name: 'Presentation State',
   key: 'test-form-sheet-presentation-state',
   details:
-    'Verifies the presentation state machine when subjected to rapid consecutive open/close state changes from JS.',
+    'Rapid open/close toggles from JS: the presentation state machine must stay in sync.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
@@ -2,18 +2,24 @@
 
 ## Details
 
-**Description:** Verify the presentation state machine. This test ensures that when the React Native state rapidly toggles between `false` and `true` the native layer correctly queues the presentation changes and prevents state desynchronization.
+**Description:** Verify the presentation state machine of the `FormSheet` component with detents `[0.6, 1.0]`. When `isOpen` rapidly toggles from `true` to `false` and back to `true` (within one frame or two), the native layer must queue the transitions – finish the dismissal, then present again – and end up in sync with the JS state, without a stuck or duplicated sheet.
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
-Other: Planned, but will be implemented separately.
+TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
+
+## Note
+
+- "Quickly dismiss & present" sets `isOpen` to `false` and back to `true` after ~32 ms, i.e. while the dismissal animation is still running.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
 
@@ -21,28 +27,116 @@ Other: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Presentation State** screen.
 
-- [ ] Content with the button "Open FormSheet" is shown.
+- [ ] The host screen shows the "Open FormSheet" button.
 
 ---
 
-### Initialization
+### Presentation
 
-2. Tap the "Open FormSheet" button.
+2. Tap "Open FormSheet".
 
-- [ ] The FormSheet opens smoothly and displays its content.
-
----
-
-### Rapid State Toggling (Stress Test)
-
-3. Tap the "Quickly dismiss & present" button.
-
-- [ ] The FormSheet should begin the dismissal animation. As soon as the dismissal animation finishes, the FormSheet should immediately automatically re-present itself. The final state should be opened FormSheet.
+- [ ] The sheet presents at the lower detent (0.6) with the "FormSheet content" title and the "Quickly dismiss & present" button.
 
 ---
 
-### Final Dismissal Verification
+### Rapid toggling (stress test)
 
-4. Grab the top edge of the FormSheet and swipe down completely to natively dismiss it.
+3. Tap "Quickly dismiss & present".
 
-- [ ] The FormSheet dismisses and returns the user to the underlying main screen. The native state is synchronized, and tapping "Open FormSheet" again works correctly.
+- [ ] The sheet starts its dismissal animation and, as soon as it finishes, presents again automatically. The final state is a single presented sheet at 0.6; no flicker, no leftover dimming, no second sheet.
+
+4. Tap "Quickly dismiss & present" three more times in a row, waiting for the sheet to come back each time.
+
+- [ ] Every cycle ends with exactly one presented sheet.
+
+---
+
+### Final dismissal
+
+5. Swipe the sheet down past the lower detent.
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+6. Tap "Open FormSheet".
+
+- [ ] The sheet presents again normally – the native state stayed in sync with JS.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Presentation State** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.6) with the "FormSheet content" title and the "Quickly dismiss & present" button.
+
+---
+
+### Rapid toggling (stress test)
+
+3. Tap "Quickly dismiss & present".
+
+- [ ] The panel starts its dismissal animation and, as soon as it finishes, presents again automatically. The final state is a single presented panel at 0.6; no flicker, no leftover dimming, no second panel.
+
+4. Tap "Quickly dismiss & present" three more times in a row, waiting for the panel to come back each time.
+
+- [ ] Every cycle ends with exactly one presented panel.
+
+---
+
+### Final dismissal
+
+5. Swipe the panel down past the lower detent.
+
+- [ ] The panel dismisses and the host screen is undimmed.
+
+6. Tap "Open FormSheet".
+
+- [ ] The panel presents again normally – the native state stayed in sync with JS.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Presentation State** screen.
+
+- [ ] The host screen shows the "Open FormSheet" button.
+
+---
+
+### Presentation
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed; the "FormSheet content" title and the "Quickly dismiss & present" button are anchored to the top of the sheet.
+
+---
+
+### Rapid toggling (stress test)
+
+3. Tap "Quickly dismiss & present".
+
+- [ ] The sheet starts its dismissal animation and, as soon as it finishes, presents again automatically. The final state is a single presented sheet at 0.6; no flicker, no leftover dimming, no second sheet.
+
+4. Tap "Quickly dismiss & present" three more times in a row, waiting for the sheet to come back each time.
+
+- [ ] Every cycle ends with exactly one presented sheet.
+
+---
+
+### Final dismissal
+
+5. Swipe the sheet down past the lower detent (or use the system back gesture).
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+6. Tap "Open FormSheet".
+
+- [ ] The sheet presents again normally – the native state stayed in sync with JS.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
@@ -19,8 +19,9 @@ TBD: Planned, but will be implemented separately.
 ## Note
 
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
+- **Android:** the content box is laid out to the largest detent and anchored to the top of the sheet.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -53,46 +54,6 @@ TBD: Planned, but will be implemented separately.
 ### Final dismissal
 
 5. Swipe the sheet down past the lower detent.
-
-- [ ] The sheet dismisses and the host screen is undimmed.
-
-6. Tap "Open FormSheet".
-
-- [ ] The sheet presents again normally – the native state stayed in sync with JS.
-
-## Steps - Android
-
-### Baseline
-
-1. Launch the app and navigate to the **Presentation State** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents at the lower detent (0.6) and the host screen is dimmed; the "FormSheet content" title and the "Quickly dismiss & present" button are anchored to the top of the sheet.
-
----
-
-### Rapid toggling (stress test)
-
-3. Tap "Quickly dismiss & present".
-
-- [ ] The sheet starts its dismissal animation and, as soon as it finishes, presents again automatically. The final state is a single presented sheet at 0.6; no flicker, no leftover dimming, no second sheet.
-
-4. Tap "Quickly dismiss & present" three more times in a row, waiting for the sheet to come back each time.
-
-- [ ] Every cycle ends with exactly one presented sheet.
-
----
-
-### Final dismissal
-
-5. Swipe the sheet down past the lower detent (or use the system back gesture).
 
 - [ ] The sheet dismisses and the host screen is undimmed.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
@@ -18,7 +18,6 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- "Quickly dismiss & present" sets `isOpen` to `false` and back to `true` after ~32 ms, i.e. while the dismissal animation is still running.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
 ## Steps - iPhone
@@ -39,7 +38,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Rapid toggling (stress test)
+### Rapid toggling
 
 3. Tap "Quickly dismiss & present".
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: Presentation state
+# Test Scenario: Presentation State
 
 ## Details
 
@@ -19,7 +19,7 @@ Other: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **Presentation state** screen.
+1. Launch the app and navigate to the **Presentation State** screen.
 
 - [ ] Content with the button "Open FormSheet" is shown.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-presentation-state/scenario.md
@@ -20,7 +20,7 @@ TBD: Planned, but will be implemented separately.
 
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width, not as a full-width bottom sheet.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -59,46 +59,6 @@ TBD: Planned, but will be implemented separately.
 6. Tap "Open FormSheet".
 
 - [ ] The sheet presents again normally – the native state stayed in sync with JS.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Presentation State** screen.
-
-- [ ] The host screen shows the "Open FormSheet" button.
-
----
-
-### Presentation
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.6) with the "FormSheet content" title and the "Quickly dismiss & present" button.
-
----
-
-### Rapid toggling (stress test)
-
-3. Tap "Quickly dismiss & present".
-
-- [ ] The panel starts its dismissal animation and, as soon as it finishes, presents again automatically. The final state is a single presented panel at 0.6; no flicker, no leftover dimming, no second panel.
-
-4. Tap "Quickly dismiss & present" three more times in a row, waiting for the panel to come back each time.
-
-- [ ] Every cycle ends with exactly one presented panel.
-
----
-
-### Final dismissal
-
-5. Swipe the panel down past the lower detent.
-
-- [ ] The panel dismisses and the host screen is undimmed.
-
-6. Tap "Open FormSheet".
-
-- [ ] The panel presents again normally – the native state stayed in sync with JS.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/index.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Alert, Button, StyleSheet, Switch, Text, View } from 'react-native';
+import {
+  Alert,
+  Button,
+  Platform,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { Colors } from '@apps/shared/styling';
@@ -96,6 +104,7 @@ const styles = StyleSheet.create({
   },
   sheetContainer: {
     flex: 1,
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     backgroundColor: Colors.background,
     padding: 24,
     alignItems: 'center',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'PreventNativeDismiss',
+  name: 'Prevent Native Dismiss',
   key: 'test-form-sheet-prevent-native-dismiss',
   details:
-    'Allows testing the preventNativeDismiss property and firing the onNativeDismissPrevented event.',
+    'preventNativeDismiss + onNativeDismissPrevented: swipe-down and backdrop tap are blocked, JS dismiss works.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -73,9 +73,9 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.
 
-## Steps - Android only
+---
 
-### System back
+### Android only - System back
 
 11. Flip the switch back so the host screen reads "Prevent Native Dismiss: ON", tap "Open FormSheet", then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** a prevented attempt makes the sheet return to its last stable detent; the system back gesture/button is intercepted the same way as the swipe.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -49,7 +49,7 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The alert closes; the sheet is still presented.
 
-6. Tap the backdrop (the dimmed area above the sheet).
+6. Tap the backdrop (the dimmed area outside the sheet).
 
 - [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
 
@@ -72,58 +72,6 @@ TBD: Planned, but will be implemented separately.
 10. Tap "Open FormSheet", then tap the backdrop.
 
 - [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
-
-- [ ] The host screen shows "Prevent Native Dismiss: ON", a switch (on) and the "Open FormSheet" button.
-
----
-
-### Native dismissal prevented
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents as a centered floating panel at the lower detent (0.5). The text inside asks to try swiping down or tapping the backdrop.
-
-3. Drag the panel up to 1.0, then back down to 0.5.
-
-- [ ] Both drags work – detent changes are not blocked.
-
-4. Swipe the panel down past the lower detent.
-
-- [ ] The panel does **not** dismiss – it bounces back to 0.5 and a "Dismissal Prevented" alert appears.
-
-5. Tap "OK" on the alert.
-
-- [ ] The alert closes; the panel is still presented.
-
-6. Tap the backdrop (the dimmed area around the panel).
-
-- [ ] The panel does **not** dismiss and the "Dismissal Prevented" alert appears again.
-
-7. Tap "OK", then tap "Dismiss from JS".
-
-- [ ] The panel dismisses – programmatic dismissal is not affected.
-
----
-
-### Native dismissal allowed
-
-8. Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", then tap "Open FormSheet".
-
-- [ ] The panel presents at 0.5. The text inside says the sheet should close without an alert.
-
-9. Swipe the panel down past the lower detent.
-
-- [ ] The panel dismisses; no alert is shown.
-
-10. Tap "Open FormSheet", then tap the backdrop.
-
-- [ ] The panel dismisses; no alert is shown. "Open FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -18,7 +18,6 @@ TBD: Planned, but will be implemented separately.
 
 ## Note
 
-- The switch on the host screen defaults to **ON**; the instruction text inside the sheet changes with the switch value.
 - **Android:** a prevented attempt makes the sheet return to its last stable detent; the system back gesture/button is intercepted the same way as the swipe.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -2,77 +2,186 @@
 
 ## Details
 
-**Description:** Verify the `preventNativeDismiss` property and the `onNativeDismissPrevented` event of the `FormSheet` component. This test ensures that when the property is set to `true`, the user cannot dismiss the sheet natively by swiping it down or tapping the backdrop behind the sheet. Instead, the sheet fires an event that displays an Alert. However, the user can still swipe between detents, and programmatic dismissals triggered by React state changes will still work. When set to `false`, the sheet can be dismissed natively without triggering the prevented event.
+**Description:** Verify the `preventNativeDismiss` property and the `onNativeDismissPrevented` event of the `FormSheet` component with detents `[0.5, 1.0]`. When the property is `true`, the sheet cannot be dismissed natively (swipe down, backdrop tap, and on Android the system back gesture); each attempt fires `onNativeDismissPrevented`, which the scenario surfaces as a "Dismissal Prevented" alert. Dragging between detents and dismissing from JS still work. When the property is `false`, native dismissal works and no event is fired.
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 
-Other: Planned, but will be implemented separately.
+TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator (iPhone)
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
 
-## Steps
+## Note
+
+- The switch on the host screen defaults to **ON**; the instruction text inside the sheet changes with the switch value.
+- **Android:** a prevented attempt makes the sheet return to its last stable detent; the system back gesture/button is intercepted the same way as the swipe.
+- **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
+
+## Steps - iPhone
 
 ### Baseline
 
 1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
 
-- [ ] A status text indicating the current prop value (e.g., "Prevent Native Dismiss: ON"), a switch component, and an "Open FormSheet" button are shown.
+- [ ] The host screen shows "Prevent Native Dismiss: ON", a switch (on) and the "Open FormSheet" button.
 
-### Native Dismissal Prevented & Event Fired
+---
 
-2. Ensure the switch is set to ON. Tap the "Open FormSheet" button.
+### Native dismissal prevented
 
-- [ ] The FormSheet opens at the initial lower detent (0.5).
+2. Tap "Open FormSheet".
 
-3. Swipe up to expand the sheet to the maximum detent (1.0).
+- [ ] The sheet presents at the lower detent (0.5). The text inside asks to try swiping down or tapping the backdrop.
 
-- [ ] The sheet expands successfully. 
+3. Drag the sheet up to 1.0, then back down to 0.5.
 
-4. Swipe down on the sheet to collapse it back to the lower detent (0.5).
+- [ ] Both drags work – detent changes are not blocked.
 
-- [ ] The sheet collapses successfully.
+4. Swipe the sheet down past the lower detent.
 
-5. Swipe down on the sheet to attempt to dismiss it completely.
+- [ ] The sheet does **not** dismiss – it bounces back to 0.5 and a "Dismissal Prevented" alert appears.
 
-- [ ] The FormSheet **does not** dismiss. It resists the gesture and bounces back to the 0.5 detent. An alert with the title "Dismissal Prevented" appears.
+5. Tap "OK" on the alert.
 
-6. Tap "OK" on the alert.
+- [ ] The alert closes; the sheet is still presented.
 
-- [ ] The alert closes and the FormSheet remains open.
+6. Tap the backdrop (the dimmed area above the sheet).
 
-7. Tap the backdrop (the dimmed area behind/above the sheet).
+- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
 
-- [ ] The FormSheet **does not** dismiss. An alert with the title "Dismissal Prevented" appears again.
+7. Tap "OK", then tap "Dismiss from JS".
 
-8. Tap "OK" on the alert.
+- [ ] The sheet dismisses – programmatic dismissal is not affected.
 
-- [ ] The alert closes and the FormSheet remains open.
+---
 
-9. Tap the "Dismiss from JS" button.
+### Native dismissal allowed
 
-- [ ] The FormSheet dismisses successfully.
+8. Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", then tap "Open FormSheet".
 
-### Native Dismissal Allowed
+- [ ] The sheet presents at 0.5. The text inside says the sheet should close without an alert.
 
-10. Tap the switch component so the status reads "Prevent Native Dismiss: OFF".
+9. Swipe the sheet down past the lower detent.
 
-11. Tap the "Open FormSheet" button.
+- [ ] The sheet dismisses; no alert is shown.
 
-- [ ] The FormSheet opens at the initial lower detent (0.5).
+10. Tap "Open FormSheet", then tap the backdrop.
 
-12. Swipe down on the sheet to attempt to dismiss it completely.
+- [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
+## Steps - iPad
 
-13. Tap the "Open FormSheet" button again.
+### Baseline
 
-- [ ] The FormSheet opens at the initial lower detent (0.5).
+1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
 
-14. Tap the backdrop.
+- [ ] The host screen shows "Prevent Native Dismiss: ON", a switch (on) and the "Open FormSheet" button.
 
-- [ ] The FormSheet dismisses smoothly and returns the user to the underlying main screen. The "Dismissal Prevented" alert **is not** shown.
+---
+
+### Native dismissal prevented
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents as a centered floating panel at the lower detent (0.5). The text inside asks to try swiping down or tapping the backdrop.
+
+3. Drag the panel up to 1.0, then back down to 0.5.
+
+- [ ] Both drags work – detent changes are not blocked.
+
+4. Swipe the panel down past the lower detent.
+
+- [ ] The panel does **not** dismiss – it bounces back to 0.5 and a "Dismissal Prevented" alert appears.
+
+5. Tap "OK" on the alert.
+
+- [ ] The alert closes; the panel is still presented.
+
+6. Tap the backdrop (the dimmed area around the panel).
+
+- [ ] The panel does **not** dismiss and the "Dismissal Prevented" alert appears again.
+
+7. Tap "OK", then tap "Dismiss from JS".
+
+- [ ] The panel dismisses – programmatic dismissal is not affected.
+
+---
+
+### Native dismissal allowed
+
+8. Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", then tap "Open FormSheet".
+
+- [ ] The panel presents at 0.5. The text inside says the sheet should close without an alert.
+
+9. Swipe the panel down past the lower detent.
+
+- [ ] The panel dismisses; no alert is shown.
+
+10. Tap "Open FormSheet", then tap the backdrop.
+
+- [ ] The panel dismisses; no alert is shown. "Open FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
+
+- [ ] The host screen shows "Prevent Native Dismiss: ON", a switch (on) and the "Open FormSheet" button.
+
+---
+
+### Native dismissal prevented
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet presents at the lower detent (0.5) and the host screen is dimmed. The text inside asks to try swiping down or tapping the backdrop; the content is anchored to the top of the sheet.
+
+3. Drag the sheet up to 1.0, then back down to 0.5.
+
+- [ ] Both drags work – detent changes are not blocked.
+
+4. Swipe the sheet down past the lower detent.
+
+- [ ] The sheet does **not** dismiss – it returns to 0.5 and a "Dismissal Prevented" alert appears.
+
+5. Tap "OK" on the alert.
+
+- [ ] The alert closes; the sheet is still presented.
+
+6. Tap the backdrop (the dimmed area above the sheet).
+
+- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
+
+7. Tap "OK", then use the system back gesture (or the back button).
+
+- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
+
+8. Tap "OK", then tap "Dismiss from JS".
+
+- [ ] The sheet dismisses – programmatic dismissal is not affected.
+
+---
+
+### Native dismissal allowed
+
+9. Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", then tap "Open FormSheet".
+
+- [ ] The sheet presents at 0.5. The text inside says the sheet should close without an alert.
+
+10. Swipe the sheet down past the lower detent.
+
+- [ ] The sheet dismisses; no alert is shown.
+
+11. Tap "Open FormSheet", then tap the backdrop.
+
+- [ ] The sheet dismisses; no alert is shown.
+
+12. Tap "Open FormSheet", then use the system back gesture (or the back button).
+
+- [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -1,4 +1,4 @@
-# Test Scenario: PreventNativeDismiss
+# Test Scenario: Prevent Native Dismiss
 
 ## Details
 
@@ -19,7 +19,7 @@ Other: Planned, but will be implemented separately.
 
 ### Baseline
 
-1. Launch the app and navigate to the **PreventNativeDismiss** screen.
+1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
 
 - [ ] A status text indicating the current prop value (e.g., "Prevent Native Dismiss: ON"), a switch component, and an "Open FormSheet" button are shown.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-prevent-native-dismiss/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - **Android:** a prevented attempt makes the sheet return to its last stable detent; the system back gesture/button is intercepted the same way as the swipe.
 - **iPad:** the sheet is presented as a centered floating panel with a fixed width; the backdrop is the dimmed area around the panel.
 
-## Steps - iOS
+## Steps
 
 ### Baseline
 
@@ -73,62 +73,14 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.
 
-## Steps - Android
+## Steps - Android only
 
-### Baseline
+### System back
 
-1. Launch the app and navigate to the **Prevent Native Dismiss** screen.
+11. Flip the switch back so the host screen reads "Prevent Native Dismiss: ON", tap "Open FormSheet", then use the system back gesture (or the back button).
 
-- [ ] The host screen shows "Prevent Native Dismiss: ON", a switch (on) and the "Open FormSheet" button.
+- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears.
 
----
-
-### Native dismissal prevented
-
-2. Tap "Open FormSheet".
-
-- [ ] The sheet presents at the lower detent (0.5) and the host screen is dimmed. The text inside asks to try swiping down or tapping the backdrop; the content is anchored to the top of the sheet.
-
-3. Drag the sheet up to 1.0, then back down to 0.5.
-
-- [ ] Both drags work – detent changes are not blocked.
-
-4. Swipe the sheet down past the lower detent.
-
-- [ ] The sheet does **not** dismiss – it returns to 0.5 and a "Dismissal Prevented" alert appears.
-
-5. Tap "OK" on the alert.
-
-- [ ] The alert closes; the sheet is still presented.
-
-6. Tap the backdrop (the dimmed area above the sheet).
-
-- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
-
-7. Tap "OK", then use the system back gesture (or the back button).
-
-- [ ] The sheet does **not** dismiss and the "Dismissal Prevented" alert appears again.
-
-8. Tap "OK", then tap "Dismiss from JS".
-
-- [ ] The sheet dismisses – programmatic dismissal is not affected.
-
----
-
-### Native dismissal allowed
-
-9. Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", then tap "Open FormSheet".
-
-- [ ] The sheet presents at 0.5. The text inside says the sheet should close without an alert.
-
-10. Swipe the sheet down past the lower detent.
-
-- [ ] The sheet dismisses; no alert is shown.
-
-11. Tap "Open FormSheet", then tap the backdrop.
-
-- [ ] The sheet dismisses; no alert is shown.
-
-12. Tap "Open FormSheet", then use the system back gesture (or the back button).
+12. Tap "OK", then tap "Dismiss from JS". Flip the switch so the host screen reads "Prevent Native Dismiss: OFF", tap "Open FormSheet", then use the system back gesture (or the back button) again.
 
 - [ ] The sheet dismisses; no alert is shown. "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import { FormSheet } from 'react-native-screens';
 import { createScenario } from '@apps/tests/shared/helpers';
 import { scenarioDescription } from './scenario-description';
@@ -118,6 +118,7 @@ const styles = StyleSheet.create({
   },
   sheetContent: {
     flex: 1,
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
     backgroundColor: Colors.background,
     padding: 24,
     alignItems: 'center',

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario-description.ts
@@ -1,10 +1,10 @@
 import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 
 export const scenarioDescription: ScenarioDescription = {
-  name: 'Stacking FormSheets',
+  name: 'Stacked Sheets',
   key: 'test-form-sheet-stacking',
   details:
-    'Allows testing of stacking multiple FormSheet components with different detents.',
+    'Three sheets presented on top of each other: dismissing the top, middle and bottom sheet.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -106,9 +106,9 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
 
-## Steps - Android only
+---
 
-### System back
+### Android only - System back
 
 16. Tap "Open First FormSheet", then "Open Second FormSheet", then use the system back gesture (or the back button).
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 - On Android the content of each sheet is anchored to the top, so the title and the buttons are reachable at the 0.4 detent (the content box is laid out to the largest detent); on iOS the content is centered within the current detent.
 - **iPad:** every sheet is presented as a centered floating panel with a fixed width.
 
-## Steps - iPhone
+## Steps - iOS
 
 ### Baseline
 
@@ -105,91 +105,6 @@ TBD: Planned, but will be implemented separately.
 15. Tap "Dismiss First FormSheet" inside the Second sheet.
 
 - [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
-## Steps - iPad
-
-### Baseline
-
-1. Launch the app and navigate to the **Stacked Sheets** screen.
-
-- [ ] The host screen shows the "Open First FormSheet" button.
-
----
-
-### Build the full stack
-
-2. Tap "Open First FormSheet".
-
-- [ ] The blue First sheet presents as a centered floating panel at 0.4. Its title reads "First FormSheet" and the "Open Second FormSheet" / "Dismiss First FormSheet" buttons are visible.
-
-3. Drag the First panel up to 1.0.
-
-- [ ] The First panel grows vertically to the maximum available height; its width stays fixed.
-
-4. Tap "Open Second FormSheet".
-
-- [ ] The green Second panel presents over the First one at 0.4. The First panel stays visible behind it, still at 1.0.
-
-5. Drag the Second panel up to 1.0.
-
-- [ ] The Second panel grows vertically to the maximum available height.
-
-6. Tap "Open Third FormSheet".
-
-- [ ] The yellow Third panel presents over the Second one at 0.4. The Second and First panels stay behind it at their previous detents.
-
----
-
-### Top dismissal
-
-7. Tap "Dismiss Third FormSheet" inside the Third panel.
-
-- [ ] Only the Third panel dismisses. The Second panel is on top again, still at 1.0, and its buttons are pressable.
-- [ ] The First panel is still present behind the Second one.
-
-8. Swipe the Second panel (now the top one) down past its lower detent.
-
-- [ ] The Second panel dismisses natively. The First panel is on top again, still at 1.0, and its buttons are pressable.
-
-9. Tap "Dismiss First FormSheet" inside the First panel.
-
-- [ ] The First panel dismisses and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
----
-
-### Middle dismissal
-
-10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
-
-- [ ] All three panels are stacked, the yellow Third one on top.
-
-11. Tap "Dismiss Second FormSheet" inside the Third panel.
-
-- [ ] The Second **and** the Third panel dismiss together. The blue First panel is on top again and its buttons are pressable.
-
-12. Tap "Open Second FormSheet" inside the First panel, then "Open Third FormSheet" inside the Second panel.
-
-- [ ] Both panels present again, in order, on top of the First one.
-
----
-
-### Bottom dismissal
-
-13. With all three panels stacked, tap "Dismiss First FormSheet" inside the Third panel.
-
-- [ ] All three panels dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
----
-
-### Bottom dismissal from a two-sheet stack
-
-14. Tap "Open First FormSheet", then "Open Second FormSheet".
-
-- [ ] The First and the Second panel are stacked, the green Second one on top.
-
-15. Tap "Dismiss First FormSheet" inside the Second panel.
-
-- [ ] Both panels dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
 
 ## Steps - Android
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -1,27 +1,33 @@
-# Test Scenario: Stacking FormSheets
+# Test Scenario: Stacked Sheets
 
 ## Details
 
-**Description:** Verify the present/dismiss flow for stacked `FormSheet` components. The screen presents up to three sheets stacked on top of each other. Every sheet exposes buttons that dismiss any sheet in the stack.
+**Description:** Verify the present / dismiss flow of several standalone `FormSheet` components presented on top of each other. The host screen owns three sheets (First – blue, Second – green, Third – yellow), each with detents `[0.4, 1.0]`. Every sheet exposes buttons that dismiss any sheet in the stack, so the scenario covers dismissing the top, the middle and the bottom sheet – dismissing a sheet must also dismiss every sheet presented above it.
 
 **OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
 
 ## E2E test
 
-Other: Planned, but will be implemented separately.
+TBD: Planned, but will be implemented separately.
 
 ## Prerequisites
 
-- iOS device or simulator: iPhone
-- Android emulator
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
+
+## Note
+
+- On Android the content of each sheet is anchored to the top, so the title and the buttons are reachable at the 0.4 detent (the content box is laid out to the largest detent); on iOS the content is centered within the current detent.
+- **iPad:** every sheet is presented as a centered floating panel with a fixed width.
 
 ## Steps - iPhone
 
 ### Baseline
 
-1. Launch the app and navigate to the **Stacking FormSheets** screen.
+1. Launch the app and navigate to the **Stacked Sheets** screen.
 
-- [ ] Content with the button "Open First FormSheet" is shown.
+- [ ] The host screen shows the "Open First FormSheet" button.
 
 ---
 
@@ -29,23 +35,23 @@ Other: Planned, but will be implemented separately.
 
 2. Tap "Open First FormSheet".
 
-- [ ] The First (blue) FormSheet opens at the initial lower detent (0.4). The "Open Second FormSheet" and "Dismiss First FormSheet" buttons are visible.
+- [ ] The blue First sheet presents at 0.4. Its title reads "First FormSheet" and the "Open Second FormSheet" / "Dismiss First FormSheet" buttons are visible.
 
-3. Grab the top edge of the First FormSheet and swipe up to its maximum detent (1.0).
+3. Drag the First sheet up to 1.0.
 
-- [ ] The First FormSheet expands smoothly to the maximum available height.
+- [ ] The First sheet expands to the maximum available height.
 
 4. Tap "Open Second FormSheet".
 
-- [ ] The Second (green) FormSheet opens over the first at its initial detent (0.4). The First FormSheet remains visible in the background, keeping its expanded 1.0 detent.
+- [ ] The green Second sheet presents over the First one at 0.4. The First sheet stays visible behind it, still at 1.0.
 
-5. Grab the top edge of the Second FormSheet and swipe up to its maximum detent (1.0).
+5. Drag the Second sheet up to 1.0.
 
-- [ ] The Second FormSheet expands smoothly.
+- [ ] The Second sheet expands to the maximum available height.
 
 6. Tap "Open Third FormSheet".
 
-- [ ] The Third (yellow) FormSheet opens over the second at its initial detent (0.4). The Second and First FormSheets remain in the background at their previous detents.
+- [ ] The yellow Third sheet presents over the Second one at 0.4. The Second and First sheets stay behind it at their previous detents.
 
 ---
 
@@ -53,16 +59,16 @@ Other: Planned, but will be implemented separately.
 
 7. Tap "Dismiss Third FormSheet" inside the Third sheet.
 
-- [ ] Only the Third FormSheet dismisses. The Second FormSheet returns and its expanded 1.0 detent. Its buttons are pressable.
-- [ ] The First FormSheet is still present behind the Second.
+- [ ] Only the Third sheet dismisses. The Second sheet is on top again, still at 1.0, and its buttons are pressable.
+- [ ] The First sheet is still present behind the Second one.
 
-8. Swipe the Second FormSheet (now the top sheet) down to fully dismiss it via native gesture.
+8. Swipe the Second sheet (now the top one) down past its lower detent.
 
-- [ ] The Second FormSheet dismisses. The First FormSheet returns and its expanded 1.0 detent. Its buttons are pressable.
+- [ ] The Second sheet dismisses natively. The First sheet is on top again, still at 1.0, and its buttons are pressable.
 
 9. Tap "Dismiss First FormSheet" inside the First sheet.
 
-- [ ] The First FormSheet dismisses, returning to the underlying main screen. Main-screen pressables work normally.
+- [ ] The First sheet dismisses and the host screen is undimmed. "Open First FormSheet" is pressable again.
 
 ---
 
@@ -70,38 +76,210 @@ Other: Planned, but will be implemented separately.
 
 10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
 
-- [ ] All three sheets are stacked, Third on top.
+- [ ] All three sheets are stacked, the yellow Third one on top.
 
-11. Tap "Dismiss Second FormSheet" inside the Third sheet. This dismisses the middle sheet while the Third sheet is still on top of it.
+11. Tap "Dismiss Second FormSheet" inside the Third sheet.
 
-- [ ] The Second **and** Third FormSheets both dismiss. The user is returned to the First FormSheet.
-- [ ] The First FormSheet remains present and interactive.
+- [ ] The Second **and** the Third sheet dismiss together. The blue First sheet is on top again and its buttons are pressable.
 
 12. Tap "Open Second FormSheet" inside the First sheet, then "Open Third FormSheet" inside the Second sheet.
 
-- [ ] Both sheets re-present correctly.
+- [ ] Both sheets present again, in order, on top of the First one.
 
 ---
 
 ### Bottom dismissal
 
-13. With all three sheets stacked, tap "Dismiss First FormSheet" inside the Third sheet. This dismisses the bottom-most sheet while the entire stack is open.
+13. With all three sheets stacked, tap "Dismiss First FormSheet" inside the Third sheet.
 
-- [ ] All three FormSheets dismiss together, returning directly to the underlying main screen.
-- [ ] Main-screen pressables work normally.
-
-14. Tap "Open First FormSheet" again.
-
-- [ ] The First FormSheet opens.
+- [ ] All three sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
 
 ---
 
-### Mid-stack dismissal from a two-sheet stack
+### Bottom dismissal from a two-sheet stack
 
-15. With the First FormSheet open, tap "Open Second FormSheet".
+14. Tap "Open First FormSheet", then "Open Second FormSheet".
 
-- [ ] First and Second are stacked, Second on top.
+- [ ] The First and the Second sheet are stacked, the green Second one on top.
 
-16. Tap "Dismiss First FormSheet" inside the Second sheet.
+15. Tap "Dismiss First FormSheet" inside the Second sheet.
 
-- [ ] Both the First and Second FormSheets dismiss, returning to the underlying main screen.
+- [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+## Steps - iPad
+
+### Baseline
+
+1. Launch the app and navigate to the **Stacked Sheets** screen.
+
+- [ ] The host screen shows the "Open First FormSheet" button.
+
+---
+
+### Build the full stack
+
+2. Tap "Open First FormSheet".
+
+- [ ] The blue First sheet presents as a centered floating panel at 0.4. Its title reads "First FormSheet" and the "Open Second FormSheet" / "Dismiss First FormSheet" buttons are visible.
+
+3. Drag the First panel up to 1.0.
+
+- [ ] The First panel grows vertically to the maximum available height; its width stays fixed.
+
+4. Tap "Open Second FormSheet".
+
+- [ ] The green Second panel presents over the First one at 0.4. The First panel stays visible behind it, still at 1.0.
+
+5. Drag the Second panel up to 1.0.
+
+- [ ] The Second panel grows vertically to the maximum available height.
+
+6. Tap "Open Third FormSheet".
+
+- [ ] The yellow Third panel presents over the Second one at 0.4. The Second and First panels stay behind it at their previous detents.
+
+---
+
+### Top dismissal
+
+7. Tap "Dismiss Third FormSheet" inside the Third panel.
+
+- [ ] Only the Third panel dismisses. The Second panel is on top again, still at 1.0, and its buttons are pressable.
+- [ ] The First panel is still present behind the Second one.
+
+8. Swipe the Second panel (now the top one) down past its lower detent.
+
+- [ ] The Second panel dismisses natively. The First panel is on top again, still at 1.0, and its buttons are pressable.
+
+9. Tap "Dismiss First FormSheet" inside the First panel.
+
+- [ ] The First panel dismisses and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+---
+
+### Middle dismissal
+
+10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
+
+- [ ] All three panels are stacked, the yellow Third one on top.
+
+11. Tap "Dismiss Second FormSheet" inside the Third panel.
+
+- [ ] The Second **and** the Third panel dismiss together. The blue First panel is on top again and its buttons are pressable.
+
+12. Tap "Open Second FormSheet" inside the First panel, then "Open Third FormSheet" inside the Second panel.
+
+- [ ] Both panels present again, in order, on top of the First one.
+
+---
+
+### Bottom dismissal
+
+13. With all three panels stacked, tap "Dismiss First FormSheet" inside the Third panel.
+
+- [ ] All three panels dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+---
+
+### Bottom dismissal from a two-sheet stack
+
+14. Tap "Open First FormSheet", then "Open Second FormSheet".
+
+- [ ] The First and the Second panel are stacked, the green Second one on top.
+
+15. Tap "Dismiss First FormSheet" inside the Second panel.
+
+- [ ] Both panels dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Stacked Sheets** screen.
+
+- [ ] The host screen shows the "Open First FormSheet" button.
+
+---
+
+### Build the full stack
+
+2. Tap "Open First FormSheet".
+
+- [ ] The blue First sheet presents at 0.4 and the host screen is dimmed. Its title reads "First FormSheet" and the "Open Second FormSheet" / "Dismiss First FormSheet" buttons are visible.
+
+3. Drag the First sheet up to 1.0.
+
+- [ ] The First sheet expands to the maximum available height (below the status bar).
+
+4. Tap "Open Second FormSheet".
+
+- [ ] The green Second sheet presents over the First one at 0.4. The First sheet stays visible behind it, still at 1.0, and is dimmed.
+
+5. Drag the Second sheet up to 1.0.
+
+- [ ] The Second sheet expands to the maximum available height.
+
+6. Tap "Open Third FormSheet".
+
+- [ ] The yellow Third sheet presents over the Second one at 0.4. The Second and First sheets stay behind it at their previous detents.
+
+---
+
+### Top dismissal
+
+7. Tap "Dismiss Third FormSheet" inside the Third sheet.
+
+- [ ] Only the Third sheet dismisses. The Second sheet is on top again, still at 1.0, no longer dimmed, and its buttons are pressable.
+- [ ] The First sheet is still present behind the Second one.
+
+8. Swipe the Second sheet (now the top one) down past its lower detent.
+
+- [ ] The Second sheet dismisses natively. The First sheet is on top again, still at 1.0, and its buttons are pressable.
+
+9. Tap "Dismiss First FormSheet" inside the First sheet.
+
+- [ ] The First sheet dismisses and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+---
+
+### Middle dismissal
+
+10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
+
+- [ ] All three sheets are stacked, the yellow Third one on top.
+
+11. Tap "Dismiss Second FormSheet" inside the Third sheet.
+
+- [ ] The Second **and** the Third sheet dismiss together. The blue First sheet is on top again and its buttons are pressable.
+
+12. Tap "Open Second FormSheet" inside the First sheet, then "Open Third FormSheet" inside the Second sheet.
+
+- [ ] Both sheets present again, in order, on top of the First one.
+
+---
+
+### Bottom dismissal
+
+13. With all three sheets stacked, tap "Dismiss First FormSheet" inside the Third sheet.
+
+- [ ] All three sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+---
+
+### Bottom dismissal from a two-sheet stack
+
+14. Tap "Open First FormSheet", then "Open Second FormSheet".
+
+- [ ] The First and the Second sheet are stacked, the green Second one on top.
+
+15. Tap "Dismiss First FormSheet" inside the Second sheet.
+
+- [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
+
+---
+
+### System back
+
+16. Tap "Open First FormSheet", then "Open Second FormSheet", then use the system back gesture (or the back button).
+
+- [ ] Only the Second (top) sheet dismisses; the First sheet stays presented and its buttons are pressable.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -4,7 +4,7 @@
 
 **Description:** Verify the present / dismiss flow of several standalone `FormSheet` components presented on top of each other. The host screen owns three sheets (First – blue, Second – green, Third – yellow), each with detents `[0.4, 1.0]`. Every sheet exposes buttons that dismiss any sheet in the stack, so the scenario covers dismissing the top, the middle and the bottom sheet – dismissing a sheet must also dismiss every sheet presented above it.
 
-**OS test creation version:** iOS: 18.6 and 26.4, Android: API Level 36.
+**OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 
 ## E2E test
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify the present / dismiss flow of several standalone `FormSheet` components presented on top of each other. The host screen owns three sheets (First – blue, Second – green, Third – yellow), each with detents `[0.4, 1.0]`. Every sheet exposes buttons that dismiss any sheet in the stack, so the scenario covers dismissing the top, the middle and the bottom sheet – dismissing a sheet must also dismiss every sheet presented above it.
+**Description:** Verify the present / dismiss flow of several `FormSheet` components presented on top of each other. The host screen owns three sheets (First – blue, Second – green, Third – yellow), each with detents `[0.4, 1.0]`. Every sheet exposes buttons that dismiss any sheet in the stack, so the scenario covers dismissing the top, the middle and the bottom sheet – dismissing a sheet must also dismiss every sheet presented above it.
 
 **OS test creation version:** iOS: 18.6 and 26.5, iPadOS: 26.5, Android: API Level 36.
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-stacking/scenario.md
@@ -21,92 +21,7 @@ TBD: Planned, but will be implemented separately.
 - On Android the content of each sheet is anchored to the top, so the title and the buttons are reachable at the 0.4 detent (the content box is laid out to the largest detent); on iOS the content is centered within the current detent.
 - **iPad:** every sheet is presented as a centered floating panel with a fixed width.
 
-## Steps - iOS
-
-### Baseline
-
-1. Launch the app and navigate to the **Stacked Sheets** screen.
-
-- [ ] The host screen shows the "Open First FormSheet" button.
-
----
-
-### Build the full stack
-
-2. Tap "Open First FormSheet".
-
-- [ ] The blue First sheet presents at 0.4. Its title reads "First FormSheet" and the "Open Second FormSheet" / "Dismiss First FormSheet" buttons are visible.
-
-3. Drag the First sheet up to 1.0.
-
-- [ ] The First sheet expands to the maximum available height.
-
-4. Tap "Open Second FormSheet".
-
-- [ ] The green Second sheet presents over the First one at 0.4. The First sheet stays visible behind it, still at 1.0.
-
-5. Drag the Second sheet up to 1.0.
-
-- [ ] The Second sheet expands to the maximum available height.
-
-6. Tap "Open Third FormSheet".
-
-- [ ] The yellow Third sheet presents over the Second one at 0.4. The Second and First sheets stay behind it at their previous detents.
-
----
-
-### Top dismissal
-
-7. Tap "Dismiss Third FormSheet" inside the Third sheet.
-
-- [ ] Only the Third sheet dismisses. The Second sheet is on top again, still at 1.0, and its buttons are pressable.
-- [ ] The First sheet is still present behind the Second one.
-
-8. Swipe the Second sheet (now the top one) down past its lower detent.
-
-- [ ] The Second sheet dismisses natively. The First sheet is on top again, still at 1.0, and its buttons are pressable.
-
-9. Tap "Dismiss First FormSheet" inside the First sheet.
-
-- [ ] The First sheet dismisses and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
----
-
-### Middle dismissal
-
-10. Rebuild the stack: tap "Open First FormSheet", then "Open Second FormSheet", then "Open Third FormSheet".
-
-- [ ] All three sheets are stacked, the yellow Third one on top.
-
-11. Tap "Dismiss Second FormSheet" inside the Third sheet.
-
-- [ ] The Second **and** the Third sheet dismiss together. The blue First sheet is on top again and its buttons are pressable.
-
-12. Tap "Open Second FormSheet" inside the First sheet, then "Open Third FormSheet" inside the Second sheet.
-
-- [ ] Both sheets present again, in order, on top of the First one.
-
----
-
-### Bottom dismissal
-
-13. With all three sheets stacked, tap "Dismiss First FormSheet" inside the Third sheet.
-
-- [ ] All three sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
----
-
-### Bottom dismissal from a two-sheet stack
-
-14. Tap "Open First FormSheet", then "Open Second FormSheet".
-
-- [ ] The First and the Second sheet are stacked, the green Second one on top.
-
-15. Tap "Dismiss First FormSheet" inside the Second sheet.
-
-- [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
-
-## Steps - Android
+## Steps
 
 ### Baseline
 
@@ -124,7 +39,7 @@ TBD: Planned, but will be implemented separately.
 
 3. Drag the First sheet up to 1.0.
 
-- [ ] The First sheet expands to the maximum available height (below the status bar).
+- [ ] The First sheet expands to the maximum available height.
 
 4. Tap "Open Second FormSheet".
 
@@ -191,7 +106,7 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] Both sheets dismiss together and the host screen is undimmed. "Open First FormSheet" is pressable again.
 
----
+## Steps - Android only
 
 ### System back
 


### PR DESCRIPTION
## Description

Fix testing scenarios for Android, iOS, and iPadOS, along with minor layout adjustments in the examples. These changes ensure that the layout aligns with expected behavior and content is always visible by adapting static content to the minimum window size and preventing incorrect centering relative to the maximum detent on Android.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1751 
Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1279 
Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1440 

## Changes

- Updated testing scenarios for Android, iOS, and iPadOS.
- Applied minor layout fixes in the examples to ensure content behaves as expected and remains fully visible.
- Adjusted static content sizing to properly adapt to the minimum window size.
- Fixed a layout on Android to prevent content from centering relative to the maximum detent.

## Before & after - visual documentation

N/A

## Test plan

Go through already-existing testing scenarios for FormSheets.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
